### PR TITLE
Add experimental causal conv1d decode update

### DIFF
--- a/benchmark/causal_conv1d_update_bias_smoke.py
+++ b/benchmark/causal_conv1d_update_bias_smoke.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""ComputeLab correctness smoke for optional decode causal-conv bias."""
+
+from pathlib import Path
+
+import cudnn
+import torch
+import torch.nn.functional as F
+
+SOURCE_CUDNN = Path(__file__).resolve().parents[1] / "python" / "cudnn"
+if str(SOURCE_CUDNN) not in cudnn.__path__:
+    cudnn.__path__.insert(0, str(SOURCE_CUDNN))
+
+from cudnn.causal_conv1d_update_sm100 import causal_conv1d_update  # noqa: E402
+
+
+@torch.no_grad()
+def main():
+    generator = torch.Generator(device="cuda").manual_seed(20260829)
+    x = torch.randn((128, 4096), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    weight = torch.randn((4096, 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    bias = torch.randn((4096,), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    initial_state = torch.randn((128, 4096, 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    rows = {}
+    for name, value in (("none", None), ("bias", bias)):
+        state = initial_state.clone()
+        expected_state = torch.cat((initial_state[..., 1:], x.unsqueeze(-1)), dim=-1)
+        accumulator = (expected_state.float() * weight.float().unsqueeze(0)).sum(-1)
+        if value is not None:
+            accumulator = accumulator + value.float()
+        expected = F.silu(accumulator).to(torch.bfloat16)
+        actual = causal_conv1d_update(x, state, weight, bias=value)
+        torch.testing.assert_close(actual, expected, atol=3e-2, rtol=3e-2)
+        torch.testing.assert_close(state.view(torch.int16), expected_state.view(torch.int16), atol=0, rtol=0)
+        rows[name] = float((actual.float() - expected.float()).abs().max())
+    print(
+        {
+            "device": torch.cuda.get_device_name(),
+            "shape": list(x.shape),
+            "max_abs": rows,
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/causal_conv1d_update_bias_smoke.py
+++ b/benchmark/causal_conv1d_update_bias_smoke.py
@@ -13,7 +13,7 @@ SOURCE_CUDNN = Path(__file__).resolve().parents[1] / "python" / "cudnn"
 if str(SOURCE_CUDNN) not in cudnn.__path__:
     cudnn.__path__.insert(0, str(SOURCE_CUDNN))
 
-from cudnn.causal_conv1d_update_sm100 import causal_conv1d_update  # noqa: E402
+from cudnn.ops import causal_conv1d_update  # noqa: E402
 
 
 @torch.no_grad()
@@ -31,7 +31,7 @@ def main():
         if value is not None:
             accumulator = accumulator + value.float()
         expected = F.silu(accumulator).to(torch.bfloat16)
-        actual = causal_conv1d_update(x, state, weight, bias=value)
+        actual = causal_conv1d_update(x, state, weight, bias=value, activation="silu")
         torch.testing.assert_close(actual, expected, atol=3e-2, rtol=3e-2)
         torch.testing.assert_close(state.view(torch.int16), expected_state.view(torch.int16), atol=0, rtol=0)
         rows[name] = float((actual.float() - expected.float()).abs().max())

--- a/benchmark/causal_conv1d_update_sm100.py
+++ b/benchmark/causal_conv1d_update_sm100.py
@@ -46,7 +46,7 @@ from cudnn._causal_conv1d_arch import (
     is_supported_causal_conv1d_update_compute_capability,
     supported_causal_conv1d_update_compute_capabilities_text,
 )
-from cudnn.causal_conv1d_update_sm100 import CausalConv1dUpdateSm100
+from cudnn.causal_conv1d_update_sm100 import _CausalConv1dUpdatePlan
 from fla.modules.conv.triton.ops import causal_conv1d_update as fla_causal_conv1d_update
 
 DEFAULT_SHAPES = (
@@ -284,7 +284,7 @@ def _benchmark_shape(n_rows: int, n_channels: int, *, samples: int, warmup: int,
     fla_state = initial_state.clone()
     native_output = torch.empty_like(x)
 
-    api = CausalConv1dUpdateSm100(x, weight, native_state, native_output)
+    api = _CausalConv1dUpdatePlan(x, weight, native_state, native_output, activation="silu")
     if not api.check_support():
         raise RuntimeError("native check_support unexpectedly returned false")
     api.compile()
@@ -363,7 +363,7 @@ def _benchmark_shape(n_rows: int, n_channels: int, *, samples: int, warmup: int,
 
 
 def _metadata(repo: Path, shapes: tuple[tuple[int, int], ...], args: argparse.Namespace) -> dict:
-    executed_native_api_path = _module_path(CausalConv1dUpdateSm100.__module__)
+    executed_native_api_path = _module_path(_CausalConv1dUpdatePlan.__module__)
     executed_native_kernel_path = _module_path("cudnn.causal_conv1d_update_sm100.kernel")
     repo_native_api_path = (repo / "python/cudnn/causal_conv1d_update_sm100/api.py").resolve()
     repo_native_kernel_path = (repo / "python/cudnn/causal_conv1d_update_sm100/kernel.py").resolve()
@@ -383,7 +383,7 @@ def _metadata(repo: Path, shapes: tuple[tuple[int, int], ...], args: argparse.Na
         "timing_contract": "warm cache-hit CUDA-graph replay; one update per sample; compile, capture, allocation, and state reset outside events",
         "comparison_contract": "single process; AB/BA interleaved; identical x/weight/initial state; BF16 N,D,W=4 no-bias SiLU",
         "shape_contract": "Qwen3.5-9B separate short-conv projections: Q D=2048, K D=2048, V D=4096; W=4",
-        "native_route": f"{CausalConv1dUpdateSm100.__module__}.{CausalConv1dUpdateSm100.__qualname__}.execute",
+        "native_route": f"{_CausalConv1dUpdatePlan.__module__}.{_CausalConv1dUpdatePlan.__qualname__}.execute",
         "fla_route": f"{fla_causal_conv1d_update.__module__}.{fla_causal_conv1d_update.__name__}",
         "provenance": {
             "benchmark": {
@@ -455,8 +455,8 @@ def _validate_environment() -> None:
             "benchmark requires a functionally supported causal-conv compute capability "
             f"({supported_causal_conv1d_update_compute_capabilities_text()}), found {capability[0]}.{capability[1]}"
         )
-    if CausalConv1dUpdateSm100.__module__ != "cudnn.causal_conv1d_update_sm100.api":
-        raise RuntimeError(f"unexpected native route: {CausalConv1dUpdateSm100.__module__}")
+    if _CausalConv1dUpdatePlan.__module__ != "cudnn.causal_conv1d_update_sm100.api":
+        raise RuntimeError(f"unexpected native route: {_CausalConv1dUpdatePlan.__module__}")
     if fla_causal_conv1d_update.__module__ != "fla.modules.conv.triton.ops":
         raise RuntimeError(f"unexpected FLA route: {fla_causal_conv1d_update.__module__}")
     if _package_version("flash-linear-attention") != "0.5.2":

--- a/benchmark/causal_conv1d_update_sm100.py
+++ b/benchmark/causal_conv1d_update_sm100.py
@@ -1,0 +1,514 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""B200-only decode microbenchmark for the SM100 causal-conv operation.
+
+This compares the direct low-level cuDNN Frontend API against FLA 0.5.2's
+public Triton update operation at representative Qwen3.5-9B decode shapes.  Q
+and K each have D=2048 channels and V has D=4096 channels; all three use W=4.
+It is a single-process, same-input, AB/BA-interleaved comparison.  Both
+implementations are compiled and CUDA-graph-captured before timing; in
+particular, the ``torch.empty_like`` in FLA's wrapper runs during capture rather
+than between the timing events.  Every timed replay starts from the same state
+bits.
+
+The script deliberately refuses to print timing results unless both output and
+the final mutable cache pass an explicit FP32/BF16 reference gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import importlib.metadata
+import json
+import os
+from pathlib import Path
+import platform
+import statistics
+import subprocess
+import sys
+from typing import Callable, NamedTuple
+
+import torch
+import torch.nn.functional as F
+
+import cudnn
+
+# Execute the Python sources from this checkout while retaining the installed
+# package's compiled extension.  This mirrors the focused pytest overlay and
+# makes the source-hash route proof independent of site-package sync state.
+_SOURCE_CUDNN = Path(__file__).resolve().parents[1] / "python" / "cudnn"
+if str(_SOURCE_CUDNN) not in cudnn.__path__:
+    cudnn.__path__.insert(0, str(_SOURCE_CUDNN))
+
+from cudnn.causal_conv1d_update_sm100 import CausalConv1dUpdateSm100
+from fla.modules.conv.triton.ops import causal_conv1d_update as fla_causal_conv1d_update
+
+DEFAULT_SHAPES = (
+    (1, 2048),
+    (8, 2048),
+    (32, 2048),
+    (128, 2048),
+    (1, 4096),
+    (8, 4096),
+    (32, 4096),
+    (128, 4096),
+)
+OUTPUT_ATOL = 3e-2
+OUTPUT_RTOL = 3e-2
+
+
+class CapturedArm(NamedTuple):
+    name: str
+    graph: torch.cuda.CUDAGraph
+    output: torch.Tensor
+    state: torch.Tensor
+
+
+def _parse_shape(value: str) -> tuple[int, int]:
+    try:
+        n_rows, n_channels = (int(piece) for piece in value.lower().split("x", maxsplit=1))
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError("shape must be N x D, for example 8x4096") from exc
+    if n_rows <= 0 or n_channels <= 0:
+        raise argparse.ArgumentTypeError("N and D must both be positive")
+    return n_rows, n_channels
+
+
+def _quantile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    position = fraction * (len(ordered) - 1)
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = position - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def _sha256(path: str | os.PathLike[str]) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(["git", "-C", str(repo), *args], text=True).strip()
+
+
+def _package_version(name: str) -> str:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return "not-installed"
+
+
+def _module_path(module_name: str) -> Path:
+    module = sys.modules.get(module_name)
+    path = getattr(module, "__file__", None)
+    if path is None:
+        raise RuntimeError(f"cannot resolve source path for loaded module {module_name}")
+    return Path(path).resolve()
+
+
+def _nvidia_driver_for_uuid(device_uuid: str) -> str:
+    """Resolve the actual NVIDIA driver, matching the CUDA-visible GPU UUID."""
+
+    output = subprocess.check_output(
+        [
+            "nvidia-smi",
+            "--query-gpu=uuid,driver_version",
+            "--format=csv,noheader,nounits",
+        ],
+        text=True,
+    )
+    normalized_uuid = device_uuid.lower().removeprefix("gpu-")
+    for line in output.splitlines():
+        gpu_uuid, separator, driver_version = line.partition(",")
+        if separator and gpu_uuid.strip().lower().removeprefix("gpu-") == normalized_uuid:
+            return driver_version.strip()
+    raise RuntimeError(f"nvidia-smi did not report CUDA-visible GPU UUID {device_uuid}")
+
+
+def _capture(call: Callable[[], torch.Tensor | tuple[torch.Tensor, torch.Tensor]], *, warmup: int):
+    """Warm and capture ``call``; all Python allocation stays outside timing."""
+
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(warmup):
+            call()
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+    torch.cuda.synchronize()
+
+    capture_stream = torch.cuda.Stream()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=capture_stream):
+        result = call()
+    torch.cuda.synchronize()
+    return graph, result
+
+
+def _reference(x: torch.Tensor, weight: torch.Tensor, initial_state: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    final_state = torch.cat((initial_state[..., 1:], x.unsqueeze(-1)), dim=-1)
+    accumulator = (final_state.float() * weight.float().unsqueeze(0)).sum(dim=-1)
+    output = F.silu(accumulator).to(torch.bfloat16)
+    return output, final_state
+
+
+def _gate_arm(
+    arm: CapturedArm,
+    initial_state: torch.Tensor,
+    reference_output: torch.Tensor,
+    reference_state: torch.Tensor,
+) -> dict:
+    arm.state.copy_(initial_state)
+    arm.graph.replay()
+    torch.cuda.synchronize()
+
+    output_diff = (arm.output.float() - reference_output.float()).abs()
+    state_bits_equal = torch.equal(arm.state.view(torch.int16), reference_state.view(torch.int16))
+    output_close = torch.allclose(arm.output, reference_output, atol=OUTPUT_ATOL, rtol=OUTPUT_RTOL)
+    gate = {
+        "output_close": bool(output_close),
+        "output_max_abs": float(output_diff.max().item()),
+        "output_mean_abs": float(output_diff.mean().item()),
+        "state_bits_equal": bool(state_bits_equal),
+    }
+    if not output_close or not state_bits_equal:
+        raise AssertionError(f"{arm.name} correctness gate failed: {gate}")
+    return gate
+
+
+def _prime_events(event_pairs: list[tuple[torch.cuda.Event, torch.cuda.Event]]) -> None:
+    """Force lazy CUDA event creation before any measured interval."""
+
+    for start, end in event_pairs:
+        start.record()
+        end.record()
+    torch.cuda.synchronize()
+
+
+def _interleaved_samples(
+    native: CapturedArm,
+    fla: CapturedArm,
+    initial_state: torch.Tensor,
+    *,
+    samples: int,
+) -> tuple[list[float], list[float], list[str]]:
+    """Measure one graph replay per sample, alternating AB and BA order."""
+
+    arms = {native.name: native, fla.name: fla}
+    timings = {native.name: [], fla.name: []}
+    event_pairs = [(torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)) for _ in range(samples * 2)]
+    _prime_events(event_pairs)
+    orders = []
+    event_index = 0
+
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        for sample_index in range(samples):
+            order = (native.name, fla.name) if sample_index % 2 == 0 else (fla.name, native.name)
+            orders.append("/".join(order))
+            pending = []
+            for name in order:
+                arm = arms[name]
+                # This reset is ordered before the start event on the same
+                # stream, hence excluded from the measured interval.
+                arm.state.copy_(initial_state)
+                start, end = event_pairs[event_index]
+                event_index += 1
+                start.record()
+                arm.graph.replay()
+                end.record()
+                pending.append((name, start, end))
+            torch.cuda.synchronize()
+            for name, start, end in pending:
+                timings[name].append(float(start.elapsed_time(end) * 1000.0))
+    finally:
+        if gc_was_enabled:
+            gc.enable()
+
+    return timings[native.name], timings[fla.name], orders
+
+
+def _summary(samples_us: list[float]) -> dict:
+    return {
+        "median_us": statistics.median(samples_us),
+        "q25_us": _quantile(samples_us, 0.25),
+        "q75_us": _quantile(samples_us, 0.75),
+        "min_us": min(samples_us),
+        "max_us": max(samples_us),
+    }
+
+
+@torch.no_grad()
+def _benchmark_shape(n_rows: int, n_channels: int, *, samples: int, warmup: int, seed: int) -> dict:
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    x = (
+        torch.randn(
+            (n_rows, n_channels),
+            device="cuda",
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.25
+    )
+    weight = torch.randn((n_channels, 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    initial_state = (
+        torch.randn(
+            (n_rows, n_channels, 4),
+            device="cuda",
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.25
+    )
+    native_state = initial_state.clone()
+    fla_state = initial_state.clone()
+    native_output = torch.empty_like(x)
+
+    api = CausalConv1dUpdateSm100(x, weight, native_state, native_output)
+    if not api.check_support():
+        raise RuntimeError("native check_support unexpectedly returned false")
+    api.compile()
+
+    def native_call() -> torch.Tensor:
+        return api.execute(x, weight, native_state, native_output)
+
+    def fla_call() -> tuple[torch.Tensor, torch.Tensor]:
+        # Use FLA's public Triton op directly.  Its real cache contract is
+        # [N, D, W], including the newest element, so W=4 here.
+        return fla_causal_conv1d_update(
+            x=x,
+            cache=fla_state,
+            residual=None,
+            weight=weight,
+            bias=None,
+            activation="silu",
+        )
+
+    native_graph, captured_native_output = _capture(native_call, warmup=warmup)
+    fla_graph, captured_fla = _capture(fla_call, warmup=warmup)
+    fla_output, returned_fla_state = captured_fla
+    if captured_native_output.data_ptr() != native_output.data_ptr():
+        raise AssertionError("native direct execute did not return its preallocated output")
+    if returned_fla_state.data_ptr() != fla_state.data_ptr():
+        raise AssertionError("FLA did not return the mutable cache passed by the benchmark")
+
+    native_arm = CapturedArm("native", native_graph, native_output, native_state)
+    fla_arm = CapturedArm("fla", fla_graph, fla_output, fla_state)
+    reference_output, reference_state = _reference(x, weight, initial_state)
+    correctness = {
+        "native": _gate_arm(native_arm, initial_state, reference_output, reference_state),
+        "fla": _gate_arm(fla_arm, initial_state, reference_output, reference_state),
+    }
+    cross_output_close = torch.allclose(native_output, fla_output, atol=OUTPUT_ATOL, rtol=OUTPUT_RTOL)
+    cross_state_bits_equal = torch.equal(native_state.view(torch.int16), fla_state.view(torch.int16))
+    correctness["native_vs_fla"] = {
+        "output_close": bool(cross_output_close),
+        "state_bits_equal": bool(cross_state_bits_equal),
+        "output_max_abs": float((native_output.float() - fla_output.float()).abs().max().item()),
+    }
+    if not cross_output_close or not cross_state_bits_equal:
+        raise AssertionError(f"native/FLA cross gate failed: {correctness['native_vs_fla']}")
+
+    # Graphs and events are warmed.  Every measured arm below is reset from the
+    # same immutable state, outside of its event pair.
+    for arm in (native_arm, fla_arm):
+        for _ in range(warmup):
+            arm.state.copy_(initial_state)
+            arm.graph.replay()
+    torch.cuda.synchronize()
+
+    native_samples, fla_samples, orders = _interleaved_samples(
+        native_arm,
+        fla_arm,
+        initial_state,
+        samples=samples,
+    )
+    native_summary = _summary(native_samples)
+    fla_summary = _summary(fla_samples)
+    paired_ratios = [fla_us / native_us for native_us, fla_us in zip(native_samples, fla_samples, strict=True)]
+    return {
+        "shape": {"N": n_rows, "D": n_channels, "W": 4},
+        "correctness": correctness,
+        "native": {**native_summary, "samples_us": native_samples},
+        "fla": {**fla_summary, "samples_us": fla_samples},
+        "ratio_of_medians_fla_over_native": fla_summary["median_us"] / native_summary["median_us"],
+        "paired_fla_over_native": {
+            "median": statistics.median(paired_ratios),
+            "min": min(paired_ratios),
+            "max": max(paired_ratios),
+            "samples": paired_ratios,
+        },
+        "sample_orders": orders,
+    }
+
+
+def _metadata(repo: Path, shapes: tuple[tuple[int, int], ...], args: argparse.Namespace) -> dict:
+    executed_native_api_path = _module_path(CausalConv1dUpdateSm100.__module__)
+    executed_native_kernel_path = _module_path("cudnn.causal_conv1d_update_sm100.kernel")
+    repo_native_api_path = (repo / "python/cudnn/causal_conv1d_update_sm100/api.py").resolve()
+    repo_native_kernel_path = (repo / "python/cudnn/causal_conv1d_update_sm100/kernel.py").resolve()
+    native_api_sha256 = _sha256(executed_native_api_path)
+    native_kernel_sha256 = _sha256(executed_native_kernel_path)
+    if native_api_sha256 != _sha256(repo_native_api_path) or native_kernel_sha256 != _sha256(repo_native_kernel_path):
+        raise RuntimeError("executed native short-conv sources do not match this worktree")
+    fla_source_path = _module_path(fla_causal_conv1d_update.__module__)
+    fla_kernel_path = _module_path("fla.modules.conv.triton.kernels")
+    device = torch.cuda.current_device()
+    properties = torch.cuda.get_device_properties(device)
+    device_uuid = str(properties.uuid)
+    return {
+        "schema_version": 1,
+        "benchmark": "causal_conv1d_update_decode_sm100",
+        "timing_contract": "warm cache-hit CUDA-graph replay; one update per sample; compile, capture, allocation, and state reset outside events",
+        "comparison_contract": "single process; AB/BA interleaved; identical x/weight/initial state; BF16 N,D,W=4 no-bias SiLU",
+        "shape_contract": "Qwen3.5-9B separate short-conv projections: Q D=2048, K D=2048, V D=4096; W=4",
+        "native_route": f"{CausalConv1dUpdateSm100.__module__}.{CausalConv1dUpdateSm100.__qualname__}.execute",
+        "fla_route": f"{fla_causal_conv1d_update.__module__}.{fla_causal_conv1d_update.__name__}",
+        "provenance": {
+            "benchmark": {
+                "path": str(Path(__file__).resolve()),
+                "sha256": _sha256(Path(__file__).resolve()),
+            },
+            "native_api": {
+                "executed_path": str(executed_native_api_path),
+                "repo_path": str(repo_native_api_path),
+                "sha256": native_api_sha256,
+            },
+            "native_kernel": {
+                "executed_path": str(executed_native_kernel_path),
+                "repo_path": str(repo_native_kernel_path),
+                "sha256": native_kernel_sha256,
+            },
+            "fla_op": {
+                "path": str(fla_source_path),
+                "sha256": _sha256(fla_source_path),
+                "license": "MIT",
+            },
+            "fla_kernel": {
+                "path": str(fla_kernel_path),
+                "sha256": _sha256(fla_kernel_path),
+                "license": "MIT",
+            },
+        },
+        "hardware": {
+            "name": properties.name,
+            "compute_capability": list(torch.cuda.get_device_capability(device)),
+            "device_index": device,
+            "uuid": device_uuid,
+            "driver": _nvidia_driver_for_uuid(device_uuid),
+            "total_memory_bytes": properties.total_memory,
+        },
+        "computelab": {
+            "slurm_job_id": os.environ["SLURM_JOB_ID"],
+            "slurmd_node_name": os.environ["SLURMD_NODENAME"],
+        },
+        "software": {
+            "python": platform.python_version(),
+            "torch": torch.__version__,
+            "cuda": torch.version.cuda,
+            "torch_cudnn": torch.backends.cudnn.version(),
+            "cudnn_frontend": cudnn.__version__,
+            "cudnn_backend": cudnn.backend_version(),
+            "cudnn_backend_string": cudnn.backend_version_string(),
+            "flash_linear_attention": _package_version("flash-linear-attention"),
+        },
+        "repository": {
+            "root": str(repo),
+            "head": _git(repo, "rev-parse", "HEAD"),
+            "branch": _git(repo, "branch", "--show-current"),
+            "dirty": bool(_git(repo, "status", "--porcelain")),
+        },
+        "parameters": {
+            "samples": args.samples,
+            "warmup": args.warmup,
+            "seed": args.seed,
+            "shapes": [list(shape) for shape in shapes],
+        },
+    }
+
+
+def _validate_environment() -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is unavailable")
+    properties = torch.cuda.get_device_properties()
+    capability = torch.cuda.get_device_capability()
+    if properties.name != "NVIDIA B200":
+        raise RuntimeError(f"benchmark requires runtime name exactly 'NVIDIA B200', found {properties.name!r}")
+    if capability != (10, 0):
+        raise RuntimeError(f"benchmark requires exactly SM100, found {capability[0]}.{capability[1]}")
+    slurm_job_id = os.environ.get("SLURM_JOB_ID")
+    if not slurm_job_id or not slurm_job_id.isdecimal():
+        raise RuntimeError("benchmark requires a numeric SLURM_JOB_ID from ComputeLab")
+    node_name = os.environ.get("SLURMD_NODENAME")
+    if not node_name or not node_name.startswith(("umb-b200-", "umbriel-b200-")):
+        raise RuntimeError(f"benchmark requires an umb-b200/umbriel-b200 node, found {node_name!r}")
+    if CausalConv1dUpdateSm100.__module__ != "cudnn.causal_conv1d_update_sm100.api":
+        raise RuntimeError(f"unexpected native route: {CausalConv1dUpdateSm100.__module__}")
+    if fla_causal_conv1d_update.__module__ != "fla.modules.conv.triton.ops":
+        raise RuntimeError(f"unexpected FLA route: {fla_causal_conv1d_update.__module__}")
+    if _package_version("flash-linear-attention") != "0.5.2":
+        raise RuntimeError("this controlled comparison requires flash-linear-attention==0.5.2")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--shape",
+        action="append",
+        type=_parse_shape,
+        help="N x D; repeat for multiple shapes (default: Qwen decode matrix)",
+    )
+    parser.add_argument(
+        "--samples",
+        type=int,
+        default=51,
+        help="timed samples per implementation and shape",
+    )
+    parser.add_argument("--warmup", type=int, default=10, help="warm replays before measurement")
+    parser.add_argument("--seed", type=int, default=20260828)
+    parser.add_argument("--output-json", type=Path, help="also write the complete result to this file")
+    args = parser.parse_args()
+    if args.samples < 3:
+        parser.error("--samples must be at least 3")
+    if args.warmup < 1:
+        parser.error("--warmup must be positive")
+    shapes = tuple(args.shape) if args.shape else DEFAULT_SHAPES
+
+    _validate_environment()
+    repo = Path(__file__).resolve().parents[1]
+    result = _metadata(repo, shapes, args)
+    result["results"] = []
+    for shape_index, (n_rows, n_channels) in enumerate(shapes):
+        row = _benchmark_shape(
+            n_rows,
+            n_channels,
+            samples=args.samples,
+            warmup=args.warmup,
+            seed=args.seed + shape_index,
+        )
+        result["results"].append(row)
+        print(
+            f"N={n_rows:3d} D={n_channels:4d}: native={row['native']['median_us']:.3f} us, "
+            f"FLA={row['fla']['median_us']:.3f} us, paired FLA/native={row['paired_fla_over_native']['median']:.3f}x",
+            flush=True,
+        )
+
+    encoded = json.dumps(result, indent=2, sort_keys=True)
+    print("RESULT_JSON_BEGIN")
+    print(encoded)
+    print("RESULT_JSON_END")
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(encoded + "\n")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmark/causal_conv1d_update_sm100.py
+++ b/benchmark/causal_conv1d_update_sm100.py
@@ -4,8 +4,10 @@
 """Decode microbenchmark for the causal-convolution update operation.
 
 This compares the direct low-level cuDNN Frontend API against FLA 0.5.2's
-public Triton update operation at representative Qwen3.5-9B decode shapes.  Q
-and K each have D=2048 channels and V has D=4096 channels; all three use W=4.
+public Triton update operation at representative Qwen3.5/Qwen3.8 decode
+shapes.  The official model applies one fused-QKV depthwise convolution before
+splitting Q, K, and V, so the benchmark uses the full convolution channel
+counts D={6144, 8192, 10240, 12288, 20480}; every model uses W=4.
 It is a single-process, same-input, AB/BA-interleaved comparison.  Both
 implementations are compiled and CUDA-graph-captured before timing; in
 particular, the ``torch.empty_like`` in FLA's wrapper runs during capture rather
@@ -49,16 +51,9 @@ from cudnn._causal_conv1d_arch import (
 from cudnn.causal_conv1d_update_sm100 import _CausalConv1dUpdatePlan
 from fla.modules.conv.triton.ops import causal_conv1d_update as fla_causal_conv1d_update
 
-DEFAULT_SHAPES = (
-    (1, 2048),
-    (8, 2048),
-    (32, 2048),
-    (128, 2048),
-    (1, 4096),
-    (8, 4096),
-    (32, 4096),
-    (128, 4096),
-)
+DEFAULT_BATCH_SIZES = (1, 8, 32, 128)
+DEFAULT_CHANNELS = (6144, 8192, 10240, 12288, 20480)
+DEFAULT_SHAPES = tuple((batch, channels) for channels in DEFAULT_CHANNELS for batch in DEFAULT_BATCH_SIZES)
 OUTPUT_ATOL = 3e-2
 OUTPUT_RTOL = 3e-2
 
@@ -74,7 +69,7 @@ def _parse_shape(value: str) -> tuple[int, int]:
     try:
         n_rows, n_channels = (int(piece) for piece in value.lower().split("x", maxsplit=1))
     except (TypeError, ValueError) as exc:
-        raise argparse.ArgumentTypeError("shape must be N x D, for example 8x4096") from exc
+        raise argparse.ArgumentTypeError("shape must be N x D, for example 8x8192") from exc
     if n_rows <= 0 or n_channels <= 0:
         raise argparse.ArgumentTypeError("N and D must both be positive")
     return n_rows, n_channels
@@ -382,7 +377,7 @@ def _metadata(repo: Path, shapes: tuple[tuple[int, int], ...], args: argparse.Na
         "benchmark": "causal_conv1d_update_decode_sm100",
         "timing_contract": "warm cache-hit CUDA-graph replay; one update per sample; compile, capture, allocation, and state reset outside events",
         "comparison_contract": "single process; AB/BA interleaved; identical x/weight/initial state; BF16 N,D,W=4 no-bias SiLU",
-        "shape_contract": "Qwen3.5-9B separate short-conv projections: Q D=2048, K D=2048, V D=4096; W=4",
+        "shape_contract": ("official Qwen3.5/Qwen3.8 fused-QKV short conv: one update over " "D in {6144,8192,10240,12288,20480}; W=4"),
         "native_route": f"{_CausalConv1dUpdatePlan.__module__}.{_CausalConv1dUpdatePlan.__qualname__}.execute",
         "fla_route": f"{fla_causal_conv1d_update.__module__}.{fla_causal_conv1d_update.__name__}",
         "provenance": {

--- a/benchmark/causal_conv1d_update_sm100.py
+++ b/benchmark/causal_conv1d_update_sm100.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""B200-only decode microbenchmark for the SM100 causal-conv operation.
+"""Decode microbenchmark for the causal-convolution update operation.
 
 This compares the direct low-level cuDNN Frontend API against FLA 0.5.2's
 public Triton update operation at representative Qwen3.5-9B decode shapes.  Q
@@ -24,17 +24,16 @@ import hashlib
 import importlib.metadata
 import json
 import os
-from pathlib import Path
 import platform
 import statistics
 import subprocess
 import sys
+from pathlib import Path
 from typing import Callable, NamedTuple
 
+import cudnn
 import torch
 import torch.nn.functional as F
-
-import cudnn
 
 # Execute the Python sources from this checkout while retaining the installed
 # package's compiled extension.  This mirrors the focused pytest overlay and
@@ -43,6 +42,10 @@ _SOURCE_CUDNN = Path(__file__).resolve().parents[1] / "python" / "cudnn"
 if str(_SOURCE_CUDNN) not in cudnn.__path__:
     cudnn.__path__.insert(0, str(_SOURCE_CUDNN))
 
+from cudnn._causal_conv1d_arch import (
+    is_supported_causal_conv1d_update_compute_capability,
+    supported_causal_conv1d_update_compute_capabilities_text,
+)
 from cudnn.causal_conv1d_update_sm100 import CausalConv1dUpdateSm100
 from fla.modules.conv.triton.ops import causal_conv1d_update as fla_causal_conv1d_update
 
@@ -103,6 +106,15 @@ def _package_version(name: str) -> str:
         return importlib.metadata.version(name)
     except importlib.metadata.PackageNotFoundError:
         return "not-installed"
+
+
+def _slurm_provenance() -> dict[str, str | None]:
+    """Return optional scheduler metadata without restricting where the benchmark runs."""
+
+    return {
+        "slurm_job_id": os.environ.get("SLURM_JOB_ID"),
+        "slurmd_node_name": os.environ.get("SLURMD_NODENAME"),
+    }
 
 
 def _module_path(module_name: str) -> Path:
@@ -363,6 +375,7 @@ def _metadata(repo: Path, shapes: tuple[tuple[int, int], ...], args: argparse.Na
     fla_kernel_path = _module_path("fla.modules.conv.triton.kernels")
     device = torch.cuda.current_device()
     properties = torch.cuda.get_device_properties(device)
+    capability = tuple(torch.cuda.get_device_capability(device))
     device_uuid = str(properties.uuid)
     return {
         "schema_version": 1,
@@ -400,16 +413,14 @@ def _metadata(repo: Path, shapes: tuple[tuple[int, int], ...], args: argparse.Na
         },
         "hardware": {
             "name": properties.name,
-            "compute_capability": list(torch.cuda.get_device_capability(device)),
+            "architecture": f"sm_{capability[0]}{capability[1]}",
+            "compute_capability": list(capability),
             "device_index": device,
             "uuid": device_uuid,
             "driver": _nvidia_driver_for_uuid(device_uuid),
             "total_memory_bytes": properties.total_memory,
         },
-        "computelab": {
-            "slurm_job_id": os.environ["SLURM_JOB_ID"],
-            "slurmd_node_name": os.environ["SLURMD_NODENAME"],
-        },
+        "slurm": _slurm_provenance(),
         "software": {
             "python": platform.python_version(),
             "torch": torch.__version__,
@@ -438,18 +449,12 @@ def _metadata(repo: Path, shapes: tuple[tuple[int, int], ...], args: argparse.Na
 def _validate_environment() -> None:
     if not torch.cuda.is_available():
         raise RuntimeError("CUDA is unavailable")
-    properties = torch.cuda.get_device_properties()
-    capability = torch.cuda.get_device_capability()
-    if properties.name != "NVIDIA B200":
-        raise RuntimeError(f"benchmark requires runtime name exactly 'NVIDIA B200', found {properties.name!r}")
-    if capability != (10, 0):
-        raise RuntimeError(f"benchmark requires exactly SM100, found {capability[0]}.{capability[1]}")
-    slurm_job_id = os.environ.get("SLURM_JOB_ID")
-    if not slurm_job_id or not slurm_job_id.isdecimal():
-        raise RuntimeError("benchmark requires a numeric SLURM_JOB_ID from ComputeLab")
-    node_name = os.environ.get("SLURMD_NODENAME")
-    if not node_name or not node_name.startswith(("umb-b200-", "umbriel-b200-")):
-        raise RuntimeError(f"benchmark requires an umb-b200/umbriel-b200 node, found {node_name!r}")
+    capability = tuple(torch.cuda.get_device_capability())
+    if not is_supported_causal_conv1d_update_compute_capability(capability):
+        raise RuntimeError(
+            "benchmark requires a functionally supported causal-conv compute capability "
+            f"({supported_causal_conv1d_update_compute_capabilities_text()}), found {capability[0]}.{capability[1]}"
+        )
     if CausalConv1dUpdateSm100.__module__ != "cudnn.causal_conv1d_update_sm100.api":
         raise RuntimeError(f"unexpected native route: {CausalConv1dUpdateSm100.__module__}")
     if fla_causal_conv1d_update.__module__ != "fla.modules.conv.triton.ops":

--- a/benchmark/fla_short_conv_shim_sm100.py
+++ b/benchmark/fla_short_conv_shim_sm100.py
@@ -24,7 +24,9 @@ arms pass full-output FP32-reference, bitwise-state, cache-identity, and cross
 implementation gates.  The timed Qwen decode layout is ``[N, 1, D]`` for
 ``N={1,8,32,128}``, ``D={6144,8192,10240,12288,20480}``, and ``W=4``.  These
 are the fused-QKV channel counts used by published Qwen3.5/Qwen3.8 models;
-Q, K, and V are split only after the convolution.  The other admitted input
+Q, K, and V are split only after the convolution.  Optional ``D:ld`` leading
+dimensions reproduce zero-copy slices from a wider fused projection and feed
+the exact same row-strided view to FLA and the shim.  The other admitted input
 layouts, ``[N,D]`` and ``[1,N,D]``, receive additional correctness/route smoke
 coverage at ``D=8192``.
 """
@@ -56,6 +58,16 @@ import fla.modules.conv.triton.ops as fla_ops
 DEFAULT_SHAPES = _base.DEFAULT_SHAPES
 SMOKE_N = 8
 SMOKE_D = 8192
+
+
+def _parse_leading_dimension(value: str) -> tuple[int, int]:
+    try:
+        n_channels, leading_dimension = (int(piece) for piece in value.split(":", maxsplit=1))
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError("leading dimension must be D:ld, for example 5120:8240") from exc
+    if n_channels <= 0 or leading_dimension < n_channels:
+        raise argparse.ArgumentTypeError(f"leading dimension must satisfy D > 0 and ld >= D, got D={n_channels}, ld={leading_dimension}")
+    return n_channels, leading_dimension
 
 
 class EagerArm(NamedTuple):
@@ -125,18 +137,48 @@ def _make_inputs(
     *,
     layout: str,
     seed: int,
+    leading_dimension: int | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     generator = torch.Generator(device="cuda")
     generator.manual_seed(seed)
-    flat_x = torch.randn((n_rows, n_channels), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
-    if layout == "N1D":
-        x = flat_x.view(n_rows, 1, n_channels)
-    elif layout == "ND":
-        x = flat_x
-    elif layout == "1ND":
-        x = flat_x.view(1, n_rows, n_channels)
+    leading_dimension = n_channels if leading_dimension is None else leading_dimension
+    if leading_dimension < n_channels:
+        raise ValueError(f"leading dimension must be at least D={n_channels}, got ld={leading_dimension}")
+    if leading_dimension != n_channels and layout != "N1D":
+        raise ValueError("row-strided timed inputs currently require the N1D layout")
+
+    if layout == "N1D" and leading_dimension != n_channels:
+        # Mirror a prefix slice from Megatron's wider [1,N,ld] fused
+        # projection.  Transpose produces [N,1,ld]; slicing the logical D
+        # channels then normalizes to the exact FE stride (ld,1) with no copy.
+        storage = (
+            torch.randn(
+                (1, n_rows, leading_dimension),
+                device="cuda",
+                dtype=torch.bfloat16,
+                generator=generator,
+            )
+            * 0.25
+        )
+        x = storage.transpose(0, 1)[..., :n_channels]
     else:
-        raise ValueError(f"unknown layout {layout!r}")
+        flat_x = (
+            torch.randn(
+                (n_rows, n_channels),
+                device="cuda",
+                dtype=torch.bfloat16,
+                generator=generator,
+            )
+            * 0.25
+        )
+        if layout == "N1D":
+            x = flat_x.view(n_rows, 1, n_channels)
+        elif layout == "ND":
+            x = flat_x
+        elif layout == "1ND":
+            x = flat_x.view(1, n_rows, n_channels)
+        else:
+            raise ValueError(f"unknown layout {layout!r}")
     weight = torch.randn((n_channels, 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
     initial_state = torch.randn((n_rows, n_channels, 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
     return x, weight, initial_state
@@ -251,8 +293,15 @@ def _benchmark_shape(
     samples: int,
     warmup: int,
     seed: int,
+    leading_dimension: int,
 ) -> dict:
-    x, weight, initial_state = _make_inputs(n_rows, n_channels, layout="N1D", seed=seed)
+    x, weight, initial_state = _make_inputs(
+        n_rows,
+        n_channels,
+        layout="N1D",
+        seed=seed,
+        leading_dimension=leading_dimension,
+    )
     reference_output, reference_state = _reference_for_layout(x, weight, initial_state)
 
     shim_graph_state = initial_state.clone()
@@ -352,7 +401,17 @@ def _benchmark_shape(
     eager_paired = [fla_us / shim_us for shim_us, fla_us in zip(shim_eager_samples, fla_eager_samples, strict=True)]
 
     return {
-        "shape": {"layout": "N1D", "x": list(x.shape), "N": n_rows, "D": n_channels, "W": 4},
+        "shape": {
+            "layout": "N1D",
+            "x": list(x.shape),
+            "x_stride": list(x.stride()),
+            "normalized_x_stride": list(x.view(n_rows, n_channels).stride()),
+            "leading_dimension": leading_dimension,
+            "data_pointer_mod_16": x.data_ptr() % 16,
+            "N": n_rows,
+            "D": n_channels,
+            "W": 4,
+        },
         "correctness": {"graph": graph_correctness, "eager": eager_correctness},
         "graph_replay_us": {
             "shim": {**shim_graph_summary, "samples_us": shim_graph_samples},
@@ -543,6 +602,14 @@ def main() -> None:
         type=_base._parse_shape,
         help="N x D; repeat for multiple timed N1D shapes (default: Qwen decode matrix)",
     )
+    parser.add_argument(
+        "--leading-dimension",
+        action="append",
+        type=_parse_leading_dimension,
+        default=[],
+        metavar="D:LD",
+        help=("use row stride LD for every timed shape with logical width D; " "repeat for multiple widths (default: compact LD=D)"),
+    )
     parser.add_argument("--samples", type=int, default=51, help="timed samples per arm, metric, and shape")
     parser.add_argument("--warmup", type=int, default=10, help="warm calls/replays before measurement")
     parser.add_argument("--seed", type=int, default=20260828)
@@ -553,6 +620,16 @@ def main() -> None:
     if args.warmup < 1:
         parser.error("--warmup must be positive")
     shapes = tuple(args.shape) if args.shape else DEFAULT_SHAPES
+    leading_dimensions = {}
+    for n_channels, leading_dimension in args.leading_dimension:
+        if n_channels in leading_dimensions:
+            parser.error(f"duplicate --leading-dimension for D={n_channels}")
+        if leading_dimension > n_channels and leading_dimension % 8 != 0:
+            parser.error(f"padded leading dimension must be divisible by 8 BF16 elements, got D={n_channels}, ld={leading_dimension}")
+        leading_dimensions[n_channels] = leading_dimension
+    unused_leading_dimensions = set(leading_dimensions) - {n_channels for _, n_channels in shapes}
+    if unused_leading_dimensions:
+        parser.error("--leading-dimension provided for widths absent from --shape: " + ", ".join(str(value) for value in sorted(unused_leading_dimensions)))
 
     _validate_environment()
     repo = Path(__file__).resolve().parents[1]
@@ -571,6 +648,7 @@ def main() -> None:
             "seed": args.seed,
             "timed_layout": "N1D",
             "shapes": [list(shape) for shape in shapes],
+            "leading_dimensions": {str(n_channels): leading_dimensions.get(n_channels, n_channels) for n_channels in sorted({shape[1] for shape in shapes})},
             "smoke": {"layouts": ["ND", "1ND"], "N": SMOKE_N, "D": SMOKE_D, "W": 4},
         }
         result["layout_smoke"] = [
@@ -587,6 +665,7 @@ def main() -> None:
                 samples=args.samples,
                 warmup=args.warmup,
                 seed=args.seed + shape_index,
+                leading_dimension=leading_dimensions.get(n_channels, n_channels),
             )
             result["results"].append(row)
     finally:
@@ -602,8 +681,9 @@ def main() -> None:
     # was restored, so a partial/failed run cannot be mistaken for a result.
     for row in result["results"]:
         n_rows, n_channels = row["shape"]["N"], row["shape"]["D"]
+        leading_dimension = row["shape"]["leading_dimension"]
         print(
-            f"N={n_rows:3d} D={n_channels:4d}: "
+            f"N={n_rows:3d} D={n_channels:5d} ld={leading_dimension:5d}: "
             f"graph shim={row['graph_replay_us']['shim']['median_us']:.3f} us, "
             f"FLA={row['graph_replay_us']['fla']['median_us']:.3f} us, "
             f"paired={row['graph_replay_us']['paired_fla_over_shim']['median']:.3f}x; "

--- a/benchmark/fla_short_conv_shim_sm100.py
+++ b/benchmark/fla_short_conv_shim_sm100.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Exact FLA-shim benchmark for the SM100 causal-convolution decode update.
+"""Exact FLA-shim benchmark for the causal-convolution decode update.
 
 This benchmark measures the public callable installed by
 ``cudnn.fla.accelerate_fla(targets="short_conv")`` against the saved FLA 0.5.2
@@ -32,7 +32,6 @@ from __future__ import annotations
 import argparse
 import gc
 import json
-import os
 import platform
 import statistics
 import sys
@@ -467,6 +466,7 @@ def _route_and_metadata(repo: Path, benchmark_path: Path, original_fla: Callable
     fla_kernel_path = _base._module_path("fla.modules.conv.triton.kernels")
     device = torch.cuda.current_device()
     properties = torch.cuda.get_device_properties(device)
+    capability = tuple(torch.cuda.get_device_capability(device))
     device_uuid = str(properties.uuid)
     return {
         "schema_version": 1,
@@ -506,16 +506,14 @@ def _route_and_metadata(repo: Path, benchmark_path: Path, original_fla: Callable
         },
         "hardware": {
             "name": properties.name,
-            "compute_capability": list(torch.cuda.get_device_capability(device)),
+            "architecture": f"sm_{capability[0]}{capability[1]}",
+            "compute_capability": list(capability),
             "device_index": device,
             "uuid": device_uuid,
             "driver": _base._nvidia_driver_for_uuid(device_uuid),
             "total_memory_bytes": properties.total_memory,
         },
-        "computelab": {
-            "slurm_job_id": os.environ["SLURM_JOB_ID"],
-            "slurmd_node_name": os.environ["SLURMD_NODENAME"],
-        },
+        "slurm": _base._slurm_provenance(),
         "software": {
             "python": platform.python_version(),
             "torch": torch.__version__,

--- a/benchmark/fla_short_conv_shim_sm100.py
+++ b/benchmark/fla_short_conv_shim_sm100.py
@@ -1,0 +1,625 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exact FLA-shim benchmark for the SM100 causal-convolution decode update.
+
+This benchmark measures the public callable installed by
+``cudnn.fla.accelerate_fla(targets="short_conv")`` against the saved FLA 0.5.2
+public callable.  It patches once, keeps both arms resident in one process, and
+restores once after all measurements.  No target toggling occurs in a sample.
+
+Two intentionally separate steady-state metrics are reported:
+
+* ``graph_replay_us`` is CUDA-event elapsed time for one warmed CUDA-graph
+  replay.  Python dispatch, output allocation, compilation, and state reset are
+  outside the replay interval.
+* ``eager_host_enqueue_us`` is host wall time from entering the public Python
+  callable until it returns after enqueuing the update.  The stream is drained
+  before each sample and synchronized after the timer.  This includes Python
+  validation, cache lookup, output allocation, and launch overhead, but it is
+  explicitly *not* kernel time or completed device latency.
+
+Timing is fail-closed unless the exact monkeypatch route is proven and both
+arms pass full-output FP32-reference, bitwise-state, cache-identity, and cross
+implementation gates.  The timed Qwen decode layout is ``[N, 1, D]`` for
+``N={1,8,32,128}``, ``D={2048,4096}``, and ``W=4``.  The other admitted input
+layouts, ``[N,D]`` and ``[1,N,D]``, receive additional correctness/route smoke
+coverage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import platform
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Callable, NamedTuple
+
+import torch
+
+# Import the shared timing/reference helpers from the adjacent low-level
+# benchmark without relying on ``benchmark`` being an installed package.
+_BENCHMARK_DIR = Path(__file__).resolve().parent
+if str(_BENCHMARK_DIR) not in sys.path:
+    sys.path.insert(0, str(_BENCHMARK_DIR))
+import causal_conv1d_update_sm100 as _base
+import cudnn
+import cudnn.fla as cudnn_fla
+import fla.modules.conv.triton.ops as fla_ops
+
+DEFAULT_SHAPES = _base.DEFAULT_SHAPES
+SMOKE_N = 8
+SMOKE_D = 2048
+
+
+class EagerArm(NamedTuple):
+    name: str
+    call: Callable[[], tuple[torch.Tensor, torch.Tensor]]
+    state: torch.Tensor
+
+
+def _callable_code_path(function: Callable) -> Path:
+    code = getattr(function, "__code__", None)
+    filename = getattr(code, "co_filename", None)
+    if filename is None:
+        raise RuntimeError(f"cannot resolve code source for {function!r}")
+    return Path(filename).resolve()
+
+
+def _tensor_gate(
+    name: str,
+    output: torch.Tensor,
+    state: torch.Tensor,
+    reference_output: torch.Tensor,
+    reference_state: torch.Tensor,
+) -> dict:
+    output_diff = (output.float() - reference_output.float()).abs()
+    output_close = torch.allclose(output, reference_output, atol=_base.OUTPUT_ATOL, rtol=_base.OUTPUT_RTOL)
+    state_bits_equal = torch.equal(state.view(torch.int16), reference_state.view(torch.int16))
+    gate = {
+        "output_close": bool(output_close),
+        "output_max_abs": float(output_diff.max().item()),
+        "output_mean_abs": float(output_diff.mean().item()),
+        "state_bits_equal": bool(state_bits_equal),
+    }
+    if not output_close or not state_bits_equal:
+        raise AssertionError(f"{name} correctness gate failed: {gate}")
+    return gate
+
+
+def _cross_gate(
+    lhs_name: str,
+    lhs_output: torch.Tensor,
+    lhs_state: torch.Tensor,
+    rhs_name: str,
+    rhs_output: torch.Tensor,
+    rhs_state: torch.Tensor,
+) -> dict:
+    output_close = torch.allclose(lhs_output, rhs_output, atol=_base.OUTPUT_ATOL, rtol=_base.OUTPUT_RTOL)
+    state_bits_equal = torch.equal(lhs_state.view(torch.int16), rhs_state.view(torch.int16))
+    gate = {
+        "output_close": bool(output_close),
+        "output_max_abs": float((lhs_output.float() - rhs_output.float()).abs().max().item()),
+        "state_bits_equal": bool(state_bits_equal),
+    }
+    if not output_close or not state_bits_equal:
+        raise AssertionError(f"{lhs_name}/{rhs_name} cross gate failed: {gate}")
+    return gate
+
+
+def _reference_for_layout(x: torch.Tensor, weight: torch.Tensor, initial_state: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    n_rows, n_channels = initial_state.shape[:2]
+    output, final_state = _base._reference(x.view(n_rows, n_channels), weight, initial_state)
+    return output.view(x.shape), final_state
+
+
+def _make_inputs(
+    n_rows: int,
+    n_channels: int,
+    *,
+    layout: str,
+    seed: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    flat_x = torch.randn((n_rows, n_channels), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    if layout == "N1D":
+        x = flat_x.view(n_rows, 1, n_channels)
+    elif layout == "ND":
+        x = flat_x
+    elif layout == "1ND":
+        x = flat_x.view(1, n_rows, n_channels)
+    else:
+        raise ValueError(f"unknown layout {layout!r}")
+    weight = torch.randn((n_channels, 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    initial_state = torch.randn((n_rows, n_channels, 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    return x, weight, initial_state
+
+
+def _make_call(
+    function: Callable,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    state: torch.Tensor,
+) -> Callable[[], tuple[torch.Tensor, torch.Tensor]]:
+    def call() -> tuple[torch.Tensor, torch.Tensor]:
+        return function(
+            x=x,
+            cache=state,
+            residual=None,
+            weight=weight,
+            bias=None,
+            activation="silu",
+        )
+
+    return call
+
+
+def _gate_eager_arm(
+    arm: EagerArm,
+    initial_state: torch.Tensor,
+    reference_output: torch.Tensor,
+    reference_state: torch.Tensor,
+    *,
+    require_native_route: bool,
+) -> tuple[torch.Tensor, dict]:
+    arm.state.copy_(initial_state)
+    output, returned_state = arm.call()
+    if returned_state is not arm.state:
+        raise AssertionError(f"{arm.name} did not return the exact mutable cache object")
+    if output.shape != reference_output.shape:
+        raise AssertionError(f"{arm.name} output shape mismatch: expected {reference_output.shape}, got {output.shape}")
+    if require_native_route and cudnn_fla.short_conv_last_path() != "native":
+        raise AssertionError(f"exact shim did not take the native route: {cudnn_fla.short_conv_last_path()}")
+    torch.cuda.synchronize()
+    gate = _tensor_gate(arm.name, output, arm.state, reference_output, reference_state)
+    gate["cache_identity"] = True
+    gate["output_shape_preserved"] = True
+    if require_native_route:
+        gate["shim_route"] = "native"
+    return output, gate
+
+
+def _warm_eager(arms: tuple[EagerArm, EagerArm], initial_state: torch.Tensor, *, warmup: int) -> None:
+    for arm in arms:
+        for _ in range(warmup):
+            arm.state.copy_(initial_state)
+            output, returned_state = arm.call()
+            if returned_state is not arm.state:
+                raise AssertionError(f"{arm.name} did not return the exact mutable cache object")
+            if arm.name == "shim" and cudnn_fla.short_conv_last_path() != "native":
+                raise AssertionError(f"exact shim warmup did not take the native route: {cudnn_fla.short_conv_last_path()}")
+            del output, returned_state
+        torch.cuda.synchronize()
+
+
+def _interleaved_eager_host_samples(
+    shim: EagerArm,
+    fla: EagerArm,
+    initial_state: torch.Tensor,
+    *,
+    samples: int,
+) -> tuple[list[float], list[float], list[str]]:
+    """Measure warm public-call host enqueue latency; never label it kernel time."""
+
+    arms = {shim.name: shim, fla.name: fla}
+    timings = {shim.name: [], fla.name: []}
+    orders = []
+
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        for sample_index in range(samples):
+            order = (shim.name, fla.name) if sample_index % 2 == 0 else (fla.name, shim.name)
+            orders.append("/".join(order))
+            for name in order:
+                arm = arms[name]
+                arm.state.copy_(initial_state)
+                # Drain the reset and any prior work outside the timed region.
+                torch.cuda.synchronize()
+                start_ns = time.perf_counter_ns()
+                output, returned_state = arm.call()
+                elapsed_us = (time.perf_counter_ns() - start_ns) / 1000.0
+                if returned_state is not arm.state:
+                    raise AssertionError(f"{name} did not return the exact mutable cache object")
+                if name == shim.name and cudnn_fla.short_conv_last_path() != "native":
+                    raise AssertionError(f"exact shim eager sample did not take the native route: {cudnn_fla.short_conv_last_path()}")
+                timings[name].append(elapsed_us)
+                # Completion and output lifetime are deliberately outside the
+                # host-enqueue timer.
+                torch.cuda.synchronize()
+                del output, returned_state
+    finally:
+        if gc_was_enabled:
+            gc.enable()
+
+    return timings[shim.name], timings[fla.name], orders
+
+
+def _benchmark_shape(
+    shim_function: Callable,
+    original_fla: Callable,
+    n_rows: int,
+    n_channels: int,
+    *,
+    samples: int,
+    warmup: int,
+    seed: int,
+) -> dict:
+    x, weight, initial_state = _make_inputs(n_rows, n_channels, layout="N1D", seed=seed)
+    reference_output, reference_state = _reference_for_layout(x, weight, initial_state)
+
+    shim_graph_state = initial_state.clone()
+    fla_graph_state = initial_state.clone()
+    shim_graph_call = _make_call(shim_function, x, weight, shim_graph_state)
+    fla_graph_call = _make_call(original_fla, x, weight, fla_graph_state)
+
+    shim_graph, captured_shim = _base._capture(shim_graph_call, warmup=warmup)
+    shim_output, returned_shim_state = captured_shim
+    if returned_shim_state is not shim_graph_state:
+        raise AssertionError("captured exact shim did not return the exact mutable cache object")
+    if shim_output.shape != x.shape:
+        raise AssertionError(f"captured exact shim output shape mismatch: expected {x.shape}, got {shim_output.shape}")
+    if cudnn_fla.short_conv_last_path() != "native":
+        raise AssertionError(f"exact shim capture did not take the native route: {cudnn_fla.short_conv_last_path()}")
+
+    fla_graph, captured_fla = _base._capture(fla_graph_call, warmup=warmup)
+    fla_output, returned_fla_state = captured_fla
+    if returned_fla_state is not fla_graph_state:
+        raise AssertionError("captured FLA did not return the exact mutable cache object")
+    if fla_output.shape != x.shape:
+        raise AssertionError(f"captured FLA output shape mismatch: expected {x.shape}, got {fla_output.shape}")
+
+    shim_graph_arm = _base.CapturedArm("shim", shim_graph, shim_output, shim_graph_state)
+    fla_graph_arm = _base.CapturedArm("fla", fla_graph, fla_output, fla_graph_state)
+    shim_graph_gate = _base._gate_arm(shim_graph_arm, initial_state, reference_output, reference_state)
+    shim_graph_gate.update(cache_identity=True, output_shape_preserved=True, shim_route_at_capture="native")
+    fla_graph_gate = _base._gate_arm(fla_graph_arm, initial_state, reference_output, reference_state)
+    fla_graph_gate.update(cache_identity=True, output_shape_preserved=True)
+    graph_correctness = {"shim": shim_graph_gate, "fla": fla_graph_gate}
+    graph_correctness["shim_vs_fla"] = _cross_gate(
+        "shim",
+        shim_output,
+        shim_graph_state,
+        "fla",
+        fla_output,
+        fla_graph_state,
+    )
+
+    for arm in (shim_graph_arm, fla_graph_arm):
+        for _ in range(warmup):
+            arm.state.copy_(initial_state)
+            arm.graph.replay()
+    torch.cuda.synchronize()
+
+    shim_graph_samples, fla_graph_samples, graph_orders = _base._interleaved_samples(
+        shim_graph_arm,
+        fla_graph_arm,
+        initial_state,
+        samples=samples,
+    )
+    shim_graph_summary = _base._summary(shim_graph_samples)
+    fla_graph_summary = _base._summary(fla_graph_samples)
+    graph_paired = [fla_us / shim_us for shim_us, fla_us in zip(shim_graph_samples, fla_graph_samples, strict=True)]
+
+    shim_eager_state = initial_state.clone()
+    fla_eager_state = initial_state.clone()
+    shim_eager_arm = EagerArm("shim", _make_call(shim_function, x, weight, shim_eager_state), shim_eager_state)
+    fla_eager_arm = EagerArm("fla", _make_call(original_fla, x, weight, fla_eager_state), fla_eager_state)
+    _warm_eager((shim_eager_arm, fla_eager_arm), initial_state, warmup=warmup)
+    shim_eager_output, shim_eager_gate = _gate_eager_arm(
+        shim_eager_arm,
+        initial_state,
+        reference_output,
+        reference_state,
+        require_native_route=True,
+    )
+    fla_eager_output, fla_eager_gate = _gate_eager_arm(
+        fla_eager_arm,
+        initial_state,
+        reference_output,
+        reference_state,
+        require_native_route=False,
+    )
+    eager_correctness = {
+        "shim": shim_eager_gate,
+        "fla": fla_eager_gate,
+        "shim_vs_fla": _cross_gate(
+            "shim",
+            shim_eager_output,
+            shim_eager_state,
+            "fla",
+            fla_eager_output,
+            fla_eager_state,
+        ),
+    }
+    del shim_eager_output, fla_eager_output
+
+    shim_eager_samples, fla_eager_samples, eager_orders = _interleaved_eager_host_samples(
+        shim_eager_arm,
+        fla_eager_arm,
+        initial_state,
+        samples=samples,
+    )
+    shim_eager_summary = _base._summary(shim_eager_samples)
+    fla_eager_summary = _base._summary(fla_eager_samples)
+    eager_paired = [fla_us / shim_us for shim_us, fla_us in zip(shim_eager_samples, fla_eager_samples, strict=True)]
+
+    return {
+        "shape": {"layout": "N1D", "x": list(x.shape), "N": n_rows, "D": n_channels, "W": 4},
+        "correctness": {"graph": graph_correctness, "eager": eager_correctness},
+        "graph_replay_us": {
+            "shim": {**shim_graph_summary, "samples_us": shim_graph_samples},
+            "fla": {**fla_graph_summary, "samples_us": fla_graph_samples},
+            "paired_fla_over_shim": {
+                "median": statistics.median(graph_paired),
+                "min": min(graph_paired),
+                "max": max(graph_paired),
+                "samples": graph_paired,
+            },
+            "sample_orders": graph_orders,
+        },
+        "eager_host_enqueue_us": {
+            "shim": {**shim_eager_summary, "samples_us": shim_eager_samples},
+            "fla": {**fla_eager_summary, "samples_us": fla_eager_samples},
+            "paired_fla_over_shim": {
+                "median": statistics.median(eager_paired),
+                "min": min(eager_paired),
+                "max": max(eager_paired),
+                "samples": eager_paired,
+            },
+            "sample_orders": eager_orders,
+            "is_kernel_time": False,
+        },
+    }
+
+
+def _layout_smoke(
+    shim_function: Callable,
+    original_fla: Callable,
+    *,
+    layout: str,
+    seed: int,
+) -> dict:
+    x, weight, initial_state = _make_inputs(SMOKE_N, SMOKE_D, layout=layout, seed=seed)
+    reference_output, reference_state = _reference_for_layout(x, weight, initial_state)
+    shim_state = initial_state.clone()
+    fla_state = initial_state.clone()
+    shim_arm = EagerArm("shim", _make_call(shim_function, x, weight, shim_state), shim_state)
+    fla_arm = EagerArm("fla", _make_call(original_fla, x, weight, fla_state), fla_state)
+
+    shim_output, shim_gate = _gate_eager_arm(
+        shim_arm,
+        initial_state,
+        reference_output,
+        reference_state,
+        require_native_route=True,
+    )
+    fla_output, fla_gate = _gate_eager_arm(
+        fla_arm,
+        initial_state,
+        reference_output,
+        reference_state,
+        require_native_route=False,
+    )
+    cross = _cross_gate("shim", shim_output, shim_state, "fla", fla_output, fla_state)
+    return {
+        "layout": layout,
+        "shape": list(x.shape),
+        "shim": shim_gate,
+        "fla": fla_gate,
+        "shim_vs_fla": cross,
+        "cache_identity": {"shim": True, "fla": True},
+        "shim_route": "native",
+    }
+
+
+def _validate_environment() -> None:
+    _base._validate_environment()
+    if _base._package_version("flash-linear-attention") != "0.5.2":
+        raise RuntimeError("exact FLA short-conv shim benchmark requires flash-linear-attention==0.5.2")
+    if cudnn_fla.is_accelerated("short_conv"):
+        raise RuntimeError("short_conv was already accelerated before the benchmark; refusing ambiguous ownership")
+    if fla_ops.causal_conv1d_update is not _base.fla_causal_conv1d_update:
+        raise RuntimeError("FLA ops attribute changed before the benchmark could save the exact original callable")
+
+
+def _route_and_metadata(repo: Path, benchmark_path: Path, original_fla: Callable, shim_function: Callable) -> dict:
+    applied = cudnn_fla._ORIGINALS.get("short_conv")
+    if applied is None:
+        raise RuntimeError("short_conv registry has no applied patch after activation")
+    if applied.owner is not fla_ops or applied.original is not original_fla or applied.replacement is not shim_function:
+        raise RuntimeError("short_conv registry ownership does not match the live FLA ops attribute")
+    if fla_ops.causal_conv1d_update is not shim_function:
+        raise RuntimeError("live FLA ops attribute is not the registered exact shim replacement")
+    if getattr(shim_function, "__wrapped__", None) is not original_fla:
+        raise RuntimeError("exact shim does not wrap the saved FLA original")
+
+    repo_shim_path = (repo / "python/cudnn/fla/short_conv.py").resolve()
+    executed_shim_path = _base._module_path("cudnn.fla.short_conv")
+    shim_code_path = _callable_code_path(shim_function)
+    repo_base_benchmark_path = (repo / "benchmark/causal_conv1d_update_sm100.py").resolve()
+    executed_base_benchmark_path = Path(_base.__file__).resolve()
+    repo_registry_path = (repo / "python/cudnn/fla/__init__.py").resolve()
+    executed_registry_path = _base._module_path("cudnn.fla")
+    repo_native_api_path = (repo / "python/cudnn/causal_conv1d_update_sm100/api.py").resolve()
+    repo_native_kernel_path = (repo / "python/cudnn/causal_conv1d_update_sm100/kernel.py").resolve()
+    executed_native_api_path = _base._module_path("cudnn.causal_conv1d_update_sm100.api")
+    executed_native_kernel_path = _base._module_path("cudnn.causal_conv1d_update_sm100.kernel")
+
+    for name, executed, expected in (
+        ("shim module", executed_shim_path, repo_shim_path),
+        ("shim callable code", shim_code_path, repo_shim_path),
+        ("shared benchmark helpers", executed_base_benchmark_path, repo_base_benchmark_path),
+        ("FLA adapter registry", executed_registry_path, repo_registry_path),
+        ("native API", executed_native_api_path, repo_native_api_path),
+        ("native kernel", executed_native_kernel_path, repo_native_kernel_path),
+    ):
+        if _base._sha256(executed) != _base._sha256(expected):
+            raise RuntimeError(f"executed {name} source does not match this worktree: {executed} != {expected}")
+
+    fla_op_path = _base._module_path("fla.modules.conv.triton.ops")
+    fla_kernel_path = _base._module_path("fla.modules.conv.triton.kernels")
+    device = torch.cuda.current_device()
+    properties = torch.cuda.get_device_properties(device)
+    device_uuid = str(properties.uuid)
+    return {
+        "schema_version": 1,
+        "benchmark": "fla_short_conv_exact_shim_sm100",
+        "timing_contracts": {
+            "graph_replay_us": "warm cache-hit CUDA-graph replay; Python, compile, capture, allocation, and state reset outside CUDA events",
+            "eager_host_enqueue_us": "warm public-call host wall time through enqueue/return; includes Python validation, cache lookup, output allocation, and launch; pre-drained stream and post-timer synchronize; not kernel time",
+        },
+        "comparison_contract": "single process; patch once/restore once; saved FLA original versus live exact shim; AB/BA interleaved; identical BF16 x/weight/initial-state; W=4 no-bias SiLU",
+        "route_proof": {
+            "target": "short_conv",
+            "live_ops_attribute_is_registry_replacement": True,
+            "registry_owner_is_fla_ops_module": True,
+            "replacement_wraps_saved_original": True,
+            "is_accelerated": cudnn_fla.is_accelerated("short_conv"),
+            "shim_code_path": str(shim_code_path),
+            "last_path_required_per_eager_call_and_at_capture": "native",
+            "restored_after_measurement": False,
+        },
+        "provenance": {
+            "benchmark": {"path": str(benchmark_path), "sha256": _base._sha256(benchmark_path)},
+            "shared_benchmark_helpers": {
+                "path": str(executed_base_benchmark_path),
+                "sha256": _base._sha256(executed_base_benchmark_path),
+                "license": "Apache-2.0",
+            },
+            "shim": {"path": str(executed_shim_path), "sha256": _base._sha256(executed_shim_path), "license": "Apache-2.0"},
+            "adapter_registry": {
+                "path": str(executed_registry_path),
+                "sha256": _base._sha256(executed_registry_path),
+                "license": "Apache-2.0",
+            },
+            "native_api": {"path": str(executed_native_api_path), "sha256": _base._sha256(executed_native_api_path)},
+            "native_kernel": {"path": str(executed_native_kernel_path), "sha256": _base._sha256(executed_native_kernel_path)},
+            "fla_op": {"path": str(fla_op_path), "sha256": _base._sha256(fla_op_path), "license": "MIT"},
+            "fla_kernel": {"path": str(fla_kernel_path), "sha256": _base._sha256(fla_kernel_path), "license": "MIT"},
+        },
+        "hardware": {
+            "name": properties.name,
+            "compute_capability": list(torch.cuda.get_device_capability(device)),
+            "device_index": device,
+            "uuid": device_uuid,
+            "driver": _base._nvidia_driver_for_uuid(device_uuid),
+            "total_memory_bytes": properties.total_memory,
+        },
+        "computelab": {
+            "slurm_job_id": os.environ["SLURM_JOB_ID"],
+            "slurmd_node_name": os.environ["SLURMD_NODENAME"],
+        },
+        "software": {
+            "python": platform.python_version(),
+            "torch": torch.__version__,
+            "cuda": torch.version.cuda,
+            "torch_cudnn": torch.backends.cudnn.version(),
+            "cudnn_frontend": cudnn.__version__,
+            "cudnn_backend": cudnn.backend_version(),
+            "cudnn_backend_string": cudnn.backend_version_string(),
+            "flash_linear_attention": _base._package_version("flash-linear-attention"),
+        },
+        "repository": {
+            "root": str(repo),
+            "head": _base._git(repo, "rev-parse", "HEAD"),
+            "branch": _base._git(repo, "branch", "--show-current"),
+            "dirty": bool(_base._git(repo, "status", "--porcelain")),
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--shape",
+        action="append",
+        type=_base._parse_shape,
+        help="N x D; repeat for multiple timed N1D shapes (default: Qwen decode matrix)",
+    )
+    parser.add_argument("--samples", type=int, default=51, help="timed samples per arm, metric, and shape")
+    parser.add_argument("--warmup", type=int, default=10, help="warm calls/replays before measurement")
+    parser.add_argument("--seed", type=int, default=20260828)
+    parser.add_argument("--output-json", type=Path, help="also write the complete result to this file")
+    args = parser.parse_args()
+    if args.samples < 3:
+        parser.error("--samples must be at least 3")
+    if args.warmup < 1:
+        parser.error("--warmup must be positive")
+    shapes = tuple(args.shape) if args.shape else DEFAULT_SHAPES
+
+    _validate_environment()
+    repo = Path(__file__).resolve().parents[1]
+    benchmark_path = Path(__file__).resolve()
+    original_fla = fla_ops.causal_conv1d_update
+    patched = False
+    result = None
+    try:
+        cudnn_fla.accelerate_fla(verbose=False, targets="short_conv")
+        patched = True
+        shim_function = fla_ops.causal_conv1d_update
+        result = _route_and_metadata(repo, benchmark_path, original_fla, shim_function)
+        result["parameters"] = {
+            "samples": args.samples,
+            "warmup": args.warmup,
+            "seed": args.seed,
+            "timed_layout": "N1D",
+            "shapes": [list(shape) for shape in shapes],
+            "smoke": {"layouts": ["ND", "1ND"], "N": SMOKE_N, "D": SMOKE_D, "W": 4},
+        }
+        result["layout_smoke"] = [
+            _layout_smoke(shim_function, original_fla, layout="ND", seed=args.seed + 1000),
+            _layout_smoke(shim_function, original_fla, layout="1ND", seed=args.seed + 1001),
+        ]
+        result["results"] = []
+        for shape_index, (n_rows, n_channels) in enumerate(shapes):
+            row = _benchmark_shape(
+                shim_function,
+                original_fla,
+                n_rows,
+                n_channels,
+                samples=args.samples,
+                warmup=args.warmup,
+                seed=args.seed + shape_index,
+            )
+            result["results"].append(row)
+    finally:
+        if patched:
+            cudnn_fla.restore_fla(targets="short_conv")
+            if fla_ops.causal_conv1d_update is not original_fla:
+                raise RuntimeError("restore_fla did not restore the exact saved FLA original")
+
+    if result is None:
+        raise RuntimeError("benchmark produced no result")
+    result["route_proof"]["restored_after_measurement"] = True
+    # Emit timings only after every gate passed and the original FLA callable
+    # was restored, so a partial/failed run cannot be mistaken for a result.
+    for row in result["results"]:
+        n_rows, n_channels = row["shape"]["N"], row["shape"]["D"]
+        print(
+            f"N={n_rows:3d} D={n_channels:4d}: "
+            f"graph shim={row['graph_replay_us']['shim']['median_us']:.3f} us, "
+            f"FLA={row['graph_replay_us']['fla']['median_us']:.3f} us, "
+            f"paired={row['graph_replay_us']['paired_fla_over_shim']['median']:.3f}x; "
+            f"eager-host shim={row['eager_host_enqueue_us']['shim']['median_us']:.3f} us, "
+            f"FLA={row['eager_host_enqueue_us']['fla']['median_us']:.3f} us, "
+            f"paired={row['eager_host_enqueue_us']['paired_fla_over_shim']['median']:.3f}x",
+            flush=True,
+        )
+    encoded = json.dumps(result, indent=2, sort_keys=True)
+    print("RESULT_JSON_BEGIN")
+    print(encoded)
+    print("RESULT_JSON_END")
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(encoded + "\n")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmark/fla_short_conv_shim_sm100.py
+++ b/benchmark/fla_short_conv_shim_sm100.py
@@ -22,9 +22,11 @@ Two intentionally separate steady-state metrics are reported:
 Timing is fail-closed unless the exact monkeypatch route is proven and both
 arms pass full-output FP32-reference, bitwise-state, cache-identity, and cross
 implementation gates.  The timed Qwen decode layout is ``[N, 1, D]`` for
-``N={1,8,32,128}``, ``D={2048,4096}``, and ``W=4``.  The other admitted input
+``N={1,8,32,128}``, ``D={6144,8192,10240,12288,20480}``, and ``W=4``.  These
+are the fused-QKV channel counts used by published Qwen3.5/Qwen3.8 models;
+Q, K, and V are split only after the convolution.  The other admitted input
 layouts, ``[N,D]`` and ``[1,N,D]``, receive additional correctness/route smoke
-coverage.
+coverage at ``D=8192``.
 """
 
 from __future__ import annotations
@@ -53,7 +55,7 @@ import fla.modules.conv.triton.ops as fla_ops
 
 DEFAULT_SHAPES = _base.DEFAULT_SHAPES
 SMOKE_N = 8
-SMOKE_D = 2048
+SMOKE_D = 8192
 
 
 class EagerArm(NamedTuple):

--- a/docs/fe-oss-apis/bsa.md
+++ b/docs/fe-oss-apis/bsa.md
@@ -25,6 +25,11 @@ pipeline.
 
 BSA is implemented with Python CuTe DSL/JIT kernels.
 
+The Python dispatch currently admits SM110 and selects the same contracts as
+the SM100/SM103 paths described below. These SM110 routes have not yet been
+validated on SM110 hardware, so their inclusion documents intended functional
+coverage only; it is not a correctness or performance claim.
+
 ## Installation
 
 Install the CuTe DSL optional dependencies:
@@ -99,8 +104,8 @@ is consumed. Values in the inactive suffix are ignored.
   `[0, K_max]` when `allow_empty_block_nums=True`, and in `[1, K_max]`
   otherwise. Backward variable counts may be in `[0, K_max]`.
 - With fixed counts, `block_sparse_num` must be in `[1, K_max]`. The
-  SM100/SM103 blk128 path additionally requires an even value, i.e. an even
-  `block_sparse_num` in `[2, K_max]`.
+  SM100/SM103/SM110 blk128 path additionally requires an even value, i.e. an
+  even `block_sparse_num` in `[2, K_max]`.
 - The `block_sizes` entry for every physical KV block referenced by an active
   `q2k_block_index` value must be in `[1, sparse_block_size]`. Entries for
   unreferenced physical KV blocks are ignored. A zero-sized referenced block is
@@ -111,8 +116,8 @@ Tensor value ranges and per-row uniqueness are not validated at runtime.
 Violating the contract is unsupported and may produce invalid results or
 invalid device memory accesses.
 
-On the SM100/SM103 blk128 path, `pack_gqa=None` automatically packs GQA when
-the GQA ratio `r = H_q / H_kv` divides 128. Packed metadata has shape
+On the SM100/SM103/SM110 blk128 path, `pack_gqa=None` automatically packs GQA
+when the GQA ratio `r = H_q / H_kv` divides 128. Packed metadata has shape
 `(B, H_kv, ceil(S_q * r / 128), K_max)`. Pass `pack_gqa=False` to use the
 unpacked `(B, H_q, ceil(S_q / 128), K_max)` contract on every architecture.
 Explicit `pack_gqa=True` requires `r` to divide 128.
@@ -122,16 +127,17 @@ Provide `block_sizes` whenever a referenced final block is only partially
 valid.
 
 `sparse_block_size=None` chooses blk64 on SM90/SM120 and blk128 on
-SM100/SM103. Passing `sparse_block_size=64` explicitly selects the SM100/SM103
-blk64 CuTe DSL path, whose shape support is narrower. `kv_splits` is available
-on SM90 and the explicit Blackwell blk64 path; `use_clc` applies only to the
-explicit Blackwell blk64 path.
+SM100/SM103/SM110. Passing `sparse_block_size=64` explicitly selects the
+SM100/SM103/SM110 blk64 CuTe DSL path, whose shape support is narrower.
+`kv_splits` is available on SM90 and the explicit Blackwell blk64 path;
+`use_clc` applies only to the explicit Blackwell blk64 path.
 
 `kv_splits=2..256` computes FP32 partial outputs and combines them, with
 workspace growing linearly in the split count. SM90 accepts an explicit integer
-split count. The SM100/SM103 blk64 path also accepts `kv_splits="auto"`; CLC is
-compatible with split execution. Pass `use_clc=True` to use persistent CLC
-scheduling with `kv_splits>1`, or `use_clc=False` to use one tile per CTA. The
+split count. The SM100/SM103/SM110 blk64 path also accepts
+`kv_splits="auto"`; CLC is compatible with split execution. Pass `use_clc=True`
+to use persistent CLC scheduling with `kv_splits>1`, or `use_clc=False` to use
+one tile per CTA. The
 default `use_clc=None` keeps CLC disabled for split execution because the
 automatic scheduler policy has not been tuned for that combination. Automatic
 split selection uses metadata capacity rather than per-row count values. It
@@ -168,11 +174,11 @@ backward implementation.
 
 The architecture-specific FP8 contracts are:
 
-- SM100/SM103 requires `B=1`, `H` equal to 4 or 8, and both sequence lengths
-  to be multiples of 64. It uses fixed `block_sparse_num` with full 64-token
-  KV blocks; `q2k_block_nums` and `block_sizes` are not supported. Split-KV is
-  selected internally, and the public FP8 API does not expose `kv_splits` or
-  `use_clc`.
+- SM100/SM103/SM110 requires `B=1`, `H` equal to 4 or 8, and both sequence
+  lengths to be multiples of 64. It uses fixed `block_sparse_num` with full
+  64-token KV blocks; `q2k_block_nums` and `block_sizes` are not supported.
+  Split-KV is selected internally, and the public FP8 API does not expose
+  `kv_splits` or `use_clc`.
 - SM120 accepts any positive batch and head counts, non-aligned Q/KV sequence
   tails, fixed or per-query-block counts, and `block_sizes` shaped `(N_kv,)`,
   `(B, N_kv)`, or `(B, H, N_kv)`. It does not use split-KV.
@@ -210,10 +216,11 @@ The backward implementation builds a bucketed K-to-Q CSR task layout on the
 GPU. `bucket_size_blocks` is an optional tuning override; leaving it unset uses
 the backend default.
 
-Backward defaults to blk64 on SM90 and blk128 on SM100/SM103. Pass the same
-explicit `sparse_block_size` used by forward when selecting the Blackwell blk64
-path. SM100/SM103 blk128 backward does not yet consume `block_sizes`; it
-therefore requires full physical KV blocks and `block_sizes=None`.
+Backward defaults to blk64 on SM90 and blk128 on SM100/SM103/SM110. Pass the
+same explicit `sparse_block_size` used by forward when selecting the Blackwell
+blk64 path. SM100/SM103/SM110 blk128 backward does not yet consume
+`block_sizes`; it therefore requires full physical KV blocks and
+`block_sizes=None`.
 
 ## Current support
 
@@ -222,15 +229,18 @@ therefore requires full physical KV blocks and `block_sizes=None`.
 | Architecture | Sparse block | Public input / kernel dtype | QK / V dimensions | Attention |
 | --- | ---: | --- | --- | --- |
 | SM90 | 64 | FP16, BF16 | each of 64, 96, 128 | MHA, GQA, MQA |
-| SM100/SM103 | 128 | FP16, BF16 | QK=V=64, 96, or 128 | MHA, GQA, MQA |
-| SM100/SM103 | 64 (explicit) | BF16 | QK=128, V=128 | MHA |
-| SM100/SM103 | 64 | BF16 / FP8 E4M3 | QK=128, V=128 | MHA (B=1, H=4 or 8) |
+| SM100/SM103/SM110* | 128 | FP16, BF16 | QK=V=64, 96, or 128 | MHA, GQA, MQA |
+| SM100/SM103/SM110* | 64 (explicit) | BF16 | QK=128, V=128 | MHA |
+| SM100/SM103/SM110* | 64 | BF16 / FP8 E4M3 | QK=128, V=128 | MHA (B=1, H=4 or 8) |
 | SM120 | 64 | FP16, BF16 | QK=128, V=128 | MHA, GQA, MQA |
 | SM120 | 64 | BF16 / FP8 E4M3 | QK=128, V=128 | MHA |
 
+`*` SM110 is admitted by the implementation but has not yet been validated on
+SM110 hardware. The same qualification applies to the backward rows below.
+
 SM90 currently requires `S_q` to be a multiple of 64. Its fixed count may be
-any positive value. The SM100/SM103 blk128 fixed count must be even and at
-least two; SM120 and the explicit Blackwell blk64 path accept any positive
+any positive value. The SM100/SM103/SM110 blk128 fixed count must be even and
+at least two; SM120 and the explicit Blackwell blk64 path accept any positive
 fixed count. Variable counts use `q2k_block_nums`. `allow_empty_block_nums`
 defaults to `False`; when it is `True`, empty rows (`q2k_block_nums == 0`)
 produce `O = 0` and `LSE = -inf`. SM90 selects the empty-row handling as a
@@ -242,8 +252,8 @@ branch-free fast path. Split-KV execution therefore excludes empty rows.
 | Architecture | Sparse block | Dtype | Head dimension | Attention |
 | --- | ---: | --- | ---: | --- |
 | SM90 | 64 | BF16 | 128 | MHA |
-| SM100/SM103 | 64 | BF16 | 128 | MHA |
-| SM100/SM103 | 128 | BF16 | 64 or 128 | MHA |
+| SM100/SM103/SM110* | 64 | BF16 | 128 | MHA |
+| SM100/SM103/SM110* | 128 | BF16 | 64 or 128 | MHA |
 
 Backward is not implemented for SM120. It requires equal QK/V dimensions and
 does not currently support GQA/MQA.

--- a/docs/fe-oss-apis/causal_conv1d_update.md
+++ b/docs/fe-oss-apis/causal_conv1d_update.md
@@ -1,0 +1,108 @@
+# Causal Conv1d Decode Update (SM100)
+
+**This FE-OSS API is experimental and subject to change.**
+
+`CausalConv1dUpdateSm100` advances a four-token depthwise causal-convolution
+cache in place and emits the fused-SiLU output for one decode step. It targets
+the no-bias, width-four short convolution used by GDN/KDA-style linear
+attention blocks. It is a standalone native primitive; it does not yet add a
+model adapter or make cuDNN the default route in FLA or a serving framework.
+
+For row `n`, channel `d`, and selected cache slot `s`, the operation is:
+
+```text
+updated_state[s, d, :] = [state[s, d, 1], state[s, d, 2],
+                          state[s, d, 3], x[n, d]]
+output[n, d] = SiLU(sum_j updated_state[s, d, j] * weight[d, j])
+```
+
+When `state_indices` is omitted, row `n` selects slot `n`. When it is present,
+`s = state_indices[n]`. Indexed slots must be in range and unique within the
+decode batch because state is mutated. The kernel checks these properties on
+device and traps on violation. The resulting CUDA error is asynchronous and
+the failed update is not transactional.
+
+## Supported contract
+
+- GPU: exactly SM100 (compute capability 10.0)
+- `x`: contiguous BF16 `[N, D]`
+- `weight`: contiguous BF16 `[D, 4]`
+- `state`: contiguous BF16 `[S, D, 4]`, updated in place
+- `state_indices`: optional contiguous CUDA int32 `[N]`
+- output: contiguous BF16 `[N, D]`
+- activation: SiLU, always fused
+- bias and autograd: unsupported
+- pointer alignment: 16 bytes for BF16 tensors and 4 bytes for indices
+
+This narrow contract does not cover a bias term, a returned intermediate state
+for speculative decoding, arbitrary convolution width, prefill, training, or a
+general Mamba causal-convolution interface. The indexed path is provided for
+functional paged-state support; its duplicate-index validation has not been
+performance-characterized as a fast path.
+
+## High-level wrapper
+
+The standard FE-OSS wrapper allocates the output and returns a `TupleDict`:
+
+```python
+import torch
+from cudnn import causal_conv1d_update_wrapper_sm100
+
+x = torch.randn(8, 2048, device="cuda", dtype=torch.bfloat16)
+weight = torch.randn(2048, 4, device="cuda", dtype=torch.bfloat16)
+state = torch.randn(8, 2048, 4, device="cuda", dtype=torch.bfloat16)
+
+result = causal_conv1d_update_wrapper_sm100(x, weight, state)
+output = result["output_tensor"]
+```
+
+`cudnn.causal_conv1d_update(...)` and
+`cudnn.ops.causal_conv1d_update(...)` expose the same mutation but return the
+output Tensor directly. They are convenient for model-integration shims and
+are not drop-in replacements for APIs with different argument order, bias, or
+return-state conventions.
+
+Both helpers cache compiled kernels by device, shape, and indexed/non-indexed
+signature. The cache is bounded. The first call for a signature performs JIT
+compilation, so warm the exact signature before latency measurement or CUDA
+Graph capture.
+
+## Class API
+
+Use the class API for explicit compilation, output ownership, and repeated
+execution:
+
+```python
+import torch
+from cudnn import CausalConv1dUpdateSm100
+
+x = torch.empty(8, 2048, device="cuda", dtype=torch.bfloat16)
+weight = torch.empty(2048, 4, device="cuda", dtype=torch.bfloat16)
+state = torch.empty(8, 2048, 4, device="cuda", dtype=torch.bfloat16)
+output = torch.empty_like(x)
+
+op = CausalConv1dUpdateSm100(x, weight, state, output)
+op.check_support()
+op.compile()
+
+with torch.no_grad():
+    op.execute(x, weight, state, output)
+```
+
+`execute(..., current_stream=...)` accepts a CUDA driver stream handle. The
+high-level helpers allocate their output on that stream as well; they require a
+concrete stream handle rather than the `CU_STREAM_PER_THREAD` sentinel. Callers
+remain responsible for cross-stream dependencies and synchronization.
+
+## Semantic provenance and benchmarking
+
+Behavioral references are FLA 0.5.2 `ShortConvolution.step` (MIT) and the
+public `causal_conv1d_update` contract from Dao-AILab/causal-conv1d at revision
+`cd81f0413cad2fc1e6f17e785ac39f59aae690cd` (BSD-3-Clause). No source from
+either project is included. The implementation uses CUTLASS/CuTe DSL, inline
+PTX, and in-tree NVIDIA FROST primitives.
+
+Use `benchmark/causal_conv1d_update_sm100.py` on the target GPU for route-proof,
+correctness, and interleaved comparison against FLA. Performance measurements
+must include the exact GPU, software environment, shapes, and raw artifacts;
+the indexed path should be reported separately from the no-index decode path.

--- a/docs/fe-oss-apis/causal_conv1d_update.md
+++ b/docs/fe-oss-apis/causal_conv1d_update.md
@@ -6,7 +6,10 @@
 cache in place and emits the fused-SiLU output for one decode step. It targets
 the no-bias, width-four short convolution used by GDN/KDA-style linear
 attention blocks. It is a standalone native primitive; it does not yet add a
-model adapter or make cuDNN the default route in FLA or a serving framework.
+serving-framework integration or make cuDNN the default route. The optional
+`cudnn.fla.accelerate_fla(targets="short_conv")` adapter preserves FLA 0.5.2's
+decode-update interface and routes only this exact supported subset to the
+native primitive; all other configurations retain FLA's original path.
 
 For row `n`, channel `d`, and selected cache slot `s`, the operation is:
 

--- a/docs/fe-oss-apis/causal_conv1d_update.md
+++ b/docs/fe-oss-apis/causal_conv1d_update.md
@@ -4,7 +4,7 @@
 
 `CausalConv1dUpdateSm100` advances a four-token depthwise causal-convolution
 cache in place and emits the fused-SiLU output for one decode step. It targets
-the no-bias, width-four short convolution used by GDN/KDA-style linear
+the width-four short convolution used by GDN/KDA-style linear
 attention blocks. It is a standalone native primitive; it does not yet add a
 serving-framework integration or make cuDNN the default route. The optional
 `cudnn.fla.accelerate_fla(targets="short_conv")` adapter preserves FLA 0.5.2's
@@ -18,8 +18,10 @@ For row `n`, channel `d`, and selected cache slot `s`, the operation is:
 ```text
 updated_state[s, d, :] = [state[s, d, 1], state[s, d, 2],
                           state[s, d, 3], x[n, d]]
-output[n, d] = SiLU(sum_j updated_state[s, d, j] * weight[d, j])
+output[n, d] = SiLU(sum_j updated_state[s, d, j] * weight[d, j] + bias[d])
 ```
+
+The optional bias term is zero when `bias` is omitted.
 
 When `state_indices` is omitted, row `n` selects slot `n`. When it is present,
 `s = state_indices[n]`. Indexed slots must be in range and unique within the
@@ -36,9 +38,10 @@ the failed update is not transactional.
 - `weight`: contiguous BF16 `[D, 4]`
 - `state`: contiguous BF16 `[S, D, 4]`, updated in place
 - `state_indices`: optional contiguous CUDA int32 `[N]`
+- `bias`: optional contiguous BF16 `[D]`
 - output: contiguous BF16 `[N, D]`
 - activation: SiLU, always fused
-- bias and autograd: unsupported
+- autograd: unsupported
 - pointer alignment: 16 bytes for BF16 tensors and 4 bytes for indices
 
 The native direct API and current kernel require CUTLASS DSL 4.7 or newer for
@@ -55,8 +58,8 @@ SM100, SM103, and SM120 are runtime-validated. SM86, SM87, SM110, and SM121
 have compile-only validation. In particular, the SM110 kernel cross-compiles
 with CUTLASS DSL 4.7, but no SM110 hardware execution is claimed.
 
-This narrow contract does not cover a bias term, a returned intermediate state
-for speculative decoding, arbitrary convolution width, prefill, training, or a
+This narrow contract does not cover a returned intermediate state for
+speculative decoding, arbitrary convolution width, prefill, training, or a
 general Mamba causal-convolution interface. The indexed path is provided for
 functional paged-state support; its duplicate-index validation has not been
 performance-characterized as a fast path.
@@ -84,13 +87,13 @@ output = result["output_tensor"]
 `cudnn.ops.causal_conv1d_update(...)` expose the same mutation but return the
 output Tensor directly. The state-before-weight positional order matches the
 common decode-update convention used by the FLA and causal-conv1d ecosystems.
-The helpers are not drop-in replacements for APIs with bias or different
-return-state conventions.
+Bias is keyword-only: pass `bias=bias`. The helpers are not drop-in
+replacements for APIs with different return-state conventions.
 
-Both helpers cache compiled kernels by device, shape, and indexed/non-indexed
-signature. The cache is bounded. The first call for a signature performs JIT
-compilation, so warm the exact signature before latency measurement or CUDA
-Graph capture.
+Both helpers cache compiled kernels by device, shape, indexed/non-indexed
+signature, and bias presence. The cache is bounded. The first call for a
+signature performs JIT compilation, so warm the exact signature before latency
+measurement or CUDA Graph capture.
 
 ## Class API
 

--- a/docs/fe-oss-apis/causal_conv1d_update.md
+++ b/docs/fe-oss-apis/causal_conv1d_update.md
@@ -2,105 +2,141 @@
 
 **This FE-OSS API is experimental and subject to change.**
 
-`cudnn.ops.causal_conv1d_update` advances a four-token depthwise
-causal-convolution cache in place and emits the fused-SiLU output for one
-decode step. It targets
-the width-four short convolution used by GDN/KDA-style linear
-attention blocks. It is a standalone native primitive; it does not yet add a
-serving-framework integration or make cuDNN the default route. The optional
-`cudnn.fla.accelerate_fla(targets="short_conv")` adapter preserves FLA 0.5.2's
-decode-update interface and routes only this exact supported subset to the
-native primitive; all other configurations retain FLA's original path.
-The public API is architecture-neutral; plan compilation, output allocation,
-stream selection, and the current schedule stay inside the implementation.
-Every admitted architecture uses the same portable one-row schedule.
+`cudnn.ops.causal_conv1d_update` advances a mutable depthwise
+causal-convolution cache in place and returns the output for one decode step.
+The semantic tensor contract uses `weight[D, W]` and `conv_state[S, D, L]`,
+where `L >= W - 1`. The first native implementation targets the width-four
+short convolution used by GDN/KDA-style linear-attention blocks. Compilation,
+architecture dispatch, output ownership, streams, and kernel schedules remain
+private implementation details.
 
-For row `n`, channel `d`, and selected cache slot `s`, the operation is:
+Without circular-buffer metadata, row `n`, channel `d`, and selected cache
+slot `s` are updated as follows:
 
 ```text
-updated_state[s, d, :] = [state[s, d, 1], state[s, d, 2],
-                          state[s, d, 3], x[n, d]]
-output[n, d] = SiLU(sum_j updated_state[s, d, j] * weight[d, j] + bias[d])
+history = concat(conv_state[s, d, :], x[n, d])
+conv_state[s, d, :] = history[-L:]
+acc[n, d] = sum_j history[-W + j] * weight[d, j] + bias[d]
+output[n, d] = activation(acc[n, d])
 ```
 
-The optional bias term is zero when `bias` is omitted.
+The bias is zero when omitted. `activation=None` and `"identity"` return the
+accumulator directly; `"silu"` and `"swish"` select the same fused SiLU
+specialization. Identity and SiLU compile as separate kernels, so the unused
+activation work is absent from the identity path.
 
-When `state_indices` is omitted, row `n` selects slot `n`. When it is present,
-`s = state_indices[n]`. Indexed slots must be in range and unique within the
-decode batch because state is mutated. The kernel checks these properties on
-device and traps on violation. The resulting CUDA error is asynchronous and
-the failed update is not transactional.
+When `conv_state_indices` is omitted, row `n` selects slot `n`. When it is
+present, `s = conv_state_indices[n]`. A value of `-1` denotes a padding row:
+its output is zero and it does not mutate `conv_state`. Other selected slots
+must be in range and unique within the decode batch because `conv_state` is
+mutated; repeated padding rows are allowed.
 
-## Supported contract
+`cache_seqlens[n]`, when present, treats the selected state as a circular
+buffer: the new token is written at `cache_seqlens[n] % L`, and the previous
+`W - 1` tokens are read modulo `L`. `cache_seqlens` itself is not mutated.
+The current native kernel declines this circular-buffer mode; it is part of
+the semantic API so adding the implementation does not require another public
+signature.
 
-- GPU: functional support on compute capabilities 8.0, 8.6, 8.7, 8.9, 9.0,
-  10.0, 10.3, 11.0, 12.0, and 12.1
-- performance-characterized GPU: SM100 (compute capability 10.0)
-- `x`: contiguous BF16 `[N, D]`
-- `weight`: contiguous BF16 `[D, 4]`
-- `conv_state`: contiguous BF16 `[S, D, 4]`, updated in place
-- `conv_state_indices`: optional contiguous CUDA int32 `[N]`
-- `bias`: optional contiguous BF16 `[D]`
-- output: contiguous BF16 `[N, D]`
-- activation: SiLU, always fused
-- autograd: unsupported
-- pointer alignment: 16 bytes for BF16 tensors and 4 bytes for indices
-
-The native direct API and current kernel require CUTLASS DSL 4.7 or newer for
-the inline-PTX integration they import. The package-wide `cutedsl` extra keeps
-its broader `>=4.5` floor for unrelated APIs; installing only that minimum is
-not sufficient for this direct API. The FLA adapter treats the resulting
-`ImportError` as a typed decline and executes FLA's original path.
-
-The full correctness suite was run on A100 SM80, L40S SM89, H200 SM90, and
-B200 SM100. The generic and indexed kernels were also executed on a GB110
-board reporting compute capability 10.3 and an RTX 5080 SM120; outputs
-matched the reference and state updates were bit-exact. Thus SM80, SM89, SM90,
-SM100, SM103, and SM120 are runtime-validated. SM86, SM87, SM110, and SM121
-have compile-only validation. In particular, the SM110 kernel cross-compiles
-with CUTLASS DSL 4.7, but no SM110 hardware execution is claimed.
-
-This narrow contract does not cover a returned intermediate state for
-speculative decoding, arbitrary convolution width, prefill, training, or a
-general Mamba causal-convolution interface. The indexed path is provided for
-functional paged-state support; its duplicate-index validation has not been
-performance-characterized as a fast path.
-
-Each CTA owns one decode row and a 256-channel tile. Indexed calls use the same
-schedule with device-side index validation and channel-tail handling.
-
-## Public Torch API
-
-The semantic API accepts ordinary tensors, owns its output allocation, and
-returns the output tensor directly:
+## Python API
 
 ```python
 import torch
-from cudnn.ops import causal_conv1d_update
+import cudnn
 
 x = torch.randn(8, 2048, device="cuda", dtype=torch.bfloat16)
 weight = torch.randn(2048, 4, device="cuda", dtype=torch.bfloat16)
 conv_state = torch.randn(8, 2048, 4, device="cuda", dtype=torch.bfloat16)
 
-with torch.no_grad():
-    output = causal_conv1d_update(
-        x,
-        conv_state,
-        weight,
-        activation="silu",
-    )
+output = cudnn.ops.causal_conv1d_update(
+    x,
+    conv_state,
+    weight,
+    bias=None,
+    activation="silu",
+)
 ```
 
-`bias` and `activation` follow the mathematical operation. Optional
-`conv_state_indices` is keyword-only because it changes state routing rather
-than tensor math. The alias `cudnn.causal_conv1d_update` resolves to the same
-function. No public parameter exposes a wrapper object, architecture name,
-plan, output buffer, or raw stream.
+The signature is:
 
-The implementation caches compiled kernels by device, shape,
-indexed/non-indexed signature, and bias presence. The cache is bounded. The
-first call for a signature performs JIT compilation, so warm the exact
-signature before latency measurement or CUDA Graph capture.
+```python
+cudnn.ops.causal_conv1d_update(
+    x,
+    conv_state,
+    weight,
+    bias=None,
+    activation=None,
+    *,
+    cache_seqlens=None,
+    conv_state_indices=None,
+) -> torch.Tensor
+```
+
+`conv_state` is mutated in place and the return value is an ordinary newly
+allocated Tensor, not a wrapper result. The operation registers the mutation
+with `torch.library`, including its FakeTensor contract. It is inference-only;
+autograd inputs are rejected.
+
+The fourth and fifth positional arguments remain `bias` and `activation`.
+State-routing metadata is keyword-only. The first call for a supported device,
+shape, optional-input signature, and activation performs JIT compilation.
+Warm the exact signature before latency measurement or CUDA Graph capture.
+
+## Semantic tensor contract
+
+- `x`: `[N, D]` for one decode token
+- `weight`: `[D, W]`
+- `conv_state`: `[S, D, L]`, updated in place, with `L >= W - 1`
+- `bias`: optional `[D]`
+- `cache_seqlens`: optional int32 `[N]` circular-buffer positions
+- `conv_state_indices`: optional int32 `[N]` state-slot selection; `-1` is padding
+- output: `[N, D]`
+
+A future multi-token extension can admit `x[N, D, Tstep]` without changing
+the state or weight meanings. The current public implementation rejects 3D
+`x` rather than silently interpreting its layout.
+
+## Current native implementation
+
+- GPU: compute capabilities 8.0, 8.6, 8.7, 8.9, 9.0, 10.0, 10.3, 11.0,
+  12.0, and 12.1; the portable one-row schedule is used on every admitted
+  target
+- performance-characterized GPU: B200 SM100
+- `x`: contiguous BF16 `[N, D]`
+- `weight`: contiguous BF16 `[D, 4]`
+- `conv_state`: contiguous BF16 `[S, D, L]` with `L` equal to 3 or 4,
+  updated in place
+- `bias`: optional contiguous BF16 `[D]`
+- `cache_seqlens`: must be omitted
+- `conv_state_indices`: optional contiguous CUDA int32 `[N]`
+- output: contiguous BF16 `[N, D]`
+- activation: identity or SiLU
+- autograd: unsupported
+- pointer alignment: 16 bytes for BF16 tensors and 4 bytes for indices
+
+The native kernel requires CUTLASS DSL 4.7 or newer for the inline-PTX
+integration it imports. The package-wide `cutedsl` extra keeps its broader
+`>=4.5` floor for unrelated APIs; installing only that minimum is not
+sufficient for this operation. The optional FLA 0.5.2 adapter treats the
+resulting `ImportError` as a typed decline and executes FLA's original path.
+
+Runtime correctness was validated on A100 SM80, L40S SM89, H200 SM90, B200
+SM100, a GB110 board reporting SM103, and RTX 5080 SM120. SM86, SM87, SM110,
+and SM121 have compile-only validation. The SM110 path is functional support,
+not a training-performance claim.
+
+For width four, `L=3` is the standard `W - 1` final state handed off by
+prefill; it uses a functionally correct scalar state-access specialization.
+`L=4` retains the original vectorized fast path used by GDN/KDA decode. Other
+semantically valid widths and state lengths, circular-buffer updates,
+multi-token updates, speculative intermediate-state returns, prefill, and
+training currently raise a clear unsupported-configuration error. The indexed
+path is functional paged-state support; its duplicate-index validation is not
+performance-characterized as a fast path. For the current native path, the
+kernel checks indices on device and traps on values below `-1`, out-of-range
+slots, or duplicate non-padding slots;
+the resulting CUDA error is asynchronous and the failed update is not
+transactional.
 
 ## Semantic provenance and benchmarking
 
@@ -110,13 +146,8 @@ public `causal_conv1d_update` contract from Dao-AILab/causal-conv1d at revision
 either project is included. The implementation uses CUTLASS/CuTe DSL, inline
 PTX, and in-tree NVIDIA FROST primitives.
 
-The FE kernel is independently implemented and keeps FE's architecture,
-alignment, alias, index, and cache contracts.
-
 Use `benchmark/causal_conv1d_update_sm100.py` for route-proof, correctness, and
-an interleaved comparison against FLA on any compute capability listed in the
-supported contract. The benchmark records the actual GPU architecture and
-software environment; Slurm job and node metadata are optional when those
-variables are unavailable. Performance measurements should include the exact
-GPU, software environment, shapes, and raw artifacts; the indexed path should
-be reported separately from the no-index decode path.
+an interleaved comparison against FLA. It intentionally uses the private
+preallocated plan so kernel timing does not include public output allocation
+or custom-op dispatch. The benchmark records the actual GPU architecture and
+software environment; Slurm metadata is optional.

--- a/docs/fe-oss-apis/causal_conv1d_update.md
+++ b/docs/fe-oss-apis/causal_conv1d_update.md
@@ -84,7 +84,9 @@ Warm the exact signature before latency measurement or CUDA Graph capture.
 
 ## Semantic tensor contract
 
-- `x`: `[N, D]` for one decode token
+- `x`: BF16 `[N, D]` for one decode token, with strides `(ld, 1)`; compact
+  `ld == D` accepts every `D`, while padded `ld > D` requires `ld % 8 == 0`
+  so every row starts at a 16-byte-aligned address
 - `weight`: `[D, W]`
 - `conv_state`: `[S, D, L]`, updated in place, with `L >= W - 1`
 - `bias`: optional `[D]`
@@ -102,7 +104,8 @@ the state or weight meanings. The current public implementation rejects 3D
   12.0, and 12.1; the portable one-row schedule is used on every admitted
   target
 - performance-characterized GPU: B200 SM100
-- `x`: contiguous BF16 `[N, D]`
+- `x`: BF16 `[N, D]` with strides `(ld, 1)`; compact `ld == D` accepts every
+  channel count, and padded `ld > D` requires `ld % 8 == 0`
 - `weight`: contiguous BF16 `[D, 4]`
 - `conv_state`: contiguous BF16 `[S, D, L]` with `L` equal to 3 or 4,
   updated in place

--- a/docs/fe-oss-apis/causal_conv1d_update.md
+++ b/docs/fe-oss-apis/causal_conv1d_update.md
@@ -2,16 +2,18 @@
 
 **This FE-OSS API is experimental and subject to change.**
 
-`CausalConv1dUpdateSm100` advances a four-token depthwise causal-convolution
-cache in place and emits the fused-SiLU output for one decode step. It targets
+`cudnn.ops.causal_conv1d_update` advances a four-token depthwise
+causal-convolution cache in place and emits the fused-SiLU output for one
+decode step. It targets
 the width-four short convolution used by GDN/KDA-style linear
 attention blocks. It is a standalone native primitive; it does not yet add a
 serving-framework integration or make cuDNN the default route. The optional
 `cudnn.fla.accelerate_fla(targets="short_conv")` adapter preserves FLA 0.5.2's
 decode-update interface and routes only this exact supported subset to the
 native primitive; all other configurations retain FLA's original path.
-The `Sm100` class and wrapper names are retained for API compatibility. Every
-admitted architecture uses the same portable one-row schedule.
+The public API is architecture-neutral; plan compilation, output allocation,
+stream selection, and the current schedule stay inside the implementation.
+Every admitted architecture uses the same portable one-row schedule.
 
 For row `n`, channel `d`, and selected cache slot `s`, the operation is:
 
@@ -36,8 +38,8 @@ the failed update is not transactional.
 - performance-characterized GPU: SM100 (compute capability 10.0)
 - `x`: contiguous BF16 `[N, D]`
 - `weight`: contiguous BF16 `[D, 4]`
-- `state`: contiguous BF16 `[S, D, 4]`, updated in place
-- `state_indices`: optional contiguous CUDA int32 `[N]`
+- `conv_state`: contiguous BF16 `[S, D, 4]`, updated in place
+- `conv_state_indices`: optional contiguous CUDA int32 `[N]`
 - `bias`: optional contiguous BF16 `[D]`
 - output: contiguous BF16 `[N, D]`
 - activation: SiLU, always fused
@@ -67,60 +69,38 @@ performance-characterized as a fast path.
 Each CTA owns one decode row and a 256-channel tile. Indexed calls use the same
 schedule with device-side index validation and channel-tail handling.
 
-## High-level wrapper
+## Public Torch API
 
-The standard FE-OSS wrapper allocates the output and returns a `TupleDict`:
+The semantic API accepts ordinary tensors, owns its output allocation, and
+returns the output tensor directly:
 
 ```python
 import torch
-from cudnn import causal_conv1d_update_wrapper_sm100
+from cudnn.ops import causal_conv1d_update
 
 x = torch.randn(8, 2048, device="cuda", dtype=torch.bfloat16)
 weight = torch.randn(2048, 4, device="cuda", dtype=torch.bfloat16)
-state = torch.randn(8, 2048, 4, device="cuda", dtype=torch.bfloat16)
-
-result = causal_conv1d_update_wrapper_sm100(x, state, weight)
-output = result["output_tensor"]
-```
-
-`cudnn.causal_conv1d_update(x, state, weight, ...)` and
-`cudnn.ops.causal_conv1d_update(...)` expose the same mutation but return the
-output Tensor directly. The state-before-weight positional order matches the
-common decode-update convention used by the FLA and causal-conv1d ecosystems.
-Bias is keyword-only: pass `bias=bias`. The helpers are not drop-in
-replacements for APIs with different return-state conventions.
-
-Both helpers cache compiled kernels by device, shape, indexed/non-indexed
-signature, and bias presence. The cache is bounded. The first call for a
-signature performs JIT compilation, so warm the exact signature before latency
-measurement or CUDA Graph capture.
-
-## Class API
-
-Use the class API for explicit compilation, output ownership, and repeated
-execution:
-
-```python
-import torch
-from cudnn import CausalConv1dUpdateSm100
-
-x = torch.empty(8, 2048, device="cuda", dtype=torch.bfloat16)
-weight = torch.empty(2048, 4, device="cuda", dtype=torch.bfloat16)
-state = torch.empty(8, 2048, 4, device="cuda", dtype=torch.bfloat16)
-output = torch.empty_like(x)
-
-op = CausalConv1dUpdateSm100(x, weight, state, output)
-op.check_support()
-op.compile()
+conv_state = torch.randn(8, 2048, 4, device="cuda", dtype=torch.bfloat16)
 
 with torch.no_grad():
-    op.execute(x, weight, state, output)
+    output = causal_conv1d_update(
+        x,
+        conv_state,
+        weight,
+        activation="silu",
+    )
 ```
 
-`execute(..., current_stream=...)` accepts a CUDA driver stream handle. The
-high-level helpers allocate their output on that stream as well; they require a
-concrete stream handle rather than the `CU_STREAM_PER_THREAD` sentinel. Callers
-remain responsible for cross-stream dependencies and synchronization.
+`bias` and `activation` follow the mathematical operation. Optional
+`conv_state_indices` is keyword-only because it changes state routing rather
+than tensor math. The alias `cudnn.causal_conv1d_update` resolves to the same
+function. No public parameter exposes a wrapper object, architecture name,
+plan, output buffer, or raw stream.
+
+The implementation caches compiled kernels by device, shape,
+indexed/non-indexed signature, and bias presence. The cache is bounded. The
+first call for a signature performs JIT compilation, so warm the exact
+signature before latency measurement or CUDA Graph capture.
 
 ## Semantic provenance and benchmarking
 

--- a/docs/fe-oss-apis/causal_conv1d_update.md
+++ b/docs/fe-oss-apis/causal_conv1d_update.md
@@ -63,14 +63,15 @@ x = torch.randn(8, 2048, device="cuda", dtype=torch.bfloat16)
 weight = torch.randn(2048, 4, device="cuda", dtype=torch.bfloat16)
 state = torch.randn(8, 2048, 4, device="cuda", dtype=torch.bfloat16)
 
-result = causal_conv1d_update_wrapper_sm100(x, weight, state)
+result = causal_conv1d_update_wrapper_sm100(x, state, weight)
 output = result["output_tensor"]
 ```
 
-`cudnn.causal_conv1d_update(...)` and
+`cudnn.causal_conv1d_update(x, state, weight, ...)` and
 `cudnn.ops.causal_conv1d_update(...)` expose the same mutation but return the
-output Tensor directly. They are convenient for model-integration shims and
-are not drop-in replacements for APIs with different argument order, bias, or
+output Tensor directly. The state-before-weight positional order matches the
+common decode-update convention used by the FLA and causal-conv1d ecosystems.
+The helpers are not drop-in replacements for APIs with bias or different
 return-state conventions.
 
 Both helpers cache compiled kernels by device, shape, and indexed/non-indexed

--- a/docs/fe-oss-apis/causal_conv1d_update.md
+++ b/docs/fe-oss-apis/causal_conv1d_update.md
@@ -10,9 +10,8 @@ serving-framework integration or make cuDNN the default route. The optional
 `cudnn.fla.accelerate_fla(targets="short_conv")` adapter preserves FLA 0.5.2's
 decode-update interface and routes only this exact supported subset to the
 native primitive; all other configurations retain FLA's original path.
-The `Sm100` class and wrapper names are retained for API compatibility. SM100
-has the tuned schedule; other admitted architectures use the portable
-functional schedule.
+The `Sm100` class and wrapper names are retained for API compatibility. Every
+admitted architecture uses the same portable one-row schedule.
 
 For row `n`, channel `d`, and selected cache slot `s`, the operation is:
 
@@ -32,7 +31,7 @@ the failed update is not transactional.
 
 - GPU: functional support on compute capabilities 8.0, 8.6, 8.7, 8.9, 9.0,
   10.0, 10.3, 11.0, 12.0, and 12.1
-- optimized and performance-characterized GPU: SM100 (compute capability 10.0)
+- performance-characterized GPU: SM100 (compute capability 10.0)
 - `x`: contiguous BF16 `[N, D]`
 - `weight`: contiguous BF16 `[D, 4]`
 - `state`: contiguous BF16 `[S, D, 4]`, updated in place
@@ -49,11 +48,11 @@ not sufficient for this direct API. The FLA adapter treats the resulting
 `ImportError` as a typed decline and executes FLA's original path.
 
 The full correctness suite was run on A100 SM80, L40S SM89, H200 SM90, and
-B200 SM100. The generic, indexed, and row-batch kernels were also executed on
-a GB110 board reporting compute capability 10.3 and an RTX 5080 SM120; outputs
+B200 SM100. The generic and indexed kernels were also executed on a GB110
+board reporting compute capability 10.3 and an RTX 5080 SM120; outputs
 matched the reference and state updates were bit-exact. Thus SM80, SM89, SM90,
 SM100, SM103, and SM120 are runtime-validated. SM86, SM87, SM110, and SM121
-have compile-only validation. In particular, both SM110 schedules cross-compile
+have compile-only validation. In particular, the SM110 kernel cross-compiles
 with CUTLASS DSL 4.7, but no SM110 hardware execution is claimed.
 
 This narrow contract does not cover a bias term, a returned intermediate state
@@ -62,14 +61,8 @@ general Mamba causal-convolution interface. The indexed path is provided for
 functional paged-state support; its duplicate-index validation has not been
 performance-characterized as a fast path.
 
-On exact SM100, the two measured Qwen3.5 decode signatures `N=128, D=2048` and
-`N=128, D=4096` compile a two-row CTA specialization for unindexed calls. It
-loads each channel's four-tap weight once and reuses it across the two rows,
-while issuing both rows' state/input loads before arithmetic. Every other
-supported architecture always uses the conservative one-row kernel. Indexed
-calls and every other shape also retain that one-row kernel, including its
-device-side index validation and channel-tail handling. This route is an
-internal schedule choice; it does not change the public API or cache key.
+Each CTA owns one decode row and a 256-channel tile. Indexed calls use the same
+schedule with device-side index validation and channel-tail handling.
 
 ## High-level wrapper
 
@@ -134,22 +127,8 @@ public `causal_conv1d_update` contract from Dao-AILab/causal-conv1d at revision
 either project is included. The implementation uses CUTLASS/CuTe DSL, inline
 PTX, and in-tree NVIDIA FROST primitives.
 
-The two-row scheduling idea was selected from audited internal Kernel Factory
-candidate `73d90c7f...`, but that standalone source was not copied into this
-module. The FE specialization is independently implemented on top of the
-existing native inline-PTX path and keeps FE's architecture, alignment, alias,
-index, and cache contracts.
-
-On ComputeLab job `3999943` (B200 SM100, driver `610.57.04`, CUDA `13.0`,
-PyTorch `2.13.0+cu130`, CUTLASS DSL `4.7.0`), an interleaved same-process CUPTI
-run measured the FE specialization against the preceding FE implementation at
-`2.304` versus `2.464` microseconds for `N=128, D=2048`, and `2.848` versus
-`3.328` microseconds for `N=128, D=4096` (201 samples per arm and shape). Paired
-median speedups were `1.134x` and `1.170x`; the `D=2048:D=4096` 2:1 weighted
-geometric mean was `1.146x`. The raw result SHA-256 is
-`fa0d3e7d5fc2d7a0ad2f53362ddf21932dfec109cde119d9dadf4e7fdb9e4cbd`.
-These are direct kernel-active measurements, not single-node CUDA-graph replay
-or end-to-end model latency.
+The FE kernel is independently implemented and keeps FE's architecture,
+alignment, alias, index, and cache contracts.
 
 Use `benchmark/causal_conv1d_update_sm100.py` for route-proof, correctness, and
 an interleaved comparison against FLA on any compute capability listed in the

--- a/docs/fe-oss-apis/causal_conv1d_update.md
+++ b/docs/fe-oss-apis/causal_conv1d_update.md
@@ -1,4 +1,4 @@
-# Causal Conv1d Decode Update (SM100)
+# Causal Conv1d Decode Update
 
 **This FE-OSS API is experimental and subject to change.**
 
@@ -10,6 +10,9 @@ serving-framework integration or make cuDNN the default route. The optional
 `cudnn.fla.accelerate_fla(targets="short_conv")` adapter preserves FLA 0.5.2's
 decode-update interface and routes only this exact supported subset to the
 native primitive; all other configurations retain FLA's original path.
+The `Sm100` class and wrapper names are retained for API compatibility. SM100
+has the tuned schedule; other admitted architectures use the portable
+functional schedule.
 
 For row `n`, channel `d`, and selected cache slot `s`, the operation is:
 
@@ -27,7 +30,9 @@ the failed update is not transactional.
 
 ## Supported contract
 
-- GPU: exactly SM100 (compute capability 10.0)
+- GPU: functional support on compute capabilities 8.0, 8.6, 8.7, 8.9, 9.0,
+  10.0, 10.3, 11.0, 12.0, and 12.1
+- optimized and performance-characterized GPU: SM100 (compute capability 10.0)
 - `x`: contiguous BF16 `[N, D]`
 - `weight`: contiguous BF16 `[D, 4]`
 - `state`: contiguous BF16 `[S, D, 4]`, updated in place
@@ -37,19 +42,34 @@ the failed update is not transactional.
 - bias and autograd: unsupported
 - pointer alignment: 16 bytes for BF16 tensors and 4 bytes for indices
 
+The native direct API and current kernel require CUTLASS DSL 4.7 or newer for
+the inline-PTX integration they import. The package-wide `cutedsl` extra keeps
+its broader `>=4.5` floor for unrelated APIs; installing only that minimum is
+not sufficient for this direct API. The FLA adapter treats the resulting
+`ImportError` as a typed decline and executes FLA's original path.
+
+The full correctness suite was run on A100 SM80, L40S SM89, H200 SM90, and
+B200 SM100. The generic, indexed, and row-batch kernels were also executed on
+a GB110 board reporting compute capability 10.3 and an RTX 5080 SM120; outputs
+matched the reference and state updates were bit-exact. Thus SM80, SM89, SM90,
+SM100, SM103, and SM120 are runtime-validated. SM86, SM87, SM110, and SM121
+have compile-only validation. In particular, both SM110 schedules cross-compile
+with CUTLASS DSL 4.7, but no SM110 hardware execution is claimed.
+
 This narrow contract does not cover a bias term, a returned intermediate state
 for speculative decoding, arbitrary convolution width, prefill, training, or a
 general Mamba causal-convolution interface. The indexed path is provided for
 functional paged-state support; its duplicate-index validation has not been
 performance-characterized as a fast path.
 
-For the two measured Qwen3.5 decode signatures `N=128, D=2048` and
-`N=128, D=4096`, an unindexed call compiles a two-row CTA specialization. It
+On exact SM100, the two measured Qwen3.5 decode signatures `N=128, D=2048` and
+`N=128, D=4096` compile a two-row CTA specialization for unindexed calls. It
 loads each channel's four-tap weight once and reuses it across the two rows,
-while issuing both rows' state/input loads before arithmetic. Indexed calls and
-every other shape retain the original one-row kernel, including its device-side
-index validation and channel-tail handling. This route is an internal schedule
-choice; it does not change the public API or cache key.
+while issuing both rows' state/input loads before arithmetic. Every other
+supported architecture always uses the conservative one-row kernel. Indexed
+calls and every other shape also retain that one-row kernel, including its
+device-side index validation and channel-tail handling. This route is an
+internal schedule choice; it does not change the public API or cache key.
 
 ## High-level wrapper
 
@@ -131,7 +151,9 @@ geometric mean was `1.146x`. The raw result SHA-256 is
 These are direct kernel-active measurements, not single-node CUDA-graph replay
 or end-to-end model latency.
 
-Use `benchmark/causal_conv1d_update_sm100.py` on the target GPU for route-proof,
-correctness, and interleaved comparison against FLA. Performance measurements
-must include the exact GPU, software environment, shapes, and raw artifacts;
-the indexed path should be reported separately from the no-index decode path.
+Use `benchmark/causal_conv1d_update_sm100.py` on a ComputeLab B200 for
+route-proof, correctness, and interleaved comparison against FLA. The
+benchmark intentionally rejects non-SM100 devices: widening functional support
+does not widen the performance claim. Performance measurements must include
+the exact GPU, software environment, shapes, and raw artifacts; the indexed
+path should be reported separately from the no-index decode path.

--- a/docs/fe-oss-apis/causal_conv1d_update.md
+++ b/docs/fe-oss-apis/causal_conv1d_update.md
@@ -151,9 +151,10 @@ geometric mean was `1.146x`. The raw result SHA-256 is
 These are direct kernel-active measurements, not single-node CUDA-graph replay
 or end-to-end model latency.
 
-Use `benchmark/causal_conv1d_update_sm100.py` on a ComputeLab B200 for
-route-proof, correctness, and interleaved comparison against FLA. The
-benchmark intentionally rejects non-SM100 devices: widening functional support
-does not widen the performance claim. Performance measurements must include
-the exact GPU, software environment, shapes, and raw artifacts; the indexed
-path should be reported separately from the no-index decode path.
+Use `benchmark/causal_conv1d_update_sm100.py` for route-proof, correctness, and
+an interleaved comparison against FLA on any compute capability listed in the
+supported contract. The benchmark records the actual GPU architecture and
+software environment; Slurm job and node metadata are optional when those
+variables are unavailable. Performance measurements should include the exact
+GPU, software environment, shapes, and raw artifacts; the indexed path should
+be reported separately from the no-index decode path.

--- a/docs/fe-oss-apis/causal_conv1d_update.md
+++ b/docs/fe-oss-apis/causal_conv1d_update.md
@@ -43,6 +43,14 @@ general Mamba causal-convolution interface. The indexed path is provided for
 functional paged-state support; its duplicate-index validation has not been
 performance-characterized as a fast path.
 
+For the two measured Qwen3.5 decode signatures `N=128, D=2048` and
+`N=128, D=4096`, an unindexed call compiles a two-row CTA specialization. It
+loads each channel's four-tap weight once and reuses it across the two rows,
+while issuing both rows' state/input loads before arithmetic. Indexed calls and
+every other shape retain the original one-row kernel, including its device-side
+index validation and channel-tail handling. This route is an internal schedule
+choice; it does not change the public API or cache key.
+
 ## High-level wrapper
 
 The standard FE-OSS wrapper allocates the output and returns a `TupleDict`:
@@ -104,6 +112,23 @@ public `causal_conv1d_update` contract from Dao-AILab/causal-conv1d at revision
 `cd81f0413cad2fc1e6f17e785ac39f59aae690cd` (BSD-3-Clause). No source from
 either project is included. The implementation uses CUTLASS/CuTe DSL, inline
 PTX, and in-tree NVIDIA FROST primitives.
+
+The two-row scheduling idea was selected from audited internal Kernel Factory
+candidate `73d90c7f...`, but that standalone source was not copied into this
+module. The FE specialization is independently implemented on top of the
+existing native inline-PTX path and keeps FE's architecture, alignment, alias,
+index, and cache contracts.
+
+On ComputeLab job `3999943` (B200 SM100, driver `610.57.04`, CUDA `13.0`,
+PyTorch `2.13.0+cu130`, CUTLASS DSL `4.7.0`), an interleaved same-process CUPTI
+run measured the FE specialization against the preceding FE implementation at
+`2.304` versus `2.464` microseconds for `N=128, D=2048`, and `2.848` versus
+`3.328` microseconds for `N=128, D=4096` (201 samples per arm and shape). Paired
+median speedups were `1.134x` and `1.170x`; the `D=2048:D=4096` 2:1 weighted
+geometric mean was `1.146x`. The raw result SHA-256 is
+`fa0d3e7d5fc2d7a0ad2f53362ddf21932dfec109cde119d9dadf4e7fdb9e4cbd`.
+These are direct kernel-active measurements, not single-node CUDA-graph replay
+or end-to-end model latency.
 
 Use `benchmark/causal_conv1d_update_sm100.py` on the target GPU for route-proof,
 correctness, and interleaved comparison against FLA. Performance measurements

--- a/docs/fe-oss-apis/fla.md
+++ b/docs/fe-oss-apis/fla.md
@@ -20,8 +20,11 @@ cudnn.fla.accelerate_fla()
 # Incrementally opt the dense FLA GatedMLP into the fused cuDNN SwiGLU MLP.
 cudnn.fla.accelerate_fla(targets="gated_mlp")
 
-# A string or iterable is accepted; "gdn" and "mlp" are aliases.
-cudnn.fla.accelerate_fla(targets=("gdn", "gated_mlp"))
+# Opt FLA 0.5.2 decode short convolution into the native SM100 update.
+cudnn.fla.accelerate_fla(targets="short_conv")
+
+# A string or iterable is accepted; "gdn", "mlp", and "shortconv" are aliases.
+cudnn.fla.accelerate_fla(targets=("gdn", "gated_mlp", "shortconv"))
 ```
 
 `accelerate_fla(verbose=True, *, targets=None)` is incremental and idempotent.
@@ -39,6 +42,34 @@ custom linears, other dtypes/layouts/devices, or graph compilation execute the
 original FLA method. Typed unsupported-kernel declines also fall back;
 unexpected binding, allocation, or launch errors propagate.
 
+The opt-in `short_conv` target patches
+`fla.modules.conv.triton.ops.causal_conv1d_update` and preserves FLA 0.5.2's
+public call and return contract:
+
+```python
+y, cache = causal_conv1d_update(
+    x, cache, residual=None, weight=weight, bias=None, activation="silu"
+)
+```
+
+The native route is deliberately restricted to inference on exact SM100 with
+BF16, a contiguous `[N, D, 4]` cache, contiguous `[D, 4]` weights, no residual
+or bias, and `silu`/`swish`. Contiguous input layouts `[N, D]`, `[N, 1, D]`,
+and `[1, N, D]` are normalized with zero-copy views; output shape and cache
+object identity are preserved. Everything else executes the saved original FLA
+callable. Typed unsupported-kernel declines fall back, while unexpected native
+binding, allocation, and launch failures propagate.
+
+The cuDNN adapter and native kernel are independent NVIDIA implementations.
+They use FLA's documented interface and observable depthwise causal-convolution
+semantics for compatibility; no FLA Triton kernel source is incorporated or
+translated.
+
+Use `benchmark/fla_short_conv_shim_sm100.py` on a ComputeLab B200 for the exact
+patched-callable comparison. It reports CUDA-graph replay separately from
+steady-state eager host enqueue time and refuses to emit timings until route,
+output, mutable-state, cache-identity, and restore gates pass.
+
 ## Inspect and restore
 
 ```python
@@ -49,8 +80,10 @@ cudnn.fla.is_accelerated("gated_mlp") # one target ("mlp" also works)
 
 cudnn.fla.mlp_last_path()  # "native", "fallback:<reason>", or "error:<type>"
 cudnn.fla.last_path()      # most recent Gated Delta Rule route
+cudnn.fla.short_conv_last_path() # most recent short-convolution route
 
 cudnn.fla.restore_fla(targets="gated_mlp") # restore only the MLP target
+cudnn.fla.restore_fla(targets="shortconv") # alias for the short-conv target
 cudnn.fla.restore_fla()                    # restore every target owned by cuDNN
 ```
 
@@ -61,13 +94,13 @@ per-thread state.
 
 ## Installation
 
-Install FLA separately. The dense MLP adapter is version-gated to the validated
-release:
+Install FLA separately. The dense MLP and short-convolution adapters are
+version-gated to the validated release:
 
 ```bash
 pip install flash-linear-attention==0.5.2
 pip install "nvidia-cudnn-frontend[cutedsl]"
 ```
 
-The `cutedsl` extra supplies the optional dependencies required by the fused
-GEMM path used by the native `gated_mlp` target.
+The `cutedsl` extra supplies the optional CUTLASS DSL and CUDA Python
+dependencies required by the native `gated_mlp` and `short_conv` targets.

--- a/docs/fe-oss-apis/fla.md
+++ b/docs/fe-oss-apis/fla.md
@@ -55,8 +55,8 @@ y, cache = causal_conv1d_update(
 The native route is deliberately restricted to inference on compute
 capabilities 8.0, 8.6, 8.7, 8.9, 9.0, 10.0, 10.3, 11.0, 12.0, and 12.1 with BF16, a
 contiguous `[N, D, 4]` cache, contiguous `[D, 4]` weights, no residual or bias,
-and `silu`/`swish`. SM100 uses the optimized row-batch schedule; every other
-admitted architecture uses the conservative functional schedule. Contiguous
+and `silu`/`swish`. Every admitted architecture uses the same one-row
+functional schedule. Contiguous
 input layouts `[N, D]`, `[N, 1, D]`, and `[1, N, D]` are normalized with
 zero-copy views; output shape and cache object identity are preserved.
 Everything else executes the saved original FLA callable. Typed
@@ -68,8 +68,8 @@ package-wide `cutedsl>=4.5` minimum is present and the native import is
 unavailable, the adapter catches that typed `ImportError` and executes FLA's
 original path. Hardware correctness coverage is SM80, SM89, SM90, and SM100;
 the native kernel is additionally runtime-validated on SM103 and SM120.
-SM86, SM87, SM110, and SM121 are compile-validated only. Both SM110 schedules
-cross-compile with CUTLASS DSL 4.7, but no SM110 hardware execution is claimed.
+SM86, SM87, SM110, and SM121 are compile-validated only. The SM110 kernel
+cross-compiles with CUTLASS DSL 4.7, but no SM110 hardware execution is claimed.
 
 The cuDNN adapter and native kernel are independent NVIDIA implementations.
 They use FLA's documented interface and observable depthwise causal-convolution

--- a/docs/fe-oss-apis/fla.md
+++ b/docs/fe-oss-apis/fla.md
@@ -20,7 +20,7 @@ cudnn.fla.accelerate_fla()
 # Incrementally opt the dense FLA GatedMLP into the fused cuDNN SwiGLU MLP.
 cudnn.fla.accelerate_fla(targets="gated_mlp")
 
-# Opt FLA 0.5.2 decode short convolution into the native SM100 update.
+# Opt FLA 0.5.2 decode short convolution into the native update.
 cudnn.fla.accelerate_fla(targets="short_conv")
 
 # A string or iterable is accepted; "gdn", "mlp", and "shortconv" are aliases.
@@ -52,13 +52,24 @@ y, cache = causal_conv1d_update(
 )
 ```
 
-The native route is deliberately restricted to inference on exact SM100 with
-BF16, a contiguous `[N, D, 4]` cache, contiguous `[D, 4]` weights, no residual
-or bias, and `silu`/`swish`. Contiguous input layouts `[N, D]`, `[N, 1, D]`,
-and `[1, N, D]` are normalized with zero-copy views; output shape and cache
-object identity are preserved. Everything else executes the saved original FLA
-callable. Typed unsupported-kernel declines fall back, while unexpected native
-binding, allocation, and launch failures propagate.
+The native route is deliberately restricted to inference on compute
+capabilities 8.0, 8.6, 8.7, 8.9, 9.0, 10.0, 10.3, 11.0, 12.0, and 12.1 with BF16, a
+contiguous `[N, D, 4]` cache, contiguous `[D, 4]` weights, no residual or bias,
+and `silu`/`swish`. SM100 uses the optimized row-batch schedule; every other
+admitted architecture uses the conservative functional schedule. Contiguous
+input layouts `[N, D]`, `[N, 1, D]`, and `[1, N, D]` are normalized with
+zero-copy views; output shape and cache object identity are preserved.
+Everything else executes the saved original FLA callable. Typed
+unsupported-kernel declines fall back, while unexpected native binding,
+allocation, and launch failures propagate.
+
+The current native kernel requires CUTLASS DSL 4.7 or newer. If only the
+package-wide `cutedsl>=4.5` minimum is present and the native import is
+unavailable, the adapter catches that typed `ImportError` and executes FLA's
+original path. Hardware correctness coverage is SM80, SM89, SM90, and SM100;
+the native kernel is additionally runtime-validated on SM103 and SM120.
+SM86, SM87, SM110, and SM121 are compile-validated only. Both SM110 schedules
+cross-compile with CUTLASS DSL 4.7, but no SM110 hardware execution is claimed.
 
 The cuDNN adapter and native kernel are independent NVIDIA implementations.
 They use FLA's documented interface and observable depthwise causal-convolution
@@ -69,6 +80,8 @@ Use `benchmark/fla_short_conv_shim_sm100.py` on a ComputeLab B200 for the exact
 patched-callable comparison. It reports CUDA-graph replay separately from
 steady-state eager host enqueue time and refuses to emit timings until route,
 output, mutable-state, cache-identity, and restore gates pass.
+The benchmark remains intentionally restricted to exact SM100 even though the
+adapter has wider functional support.
 
 ## Inspect and restore
 
@@ -103,4 +116,6 @@ pip install "nvidia-cudnn-frontend[cutedsl]"
 ```
 
 The `cutedsl` extra supplies the optional CUTLASS DSL and CUDA Python
-dependencies required by the native `gated_mlp` and `short_conv` targets.
+dependencies required by the native `gated_mlp` and `short_conv` targets. To
+require the native `short_conv` route instead of its typed fallback, also
+ensure `nvidia-cutlass-dsl[cu13]>=4.7` is installed.

--- a/docs/fe-oss-apis/fla.md
+++ b/docs/fe-oss-apis/fla.md
@@ -56,9 +56,10 @@ The native route is deliberately restricted to inference on compute
 capabilities 8.0, 8.6, 8.7, 8.9, 9.0, 10.0, 10.3, 11.0, 12.0, and 12.1 with BF16, a
 contiguous `[N, D, 4]` cache, contiguous `[D, 4]` weights, no residual or bias,
 and `silu`/`swish`. Every admitted architecture uses the same one-row
-functional schedule. Contiguous
-input layouts `[N, D]`, `[N, 1, D]`, and `[1, N, D]` are normalized with
-zero-copy views; output shape and cache object identity are preserved.
+functional schedule. Input layouts `[N, D]`, `[N, 1, D]`, and `[1, N, D]` are
+normalized to `[N, D]` with zero-copy views. Compact X rows accept every D;
+padded `(ld, 1)` rows, including slices of wider fused projections, require `ld > D`
+and `ld % 8 == 0`. Output shape and cache object identity are preserved.
 Everything else executes the saved original FLA callable. Typed
 unsupported-kernel declines fall back, while unexpected native binding,
 allocation, and launch failures propagate.
@@ -76,12 +77,11 @@ They use FLA's documented interface and observable depthwise causal-convolution
 semantics for compatibility; no FLA Triton kernel source is incorporated or
 translated.
 
-Use `benchmark/fla_short_conv_shim_sm100.py` on a ComputeLab B200 for the exact
-patched-callable comparison. It reports CUDA-graph replay separately from
-steady-state eager host enqueue time and refuses to emit timings until route,
+Use `benchmark/fla_short_conv_shim_sm100.py` for an exact patched-callable
+comparison. It runs on every functionally admitted target, records the actual
+hardware and software metadata, reports CUDA-graph replay separately from
+steady-state eager host enqueue time, and refuses to emit timings until route,
 output, mutable-state, cache-identity, and restore gates pass.
-The benchmark remains intentionally restricted to exact SM100 even though the
-adapter has wider functional support.
 
 ## Inspect and restore
 

--- a/docs/fe-oss-apis/overview.md
+++ b/docs/fe-oss-apis/overview.md
@@ -36,6 +36,7 @@ This folder documents the Python FE APIs implemented under `python/cudnn`. For d
 - [RMSNorm + RHT + Amax](rmsnorm_rht_amax.md)
 - [SDPA Backward (SM120)](attention/sdpa_bwd_sm120.md)
 - [RMSNorm + SiLU](rmsnorm_silu.md)
+- [Causal Conv1d Decode Update (SM100)](causal_conv1d_update.md)
 
 ## Installation and setup
 

--- a/docs/fe-oss-apis/overview.md
+++ b/docs/fe-oss-apis/overview.md
@@ -36,7 +36,7 @@ This folder documents the Python FE APIs implemented under `python/cudnn`. For d
 - [RMSNorm + RHT + Amax](rmsnorm_rht_amax.md)
 - [SDPA Backward (SM120)](attention/sdpa_bwd_sm120.md)
 - [RMSNorm + SiLU](rmsnorm_silu.md)
-- [Causal Conv1d Decode Update (SM100 optimized)](causal_conv1d_update.md)
+- [Causal Conv1d Decode Update](causal_conv1d_update.md)
 
 ## Installation and setup
 

--- a/docs/fe-oss-apis/overview.md
+++ b/docs/fe-oss-apis/overview.md
@@ -36,7 +36,7 @@ This folder documents the Python FE APIs implemented under `python/cudnn`. For d
 - [RMSNorm + RHT + Amax](rmsnorm_rht_amax.md)
 - [SDPA Backward (SM120)](attention/sdpa_bwd_sm120.md)
 - [RMSNorm + SiLU](rmsnorm_silu.md)
-- [Causal Conv1d Decode Update (SM100)](causal_conv1d_update.md)
+- [Causal Conv1d Decode Update (SM100 optimized)](causal_conv1d_update.md)
 
 ## Installation and setup
 

--- a/python/cudnn/README.md
+++ b/python/cudnn/README.md
@@ -82,6 +82,7 @@ To add a new frontend-only API, follow these steps:
 - `HSTU Attention (Blackwell SM100/SM103)`
 - `SDPA Forward (SM100, D=256)`
 - `SDPA Backward (SM100, D=256)`
+- `Causal Conv1d Decode Update (SM100, BF16, K=4)`
 
 **In progress frontend-only APIs**:
 - GEMM + Dswiglu

--- a/python/cudnn/README.md
+++ b/python/cudnn/README.md
@@ -82,7 +82,7 @@ To add a new frontend-only API, follow these steps:
 - `HSTU Attention (Blackwell SM100/SM103)`
 - `SDPA Forward (SM100, D=256)`
 - `SDPA Backward (SM100, D=256)`
-- `Causal Conv1d Decode Update (SM100, BF16, K=4)`
+- `Causal Conv1d Decode Update (SM80/86/87/89/90/100/103/110/120/121 functional; SM100 optimized, BF16, K=4)`
 
 **In progress frontend-only APIs**:
 - GEMM + Dswiglu

--- a/python/cudnn/README.md
+++ b/python/cudnn/README.md
@@ -82,7 +82,7 @@ To add a new frontend-only API, follow these steps:
 - `HSTU Attention (Blackwell SM100/SM103)`
 - `SDPA Forward (SM100, D=256)`
 - `SDPA Backward (SM100, D=256)`
-- `Causal Conv1d Decode Update (SM80/86/87/89/90/100/103/110/120/121 functional; SM100 optimized, BF16, K=4)`
+- `Causal Conv1d Decode Update (cudnn.ops semantic API; SM80/86/87/89/90/100/103/110/120/121 functional; B200 performance-characterized, BF16, K=4)`
 
 **In progress frontend-only APIs**:
 - GEMM + Dswiglu

--- a/python/cudnn/__init__.py
+++ b/python/cudnn/__init__.py
@@ -338,12 +338,7 @@ _LAZY_OPTIONAL_IMPORTS = {
     "gemm_proj_rope_mxfp8_jax_sm100": (".gemm.cutedsl.dense.proj_rope_mxfp8", "gemm_proj_rope_mxfp8_jax_sm100"),
     "RmsNormRhtAmaxSm100": (".rmsnorm_rht_amax", "RmsNormRhtAmaxSm100"),
     "rmsnorm_rht_amax_wrapper_sm100": (".rmsnorm_rht_amax", "rmsnorm_rht_amax_wrapper_sm100"),
-    "CausalConv1dUpdateSm100": (".causal_conv1d_update_sm100", "CausalConv1dUpdateSm100"),
-    "causal_conv1d_update": (".causal_conv1d_update_sm100", "causal_conv1d_update"),
-    "causal_conv1d_update_wrapper_sm100": (
-        ".causal_conv1d_update_sm100",
-        "causal_conv1d_update_wrapper_sm100",
-    ),
+    "causal_conv1d_update": (".ops", "causal_conv1d_update"),
     "grouped_gemm": (".gemm.cutedsl.grouped", None),
     "GroupedGemmSm100": (".gemm.cutedsl.grouped", "GroupedGemmSm100"),
     "grouped_gemm_wrapper_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_wrapper_sm100"),

--- a/python/cudnn/__init__.py
+++ b/python/cudnn/__init__.py
@@ -338,7 +338,6 @@ _LAZY_OPTIONAL_IMPORTS = {
     "gemm_proj_rope_mxfp8_jax_sm100": (".gemm.cutedsl.dense.proj_rope_mxfp8", "gemm_proj_rope_mxfp8_jax_sm100"),
     "RmsNormRhtAmaxSm100": (".rmsnorm_rht_amax", "RmsNormRhtAmaxSm100"),
     "rmsnorm_rht_amax_wrapper_sm100": (".rmsnorm_rht_amax", "rmsnorm_rht_amax_wrapper_sm100"),
-    "causal_conv1d_update": (".ops", "causal_conv1d_update"),
     "grouped_gemm": (".gemm.cutedsl.grouped", None),
     "GroupedGemmSm100": (".gemm.cutedsl.grouped", "GroupedGemmSm100"),
     "grouped_gemm_wrapper_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_wrapper_sm100"),

--- a/python/cudnn/__init__.py
+++ b/python/cudnn/__init__.py
@@ -338,6 +338,12 @@ _LAZY_OPTIONAL_IMPORTS = {
     "gemm_proj_rope_mxfp8_jax_sm100": (".gemm.cutedsl.dense.proj_rope_mxfp8", "gemm_proj_rope_mxfp8_jax_sm100"),
     "RmsNormRhtAmaxSm100": (".rmsnorm_rht_amax", "RmsNormRhtAmaxSm100"),
     "rmsnorm_rht_amax_wrapper_sm100": (".rmsnorm_rht_amax", "rmsnorm_rht_amax_wrapper_sm100"),
+    "CausalConv1dUpdateSm100": (".causal_conv1d_update_sm100", "CausalConv1dUpdateSm100"),
+    "causal_conv1d_update": (".causal_conv1d_update_sm100", "causal_conv1d_update"),
+    "causal_conv1d_update_wrapper_sm100": (
+        ".causal_conv1d_update_sm100",
+        "causal_conv1d_update_wrapper_sm100",
+    ),
     "grouped_gemm": (".gemm.cutedsl.grouped", None),
     "GroupedGemmSm100": (".gemm.cutedsl.grouped", "GroupedGemmSm100"),
     "grouped_gemm_wrapper_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_wrapper_sm100"),

--- a/python/cudnn/_causal_conv1d_arch.py
+++ b/python/cudnn/_causal_conv1d_arch.py
@@ -17,19 +17,12 @@ SUPPORTED_CAUSAL_CONV1D_UPDATE_COMPUTE_CAPABILITIES = frozenset(
         (12, 1),
     }
 )
-SM100_COMPUTE_CAPABILITY = (10, 0)
 
 
 def is_supported_causal_conv1d_update_compute_capability(compute_capability: tuple[int, int]) -> bool:
     """Return whether the operation admits this functional target."""
 
     return compute_capability in SUPPORTED_CAUSAL_CONV1D_UPDATE_COMPUTE_CAPABILITIES
-
-
-def uses_sm100_causal_conv1d_update_schedule(compute_capability: tuple[int, int]) -> bool:
-    """Return whether the measured SM100-only row-batch schedule is allowed."""
-
-    return compute_capability == SM100_COMPUTE_CAPABILITY
 
 
 def supported_causal_conv1d_update_compute_capabilities_text() -> str:

--- a/python/cudnn/_causal_conv1d_arch.py
+++ b/python/cudnn/_causal_conv1d_arch.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal architecture policy for the causal-convolution decode update."""
+
+SUPPORTED_CAUSAL_CONV1D_UPDATE_COMPUTE_CAPABILITIES = frozenset(
+    {
+        (8, 0),
+        (8, 6),
+        (8, 7),
+        (8, 9),
+        (9, 0),
+        (10, 0),
+        (10, 3),
+        (11, 0),
+        (12, 0),
+        (12, 1),
+    }
+)
+SM100_COMPUTE_CAPABILITY = (10, 0)
+
+
+def is_supported_causal_conv1d_update_compute_capability(compute_capability: tuple[int, int]) -> bool:
+    """Return whether the operation admits this functional target."""
+
+    return compute_capability in SUPPORTED_CAUSAL_CONV1D_UPDATE_COMPUTE_CAPABILITIES
+
+
+def uses_sm100_causal_conv1d_update_schedule(compute_capability: tuple[int, int]) -> bool:
+    """Return whether the measured SM100-only row-batch schedule is allowed."""
+
+    return compute_capability == SM100_COMPUTE_CAPABILITY
+
+
+def supported_causal_conv1d_update_compute_capabilities_text() -> str:
+    """Return the functional allowlist in a stable diagnostic format."""
+
+    return ", ".join(f"{major}.{minor}" for major, minor in sorted(SUPPORTED_CAUSAL_CONV1D_UPDATE_COMPUTE_CAPABILITIES))

--- a/python/cudnn/causal_conv1d_update_sm100/__init__.py
+++ b/python/cudnn/causal_conv1d_update_sm100/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from .api import (
+    CausalConv1dUpdateSm100,
+    causal_conv1d_update,
+    causal_conv1d_update_wrapper_sm100,
+)
+
+__all__ = [
+    "CausalConv1dUpdateSm100",
+    "causal_conv1d_update",
+    "causal_conv1d_update_wrapper_sm100",
+]

--- a/python/cudnn/causal_conv1d_update_sm100/__init__.py
+++ b/python/cudnn/causal_conv1d_update_sm100/__init__.py
@@ -1,14 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from .api import (
-    CausalConv1dUpdateSm100,
-    causal_conv1d_update,
-    causal_conv1d_update_wrapper_sm100,
-)
+"""Private implementation package for :mod:`cudnn.ops` causal-conv update."""
 
-__all__ = [
-    "CausalConv1dUpdateSm100",
-    "causal_conv1d_update",
-    "causal_conv1d_update_wrapper_sm100",
-]
+from .api import _causal_conv1d_update as _causal_conv1d_update
+from .api import _CausalConv1dUpdatePlan as _CausalConv1dUpdatePlan
+
+__all__ = []

--- a/python/cudnn/causal_conv1d_update_sm100/api.py
+++ b/python/cudnn/causal_conv1d_update_sm100/api.py
@@ -3,9 +3,8 @@
 
 """Experimental FE-OSS API for causal-convolution decode update.
 
-The ``Sm100`` names are retained for API compatibility.  SM100 has the tuned
-row-batch schedule; other admitted architectures use the portable one-row
-schedule.
+The ``Sm100`` names are retained for API compatibility.  Every admitted
+architecture uses the same portable one-row schedule.
 """
 
 import threading
@@ -21,15 +20,10 @@ from cutlass.cute.runtime import make_fake_stream
 from cudnn._causal_conv1d_arch import (
     is_supported_causal_conv1d_update_compute_capability,
     supported_causal_conv1d_update_compute_capabilities_text,
-    uses_sm100_causal_conv1d_update_schedule,
 )
 from cudnn.api_base import APIBase, TensorDesc, TupleDict
 
-from .kernel import (
-    CausalConv1dUpdateKernel,
-    CausalConv1dUpdateRowBatchKernel,
-    select_rows_per_cta,
-)
+from .kernel import CausalConv1dUpdateKernel
 
 _API_CACHE = {}
 _API_CACHE_LOCK = threading.Lock()
@@ -85,9 +79,9 @@ def _tensors_overlap(lhs: torch.Tensor, rhs: torch.Tensor) -> bool:
 class CausalConv1dUpdateSm100(APIBase):
     """Compile and execute BF16 K=4 causal-convolution decode.
 
-    The class name is retained for compatibility.  SM100 uses the optimized
-    schedule; compute capabilities 8.0, 8.6, 8.7, 8.9, 9.0, 10.3, 11.0, 12.0,
-    and 12.1 use a conservative functional schedule.
+    The class name is retained for compatibility. Compute capabilities 8.0,
+    8.6, 8.7, 8.9, 9.0, 10.0, 10.3, 11.0, 12.0, and 12.1 use the same
+    functional schedule.
 
     This inference-only API advances ``state`` in place and writes ``output``.
     It deliberately supports one narrow contract:
@@ -140,7 +134,6 @@ class CausalConv1dUpdateSm100(APIBase):
         self.n_rows = None
         self.n_channels = None
         self.n_slots = None
-        self.rows_per_cta = None
 
     @staticmethod
     def _require_rank(desc: TensorDesc, rank: int, name: str) -> None:
@@ -256,12 +249,6 @@ class CausalConv1dUpdateSm100(APIBase):
         self.n_rows = n_rows
         self.n_channels = n_channels
         self.n_slots = n_slots
-        self.rows_per_cta = select_rows_per_cta(
-            n_rows,
-            n_channels,
-            self.state_indices_desc is not None,
-            use_sm100_optimized_schedule=uses_sm100_causal_conv1d_update_schedule(compute_capability),
-        )
         self._is_supported = True
         return True
 
@@ -277,7 +264,7 @@ class CausalConv1dUpdateSm100(APIBase):
         fake_state_indices = self._make_fake_cute_tensor_from_desc(self.state_indices_desc, assumed_align=4)
         fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
 
-        kernel = CausalConv1dUpdateRowBatchKernel() if self.rows_per_cta == 2 else CausalConv1dUpdateKernel()
+        kernel = CausalConv1dUpdateKernel()
         # CuTe DSL targets the current CUDA device.  Honor the sample tensor's
         # device even when a multi-GPU caller has another device current.
         with torch.cuda.device(self.x_desc.device):
@@ -404,8 +391,8 @@ def causal_conv1d_update(
     """Advance a BF16 K=4 causal-convolution cache and return fused-SiLU output.
 
     ``state`` is updated in place.  This experimental operation is
-    inference-only, no-bias, and always applies SiLU.  SM100 uses the optimized
-    schedule; other supported architectures use the functional schedule.  See
+    inference-only, no-bias, and always applies SiLU. Every supported
+    architecture uses the same functional schedule. See
     :class:`CausalConv1dUpdateSm100` for the exact tensor contract.
     """
 

--- a/python/cudnn/causal_conv1d_update_sm100/api.py
+++ b/python/cudnn/causal_conv1d_update_sm100/api.py
@@ -90,7 +90,7 @@ class CausalConv1dUpdateSm100(APIBase):
     * ``weight``: contiguous ``[D, 4]`` BF16
     * ``state``: contiguous ``[S, D, 4]`` BF16, mutated in place
     * optional ``state_indices``: contiguous CUDA ``int32[N]``
-    * no bias; SiLU is always fused
+    * optional ``bias``: contiguous ``[D]`` BF16; SiLU is always fused
 
     Indexed slots must be in ``[0, S)`` and unique.  The kernel checks both
     properties on device and executes a PTX trap on violation, so invalid
@@ -105,6 +105,7 @@ class CausalConv1dUpdateSm100(APIBase):
         sample_state: Union[torch.Tensor, TensorDesc],
         sample_output: Union[torch.Tensor, TensorDesc],
         sample_state_indices: Optional[Union[torch.Tensor, TensorDesc]] = None,
+        sample_bias: Optional[Union[torch.Tensor, TensorDesc]] = None,
     ):
         super().__init__()
         self._warn_experimental_api()
@@ -114,6 +115,7 @@ class CausalConv1dUpdateSm100(APIBase):
         self.state_desc = self._make_tensor_desc(sample_state, name="sample_state")
         self.output_desc = self._make_tensor_desc(sample_output, name="sample_output")
         self.state_indices_desc = self._make_tensor_desc(sample_state_indices, name="sample_state_indices")
+        self.bias_desc = self._make_tensor_desc(sample_bias, name="sample_bias")
 
         # TensorDesc deliberately does not retain sample tensors.  Preserve
         # only the pointer remainders needed to validate the assumed alignment
@@ -126,6 +128,7 @@ class CausalConv1dUpdateSm100(APIBase):
             ("State", sample_state, 16),
             ("Output", sample_output, 16),
             ("State indices", sample_state_indices, 4),
+            ("Bias", sample_bias, 16),
         ):
             data_ptr = getattr(sample, "data_ptr", None)
             if callable(data_ptr):
@@ -150,6 +153,8 @@ class CausalConv1dUpdateSm100(APIBase):
         self._require_rank(self.weight_desc, 2, "Weight")
         self._require_rank(self.state_desc, 3, "State")
         self._require_rank(self.output_desc, 2, "Output")
+        if self.bias_desc is not None:
+            self._require_rank(self.bias_desc, 1, "Bias")
         if self.state_indices_desc is not None:
             self._require_rank(self.state_indices_desc, 1, "State indices")
 
@@ -168,6 +173,8 @@ class CausalConv1dUpdateSm100(APIBase):
         self._check_tensor_shape(self.weight_desc, (n_channels, 4), "Weight")
         self._check_tensor_shape(self.state_desc, (n_slots, n_channels, 4), "State")
         self._check_tensor_shape(self.output_desc, (n_rows, n_channels), "Output")
+        if self.bias_desc is not None:
+            self._check_tensor_shape(self.bias_desc, (n_channels,), "Bias")
         if self.state_indices_desc is None:
             self._value_error_if(
                 n_slots < n_rows,
@@ -200,6 +207,13 @@ class CausalConv1dUpdateSm100(APIBase):
             name="Output",
             extra_error_msg="Output must be row-major contiguous",
         )
+        if self.bias_desc is not None:
+            self._check_tensor_stride(
+                self.bias_desc,
+                stride=(1,),
+                name="Bias",
+                extra_error_msg="Bias must be contiguous",
+            )
         if self.state_indices_desc is not None:
             self._check_tensor_stride(
                 self.state_indices_desc,
@@ -212,6 +226,8 @@ class CausalConv1dUpdateSm100(APIBase):
         self._check_dtype(self.weight_desc, dtype=torch.bfloat16, name="Weight")
         self._check_dtype(self.state_desc, dtype=torch.bfloat16, name="State")
         self._check_dtype(self.output_desc, dtype=torch.bfloat16, name="Output")
+        if self.bias_desc is not None:
+            self._check_dtype(self.bias_desc, dtype=torch.bfloat16, name="Bias")
         if self.state_indices_desc is not None:
             self._check_dtype(self.state_indices_desc, dtype=torch.int32, name="State indices")
 
@@ -228,6 +244,8 @@ class CausalConv1dUpdateSm100(APIBase):
             ("State", self.state_desc),
             ("Output", self.output_desc),
         ]
+        if self.bias_desc is not None:
+            descs.append(("Bias", self.bias_desc))
         if self.state_indices_desc is not None:
             descs.append(("State indices", self.state_indices_desc))
         for name, desc in descs:
@@ -259,6 +277,7 @@ class CausalConv1dUpdateSm100(APIBase):
 
         fake_x = self._make_fake_cute_tensor_from_desc(self.x_desc, assumed_align=16)
         fake_weight = self._make_fake_cute_tensor_from_desc(self.weight_desc, assumed_align=16)
+        fake_bias = self._make_fake_cute_tensor_from_desc(self.bias_desc, assumed_align=16)
         fake_state = self._make_fake_cute_tensor_from_desc(self.state_desc, assumed_align=16)
         fake_output = self._make_fake_cute_tensor_from_desc(self.output_desc, assumed_align=16)
         fake_state_indices = self._make_fake_cute_tensor_from_desc(self.state_indices_desc, assumed_align=4)
@@ -272,6 +291,7 @@ class CausalConv1dUpdateSm100(APIBase):
                 kernel,
                 fake_x,
                 fake_weight,
+                fake_bias,
                 fake_state,
                 fake_output,
                 fake_state_indices,
@@ -302,6 +322,7 @@ class CausalConv1dUpdateSm100(APIBase):
         output_tensor: torch.Tensor,
         state_indices_tensor: Optional[torch.Tensor] = None,
         current_stream: Optional[cuda.CUstream] = None,
+        bias_tensor: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         self._runtime_error_if(
             self._compiled_kernel is None,
@@ -312,6 +333,10 @@ class CausalConv1dUpdateSm100(APIBase):
         self._validate_runtime_tensor(weight_tensor, self.weight_desc, "Weight")
         self._validate_runtime_tensor(state_tensor, self.state_desc, "State")
         self._validate_runtime_tensor(output_tensor, self.output_desc, "Output")
+        if (bias_tensor is None) != (self.bias_desc is None):
+            raise ValueError("bias presence must match the compiled signature")
+        if bias_tensor is not None:
+            self._validate_runtime_tensor(bias_tensor, self.bias_desc, "Bias")
         if (state_indices_tensor is None) != (self.state_indices_desc is None):
             raise ValueError("state_indices presence must match the compiled signature")
         if state_indices_tensor is not None:
@@ -326,24 +351,38 @@ class CausalConv1dUpdateSm100(APIBase):
             ("Weight", weight_tensor),
             ("State", state_tensor),
             ("Output", output_tensor),
+            ("Bias", bias_tensor),
         ):
-            _require_storage_alignment(tensor, 16, name)
+            if tensor is not None:
+                _require_storage_alignment(tensor, 16, name)
         if state_indices_tensor is not None:
             _require_storage_alignment(state_indices_tensor, 4, "State indices")
 
-        if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in (x_tensor, weight_tensor, state_tensor, output_tensor)):
+        grad_tensors = (
+            x_tensor,
+            weight_tensor,
+            state_tensor,
+            output_tensor,
+            bias_tensor,
+        )
+        if torch.is_grad_enabled() and any(tensor is not None and tensor.requires_grad for tensor in grad_tensors):
             raise RuntimeError("causal_conv1d_update is inference-only; call it under torch.no_grad()")
         for name, tensor in (
             ("X", x_tensor),
             ("Weight", weight_tensor),
             ("Output", output_tensor),
+            ("Bias", bias_tensor),
         ):
-            if _tensors_overlap(state_tensor, tensor):
+            if tensor is not None and _tensors_overlap(state_tensor, tensor):
                 raise ValueError(f"State must not overlap {name}")
         if state_indices_tensor is not None and _tensors_overlap(state_tensor, state_indices_tensor):
             raise ValueError("State must not overlap State indices")
-        for name, tensor in (("X", x_tensor), ("Weight", weight_tensor)):
-            if _tensors_overlap(output_tensor, tensor):
+        for name, tensor in (
+            ("X", x_tensor),
+            ("Weight", weight_tensor),
+            ("Bias", bias_tensor),
+        ):
+            if tensor is not None and _tensors_overlap(output_tensor, tensor):
                 raise ValueError(f"Output must not overlap {name}")
         if state_indices_tensor is not None and _tensors_overlap(output_tensor, state_indices_tensor):
             raise ValueError("Output must not overlap State indices")
@@ -354,6 +393,7 @@ class CausalConv1dUpdateSm100(APIBase):
         self._compiled_kernel(
             x_tensor,
             weight_tensor,
+            bias_tensor,
             state_tensor,
             output_tensor,
             state_indices_tensor,
@@ -369,6 +409,7 @@ def _cache_key(
     state_tensor: torch.Tensor,
     weight_tensor: torch.Tensor,
     state_indices_tensor: Optional[torch.Tensor],
+    bias_tensor: Optional[torch.Tensor],
 ):
     return (
         x_tensor.device.type,
@@ -377,6 +418,7 @@ def _cache_key(
         tuple(weight_tensor.shape),
         tuple(state_tensor.shape),
         state_indices_tensor is not None,
+        bias_tensor is not None,
     )
 
 
@@ -386,13 +428,14 @@ def causal_conv1d_update(
     weight: torch.Tensor,
     state_indices: Optional[torch.Tensor] = None,
     *,
+    bias: Optional[torch.Tensor] = None,
     current_stream: Optional[cuda.CUstream] = None,
 ) -> torch.Tensor:
     """Advance a BF16 K=4 causal-convolution cache and return fused-SiLU output.
 
     ``state`` is updated in place.  This experimental operation is
-    inference-only, no-bias, and always applies SiLU. Every supported
-    architecture uses the same functional schedule. See
+    inference-only and always applies SiLU; ``bias`` is optional. Every
+    supported architecture uses the same functional schedule. See
     :class:`CausalConv1dUpdateSm100` for the exact tensor contract.
     """
 
@@ -401,9 +444,11 @@ def causal_conv1d_update(
             raise TypeError(f"{name} must be a torch.Tensor, got {type(tensor).__name__}")
     if state_indices is not None and not isinstance(state_indices, torch.Tensor):
         raise TypeError("State indices must be a torch.Tensor or None, " f"got {type(state_indices).__name__}")
+    if bias is not None and not isinstance(bias, torch.Tensor):
+        raise TypeError("Bias must be a torch.Tensor or None, " f"got {type(bias).__name__}")
     if not x.is_cuda:
         raise ValueError(f"X must be a CUDA tensor, got device {x.device}")
-    key = _cache_key(x, state, weight, state_indices)
+    key = _cache_key(x, state, weight, state_indices, bias)
 
     with torch.cuda.device(x.device), _torch_stream_context(current_stream, x.device):
         output = torch.empty_like(x, memory_format=torch.contiguous_format)
@@ -418,6 +463,7 @@ def causal_conv1d_update(
                         sample_state=state,
                         sample_output=output,
                         sample_state_indices=state_indices,
+                        sample_bias=bias,
                     )
                     api.check_support()
                     api.compile()
@@ -432,6 +478,7 @@ def causal_conv1d_update(
             output_tensor=output,
             state_indices_tensor=state_indices,
             current_stream=current_stream,
+            bias_tensor=bias,
         )
 
 
@@ -441,6 +488,7 @@ def causal_conv1d_update_wrapper_sm100(
     weight: torch.Tensor,
     state_indices: Optional[torch.Tensor] = None,
     *,
+    bias: Optional[torch.Tensor] = None,
     current_stream: Optional[cuda.CUstream] = None,
 ) -> TupleDict:
     """Run the decode update and return ``TupleDict(output_tensor=...)``.
@@ -455,6 +503,7 @@ def causal_conv1d_update_wrapper_sm100(
         state,
         weight,
         state_indices,
+        bias=bias,
         current_stream=current_stream,
     )
     return TupleDict(output_tensor=output)

--- a/python/cudnn/causal_conv1d_update_sm100/api.py
+++ b/python/cudnn/causal_conv1d_update_sm100/api.py
@@ -85,19 +85,48 @@ def _require_storage_alignment(tensor: torch.Tensor, alignment: int, name: str) 
         raise ValueError(f"{name} data pointer must be {alignment}-byte aligned, " f"got address modulo {alignment} = {remainder}")
 
 
+def _tensor_byte_span(tensor: torch.Tensor) -> tuple[int, int]:
+    """Return the conservative byte span of one positive-stride tensor."""
+
+    begin = tensor.data_ptr()
+    if tensor.numel() == 0:
+        return begin, begin
+
+    # Every operand except row-strided X is contiguous.  Keep that hot path
+    # constant-time; execute() reuses the resulting span across all alias
+    # pairs instead of rebuilding it for each comparison.
+    is_contiguous = getattr(tensor, "is_contiguous", None)
+    if is_contiguous is not None and is_contiguous():
+        return begin, begin + tensor.numel() * tensor.element_size()
+
+    shape = tuple(tensor.shape)
+    stride = tuple(tensor.stride())
+    last_element = 0
+    for dim, axis_stride in zip(shape, stride):
+        if dim > 1 and axis_stride <= 0:
+            raise ValueError("alias validation requires positive strides, " f"got shape {shape}, strides {stride}")
+        last_element += (dim - 1) * axis_stride
+    return begin, begin + (last_element + 1) * tensor.element_size()
+
+
+def _byte_spans_overlap(lhs: tuple[int, int], rhs: tuple[int, int]) -> bool:
+    lhs_begin, lhs_end = lhs
+    rhs_begin, rhs_end = rhs
+    if lhs_begin == lhs_end or rhs_begin == rhs_end:
+        return False
+    return lhs_begin < rhs_end and rhs_begin < lhs_end
+
+
 def _tensors_overlap(lhs: torch.Tensor, rhs: torch.Tensor) -> bool:
-    """Return whether two exact-contiguous tensors share any device bytes.
+    """Return whether two positive-stride tensor spans share device bytes.
 
     ``torch._C._overlaps`` only compares PyTorch Storage identity. DLPack can
-    wrap the same device address in a distinct Storage, so use the byte spans
-    guaranteed by this API's exact-contiguous tensor contract instead.
+    wrap the same device address in a distinct Storage, so compare byte spans
+    derived from shape and stride.  The span conservatively includes padding
+    between rows of a strided tensor.
     """
 
-    lhs_begin = lhs.data_ptr()
-    rhs_begin = rhs.data_ptr()
-    lhs_end = lhs_begin + lhs.numel() * lhs.element_size()
-    rhs_end = rhs_begin + rhs.numel() * rhs.element_size()
-    return lhs_begin < rhs_end and rhs_begin < lhs_end
+    return _byte_spans_overlap(_tensor_byte_span(lhs), _tensor_byte_span(rhs))
 
 
 class _CausalConv1dUpdatePlan(APIBase):
@@ -109,7 +138,9 @@ class _CausalConv1dUpdatePlan(APIBase):
     This inference-only API advances ``state`` in place and writes ``output``.
     It deliberately supports one narrow contract:
 
-    * ``x`` and ``output``: contiguous ``[N, D]`` BF16
+    * ``x``: BF16 ``[N, D]`` with strides ``(ld, 1)``; compact rows admit any
+      ``D``, while padded rows require ``ld > D`` and ``ld % 8 == 0``
+    * ``output``: contiguous ``[N, D]`` BF16
     * ``weight``: contiguous ``[D, 4]`` BF16
     * ``state``: contiguous ``[S, D, L]`` BF16 with ``L`` in ``{3, 4}``,
       mutated in place
@@ -220,11 +251,18 @@ class _CausalConv1dUpdatePlan(APIBase):
         else:
             self._check_tensor_shape(self.state_indices_desc, (n_rows,), "State indices")
 
-        self._check_tensor_stride(
-            self.x_desc,
-            stride=(n_channels, 1),
-            name="X",
-            extra_error_msg="X must be row-major contiguous",
+        x_row_stride, x_channel_stride = self.x_desc.stride
+        self._value_error_if(
+            x_channel_stride != 1,
+            f"X must have row-major strides (ld, 1), got {self.x_desc.stride}",
+        )
+        self._value_error_if(
+            x_row_stride < n_channels,
+            f"X row stride ld must be at least D={n_channels}, got ld={x_row_stride}",
+        )
+        self._value_error_if(
+            x_row_stride > n_channels and x_row_stride % 8 != 0,
+            "Padded X rows must start at 16-byte-aligned BF16 addresses " f"(ld % 8 == 0), got D={n_channels}, ld={x_row_stride}",
         )
         self._check_tensor_stride(
             self.weight_desc,
@@ -387,17 +425,19 @@ class _CausalConv1dUpdatePlan(APIBase):
                 "State indices",
             )
 
-        for name, tensor in (
-            ("X", x_tensor),
-            ("Weight", weight_tensor),
-            ("State", state_tensor),
-            ("Output", output_tensor),
-            ("Bias", bias_tensor),
-        ):
+        operands = (
+            ("X", x_tensor, 16),
+            ("Weight", weight_tensor, 16),
+            ("State", state_tensor, 16),
+            ("Output", output_tensor, 16),
+            ("Bias", bias_tensor, 16),
+            ("State indices", state_indices_tensor, 4),
+        )
+        spans = {}
+        for name, tensor, alignment in operands:
             if tensor is not None:
-                _require_storage_alignment(tensor, 16, name)
-        if state_indices_tensor is not None:
-            _require_storage_alignment(state_indices_tensor, 4, "State indices")
+                _require_storage_alignment(tensor, alignment, name)
+                spans[name] = _tensor_byte_span(tensor)
 
         grad_tensors = (
             x_tensor,
@@ -408,25 +448,19 @@ class _CausalConv1dUpdatePlan(APIBase):
         )
         if torch.is_grad_enabled() and any(tensor is not None and tensor.requires_grad for tensor in grad_tensors):
             raise RuntimeError("causal_conv1d_update is inference-only; call it under torch.no_grad()")
-        for name, tensor in (
-            ("X", x_tensor),
-            ("Weight", weight_tensor),
-            ("Output", output_tensor),
-            ("Bias", bias_tensor),
+        for owner, other in (
+            ("State", "X"),
+            ("State", "Weight"),
+            ("State", "Output"),
+            ("State", "Bias"),
+            ("State", "State indices"),
+            ("Output", "X"),
+            ("Output", "Weight"),
+            ("Output", "Bias"),
+            ("Output", "State indices"),
         ):
-            if tensor is not None and _tensors_overlap(state_tensor, tensor):
-                raise ValueError(f"State must not overlap {name}")
-        if state_indices_tensor is not None and _tensors_overlap(state_tensor, state_indices_tensor):
-            raise ValueError("State must not overlap State indices")
-        for name, tensor in (
-            ("X", x_tensor),
-            ("Weight", weight_tensor),
-            ("Bias", bias_tensor),
-        ):
-            if tensor is not None and _tensors_overlap(output_tensor, tensor):
-                raise ValueError(f"Output must not overlap {name}")
-        if state_indices_tensor is not None and _tensors_overlap(output_tensor, state_indices_tensor):
-            raise ValueError("Output must not overlap State indices")
+            if other in spans and _byte_spans_overlap(spans[owner], spans[other]):
+                raise ValueError(f"{owner} must not overlap {other}")
 
         if current_stream is None:
             consumer_stream = torch.cuda.current_stream(x_tensor.device)
@@ -472,6 +506,7 @@ def _cache_key(
         x_tensor.device.type,
         x_tensor.device.index,
         tuple(x_tensor.shape),
+        tuple(x_tensor.stride()),
         tuple(weight_tensor.shape),
         tuple(state_tensor.shape),
         state_indices_tensor is not None,

--- a/python/cudnn/causal_conv1d_update_sm100/api.py
+++ b/python/cudnn/causal_conv1d_update_sm100/api.py
@@ -1,10 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Experimental FE-OSS API for causal-convolution decode update.
+"""Private prepared implementation for causal-convolution decode update.
 
-The ``Sm100`` names are retained for API compatibility.  Every admitted
-architecture uses the same portable one-row schedule.
+The model-facing API lives at :func:`cudnn.ops.causal_conv1d_update`. This
+module owns compilation, preallocated output execution, and explicit-stream
+support used by focused benchmarks; none of those mechanics are public API.
 """
 
 import threading
@@ -21,9 +22,9 @@ from cudnn._causal_conv1d_arch import (
     is_supported_causal_conv1d_update_compute_capability,
     supported_causal_conv1d_update_compute_capabilities_text,
 )
-from cudnn.api_base import APIBase, TensorDesc, TupleDict
+from cudnn.api_base import APIBase, TensorDesc
 
-from .kernel import CausalConv1dUpdateKernel
+from .kernel import _CausalConv1dUpdateKernel
 
 _API_CACHE = {}
 _API_CACHE_LOCK = threading.Lock()
@@ -41,22 +42,39 @@ def _torch_stream_context(
         yield
         return
 
+    launch_stream = _as_torch_stream(current_stream, device)
+    with torch.cuda.stream(launch_stream):
+        yield
+
+
+def _as_torch_stream(current_stream: cuda.CUstream, device: torch.device) -> torch.cuda.Stream:
+    """Resolve a concrete driver handle to the matching PyTorch stream."""
+
     handle = int(current_stream)
     torch_current = torch.cuda.current_stream(device)
     torch_default = torch.cuda.default_stream(device)
     if handle in (0, 1, torch_default.cuda_stream):
-        launch_stream = torch_default
-    elif handle == 2:
+        return torch_default
+    if handle == 2:
         # CU_STREAM_PER_THREAD cannot be represented safely as a PyTorch
-        # ExternalStream on every supported build.  The class API remains
-        # available to callers that own a preallocated output on that stream.
+        # ExternalStream on every supported build.
         raise ValueError("causal_conv1d_update helpers do not support the " "CU_STREAM_PER_THREAD sentinel; pass a concrete stream handle")
-    elif handle == torch_current.cuda_stream:
-        launch_stream = torch_current
-    else:
-        launch_stream = torch.cuda.ExternalStream(handle, device=device)
-    with torch.cuda.stream(launch_stream):
-        yield
+    if handle == torch_current.cuda_stream:
+        return torch_current
+    return torch.cuda.ExternalStream(handle, device=device)
+
+
+def _record_streams(
+    tensors: tuple[Optional[torch.Tensor], ...],
+    consumer: Optional[torch.cuda.Stream],
+) -> None:
+    """Keep raw-pointer operands alive through an explicit-stream launch."""
+
+    if consumer is None:
+        return
+    for tensor in tensors:
+        if tensor is not None:
+            tensor.record_stream(consumer)
 
 
 def _require_storage_alignment(tensor: torch.Tensor, alignment: int, name: str) -> None:
@@ -68,34 +86,42 @@ def _require_storage_alignment(tensor: torch.Tensor, alignment: int, name: str) 
 
 
 def _tensors_overlap(lhs: torch.Tensor, rhs: torch.Tensor) -> bool:
-    """Conservative storage-overlap check used by the mutating public API."""
+    """Return whether two exact-contiguous tensors share any device bytes.
 
-    overlaps = getattr(torch._C, "_overlaps", None)
-    if overlaps is not None:
-        return bool(overlaps(lhs, rhs))
-    return lhs.untyped_storage().data_ptr() == rhs.untyped_storage().data_ptr()
+    ``torch._C._overlaps`` only compares PyTorch Storage identity. DLPack can
+    wrap the same device address in a distinct Storage, so use the byte spans
+    guaranteed by this API's exact-contiguous tensor contract instead.
+    """
+
+    lhs_begin = lhs.data_ptr()
+    rhs_begin = rhs.data_ptr()
+    lhs_end = lhs_begin + lhs.numel() * lhs.element_size()
+    rhs_end = rhs_begin + rhs.numel() * rhs.element_size()
+    return lhs_begin < rhs_end and rhs_begin < lhs_end
 
 
-class CausalConv1dUpdateSm100(APIBase):
+class _CausalConv1dUpdatePlan(APIBase):
     """Compile and execute BF16 K=4 causal-convolution decode.
 
-    The class name is retained for compatibility. Compute capabilities 8.0,
-    8.6, 8.7, 8.9, 9.0, 10.0, 10.3, 11.0, 12.0, and 12.1 use the same
-    functional schedule.
+    Every compute capability admitted by the decode architecture policy uses
+    the same functional schedule.
 
     This inference-only API advances ``state`` in place and writes ``output``.
     It deliberately supports one narrow contract:
 
     * ``x`` and ``output``: contiguous ``[N, D]`` BF16
     * ``weight``: contiguous ``[D, 4]`` BF16
-    * ``state``: contiguous ``[S, D, 4]`` BF16, mutated in place
+    * ``state``: contiguous ``[S, D, L]`` BF16 with ``L`` in ``{3, 4}``,
+      mutated in place
     * optional ``state_indices``: contiguous CUDA ``int32[N]``
-    * optional ``bias``: contiguous ``[D]`` BF16; SiLU is always fused
+    * optional ``bias``: contiguous ``[D]`` BF16
+    * ``activation``: compile-time ``"identity"`` or ``"silu"``
 
-    Indexed slots must be in ``[0, S)`` and unique.  The kernel checks both
-    properties on device and executes a PTX trap on violation, so invalid
-    mutable routing never silently races.  The CUDA error is asynchronous and
-    the failed launch is not transactional.
+    Indexed slots must be ``-1`` or in ``[0, S)``.  ``-1`` marks a padding row
+    whose output is zero and whose state is untouched.  Non-padding slots must
+    be unique.  The kernel checks these properties on device and executes a
+    PTX trap on violation, so invalid mutable routing never silently races.
+    The CUDA error is asynchronous and the failed launch is not transactional.
     """
 
     def __init__(
@@ -106,6 +132,8 @@ class CausalConv1dUpdateSm100(APIBase):
         sample_output: Union[torch.Tensor, TensorDesc],
         sample_state_indices: Optional[Union[torch.Tensor, TensorDesc]] = None,
         sample_bias: Optional[Union[torch.Tensor, TensorDesc]] = None,
+        *,
+        activation: str = "identity",
     ):
         super().__init__()
         self._warn_experimental_api()
@@ -116,6 +144,9 @@ class CausalConv1dUpdateSm100(APIBase):
         self.output_desc = self._make_tensor_desc(sample_output, name="sample_output")
         self.state_indices_desc = self._make_tensor_desc(sample_state_indices, name="sample_state_indices")
         self.bias_desc = self._make_tensor_desc(sample_bias, name="sample_bias")
+        if activation not in ("identity", "silu"):
+            raise ValueError(f"activation must be 'identity' or 'silu', got {activation!r}")
+        self.activation = activation
 
         # TensorDesc deliberately does not retain sample tensors.  Preserve
         # only the pointer remainders needed to validate the assumed alignment
@@ -137,6 +168,7 @@ class CausalConv1dUpdateSm100(APIBase):
         self.n_rows = None
         self.n_channels = None
         self.n_slots = None
+        self.state_len = None
 
     @staticmethod
     def _require_rank(desc: TensorDesc, rank: int, name: str) -> None:
@@ -160,6 +192,7 @@ class CausalConv1dUpdateSm100(APIBase):
 
         n_rows, n_channels = self.x_desc.shape
         n_slots = self.state_desc.shape[0]
+        state_len = self.state_desc.shape[2]
         self._value_error_if(n_rows <= 0, f"N must be positive, got {n_rows}")
         self._value_error_if(n_channels <= 0, f"D must be positive, got {n_channels}")
         self._value_error_if(n_slots <= 0, f"S must be positive, got {n_slots}")
@@ -169,9 +202,13 @@ class CausalConv1dUpdateSm100(APIBase):
             n_channels > 256 * 65535,
             f"D exceeds the CUDA grid-y limit for 256-channel tiles: {n_channels}",
         )
+        self._value_error_if(
+            state_len not in (3, 4),
+            f"State length must be 3 or 4 for width-four decode, got L={state_len}",
+        )
 
         self._check_tensor_shape(self.weight_desc, (n_channels, 4), "Weight")
-        self._check_tensor_shape(self.state_desc, (n_slots, n_channels, 4), "State")
+        self._check_tensor_shape(self.state_desc, (n_slots, n_channels, state_len), "State")
         self._check_tensor_shape(self.output_desc, (n_rows, n_channels), "Output")
         if self.bias_desc is not None:
             self._check_tensor_shape(self.bias_desc, (n_channels,), "Bias")
@@ -197,7 +234,7 @@ class CausalConv1dUpdateSm100(APIBase):
         )
         self._check_tensor_stride(
             self.state_desc,
-            stride=(n_channels * 4, 4, 1),
+            stride=(n_channels * state_len, state_len, 1),
             name="State",
             extra_error_msg="State must be row-major contiguous",
         )
@@ -259,7 +296,7 @@ class CausalConv1dUpdateSm100(APIBase):
         compute_capability = torch.cuda.get_device_capability(self.x_desc.device)
         self._runtime_error_if(
             not is_supported_causal_conv1d_update_compute_capability(compute_capability),
-            "CausalConv1dUpdateSm100 supports compute capabilities "
+            "causal_conv1d_update supports compute capabilities "
             f"{supported_causal_conv1d_update_compute_capabilities_text()}, "
             f"found {compute_capability[0]}.{compute_capability[1]}",
         )
@@ -267,6 +304,7 @@ class CausalConv1dUpdateSm100(APIBase):
         self.n_rows = n_rows
         self.n_channels = n_channels
         self.n_slots = n_slots
+        self.state_len = state_len
         self._is_supported = True
         return True
 
@@ -283,7 +321,10 @@ class CausalConv1dUpdateSm100(APIBase):
         fake_state_indices = self._make_fake_cute_tensor_from_desc(self.state_indices_desc, assumed_align=4)
         fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
 
-        kernel = CausalConv1dUpdateKernel()
+        kernel = _CausalConv1dUpdateKernel(
+            apply_silu=self.activation == "silu",
+            state_len=self.state_len,
+        )
         # CuTe DSL targets the current CUDA device.  Honor the sample tensor's
         # device even when a multi-GPU caller has another device current.
         with torch.cuda.device(self.x_desc.device):
@@ -326,7 +367,7 @@ class CausalConv1dUpdateSm100(APIBase):
     ) -> torch.Tensor:
         self._runtime_error_if(
             self._compiled_kernel is None,
-            "CausalConv1dUpdateSm100 kernel not compiled; call compile() first",
+            "causal_conv1d_update plan not compiled; call compile() first",
         )
 
         self._validate_runtime_tensor(x_tensor, self.x_desc, "X")
@@ -388,7 +429,11 @@ class CausalConv1dUpdateSm100(APIBase):
             raise ValueError("Output must not overlap State indices")
 
         if current_stream is None:
-            current_stream = cuda.CUstream(torch.cuda.current_stream(x_tensor.device).cuda_stream)
+            consumer_stream = torch.cuda.current_stream(x_tensor.device)
+            launch_stream = cuda.CUstream(consumer_stream.cuda_stream)
+        else:
+            consumer_stream = _as_torch_stream(current_stream, x_tensor.device)
+            launch_stream = current_stream
 
         self._compiled_kernel(
             x_tensor,
@@ -399,7 +444,18 @@ class CausalConv1dUpdateSm100(APIBase):
             state_indices_tensor,
             cutlass.Int32(self.n_slots),
             cutlass.Int32(self.n_channels),
-            current_stream,
+            launch_stream,
+        )
+        _record_streams(
+            (
+                x_tensor,
+                weight_tensor,
+                bias_tensor,
+                state_tensor,
+                output_tensor,
+                state_indices_tensor,
+            ),
+            consumer_stream,
         )
         return output_tensor
 
@@ -410,6 +466,7 @@ def _cache_key(
     weight_tensor: torch.Tensor,
     state_indices_tensor: Optional[torch.Tensor],
     bias_tensor: Optional[torch.Tensor],
+    activation: str,
 ):
     return (
         x_tensor.device.type,
@@ -419,36 +476,40 @@ def _cache_key(
         tuple(state_tensor.shape),
         state_indices_tensor is not None,
         bias_tensor is not None,
+        activation,
     )
 
 
-def causal_conv1d_update(
+def _causal_conv1d_update(
     x: torch.Tensor,
-    state: torch.Tensor,
+    conv_state: torch.Tensor,
     weight: torch.Tensor,
-    state_indices: Optional[torch.Tensor] = None,
-    *,
     bias: Optional[torch.Tensor] = None,
+    activation: str = "identity",
+    *,
+    conv_state_indices: Optional[torch.Tensor] = None,
     current_stream: Optional[cuda.CUstream] = None,
 ) -> torch.Tensor:
-    """Advance a BF16 K=4 causal-convolution cache and return fused-SiLU output.
+    """Private allocating route used by the public custom op and FLA adapter.
 
-    ``state`` is updated in place.  This experimental operation is
-    inference-only and always applies SiLU; ``bias`` is optional. Every
-    supported architecture uses the same functional schedule. See
-    :class:`CausalConv1dUpdateSm100` for the exact tensor contract.
+    ``conv_state`` is updated in place. ``activation`` is already normalized
+    to ``"identity"`` or ``"silu"`` by the public semantic API. Explicit
+    streams remain private because the public PyTorch operation follows the
+    current-stream convention.
     """
 
-    for name, tensor in (("X", x), ("Weight", weight), ("State", state)):
+    for name, tensor in (("X", x), ("Weight", weight), ("State", conv_state)):
         if not isinstance(tensor, torch.Tensor):
             raise TypeError(f"{name} must be a torch.Tensor, got {type(tensor).__name__}")
-    if state_indices is not None and not isinstance(state_indices, torch.Tensor):
-        raise TypeError("State indices must be a torch.Tensor or None, " f"got {type(state_indices).__name__}")
+    if conv_state_indices is not None and not isinstance(conv_state_indices, torch.Tensor):
+        raise TypeError("State indices must be a torch.Tensor or None, " f"got {type(conv_state_indices).__name__}")
     if bias is not None and not isinstance(bias, torch.Tensor):
         raise TypeError("Bias must be a torch.Tensor or None, " f"got {type(bias).__name__}")
+    if activation not in ("identity", "silu"):
+        raise ValueError(f"activation must be 'identity' or 'silu', got {activation!r}")
     if not x.is_cuda:
         raise ValueError(f"X must be a CUDA tensor, got device {x.device}")
-    key = _cache_key(x, state, weight, state_indices, bias)
+    key = _cache_key(x, conv_state, weight, conv_state_indices, bias, activation)
 
     with torch.cuda.device(x.device), _torch_stream_context(current_stream, x.device):
         output = torch.empty_like(x, memory_format=torch.contiguous_format)
@@ -457,13 +518,14 @@ def causal_conv1d_update(
             with _API_CACHE_LOCK:
                 api = _API_CACHE.get(key)
                 if api is None:
-                    api = CausalConv1dUpdateSm100(
+                    api = _CausalConv1dUpdatePlan(
                         sample_x=x,
                         sample_weight=weight,
-                        sample_state=state,
+                        sample_state=conv_state,
                         sample_output=output,
-                        sample_state_indices=state_indices,
+                        sample_state_indices=conv_state_indices,
                         sample_bias=bias,
+                        activation=activation,
                     )
                     api.check_support()
                     api.compile()
@@ -474,36 +536,9 @@ def causal_conv1d_update(
         return api.execute(
             x_tensor=x,
             weight_tensor=weight,
-            state_tensor=state,
+            state_tensor=conv_state,
             output_tensor=output,
-            state_indices_tensor=state_indices,
+            state_indices_tensor=conv_state_indices,
             current_stream=current_stream,
             bias_tensor=bias,
         )
-
-
-def causal_conv1d_update_wrapper_sm100(
-    x: torch.Tensor,
-    state: torch.Tensor,
-    weight: torch.Tensor,
-    state_indices: Optional[torch.Tensor] = None,
-    *,
-    bias: Optional[torch.Tensor] = None,
-    current_stream: Optional[cuda.CUstream] = None,
-) -> TupleDict:
-    """Run the decode update and return ``TupleDict(output_tensor=...)``.
-
-    The function name is retained for compatibility.  ``state`` is updated in
-    place.  Use :func:`causal_conv1d_update` when a direct Tensor return is more
-    convenient for model-integration shims.
-    """
-
-    output = causal_conv1d_update(
-        x,
-        state,
-        weight,
-        state_indices,
-        bias=bias,
-        current_stream=current_stream,
-    )
-    return TupleDict(output_tensor=output)

--- a/python/cudnn/causal_conv1d_update_sm100/api.py
+++ b/python/cudnn/causal_conv1d_update_sm100/api.py
@@ -358,8 +358,8 @@ class CausalConv1dUpdateSm100(APIBase):
 
 def _cache_key(
     x_tensor: torch.Tensor,
-    weight_tensor: torch.Tensor,
     state_tensor: torch.Tensor,
+    weight_tensor: torch.Tensor,
     state_indices_tensor: Optional[torch.Tensor],
 ):
     return (
@@ -374,8 +374,8 @@ def _cache_key(
 
 def causal_conv1d_update(
     x: torch.Tensor,
-    weight: torch.Tensor,
     state: torch.Tensor,
+    weight: torch.Tensor,
     state_indices: Optional[torch.Tensor] = None,
     *,
     current_stream: Optional[cuda.CUstream] = None,
@@ -394,7 +394,7 @@ def causal_conv1d_update(
         raise TypeError("State indices must be a torch.Tensor or None, " f"got {type(state_indices).__name__}")
     if not x.is_cuda:
         raise ValueError(f"X must be a CUDA tensor, got device {x.device}")
-    key = _cache_key(x, weight, state, state_indices)
+    key = _cache_key(x, state, weight, state_indices)
 
     with torch.cuda.device(x.device), _torch_stream_context(current_stream, x.device):
         output = torch.empty_like(x, memory_format=torch.contiguous_format)
@@ -428,8 +428,8 @@ def causal_conv1d_update(
 
 def causal_conv1d_update_wrapper_sm100(
     x: torch.Tensor,
-    weight: torch.Tensor,
     state: torch.Tensor,
+    weight: torch.Tensor,
     state_indices: Optional[torch.Tensor] = None,
     *,
     current_stream: Optional[cuda.CUstream] = None,
@@ -442,8 +442,8 @@ def causal_conv1d_update_wrapper_sm100(
 
     output = causal_conv1d_update(
         x,
-        weight,
         state,
+        weight,
         state_indices,
         current_stream=current_stream,
     )

--- a/python/cudnn/causal_conv1d_update_sm100/api.py
+++ b/python/cudnn/causal_conv1d_update_sm100/api.py
@@ -1,18 +1,28 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Experimental FE-OSS API for SM100 causal-convolution decode update."""
+"""Experimental FE-OSS API for causal-convolution decode update.
 
-from contextlib import contextmanager
+The ``Sm100`` names are retained for API compatibility.  SM100 has the tuned
+row-batch schedule; other admitted architectures use the portable one-row
+schedule.
+"""
+
 import threading
+from contextlib import contextmanager
 from typing import Iterator, Optional
 
-from cuda.bindings import driver as cuda
 import cutlass
 import cutlass.cute as cute
-from cutlass.cute.runtime import make_fake_stream
 import torch
+from cuda.bindings import driver as cuda
+from cutlass.cute.runtime import make_fake_stream
 
+from cudnn._causal_conv1d_arch import (
+    is_supported_causal_conv1d_update_compute_capability,
+    supported_causal_conv1d_update_compute_capabilities_text,
+    uses_sm100_causal_conv1d_update_schedule,
+)
 from cudnn.api_base import APIBase, TensorDesc, TupleDict
 
 from .kernel import (
@@ -73,7 +83,11 @@ def _tensors_overlap(lhs: torch.Tensor, rhs: torch.Tensor) -> bool:
 
 
 class CausalConv1dUpdateSm100(APIBase):
-    """Compile and execute BF16 K=4 causal-convolution decode on SM100.
+    """Compile and execute BF16 K=4 causal-convolution decode.
+
+    The class name is retained for compatibility.  SM100 uses the optimized
+    schedule; compute capabilities 8.0, 8.6, 8.7, 8.9, 9.0, 10.3, 11.0, 12.0,
+    and 12.1 use a conservative functional schedule.
 
     This inference-only API advances ``state`` in place and writes ``output``.
     It deliberately supports one narrow contract:
@@ -229,8 +243,10 @@ class CausalConv1dUpdateSm100(APIBase):
         self._runtime_error_if(not torch.cuda.is_available(), "CUDA is not available")
         compute_capability = torch.cuda.get_device_capability(self.x_desc.device)
         self._runtime_error_if(
-            compute_capability != (10, 0),
-            "CausalConv1dUpdateSm100 requires exactly SM100 " f"(compute capability 10.0), found {compute_capability[0]}.{compute_capability[1]}",
+            not is_supported_causal_conv1d_update_compute_capability(compute_capability),
+            "CausalConv1dUpdateSm100 supports compute capabilities "
+            f"{supported_causal_conv1d_update_compute_capabilities_text()}, "
+            f"found {compute_capability[0]}.{compute_capability[1]}",
         )
 
         self.n_rows = n_rows
@@ -240,6 +256,7 @@ class CausalConv1dUpdateSm100(APIBase):
             n_rows,
             n_channels,
             self.state_indices_desc is not None,
+            use_sm100_optimized_schedule=uses_sm100_causal_conv1d_update_schedule(compute_capability),
         )
         self._is_supported = True
         return True
@@ -382,8 +399,9 @@ def causal_conv1d_update(
 ) -> torch.Tensor:
     """Advance a BF16 K=4 causal-convolution cache and return fused-SiLU output.
 
-    ``state`` is updated in place.  This experimental operation is SM100-only,
-    inference-only, no-bias, and always applies SiLU.  See
+    ``state`` is updated in place.  This experimental operation is
+    inference-only, no-bias, and always applies SiLU.  SM100 uses the optimized
+    schedule; other supported architectures use the functional schedule.  See
     :class:`CausalConv1dUpdateSm100` for the exact tensor contract.
     """
 
@@ -434,10 +452,11 @@ def causal_conv1d_update_wrapper_sm100(
     *,
     current_stream: Optional[cuda.CUstream] = None,
 ) -> TupleDict:
-    """Run the SM100 decode update and return ``TupleDict(output_tensor=...)``.
+    """Run the decode update and return ``TupleDict(output_tensor=...)``.
 
-    ``state`` is updated in place.  Use :func:`causal_conv1d_update` when a
-    direct Tensor return is more convenient for model-integration shims.
+    The function name is retained for compatibility.  ``state`` is updated in
+    place.  Use :func:`causal_conv1d_update` when a direct Tensor return is more
+    convenient for model-integration shims.
     """
 
     output = causal_conv1d_update(

--- a/python/cudnn/causal_conv1d_update_sm100/api.py
+++ b/python/cudnn/causal_conv1d_update_sm100/api.py
@@ -15,7 +15,11 @@ import torch
 
 from cudnn.api_base import APIBase, TensorDesc, TupleDict
 
-from .kernel import CausalConv1dUpdateKernel
+from .kernel import (
+    CausalConv1dUpdateKernel,
+    CausalConv1dUpdateRowBatchKernel,
+    select_rows_per_cta,
+)
 
 _API_CACHE = {}
 _API_CACHE_LOCK = threading.Lock()
@@ -118,6 +122,7 @@ class CausalConv1dUpdateSm100(APIBase):
         self.n_rows = None
         self.n_channels = None
         self.n_slots = None
+        self.rows_per_cta = None
 
     @staticmethod
     def _require_rank(desc: TensorDesc, rank: int, name: str) -> None:
@@ -231,6 +236,11 @@ class CausalConv1dUpdateSm100(APIBase):
         self.n_rows = n_rows
         self.n_channels = n_channels
         self.n_slots = n_slots
+        self.rows_per_cta = select_rows_per_cta(
+            n_rows,
+            n_channels,
+            self.state_indices_desc is not None,
+        )
         self._is_supported = True
         return True
 
@@ -246,7 +256,7 @@ class CausalConv1dUpdateSm100(APIBase):
         fake_state_indices = self._make_fake_cute_tensor_from_desc(self.state_indices_desc, assumed_align=4)
         fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
 
-        kernel = CausalConv1dUpdateKernel()
+        kernel = CausalConv1dUpdateRowBatchKernel() if self.rows_per_cta == 2 else CausalConv1dUpdateKernel()
         # CuTe DSL targets the current CUDA device.  Honor the sample tensor's
         # device even when a multi-GPU caller has another device current.
         with torch.cuda.device(self.x_desc.device):

--- a/python/cudnn/causal_conv1d_update_sm100/api.py
+++ b/python/cudnn/causal_conv1d_update_sm100/api.py
@@ -10,7 +10,7 @@ schedule.
 
 import threading
 from contextlib import contextmanager
-from typing import Iterator, Optional
+from typing import Iterator, Optional, Union
 
 import cutlass
 import cutlass.cute as cute
@@ -106,11 +106,11 @@ class CausalConv1dUpdateSm100(APIBase):
 
     def __init__(
         self,
-        sample_x: torch.Tensor,
-        sample_weight: torch.Tensor,
-        sample_state: torch.Tensor,
-        sample_output: torch.Tensor,
-        sample_state_indices: Optional[torch.Tensor] = None,
+        sample_x: Union[torch.Tensor, TensorDesc],
+        sample_weight: Union[torch.Tensor, TensorDesc],
+        sample_state: Union[torch.Tensor, TensorDesc],
+        sample_output: Union[torch.Tensor, TensorDesc],
+        sample_state_indices: Optional[Union[torch.Tensor, TensorDesc]] = None,
     ):
         super().__init__()
         self._warn_experimental_api()
@@ -123,15 +123,19 @@ class CausalConv1dUpdateSm100(APIBase):
 
         # TensorDesc deliberately does not retain sample tensors.  Preserve
         # only the pointer remainders needed to validate the assumed alignment
-        # passed to make_fake_cute_tensor_from_desc().
-        self._sample_alignment_remainders = {
-            "X": sample_x.data_ptr() % 16,
-            "Weight": sample_weight.data_ptr() % 16,
-            "State": sample_state.data_ptr() % 16,
-            "Output": sample_output.data_ptr() % 16,
-        }
-        if sample_state_indices is not None:
-            self._sample_alignment_remainders["State indices"] = sample_state_indices.data_ptr() % 4
+        # passed to make_fake_cute_tensor_from_desc().  Metadata-only samples
+        # defer this check to the live tensors validated by execute().
+        self._sample_alignment_remainders = {}
+        for name, sample, alignment in (
+            ("X", sample_x, 16),
+            ("Weight", sample_weight, 16),
+            ("State", sample_state, 16),
+            ("Output", sample_output, 16),
+            ("State indices", sample_state_indices, 4),
+        ):
+            data_ptr = getattr(sample, "data_ptr", None)
+            if callable(data_ptr):
+                self._sample_alignment_remainders[name] = data_ptr() % alignment
 
         self.n_rows = None
         self.n_channels = None

--- a/python/cudnn/causal_conv1d_update_sm100/api.py
+++ b/python/cudnn/causal_conv1d_update_sm100/api.py
@@ -1,0 +1,440 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Experimental FE-OSS API for SM100 causal-convolution decode update."""
+
+from contextlib import contextmanager
+import threading
+from typing import Iterator, Optional
+
+from cuda.bindings import driver as cuda
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.runtime import make_fake_stream
+import torch
+
+from cudnn.api_base import APIBase, TensorDesc, TupleDict
+
+from .kernel import CausalConv1dUpdateKernel
+
+_API_CACHE = {}
+_API_CACHE_LOCK = threading.Lock()
+_API_CACHE_CAPACITY = 128
+
+
+@contextmanager
+def _torch_stream_context(
+    current_stream: Optional[cuda.CUstream],
+    device: torch.device,
+) -> Iterator[None]:
+    """Run PyTorch allocations on the CUDA stream used by the kernel."""
+
+    if current_stream is None:
+        yield
+        return
+
+    handle = int(current_stream)
+    torch_current = torch.cuda.current_stream(device)
+    torch_default = torch.cuda.default_stream(device)
+    if handle in (0, 1, torch_default.cuda_stream):
+        launch_stream = torch_default
+    elif handle == 2:
+        # CU_STREAM_PER_THREAD cannot be represented safely as a PyTorch
+        # ExternalStream on every supported build.  The class API remains
+        # available to callers that own a preallocated output on that stream.
+        raise ValueError("causal_conv1d_update helpers do not support the " "CU_STREAM_PER_THREAD sentinel; pass a concrete stream handle")
+    elif handle == torch_current.cuda_stream:
+        launch_stream = torch_current
+    else:
+        launch_stream = torch.cuda.ExternalStream(handle, device=device)
+    with torch.cuda.stream(launch_stream):
+        yield
+
+
+def _require_storage_alignment(tensor: torch.Tensor, alignment: int, name: str) -> None:
+    """Enforce the runtime alignment promised to CuTe during compilation."""
+
+    remainder = tensor.data_ptr() % alignment
+    if remainder:
+        raise ValueError(f"{name} data pointer must be {alignment}-byte aligned, " f"got address modulo {alignment} = {remainder}")
+
+
+def _tensors_overlap(lhs: torch.Tensor, rhs: torch.Tensor) -> bool:
+    """Conservative storage-overlap check used by the mutating public API."""
+
+    overlaps = getattr(torch._C, "_overlaps", None)
+    if overlaps is not None:
+        return bool(overlaps(lhs, rhs))
+    return lhs.untyped_storage().data_ptr() == rhs.untyped_storage().data_ptr()
+
+
+class CausalConv1dUpdateSm100(APIBase):
+    """Compile and execute BF16 K=4 causal-convolution decode on SM100.
+
+    This inference-only API advances ``state`` in place and writes ``output``.
+    It deliberately supports one narrow contract:
+
+    * ``x`` and ``output``: contiguous ``[N, D]`` BF16
+    * ``weight``: contiguous ``[D, 4]`` BF16
+    * ``state``: contiguous ``[S, D, 4]`` BF16, mutated in place
+    * optional ``state_indices``: contiguous CUDA ``int32[N]``
+    * no bias; SiLU is always fused
+
+    Indexed slots must be in ``[0, S)`` and unique.  The kernel checks both
+    properties on device and executes a PTX trap on violation, so invalid
+    mutable routing never silently races.  The CUDA error is asynchronous and
+    the failed launch is not transactional.
+    """
+
+    def __init__(
+        self,
+        sample_x: torch.Tensor,
+        sample_weight: torch.Tensor,
+        sample_state: torch.Tensor,
+        sample_output: torch.Tensor,
+        sample_state_indices: Optional[torch.Tensor] = None,
+    ):
+        super().__init__()
+        self._warn_experimental_api()
+
+        self.x_desc = self._make_tensor_desc(sample_x, name="sample_x")
+        self.weight_desc = self._make_tensor_desc(sample_weight, name="sample_weight")
+        self.state_desc = self._make_tensor_desc(sample_state, name="sample_state")
+        self.output_desc = self._make_tensor_desc(sample_output, name="sample_output")
+        self.state_indices_desc = self._make_tensor_desc(sample_state_indices, name="sample_state_indices")
+
+        # TensorDesc deliberately does not retain sample tensors.  Preserve
+        # only the pointer remainders needed to validate the assumed alignment
+        # passed to make_fake_cute_tensor_from_desc().
+        self._sample_alignment_remainders = {
+            "X": sample_x.data_ptr() % 16,
+            "Weight": sample_weight.data_ptr() % 16,
+            "State": sample_state.data_ptr() % 16,
+            "Output": sample_output.data_ptr() % 16,
+        }
+        if sample_state_indices is not None:
+            self._sample_alignment_remainders["State indices"] = sample_state_indices.data_ptr() % 4
+
+        self.n_rows = None
+        self.n_channels = None
+        self.n_slots = None
+
+    @staticmethod
+    def _require_rank(desc: TensorDesc, rank: int, name: str) -> None:
+        if desc.ndim != rank:
+            raise ValueError(f"{name} must be {rank}D, got shape {desc.shape}")
+
+    @staticmethod
+    def _require_cuda(desc: TensorDesc, name: str) -> None:
+        if desc.device.type != "cuda":
+            raise ValueError(f"{name} must be a CUDA tensor, got device {desc.device}")
+
+    def check_support(self) -> bool:
+        self._require_rank(self.x_desc, 2, "X")
+        self._require_rank(self.weight_desc, 2, "Weight")
+        self._require_rank(self.state_desc, 3, "State")
+        self._require_rank(self.output_desc, 2, "Output")
+        if self.state_indices_desc is not None:
+            self._require_rank(self.state_indices_desc, 1, "State indices")
+
+        n_rows, n_channels = self.x_desc.shape
+        n_slots = self.state_desc.shape[0]
+        self._value_error_if(n_rows <= 0, f"N must be positive, got {n_rows}")
+        self._value_error_if(n_channels <= 0, f"D must be positive, got {n_channels}")
+        self._value_error_if(n_slots <= 0, f"S must be positive, got {n_slots}")
+        self._value_error_if(n_rows > 2**31 - 1, f"N exceeds the Int32 launch limit: {n_rows}")
+        self._value_error_if(n_slots > 2**31 - 1, f"S exceeds the Int32 indexing limit: {n_slots}")
+        self._value_error_if(
+            n_channels > 256 * 65535,
+            f"D exceeds the CUDA grid-y limit for 256-channel tiles: {n_channels}",
+        )
+
+        self._check_tensor_shape(self.weight_desc, (n_channels, 4), "Weight")
+        self._check_tensor_shape(self.state_desc, (n_slots, n_channels, 4), "State")
+        self._check_tensor_shape(self.output_desc, (n_rows, n_channels), "Output")
+        if self.state_indices_desc is None:
+            self._value_error_if(
+                n_slots < n_rows,
+                f"State needs at least N slots when state_indices is omitted, got S={n_slots}, N={n_rows}",
+            )
+        else:
+            self._check_tensor_shape(self.state_indices_desc, (n_rows,), "State indices")
+
+        self._check_tensor_stride(
+            self.x_desc,
+            stride=(n_channels, 1),
+            name="X",
+            extra_error_msg="X must be row-major contiguous",
+        )
+        self._check_tensor_stride(
+            self.weight_desc,
+            stride=(4, 1),
+            name="Weight",
+            extra_error_msg="Weight must be row-major contiguous",
+        )
+        self._check_tensor_stride(
+            self.state_desc,
+            stride=(n_channels * 4, 4, 1),
+            name="State",
+            extra_error_msg="State must be row-major contiguous",
+        )
+        self._check_tensor_stride(
+            self.output_desc,
+            stride=(n_channels, 1),
+            name="Output",
+            extra_error_msg="Output must be row-major contiguous",
+        )
+        if self.state_indices_desc is not None:
+            self._check_tensor_stride(
+                self.state_indices_desc,
+                stride=(1,),
+                name="State indices",
+                extra_error_msg="State indices must be contiguous",
+            )
+
+        self._check_dtype(self.x_desc, dtype=torch.bfloat16, name="X")
+        self._check_dtype(self.weight_desc, dtype=torch.bfloat16, name="Weight")
+        self._check_dtype(self.state_desc, dtype=torch.bfloat16, name="State")
+        self._check_dtype(self.output_desc, dtype=torch.bfloat16, name="Output")
+        if self.state_indices_desc is not None:
+            self._check_dtype(self.state_indices_desc, dtype=torch.int32, name="State indices")
+
+        for name, remainder in self._sample_alignment_remainders.items():
+            alignment = 4 if name == "State indices" else 16
+            self._value_error_if(
+                remainder != 0,
+                f"{name} data pointer must be {alignment}-byte aligned, " f"got address modulo {alignment} = {remainder}",
+            )
+
+        descs = [
+            ("X", self.x_desc),
+            ("Weight", self.weight_desc),
+            ("State", self.state_desc),
+            ("Output", self.output_desc),
+        ]
+        if self.state_indices_desc is not None:
+            descs.append(("State indices", self.state_indices_desc))
+        for name, desc in descs:
+            self._require_cuda(desc, name)
+            self._value_error_if(
+                desc.device != self.x_desc.device,
+                f"{name} must be on {self.x_desc.device}, got {desc.device}",
+            )
+
+        self._runtime_error_if(not torch.cuda.is_available(), "CUDA is not available")
+        compute_capability = torch.cuda.get_device_capability(self.x_desc.device)
+        self._runtime_error_if(
+            compute_capability != (10, 0),
+            "CausalConv1dUpdateSm100 requires exactly SM100 " f"(compute capability 10.0), found {compute_capability[0]}.{compute_capability[1]}",
+        )
+
+        self.n_rows = n_rows
+        self.n_channels = n_channels
+        self.n_slots = n_slots
+        self._is_supported = True
+        return True
+
+    def compile(self) -> None:
+        self._ensure_support_checked()
+        if self._compiled_kernel is not None:
+            return
+
+        fake_x = self._make_fake_cute_tensor_from_desc(self.x_desc, assumed_align=16)
+        fake_weight = self._make_fake_cute_tensor_from_desc(self.weight_desc, assumed_align=16)
+        fake_state = self._make_fake_cute_tensor_from_desc(self.state_desc, assumed_align=16)
+        fake_output = self._make_fake_cute_tensor_from_desc(self.output_desc, assumed_align=16)
+        fake_state_indices = self._make_fake_cute_tensor_from_desc(self.state_indices_desc, assumed_align=4)
+        fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
+
+        kernel = CausalConv1dUpdateKernel()
+        # CuTe DSL targets the current CUDA device.  Honor the sample tensor's
+        # device even when a multi-GPU caller has another device current.
+        with torch.cuda.device(self.x_desc.device):
+            self._compiled_kernel = cute.compile(
+                kernel,
+                fake_x,
+                fake_weight,
+                fake_state,
+                fake_output,
+                fake_state_indices,
+                cutlass.Int32(self.n_slots),
+                cutlass.Int32(self.n_channels),
+                fake_stream,
+                options="--enable-tvm-ffi --generate-line-info",
+            )
+
+    @staticmethod
+    def _validate_runtime_tensor(tensor: torch.Tensor, desc: TensorDesc, name: str) -> None:
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(f"{name} must be a torch.Tensor, got {type(tensor).__name__}")
+        if tuple(tensor.shape) != desc.shape:
+            raise ValueError(f"{name} shape mismatch: expected {desc.shape}, got {tuple(tensor.shape)}")
+        if tuple(tensor.stride()) != desc.stride:
+            raise ValueError(f"{name} stride mismatch: expected {desc.stride}, got {tuple(tensor.stride())}")
+        if tensor.dtype != desc.dtype:
+            raise TypeError(f"{name} dtype mismatch: expected {desc.dtype}, got {tensor.dtype}")
+        if tensor.device != desc.device:
+            raise ValueError(f"{name} device mismatch: expected {desc.device}, got {tensor.device}")
+
+    def execute(
+        self,
+        x_tensor: torch.Tensor,
+        weight_tensor: torch.Tensor,
+        state_tensor: torch.Tensor,
+        output_tensor: torch.Tensor,
+        state_indices_tensor: Optional[torch.Tensor] = None,
+        current_stream: Optional[cuda.CUstream] = None,
+    ) -> torch.Tensor:
+        self._runtime_error_if(
+            self._compiled_kernel is None,
+            "CausalConv1dUpdateSm100 kernel not compiled; call compile() first",
+        )
+
+        self._validate_runtime_tensor(x_tensor, self.x_desc, "X")
+        self._validate_runtime_tensor(weight_tensor, self.weight_desc, "Weight")
+        self._validate_runtime_tensor(state_tensor, self.state_desc, "State")
+        self._validate_runtime_tensor(output_tensor, self.output_desc, "Output")
+        if (state_indices_tensor is None) != (self.state_indices_desc is None):
+            raise ValueError("state_indices presence must match the compiled signature")
+        if state_indices_tensor is not None:
+            self._validate_runtime_tensor(
+                state_indices_tensor,
+                self.state_indices_desc,
+                "State indices",
+            )
+
+        for name, tensor in (
+            ("X", x_tensor),
+            ("Weight", weight_tensor),
+            ("State", state_tensor),
+            ("Output", output_tensor),
+        ):
+            _require_storage_alignment(tensor, 16, name)
+        if state_indices_tensor is not None:
+            _require_storage_alignment(state_indices_tensor, 4, "State indices")
+
+        if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in (x_tensor, weight_tensor, state_tensor, output_tensor)):
+            raise RuntimeError("causal_conv1d_update is inference-only; call it under torch.no_grad()")
+        for name, tensor in (
+            ("X", x_tensor),
+            ("Weight", weight_tensor),
+            ("Output", output_tensor),
+        ):
+            if _tensors_overlap(state_tensor, tensor):
+                raise ValueError(f"State must not overlap {name}")
+        if state_indices_tensor is not None and _tensors_overlap(state_tensor, state_indices_tensor):
+            raise ValueError("State must not overlap State indices")
+        for name, tensor in (("X", x_tensor), ("Weight", weight_tensor)):
+            if _tensors_overlap(output_tensor, tensor):
+                raise ValueError(f"Output must not overlap {name}")
+        if state_indices_tensor is not None and _tensors_overlap(output_tensor, state_indices_tensor):
+            raise ValueError("Output must not overlap State indices")
+
+        if current_stream is None:
+            current_stream = cuda.CUstream(torch.cuda.current_stream(x_tensor.device).cuda_stream)
+
+        self._compiled_kernel(
+            x_tensor,
+            weight_tensor,
+            state_tensor,
+            output_tensor,
+            state_indices_tensor,
+            cutlass.Int32(self.n_slots),
+            cutlass.Int32(self.n_channels),
+            current_stream,
+        )
+        return output_tensor
+
+
+def _cache_key(
+    x_tensor: torch.Tensor,
+    weight_tensor: torch.Tensor,
+    state_tensor: torch.Tensor,
+    state_indices_tensor: Optional[torch.Tensor],
+):
+    return (
+        x_tensor.device.type,
+        x_tensor.device.index,
+        tuple(x_tensor.shape),
+        tuple(weight_tensor.shape),
+        tuple(state_tensor.shape),
+        state_indices_tensor is not None,
+    )
+
+
+def causal_conv1d_update(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    state: torch.Tensor,
+    state_indices: Optional[torch.Tensor] = None,
+    *,
+    current_stream: Optional[cuda.CUstream] = None,
+) -> torch.Tensor:
+    """Advance a BF16 K=4 causal-convolution cache and return fused-SiLU output.
+
+    ``state`` is updated in place.  This experimental operation is SM100-only,
+    inference-only, no-bias, and always applies SiLU.  See
+    :class:`CausalConv1dUpdateSm100` for the exact tensor contract.
+    """
+
+    for name, tensor in (("X", x), ("Weight", weight), ("State", state)):
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(f"{name} must be a torch.Tensor, got {type(tensor).__name__}")
+    if state_indices is not None and not isinstance(state_indices, torch.Tensor):
+        raise TypeError("State indices must be a torch.Tensor or None, " f"got {type(state_indices).__name__}")
+    if not x.is_cuda:
+        raise ValueError(f"X must be a CUDA tensor, got device {x.device}")
+    key = _cache_key(x, weight, state, state_indices)
+
+    with torch.cuda.device(x.device), _torch_stream_context(current_stream, x.device):
+        output = torch.empty_like(x, memory_format=torch.contiguous_format)
+        api = _API_CACHE.get(key)
+        if api is None:
+            with _API_CACHE_LOCK:
+                api = _API_CACHE.get(key)
+                if api is None:
+                    api = CausalConv1dUpdateSm100(
+                        sample_x=x,
+                        sample_weight=weight,
+                        sample_state=state,
+                        sample_output=output,
+                        sample_state_indices=state_indices,
+                    )
+                    api.check_support()
+                    api.compile()
+                    if len(_API_CACHE) >= _API_CACHE_CAPACITY:
+                        _API_CACHE.pop(next(iter(_API_CACHE)))
+                    _API_CACHE[key] = api
+
+        return api.execute(
+            x_tensor=x,
+            weight_tensor=weight,
+            state_tensor=state,
+            output_tensor=output,
+            state_indices_tensor=state_indices,
+            current_stream=current_stream,
+        )
+
+
+def causal_conv1d_update_wrapper_sm100(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    state: torch.Tensor,
+    state_indices: Optional[torch.Tensor] = None,
+    *,
+    current_stream: Optional[cuda.CUstream] = None,
+) -> TupleDict:
+    """Run the SM100 decode update and return ``TupleDict(output_tensor=...)``.
+
+    ``state`` is updated in place.  Use :func:`causal_conv1d_update` when a
+    direct Tensor return is more convenient for model-integration shims.
+    """
+
+    output = causal_conv1d_update(
+        x,
+        weight,
+        state,
+        state_indices,
+        current_stream=current_stream,
+    )
+    return TupleDict(output_tensor=output)

--- a/python/cudnn/causal_conv1d_update_sm100/kernel.py
+++ b/python/cudnn/causal_conv1d_update_sm100/kernel.py
@@ -17,8 +17,13 @@ Semantic references consulted:
   (BSD-3-Clause), revision ``cd81f0413cad2fc1e6f17e785ac39f59aae690cd``.
 
 Only the four-wide, BF16, no-bias, SiLU inference specialization lives here.
-Each CTA owns a 256-channel tile of one decode row, so a single launch both
-advances the selected state slot in place and writes the output row.
+The general and indexed kernel assigns one decode row to each CTA.  A narrow
+``N=128`` no-index specialization assigns two rows to a CTA and reuses each
+channel's weight vector across them.  That scheduling idea came from audited
+internal Kernel Factory candidate
+``73d90c7fa5ae2e3e2ceb195bfa5af4db87cff8aaaefb7938cdd96b3128dd3a2e``;
+the standalone candidate source is not included here.  This is an independent
+FE-native implementation which retains the original inline-PTX data path.
 """
 
 from typing import Optional
@@ -31,6 +36,25 @@ from cutlass.cute.arch.nvvm_wrappers import inline_ptx
 from cudnn.frost.tile_dsl.pointwise import f16x2_to_f32, sigmoid
 
 THREADS = 256
+ROW_BATCH_ROWS = 2
+ROW_BATCH_SHAPES = frozenset(((128, 2048), (128, 4096)))
+
+
+def select_rows_per_cta(
+    n_rows: int,
+    n_channels: int,
+    has_state_indices: bool,
+) -> int:
+    """Select the audited two-row schedule only for its measured domain.
+
+    Indexed calls deliberately retain one-row CTAs: their per-row range and
+    duplicate validation is part of the mutation contract, and the Kernel
+    Factory artifact did not implement that ABI.
+    """
+
+    if not has_state_indices and (n_rows, n_channels) in ROW_BATCH_SHAPES:
+        return ROW_BATCH_ROWS
+    return 1
 
 
 @cute.kernel
@@ -155,6 +179,151 @@ class CausalConv1dUpdateKernel:
             n_channels,
         ).launch(
             grid=(x.shape[0], cute.ceil_div(x.shape[1], THREADS), 1),
+            block=(THREADS, 1, 1),
+            stream=stream,
+        )
+
+
+@cute.kernel
+def _causal_conv1d_update_row_batch_kernel(
+    x: cute.Tensor,
+    weight: cute.Tensor,
+    state: cute.Tensor,
+    output: cute.Tensor,
+    n_channels: cutlass.Int32,
+) -> None:
+    """Advance two unindexed decode rows while loading each weight once.
+
+    The host only selects this kernel for ``N=128`` and ``D`` in
+    ``{2048, 4096}``.  Those dimensions are divisible by the 256-thread channel
+    tile, so every CTA owns exactly two complete, disjoint row/channel tiles.
+    Both rows' state and input loads are issued before either row's arithmetic.
+    """
+
+    row_0 = cutlass.Int32(cute.arch.block_idx()[0]) * cutlass.Int32(ROW_BATCH_ROWS)
+    row_1 = row_0 + cutlass.Int32(1)
+    channel_tile = cutlass.Int32(cute.arch.block_idx()[1])
+    tidx = cutlass.Int32(cute.arch.thread_idx()[0])
+    channel = channel_tile * cutlass.Int32(THREADS) + tidx
+
+    if channel < n_channels:
+        weight_address = weight.iterator.toint() + cutlass.Int64(channel) * cutlass.Int64(weight.stride[0]) * cutlass.Int64(2)
+        state_element_0 = cutlass.Int64(row_0) * cutlass.Int64(state.stride[0]) + cutlass.Int64(channel) * cutlass.Int64(state.stride[1])
+        state_element_1 = cutlass.Int64(row_1) * cutlass.Int64(state.stride[0]) + cutlass.Int64(channel) * cutlass.Int64(state.stride[1])
+        state_address_0 = state.iterator.toint() + state_element_0 * cutlass.Int64(2)
+        state_address_1 = state.iterator.toint() + state_element_1 * cutlass.Int64(2)
+        x_element_0 = cutlass.Int64(row_0) * cutlass.Int64(x.stride[0]) + cutlass.Int64(channel) * cutlass.Int64(x.stride[1])
+        x_element_1 = cutlass.Int64(row_1) * cutlass.Int64(x.stride[0]) + cutlass.Int64(channel) * cutlass.Int64(x.stride[1])
+        x_address_0 = x.iterator.toint() + x_element_0 * cutlass.Int64(2)
+        x_address_1 = x.iterator.toint() + x_element_1 * cutlass.Int64(2)
+
+        # Reuse the four-tap channel weight for both rows.  Keep both rows'
+        # independent memory requests in flight before consuming either one.
+        weight_01, weight_23 = inline_ptx(
+            "ld.global.v2.b32 {$0, $1}, [$2];",
+            write_only_types=[cutlass.Int32, cutlass.Int32],
+            read_only_args=[weight_address],
+        )
+        state_0_01, state_0_23 = inline_ptx(
+            "ld.global.v2.b32 {$0, $1}, [$2];",
+            write_only_types=[cutlass.Int32, cutlass.Int32],
+            read_only_args=[state_address_0],
+        )
+        x_bits_0 = inline_ptx(
+            "ld.global.u16 $0, [$1];",
+            write_only_types=[cutlass.Uint16],
+            read_only_args=[x_address_0],
+        )
+        state_1_01, state_1_23 = inline_ptx(
+            "ld.global.v2.b32 {$0, $1}, [$2];",
+            write_only_types=[cutlass.Int32, cutlass.Int32],
+            read_only_args=[state_address_1],
+        )
+        x_bits_1 = inline_ptx(
+            "ld.global.u16 $0, [$1];",
+            write_only_types=[cutlass.Uint16],
+            read_only_args=[x_address_1],
+        )
+
+        weight_0, weight_1 = f16x2_to_f32(weight_01, dtype=cutlass.BFloat16)
+        weight_2, weight_3 = f16x2_to_f32(weight_23, dtype=cutlass.BFloat16)
+
+        _state_0_0, state_0_1 = f16x2_to_f32(state_0_01, dtype=cutlass.BFloat16)
+        state_0_2, state_0_3 = f16x2_to_f32(state_0_23, dtype=cutlass.BFloat16)
+        x_f32_0 = inline_ptx(
+            "{ .reg .b16 x; mov.b16 x, $1; mov.b32 $0, {0, x}; }",
+            write_only_types=[cutlass.Float32],
+            read_only_args=[x_bits_0],
+        )
+
+        _state_1_0, state_1_1 = f16x2_to_f32(state_1_01, dtype=cutlass.BFloat16)
+        state_1_2, state_1_3 = f16x2_to_f32(state_1_23, dtype=cutlass.BFloat16)
+        x_f32_1 = inline_ptx(
+            "{ .reg .b16 x; mov.b16 x, $1; mov.b32 $0, {0, x}; }",
+            write_only_types=[cutlass.Float32],
+            read_only_args=[x_bits_1],
+        )
+
+        # Pack the shift from the original BF16 payloads.  This retains exact
+        # state bits, including signed zero and NaN payloads, for both rows.
+        updated_0_01, updated_0_23 = inline_ptx(
+            "{ .reg .b16 s0, s1, s2, s3, xv; " "mov.b32 {s0, s1}, $2; mov.b32 {s2, s3}, $3; mov.b16 xv, $4; " "mov.b32 $0, {s1, s2}; mov.b32 $1, {s3, xv}; }",
+            write_only_types=[cutlass.Int32, cutlass.Int32],
+            read_only_args=[state_0_01, state_0_23, x_bits_0],
+        )
+        updated_1_01, updated_1_23 = inline_ptx(
+            "{ .reg .b16 s0, s1, s2, s3, xv; " "mov.b32 {s0, s1}, $2; mov.b32 {s2, s3}, $3; mov.b16 xv, $4; " "mov.b32 $0, {s1, s2}; mov.b32 $1, {s3, xv}; }",
+            write_only_types=[cutlass.Int32, cutlass.Int32],
+            read_only_args=[state_1_01, state_1_23, x_bits_1],
+        )
+        inline_ptx(
+            "st.global.v2.b32 [$0], {$1, $2};",
+            read_only_args=[state_address_0, updated_0_01, updated_0_23],
+        )
+        inline_ptx(
+            "st.global.v2.b32 [$0], {$1, $2};",
+            read_only_args=[state_address_1, updated_1_01, updated_1_23],
+        )
+
+        acc_0 = state_0_1 * weight_0
+        acc_0 = acc_0 + state_0_2 * weight_1
+        acc_0 = acc_0 + state_0_3 * weight_2
+        acc_0 = acc_0 + x_f32_0 * weight_3
+        output[row_0, channel] = (acc_0 * sigmoid(acc_0)).to(cutlass.BFloat16)
+
+        acc_1 = state_1_1 * weight_0
+        acc_1 = acc_1 + state_1_2 * weight_1
+        acc_1 = acc_1 + state_1_3 * weight_2
+        acc_1 = acc_1 + x_f32_1 * weight_3
+        output[row_1, channel] = (acc_1 * sigmoid(acc_1)).to(cutlass.BFloat16)
+
+
+class CausalConv1dUpdateRowBatchKernel:
+    """Host launcher for the guarded two-row, no-index specialization."""
+
+    @cute.jit
+    def __call__(
+        self,
+        x: cute.Tensor,
+        weight: cute.Tensor,
+        state: cute.Tensor,
+        output: cute.Tensor,
+        state_indices: Optional[cute.Tensor],
+        n_slots: cutlass.Int32,
+        n_channels: cutlass.Int32,
+        stream: cuda.CUstream,
+    ) -> None:
+        # ``state_indices`` and ``n_slots`` remain in the common compiled ABI.
+        # API-side selection guarantees an unindexed N=128 descriptor with
+        # enough identity-mapped slots before this specialization is compiled.
+        _causal_conv1d_update_row_batch_kernel(
+            x,
+            weight,
+            state,
+            output,
+            n_channels,
+        ).launch(
+            grid=(x.shape[0] // ROW_BATCH_ROWS, cute.ceil_div(x.shape[1], THREADS), 1),
             block=(THREADS, 1, 1),
             stream=stream,
         )

--- a/python/cudnn/causal_conv1d_update_sm100/kernel.py
+++ b/python/cudnn/causal_conv1d_update_sm100/kernel.py
@@ -16,7 +16,7 @@ Semantic references consulted:
 * Dao-AILab/causal-conv1d's public ``causal_conv1d_update`` API contract
   (BSD-3-Clause), revision ``cd81f0413cad2fc1e6f17e785ac39f59aae690cd``.
 
-Only the four-wide, BF16, no-bias, SiLU inference specialization lives here.
+Only the four-wide, BF16, optional-bias, SiLU inference specialization lives here.
 One decode row is assigned to each CTA on every admitted architecture. This is
 an independent FE-native implementation using the original inline-PTX data
 path.
@@ -38,6 +38,7 @@ THREADS = 256
 def _causal_conv1d_update_kernel(
     x: cute.Tensor,
     weight: cute.Tensor,
+    bias: Optional[cute.Tensor],
     state: cute.Tensor,
     output: cute.Tensor,
     state_indices: Optional[cute.Tensor],
@@ -105,6 +106,9 @@ def _causal_conv1d_update_kernel(
         state_2, state_3 = f16x2_to_f32(state_23, dtype=cutlass.BFloat16)
         weight_0, weight_1 = f16x2_to_f32(weight_01, dtype=cutlass.BFloat16)
         weight_2, weight_3 = f16x2_to_f32(weight_23, dtype=cutlass.BFloat16)
+        bias_value = cutlass.Float32(0.0)
+        if cutlass.const_expr(bias is not None):
+            bias_value = bias[channel].to(cutlass.Float32)
         x_f32 = inline_ptx(
             "{ .reg .b16 x; mov.b16 x, $1; mov.b32 $0, {0, x}; }",
             write_only_types=[cutlass.Float32],
@@ -128,6 +132,7 @@ def _causal_conv1d_update_kernel(
         acc = acc + state_2 * weight_1
         acc = acc + state_3 * weight_2
         acc = acc + x_f32 * weight_3
+        acc = acc + bias_value
         output[row, channel] = (acc * sigmoid(acc)).to(cutlass.BFloat16)
 
 
@@ -139,6 +144,7 @@ class CausalConv1dUpdateKernel:
         self,
         x: cute.Tensor,
         weight: cute.Tensor,
+        bias: Optional[cute.Tensor],
         state: cute.Tensor,
         output: cute.Tensor,
         state_indices: Optional[cute.Tensor],
@@ -149,6 +155,7 @@ class CausalConv1dUpdateKernel:
         _causal_conv1d_update_kernel(
             x,
             weight,
+            bias,
             state,
             output,
             state_indices,

--- a/python/cudnn/causal_conv1d_update_sm100/kernel.py
+++ b/python/cudnn/causal_conv1d_update_sm100/kernel.py
@@ -17,14 +17,9 @@ Semantic references consulted:
   (BSD-3-Clause), revision ``cd81f0413cad2fc1e6f17e785ac39f59aae690cd``.
 
 Only the four-wide, BF16, no-bias, SiLU inference specialization lives here.
-The general and indexed kernel assigns one decode row to each CTA.  On exact
-SM100, a narrow ``N=128`` no-index specialization assigns two rows to a CTA and
-reuses each channel's weight vector across them.  Every other admitted
-architecture uses the one-row schedule.  The two-row scheduling idea came from
-audited internal Kernel Factory candidate
-``73d90c7fa5ae2e3e2ceb195bfa5af4db87cff8aaaefb7938cdd96b3128dd3a2e``;
-the standalone candidate source is not included here.  This is an independent
-FE-native implementation which retains the original inline-PTX data path.
+One decode row is assigned to each CTA on every admitted architecture. This is
+an independent FE-native implementation using the original inline-PTX data
+path.
 """
 
 from typing import Optional
@@ -37,28 +32,6 @@ from cutlass.cute.arch.nvvm_wrappers import inline_ptx
 from cudnn.frost.tile_dsl.pointwise import f16x2_to_f32, sigmoid
 
 THREADS = 256
-ROW_BATCH_ROWS = 2
-ROW_BATCH_SHAPES = frozenset(((128, 2048), (128, 4096)))
-
-
-def select_rows_per_cta(
-    n_rows: int,
-    n_channels: int,
-    has_state_indices: bool,
-    *,
-    use_sm100_optimized_schedule: bool,
-) -> int:
-    """Select the audited SM100 two-row schedule only for its measured domain.
-
-    Indexed calls deliberately retain one-row CTAs: their per-row range and
-    duplicate validation is part of the mutation contract, and the Kernel
-    Factory artifact did not implement that ABI.  Non-SM100 architectures also
-    retain one-row CTAs because the two-row schedule was only tuned on SM100.
-    """
-
-    if use_sm100_optimized_schedule and not has_state_indices and (n_rows, n_channels) in ROW_BATCH_SHAPES:
-        return ROW_BATCH_ROWS
-    return 1
 
 
 @cute.kernel
@@ -183,151 +156,6 @@ class CausalConv1dUpdateKernel:
             n_channels,
         ).launch(
             grid=(x.shape[0], cute.ceil_div(x.shape[1], THREADS), 1),
-            block=(THREADS, 1, 1),
-            stream=stream,
-        )
-
-
-@cute.kernel
-def _causal_conv1d_update_row_batch_kernel(
-    x: cute.Tensor,
-    weight: cute.Tensor,
-    state: cute.Tensor,
-    output: cute.Tensor,
-    n_channels: cutlass.Int32,
-) -> None:
-    """Advance two unindexed decode rows while loading each weight once.
-
-    The host only selects this kernel for ``N=128`` and ``D`` in
-    ``{2048, 4096}``.  Those dimensions are divisible by the 256-thread channel
-    tile, so every CTA owns exactly two complete, disjoint row/channel tiles.
-    Both rows' state and input loads are issued before either row's arithmetic.
-    """
-
-    row_0 = cutlass.Int32(cute.arch.block_idx()[0]) * cutlass.Int32(ROW_BATCH_ROWS)
-    row_1 = row_0 + cutlass.Int32(1)
-    channel_tile = cutlass.Int32(cute.arch.block_idx()[1])
-    tidx = cutlass.Int32(cute.arch.thread_idx()[0])
-    channel = channel_tile * cutlass.Int32(THREADS) + tidx
-
-    if channel < n_channels:
-        weight_address = weight.iterator.toint() + cutlass.Int64(channel) * cutlass.Int64(weight.stride[0]) * cutlass.Int64(2)
-        state_element_0 = cutlass.Int64(row_0) * cutlass.Int64(state.stride[0]) + cutlass.Int64(channel) * cutlass.Int64(state.stride[1])
-        state_element_1 = cutlass.Int64(row_1) * cutlass.Int64(state.stride[0]) + cutlass.Int64(channel) * cutlass.Int64(state.stride[1])
-        state_address_0 = state.iterator.toint() + state_element_0 * cutlass.Int64(2)
-        state_address_1 = state.iterator.toint() + state_element_1 * cutlass.Int64(2)
-        x_element_0 = cutlass.Int64(row_0) * cutlass.Int64(x.stride[0]) + cutlass.Int64(channel) * cutlass.Int64(x.stride[1])
-        x_element_1 = cutlass.Int64(row_1) * cutlass.Int64(x.stride[0]) + cutlass.Int64(channel) * cutlass.Int64(x.stride[1])
-        x_address_0 = x.iterator.toint() + x_element_0 * cutlass.Int64(2)
-        x_address_1 = x.iterator.toint() + x_element_1 * cutlass.Int64(2)
-
-        # Reuse the four-tap channel weight for both rows.  Keep both rows'
-        # independent memory requests in flight before consuming either one.
-        weight_01, weight_23 = inline_ptx(
-            "ld.global.v2.b32 {$0, $1}, [$2];",
-            write_only_types=[cutlass.Int32, cutlass.Int32],
-            read_only_args=[weight_address],
-        )
-        state_0_01, state_0_23 = inline_ptx(
-            "ld.global.v2.b32 {$0, $1}, [$2];",
-            write_only_types=[cutlass.Int32, cutlass.Int32],
-            read_only_args=[state_address_0],
-        )
-        x_bits_0 = inline_ptx(
-            "ld.global.u16 $0, [$1];",
-            write_only_types=[cutlass.Uint16],
-            read_only_args=[x_address_0],
-        )
-        state_1_01, state_1_23 = inline_ptx(
-            "ld.global.v2.b32 {$0, $1}, [$2];",
-            write_only_types=[cutlass.Int32, cutlass.Int32],
-            read_only_args=[state_address_1],
-        )
-        x_bits_1 = inline_ptx(
-            "ld.global.u16 $0, [$1];",
-            write_only_types=[cutlass.Uint16],
-            read_only_args=[x_address_1],
-        )
-
-        weight_0, weight_1 = f16x2_to_f32(weight_01, dtype=cutlass.BFloat16)
-        weight_2, weight_3 = f16x2_to_f32(weight_23, dtype=cutlass.BFloat16)
-
-        _state_0_0, state_0_1 = f16x2_to_f32(state_0_01, dtype=cutlass.BFloat16)
-        state_0_2, state_0_3 = f16x2_to_f32(state_0_23, dtype=cutlass.BFloat16)
-        x_f32_0 = inline_ptx(
-            "{ .reg .b16 x; mov.b16 x, $1; mov.b32 $0, {0, x}; }",
-            write_only_types=[cutlass.Float32],
-            read_only_args=[x_bits_0],
-        )
-
-        _state_1_0, state_1_1 = f16x2_to_f32(state_1_01, dtype=cutlass.BFloat16)
-        state_1_2, state_1_3 = f16x2_to_f32(state_1_23, dtype=cutlass.BFloat16)
-        x_f32_1 = inline_ptx(
-            "{ .reg .b16 x; mov.b16 x, $1; mov.b32 $0, {0, x}; }",
-            write_only_types=[cutlass.Float32],
-            read_only_args=[x_bits_1],
-        )
-
-        # Pack the shift from the original BF16 payloads.  This retains exact
-        # state bits, including signed zero and NaN payloads, for both rows.
-        updated_0_01, updated_0_23 = inline_ptx(
-            "{ .reg .b16 s0, s1, s2, s3, xv; " "mov.b32 {s0, s1}, $2; mov.b32 {s2, s3}, $3; mov.b16 xv, $4; " "mov.b32 $0, {s1, s2}; mov.b32 $1, {s3, xv}; }",
-            write_only_types=[cutlass.Int32, cutlass.Int32],
-            read_only_args=[state_0_01, state_0_23, x_bits_0],
-        )
-        updated_1_01, updated_1_23 = inline_ptx(
-            "{ .reg .b16 s0, s1, s2, s3, xv; " "mov.b32 {s0, s1}, $2; mov.b32 {s2, s3}, $3; mov.b16 xv, $4; " "mov.b32 $0, {s1, s2}; mov.b32 $1, {s3, xv}; }",
-            write_only_types=[cutlass.Int32, cutlass.Int32],
-            read_only_args=[state_1_01, state_1_23, x_bits_1],
-        )
-        inline_ptx(
-            "st.global.v2.b32 [$0], {$1, $2};",
-            read_only_args=[state_address_0, updated_0_01, updated_0_23],
-        )
-        inline_ptx(
-            "st.global.v2.b32 [$0], {$1, $2};",
-            read_only_args=[state_address_1, updated_1_01, updated_1_23],
-        )
-
-        acc_0 = state_0_1 * weight_0
-        acc_0 = acc_0 + state_0_2 * weight_1
-        acc_0 = acc_0 + state_0_3 * weight_2
-        acc_0 = acc_0 + x_f32_0 * weight_3
-        output[row_0, channel] = (acc_0 * sigmoid(acc_0)).to(cutlass.BFloat16)
-
-        acc_1 = state_1_1 * weight_0
-        acc_1 = acc_1 + state_1_2 * weight_1
-        acc_1 = acc_1 + state_1_3 * weight_2
-        acc_1 = acc_1 + x_f32_1 * weight_3
-        output[row_1, channel] = (acc_1 * sigmoid(acc_1)).to(cutlass.BFloat16)
-
-
-class CausalConv1dUpdateRowBatchKernel:
-    """Host launcher for the guarded two-row, no-index specialization."""
-
-    @cute.jit
-    def __call__(
-        self,
-        x: cute.Tensor,
-        weight: cute.Tensor,
-        state: cute.Tensor,
-        output: cute.Tensor,
-        state_indices: Optional[cute.Tensor],
-        n_slots: cutlass.Int32,
-        n_channels: cutlass.Int32,
-        stream: cuda.CUstream,
-    ) -> None:
-        # ``state_indices`` and ``n_slots`` remain in the common compiled ABI.
-        # API-side selection guarantees an unindexed N=128 descriptor with
-        # enough identity-mapped slots before this specialization is compiled.
-        _causal_conv1d_update_row_batch_kernel(
-            x,
-            weight,
-            state,
-            output,
-            n_channels,
-        ).launch(
-            grid=(x.shape[0] // ROW_BATCH_ROWS, cute.ceil_div(x.shape[1], THREADS), 1),
             block=(THREADS, 1, 1),
             stream=stream,
         )

--- a/python/cudnn/causal_conv1d_update_sm100/kernel.py
+++ b/python/cudnn/causal_conv1d_update_sm100/kernel.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SM100 BF16 causal-convolution decode update kernel.
+
+The state transition follows the public ``causal_conv1d_update`` contract used
+by FLA's ``ShortConvolution.step``: shift the four-element history left, append
+the current token, take a depthwise dot product, then apply SiLU.  No source
+from either behavioral reference below is included.  This implementation uses
+CUTLASS/CuTe DSL, inline PTX, and in-tree NVIDIA FROST primitives.
+
+Semantic references consulted:
+
+* fla-org/flash-linear-attention, ``fla/modules/conv/short_conv.py`` and
+  ``fla/modules/conv/triton/kernels.py`` (MIT), FLA 0.5.2.
+* Dao-AILab/causal-conv1d's public ``causal_conv1d_update`` API contract
+  (BSD-3-Clause), revision ``cd81f0413cad2fc1e6f17e785ac39f59aae690cd``.
+
+Only the four-wide, BF16, no-bias, SiLU inference specialization lives here.
+Each CTA owns a 256-channel tile of one decode row, so a single launch both
+advances the selected state slot in place and writes the output row.
+"""
+
+from typing import Optional
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.arch.nvvm_wrappers import inline_ptx
+
+from cudnn.frost.tile_dsl.pointwise import f16x2_to_f32, sigmoid
+
+THREADS = 256
+
+
+@cute.kernel
+def _causal_conv1d_update_kernel(
+    x: cute.Tensor,
+    weight: cute.Tensor,
+    state: cute.Tensor,
+    output: cute.Tensor,
+    state_indices: Optional[cute.Tensor],
+    n_slots: cutlass.Int32,
+    n_channels: cutlass.Int32,
+) -> None:
+    """Advance one 256-channel tile of a state row and emit its output tile.
+
+    ``state_indices`` is optional-specialized.  Indexed calls trap on an
+    out-of-range or duplicate slot before that CTA writes state.
+    Rejecting duplicates makes the mutation deterministic rather than allowing
+    two decode rows to race on the same mutable cache slot.
+    """
+
+    row = cutlass.Int32(cute.arch.block_idx()[0])
+    channel_tile = cutlass.Int32(cute.arch.block_idx()[1])
+    tidx = cutlass.Int32(cute.arch.thread_idx()[0])
+
+    slot = row
+    if cutlass.const_expr(state_indices is not None):
+        slot = cutlass.Int32(state_indices[row])
+        if tidx == cutlass.Int32(0):
+            # CuTe's testing assert lowers away in release device builds.  PTX
+            # trap is the fail-closed primitive here and is covered by exact
+            # SM100 subprocess tests for every invalid-index class.
+            inline_ptx("trap;", predicate=slot < cutlass.Int32(0))
+            inline_ptx("trap;", predicate=slot >= n_slots)
+
+            # Decode batches are small.  A lane-zero scan keeps the operation
+            # single-kernel while failing closed on duplicate mutable slots.
+            previous_row = cutlass.Int32(0)
+            while previous_row < row:
+                inline_ptx(
+                    "trap;",
+                    predicate=cutlass.Int32(state_indices[previous_row]) == slot,
+                )
+                previous_row += cutlass.Int32(1)
+        cute.arch.barrier()
+
+    channel = channel_tile * cutlass.Int32(THREADS) + tidx
+    if channel < n_channels:
+        state_element = cutlass.Int64(slot) * cutlass.Int64(state.stride[0]) + cutlass.Int64(channel) * cutlass.Int64(state.stride[1])
+        state_address = state.iterator.toint() + state_element * cutlass.Int64(2)
+        weight_address = weight.iterator.toint() + cutlass.Int64(channel) * cutlass.Int64(weight.stride[0]) * cutlass.Int64(2)
+        x_element = cutlass.Int64(row) * cutlass.Int64(x.stride[0]) + cutlass.Int64(channel) * cutlass.Int64(x.stride[1])
+        x_address = x.iterator.toint() + x_element * cutlass.Int64(2)
+
+        state_01, state_23 = inline_ptx(
+            "ld.global.v2.b32 {$0, $1}, [$2];",
+            write_only_types=[cutlass.Int32, cutlass.Int32],
+            read_only_args=[state_address],
+        )
+        weight_01, weight_23 = inline_ptx(
+            "ld.global.v2.b32 {$0, $1}, [$2];",
+            write_only_types=[cutlass.Int32, cutlass.Int32],
+            read_only_args=[weight_address],
+        )
+        x_bits = inline_ptx(
+            "ld.global.u16 $0, [$1];",
+            write_only_types=[cutlass.Uint16],
+            read_only_args=[x_address],
+        )
+
+        _state_0, state_1 = f16x2_to_f32(state_01, dtype=cutlass.BFloat16)
+        state_2, state_3 = f16x2_to_f32(state_23, dtype=cutlass.BFloat16)
+        weight_0, weight_1 = f16x2_to_f32(weight_01, dtype=cutlass.BFloat16)
+        weight_2, weight_3 = f16x2_to_f32(weight_23, dtype=cutlass.BFloat16)
+        x_f32 = inline_ptx(
+            "{ .reg .b16 x; mov.b16 x, $1; mov.b32 $0, {0, x}; }",
+            write_only_types=[cutlass.Float32],
+            read_only_args=[x_bits],
+        )
+
+        # The updated state is [old_1, old_2, old_3, x].  Pack from the raw
+        # BF16 words so the shift and append are bitwise, including signed zero
+        # and NaN payloads; only the output path converts through FP32.
+        updated_01, updated_23 = inline_ptx(
+            "{ .reg .b16 s0, s1, s2, s3, xv; " "mov.b32 {s0, s1}, $2; mov.b32 {s2, s3}, $3; mov.b16 xv, $4; " "mov.b32 $0, {s1, s2}; mov.b32 $1, {s3, xv}; }",
+            write_only_types=[cutlass.Int32, cutlass.Int32],
+            read_only_args=[state_01, state_23, x_bits],
+        )
+        inline_ptx(
+            "st.global.v2.b32 [$0], {$1, $2};",
+            read_only_args=[state_address, updated_01, updated_23],
+        )
+
+        acc = state_1 * weight_0
+        acc = acc + state_2 * weight_1
+        acc = acc + state_3 * weight_2
+        acc = acc + x_f32 * weight_3
+        output[row, channel] = (acc * sigmoid(acc)).to(cutlass.BFloat16)
+
+
+class CausalConv1dUpdateKernel:
+    """Host launcher for the fixed SM100 decode specialization."""
+
+    @cute.jit
+    def __call__(
+        self,
+        x: cute.Tensor,
+        weight: cute.Tensor,
+        state: cute.Tensor,
+        output: cute.Tensor,
+        state_indices: Optional[cute.Tensor],
+        n_slots: cutlass.Int32,
+        n_channels: cutlass.Int32,
+        stream: cuda.CUstream,
+    ) -> None:
+        _causal_conv1d_update_kernel(
+            x,
+            weight,
+            state,
+            output,
+            state_indices,
+            n_slots,
+            n_channels,
+        ).launch(
+            grid=(x.shape[0], cute.ceil_div(x.shape[1], THREADS), 1),
+            block=(THREADS, 1, 1),
+            stream=stream,
+        )

--- a/python/cudnn/causal_conv1d_update_sm100/kernel.py
+++ b/python/cudnn/causal_conv1d_update_sm100/kernel.py
@@ -21,6 +21,9 @@ Only the four-wide, BF16, optional-bias inference specialization lives here.
 State length four keeps the original vectorized path. State length three, the
 standard ``W - 1`` prefill handoff, uses a separate scalar state specialization.
 Identity and SiLU are separate compile-time specializations.
+The input is addressed through its compiled ``(ld, 1)`` strides, including a
+16-byte-row-aligned padded leading dimension; output and mutable state remain
+compact.
 One decode row is assigned to each CTA on every admitted architecture. This is
 an independent FE-native implementation using the original inline-PTX data
 path.

--- a/python/cudnn/causal_conv1d_update_sm100/kernel.py
+++ b/python/cudnn/causal_conv1d_update_sm100/kernel.py
@@ -4,10 +4,11 @@
 """BF16 causal-convolution decode update kernel.
 
 The state transition follows the public ``causal_conv1d_update`` contract used
-by FLA's ``ShortConvolution.step``: shift the four-element history left, append
-the current token, take a depthwise dot product, then apply SiLU.  No source
-from either behavioral reference below is included.  This implementation uses
-CUTLASS/CuTe DSL, inline PTX, and in-tree NVIDIA FROST primitives.
+by FLA's ``ShortConvolution.step``: append the current token to the history,
+retain the configured state length, take a four-wide depthwise dot product,
+then optionally apply SiLU. No source from either behavioral reference below
+is included. This implementation uses CUTLASS/CuTe DSL, inline PTX, and in-tree
+NVIDIA FROST primitives.
 
 Semantic references consulted:
 
@@ -16,7 +17,10 @@ Semantic references consulted:
 * Dao-AILab/causal-conv1d's public ``causal_conv1d_update`` API contract
   (BSD-3-Clause), revision ``cd81f0413cad2fc1e6f17e785ac39f59aae690cd``.
 
-Only the four-wide, BF16, optional-bias, SiLU inference specialization lives here.
+Only the four-wide, BF16, optional-bias inference specialization lives here.
+State length four keeps the original vectorized path. State length three, the
+standard ``W - 1`` prefill handoff, uses a separate scalar state specialization.
+Identity and SiLU are separate compile-time specializations.
 One decode row is assigned to each CTA on every admitted architecture. This is
 an independent FE-native implementation using the original inline-PTX data
 path.
@@ -44,11 +48,13 @@ def _causal_conv1d_update_kernel(
     state_indices: Optional[cute.Tensor],
     n_slots: cutlass.Int32,
     n_channels: cutlass.Int32,
+    apply_silu: cutlass.Constexpr[bool],
 ) -> None:
     """Advance one 256-channel tile of a state row and emit its output tile.
 
-    ``state_indices`` is optional-specialized.  Indexed calls trap on an
-    out-of-range or duplicate slot before that CTA writes state.
+    ``state_indices`` is optional-specialized.  ``-1`` is a padding row: it
+    writes a zero output and does not mutate state.  Other indexed calls trap
+    on an out-of-range or duplicate slot before that CTA writes state.
     Rejecting duplicates makes the mutation deterministic rather than allowing
     two decode rows to race on the same mutable cache slot.
     """
@@ -64,19 +70,29 @@ def _causal_conv1d_update_kernel(
             # CuTe's testing assert lowers away in release device builds.  PTX
             # trap is the fail-closed primitive here and is covered by GPU
             # subprocess tests for every invalid-index class.
-            inline_ptx("trap;", predicate=slot < cutlass.Int32(0))
+            inline_ptx("trap;", predicate=slot < cutlass.Int32(-1))
             inline_ptx("trap;", predicate=slot >= n_slots)
 
             # Decode batches are small.  A lane-zero scan keeps the operation
             # single-kernel while failing closed on duplicate mutable slots.
-            previous_row = cutlass.Int32(0)
-            while previous_row < row:
-                inline_ptx(
-                    "trap;",
-                    predicate=cutlass.Int32(state_indices[previous_row]) == slot,
-                )
-                previous_row += cutlass.Int32(1)
+            # Padding rows do not own state, so repeated -1 entries are valid.
+            if slot >= cutlass.Int32(0):
+                previous_row = cutlass.Int32(0)
+                while previous_row < row:
+                    inline_ptx(
+                        "trap;",
+                        predicate=cutlass.Int32(state_indices[previous_row]) == slot,
+                    )
+                    previous_row += cutlass.Int32(1)
         cute.arch.barrier()
+
+    if cutlass.const_expr(state_indices is not None):
+        is_padding = slot == cutlass.Int32(-1)
+        if is_padding:
+            # Keep all later pointer arithmetic in range.  Loads from slot zero
+            # are harmless because the indexed padding branch suppresses the
+            # state store and observable convolution result.
+            slot = cutlass.Int32(0)
 
     channel = channel_tile * cutlass.Int32(THREADS) + tidx
     if channel < n_channels:
@@ -123,21 +139,194 @@ def _causal_conv1d_update_kernel(
             write_only_types=[cutlass.Int32, cutlass.Int32],
             read_only_args=[state_01, state_23, x_bits],
         )
-        inline_ptx(
-            "st.global.v2.b32 [$0], {$1, $2};",
-            read_only_args=[state_address, updated_01, updated_23],
-        )
+        if cutlass.const_expr(state_indices is not None):
+            if not is_padding:
+                inline_ptx(
+                    "st.global.v2.b32 [$0], {$1, $2};",
+                    read_only_args=[state_address, updated_01, updated_23],
+                )
+        else:
+            inline_ptx(
+                "st.global.v2.b32 [$0], {$1, $2};",
+                read_only_args=[state_address, updated_01, updated_23],
+            )
 
         acc = state_1 * weight_0
         acc = acc + state_2 * weight_1
         acc = acc + state_3 * weight_2
         acc = acc + x_f32 * weight_3
         acc = acc + bias_value
-        output[row, channel] = (acc * sigmoid(acc)).to(cutlass.BFloat16)
+        if cutlass.const_expr(apply_silu):
+            acc = acc * sigmoid(acc)
+
+        if cutlass.const_expr(state_indices is not None):
+            if is_padding:
+                output[row, channel] = cutlass.Float32(0.0).to(cutlass.BFloat16)
+            else:
+                output[row, channel] = acc.to(cutlass.BFloat16)
+        else:
+            output[row, channel] = acc.to(cutlass.BFloat16)
 
 
-class CausalConv1dUpdateKernel:
+@cute.kernel
+def _causal_conv1d_update_l3_kernel(
+    x: cute.Tensor,
+    weight: cute.Tensor,
+    bias: Optional[cute.Tensor],
+    state: cute.Tensor,
+    output: cute.Tensor,
+    state_indices: Optional[cute.Tensor],
+    n_slots: cutlass.Int32,
+    n_channels: cutlass.Int32,
+    apply_silu: cutlass.Constexpr[bool],
+) -> None:
+    """Advance a three-element ``W - 1`` state for one decode token.
+
+    This specialization deliberately uses scalar state loads and stores. The
+    four-element kernel above retains its original vector load/store path.
+    """
+
+    row = cutlass.Int32(cute.arch.block_idx()[0])
+    channel_tile = cutlass.Int32(cute.arch.block_idx()[1])
+    tidx = cutlass.Int32(cute.arch.thread_idx()[0])
+
+    slot = row
+    if cutlass.const_expr(state_indices is not None):
+        slot = cutlass.Int32(state_indices[row])
+        if tidx == cutlass.Int32(0):
+            inline_ptx("trap;", predicate=slot < cutlass.Int32(-1))
+            inline_ptx("trap;", predicate=slot >= n_slots)
+            if slot >= cutlass.Int32(0):
+                previous_row = cutlass.Int32(0)
+                while previous_row < row:
+                    inline_ptx(
+                        "trap;",
+                        predicate=cutlass.Int32(state_indices[previous_row]) == slot,
+                    )
+                    previous_row += cutlass.Int32(1)
+        cute.arch.barrier()
+
+    if cutlass.const_expr(state_indices is not None):
+        is_padding = slot == cutlass.Int32(-1)
+        if is_padding:
+            slot = cutlass.Int32(0)
+
+    channel = channel_tile * cutlass.Int32(THREADS) + tidx
+    if channel < n_channels:
+        state_element = cutlass.Int64(slot) * cutlass.Int64(state.stride[0]) + cutlass.Int64(channel) * cutlass.Int64(state.stride[1])
+        state_address = state.iterator.toint() + state_element * cutlass.Int64(2)
+        state_1_address = state_address + cutlass.Int64(2)
+        state_2_address = state_address + cutlass.Int64(4)
+        weight_address = weight.iterator.toint() + cutlass.Int64(channel) * cutlass.Int64(weight.stride[0]) * cutlass.Int64(2)
+        x_element = cutlass.Int64(row) * cutlass.Int64(x.stride[0]) + cutlass.Int64(channel) * cutlass.Int64(x.stride[1])
+        x_address = x.iterator.toint() + x_element * cutlass.Int64(2)
+
+        state_0_bits = inline_ptx(
+            "ld.global.u16 $0, [$1];",
+            write_only_types=[cutlass.Uint16],
+            read_only_args=[state_address],
+        )
+        state_1_bits = inline_ptx(
+            "ld.global.u16 $0, [$1];",
+            write_only_types=[cutlass.Uint16],
+            read_only_args=[state_1_address],
+        )
+        state_2_bits = inline_ptx(
+            "ld.global.u16 $0, [$1];",
+            write_only_types=[cutlass.Uint16],
+            read_only_args=[state_2_address],
+        )
+        weight_01, weight_23 = inline_ptx(
+            "ld.global.v2.b32 {$0, $1}, [$2];",
+            write_only_types=[cutlass.Int32, cutlass.Int32],
+            read_only_args=[weight_address],
+        )
+        x_bits = inline_ptx(
+            "ld.global.u16 $0, [$1];",
+            write_only_types=[cutlass.Uint16],
+            read_only_args=[x_address],
+        )
+
+        state_0 = inline_ptx(
+            "{ .reg .b16 x; mov.b16 x, $1; mov.b32 $0, {0, x}; }",
+            write_only_types=[cutlass.Float32],
+            read_only_args=[state_0_bits],
+        )
+        state_1 = inline_ptx(
+            "{ .reg .b16 x; mov.b16 x, $1; mov.b32 $0, {0, x}; }",
+            write_only_types=[cutlass.Float32],
+            read_only_args=[state_1_bits],
+        )
+        state_2 = inline_ptx(
+            "{ .reg .b16 x; mov.b16 x, $1; mov.b32 $0, {0, x}; }",
+            write_only_types=[cutlass.Float32],
+            read_only_args=[state_2_bits],
+        )
+        weight_0, weight_1 = f16x2_to_f32(weight_01, dtype=cutlass.BFloat16)
+        weight_2, weight_3 = f16x2_to_f32(weight_23, dtype=cutlass.BFloat16)
+        bias_value = cutlass.Float32(0.0)
+        if cutlass.const_expr(bias is not None):
+            bias_value = bias[channel].to(cutlass.Float32)
+        x_f32 = inline_ptx(
+            "{ .reg .b16 x; mov.b16 x, $1; mov.b32 $0, {0, x}; }",
+            write_only_types=[cutlass.Float32],
+            read_only_args=[x_bits],
+        )
+
+        # Preserve BF16 payload bits in the state transition [old_1, old_2, x].
+        # A three-element channel row is only two-byte aligned for odd channels,
+        # so every state access is deliberately scalar.
+        if cutlass.const_expr(state_indices is not None):
+            if not is_padding:
+                inline_ptx(
+                    "st.global.u16 [$0], $1;",
+                    read_only_args=[state_address, state_1_bits],
+                )
+                inline_ptx(
+                    "st.global.u16 [$0], $1;",
+                    read_only_args=[state_1_address, state_2_bits],
+                )
+                inline_ptx(
+                    "st.global.u16 [$0], $1;",
+                    read_only_args=[state_2_address, x_bits],
+                )
+        else:
+            inline_ptx(
+                "st.global.u16 [$0], $1;",
+                read_only_args=[state_address, state_1_bits],
+            )
+            inline_ptx(
+                "st.global.u16 [$0], $1;",
+                read_only_args=[state_1_address, state_2_bits],
+            )
+            inline_ptx(
+                "st.global.u16 [$0], $1;",
+                read_only_args=[state_2_address, x_bits],
+            )
+
+        acc = state_0 * weight_0
+        acc = acc + state_1 * weight_1
+        acc = acc + state_2 * weight_2
+        acc = acc + x_f32 * weight_3
+        acc = acc + bias_value
+        if cutlass.const_expr(apply_silu):
+            acc = acc * sigmoid(acc)
+
+        if cutlass.const_expr(state_indices is not None):
+            if is_padding:
+                output[row, channel] = cutlass.Float32(0.0).to(cutlass.BFloat16)
+            else:
+                output[row, channel] = acc.to(cutlass.BFloat16)
+        else:
+            output[row, channel] = acc.to(cutlass.BFloat16)
+
+
+class _CausalConv1dUpdateKernel:
     """Host launcher for the portable one-row decode specialization."""
+
+    def __init__(self, *, apply_silu: bool, state_len: int):
+        self.apply_silu = apply_silu
+        self.state_len = state_len
 
     @cute.jit
     def __call__(
@@ -152,17 +341,35 @@ class CausalConv1dUpdateKernel:
         n_channels: cutlass.Int32,
         stream: cuda.CUstream,
     ) -> None:
-        _causal_conv1d_update_kernel(
-            x,
-            weight,
-            bias,
-            state,
-            output,
-            state_indices,
-            n_slots,
-            n_channels,
-        ).launch(
-            grid=(x.shape[0], cute.ceil_div(x.shape[1], THREADS), 1),
-            block=(THREADS, 1, 1),
-            stream=stream,
-        )
+        if cutlass.const_expr(self.state_len == 4):
+            _causal_conv1d_update_kernel(
+                x,
+                weight,
+                bias,
+                state,
+                output,
+                state_indices,
+                n_slots,
+                n_channels,
+                self.apply_silu,
+            ).launch(
+                grid=(x.shape[0], cute.ceil_div(x.shape[1], THREADS), 1),
+                block=(THREADS, 1, 1),
+                stream=stream,
+            )
+        else:
+            _causal_conv1d_update_l3_kernel(
+                x,
+                weight,
+                bias,
+                state,
+                output,
+                state_indices,
+                n_slots,
+                n_channels,
+                self.apply_silu,
+            ).launch(
+                grid=(x.shape[0], cute.ceil_div(x.shape[1], THREADS), 1),
+                block=(THREADS, 1, 1),
+                stream=stream,
+            )

--- a/python/cudnn/causal_conv1d_update_sm100/kernel.py
+++ b/python/cudnn/causal_conv1d_update_sm100/kernel.py
@@ -79,7 +79,10 @@ def _causal_conv1d_update_kernel(
             # Decode batches are small.  A lane-zero scan keeps the operation
             # single-kernel while failing closed on duplicate mutable slots.
             # Padding rows do not own state, so repeated -1 entries are valid.
-            if slot >= cutlass.Int32(0):
+            if slot >= cutlass.Int32(0) and channel_tile == cutlass.Int32(0):
+                # A trap in the first channel tile aborts the whole launch;
+                # repeating this O(N^2) scan in every channel tile adds no
+                # validation coverage.
                 previous_row = cutlass.Int32(0)
                 while previous_row < row:
                     inline_ptx(
@@ -199,7 +202,10 @@ def _causal_conv1d_update_l3_kernel(
         if tidx == cutlass.Int32(0):
             inline_ptx("trap;", predicate=slot < cutlass.Int32(-1))
             inline_ptx("trap;", predicate=slot >= n_slots)
-            if slot >= cutlass.Int32(0):
+            if slot >= cutlass.Int32(0) and channel_tile == cutlass.Int32(0):
+                # A trap in the first channel tile aborts the whole launch;
+                # repeating this O(N^2) scan in every channel tile adds no
+                # validation coverage.
                 previous_row = cutlass.Int32(0)
                 while previous_row < row:
                     inline_ptx(

--- a/python/cudnn/causal_conv1d_update_sm100/kernel.py
+++ b/python/cudnn/causal_conv1d_update_sm100/kernel.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""SM100 BF16 causal-convolution decode update kernel.
+"""BF16 causal-convolution decode update kernel.
 
 The state transition follows the public ``causal_conv1d_update`` contract used
 by FLA's ``ShortConvolution.step``: shift the four-element history left, append
@@ -17,10 +17,11 @@ Semantic references consulted:
   (BSD-3-Clause), revision ``cd81f0413cad2fc1e6f17e785ac39f59aae690cd``.
 
 Only the four-wide, BF16, no-bias, SiLU inference specialization lives here.
-The general and indexed kernel assigns one decode row to each CTA.  A narrow
-``N=128`` no-index specialization assigns two rows to a CTA and reuses each
-channel's weight vector across them.  That scheduling idea came from audited
-internal Kernel Factory candidate
+The general and indexed kernel assigns one decode row to each CTA.  On exact
+SM100, a narrow ``N=128`` no-index specialization assigns two rows to a CTA and
+reuses each channel's weight vector across them.  Every other admitted
+architecture uses the one-row schedule.  The two-row scheduling idea came from
+audited internal Kernel Factory candidate
 ``73d90c7fa5ae2e3e2ceb195bfa5af4db87cff8aaaefb7938cdd96b3128dd3a2e``;
 the standalone candidate source is not included here.  This is an independent
 FE-native implementation which retains the original inline-PTX data path.
@@ -44,15 +45,18 @@ def select_rows_per_cta(
     n_rows: int,
     n_channels: int,
     has_state_indices: bool,
+    *,
+    use_sm100_optimized_schedule: bool,
 ) -> int:
-    """Select the audited two-row schedule only for its measured domain.
+    """Select the audited SM100 two-row schedule only for its measured domain.
 
     Indexed calls deliberately retain one-row CTAs: their per-row range and
     duplicate validation is part of the mutation contract, and the Kernel
-    Factory artifact did not implement that ABI.
+    Factory artifact did not implement that ABI.  Non-SM100 architectures also
+    retain one-row CTAs because the two-row schedule was only tuned on SM100.
     """
 
-    if not has_state_indices and (n_rows, n_channels) in ROW_BATCH_SHAPES:
+    if use_sm100_optimized_schedule and not has_state_indices and (n_rows, n_channels) in ROW_BATCH_SHAPES:
         return ROW_BATCH_ROWS
     return 1
 
@@ -84,8 +88,8 @@ def _causal_conv1d_update_kernel(
         slot = cutlass.Int32(state_indices[row])
         if tidx == cutlass.Int32(0):
             # CuTe's testing assert lowers away in release device builds.  PTX
-            # trap is the fail-closed primitive here and is covered by exact
-            # SM100 subprocess tests for every invalid-index class.
+            # trap is the fail-closed primitive here and is covered by GPU
+            # subprocess tests for every invalid-index class.
             inline_ptx("trap;", predicate=slot < cutlass.Int32(0))
             inline_ptx("trap;", predicate=slot >= n_slots)
 
@@ -155,7 +159,7 @@ def _causal_conv1d_update_kernel(
 
 
 class CausalConv1dUpdateKernel:
-    """Host launcher for the fixed SM100 decode specialization."""
+    """Host launcher for the portable one-row decode specialization."""
 
     @cute.jit
     def __call__(

--- a/python/cudnn/fla/__init__.py
+++ b/python/cudnn/fla/__init__.py
@@ -6,13 +6,15 @@
 ``accelerate_fla()`` monkeypatches FLA entry points cuDNN can serve and
 transparently calls the original implementation for unsupported configurations.
 The backward-compatible no-argument call enables the linear-attention targets
-(``gated_delta_rule`` and ``kda``).  The dense MLP adapter is intentionally
-opt-in because it has a narrower FLA 0.5.2/local-module contract::
+(``gated_delta_rule`` and ``kda``).  The dense MLP and decode short-convolution
+adapters are intentionally opt-in because they have narrower FLA 0.5.2
+contracts::
 
     import cudnn.fla
 
     cudnn.fla.accelerate_fla()                    # GDN + KDA, as before
     cudnn.fla.accelerate_fla(targets="gated_mlp") # incremental MLP opt-in
+    cudnn.fla.accelerate_fla(targets="short_conv") # decode short-conv opt-in
 
 Targets can be enabled and restored independently.  Every adapter is
 fail-closed: an incompatible installed FLA target rejects explicit activation,
@@ -32,8 +34,18 @@ from .gated_mlp import last_path as mlp_last_path
 from .gated_mlp import make_gated_mlp_forward
 from .gated_mlp import _supports_installed_fla
 from .kda import make_chunk_kda
+from .short_conv import last_path as short_conv_last_path
+from .short_conv import make_causal_conv1d_update
+from .short_conv import _supports_installed_fla as _supports_short_conv_fla
 
-__all__ = ["accelerate_fla", "is_accelerated", "last_path", "mlp_last_path", "restore_fla"]
+__all__ = [
+    "accelerate_fla",
+    "is_accelerated",
+    "last_path",
+    "mlp_last_path",
+    "restore_fla",
+    "short_conv_last_path",
+]
 
 
 @dataclass(frozen=True)
@@ -74,6 +86,50 @@ def _gated_mlp_replacement(module, owner, original):
     return make_gated_mlp_forward(original, owner, swiglu_linear_cls)
 
 
+_SHORT_CONV_CODE_SUFFIXES = (
+    "torch/_dynamo/eval_frame.py",
+    "fla/ops/backends/__init__.py",
+    "fla/utils/_decorators.py",
+    "fla/modules/conv/triton/ops.py",
+)
+
+
+def _matches_short_conv_target(module, original) -> bool:
+    """Match the exact decorated FLA 0.5.2 callable, not a later wrapper."""
+
+    if (
+        not callable(original)
+        or getattr(original, "__module__", None) != module.__name__
+        or getattr(original, "__name__", None) != "causal_conv1d_update"
+        or getattr(original, "__qualname__", None) != "causal_conv1d_update"
+        or getattr(original, "_torchdynamo_disable", None) is not True
+        or getattr(original, "_torchdynamo_orig_callable", None) is not getattr(original, "__wrapped__", None)
+    ):
+        return False
+
+    current = original
+    for index, suffix in enumerate(_SHORT_CONV_CODE_SUFFIXES):
+        code = getattr(current, "__code__", None)
+        if code is None or not code.co_filename.replace("\\", "/").endswith(suffix):
+            return False
+        wrapped = getattr(current, "__wrapped__", None)
+        if index + 1 == len(_SHORT_CONV_CODE_SUFFIXES):
+            return wrapped is None
+        if wrapped is None:
+            return False
+        current = wrapped
+    return False
+
+
+def _short_conv_replacement(module, owner, original):
+    del owner
+    if not _supports_short_conv_fla():
+        raise ImportError("the cuDNN short-conv shim requires flash-linear-attention==0.5.2")
+    if not _matches_short_conv_target(module, original):
+        raise ImportError("FLA causal_conv1d_update does not match the expected owning module")
+    return make_causal_conv1d_update(original)
+
+
 _TARGETS = {
     "gated_delta_rule": _PatchSpec(
         "fla.ops.gated_delta_rule",
@@ -92,8 +148,14 @@ _TARGETS = {
         owner_attribute="GatedMLP",
         default=False,
     ),
+    "short_conv": _PatchSpec(
+        "fla.modules.conv.triton.ops",
+        "causal_conv1d_update",
+        _short_conv_replacement,
+        default=False,
+    ),
 }
-_ALIASES = {"gdn": "gated_delta_rule", "mlp": "gated_mlp"}
+_ALIASES = {"gdn": "gated_delta_rule", "mlp": "gated_mlp", "shortconv": "short_conv"}
 _DEFAULT_TARGETS = tuple(name for name, spec in _TARGETS.items() if spec.default)
 _ORIGINALS: dict[str, _AppliedPatch] = {}
 
@@ -158,7 +220,9 @@ def accelerate_fla(verbose: bool = True, *, targets: str | Iterable[str] | None 
 
     ``targets=None`` preserves the original behavior and enables only GDN/KDA.
     Use ``targets="gated_mlp"`` (or the ``"mlp"`` alias) for the opt-in dense
-    MLP adapter.  A string or iterable of strings is accepted.
+    MLP adapter, and ``targets="short_conv"`` (or ``"shortconv"``) for the
+    FLA 0.5.2 decode short-convolution adapter.  A string or iterable of
+    strings is accepted.
     """
     requested = _normalize_targets(targets, default=_DEFAULT_TARGETS)
     available = {target for target in requested if is_accelerated(target)}

--- a/python/cudnn/fla/gated_delta_rule.py
+++ b/python/cudnn/fla/gated_delta_rule.py
@@ -178,8 +178,16 @@ def make_chunk_gated_delta_rule(real_fn):
         # for a stateless (training) call; decline only when a state is exchanged.
         if not state_v_first and (initial_state is not None or output_final_state):
             return fallback("state_v_first=False")
-        if not (q.is_cuda and torch.cuda.get_device_capability(q.device)[0] >= 10):
+        if not q.is_cuda:
             return fallback("pre-Blackwell")
+        cc_major = torch.cuda.get_device_capability(q.device)[0]
+        if cc_major < 10:
+            return fallback("pre-Blackwell")
+        # FROST has not been validated on SM11x, while a cuTile plan can fail
+        # only after this wrapper's typed-decline boundary.  Preserve functional
+        # compatibility by staying on the saved FLA implementation there.
+        if cc_major == 11:
+            return fallback("sm11")
         try:
             out = _to_native(
                 q,

--- a/python/cudnn/fla/gated_delta_rule.py
+++ b/python/cudnn/fla/gated_delta_rule.py
@@ -4,8 +4,9 @@
 """cuDNN-accelerated drop-in for ``fla.ops.gated_delta_rule.chunk_gated_delta_rule``.
 
 Maps the flash-linear-attention public signature onto cuDNN's native
-``gated_delta_net`` (Blackwell/SM100) and falls back to the wrapped FLA function
-for anything cuDNN does not serve, so results never change and never regress.
+``gated_delta_net`` on the adapter's validated SM100/SM103/SM107 targets and
+falls back to the wrapped FLA function everywhere else, so results never change
+and never regress.
 
 FLA layout is ``[B, T, H, ...]`` batch-first; ``g``/``beta`` are indexed by the
 *value* heads ``HV`` and FLA's grouped-value attention has ``HV >= H``, so native
@@ -33,6 +34,12 @@ from cudnn.linear_attention.ops import gated_delta_net
 
 # Native declines a graph it cannot serve with one of these; treat as a fallback.
 _DECLINE = (cudnn.cudnnGraphNotSupportedError, NotImplementedError)
+
+# The native graph also has an experimental portable cuTile engine, but the FLA
+# compatibility adapter stays fail-closed to targets with end-to-end parity
+# coverage. Compilation or launch failures outside this set are not typed graph
+# declines and therefore cannot be converted safely into an FLA fallback here.
+_VALIDATED_NATIVE_CAPABILITIES = frozenset({(10, 0), (10, 3), (10, 7)})
 
 # Diagnostic: which path the last shimmed call took ("native" | "fallback:<reason>").
 _LAST = {"path": None}
@@ -180,14 +187,11 @@ def make_chunk_gated_delta_rule(real_fn):
             return fallback("state_v_first=False")
         if not q.is_cuda:
             return fallback("pre-Blackwell")
-        cc_major = torch.cuda.get_device_capability(q.device)[0]
-        if cc_major < 10:
+        capability = torch.cuda.get_device_capability(q.device)
+        if capability[0] < 10:
             return fallback("pre-Blackwell")
-        # FROST has not been validated on SM11x, while a cuTile plan can fail
-        # only after this wrapper's typed-decline boundary.  Preserve functional
-        # compatibility by staying on the saved FLA implementation there.
-        if cc_major == 11:
-            return fallback("sm11")
+        if capability not in _VALIDATED_NATIVE_CAPABILITIES:
+            return fallback("unsupported-arch")
         try:
             out = _to_native(
                 q,

--- a/python/cudnn/fla/kda.py
+++ b/python/cudnn/fla/kda.py
@@ -3,8 +3,9 @@
 
 """cuDNN-accelerated drop-in for ``fla.ops.kda.chunk_kda`` (Kimi Delta Attention).
 
-Maps FLA's ``chunk_kda`` onto cuDNN's native ``kimi_delta_attention`` (Blackwell/
-SM100) and falls back to the wrapped FLA function for anything cuDNN does not serve.
+Maps FLA's ``chunk_kda`` onto cuDNN's native ``kimi_delta_attention`` on the
+adapter's validated SM100/SM103/SM107 targets and falls back to the wrapped FLA
+function everywhere else.
 
 KDA uses a **channel-wise** log decay ``g: [B,T,H,K]`` and a **scalar** write
 strength ``beta: [B,T,H]``. cuDNN's KDA kernel L2-normalizes q/k in-kernel and now
@@ -28,6 +29,12 @@ import cudnn
 from cudnn.linear_attention.ops import kimi_delta_attention
 
 _DECLINE = (cudnn.cudnnGraphNotSupportedError, NotImplementedError)
+
+# The native graph also has an experimental portable cuTile engine, but the FLA
+# compatibility adapter stays fail-closed to targets with end-to-end parity
+# coverage. Compilation or launch failures outside this set are not typed graph
+# declines and therefore cannot be converted safely into an FLA fallback here.
+_VALIDATED_NATIVE_CAPABILITIES = frozenset({(10, 0), (10, 3), (10, 7)})
 
 _LAST = {"path": None}
 
@@ -187,14 +194,11 @@ def make_chunk_kda(real_fn):
             return fallback("state_v_first=False")
         if not q.is_cuda:
             return fallback("pre-Blackwell")
-        cc_major = torch.cuda.get_device_capability(q.device)[0]
-        if cc_major < 10:
+        capability = torch.cuda.get_device_capability(q.device)
+        if capability[0] < 10:
             return fallback("pre-Blackwell")
-        # FROST has not been validated on SM11x, while a cuTile plan can fail
-        # only after this wrapper's typed-decline boundary.  Preserve functional
-        # compatibility by staying on the saved FLA implementation there.
-        if cc_major == 11:
-            return fallback("sm11")
+        if capability not in _VALIDATED_NATIVE_CAPABILITIES:
+            return fallback("unsupported-arch")
         try:
             out = _to_native(
                 q,

--- a/python/cudnn/fla/kda.py
+++ b/python/cudnn/fla/kda.py
@@ -185,8 +185,16 @@ def make_chunk_kda(real_fn):
             return fallback("variant")
         if not state_v_first and (initial_state is not None or output_final_state):
             return fallback("state_v_first=False")
-        if not (q.is_cuda and torch.cuda.get_device_capability(q.device)[0] >= 10):
+        if not q.is_cuda:
             return fallback("pre-Blackwell")
+        cc_major = torch.cuda.get_device_capability(q.device)[0]
+        if cc_major < 10:
+            return fallback("pre-Blackwell")
+        # FROST has not been validated on SM11x, while a cuTile plan can fail
+        # only after this wrapper's typed-decline boundary.  Preserve functional
+        # compatibility by staying on the saved FLA implementation there.
+        if cc_major == 11:
+            return fallback("sm11")
         try:
             out = _to_native(
                 q,

--- a/python/cudnn/fla/short_conv.py
+++ b/python/cudnn/fla/short_conv.py
@@ -18,6 +18,9 @@ from importlib import metadata
 import torch
 
 import cudnn
+from cudnn._causal_conv1d_arch import (
+    is_supported_causal_conv1d_update_compute_capability,
+)
 
 _SUPPORTED_FLA_VERSION = "0.5.2"
 _DECLINE_ERRORS = (NotImplementedError, cudnn.cudnnGraphNotSupportedError, ImportError)
@@ -78,8 +81,8 @@ def _native_input_view(x: torch.Tensor, weight: torch.Tensor, cache: torch.Tenso
         raise ValueError("non-cuda")
     if not (x.device == weight.device == cache.device):
         raise ValueError("device")
-    if _device_capability(x.device) != (10, 0):
-        raise ValueError("non-sm100")
+    if not is_supported_causal_conv1d_update_compute_capability(_device_capability(x.device)):
+        raise ValueError("unsupported-arch")
     if not (x.is_contiguous() and weight.is_contiguous() and cache.is_contiguous()):
         raise ValueError("noncontiguous")
 

--- a/python/cudnn/fla/short_conv.py
+++ b/python/cudnn/fla/short_conv.py
@@ -69,7 +69,7 @@ def _call_native(x: torch.Tensor, cache: torch.Tensor, weight: torch.Tensor) -> 
 
 
 def _native_input_view(x: torch.Tensor, weight: torch.Tensor, cache: torch.Tensor) -> torch.Tensor:
-    """Validate the narrow native contract and return a zero-copy ``[N, D]`` view."""
+    """Validate the native contract and return a zero-copy row-strided ``[N, D]`` view."""
 
     if type(x) is not torch.Tensor or type(weight) is not torch.Tensor or type(cache) is not torch.Tensor:
         raise ValueError("tensor-subclass")
@@ -83,7 +83,7 @@ def _native_input_view(x: torch.Tensor, weight: torch.Tensor, cache: torch.Tenso
         raise ValueError("device")
     if not is_supported_causal_conv1d_update_compute_capability(_device_capability(x.device)):
         raise ValueError("unsupported-arch")
-    if not (x.is_contiguous() and weight.is_contiguous() and cache.is_contiguous()):
+    if not (weight.is_contiguous() and cache.is_contiguous()):
         raise ValueError("noncontiguous")
 
     if x.ndim == 2:
@@ -96,6 +96,21 @@ def _native_input_view(x: torch.Tensor, weight: torch.Tensor, cache: torch.Tenso
         raise ValueError("shape")
     if n_rows <= 0 or n_channels <= 0:
         raise ValueError("shape")
+
+    # Each admitted 3D layout only adds a singleton dimension, so view() is a
+    # zero-copy normalization.  Preserve X's leading dimension: fused QKV
+    # projections commonly expose each slice as (3 * D, 1), which the native
+    # kernel addresses directly without an adapter-side copy.
+    try:
+        native_x = x.view(n_rows, n_channels)
+    except RuntimeError as error:
+        raise ValueError("noncontiguous") from error
+    row_stride, channel_stride = native_x.stride()
+    if channel_stride != 1 or row_stride < n_channels:
+        raise ValueError("noncontiguous")
+    if row_stride > n_channels and row_stride % 8 != 0:
+        raise ValueError("alignment")
+
     if tuple(weight.shape) != (n_channels, 4) or tuple(cache.shape) != (n_rows, n_channels, 4):
         raise ValueError("shape")
     if x.data_ptr() % 16 or weight.data_ptr() % 16 or cache.data_ptr() % 16:
@@ -103,9 +118,9 @@ def _native_input_view(x: torch.Tensor, weight: torch.Tensor, cache: torch.Tenso
     if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in (x, weight, cache)):
         raise ValueError("autograd")
 
-    # Contiguity and the singleton layout checks above make this a true view;
-    # no adapter-side allocation, gather, or copy is permitted here.
-    return x.view(n_rows, n_channels)
+    # The singleton layout and explicit stride checks above make this a true
+    # view; no adapter-side allocation, gather, or copy is permitted here.
+    return native_x
 
 
 def make_causal_conv1d_update(real_fn):

--- a/python/cudnn/fla/short_conv.py
+++ b/python/cudnn/fla/short_conv.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""cuDNN acceleration for FLA 0.5.2's decode short-convolution entry point.
+
+This adapter was implemented independently against FLA's public call contract.
+It does not include or translate FLA's Triton kernel implementation.  The
+supported path only normalizes FLA's decode layouts into zero-copy 2D views and
+calls :func:`cudnn.causal_conv1d_update`; every other configuration calls the
+original FLA function unchanged.
+"""
+
+from __future__ import annotations
+
+import functools
+from importlib import metadata
+
+import torch
+
+import cudnn
+
+_SUPPORTED_FLA_VERSION = "0.5.2"
+_DECLINE_ERRORS = (NotImplementedError, cudnn.cudnnGraphNotSupportedError, ImportError)
+_LAST = {"path": None}
+
+
+def last_path() -> str | None:
+    """Return the route taken by the most recent shimmed call."""
+
+    return _LAST["path"]
+
+
+def _installed_fla_version() -> str | None:
+    try:
+        return metadata.version("flash-linear-attention")
+    except metadata.PackageNotFoundError:
+        return None
+
+
+def _supports_installed_fla() -> bool:
+    return _installed_fla_version() == _SUPPORTED_FLA_VERSION
+
+
+def _is_cuda_tensor(tensor: torch.Tensor) -> bool:
+    return tensor.is_cuda
+
+
+def _device_capability(device: torch.device) -> tuple[int, int]:
+    return torch.cuda.get_device_capability(device)
+
+
+def _is_compiling() -> bool:
+    compiler = getattr(torch, "compiler", None)
+    if compiler is not None and compiler.is_compiling():
+        return True
+    dynamo = getattr(torch, "_dynamo", None)
+    return bool(dynamo is not None and dynamo.is_compiling())
+
+
+def _call_native(x: torch.Tensor, weight: torch.Tensor, cache: torch.Tensor) -> torch.Tensor:
+    # Resolve lazily so importing cudnn.fla does not import the optional
+    # CuTeDSL stack or compile a kernel.
+    from cudnn.causal_conv1d_update_sm100 import causal_conv1d_update
+
+    return causal_conv1d_update(x, weight, cache)
+
+
+def _native_input_view(x: torch.Tensor, weight: torch.Tensor, cache: torch.Tensor) -> torch.Tensor:
+    """Validate the narrow native contract and return a zero-copy ``[N, D]`` view."""
+
+    if type(x) is not torch.Tensor or type(weight) is not torch.Tensor or type(cache) is not torch.Tensor:
+        raise ValueError("tensor-subclass")
+    if _is_compiling():
+        raise ValueError("compile")
+    if not (x.dtype == weight.dtype == cache.dtype == torch.bfloat16):
+        raise ValueError("non-bf16")
+    if not (_is_cuda_tensor(x) and _is_cuda_tensor(weight) and _is_cuda_tensor(cache)):
+        raise ValueError("non-cuda")
+    if not (x.device == weight.device == cache.device):
+        raise ValueError("device")
+    if _device_capability(x.device) != (10, 0):
+        raise ValueError("non-sm100")
+    if not (x.is_contiguous() and weight.is_contiguous() and cache.is_contiguous()):
+        raise ValueError("noncontiguous")
+
+    if x.ndim == 2:
+        n_rows, n_channels = x.shape
+    elif x.ndim == 3 and x.shape[1] == 1:
+        n_rows, _, n_channels = x.shape
+    elif x.ndim == 3 and x.shape[0] == 1:
+        _, n_rows, n_channels = x.shape
+    else:
+        raise ValueError("shape")
+    if n_rows <= 0 or n_channels <= 0:
+        raise ValueError("shape")
+    if tuple(weight.shape) != (n_channels, 4) or tuple(cache.shape) != (n_rows, n_channels, 4):
+        raise ValueError("shape")
+    if x.data_ptr() % 16 or weight.data_ptr() % 16 or cache.data_ptr() % 16:
+        raise ValueError("alignment")
+    if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in (x, weight, cache)):
+        raise ValueError("autograd")
+
+    # Contiguity and the singleton layout checks above make this a true view;
+    # no adapter-side allocation, gather, or copy is permitted here.
+    return x.view(n_rows, n_channels)
+
+
+def make_causal_conv1d_update(real_fn):
+    """Wrap FLA's public decode update with a narrow cuDNN native path."""
+
+    @functools.wraps(real_fn)
+    def causal_conv1d_update(
+        x,
+        cache,
+        residual=None,
+        weight=None,
+        bias=None,
+        activation=None,
+    ):
+        def fallback(reason):
+            _LAST["path"] = f"fallback:{reason}"
+            return real_fn(
+                x,
+                cache,
+                residual=residual,
+                weight=weight,
+                bias=bias,
+                activation=activation,
+            )
+
+        if residual is not None:
+            return fallback("residual")
+        if weight is None:
+            return fallback("weight")
+        if bias is not None:
+            return fallback("bias")
+        if activation not in ("silu", "swish"):
+            return fallback("activation")
+
+        try:
+            native_x = _native_input_view(x, weight, cache)
+        except (TypeError, ValueError) as error:
+            return fallback(str(error) or type(error).__name__)
+
+        try:
+            native_y = _call_native(native_x, weight, cache)
+        except _DECLINE_ERRORS as error:
+            return fallback(type(error).__name__)
+        except Exception as error:
+            # Binding/allocation/launch failures are not evidence that the
+            # configuration is unsupported.  Surface them to the caller.
+            _LAST["path"] = f"error:{type(error).__name__}"
+            raise
+
+        _LAST["path"] = "native"
+        return native_y.view(x.shape), cache
+
+    return causal_conv1d_update
+
+
+__all__ = ["last_path", "make_causal_conv1d_update"]

--- a/python/cudnn/fla/short_conv.py
+++ b/python/cudnn/fla/short_conv.py
@@ -6,7 +6,7 @@
 This adapter was implemented independently against FLA's public call contract.
 It does not include or translate FLA's Triton kernel implementation.  The
 supported path only normalizes FLA's decode layouts into zero-copy 2D views and
-calls :func:`cudnn.causal_conv1d_update`; every other configuration calls the
+calls :func:`cudnn.ops.causal_conv1d_update`; every other configuration calls the
 original FLA function unchanged.
 """
 
@@ -63,9 +63,9 @@ def _is_compiling() -> bool:
 def _call_native(x: torch.Tensor, cache: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
     # Resolve lazily so importing cudnn.fla does not import the optional
     # CuTeDSL stack or compile a kernel.
-    from cudnn.causal_conv1d_update_sm100 import causal_conv1d_update
+    from cudnn.ops import causal_conv1d_update
 
-    return causal_conv1d_update(x, cache, weight)
+    return causal_conv1d_update(x, cache, weight, activation="silu")
 
 
 def _native_input_view(x: torch.Tensor, weight: torch.Tensor, cache: torch.Tensor) -> torch.Tensor:

--- a/python/cudnn/fla/short_conv.py
+++ b/python/cudnn/fla/short_conv.py
@@ -57,12 +57,12 @@ def _is_compiling() -> bool:
     return bool(dynamo is not None and dynamo.is_compiling())
 
 
-def _call_native(x: torch.Tensor, weight: torch.Tensor, cache: torch.Tensor) -> torch.Tensor:
+def _call_native(x: torch.Tensor, cache: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
     # Resolve lazily so importing cudnn.fla does not import the optional
     # CuTeDSL stack or compile a kernel.
     from cudnn.causal_conv1d_update_sm100 import causal_conv1d_update
 
-    return causal_conv1d_update(x, weight, cache)
+    return causal_conv1d_update(x, cache, weight)
 
 
 def _native_input_view(x: torch.Tensor, weight: torch.Tensor, cache: torch.Tensor) -> torch.Tensor:
@@ -143,7 +143,7 @@ def make_causal_conv1d_update(real_fn):
             return fallback(str(error) or type(error).__name__)
 
         try:
-            native_y = _call_native(native_x, weight, cache)
+            native_y = _call_native(native_x, cache, weight)
         except _DECLINE_ERRORS as error:
             return fallback(type(error).__name__)
         except Exception as error:

--- a/python/cudnn/ops/__init__.py
+++ b/python/cudnn/ops/__init__.py
@@ -16,7 +16,7 @@ _LAZY_EXPORTS = {
     "causal_conv1d": (".causal_conv1d", "causal_conv1d"),
     "causal_conv1d_nwh": (".causal_conv1d", "causal_conv1d_nwh"),
     "b2b_causal_conv1d": (".causal_conv1d", "b2b_causal_conv1d"),
-    "causal_conv1d_update": ("..causal_conv1d_update_sm100", "causal_conv1d_update"),
+    "causal_conv1d_update": (".causal_conv1d", "causal_conv1d_update"),
     "fft_causal_conv1d": (".fft_causal_conv1d", "fft_causal_conv1d"),
 }
 

--- a/python/cudnn/ops/__init__.py
+++ b/python/cudnn/ops/__init__.py
@@ -16,6 +16,7 @@ _LAZY_EXPORTS = {
     "causal_conv1d": (".causal_conv1d", "causal_conv1d"),
     "causal_conv1d_nwh": (".causal_conv1d", "causal_conv1d_nwh"),
     "b2b_causal_conv1d": (".causal_conv1d", "b2b_causal_conv1d"),
+    "causal_conv1d_update": ("..causal_conv1d_update_sm100", "causal_conv1d_update"),
     "fft_causal_conv1d": (".fft_causal_conv1d", "fft_causal_conv1d"),
 }
 

--- a/python/cudnn/ops/__init__.py
+++ b/python/cudnn/ops/__init__.py
@@ -16,7 +16,7 @@ _LAZY_EXPORTS = {
     "causal_conv1d": (".causal_conv1d", "causal_conv1d"),
     "causal_conv1d_nwh": (".causal_conv1d", "causal_conv1d_nwh"),
     "b2b_causal_conv1d": (".causal_conv1d", "b2b_causal_conv1d"),
-    "causal_conv1d_update": (".causal_conv1d", "causal_conv1d_update"),
+    "causal_conv1d_update": ("._causal_conv1d_update", "causal_conv1d_update"),
     "fft_causal_conv1d": (".fft_causal_conv1d", "fft_causal_conv1d"),
 }
 

--- a/python/cudnn/ops/_causal_conv1d_update.py
+++ b/python/cudnn/ops/_causal_conv1d_update.py
@@ -17,6 +17,24 @@ def _normalize_activation(activation: Optional[str]) -> str:
     raise ValueError("activation must be None, 'identity', 'silu', or 'swish', " f"got {activation!r}")
 
 
+def _validate_x_stride(x: Tensor) -> None:
+    """Validate the native BF16 ``[N, D]`` row-strided input contract.
+
+    Compact rows retain the legacy behavior for every channel count.  Padded
+    rows are admitted only when every row begins at a 16-byte boundary; BF16
+    therefore requires an eight-element-aligned leading dimension.
+    """
+
+    n_channels = x.shape[1]
+    row_stride, channel_stride = x.stride()
+    if channel_stride != 1:
+        raise ValueError(f"x must have row-major strides (ld, 1), got {tuple(x.stride())}")
+    if row_stride < n_channels:
+        raise ValueError(f"x row stride ld must be at least D={n_channels}, got ld={row_stride}")
+    if row_stride > n_channels and row_stride % 8 != 0:
+        raise ValueError("padded x rows must start at 16-byte-aligned BF16 addresses " f"(ld % 8 == 0), got D={n_channels}, ld={row_stride}")
+
+
 def _validate_semantic_contract(
     x: Tensor,
     conv_state: Tensor,
@@ -66,7 +84,9 @@ def _validate_semantic_contract(
             continue
         if tensor.dtype != torch.bfloat16:
             raise TypeError(f"{name} must have dtype torch.bfloat16, got {tensor.dtype}")
-        if not tensor.is_contiguous():
+        if name == "x":
+            _validate_x_stride(tensor)
+        elif not tensor.is_contiguous():
             raise ValueError(f"{name} must be contiguous")
         if tensor.device != x.device:
             raise ValueError(f"{name} must be on {x.device}, got {tensor.device}")
@@ -223,7 +243,10 @@ def causal_conv1d_update(
     select the same compile-time SiLU specialization.
 
     Args:
-        x: Contiguous CUDA BF16 tensor with shape ``[N, D]``.
+        x: CUDA BF16 tensor with shape ``[N, D]`` and strides ``(ld, 1)``.
+            Compact ``ld == D`` is supported for every ``D``. Padded
+            ``ld > D`` must be divisible by eight so each BF16 row starts at a
+            16-byte-aligned address.
         conv_state: Contiguous CUDA BF16 tensor with shape ``[S, D, L]``, where
             ``L >= W - 1``.
         weight: Contiguous CUDA BF16 tensor with shape ``[D, W]``.

--- a/python/cudnn/ops/_causal_conv1d_update.py
+++ b/python/cudnn/ops/_causal_conv1d_update.py
@@ -1,0 +1,211 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model-facing causal-convolution decode update implementation."""
+
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+
+def _normalize_activation(activation: Optional[str]) -> str:
+    if activation is None or activation == "identity":
+        return "identity"
+    if activation in ("silu", "swish"):
+        return "silu"
+    raise ValueError("activation must be None, 'identity', 'silu', or 'swish', " f"got {activation!r}")
+
+
+def _validate_semantic_contract(
+    x: Tensor,
+    conv_state: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor],
+    cache_seqlens: Optional[Tensor],
+    conv_state_indices: Optional[Tensor],
+) -> None:
+    if x.ndim != 2:
+        raise ValueError(f"x must have shape [N, D], got {tuple(x.shape)}")
+    if conv_state.ndim != 3:
+        raise ValueError(f"conv_state must have shape [S, D, L], got {tuple(conv_state.shape)}")
+    if weight.ndim != 2:
+        raise ValueError(f"weight must have shape [D, W], got {tuple(weight.shape)}")
+
+    n_rows, n_channels = x.shape
+    n_slots = conv_state.shape[0]
+    if n_rows <= 0:
+        raise ValueError(f"x row count N must be positive, got N={n_rows}")
+    if n_channels <= 0:
+        raise ValueError(f"x channel count D must be positive, got D={n_channels}")
+    if n_slots <= 0:
+        raise ValueError(f"conv_state slot count S must be positive, got S={n_slots}")
+    width = weight.shape[1]
+    state_len = conv_state.shape[2]
+    if width < 1:
+        raise ValueError(f"weight width W must be positive, got W={width}")
+    if weight.shape[0] != n_channels:
+        raise ValueError(f"weight must have shape [D, W] with D={n_channels}, got {tuple(weight.shape)}")
+    if conv_state.shape[1] != n_channels:
+        raise ValueError(f"conv_state must have shape [S, D, L] with D={n_channels}, got {tuple(conv_state.shape)}")
+    if state_len < width - 1:
+        raise ValueError(f"conv_state length L must satisfy L >= W - 1, got L={state_len}, W={width}")
+    if bias is not None and tuple(bias.shape) != (n_channels,):
+        raise ValueError(f"bias must have shape {(n_channels,)}, got {tuple(bias.shape)}")
+    if conv_state_indices is None:
+        if n_slots < n_rows:
+            raise ValueError(f"conv_state needs at least N slots when conv_state_indices is omitted, got S={n_slots}, N={n_rows}")
+    elif tuple(conv_state_indices.shape) != (n_rows,):
+        raise ValueError(f"conv_state_indices must have shape {(n_rows,)}, got {tuple(conv_state_indices.shape)}")
+    if cache_seqlens is not None and tuple(cache_seqlens.shape) != (n_rows,):
+        raise ValueError(f"cache_seqlens must have shape {(n_rows,)}, got {tuple(cache_seqlens.shape)}")
+
+    tensors = (("x", x), ("conv_state", conv_state), ("weight", weight), ("bias", bias))
+    for name, tensor in tensors:
+        if tensor is None:
+            continue
+        if tensor.dtype != torch.bfloat16:
+            raise TypeError(f"{name} must have dtype torch.bfloat16, got {tensor.dtype}")
+        if not tensor.is_contiguous():
+            raise ValueError(f"{name} must be contiguous")
+        if tensor.device != x.device:
+            raise ValueError(f"{name} must be on {x.device}, got {tensor.device}")
+    for name, tensor in (("cache_seqlens", cache_seqlens), ("conv_state_indices", conv_state_indices)):
+        if tensor is None:
+            continue
+        if tensor.dtype != torch.int32:
+            raise TypeError(f"{name} must have dtype torch.int32, got {tensor.dtype}")
+        if not tensor.is_contiguous():
+            raise ValueError(f"{name} must be contiguous")
+        if tensor.device != x.device:
+            raise ValueError(f"{name} must be on {x.device}, got {tensor.device}")
+
+
+def _require_native_subset(
+    x: Tensor,
+    conv_state: Tensor,
+    weight: Tensor,
+    cache_seqlens: Optional[Tensor],
+) -> None:
+    """Decline semantic configurations the current native kernel cannot run."""
+
+    width = weight.shape[1]
+    state_len = conv_state.shape[2]
+    if width != 4 or state_len not in (3, 4) or cache_seqlens is not None:
+        circular = "present" if cache_seqlens is not None else "omitted"
+        raise NotImplementedError(
+            "the current native causal_conv1d_update kernel supports only one-token "
+            "x[N, D], weight[D, 4], conv_state[S, D, L] with L in {3, 4}, "
+            "and cache_seqlens=None; "
+            f"got x{tuple(x.shape)}, weight{tuple(weight.shape)}, "
+            f"conv_state{tuple(conv_state.shape)}, cache_seqlens={circular}"
+        )
+
+
+@torch.library.custom_op(
+    "cudnn::_causal_conv1d_update",
+    mutates_args=("conv_state",),
+    device_types="cuda",
+)
+def _causal_conv1d_update_primitive(
+    x: Tensor,
+    conv_state: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor],
+    activation: str,
+    cache_seqlens: Optional[Tensor],
+    conv_state_indices: Optional[Tensor],
+) -> Tensor:
+    from cudnn.causal_conv1d_update_sm100 import _causal_conv1d_update
+
+    activation = _normalize_activation(activation)
+    _validate_semantic_contract(x, conv_state, weight, bias, cache_seqlens, conv_state_indices)
+    _require_native_subset(x, conv_state, weight, cache_seqlens)
+    return _causal_conv1d_update(
+        x,
+        conv_state,
+        weight,
+        bias,
+        activation,
+        conv_state_indices=conv_state_indices,
+    )
+
+
+@torch.library.register_fake("cudnn::_causal_conv1d_update")
+def _causal_conv1d_update_fake(
+    x: Tensor,
+    conv_state: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor],
+    activation: str,
+    cache_seqlens: Optional[Tensor],
+    conv_state_indices: Optional[Tensor],
+) -> Tensor:
+    _normalize_activation(activation)
+    _validate_semantic_contract(x, conv_state, weight, bias, cache_seqlens, conv_state_indices)
+    _require_native_subset(x, conv_state, weight, cache_seqlens)
+    return torch.empty_like(x, memory_format=torch.contiguous_format)
+
+
+def causal_conv1d_update(
+    x: Tensor,
+    conv_state: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor] = None,
+    activation: Optional[str] = None,
+    *,
+    cache_seqlens: Optional[Tensor] = None,
+    conv_state_indices: Optional[Tensor] = None,
+) -> Tensor:
+    r"""Advance a mutable causal-convolution state for one decode step.
+
+    ``conv_state`` is mutated in place. The returned Tensor is newly allocated
+    and has the same shape and dtype as ``x``. ``activation=None`` and
+    ``"identity"`` select the identity epilogue; ``"silu"`` and ``"swish"``
+    select the same compile-time SiLU specialization.
+
+    Args:
+        x: Contiguous CUDA BF16 tensor with shape ``[N, D]``.
+        conv_state: Contiguous CUDA BF16 tensor with shape ``[S, D, L]``, where
+            ``L >= W - 1``.
+        weight: Contiguous CUDA BF16 tensor with shape ``[D, W]``.
+        bias: Optional contiguous CUDA BF16 tensor with shape ``[D]``.
+        activation: ``None``, ``"identity"``, ``"silu"``, or ``"swish"``.
+        cache_seqlens: Optional contiguous CUDA int32 tensor with shape ``[N]``.
+            When present, ``conv_state`` is interpreted as a circular buffer.
+        conv_state_indices: Optional contiguous CUDA int32 tensor with shape
+            ``[N]`` selecting unique state slots.
+
+    Returns:
+        A contiguous CUDA BF16 Tensor with shape ``[N, D]``.
+    """
+
+    for name, tensor in (("x", x), ("conv_state", conv_state), ("weight", weight)):
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(f"{name} must be a torch.Tensor, got {type(tensor).__name__}")
+    if bias is not None and not isinstance(bias, torch.Tensor):
+        raise TypeError(f"bias must be a torch.Tensor or None, got {type(bias).__name__}")
+    if cache_seqlens is not None and not isinstance(cache_seqlens, torch.Tensor):
+        raise TypeError(f"cache_seqlens must be a torch.Tensor or None, got {type(cache_seqlens).__name__}")
+    if conv_state_indices is not None and not isinstance(conv_state_indices, torch.Tensor):
+        raise TypeError("conv_state_indices must be a torch.Tensor or None, " f"got {type(conv_state_indices).__name__}")
+    if not x.is_cuda and x.device.type != "meta":
+        raise ValueError(f"x must be a CUDA tensor, got {x.device}")
+
+    normalized_activation = _normalize_activation(activation)
+    grad_tensors = (x, conv_state, weight, bias)
+    if torch.is_grad_enabled() and any(tensor is not None and tensor.requires_grad for tensor in grad_tensors):
+        raise RuntimeError("causal_conv1d_update is inference-only; call it under torch.no_grad()")
+
+    return torch.ops.cudnn._causal_conv1d_update(
+        x,
+        conv_state,
+        weight,
+        bias,
+        normalized_activation,
+        cache_seqlens,
+        conv_state_indices,
+    )
+
+
+__all__ = ["causal_conv1d_update"]

--- a/python/cudnn/ops/_causal_conv1d_update.py
+++ b/python/cudnn/ops/_causal_conv1d_update.py
@@ -102,6 +102,67 @@ def _require_native_subset(
         )
 
 
+def _validated_native_update(
+    x: Tensor,
+    conv_state: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor],
+    activation: str,
+    cache_seqlens: Optional[Tensor],
+    conv_state_indices: Optional[Tensor],
+) -> Tensor:
+    """Validate the semantic contract and enter the prepared native route."""
+
+    _validate_semantic_contract(x, conv_state, weight, bias, cache_seqlens, conv_state_indices)
+    _require_native_subset(x, conv_state, weight, cache_seqlens)
+
+    from cudnn.causal_conv1d_update_sm100 import _causal_conv1d_update
+
+    return _causal_conv1d_update(
+        x,
+        conv_state,
+        weight,
+        bias,
+        activation,
+        conv_state_indices=conv_state_indices,
+    )
+
+
+def _is_compiling() -> bool:
+    compiler = getattr(torch, "compiler", None)
+    if compiler is not None and compiler.is_compiling():
+        return True
+    dynamo = getattr(torch, "_dynamo", None)
+    return bool(dynamo is not None and dynamo.is_compiling())
+
+
+def _can_use_eager_native_fast_path(
+    x: Tensor,
+    conv_state: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor],
+    cache_seqlens: Optional[Tensor],
+    conv_state_indices: Optional[Tensor],
+) -> bool:
+    """Keep dispatch-aware tensors on the custom op while avoiding it in plain eager mode."""
+
+    if _is_compiling() or not x.is_cuda or cache_seqlens is not None:
+        return False
+    dispatch_stack_length = getattr(torch._C, "_len_torch_dispatch_stack", None)
+    torch_function_mode_enabled = getattr(torch._C, "_is_torch_function_mode_enabled", None)
+    if dispatch_stack_length is None or dispatch_stack_length() != 0:
+        return False
+    if torch_function_mode_enabled is None or torch_function_mode_enabled():
+        return False
+    if type(x) is not torch.Tensor or type(conv_state) is not torch.Tensor:
+        return False
+    if type(weight) is not torch.Tensor:
+        return False
+    if bias is not None and type(bias) is not torch.Tensor:
+        return False
+    return conv_state_indices is None or type(conv_state_indices) is torch.Tensor
+
+
 @torch.library.custom_op(
     "cudnn::_causal_conv1d_update",
     mutates_args=("conv_state",),
@@ -116,18 +177,15 @@ def _causal_conv1d_update_primitive(
     cache_seqlens: Optional[Tensor],
     conv_state_indices: Optional[Tensor],
 ) -> Tensor:
-    from cudnn.causal_conv1d_update_sm100 import _causal_conv1d_update
-
     activation = _normalize_activation(activation)
-    _validate_semantic_contract(x, conv_state, weight, bias, cache_seqlens, conv_state_indices)
-    _require_native_subset(x, conv_state, weight, cache_seqlens)
-    return _causal_conv1d_update(
+    return _validated_native_update(
         x,
         conv_state,
         weight,
         bias,
         activation,
-        conv_state_indices=conv_state_indices,
+        cache_seqlens,
+        conv_state_indices,
     )
 
 
@@ -196,6 +254,17 @@ def causal_conv1d_update(
     grad_tensors = (x, conv_state, weight, bias)
     if torch.is_grad_enabled() and any(tensor is not None and tensor.requires_grad for tensor in grad_tensors):
         raise RuntimeError("causal_conv1d_update is inference-only; call it under torch.no_grad()")
+
+    if _can_use_eager_native_fast_path(x, conv_state, weight, bias, cache_seqlens, conv_state_indices):
+        return _validated_native_update(
+            x,
+            conv_state,
+            weight,
+            bias,
+            normalized_activation,
+            cache_seqlens,
+            conv_state_indices,
+        )
 
     return torch.ops.cudnn._causal_conv1d_update(
         x,

--- a/python/cudnn/ops/causal_conv1d.py
+++ b/python/cudnn/ops/causal_conv1d.py
@@ -243,6 +243,46 @@ def causal_conv1d(
     return torch.ops.cudnn.causal_conv1d_fwd_primitive(x, weight, bias, activation)
 
 
+def causal_conv1d_update(
+    x: Tensor,
+    conv_state: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor] = None,
+    activation: Optional[str] = None,
+    *,
+    conv_state_indices: Optional[Tensor] = None,
+) -> Tensor:
+    r"""Advance a mutable causal-convolution state by one decode token.
+
+    This is the semantic Torch API. It owns output allocation and kernel-plan
+    caching internally; callers pass tensors and receive a tensor. ``conv_state``
+    is updated in place.
+
+    The current native implementation supports contiguous BF16 ``x[N, D]``,
+    ``conv_state[S, D, 4]``, and ``weight[D, 4]`` tensors with fused SiLU.
+    ``conv_state_indices[N]`` optionally selects a unique state slot for each
+    row. The operation is inference-only.
+    """
+
+    if activation not in ("silu", "swish"):
+        raise NotImplementedError("causal_conv1d_update currently requires activation='silu' or 'swish'")
+
+    # Keep the lifecycle-oriented implementation private to this semantic API.
+    # It validates the complete tensor, mutation, aliasing, and architecture
+    # contract before compiling or launching the kernel.
+    from cudnn.causal_conv1d_update_sm100 import (
+        causal_conv1d_update as _causal_conv1d_update_impl,
+    )
+
+    return _causal_conv1d_update_impl(
+        x,
+        conv_state,
+        weight,
+        conv_state_indices,
+        bias=bias,
+    )
+
+
 # ===========================================================================
 # NWH variant — x is (batch, seq_len, dim)
 # ===========================================================================

--- a/python/cudnn/ops/causal_conv1d.py
+++ b/python/cudnn/ops/causal_conv1d.py
@@ -248,7 +248,7 @@ def causal_conv1d_update(
     conv_state: Tensor,
     weight: Tensor,
     bias: Optional[Tensor] = None,
-    activation: Optional[str] = None,
+    activation: str = "silu",
     *,
     conv_state_indices: Optional[Tensor] = None,
 ) -> Tensor:

--- a/python/cudnn/ops/causal_conv1d.py
+++ b/python/cudnn/ops/causal_conv1d.py
@@ -243,46 +243,6 @@ def causal_conv1d(
     return torch.ops.cudnn.causal_conv1d_fwd_primitive(x, weight, bias, activation)
 
 
-def causal_conv1d_update(
-    x: Tensor,
-    conv_state: Tensor,
-    weight: Tensor,
-    bias: Optional[Tensor] = None,
-    activation: str = "silu",
-    *,
-    conv_state_indices: Optional[Tensor] = None,
-) -> Tensor:
-    r"""Advance a mutable causal-convolution state by one decode token.
-
-    This is the semantic Torch API. It owns output allocation and kernel-plan
-    caching internally; callers pass tensors and receive a tensor. ``conv_state``
-    is updated in place.
-
-    The current native implementation supports contiguous BF16 ``x[N, D]``,
-    ``conv_state[S, D, 4]``, and ``weight[D, 4]`` tensors with fused SiLU.
-    ``conv_state_indices[N]`` optionally selects a unique state slot for each
-    row. The operation is inference-only.
-    """
-
-    if activation not in ("silu", "swish"):
-        raise NotImplementedError("causal_conv1d_update currently requires activation='silu' or 'swish'")
-
-    # Keep the lifecycle-oriented implementation private to this semantic API.
-    # It validates the complete tensor, mutation, aliasing, and architecture
-    # contract before compiling or launching the kernel.
-    from cudnn.causal_conv1d_update_sm100 import (
-        causal_conv1d_update as _causal_conv1d_update_impl,
-    )
-
-    return _causal_conv1d_update_impl(
-        x,
-        conv_state,
-        weight,
-        conv_state_indices,
-        bias=bias,
-    )
-
-
 # ===========================================================================
 # NWH variant — x is (batch, seq_len, dim)
 # ===========================================================================

--- a/test/python/fe_api/causal_conv1d_update/conftest.py
+++ b/test/python/fe_api/causal_conv1d_update/conftest.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Overlay this checkout's Python modules onto a prebuilt frontend package."""
+
+from pathlib import Path
+
+import cudnn
+
+_SOURCE_CUDNN = Path(__file__).resolve().parents[4] / "python" / "cudnn"
+if str(_SOURCE_CUDNN) not in cudnn.__path__:
+    cudnn.__path__.insert(0, str(_SOURCE_CUDNN))

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_benchmark_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_benchmark_contract_unit.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host-contract tests for the causal-convolution benchmark environment gate."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.L0
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_SUPPORTED_COMPUTE_CAPABILITIES = (
+    (8, 0),
+    (8, 6),
+    (8, 7),
+    (8, 9),
+    (9, 0),
+    (10, 0),
+    (10, 3),
+    (11, 0),
+    (12, 0),
+    (12, 1),
+)
+
+
+def _fake_fla_ops(monkeypatch):
+    packages = {}
+    for name in ("fla", "fla.modules", "fla.modules.conv", "fla.modules.conv.triton"):
+        package = types.ModuleType(name)
+        package.__path__ = []
+        packages[name] = package
+        monkeypatch.setitem(sys.modules, name, package)
+
+    ops = types.ModuleType("fla.modules.conv.triton.ops")
+
+    def causal_conv1d_update(x, cache, residual=None, weight=None, bias=None, activation=None):
+        del residual, weight, bias, activation
+        return x, cache
+
+    causal_conv1d_update.__module__ = ops.__name__
+    ops.causal_conv1d_update = causal_conv1d_update
+    monkeypatch.setitem(sys.modules, ops.__name__, ops)
+
+    packages["fla"].modules = packages["fla.modules"]
+    packages["fla.modules"].conv = packages["fla.modules.conv"]
+    packages["fla.modules.conv"].triton = packages["fla.modules.conv.triton"]
+    packages["fla.modules.conv.triton"].ops = ops
+
+
+def _load_benchmark(monkeypatch):
+    _fake_fla_ops(monkeypatch)
+    benchmark_path = _REPO_ROOT / "benchmark" / "causal_conv1d_update_sm100.py"
+    module_name = "_test_causal_conv1d_update_sm100_benchmark"
+    spec = importlib.util.spec_from_file_location(module_name, benchmark_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    try:
+        spec.loader.exec_module(module)
+    except ImportError as exc:
+        pytest.skip(f"CuTe DSL benchmark dependencies unavailable: {exc}")
+    return module
+
+
+def test_benchmark_accepts_supported_architectures_without_slurm(monkeypatch):
+    benchmark = _load_benchmark(monkeypatch)
+    monkeypatch.setattr(benchmark.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(benchmark, "_package_version", lambda unused: "0.5.2")
+    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+    monkeypatch.delenv("SLURMD_NODENAME", raising=False)
+
+    for capability in _SUPPORTED_COMPUTE_CAPABILITIES:
+        monkeypatch.setattr(benchmark.torch.cuda, "get_device_capability", lambda device=None, value=capability: value)
+        benchmark._validate_environment()
+
+    assert benchmark._slurm_provenance() == {
+        "slurm_job_id": None,
+        "slurmd_node_name": None,
+    }
+
+
+def test_benchmark_records_available_slurm_provenance(monkeypatch):
+    benchmark = _load_benchmark(monkeypatch)
+    monkeypatch.setenv("SLURM_JOB_ID", "12345")
+    monkeypatch.setenv("SLURMD_NODENAME", "customer-node-7")
+
+    assert benchmark._slurm_provenance() == {
+        "slurm_job_id": "12345",
+        "slurmd_node_name": "customer-node-7",
+    }
+
+
+@pytest.mark.parametrize("filename", ["causal_conv1d_update_sm100.py", "fla_short_conv_shim_sm100.py"])
+def test_benchmark_scripts_never_require_slurm_environment(filename):
+    tree = ast.parse((_REPO_ROOT / "benchmark" / filename).read_text())
+    required_lookups = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Subscript)
+        and isinstance(node.value, ast.Attribute)
+        and isinstance(node.value.value, ast.Name)
+        and node.value.value.id == "os"
+        and node.value.attr == "environ"
+    ]
+
+    assert required_lookups == []
+
+
+def test_benchmark_rejects_unavailable_or_unsupported_cuda(monkeypatch):
+    benchmark = _load_benchmark(monkeypatch)
+    monkeypatch.setattr(benchmark, "_package_version", lambda unused: "0.5.2")
+    monkeypatch.setattr(benchmark.torch.cuda, "is_available", lambda: False)
+    with pytest.raises(RuntimeError, match="CUDA is unavailable"):
+        benchmark._validate_environment()
+
+    monkeypatch.setattr(benchmark.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(benchmark.torch.cuda, "get_device_capability", lambda device=None: (11, 1))
+    with pytest.raises(RuntimeError, match="functionally supported causal-conv compute capability"):
+        benchmark._validate_environment()

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_benchmark_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_benchmark_contract_unit.py
@@ -78,6 +78,24 @@ def test_default_matrix_uses_fused_qkv_model_channels(monkeypatch):
     assert all(channels not in (2048, 4096) for _, channels in benchmark.DEFAULT_SHAPES)
 
 
+def test_fla_shim_smoke_uses_model_faithful_fused_qkv_width():
+    benchmark_path = _REPO_ROOT / "benchmark" / "fla_short_conv_shim_sm100.py"
+    tree = ast.parse(benchmark_path.read_text())
+    assignments = {
+        target.id: ast.literal_eval(node.value)
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name) and target.id in {"SMOKE_N", "SMOKE_D"}
+    }
+
+    assert assignments == {"SMOKE_N": 8, "SMOKE_D": 8192}
+    docstring = ast.get_docstring(tree)
+    assert docstring is not None
+    assert "D={6144,8192,10240,12288,20480}" in docstring
+    assert "D={2048,4096}" not in docstring
+
+
 def test_benchmark_accepts_supported_architectures_without_slurm(monkeypatch):
     benchmark = _load_benchmark(monkeypatch)
     monkeypatch.setattr(benchmark.torch.cuda, "is_available", lambda: True)

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_benchmark_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_benchmark_contract_unit.py
@@ -69,6 +69,15 @@ def _load_benchmark(monkeypatch):
     return module
 
 
+def test_default_matrix_uses_fused_qkv_model_channels(monkeypatch):
+    benchmark = _load_benchmark(monkeypatch)
+
+    assert benchmark.DEFAULT_BATCH_SIZES == (1, 8, 32, 128)
+    assert benchmark.DEFAULT_CHANNELS == (6144, 8192, 10240, 12288, 20480)
+    assert benchmark.DEFAULT_SHAPES == tuple((batch, channels) for channels in benchmark.DEFAULT_CHANNELS for batch in benchmark.DEFAULT_BATCH_SIZES)
+    assert all(channels not in (2048, 4096) for _, channels in benchmark.DEFAULT_SHAPES)
+
+
 def test_benchmark_accepts_supported_architectures_without_slurm(monkeypatch):
     benchmark = _load_benchmark(monkeypatch)
     monkeypatch.setattr(benchmark.torch.cuda, "is_available", lambda: True)

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
@@ -47,6 +47,22 @@ def _inputs(*, n_rows=2, n_channels=8, n_slots=3, indexed=True):
     return x, weight, state, output, indices
 
 
+def _metadata_desc(tensor):
+    if tensor is None:
+        return None
+    from cudnn.api_base import TensorDesc
+
+    shape = tuple(tensor.shape)
+    stride = tuple(tensor.stride())
+    return TensorDesc(
+        dtype=tensor.dtype,
+        shape=shape,
+        stride=stride,
+        stride_order=TensorDesc._compute_stride_order(shape, stride),
+        device=torch.device("cuda"),
+    )
+
+
 def _mock_cuda_contract(monkeypatch, api, capability=(10, 0)):
     # These tests exercise descriptor/contract logic on CPU tensors only.  The
     # real GPU suite independently checks the CUDA-device and architecture gate.
@@ -123,6 +139,16 @@ def test_valid_descriptor_contract_without_kernel(monkeypatch):
     assert api.check_support()
     assert (api.n_rows, api.n_channels, api.n_slots) == (2, 8, 3)
     assert api.rows_per_cta == 1
+
+
+def test_metadata_only_descriptors_skip_sample_pointer_alignment(monkeypatch):
+    cls = _api_class()
+    api = cls(*(_metadata_desc(tensor) for tensor in _inputs()))
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: (10, 0))
+
+    assert api._sample_alignment_remainders == {}
+    assert api.check_support()
 
 
 @pytest.mark.parametrize("n_channels", [2048, 4096])

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
@@ -97,6 +97,55 @@ def test_valid_descriptor_contract_without_kernel(monkeypatch):
 
     assert api.check_support()
     assert (api.n_rows, api.n_channels, api.n_slots) == (2, 8, 3)
+    assert api.rows_per_cta == 1
+
+
+@pytest.mark.parametrize("n_channels", [2048, 4096])
+def test_n128_no_index_selects_two_row_specialization(monkeypatch, n_channels):
+    cls = _api_class()
+    api = cls(
+        *_inputs(
+            n_rows=128,
+            n_channels=n_channels,
+            n_slots=128,
+            indexed=False,
+        )
+    )
+    _mock_cuda_contract(monkeypatch, api)
+
+    assert api.check_support()
+    assert api.rows_per_cta == 2
+
+
+@pytest.mark.parametrize(
+    "n_rows,n_channels,indexed",
+    [
+        (32, 2048, False),
+        (128, 1024, False),
+        (128, 2048, True),
+        (128, 4096, True),
+    ],
+    ids=["different-rows", "different-width", "indexed-d2048", "indexed-d4096"],
+)
+def test_row_batch_specialization_declines_unmeasured_or_indexed_signatures(
+    monkeypatch,
+    n_rows,
+    n_channels,
+    indexed,
+):
+    cls = _api_class()
+    api = cls(
+        *_inputs(
+            n_rows=n_rows,
+            n_channels=n_channels,
+            n_slots=n_rows + int(indexed),
+            indexed=indexed,
+        )
+    )
+    _mock_cuda_contract(monkeypatch, api)
+
+    assert api.check_support()
+    assert api.rows_per_cta == 1
 
 
 @pytest.mark.parametrize(

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
@@ -49,6 +49,14 @@ def _inputs(*, n_rows=2, n_channels=8, n_slots=3, state_len=4, indexed=True):
     return x, weight, state, output, indices
 
 
+def _row_strided_x(n_rows, n_channels, row_stride):
+    return torch.empty_strided(
+        (n_rows, n_channels),
+        (row_stride, 1),
+        dtype=torch.bfloat16,
+    ).zero_()
+
+
 def _metadata_desc(tensor):
     if tensor is None:
         return None
@@ -197,6 +205,41 @@ def test_semantic_shape_contract_is_not_hard_coded_to_width_four():
     )
 
 
+@pytest.mark.parametrize(
+    "n_channels,row_stride",
+    [(7, 7), (10, 10), (10, 16)],
+    ids=["compact-unaligned-row", "compact-nonmultiple-eight", "padded-aligned"],
+)
+def test_semantic_contract_accepts_supported_x_row_strides(n_channels, row_stride):
+    ops_module = importlib.import_module("cudnn.ops._causal_conv1d_update")
+    n_rows = 2
+    x = _row_strided_x(n_rows, n_channels, row_stride)
+    state = torch.zeros(n_rows, n_channels, 4, dtype=torch.bfloat16)
+    weight = torch.zeros(n_channels, 4, dtype=torch.bfloat16)
+
+    ops_module._validate_semantic_contract(x, state, weight, None, None, None)
+
+
+@pytest.mark.parametrize(
+    "n_channels,stride,match",
+    [
+        (8, (16, 2), r"row-major strides \(ld, 1\)"),
+        (8, (7, 1), "row stride ld must be at least D=8"),
+        (10, (12, 1), "padded x rows must start at 16-byte-aligned"),
+    ],
+    ids=["channel-stride", "overlapping-rows", "misaligned-padded-rows"],
+)
+def test_semantic_contract_rejects_unsupported_x_row_strides(n_channels, stride, match):
+    ops_module = importlib.import_module("cudnn.ops._causal_conv1d_update")
+    n_rows = 2
+    x = torch.empty_strided((n_rows, n_channels), stride, dtype=torch.bfloat16)
+    state = torch.zeros(n_rows, n_channels, 4, dtype=torch.bfloat16)
+    weight = torch.zeros(n_channels, 4, dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match=match):
+        ops_module._validate_semantic_contract(x, state, weight, None, None, None)
+
+
 def test_semantic_shape_contract_rejects_state_shorter_than_history():
     ops_module = importlib.import_module("cudnn.ops._causal_conv1d_update")
     x = torch.zeros(2, 8, dtype=torch.bfloat16)
@@ -302,6 +345,10 @@ def test_activation_aliases_and_cache_keys_are_canonical():
     silu_key = api_module._cache_key(x, state, weight, indices, None, "silu")
     assert identity_key != silu_key
 
+    padded_x = _row_strided_x(x.shape[0], x.shape[1], 16)
+    padded_key = api_module._cache_key(padded_x, state, weight, indices, None, "identity")
+    assert padded_key != identity_key
+
 
 def test_valid_descriptor_contract_without_kernel(monkeypatch):
     cls = _api_class()
@@ -311,6 +358,42 @@ def test_valid_descriptor_contract_without_kernel(monkeypatch):
 
     assert api.check_support()
     assert (api.n_rows, api.n_channels, api.n_slots) == (2, 8, 3)
+
+
+@pytest.mark.parametrize(
+    "n_channels,row_stride",
+    [(10, 10), (10, 16)],
+    ids=["compact-any-d", "padded-aligned"],
+)
+def test_plan_accepts_supported_x_row_strides_without_kernel(monkeypatch, n_channels, row_stride):
+    cls = _api_class()
+    x, weight, state, output, indices = _inputs(n_channels=n_channels)
+    x = _row_strided_x(x.shape[0], n_channels, row_stride)
+    api = cls(x, weight, state, output, indices)
+    _mock_cuda_contract(monkeypatch, api)
+
+    assert api.check_support()
+    assert api.x_desc.stride == (row_stride, 1)
+
+
+@pytest.mark.parametrize(
+    "n_channels,stride,match",
+    [
+        (8, (16, 2), r"X must have row-major strides \(ld, 1\)"),
+        (8, (7, 1), "X row stride ld must be at least D=8"),
+        (10, (12, 1), "Padded X rows must start at 16-byte-aligned"),
+    ],
+    ids=["channel-stride", "overlapping-rows", "misaligned-padded-rows"],
+)
+def test_plan_rejects_unsupported_x_row_strides_without_kernel(monkeypatch, n_channels, stride, match):
+    cls = _api_class()
+    x, weight, state, output, indices = _inputs(n_channels=n_channels)
+    x = torch.empty_strided(x.shape, stride, dtype=x.dtype)
+    api = cls(x, weight, state, output, indices)
+    _mock_cuda_contract(monkeypatch, api)
+
+    with pytest.raises(ValueError, match=match):
+        api.check_support()
 
 
 def test_width_four_minimum_state_descriptor_contract_without_kernel(monkeypatch):
@@ -362,7 +445,7 @@ def test_metadata_only_descriptors_skip_sample_pointer_alignment(monkeypatch):
                 o,
                 i,
             ),
-            "X tensor stride mismatch",
+            r"X must have row-major strides \(ld, 1\)",
         ),
         (lambda x, w, s, o, i: (x.float(), w, s, o.float(), i), "X dtype mismatch"),
         (lambda x, w, s, o, i: (x, w, s[:1], o, None), "State needs at least N slots"),
@@ -491,14 +574,37 @@ def test_execute_revalidates_presence_and_aliases(monkeypatch):
         )
 
 
-def test_overlap_uses_exact_contiguous_byte_spans():
+def test_execute_requires_the_exact_compiled_x_stride(monkeypatch):
+    cls = _api_class()
+    x, weight, state, output, indices = _inputs(n_channels=10)
+    x = _row_strided_x(x.shape[0], x.shape[1], 16)
+    api = cls(x, weight, state, output, indices)
+    _mock_cuda_contract(monkeypatch, api)
+    assert api.check_support()
+    api._compiled_kernel = lambda *args: None
+
+    different_valid_stride = _row_strided_x(x.shape[0], x.shape[1], 24)
+    with pytest.raises(ValueError, match=r"X stride mismatch: expected \(16, 1\), got \(24, 1\)"):
+        api.execute(
+            different_valid_stride,
+            weight,
+            state,
+            output,
+            indices,
+            current_stream=cuda.CUstream(7),
+        )
+
+
+def test_overlap_uses_positive_stride_byte_spans():
     api_module = importlib.import_module("cudnn.causal_conv1d_update_sm100.api")
 
     class Span:
-        def __init__(self, address, numel, element_size):
+        def __init__(self, address, numel, element_size, *, shape=None, stride=None):
             self.address = address
             self.length = numel
             self.itemsize = element_size
+            self.shape = shape if shape is not None else (numel,)
+            self.strides = stride if stride is not None else (1,)
 
         def data_ptr(self):
             return self.address
@@ -509,11 +615,20 @@ def test_overlap_uses_exact_contiguous_byte_spans():
         def element_size(self):
             return self.itemsize
 
+        def stride(self):
+            return self.strides
+
     left = Span(0x1000, 4, 2)
 
     assert api_module._tensors_overlap(left, Span(0x1006, 2, 2))
     assert api_module._tensors_overlap(Span(0x0FFE, 2, 2), left)
     assert not api_module._tensors_overlap(left, Span(0x1008, 2, 2))
+
+    # A 2x4 BF16 view with ld=8 occupies a 24-byte bounding span, not the
+    # 16 bytes implied by numel().  Alias checks must include the second row.
+    padded = Span(0x2000, 8, 2, shape=(2, 4), stride=(8, 1))
+    assert api_module._tensors_overlap(padded, Span(0x2014, 2, 2))
+    assert not api_module._tensors_overlap(padded, Span(0x2018, 2, 2))
 
 
 def test_record_streams_covers_every_present_raw_pointer_operand():

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
@@ -91,21 +91,21 @@ import cudnn
 import cudnn.ops
 from cudnn.causal_conv1d_update_sm100 import (
     CausalConv1dUpdateSm100,
-    causal_conv1d_update,
+    causal_conv1d_update as implementation,
     causal_conv1d_update_wrapper_sm100,
 )
 
 exports = (
     cudnn.causal_conv1d_update,
-    cudnn.causal_conv1d_update_wrapper_sm100,
-    cudnn.CausalConv1dUpdateSm100,
     cudnn.ops.causal_conv1d_update,
 )
 assert all(callable(export) and not isinstance(export, types.ModuleType) for export in exports)
-assert cudnn.causal_conv1d_update is causal_conv1d_update
-assert cudnn.causal_conv1d_update_wrapper_sm100 is causal_conv1d_update_wrapper_sm100
-assert cudnn.CausalConv1dUpdateSm100 is CausalConv1dUpdateSm100
-assert cudnn.ops.causal_conv1d_update is causal_conv1d_update
+assert cudnn.causal_conv1d_update is cudnn.ops.causal_conv1d_update
+assert cudnn.ops.causal_conv1d_update is not implementation
+assert not hasattr(cudnn, "causal_conv1d_update_wrapper_sm100")
+assert not hasattr(cudnn, "CausalConv1dUpdateSm100")
+assert callable(causal_conv1d_update_wrapper_sm100)
+assert callable(CausalConv1dUpdateSm100)
 """
     environment = os.environ.copy()
     environment["PYTHONPATH"] = os.pathsep.join((str(tmp_path), environment.get("PYTHONPATH", ""))).rstrip(os.pathsep)
@@ -119,17 +119,76 @@ assert cudnn.ops.causal_conv1d_update is causal_conv1d_update
     )
 
 
-def test_public_helpers_use_state_before_weight_positional_order():
-    from cudnn.causal_conv1d_update_sm100 import (
-        causal_conv1d_update,
-        causal_conv1d_update_wrapper_sm100,
+def test_public_helper_is_semantic_and_hides_lifecycle_parameters():
+    from cudnn.ops import causal_conv1d_update
+
+    signature = inspect.signature(causal_conv1d_update)
+    assert tuple(signature.parameters) == (
+        "x",
+        "conv_state",
+        "weight",
+        "bias",
+        "activation",
+        "conv_state_indices",
+    )
+    assert signature.parameters["conv_state_indices"].kind is inspect.Parameter.KEYWORD_ONLY
+    for implementation_detail in (
+        "current_stream",
+        "output",
+        "plan",
+        "wrapper",
+        "sm100",
+    ):
+        assert implementation_detail not in signature.parameters
+
+
+def test_public_helper_delegates_tensor_contract_without_lifecycle(monkeypatch):
+    import cudnn.causal_conv1d_update_sm100 as implementation
+    from cudnn.ops import causal_conv1d_update
+
+    x = torch.zeros(2, 8, dtype=torch.bfloat16)
+    state = torch.zeros(3, 8, 4, dtype=torch.bfloat16)
+    weight = torch.zeros(8, 4, dtype=torch.bfloat16)
+    bias = torch.zeros(8, dtype=torch.bfloat16)
+    indices = torch.tensor([2, 0], dtype=torch.int32)
+    expected = torch.ones_like(x)
+    observed = {}
+
+    def run(native_x, native_state, native_weight, state_indices, *, bias):
+        observed.update(
+            x=native_x,
+            state=native_state,
+            weight=native_weight,
+            state_indices=state_indices,
+            bias=bias,
+        )
+        return expected
+
+    monkeypatch.setattr(implementation, "causal_conv1d_update", run)
+    output = causal_conv1d_update(
+        x,
+        state,
+        weight,
+        bias,
+        "silu",
+        conv_state_indices=indices,
     )
 
-    expected = ("x", "state", "weight", "state_indices")
-    assert tuple(inspect.signature(causal_conv1d_update).parameters)[:4] == expected
-    assert tuple(inspect.signature(causal_conv1d_update_wrapper_sm100).parameters)[:4] == expected
-    assert inspect.signature(causal_conv1d_update).parameters["bias"].kind is inspect.Parameter.KEYWORD_ONLY
-    assert inspect.signature(causal_conv1d_update_wrapper_sm100).parameters["bias"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert output is expected
+    assert observed["x"] is x
+    assert observed["state"] is state
+    assert observed["weight"] is weight
+    assert observed["state_indices"] is indices
+    assert observed["bias"] is bias
+
+
+@pytest.mark.parametrize("activation", [None, "identity", "relu"])
+def test_public_helper_rejects_unimplemented_activation(activation):
+    from cudnn.ops import causal_conv1d_update
+
+    x, weight, state, _, _ = _inputs(indexed=False)
+    with pytest.raises(NotImplementedError, match="requires activation"):
+        causal_conv1d_update(x, state, weight, activation=activation)
 
 
 def test_valid_descriptor_contract_without_kernel(monkeypatch):

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
@@ -3,8 +3,10 @@
 
 """Host-contract tests that do not compile or launch a GPU kernel."""
 
+import importlib
 import inspect
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -32,16 +34,16 @@ _SUPPORTED_COMPUTE_CAPABILITIES = (
 
 def _api_class():
     try:
-        from cudnn.causal_conv1d_update_sm100 import CausalConv1dUpdateSm100
+        from cudnn.causal_conv1d_update_sm100 import _CausalConv1dUpdatePlan
     except ImportError as exc:
         pytest.skip(f"CuTe DSL dependencies unavailable: {exc}")
-    return CausalConv1dUpdateSm100
+    return _CausalConv1dUpdatePlan
 
 
-def _inputs(*, n_rows=2, n_channels=8, n_slots=3, indexed=True):
+def _inputs(*, n_rows=2, n_channels=8, n_slots=3, state_len=4, indexed=True):
     x = torch.zeros(n_rows, n_channels, dtype=torch.bfloat16)
     weight = torch.zeros(n_channels, 4, dtype=torch.bfloat16)
-    state = torch.zeros(n_slots, n_channels, 4, dtype=torch.bfloat16)
+    state = torch.zeros(n_slots, n_channels, state_len, dtype=torch.bfloat16)
     output = torch.empty_like(x)
     indices = torch.arange(n_rows, dtype=torch.int32) if indexed else None
     return x, weight, state, output, indices
@@ -69,13 +71,14 @@ def _mock_cuda_contract(monkeypatch, api, capability=(10, 0)):
     monkeypatch.setattr(api, "_require_cuda", lambda desc, name: None)
     monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
     monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: capability)
+    api_module = sys.modules[api.__class__.__module__]
+    monkeypatch.setattr(api_module, "_as_torch_stream", lambda current_stream, device: object())
+    monkeypatch.setattr(api_module, "_record_streams", lambda tensors, stream: None)
 
 
-def test_public_exports_remain_callables_not_modules(tmp_path):
-    # A same-named ``cudnn.causal_conv1d_update`` package previously replaced
-    # the lazy top-level function with the imported module object. Test a fresh
-    # interpreter against this checkout's __init__.py rather than the prebuilt
-    # package which conftest overlays for the other host-contract tests.
+def test_only_cudnn_ops_exports_the_semantic_api(tmp_path):
+    # Test a fresh interpreter against this checkout's __init__.py rather than
+    # the prebuilt package which conftest overlays for other contract tests.
     import cudnn
 
     source = Path(__file__).resolve().parents[4] / "python" / "cudnn"
@@ -89,23 +92,18 @@ def test_public_exports_remain_callables_not_modules(tmp_path):
 import types
 import cudnn
 import cudnn.ops
-from cudnn.causal_conv1d_update_sm100 import (
-    CausalConv1dUpdateSm100,
-    causal_conv1d_update as implementation,
-    causal_conv1d_update_wrapper_sm100,
-)
+from cudnn.ops import causal_conv1d_update
+import cudnn.causal_conv1d_update_sm100 as implementation
 
-exports = (
-    cudnn.causal_conv1d_update,
-    cudnn.ops.causal_conv1d_update,
-)
-assert all(callable(export) and not isinstance(export, types.ModuleType) for export in exports)
-assert cudnn.causal_conv1d_update is cudnn.ops.causal_conv1d_update
-assert cudnn.ops.causal_conv1d_update is not implementation
+assert callable(causal_conv1d_update) and not isinstance(causal_conv1d_update, types.ModuleType)
+assert cudnn.ops.causal_conv1d_update is causal_conv1d_update
+assert not hasattr(cudnn, "causal_conv1d_update")
 assert not hasattr(cudnn, "causal_conv1d_update_wrapper_sm100")
 assert not hasattr(cudnn, "CausalConv1dUpdateSm100")
-assert callable(causal_conv1d_update_wrapper_sm100)
-assert callable(CausalConv1dUpdateSm100)
+assert implementation.__all__ == []
+assert not hasattr(implementation, "causal_conv1d_update")
+assert not hasattr(implementation, "causal_conv1d_update_wrapper_sm100")
+assert not hasattr(implementation, "CausalConv1dUpdateSm100")
 """
     environment = os.environ.copy()
     environment["PYTHONPATH"] = os.pathsep.join((str(tmp_path), environment.get("PYTHONPATH", ""))).rstrip(os.pathsep)
@@ -119,76 +117,190 @@ assert callable(CausalConv1dUpdateSm100)
     )
 
 
-def test_public_helper_is_semantic_and_hides_lifecycle_parameters():
+def test_public_semantic_signature():
     from cudnn.ops import causal_conv1d_update
 
-    signature = inspect.signature(causal_conv1d_update)
-    assert tuple(signature.parameters) == (
+    parameters = inspect.signature(causal_conv1d_update).parameters
+    assert tuple(parameters) == (
         "x",
         "conv_state",
         "weight",
         "bias",
         "activation",
+        "cache_seqlens",
         "conv_state_indices",
     )
-    assert signature.parameters["conv_state_indices"].kind is inspect.Parameter.KEYWORD_ONLY
-    assert signature.parameters["activation"].default == "silu"
-    for implementation_detail in (
-        "current_stream",
-        "output",
-        "plan",
-        "wrapper",
-        "sm100",
-    ):
-        assert implementation_detail not in signature.parameters
+    assert parameters["bias"].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert parameters["bias"].default is None
+    assert parameters["activation"].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert parameters["activation"].default is None
+    assert parameters["cache_seqlens"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters["cache_seqlens"].default is None
+    assert parameters["conv_state_indices"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters["conv_state_indices"].default is None
 
 
-def test_public_helper_delegates_tensor_contract_without_lifecycle(monkeypatch):
-    import cudnn.causal_conv1d_update_sm100 as implementation
-    from cudnn.ops import causal_conv1d_update
+def test_public_custom_op_declares_state_mutation():
+    from cudnn.ops import causal_conv1d_update  # noqa: F401
 
+    schema = str(torch.ops.cudnn._causal_conv1d_update.default._schema)
+    assert re.search(r"Tensor\(a\d*!\) conv_state", schema)
+    assert schema.count("!") == 1
+    assert "Tensor? cache_seqlens" in schema
+    assert "Tensor? conv_state_indices" in schema
+    assert schema.endswith(" -> Tensor")
+
+
+def test_private_raw_op_canonicalizes_activation_before_native_call(monkeypatch):
+    ops_module = importlib.import_module("cudnn.ops._causal_conv1d_update")
+    implementation = importlib.import_module("cudnn.causal_conv1d_update_sm100")
+    x, weight, state, _, indices = _inputs()
+    calls = []
+    sentinel = object()
+
+    def native(*args, **kwargs):
+        calls.append((args, kwargs))
+        return sentinel
+
+    monkeypatch.setattr(implementation, "_causal_conv1d_update", native)
+
+    result = ops_module._causal_conv1d_update_primitive._init_fn(x, state, weight, None, "swish", None, indices)
+
+    assert result is sentinel
+    assert calls == [((x, state, weight, None, "silu"), {"conv_state_indices": indices})]
+
+
+def test_semantic_shape_contract_is_not_hard_coded_to_width_four():
+    ops_module = importlib.import_module("cudnn.ops._causal_conv1d_update")
     x = torch.zeros(2, 8, dtype=torch.bfloat16)
-    state = torch.zeros(3, 8, 4, dtype=torch.bfloat16)
-    weight = torch.zeros(8, 4, dtype=torch.bfloat16)
     bias = torch.zeros(8, dtype=torch.bfloat16)
-    indices = torch.tensor([2, 0], dtype=torch.int32)
-    expected = torch.ones_like(x)
-    observed = {}
+    cache_seqlens = torch.zeros(2, dtype=torch.int32)
+    indices = torch.tensor([4, 1], dtype=torch.int32)
 
-    def run(native_x, native_state, native_weight, state_indices, *, bias):
-        observed.update(
-            x=native_x,
-            state=native_state,
-            weight=native_weight,
-            state_indices=state_indices,
-            bias=bias,
-        )
-        return expected
-
-    monkeypatch.setattr(implementation, "causal_conv1d_update", run)
-    output = causal_conv1d_update(
+    # Minimum legal state length (L = W - 1).
+    ops_module._validate_semantic_contract(
         x,
-        state,
-        weight,
+        torch.zeros(5, 8, 2, dtype=torch.bfloat16),
+        torch.zeros(8, 3, dtype=torch.bfloat16),
         bias,
-        conv_state_indices=indices,
+        cache_seqlens,
+        indices,
+    )
+    # Longer state remains part of the same semantic contract.
+    ops_module._validate_semantic_contract(
+        x,
+        torch.zeros(5, 8, 7, dtype=torch.bfloat16),
+        torch.zeros(8, 4, dtype=torch.bfloat16),
+        bias,
+        None,
+        indices,
     )
 
-    assert output is expected
-    assert observed["x"] is x
-    assert observed["state"] is state
-    assert observed["weight"] is weight
-    assert observed["state_indices"] is indices
-    assert observed["bias"] is bias
+
+def test_semantic_shape_contract_rejects_state_shorter_than_history():
+    ops_module = importlib.import_module("cudnn.ops._causal_conv1d_update")
+    x = torch.zeros(2, 8, dtype=torch.bfloat16)
+    state = torch.zeros(2, 8, 2, dtype=torch.bfloat16)
+    weight = torch.zeros(8, 4, dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match=r"L >= W - 1, got L=2, W=4"):
+        ops_module._validate_semantic_contract(x, state, weight, None, None, None)
 
 
-@pytest.mark.parametrize("activation", [None, "identity", "relu"])
-def test_public_helper_rejects_unimplemented_activation(activation):
+@pytest.mark.parametrize(
+    "x_shape,state_shape,match",
+    [
+        ((0, 8), (1, 8, 4), "row count N must be positive"),
+        ((2, 0), (2, 0, 4), "channel count D must be positive"),
+        ((2, 8), (0, 8, 4), "slot count S must be positive"),
+    ],
+)
+def test_semantic_shape_contract_rejects_empty_native_extents(x_shape, state_shape, match):
+    ops_module = importlib.import_module("cudnn.ops._causal_conv1d_update")
+    x = torch.zeros(x_shape, dtype=torch.bfloat16)
+    state = torch.zeros(state_shape, dtype=torch.bfloat16)
+    weight = torch.zeros(x_shape[1], 4, dtype=torch.bfloat16)
+    indices = torch.zeros(x_shape[0], dtype=torch.int32) if state_shape[0] == 0 else None
+
+    with pytest.raises(ValueError, match=match):
+        ops_module._validate_semantic_contract(x, state, weight, None, None, indices)
+
+
+def test_public_meta_tensor_uses_registered_fake_kernel():
     from cudnn.ops import causal_conv1d_update
 
-    x, weight, state, _, _ = _inputs(indexed=False)
-    with pytest.raises(NotImplementedError, match="requires activation"):
-        causal_conv1d_update(x, state, weight, activation=activation)
+    x = torch.empty(2, 8, device="meta", dtype=torch.bfloat16)
+    state = torch.empty(2, 8, 4, device="meta", dtype=torch.bfloat16)
+    weight = torch.empty(8, 4, device="meta", dtype=torch.bfloat16)
+
+    output = causal_conv1d_update(x, state, weight)
+
+    assert output.device.type == "meta"
+    assert output.shape == x.shape
+    assert output.stride() == x.stride()
+
+
+@pytest.mark.parametrize(
+    "state_len,width,has_cache",
+    [(2, 3, False), (5, 4, False), (4, 4, True)],
+    ids=["width-three", "state-length-five", "circular-buffer"],
+)
+def test_semantically_valid_unimplemented_configs_decline_clearly(state_len, width, has_cache):
+    from cudnn.ops import causal_conv1d_update
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode(), pytest.raises(NotImplementedError, match="current native.*supports only"):
+        x = torch.empty(2, 8, device="cuda", dtype=torch.bfloat16)
+        state = torch.empty(2, 8, state_len, device="cuda", dtype=torch.bfloat16)
+        weight = torch.empty(8, width, device="cuda", dtype=torch.bfloat16)
+        cache_seqlens = torch.empty(2, device="cuda", dtype=torch.int32) if has_cache else None
+        causal_conv1d_update(x, state, weight, cache_seqlens=cache_seqlens)
+
+
+def test_multi_token_update_is_reserved_but_not_silently_interpreted():
+    ops_module = importlib.import_module("cudnn.ops._causal_conv1d_update")
+    x = torch.zeros(2, 8, 3, dtype=torch.bfloat16)
+    state = torch.zeros(2, 8, 4, dtype=torch.bfloat16)
+    weight = torch.zeros(8, 4, dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match=r"x must have shape \[N, D\]"):
+        ops_module._validate_semantic_contract(x, state, weight, None, None, None)
+
+
+@pytest.mark.parametrize("state_len", [3, 4], ids=["w-minus-one", "legacy-four"])
+def test_public_fake_tensor_contract_preserves_output_metadata(state_len):
+    from cudnn.ops import causal_conv1d_update
+    from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+
+    with FakeTensorMode():
+        x = torch.empty(2, 8, device="cuda", dtype=torch.bfloat16)
+        state = torch.empty(3, 8, state_len, device="cuda", dtype=torch.bfloat16)
+        weight = torch.empty(8, 4, device="cuda", dtype=torch.bfloat16)
+        indices = torch.empty(2, device="cuda", dtype=torch.int32)
+        output = causal_conv1d_update(x, state, weight, activation="swish", conv_state_indices=indices)
+
+    assert isinstance(output, FakeTensor)
+    assert output.shape == x.shape
+    assert output.stride() == x.stride()
+    assert output.dtype == x.dtype
+    assert output.device == x.device
+
+
+def test_activation_aliases_and_cache_keys_are_canonical():
+    ops_module = importlib.import_module("cudnn.ops._causal_conv1d_update")
+    api_module = importlib.import_module("cudnn.causal_conv1d_update_sm100.api")
+    x, weight, state, _, indices = _inputs()
+
+    assert ops_module._normalize_activation(None) == "identity"
+    assert ops_module._normalize_activation("identity") == "identity"
+    assert ops_module._normalize_activation("silu") == "silu"
+    assert ops_module._normalize_activation("swish") == "silu"
+    with pytest.raises(ValueError, match="activation must be"):
+        ops_module._normalize_activation("relu")
+
+    identity_key = api_module._cache_key(x, state, weight, indices, None, "identity")
+    silu_key = api_module._cache_key(x, state, weight, indices, None, "silu")
+    assert identity_key != silu_key
 
 
 def test_valid_descriptor_contract_without_kernel(monkeypatch):
@@ -199,6 +311,16 @@ def test_valid_descriptor_contract_without_kernel(monkeypatch):
 
     assert api.check_support()
     assert (api.n_rows, api.n_channels, api.n_slots) == (2, 8, 3)
+
+
+def test_width_four_minimum_state_descriptor_contract_without_kernel(monkeypatch):
+    cls = _api_class()
+    x, weight, state, output, indices = _inputs(state_len=3)
+    api = cls(x, weight, state, output, indices)
+    _mock_cuda_contract(monkeypatch, api)
+
+    assert api.check_support()
+    assert (api.n_rows, api.n_channels, api.n_slots, api.state_len) == (2, 8, 3, 3)
 
 
 def test_optional_bias_descriptor_contract_without_kernel(monkeypatch):
@@ -262,7 +384,7 @@ def test_bad_descriptor_contract_fails_before_compile(monkeypatch, mutate, match
 
 
 @pytest.mark.parametrize("capability", _SUPPORTED_COMPUTE_CAPABILITIES)
-def test_functional_architecture_allowlist(monkeypatch, capability):
+def test_supported_architecture_gate(monkeypatch, capability):
     cls = _api_class()
     api = cls(*_inputs())
     _mock_cuda_contract(monkeypatch, api, capability=capability)
@@ -270,7 +392,7 @@ def test_functional_architecture_allowlist(monkeypatch, capability):
     assert api.check_support()
 
 
-@pytest.mark.parametrize("capability", [(7, 5), (10, 1), (11, 1), (13, 0)])
+@pytest.mark.parametrize("capability", [(7, 5), (7, 9), (11, 1)])
 def test_unsupported_architecture_gate(monkeypatch, capability):
     cls = _api_class()
     api = cls(*_inputs())
@@ -367,6 +489,91 @@ def test_execute_revalidates_presence_and_aliases(monkeypatch):
             indices4,
             current_stream=stream,
         )
+
+
+def test_overlap_uses_exact_contiguous_byte_spans():
+    api_module = importlib.import_module("cudnn.causal_conv1d_update_sm100.api")
+
+    class Span:
+        def __init__(self, address, numel, element_size):
+            self.address = address
+            self.length = numel
+            self.itemsize = element_size
+
+        def data_ptr(self):
+            return self.address
+
+        def numel(self):
+            return self.length
+
+        def element_size(self):
+            return self.itemsize
+
+    left = Span(0x1000, 4, 2)
+
+    assert api_module._tensors_overlap(left, Span(0x1006, 2, 2))
+    assert api_module._tensors_overlap(Span(0x0FFE, 2, 2), left)
+    assert not api_module._tensors_overlap(left, Span(0x1008, 2, 2))
+
+
+def test_record_streams_covers_every_present_raw_pointer_operand():
+    api_module = importlib.import_module("cudnn.causal_conv1d_update_sm100.api")
+    consumer = object()
+
+    class TensorRecorder:
+        def __init__(self):
+            self.streams = []
+
+        def record_stream(self, stream):
+            self.streams.append(stream)
+
+    first = TensorRecorder()
+    second = TensorRecorder()
+    api_module._record_streams((first, None, second), consumer)
+    api_module._record_streams((first, second), None)
+
+    assert first.streams == [consumer]
+    assert second.streams == [consumer]
+
+
+def test_execute_records_operands_on_resolved_explicit_stream(monkeypatch):
+    api_module = importlib.import_module("cudnn.causal_conv1d_update_sm100.api")
+    cls = _api_class()
+    x, weight, state, output, indices = _inputs()
+    bias = torch.zeros(x.shape[1], dtype=torch.bfloat16)
+    api = cls(x, weight, state, output, indices, bias)
+    _mock_cuda_contract(monkeypatch, api)
+    assert api.check_support()
+
+    launches = []
+    recorded = []
+    resolved = []
+    consumer = object()
+    stream = cuda.CUstream(17)
+    api._compiled_kernel = lambda *args: launches.append(args)
+
+    def resolve(current_stream, device):
+        resolved.append((current_stream, device))
+        return consumer
+
+    monkeypatch.setattr(api_module, "_as_torch_stream", resolve)
+    monkeypatch.setattr(api_module, "_record_streams", lambda tensors, stream: recorded.append((tensors, stream)))
+
+    result = api.execute(
+        x,
+        weight,
+        state,
+        output,
+        indices,
+        current_stream=stream,
+        bias_tensor=bias,
+    )
+
+    assert result is output
+    assert resolved == [(stream, x.device)]
+    assert len(launches) == 1
+    assert launches[0][-1] == stream
+    assert recorded == [((x, weight, bias, state, output, indices), consumer)]
 
 
 def test_execute_rejects_autograd(monkeypatch):

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
@@ -128,6 +128,8 @@ def test_public_helpers_use_state_before_weight_positional_order():
     expected = ("x", "state", "weight", "state_indices")
     assert tuple(inspect.signature(causal_conv1d_update).parameters)[:4] == expected
     assert tuple(inspect.signature(causal_conv1d_update_wrapper_sm100).parameters)[:4] == expected
+    assert inspect.signature(causal_conv1d_update).parameters["bias"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert inspect.signature(causal_conv1d_update_wrapper_sm100).parameters["bias"].kind is inspect.Parameter.KEYWORD_ONLY
 
 
 def test_valid_descriptor_contract_without_kernel(monkeypatch):
@@ -138,6 +140,23 @@ def test_valid_descriptor_contract_without_kernel(monkeypatch):
 
     assert api.check_support()
     assert (api.n_rows, api.n_channels, api.n_slots) == (2, 8, 3)
+
+
+def test_optional_bias_descriptor_contract_without_kernel(monkeypatch):
+    cls = _api_class()
+    x, weight, state, output, indices = _inputs()
+    bias = torch.zeros(x.shape[1], dtype=torch.bfloat16)
+    api = cls(x, weight, state, output, indices, bias)
+    _mock_cuda_contract(monkeypatch, api)
+
+    assert api.check_support()
+    assert api.bias_desc.shape == (x.shape[1],)
+
+    bad_bias = torch.zeros(x.shape[1] + 1, dtype=torch.bfloat16)
+    bad_api = cls(x, weight, state, output, indices, bad_bias)
+    _mock_cuda_contract(monkeypatch, bad_api)
+    with pytest.raises(ValueError, match="Bias tensor shape mismatch"):
+        bad_api.check_support()
 
 
 def test_metadata_only_descriptors_skip_sample_pointer_alignment(monkeypatch):
@@ -229,6 +248,30 @@ def test_execute_revalidates_presence_and_aliases(monkeypatch):
 
     with pytest.raises(ValueError, match="presence must match"):
         api.execute(x, weight, state, output, None, current_stream=stream)
+
+    bias = torch.zeros(x.shape[1], dtype=torch.bfloat16)
+    biased_api = cls(x, weight, state, output, indices, bias)
+    _mock_cuda_contract(monkeypatch, biased_api)
+    assert biased_api.check_support()
+    biased_api._compiled_kernel = lambda *args: None
+    with pytest.raises(ValueError, match="bias presence must match"):
+        biased_api.execute(
+            x,
+            weight,
+            state,
+            output,
+            indices,
+            current_stream=stream,
+        )
+    biased_api.execute(
+        x,
+        weight,
+        state,
+        output,
+        indices,
+        current_stream=stream,
+        bias_tensor=bias,
+    )
 
     storage = torch.empty(x.numel() + 1, dtype=x.dtype)
     misaligned_x = storage[1:].view_as(x)

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
@@ -3,6 +3,7 @@
 
 """Host-contract tests that do not compile or launch a GPU kernel."""
 
+import inspect
 import os
 from pathlib import Path
 import shutil
@@ -87,6 +88,17 @@ assert cudnn.ops.causal_conv1d_update is causal_conv1d_update
         capture_output=True,
         text=True,
     )
+
+
+def test_public_helpers_use_state_before_weight_positional_order():
+    from cudnn.causal_conv1d_update_sm100 import (
+        causal_conv1d_update,
+        causal_conv1d_update_wrapper_sm100,
+    )
+
+    expected = ("x", "state", "weight", "state_indices")
+    assert tuple(inspect.signature(causal_conv1d_update).parameters)[:4] == expected
+    assert tuple(inspect.signature(causal_conv1d_update_wrapper_sm100).parameters)[:4] == expected
 
 
 def test_valid_descriptor_contract_without_kernel(monkeypatch):

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
@@ -132,6 +132,7 @@ def test_public_helper_is_semantic_and_hides_lifecycle_parameters():
         "conv_state_indices",
     )
     assert signature.parameters["conv_state_indices"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert signature.parameters["activation"].default == "silu"
     for implementation_detail in (
         "current_stream",
         "output",
@@ -170,7 +171,6 @@ def test_public_helper_delegates_tensor_contract_without_lifecycle(monkeypatch):
         state,
         weight,
         bias,
-        "silu",
         conv_state_indices=indices,
     )
 

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
@@ -138,7 +138,6 @@ def test_valid_descriptor_contract_without_kernel(monkeypatch):
 
     assert api.check_support()
     assert (api.n_rows, api.n_channels, api.n_slots) == (2, 8, 3)
-    assert api.rows_per_cta == 1
 
 
 def test_metadata_only_descriptors_skip_sample_pointer_alignment(monkeypatch):
@@ -149,71 +148,6 @@ def test_metadata_only_descriptors_skip_sample_pointer_alignment(monkeypatch):
 
     assert api._sample_alignment_remainders == {}
     assert api.check_support()
-
-
-@pytest.mark.parametrize("n_channels", [2048, 4096])
-def test_n128_no_index_selects_two_row_specialization_on_sm100(monkeypatch, n_channels):
-    cls = _api_class()
-    api = cls(
-        *_inputs(
-            n_rows=128,
-            n_channels=n_channels,
-            n_slots=128,
-            indexed=False,
-        )
-    )
-    _mock_cuda_contract(monkeypatch, api)
-
-    assert api.check_support()
-    assert api.rows_per_cta == 2
-
-
-@pytest.mark.parametrize("capability", [capability for capability in _SUPPORTED_COMPUTE_CAPABILITIES if capability != (10, 0)])
-def test_n128_no_index_uses_one_row_schedule_off_sm100(monkeypatch, capability):
-    cls = _api_class()
-    api = cls(
-        *_inputs(
-            n_rows=128,
-            n_channels=2048,
-            n_slots=128,
-            indexed=False,
-        )
-    )
-    _mock_cuda_contract(monkeypatch, api, capability=capability)
-
-    assert api.check_support()
-    assert api.rows_per_cta == 1
-
-
-@pytest.mark.parametrize(
-    "n_rows,n_channels,indexed",
-    [
-        (32, 2048, False),
-        (128, 1024, False),
-        (128, 2048, True),
-        (128, 4096, True),
-    ],
-    ids=["different-rows", "different-width", "indexed-d2048", "indexed-d4096"],
-)
-def test_row_batch_specialization_declines_unmeasured_or_indexed_signatures(
-    monkeypatch,
-    n_rows,
-    n_channels,
-    indexed,
-):
-    cls = _api_class()
-    api = cls(
-        *_inputs(
-            n_rows=n_rows,
-            n_channels=n_channels,
-            n_slots=n_rows + int(indexed),
-            indexed=indexed,
-        )
-    )
-    _mock_cuda_contract(monkeypatch, api)
-
-    assert api.check_support()
-    assert api.rows_per_cta == 1
 
 
 @pytest.mark.parametrize(

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
@@ -1,0 +1,232 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host-contract tests that do not compile or launch a GPU kernel."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+import torch
+from cuda.bindings import driver as cuda
+
+pytestmark = pytest.mark.L0
+
+
+def _api_class():
+    try:
+        from cudnn.causal_conv1d_update_sm100 import CausalConv1dUpdateSm100
+    except ImportError as exc:
+        pytest.skip(f"CuTe DSL dependencies unavailable: {exc}")
+    return CausalConv1dUpdateSm100
+
+
+def _inputs(*, n_rows=2, n_channels=8, n_slots=3, indexed=True):
+    x = torch.zeros(n_rows, n_channels, dtype=torch.bfloat16)
+    weight = torch.zeros(n_channels, 4, dtype=torch.bfloat16)
+    state = torch.zeros(n_slots, n_channels, 4, dtype=torch.bfloat16)
+    output = torch.empty_like(x)
+    indices = torch.arange(n_rows, dtype=torch.int32) if indexed else None
+    return x, weight, state, output, indices
+
+
+def _mock_cuda_contract(monkeypatch, api, capability=(10, 0)):
+    # These tests exercise descriptor/contract logic on CPU tensors only.  The
+    # real GPU suite independently checks the CUDA-device and SM100 gates.
+    monkeypatch.setattr(api, "_require_cuda", lambda desc, name: None)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: capability)
+
+
+def test_public_exports_remain_callables_not_modules(tmp_path):
+    # A same-named ``cudnn.causal_conv1d_update`` package previously replaced
+    # the lazy top-level function with the imported module object. Test a fresh
+    # interpreter against this checkout's __init__.py rather than the prebuilt
+    # package which conftest overlays for the other host-contract tests.
+    import cudnn
+
+    source = Path(__file__).resolve().parents[4] / "python" / "cudnn"
+    probe = tmp_path / "cudnn"
+    shutil.copytree(source, probe)
+    compiled_modules = list(Path(cudnn.__file__).resolve().parent.glob("_compiled_module*.so"))
+    assert len(compiled_modules) == 1
+    (probe / compiled_modules[0].name).symlink_to(compiled_modules[0])
+
+    script = """
+import types
+import cudnn
+import cudnn.ops
+from cudnn.causal_conv1d_update_sm100 import (
+    CausalConv1dUpdateSm100,
+    causal_conv1d_update,
+    causal_conv1d_update_wrapper_sm100,
+)
+
+exports = (
+    cudnn.causal_conv1d_update,
+    cudnn.causal_conv1d_update_wrapper_sm100,
+    cudnn.CausalConv1dUpdateSm100,
+    cudnn.ops.causal_conv1d_update,
+)
+assert all(callable(export) and not isinstance(export, types.ModuleType) for export in exports)
+assert cudnn.causal_conv1d_update is causal_conv1d_update
+assert cudnn.causal_conv1d_update_wrapper_sm100 is causal_conv1d_update_wrapper_sm100
+assert cudnn.CausalConv1dUpdateSm100 is CausalConv1dUpdateSm100
+assert cudnn.ops.causal_conv1d_update is causal_conv1d_update
+"""
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = os.pathsep.join((str(tmp_path), environment.get("PYTHONPATH", ""))).rstrip(os.pathsep)
+    subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_valid_descriptor_contract_without_kernel(monkeypatch):
+    cls = _api_class()
+    x, weight, state, output, indices = _inputs()
+    api = cls(x, weight, state, output, indices)
+    _mock_cuda_contract(monkeypatch, api)
+
+    assert api.check_support()
+    assert (api.n_rows, api.n_channels, api.n_slots) == (2, 8, 3)
+
+
+@pytest.mark.parametrize(
+    "mutate,match",
+    [
+        (lambda x, w, s, o, i: (x, w[:, :3], s, o, i), "Weight tensor shape mismatch"),
+        (
+            lambda x, w, s, o, i: (
+                torch.empty((x.shape[0], x.shape[1] * 2), dtype=x.dtype)[:, ::2],
+                w,
+                s,
+                o,
+                i,
+            ),
+            "X tensor stride mismatch",
+        ),
+        (lambda x, w, s, o, i: (x.float(), w, s, o.float(), i), "X dtype mismatch"),
+        (lambda x, w, s, o, i: (x, w, s[:1], o, None), "State needs at least N slots"),
+        (
+            lambda x, w, s, o, i: (x, w, s, o, i.to(torch.int64)),
+            "State indices dtype mismatch",
+        ),
+    ],
+    ids=["kernel-width", "shape", "dtype", "too-few-slots", "index-dtype"],
+)
+def test_bad_descriptor_contract_fails_before_compile(monkeypatch, mutate, match):
+    cls = _api_class()
+    args = mutate(*_inputs())
+    api = cls(*args)
+    _mock_cuda_contract(monkeypatch, api)
+
+    with pytest.raises((TypeError, ValueError), match=match):
+        api.check_support()
+
+
+def test_exact_sm100_gate(monkeypatch):
+    cls = _api_class()
+    api = cls(*_inputs())
+    _mock_cuda_contract(monkeypatch, api, capability=(10, 3))
+
+    with pytest.raises(RuntimeError, match="requires exactly SM100"):
+        api.check_support()
+
+
+def test_sample_pointer_alignment_is_part_of_compile_contract(monkeypatch):
+    cls = _api_class()
+    x, weight, state, output, indices = _inputs()
+    storage = torch.empty(x.numel() + 1, dtype=x.dtype)
+    misaligned_x = storage[1:].view_as(x)
+    api = cls(misaligned_x, weight, state, output, indices)
+    _mock_cuda_contract(monkeypatch, api)
+
+    with pytest.raises(ValueError, match="X data pointer must be 16-byte aligned"):
+        api.check_support()
+
+
+def test_execute_revalidates_presence_and_aliases(monkeypatch):
+    cls = _api_class()
+    x, weight, state, output, indices = _inputs()
+    api = cls(x, weight, state, output, indices)
+    _mock_cuda_contract(monkeypatch, api)
+    assert api.check_support()
+
+    calls = []
+    api._compiled_kernel = lambda *args: calls.append(args)
+    stream = cuda.CUstream(7)
+    api.execute(x, weight, state, output, indices, current_stream=stream)
+    assert len(calls) == 1
+
+    with pytest.raises(ValueError, match="presence must match"):
+        api.execute(x, weight, state, output, None, current_stream=stream)
+
+    storage = torch.empty(x.numel() + 1, dtype=x.dtype)
+    misaligned_x = storage[1:].view_as(x)
+    with pytest.raises(ValueError, match="X data pointer must be 16-byte aligned"):
+        api.execute(misaligned_x, weight, state, output, indices, current_stream=stream)
+
+    overlapping_output = state.view(-1)[: x.numel()].view_as(x)
+    with pytest.raises(ValueError, match="State must not overlap Output"):
+        api.execute(x, weight, state, overlapping_output, indices, current_stream=stream)
+
+    overlapping_indices = state.view(torch.int32).view(-1)[: x.shape[0]]
+    with pytest.raises(ValueError, match="State must not overlap State indices"):
+        api.execute(x, weight, state, output, overlapping_indices, current_stream=stream)
+
+    # Four output rows and a width-four filter have the same storage size.
+    # Rejecting this alias is required because row CTAs would otherwise race
+    # while overwriting weights that other rows still need to read.
+    aliased_storage = torch.empty(weight.numel(), dtype=torch.bfloat16)
+    aliased_weight = aliased_storage.view_as(weight)
+    aliased_output = aliased_storage.view(4, x.shape[1])
+    x4 = torch.zeros_like(aliased_output)
+    state4 = torch.zeros(4, state.shape[1], state.shape[2], dtype=state.dtype)
+    indices4 = torch.arange(4, dtype=torch.int32)
+    api4 = cls(x4, aliased_weight, state4, aliased_output, indices4)
+    _mock_cuda_contract(monkeypatch, api4)
+    assert api4.check_support()
+    api4._compiled_kernel = lambda *args: None
+    with pytest.raises(ValueError, match="Output must not overlap Weight"):
+        api4.execute(
+            x4,
+            aliased_weight,
+            state4,
+            aliased_output,
+            indices4,
+            current_stream=stream,
+        )
+
+
+def test_execute_rejects_autograd(monkeypatch):
+    cls = _api_class()
+    x, weight, state, output, indices = _inputs()
+    weight.requires_grad_(True)
+    api = cls(x, weight, state, output, indices)
+    _mock_cuda_contract(monkeypatch, api)
+    assert api.check_support()
+    api._compiled_kernel = lambda *args: None
+
+    with pytest.raises(RuntimeError, match="inference-only"):
+        api.execute(x, weight, state, output, indices, current_stream=cuda.CUstream(7))
+
+
+def test_execute_rejects_requires_grad_output(monkeypatch):
+    cls = _api_class()
+    x, weight, state, output, indices = _inputs()
+    output.requires_grad_(True)
+    api = cls(x, weight, state, output, indices)
+    _mock_cuda_contract(monkeypatch, api)
+    assert api.check_support()
+    api._compiled_kernel = lambda *args: None
+
+    with pytest.raises(RuntimeError, match="inference-only"):
+        api.execute(x, weight, state, output, indices, current_stream=cuda.CUstream(7))

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
@@ -5,16 +5,29 @@
 
 import inspect
 import os
-from pathlib import Path
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 import torch
 from cuda.bindings import driver as cuda
 
 pytestmark = pytest.mark.L0
+
+_SUPPORTED_COMPUTE_CAPABILITIES = (
+    (8, 0),
+    (8, 6),
+    (8, 7),
+    (8, 9),
+    (9, 0),
+    (10, 0),
+    (10, 3),
+    (11, 0),
+    (12, 0),
+    (12, 1),
+)
 
 
 def _api_class():
@@ -36,7 +49,7 @@ def _inputs(*, n_rows=2, n_channels=8, n_slots=3, indexed=True):
 
 def _mock_cuda_contract(monkeypatch, api, capability=(10, 0)):
     # These tests exercise descriptor/contract logic on CPU tensors only.  The
-    # real GPU suite independently checks the CUDA-device and SM100 gates.
+    # real GPU suite independently checks the CUDA-device and architecture gate.
     monkeypatch.setattr(api, "_require_cuda", lambda desc, name: None)
     monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
     monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: capability)
@@ -113,7 +126,7 @@ def test_valid_descriptor_contract_without_kernel(monkeypatch):
 
 
 @pytest.mark.parametrize("n_channels", [2048, 4096])
-def test_n128_no_index_selects_two_row_specialization(monkeypatch, n_channels):
+def test_n128_no_index_selects_two_row_specialization_on_sm100(monkeypatch, n_channels):
     cls = _api_class()
     api = cls(
         *_inputs(
@@ -127,6 +140,23 @@ def test_n128_no_index_selects_two_row_specialization(monkeypatch, n_channels):
 
     assert api.check_support()
     assert api.rows_per_cta == 2
+
+
+@pytest.mark.parametrize("capability", [capability for capability in _SUPPORTED_COMPUTE_CAPABILITIES if capability != (10, 0)])
+def test_n128_no_index_uses_one_row_schedule_off_sm100(monkeypatch, capability):
+    cls = _api_class()
+    api = cls(
+        *_inputs(
+            n_rows=128,
+            n_channels=2048,
+            n_slots=128,
+            indexed=False,
+        )
+    )
+    _mock_cuda_contract(monkeypatch, api, capability=capability)
+
+    assert api.check_support()
+    assert api.rows_per_cta == 1
 
 
 @pytest.mark.parametrize(
@@ -193,12 +223,22 @@ def test_bad_descriptor_contract_fails_before_compile(monkeypatch, mutate, match
         api.check_support()
 
 
-def test_exact_sm100_gate(monkeypatch):
+@pytest.mark.parametrize("capability", _SUPPORTED_COMPUTE_CAPABILITIES)
+def test_functional_architecture_allowlist(monkeypatch, capability):
     cls = _api_class()
     api = cls(*_inputs())
-    _mock_cuda_contract(monkeypatch, api, capability=(10, 3))
+    _mock_cuda_contract(monkeypatch, api, capability=capability)
 
-    with pytest.raises(RuntimeError, match="requires exactly SM100"):
+    assert api.check_support()
+
+
+@pytest.mark.parametrize("capability", [(7, 5), (10, 1), (11, 1), (13, 0)])
+def test_unsupported_architecture_gate(monkeypatch, capability):
+    cls = _api_class()
+    api = cls(*_inputs())
+    _mock_cuda_contract(monkeypatch, api, capability=capability)
+
+    with pytest.raises(RuntimeError, match="supports compute capabilities"):
         api.check_support()
 
 

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
@@ -84,6 +84,7 @@ def _mock_cuda_contract(monkeypatch, api, capability=(10, 0)):
     monkeypatch.setattr(api_module, "_record_streams", lambda tensors, stream: None)
 
 
+@pytest.mark.L1
 def test_only_cudnn_ops_exports_the_semantic_api(tmp_path):
     # Test a fresh interpreter against this checkout's __init__.py rather than
     # the prebuilt package which conftest overlays for other contract tests.
@@ -93,8 +94,12 @@ def test_only_cudnn_ops_exports_the_semantic_api(tmp_path):
     probe = tmp_path / "cudnn"
     shutil.copytree(source, probe)
     compiled_modules = list(Path(cudnn.__file__).resolve().parent.glob("_compiled_module*.so"))
-    assert len(compiled_modules) == 1
-    (probe / compiled_modules[0].name).symlink_to(compiled_modules[0])
+    if len(compiled_modules) != 1:
+        pytest.skip(f"expected one compiled module next to {cudnn.__file__}, found {len(compiled_modules)}")
+    try:
+        (probe / compiled_modules[0].name).symlink_to(compiled_modules[0])
+    except OSError as error:
+        pytest.skip(f"cannot link the compiled module into the probe package: {error}")
 
     script = """
 import types
@@ -292,7 +297,7 @@ def test_semantically_valid_unimplemented_configs_decline_clearly(state_len, wid
     from cudnn.ops import causal_conv1d_update
     from torch._subclasses.fake_tensor import FakeTensorMode
 
-    with FakeTensorMode(), pytest.raises(NotImplementedError, match="current native.*supports only"):
+    with FakeTensorMode(), pytest.raises(NotImplementedError, match=r"current native.*supports only"):
         x = torch.empty(2, 8, device="cuda", dtype=torch.bfloat16)
         state = torch.empty(2, 8, state_len, device="cuda", dtype=torch.bfloat16)
         weight = torch.empty(8, width, device="cuda", dtype=torch.bfloat16)

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
@@ -30,24 +30,35 @@ pytestmark = [
 def _load_api():
     try:
         from cudnn.causal_conv1d_update_sm100 import (
-            CausalConv1dUpdateSm100,
-            causal_conv1d_update,
+            _CausalConv1dUpdatePlan,
         )
+        from cudnn.ops import causal_conv1d_update
     except ImportError as exc:
         pytest.skip(f"CuTe DSL dependencies unavailable: {exc}")
-    return CausalConv1dUpdateSm100, causal_conv1d_update
+    return _CausalConv1dUpdatePlan, causal_conv1d_update
 
 
-def _reference_step(x, weight, state, state_indices=None):
+def _reference_step(x, weight, state, state_indices=None, bias=None, activation=None):
     """Explicit FP32 output reference plus exact BF16 state transition."""
 
     n_rows = x.shape[0]
     slots = torch.arange(n_rows, device=x.device, dtype=torch.long) if state_indices is None else state_indices.long()
-    selected = state.index_select(0, slots)
-    updated = torch.cat((selected[..., 1:], x.unsqueeze(-1)), dim=-1)
-    output = F.silu((updated.float() * weight.float().unsqueeze(0)).sum(dim=-1)).to(torch.bfloat16)
+    valid = slots >= 0
+    output = torch.zeros_like(x)
     expected_state = state.clone()
-    expected_state.index_copy_(0, slots, updated)
+    if valid.any():
+        valid_slots = slots[valid]
+        selected = state.index_select(0, valid_slots)
+        history = torch.cat((selected, x[valid].unsqueeze(-1)), dim=-1)
+        updated = history[..., -state.shape[-1] :]
+        window = history[..., -weight.shape[-1] :]
+        accumulator = (window.float() * weight.float().unsqueeze(0)).sum(dim=-1)
+        if bias is not None:
+            accumulator = accumulator + bias.float()
+        if activation in ("silu", "swish"):
+            accumulator = F.silu(accumulator)
+        output[valid] = accumulator.to(torch.bfloat16)
+        expected_state.index_copy_(0, valid_slots, updated)
     return output, expected_state
 
 
@@ -57,14 +68,14 @@ def _assert_state_bits_equal(actual, expected):
 
 @torch.no_grad()
 def test_nonzero_state_across_consecutive_steps():
-    CausalConv1dUpdateSm100, _ = _load_api()
+    plan_cls, _ = _load_api()
     torch.manual_seed(0)
     n_rows, n_channels = 3, 521
     state = torch.randn(n_rows, n_channels, 4, device="cuda", dtype=torch.bfloat16)
     weight = torch.randn(n_channels, 4, device="cuda", dtype=torch.bfloat16)
     output = torch.empty(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
 
-    api = CausalConv1dUpdateSm100(
+    api = plan_cls(
         sample_x=torch.empty_like(output),
         sample_weight=weight,
         sample_state=state,
@@ -147,7 +158,7 @@ def test_paged_state_slots_and_untouched_rows():
     state_indices = torch.tensor([6, 1, 4], device="cuda", dtype=torch.int32)
     expected_output, expected_state = _reference_step(x, weight, state, state_indices)
 
-    output = causal_conv1d_update(x, state, weight, state_indices)
+    output = causal_conv1d_update(x, state, weight, conv_state_indices=state_indices)
 
     torch.testing.assert_close(output, expected_output, atol=3e-2, rtol=3e-2)
     _assert_state_bits_equal(state, expected_state)
@@ -159,10 +170,72 @@ def test_paged_state_slots_and_untouched_rows():
 
 
 @torch.no_grad()
-def test_standard_wrapper_returns_tupledict():
-    from cudnn.api_base import TupleDict
-    from cudnn.causal_conv1d_update_sm100 import causal_conv1d_update_wrapper_sm100
+@pytest.mark.parametrize("state_len", [3, 4], ids=["w-minus-one", "legacy-four"])
+def test_padding_state_indices_write_zero_and_do_not_mutate_state(state_len):
+    _, causal_conv1d_update = _load_api()
+    torch.manual_seed(5)
+    n_rows, n_channels, n_slots = 4, 257, 5
+    x = torch.randn(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(n_channels, device="cuda", dtype=torch.bfloat16)
+    state = torch.randn(n_slots, n_channels, state_len, device="cuda", dtype=torch.bfloat16)
+    state_indices = torch.tensor([-1, 3, -1, 1], device="cuda", dtype=torch.int32)
+    expected_output, expected_state = _reference_step(
+        x,
+        weight,
+        state,
+        state_indices,
+        bias=bias,
+        activation="silu",
+    )
 
+    output = causal_conv1d_update(
+        x,
+        state,
+        weight,
+        bias,
+        activation="silu",
+        conv_state_indices=state_indices,
+    )
+
+    torch.testing.assert_close(output, expected_output, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(output[[0, 2]], torch.zeros_like(output[[0, 2]]), rtol=0, atol=0)
+    _assert_state_bits_equal(state, expected_state)
+
+
+@torch.no_grad()
+def test_wminus1_state_handoff_from_prefill_matches_next_causal_output():
+    _, causal_conv1d_update = _load_api()
+    torch.manual_seed(7)
+    n_rows, n_channels, prefix_len = 3, 259, 11
+    prefix = torch.randn(n_rows, n_channels, prefix_len, device="cuda", dtype=torch.bfloat16)
+    next_x = torch.randn(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(n_channels, device="cuda", dtype=torch.bfloat16)
+
+    # Bulk prefill returns exactly W - 1 history elements. Decode must consume
+    # that state without padding it to the legacy four-element cache layout.
+    state = prefix[..., -3:].contiguous()
+    full_history = torch.cat((prefix, next_x.unsqueeze(-1)), dim=-1)
+    expected_window = full_history[..., -4:]
+    expected_output = F.silu((expected_window.float() * weight.float().unsqueeze(0)).sum(dim=-1) + bias.float()).to(torch.bfloat16)
+    expected_state = full_history[..., -3:].contiguous()
+
+    output = causal_conv1d_update(
+        next_x,
+        state,
+        weight,
+        bias,
+        activation="silu",
+    )
+
+    torch.testing.assert_close(output, expected_output, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(state, expected_state)
+
+
+@torch.no_grad()
+def test_public_api_returns_an_ordinary_tensor():
+    _, causal_conv1d_update = _load_api()
     torch.manual_seed(11)
     n_rows, n_channels = 2, 259
     x = torch.randn(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
@@ -170,17 +243,16 @@ def test_standard_wrapper_returns_tupledict():
     state = torch.randn(n_rows, n_channels, 4, device="cuda", dtype=torch.bfloat16)
     expected_output, expected_state = _reference_step(x, weight, state)
 
-    result = causal_conv1d_update_wrapper_sm100(x, state, weight)
+    result = causal_conv1d_update(x, state, weight)
 
-    assert isinstance(result, TupleDict)
-    assert list(result.keys()) == ["output_tensor"]
-    assert result[0] is result["output_tensor"]
-    torch.testing.assert_close(result["output_tensor"], expected_output, atol=3e-2, rtol=3e-2)
+    assert type(result) is torch.Tensor
+    torch.testing.assert_close(result, expected_output, atol=3e-2, rtol=3e-2)
     _assert_state_bits_equal(state, expected_state)
 
 
 @torch.no_grad()
-def test_state_shift_and_append_are_bitwise():
+@pytest.mark.parametrize("state_len", [3, 4], ids=["w-minus-one", "legacy-four"])
+def test_state_shift_and_append_are_bitwise(state_len):
     _, causal_conv1d_update = _load_api()
     torch.manual_seed(2)
     n_rows, n_channels = 2, 257
@@ -191,7 +263,7 @@ def test_state_shift_and_append_are_bitwise():
     state_bits = torch.randint(
         -(2**15),
         2**15,
-        (n_rows, n_channels, 4),
+        (n_rows, n_channels, state_len),
         device="cuda",
         dtype=torch.int16,
     )
@@ -205,7 +277,7 @@ def test_state_shift_and_append_are_bitwise():
     state = state_bits.view(torch.bfloat16)
     x = x_bits.view(torch.bfloat16)
     weight = torch.zeros(n_channels, 4, device="cuda", dtype=torch.bfloat16)
-    expected_bits = torch.cat((state_bits[..., 1:], x_bits.unsqueeze(-1)), dim=-1)
+    expected_bits = torch.cat((state_bits, x_bits.unsqueeze(-1)), dim=-1)[..., -state_len:]
 
     causal_conv1d_update(x, state, weight)
 
@@ -238,9 +310,9 @@ def test_silu_special_values_and_tails():
     state = torch.zeros(1, values.numel(), 4, device="cuda", dtype=torch.bfloat16)
     weight = torch.zeros(values.numel(), 4, device="cuda", dtype=torch.bfloat16)
     weight[:, -1] = 1
-    expected, expected_state = _reference_step(x, weight, state)
+    expected, expected_state = _reference_step(x, weight, state, activation="silu")
 
-    output = causal_conv1d_update(x, state, weight)
+    output = causal_conv1d_update(x, state, weight, activation="silu")
 
     torch.testing.assert_close(output, expected, atol=3e-2, rtol=3e-2, equal_nan=True)
     _assert_state_bits_equal(state, expected_state)
@@ -257,8 +329,91 @@ def test_silu_special_values_and_tails():
 
 
 @torch.no_grad()
+def test_public_custom_op_registration_contract():
+    from cudnn.ops._causal_conv1d_update import _causal_conv1d_update_primitive
+
+    torch.manual_seed(31)
+    n_rows, n_channels, n_slots = 2, 257, 5
+    x = torch.randn(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
+    state = torch.randn(n_slots, n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(n_channels, device="cuda", dtype=torch.bfloat16)
+    state_indices = torch.tensor([4, 1], device="cuda", dtype=torch.int32)
+    test_utils = (
+        "test_schema",
+        "test_faketensor",
+        "test_aot_dispatch_dynamic",
+    )
+
+    results = torch.library.opcheck(
+        _causal_conv1d_update_primitive,
+        (x, state, weight, bias, "silu", None, state_indices),
+        test_utils=test_utils,
+    )
+
+    assert results == {test: "SUCCESS" for test in test_utils}
+
+
+@torch.no_grad()
+def test_public_torch_compile_fullgraph_observes_state_mutation():
+    _, causal_conv1d_update = _load_api()
+    torch.manual_seed(37)
+    n_rows, n_channels = 2, 257
+    x = torch.randn(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
+    state = torch.randn(n_rows, n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    expected_output, expected_state = _reference_step(x, weight, state, activation="silu")
+
+    compiled_update = torch.compile(causal_conv1d_update, fullgraph=True)
+    output = compiled_update(x, state, weight, activation="silu")
+
+    torch.testing.assert_close(output, expected_output, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(state, expected_state)
+
+
+@torch.no_grad()
+def test_public_cuda_graph_capture_and_replay_observe_state_mutation():
+    _, causal_conv1d_update = _load_api()
+    torch.manual_seed(43)
+    n_rows, n_channels = 2, 257
+    x = torch.randn(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    initial_state = torch.randn(n_rows, n_channels, 4, device="cuda", dtype=torch.bfloat16)
+
+    # Compile and cache the exact native specialization before capture.
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        causal_conv1d_update(x, initial_state.clone(), weight, activation="silu")
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+    torch.cuda.synchronize()
+
+    state = initial_state.clone()
+    expected_output, expected_state = _reference_step(x, weight, initial_state, activation="silu")
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output = causal_conv1d_update(x, state, weight, activation="silu")
+
+    # Capture records the launch; only replay makes its output and mutation
+    # observable. Poison the graph-owned output to prove replay overwrites it.
+    captured_output.fill_(float("nan"))
+    torch.cuda.synchronize()
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(captured_output, expected_output, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(state, expected_state)
+
+    expected_output_2, expected_state_2 = _reference_step(x, weight, expected_state, activation="silu")
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(captured_output, expected_output_2, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(state, expected_state_2)
+
+
+@torch.no_grad()
 def test_execute_respects_current_torch_stream():
-    CausalConv1dUpdateSm100, _ = _load_api()
+    plan_cls, _ = _load_api()
     torch.manual_seed(3)
     n_rows, n_channels = 2, 1024
     x_real = torch.randn(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
@@ -269,7 +424,7 @@ def test_execute_respects_current_torch_stream():
     x = torch.full_like(x_real, float("nan"))
     state = torch.full_like(state_real, float("nan"))
     output = torch.empty_like(x)
-    api = CausalConv1dUpdateSm100(x, weight, state, output)
+    api = plan_cls(x, weight, state, output)
     assert api.check_support()
     api.compile()
     torch.cuda.synchronize()
@@ -289,8 +444,8 @@ def test_execute_respects_current_torch_stream():
 
 
 @torch.no_grad()
-def test_wrapper_respects_explicit_cuda_stream():
-    from cudnn.causal_conv1d_update_sm100 import causal_conv1d_update_wrapper_sm100
+def test_private_allocating_route_respects_explicit_cuda_stream():
+    from cudnn.causal_conv1d_update_sm100 import _causal_conv1d_update
 
     torch.manual_seed(13)
     n_rows, n_channels = 2, 1024
@@ -302,7 +457,7 @@ def test_wrapper_respects_explicit_cuda_stream():
     # Warm the exact signature so this test isolates stream ordering rather
     # than JIT compilation behavior.
     warm_state = state_real.clone()
-    causal_conv1d_update_wrapper_sm100(x_real, warm_state, weight)
+    _causal_conv1d_update(x_real, warm_state, weight)
     torch.cuda.synchronize()
 
     x = torch.full_like(x_real, float("nan"))
@@ -314,7 +469,7 @@ def test_wrapper_respects_explicit_cuda_stream():
         x.copy_(x_real)
         state.copy_(state_real)
 
-    result = causal_conv1d_update_wrapper_sm100(
+    result = _causal_conv1d_update(
         x,
         state,
         weight,
@@ -322,8 +477,8 @@ def test_wrapper_respects_explicit_cuda_stream():
     )
     side.synchronize()
 
-    assert not torch.isnan(result["output_tensor"]).any(), "kernel read poisoned input from the wrong stream"
-    torch.testing.assert_close(result["output_tensor"], expected_output, atol=3e-2, rtol=3e-2)
+    assert not torch.isnan(result).any(), "kernel read poisoned input from the wrong stream"
+    torch.testing.assert_close(result, expected_output, atol=3e-2, rtol=3e-2)
     _assert_state_bits_equal(state, expected_state)
 
 
@@ -338,7 +493,7 @@ case = sys.argv[1]
 source_cudnn = sys.argv[2]
 cudnn.__path__.insert(0, source_cudnn)
 
-from cudnn.causal_conv1d_update_sm100 import CausalConv1dUpdateSm100
+from cudnn.causal_conv1d_update_sm100 import _CausalConv1dUpdatePlan
 
 torch.manual_seed(17)
 n_rows, n_channels, n_slots = 2, 257, 3
@@ -347,14 +502,14 @@ weight = torch.randn(n_channels, 4, device="cuda", dtype=torch.bfloat16)
 state = torch.randn(n_slots, n_channels, 4, device="cuda", dtype=torch.bfloat16)
 output = torch.empty_like(x)
 valid_indices = torch.tensor([0, 1], device="cuda", dtype=torch.int32)
-api = CausalConv1dUpdateSm100(x, weight, state, output, valid_indices)
+api = _CausalConv1dUpdatePlan(x, weight, state, output, valid_indices)
 api.check_support()
 api.compile()
 api.execute(x, weight, state, output, valid_indices)
 torch.cuda.synchronize()
 
 invalid_indices = {
-    "negative": [-1, 1],
+    "below_padding": [-2, 1],
     "out_of_range": [0, n_slots],
     "duplicate": [1, 1],
 }[case]
@@ -372,7 +527,7 @@ os._exit(9)
 """
 
 
-@pytest.mark.parametrize("case", ["negative", "out_of_range", "duplicate"])
+@pytest.mark.parametrize("case", ["below_padding", "out_of_range", "duplicate"])
 def test_invalid_state_indices_fail_closed_in_fresh_process(case):
     # A CUDA device assert poisons its process context.  Keep each contract
     # case isolated and first prove the same compiled object launches validly.
@@ -420,7 +575,7 @@ def test_invalid_state_indices_fail_closed_in_fresh_process(case):
     ids=["kernel-width", "shape-mismatch", "dtype", "too-few-slots", "index-dtype"],
 )
 def test_bad_host_contracts_fail_closed(mutate, match):
-    CausalConv1dUpdateSm100, _ = _load_api()
+    plan_cls, _ = _load_api()
     n_rows, n_channels = 2, 8
     x = torch.zeros(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
     weight = torch.zeros(n_channels, 4, device="cuda", dtype=torch.bfloat16)
@@ -429,6 +584,6 @@ def test_bad_host_contracts_fail_closed(mutate, match):
     x, weight, state, indices = mutate(x, weight, state, indices)
     output = torch.empty_like(x)
 
-    api = CausalConv1dUpdateSm100(x, weight, state, output, indices)
+    api = plan_cls(x, weight, state, output, indices)
     with pytest.raises((TypeError, ValueError), match=match):
         api.check_support()

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
@@ -84,7 +84,7 @@ def test_nonzero_state_across_consecutive_steps():
 
 @torch.no_grad()
 @pytest.mark.parametrize("n_channels", [2048, 4096])
-def test_n128_no_index_measured_shape_correctness(n_channels):
+def test_n128_no_index_representative_shape_correctness(n_channels):
     _, causal_conv1d_update = _load_api()
     torch.manual_seed(29 + n_channels)
     n_rows = 128
@@ -92,9 +92,8 @@ def test_n128_no_index_measured_shape_correctness(n_channels):
     state = torch.randn(n_rows, n_channels, 4, device="cuda", dtype=torch.bfloat16)
     expected_state = state.clone()
 
-    # Use the public cached route for two updates.  The host-only contract test
-    # independently proves that these descriptors select rows_per_cta=2 only
-    # on SM100 and the conservative one-row schedule elsewhere.
+    # Use the public cached route for two updates at representative decode
+    # shapes. Every architecture uses the same one-row schedule.
     for _ in range(2):
         x = torch.randn(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
         expected_output, expected_state = _reference_step(x, weight, expected_state)
@@ -105,7 +104,7 @@ def test_n128_no_index_measured_shape_correctness(n_channels):
 
 @torch.no_grad()
 @pytest.mark.parametrize("n_channels", [2048, 4096])
-def test_n128_measured_shape_state_shift_is_bitwise(n_channels):
+def test_n128_representative_shape_state_shift_is_bitwise(n_channels):
     _, causal_conv1d_update = _load_api()
     torch.manual_seed(41 + n_channels)
     n_rows = 128

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
@@ -1,0 +1,333 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Correctness and contract tests for the SM100 decode-update operation."""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+import torch
+import torch.nn.functional as F
+from cuda.bindings import driver as cuda
+
+
+def _is_sm100() -> bool:
+    return torch.cuda.is_available() and torch.cuda.get_device_capability() == (10, 0)
+
+
+pytestmark = [
+    pytest.mark.L0,
+    pytest.mark.skipif(not _is_sm100(), reason="requires exactly SM100 (compute capability 10.0)"),
+]
+
+
+def _load_api():
+    try:
+        from cudnn.causal_conv1d_update_sm100 import (
+            CausalConv1dUpdateSm100,
+            causal_conv1d_update,
+        )
+    except ImportError as exc:
+        pytest.skip(f"CuTe DSL dependencies unavailable: {exc}")
+    return CausalConv1dUpdateSm100, causal_conv1d_update
+
+
+def _reference_step(x, weight, state, state_indices=None):
+    """Explicit FP32 output reference plus exact BF16 state transition."""
+
+    n_rows = x.shape[0]
+    slots = torch.arange(n_rows, device=x.device, dtype=torch.long) if state_indices is None else state_indices.long()
+    selected = state.index_select(0, slots)
+    updated = torch.cat((selected[..., 1:], x.unsqueeze(-1)), dim=-1)
+    output = F.silu((updated.float() * weight.float().unsqueeze(0)).sum(dim=-1)).to(torch.bfloat16)
+    expected_state = state.clone()
+    expected_state.index_copy_(0, slots, updated)
+    return output, expected_state
+
+
+def _assert_state_bits_equal(actual, expected):
+    torch.testing.assert_close(actual.view(torch.int16), expected.view(torch.int16), rtol=0, atol=0)
+
+
+@torch.no_grad()
+def test_nonzero_state_across_consecutive_steps():
+    CausalConv1dUpdateSm100, _ = _load_api()
+    torch.manual_seed(0)
+    n_rows, n_channels = 3, 521
+    state = torch.randn(n_rows, n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    output = torch.empty(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
+
+    api = CausalConv1dUpdateSm100(
+        sample_x=torch.empty_like(output),
+        sample_weight=weight,
+        sample_state=state,
+        sample_output=output,
+    )
+    assert api.check_support()
+    api.compile()
+
+    expected_state = state.clone()
+    for _ in range(3):
+        x = torch.randn(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
+        expected_output, expected_state = _reference_step(x, weight, expected_state)
+        api.execute(x, weight, state, output)
+        torch.testing.assert_close(output, expected_output, atol=3e-2, rtol=3e-2)
+        _assert_state_bits_equal(state, expected_state)
+
+
+@torch.no_grad()
+def test_paged_state_slots_and_untouched_rows():
+    _, causal_conv1d_update = _load_api()
+    torch.manual_seed(1)
+    n_rows, n_channels, n_slots = 3, 257, 7
+    x = torch.randn(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    state = torch.randn(n_slots, n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    state_indices = torch.tensor([6, 1, 4], device="cuda", dtype=torch.int32)
+    expected_output, expected_state = _reference_step(x, weight, state, state_indices)
+
+    output = causal_conv1d_update(x, weight, state, state_indices)
+
+    torch.testing.assert_close(output, expected_output, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(state, expected_state)
+    untouched = torch.tensor([0, 2, 3, 5], device="cuda", dtype=torch.long)
+    _assert_state_bits_equal(
+        state.index_select(0, untouched),
+        expected_state.index_select(0, untouched),
+    )
+
+
+@torch.no_grad()
+def test_standard_wrapper_returns_tupledict():
+    from cudnn.api_base import TupleDict
+    from cudnn.causal_conv1d_update_sm100 import causal_conv1d_update_wrapper_sm100
+
+    torch.manual_seed(11)
+    n_rows, n_channels = 2, 259
+    x = torch.randn(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    state = torch.randn(n_rows, n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    expected_output, expected_state = _reference_step(x, weight, state)
+
+    result = causal_conv1d_update_wrapper_sm100(x, weight, state)
+
+    assert isinstance(result, TupleDict)
+    assert list(result.keys()) == ["output_tensor"]
+    assert result[0] is result["output_tensor"]
+    torch.testing.assert_close(result["output_tensor"], expected_output, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(state, expected_state)
+
+
+@torch.no_grad()
+def test_state_shift_and_append_are_bitwise():
+    _, causal_conv1d_update = _load_api()
+    torch.manual_seed(2)
+    n_rows, n_channels = 2, 257
+
+    # Exercise raw BF16 payloads rather than only finite values.  The output is
+    # intentionally ignored; this test proves the mutable cache path is a
+    # bitwise shift/append, including signed zero and NaN payloads.
+    state_bits = torch.randint(
+        -(2**15),
+        2**15,
+        (n_rows, n_channels, 4),
+        device="cuda",
+        dtype=torch.int16,
+    )
+    x_bits = torch.randint(
+        -(2**15),
+        2**15,
+        (n_rows, n_channels),
+        device="cuda",
+        dtype=torch.int16,
+    )
+    state = state_bits.view(torch.bfloat16)
+    x = x_bits.view(torch.bfloat16)
+    weight = torch.zeros(n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    expected_bits = torch.cat((state_bits[..., 1:], x_bits.unsqueeze(-1)), dim=-1)
+
+    causal_conv1d_update(x, weight, state)
+
+    torch.testing.assert_close(state.view(torch.int16), expected_bits, rtol=0, atol=0)
+
+
+@torch.no_grad()
+def test_execute_respects_current_torch_stream():
+    CausalConv1dUpdateSm100, _ = _load_api()
+    torch.manual_seed(3)
+    n_rows, n_channels = 2, 1024
+    x_real = torch.randn(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    state_real = torch.randn(n_rows, n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    expected_output, expected_state = _reference_step(x_real, weight, state_real)
+
+    x = torch.full_like(x_real, float("nan"))
+    state = torch.full_like(state_real, float("nan"))
+    output = torch.empty_like(x)
+    api = CausalConv1dUpdateSm100(x, weight, state, output)
+    assert api.check_support()
+    api.compile()
+    torch.cuda.synchronize()
+
+    side = torch.cuda.Stream()
+    with torch.cuda.stream(side):
+        # Make wrong-stream execution reliably overtake the real input copies.
+        torch.cuda._sleep(100_000_000)
+        x.copy_(x_real)
+        state.copy_(state_real)
+        api.execute(x, weight, state, output)
+    side.synchronize()
+
+    assert not torch.isnan(output).any(), "kernel read poisoned input from the wrong stream"
+    torch.testing.assert_close(output, expected_output, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(state, expected_state)
+
+
+@torch.no_grad()
+def test_wrapper_respects_explicit_cuda_stream():
+    from cudnn.causal_conv1d_update_sm100 import causal_conv1d_update_wrapper_sm100
+
+    torch.manual_seed(13)
+    n_rows, n_channels = 2, 1024
+    x_real = torch.randn(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    state_real = torch.randn(n_rows, n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    expected_output, expected_state = _reference_step(x_real, weight, state_real)
+
+    # Warm the exact signature so this test isolates stream ordering rather
+    # than JIT compilation behavior.
+    warm_state = state_real.clone()
+    causal_conv1d_update_wrapper_sm100(x_real, weight, warm_state)
+    torch.cuda.synchronize()
+
+    x = torch.full_like(x_real, float("nan"))
+    state = torch.full_like(state_real, float("nan"))
+    torch.cuda.synchronize()
+    side = torch.cuda.Stream()
+    with torch.cuda.stream(side):
+        torch.cuda._sleep(100_000_000)
+        x.copy_(x_real)
+        state.copy_(state_real)
+
+    result = causal_conv1d_update_wrapper_sm100(
+        x,
+        weight,
+        state,
+        current_stream=cuda.CUstream(side.cuda_stream),
+    )
+    side.synchronize()
+
+    assert not torch.isnan(result["output_tensor"]).any(), "kernel read poisoned input from the wrong stream"
+    torch.testing.assert_close(result["output_tensor"], expected_output, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(state, expected_state)
+
+
+_DEVICE_ASSERT_WORKER = r"""
+import os
+import sys
+
+import torch
+import cudnn
+
+case = sys.argv[1]
+source_cudnn = sys.argv[2]
+cudnn.__path__.insert(0, source_cudnn)
+
+from cudnn.causal_conv1d_update_sm100 import CausalConv1dUpdateSm100
+
+torch.manual_seed(17)
+n_rows, n_channels, n_slots = 2, 257, 3
+x = torch.randn(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
+weight = torch.randn(n_channels, 4, device="cuda", dtype=torch.bfloat16)
+state = torch.randn(n_slots, n_channels, 4, device="cuda", dtype=torch.bfloat16)
+output = torch.empty_like(x)
+valid_indices = torch.tensor([0, 1], device="cuda", dtype=torch.int32)
+api = CausalConv1dUpdateSm100(x, weight, state, output, valid_indices)
+api.check_support()
+api.compile()
+api.execute(x, weight, state, output, valid_indices)
+torch.cuda.synchronize()
+
+invalid_indices = {
+    "negative": [-1, 1],
+    "out_of_range": [0, n_slots],
+    "duplicate": [1, 1],
+}[case]
+invalid_indices = torch.tensor(invalid_indices, device="cuda", dtype=torch.int32)
+
+try:
+    api.execute(x, weight, state, output, invalid_indices)
+    torch.cuda.synchronize()
+except Exception as error:
+    print(f"EXPECTED_DEVICE_FAILURE:{case}:{type(error).__name__}:{error}", flush=True)
+    os._exit(0)
+
+print(f"MISSING_DEVICE_FAILURE:{case}", flush=True)
+os._exit(9)
+"""
+
+
+@pytest.mark.parametrize("case", ["negative", "out_of_range", "duplicate"])
+def test_invalid_state_indices_fail_closed_in_fresh_process(case):
+    # A CUDA device assert poisons its process context.  Keep each contract
+    # case isolated and first prove the same compiled object launches validly.
+    source_cudnn = Path(__file__).resolve().parents[4] / "python" / "cudnn"
+    environment = os.environ.copy()
+    environment["PYTHONNOUSERSITE"] = "1"
+    result = subprocess.run(
+        [sys.executable, "-c", _DEVICE_ASSERT_WORKER, case, str(source_cudnn)],
+        cwd=Path(__file__).resolve().parents[4],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    diagnostics = result.stdout + result.stderr
+    assert result.returncode == 0, diagnostics
+    assert f"EXPECTED_DEVICE_FAILURE:{case}:" in diagnostics, diagnostics
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "mutate,match",
+    [
+        (lambda x, w, s, i: (x, w[:, :3], s, i), "Weight tensor shape mismatch"),
+        (
+            lambda x, w, s, i: (
+                torch.empty(
+                    (x.shape[0], x.shape[1] * 2),
+                    device=x.device,
+                    dtype=x.dtype,
+                )[:, ::2],
+                w,
+                s,
+                i,
+            ),
+            "X tensor stride mismatch",
+        ),
+        (lambda x, w, s, i: (x.float(), w, s, i), "X dtype mismatch"),
+        (lambda x, w, s, i: (x, w, s[:1], None), "State needs at least N slots"),
+        (
+            lambda x, w, s, i: (x, w, s, i.to(torch.int64)),
+            "State indices dtype mismatch",
+        ),
+    ],
+    ids=["kernel-width", "shape-mismatch", "dtype", "too-few-slots", "index-dtype"],
+)
+def test_bad_host_contracts_fail_closed(mutate, match):
+    CausalConv1dUpdateSm100, _ = _load_api()
+    n_rows, n_channels = 2, 8
+    x = torch.zeros(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.zeros(n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    state = torch.zeros(n_rows, n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    indices = torch.arange(n_rows, device="cuda", dtype=torch.int32)
+    x, weight, state, indices = mutate(x, weight, state, indices)
+    output = torch.empty_like(x)
+
+    api = CausalConv1dUpdateSm100(x, weight, state, output, indices)
+    with pytest.raises((TypeError, ValueError), match=match):
+        api.check_support()

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
@@ -1,26 +1,29 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Correctness and contract tests for the SM100 decode-update operation."""
+"""GPU correctness and contract tests for the decode-update operation."""
 
 import os
-from pathlib import Path
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 import torch
 import torch.nn.functional as F
 from cuda.bindings import driver as cuda
+from cudnn._causal_conv1d_arch import (
+    is_supported_causal_conv1d_update_compute_capability,
+)
 
 
-def _is_sm100() -> bool:
-    return torch.cuda.is_available() and torch.cuda.get_device_capability() == (10, 0)
+def _has_supported_gpu() -> bool:
+    return torch.cuda.is_available() and is_supported_causal_conv1d_update_compute_capability(torch.cuda.get_device_capability())
 
 
 pytestmark = [
     pytest.mark.L0,
-    pytest.mark.skipif(not _is_sm100(), reason="requires exactly SM100 (compute capability 10.0)"),
+    pytest.mark.skipif(not _has_supported_gpu(), reason="requires a functionally supported GPU architecture"),
 ]
 
 
@@ -81,7 +84,7 @@ def test_nonzero_state_across_consecutive_steps():
 
 @torch.no_grad()
 @pytest.mark.parametrize("n_channels", [2048, 4096])
-def test_n128_no_index_row_batch_specialization(n_channels):
+def test_n128_no_index_measured_shape_correctness(n_channels):
     _, causal_conv1d_update = _load_api()
     torch.manual_seed(29 + n_channels)
     n_rows = 128
@@ -90,7 +93,8 @@ def test_n128_no_index_row_batch_specialization(n_channels):
     expected_state = state.clone()
 
     # Use the public cached route for two updates.  The host-only contract test
-    # independently proves that these two descriptors select rows_per_cta=2.
+    # independently proves that these descriptors select rows_per_cta=2 only
+    # on SM100 and the conservative one-row schedule elsewhere.
     for _ in range(2):
         x = torch.randn(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
         expected_output, expected_state = _reference_step(x, weight, expected_state)
@@ -101,14 +105,14 @@ def test_n128_no_index_row_batch_specialization(n_channels):
 
 @torch.no_grad()
 @pytest.mark.parametrize("n_channels", [2048, 4096])
-def test_n128_row_batch_state_shift_is_bitwise(n_channels):
+def test_n128_measured_shape_state_shift_is_bitwise(n_channels):
     _, causal_conv1d_update = _load_api()
     torch.manual_seed(41 + n_channels)
     n_rows = 128
 
-    # Exercise arbitrary BF16 payloads through the specialized public/cache
-    # route.  Ignore output: NaN payloads make only the state mutation contract
-    # meaningful, and that contract must remain bitwise over repeated steps.
+    # Exercise arbitrary BF16 payloads through the public/cache route.  Ignore
+    # output: NaN payloads make only the state mutation contract meaningful,
+    # and that contract must remain bitwise over repeated steps.
     state_bits = torch.randint(
         -(2**15),
         2**15,

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
@@ -67,6 +67,18 @@ def _assert_state_bits_equal(actual, expected):
     torch.testing.assert_close(actual.view(torch.int16), expected.view(torch.int16), rtol=0, atol=0)
 
 
+def _padded_x(values, row_stride):
+    storage = torch.empty(
+        values.shape[0],
+        row_stride,
+        device=values.device,
+        dtype=values.dtype,
+    )
+    result = storage[:, : values.shape[1]]
+    result.copy_(values)
+    return result
+
+
 @torch.no_grad()
 def test_nonzero_state_across_consecutive_steps():
     plan_cls, _ = _load_api()
@@ -92,6 +104,27 @@ def test_nonzero_state_across_consecutive_steps():
         api.execute(x, weight, state, output)
         torch.testing.assert_close(output, expected_output, atol=3e-2, rtol=3e-2)
         _assert_state_bits_equal(state, expected_state)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("state_len", [3, 4], ids=["w-minus-one", "legacy-four"])
+def test_padded_x_rows_match_reference_and_preserve_compact_output(state_len):
+    _, causal_conv1d_update = _load_api()
+    torch.manual_seed(53 + state_len)
+    n_rows, n_channels, row_stride = 4, 257, 264
+    dense_x = torch.randn(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
+    x = _padded_x(dense_x, row_stride)
+    weight = torch.randn(n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    state = torch.randn(n_rows, n_channels, state_len, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(n_channels, device="cuda", dtype=torch.bfloat16)
+    expected_output, expected_state = _reference_step(dense_x, weight, state, bias=bias, activation="silu")
+
+    assert x.stride() == (row_stride, 1)
+    output = causal_conv1d_update(x, state, weight, bias, activation="silu")
+
+    assert output.is_contiguous()
+    torch.testing.assert_close(output, expected_output, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(state, expected_state)
 
 
 @torch.no_grad()
@@ -603,7 +636,7 @@ def test_invalid_state_indices_fail_closed_in_fresh_process(case):
                 s,
                 i,
             ),
-            "X tensor stride mismatch",
+            r"X must have row-major strides \(ld, 1\)",
         ),
         (lambda x, w, s, i: (x.float(), w, s, i), "X dtype mismatch"),
         (lambda x, w, s, i: (x, w, s[:1], None), "State needs at least N slots"),

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
@@ -94,7 +94,7 @@ def test_n128_no_index_row_batch_specialization(n_channels):
     for _ in range(2):
         x = torch.randn(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
         expected_output, expected_state = _reference_step(x, weight, expected_state)
-        output = causal_conv1d_update(x, weight, state)
+        output = causal_conv1d_update(x, state, weight)
         torch.testing.assert_close(output, expected_output, atol=3e-2, rtol=3e-2)
         _assert_state_bits_equal(state, expected_state)
 
@@ -128,7 +128,7 @@ def test_n128_row_batch_state_shift_is_bitwise(n_channels):
             device="cuda",
             dtype=torch.int16,
         )
-        causal_conv1d_update(x_bits.view(torch.bfloat16), weight, state)
+        causal_conv1d_update(x_bits.view(torch.bfloat16), state, weight)
         expected_bits = torch.cat((expected_bits[..., 1:], x_bits.unsqueeze(-1)), dim=-1)
         torch.testing.assert_close(state.view(torch.int16), expected_bits, rtol=0, atol=0)
 
@@ -144,7 +144,7 @@ def test_paged_state_slots_and_untouched_rows():
     state_indices = torch.tensor([6, 1, 4], device="cuda", dtype=torch.int32)
     expected_output, expected_state = _reference_step(x, weight, state, state_indices)
 
-    output = causal_conv1d_update(x, weight, state, state_indices)
+    output = causal_conv1d_update(x, state, weight, state_indices)
 
     torch.testing.assert_close(output, expected_output, atol=3e-2, rtol=3e-2)
     _assert_state_bits_equal(state, expected_state)
@@ -167,7 +167,7 @@ def test_standard_wrapper_returns_tupledict():
     state = torch.randn(n_rows, n_channels, 4, device="cuda", dtype=torch.bfloat16)
     expected_output, expected_state = _reference_step(x, weight, state)
 
-    result = causal_conv1d_update_wrapper_sm100(x, weight, state)
+    result = causal_conv1d_update_wrapper_sm100(x, state, weight)
 
     assert isinstance(result, TupleDict)
     assert list(result.keys()) == ["output_tensor"]
@@ -204,7 +204,7 @@ def test_state_shift_and_append_are_bitwise():
     weight = torch.zeros(n_channels, 4, device="cuda", dtype=torch.bfloat16)
     expected_bits = torch.cat((state_bits[..., 1:], x_bits.unsqueeze(-1)), dim=-1)
 
-    causal_conv1d_update(x, weight, state)
+    causal_conv1d_update(x, state, weight)
 
     torch.testing.assert_close(state.view(torch.int16), expected_bits, rtol=0, atol=0)
 
@@ -237,7 +237,7 @@ def test_silu_special_values_and_tails():
     weight[:, -1] = 1
     expected, expected_state = _reference_step(x, weight, state)
 
-    output = causal_conv1d_update(x, weight, state)
+    output = causal_conv1d_update(x, state, weight)
 
     torch.testing.assert_close(output, expected, atol=3e-2, rtol=3e-2, equal_nan=True)
     _assert_state_bits_equal(state, expected_state)
@@ -299,7 +299,7 @@ def test_wrapper_respects_explicit_cuda_stream():
     # Warm the exact signature so this test isolates stream ordering rather
     # than JIT compilation behavior.
     warm_state = state_real.clone()
-    causal_conv1d_update_wrapper_sm100(x_real, weight, warm_state)
+    causal_conv1d_update_wrapper_sm100(x_real, warm_state, weight)
     torch.cuda.synchronize()
 
     x = torch.full_like(x_real, float("nan"))
@@ -313,8 +313,8 @@ def test_wrapper_respects_explicit_cuda_stream():
 
     result = causal_conv1d_update_wrapper_sm100(
         x,
-        weight,
         state,
+        weight,
         current_stream=cuda.CUstream(side.cuda_stream),
     )
     side.synchronize()

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
@@ -156,6 +156,50 @@ def test_state_shift_and_append_are_bitwise():
 
 
 @torch.no_grad()
+def test_silu_special_values_and_tails():
+    _, causal_conv1d_update = _load_api()
+    values = torch.tensor(
+        [
+            -float("inf"),
+            -100.0,
+            -20.0,
+            -10.0,
+            -1.0,
+            -0.0,
+            0.0,
+            1.0,
+            10.0,
+            20.0,
+            100.0,
+            float("inf"),
+            float("nan"),
+        ],
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    x = values.unsqueeze(0)
+    state = torch.zeros(1, values.numel(), 4, device="cuda", dtype=torch.bfloat16)
+    weight = torch.zeros(values.numel(), 4, device="cuda", dtype=torch.bfloat16)
+    weight[:, -1] = 1
+    expected, expected_state = _reference_step(x, weight, state)
+
+    output = causal_conv1d_update(x, weight, state)
+
+    torch.testing.assert_close(output, expected, atol=3e-2, rtol=3e-2, equal_nan=True)
+    _assert_state_bits_equal(state, expected_state)
+    # Signed zero is determined by the four-term convolution reduction, not by
+    # applying SiLU directly to the final x lane.  Compare the observable
+    # reduction result bitwise for both zero inputs.
+    zero_lanes = torch.tensor([5, 6], device="cuda")
+    torch.testing.assert_close(
+        output.view(torch.int16).index_select(1, zero_lanes),
+        expected.view(torch.int16).index_select(1, zero_lanes),
+        rtol=0,
+        atol=0,
+    )
+
+
+@torch.no_grad()
 def test_execute_respects_current_torch_stream():
     CausalConv1dUpdateSm100, _ = _load_api()
     torch.manual_seed(3)

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
@@ -3,6 +3,7 @@
 
 """GPU correctness and contract tests for the decode-update operation."""
 
+import importlib
 import os
 import subprocess
 import sys
@@ -352,6 +353,45 @@ def test_public_custom_op_registration_contract():
     )
 
     assert results == {test: "SUCCESS" for test in test_utils}
+
+
+@torch.no_grad()
+def test_public_plain_cuda_tensors_use_validated_eager_fast_path(monkeypatch):
+    ops_module = importlib.import_module("cudnn.ops._causal_conv1d_update")
+    x = torch.zeros(2, 257, device="cuda", dtype=torch.bfloat16)
+    state = torch.zeros(2, 257, 4, device="cuda", dtype=torch.bfloat16)
+    weight = torch.zeros(257, 4, device="cuda", dtype=torch.bfloat16)
+    sentinel = torch.empty_like(x)
+    calls = []
+
+    def validated_native(*args):
+        calls.append(args)
+        return sentinel
+
+    monkeypatch.setattr(ops_module, "_validated_native_update", validated_native)
+
+    output = ops_module.causal_conv1d_update(x, state, weight, activation="swish")
+
+    assert output is sentinel
+    assert calls == [(x, state, weight, None, "silu", None, None)]
+
+
+@torch.no_grad()
+def test_public_eager_fast_path_declines_active_torch_dispatch_mode():
+    from torch.utils._python_dispatch import TorchDispatchMode
+
+    ops_module = importlib.import_module("cudnn.ops._causal_conv1d_update")
+    x = torch.zeros(2, 257, device="cuda", dtype=torch.bfloat16)
+    state = torch.zeros(2, 257, 4, device="cuda", dtype=torch.bfloat16)
+    weight = torch.zeros(257, 4, device="cuda", dtype=torch.bfloat16)
+
+    class PassthroughMode(TorchDispatchMode):
+        def __torch_dispatch__(self, function, types, args=(), kwargs=None):
+            return function(*args, **(kwargs or {}))
+
+    assert ops_module._can_use_eager_native_fast_path(x, state, weight, None, None, None)
+    with PassthroughMode():
+        assert not ops_module._can_use_eager_native_fast_path(x, state, weight, None, None, None)
 
 
 @torch.no_grad()

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
@@ -80,6 +80,60 @@ def test_nonzero_state_across_consecutive_steps():
 
 
 @torch.no_grad()
+@pytest.mark.parametrize("n_channels", [2048, 4096])
+def test_n128_no_index_row_batch_specialization(n_channels):
+    _, causal_conv1d_update = _load_api()
+    torch.manual_seed(29 + n_channels)
+    n_rows = 128
+    weight = torch.randn(n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    state = torch.randn(n_rows, n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    expected_state = state.clone()
+
+    # Use the public cached route for two updates.  The host-only contract test
+    # independently proves that these two descriptors select rows_per_cta=2.
+    for _ in range(2):
+        x = torch.randn(n_rows, n_channels, device="cuda", dtype=torch.bfloat16)
+        expected_output, expected_state = _reference_step(x, weight, expected_state)
+        output = causal_conv1d_update(x, weight, state)
+        torch.testing.assert_close(output, expected_output, atol=3e-2, rtol=3e-2)
+        _assert_state_bits_equal(state, expected_state)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("n_channels", [2048, 4096])
+def test_n128_row_batch_state_shift_is_bitwise(n_channels):
+    _, causal_conv1d_update = _load_api()
+    torch.manual_seed(41 + n_channels)
+    n_rows = 128
+
+    # Exercise arbitrary BF16 payloads through the specialized public/cache
+    # route.  Ignore output: NaN payloads make only the state mutation contract
+    # meaningful, and that contract must remain bitwise over repeated steps.
+    state_bits = torch.randint(
+        -(2**15),
+        2**15,
+        (n_rows, n_channels, 4),
+        device="cuda",
+        dtype=torch.int16,
+    )
+    state = state_bits.view(torch.bfloat16)
+    weight = torch.zeros(n_channels, 4, device="cuda", dtype=torch.bfloat16)
+    expected_bits = state_bits.clone()
+
+    for _ in range(2):
+        x_bits = torch.randint(
+            -(2**15),
+            2**15,
+            (n_rows, n_channels),
+            device="cuda",
+            dtype=torch.int16,
+        )
+        causal_conv1d_update(x_bits.view(torch.bfloat16), weight, state)
+        expected_bits = torch.cat((expected_bits[..., 1:], x_bits.unsqueeze(-1)), dim=-1)
+        torch.testing.assert_close(state.view(torch.int16), expected_bits, rtol=0, atol=0)
+
+
+@torch.no_grad()
 def test_paged_state_slots_and_untouched_rows():
     _, causal_conv1d_update = _load_api()
     torch.manual_seed(1)

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
@@ -600,6 +600,7 @@ os._exit(9)
 """
 
 
+@pytest.mark.L1
 @pytest.mark.parametrize("case", ["below_padding", "out_of_range", "duplicate"])
 def test_invalid_state_indices_fail_closed_in_fresh_process(case):
     # A CUDA device assert poisons its process context.  Keep each contract

--- a/test/python/linear_attention/conftest.py
+++ b/test/python/linear_attention/conftest.py
@@ -23,8 +23,11 @@ try:
     import cudnn
 
     _SRC_CUDNN = Path(__file__).resolve().parents[3] / "python" / "cudnn"
-    if _SRC_CUDNN.is_dir() and str(_SRC_CUDNN) not in cudnn.__path__:
-        cudnn.__path__.append(str(_SRC_CUDNN))
+    if _SRC_CUDNN.is_dir():
+        source_path = str(_SRC_CUDNN)
+        if source_path in cudnn.__path__:
+            cudnn.__path__.remove(source_path)
+        cudnn.__path__.insert(0, source_path)
 except ImportError:
     pass  # test_la.py skips via importorskip
 

--- a/test/python/linear_attention/test_fla_arch_route_unit.py
+++ b/test/python/linear_attention/test_fla_arch_route_unit.py
@@ -23,7 +23,17 @@ pytestmark = pytest.mark.L0
         pytest.param(kda, kda.make_chunk_kda, id="kda"),
     ],
 )
-def test_sm110_calls_saved_fla_once_without_trying_native(monkeypatch, shim_module, factory):
+@pytest.mark.parametrize(
+    "capability,reason",
+    [
+        pytest.param((9, 0), "pre-Blackwell", id="sm90"),
+        pytest.param((10, 1), "unsupported-arch", id="sm101"),
+        pytest.param((11, 0), "unsupported-arch", id="sm110"),
+        pytest.param((12, 0), "unsupported-arch", id="sm120"),
+        pytest.param((13, 0), "unsupported-arch", id="sm130"),
+    ],
+)
+def test_unvalidated_arch_calls_saved_fla_once_without_trying_native(monkeypatch, shim_module, factory, capability, reason):
     q = SimpleNamespace(is_cuda=True, device=object())
     k, v, g, beta = object(), object(), object(), object()
     expected = object()
@@ -36,9 +46,9 @@ def test_sm110_calls_saved_fla_once_without_trying_native(monkeypatch, shim_modu
 
     def native(*args, **kwargs):
         native_calls.append((args, kwargs))
-        pytest.fail("SM110 must not enter the native/cuTile route")
+        pytest.fail(f"{capability} must not enter the native/cuTile route")
 
-    monkeypatch.setattr(shim_module.torch.cuda, "get_device_capability", lambda device: (11, 0))
+    monkeypatch.setattr(shim_module.torch.cuda, "get_device_capability", lambda device: capability)
     monkeypatch.setattr(shim_module, "_to_native", native)
 
     result = factory(original)(q, k, v, g, beta)
@@ -47,7 +57,7 @@ def test_sm110_calls_saved_fla_once_without_trying_native(monkeypatch, shim_modu
     assert len(original_calls) == 1
     assert original_calls[0][0] == (q, k, v, g, beta)
     assert native_calls == []
-    assert shim_module.last_path() == "fallback:sm11"
+    assert shim_module.last_path() == f"fallback:{reason}"
 
 
 @pytest.mark.parametrize(

--- a/test/python/linear_attention/test_fla_arch_route_unit.py
+++ b/test/python/linear_attention/test_fla_arch_route_unit.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU/mock architecture-routing tests for the FLA linear-attention shims."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+gated_delta_rule = importlib.import_module("cudnn.fla.gated_delta_rule")
+kda = importlib.import_module("cudnn.fla.kda")
+
+pytestmark = pytest.mark.L0
+
+
+@pytest.mark.parametrize(
+    "shim_module,factory",
+    [
+        pytest.param(gated_delta_rule, gated_delta_rule.make_chunk_gated_delta_rule, id="gdn"),
+        pytest.param(kda, kda.make_chunk_kda, id="kda"),
+    ],
+)
+def test_sm110_calls_saved_fla_once_without_trying_native(monkeypatch, shim_module, factory):
+    q = SimpleNamespace(is_cuda=True, device=object())
+    k, v, g, beta = object(), object(), object(), object()
+    expected = object()
+    original_calls = []
+    native_calls = []
+
+    def original(*args, **kwargs):
+        original_calls.append((args, kwargs))
+        return expected
+
+    def native(*args, **kwargs):
+        native_calls.append((args, kwargs))
+        pytest.fail("SM110 must not enter the native/cuTile route")
+
+    monkeypatch.setattr(shim_module.torch.cuda, "get_device_capability", lambda device: (11, 0))
+    monkeypatch.setattr(shim_module, "_to_native", native)
+
+    result = factory(original)(q, k, v, g, beta)
+
+    assert result is expected
+    assert len(original_calls) == 1
+    assert original_calls[0][0] == (q, k, v, g, beta)
+    assert native_calls == []
+    assert shim_module.last_path() == "fallback:sm11"
+
+
+@pytest.mark.parametrize(
+    "shim_module,factory",
+    [
+        pytest.param(gated_delta_rule, gated_delta_rule.make_chunk_gated_delta_rule, id="gdn"),
+        pytest.param(kda, kda.make_chunk_kda, id="kda"),
+    ],
+)
+@pytest.mark.parametrize("capability", [(10, 0), (10, 3), (10, 7)], ids=["sm100", "sm103", "sm107"])
+def test_validated_sm10_variants_keep_native_route(monkeypatch, shim_module, factory, capability):
+    q = SimpleNamespace(is_cuda=True, device=object())
+    k, v, g, beta = object(), object(), object(), object()
+    expected = object()
+    original_calls = []
+    native_calls = []
+
+    def original(*args, **kwargs):
+        original_calls.append((args, kwargs))
+        pytest.fail("validated SM10x must keep the native route")
+
+    def native(*args, **kwargs):
+        native_calls.append((args, kwargs))
+        return expected
+
+    monkeypatch.setattr(shim_module.torch.cuda, "get_device_capability", lambda device: capability)
+    monkeypatch.setattr(shim_module, "_to_native", native)
+
+    result = factory(original)(q, k, v, g, beta)
+
+    assert result is expected
+    assert original_calls == []
+    assert len(native_calls) == 1
+    assert shim_module.last_path() == "native"

--- a/test/python/linear_attention/test_fla_short_conv_compat.py
+++ b/test/python/linear_attention/test_fla_short_conv_compat.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""B200 route and parity gates for the FLA decode short-convolution shim."""
+"""Supported-GPU route and parity gates for the FLA short-convolution shim."""
 
 from __future__ import annotations
 
@@ -9,6 +9,9 @@ from importlib import metadata
 
 import pytest
 import torch
+from cudnn._causal_conv1d_arch import (
+    is_supported_causal_conv1d_update_compute_capability,
+)
 
 fla_ops = pytest.importorskip("fla.modules.conv.triton.ops")
 fla_short_conv = pytest.importorskip("fla.modules.conv.short_conv")
@@ -28,8 +31,8 @@ from cudnn.fla import (
 pytestmark = [
     pytest.mark.L0,
     pytest.mark.skipif(
-        not (torch.cuda.is_available() and torch.cuda.get_device_capability() == (10, 0)),
-        reason="the native decode short-convolution update requires exact SM100",
+        not (torch.cuda.is_available() and is_supported_causal_conv1d_update_compute_capability(torch.cuda.get_device_capability())),
+        reason="the native decode short-convolution update requires a functionally supported GPU architecture",
     ),
     pytest.mark.skipif(
         _FLA_VERSION != "0.5.2",

--- a/test/python/linear_attention/test_fla_short_conv_compat.py
+++ b/test/python/linear_attention/test_fla_short_conv_compat.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""B200 route and parity gates for the FLA decode short-convolution shim."""
+
+from __future__ import annotations
+
+from importlib import metadata
+
+import pytest
+import torch
+
+fla_ops = pytest.importorskip("fla.modules.conv.triton.ops")
+fla_short_conv = pytest.importorskip("fla.modules.conv.short_conv")
+
+try:
+    _FLA_VERSION = metadata.version("flash-linear-attention")
+except metadata.PackageNotFoundError:
+    _FLA_VERSION = None
+
+from cudnn.fla import (
+    accelerate_fla,
+    is_accelerated,
+    restore_fla,
+    short_conv_last_path,
+)
+
+pytestmark = [
+    pytest.mark.L0,
+    pytest.mark.skipif(
+        not (torch.cuda.is_available() and torch.cuda.get_device_capability() == (10, 0)),
+        reason="the native decode short-convolution update requires exact SM100",
+    ),
+    pytest.mark.skipif(
+        _FLA_VERSION != "0.5.2",
+        reason="the production short-convolution shim intentionally supports FLA 0.5.2 exactly",
+    ),
+]
+
+_REAL_UPDATE = fla_ops.causal_conv1d_update
+_ATOL = 3e-2
+_RTOL = 3e-2
+
+
+@pytest.fixture(autouse=True)
+def _restore_short_conv_patch():
+    restore_fla(targets="short_conv")
+    yield
+    restore_fla(targets="short_conv")
+    assert fla_ops.causal_conv1d_update is _REAL_UPDATE
+
+
+def _layout(base: torch.Tensor, name: str) -> torch.Tensor:
+    if name == "ND":
+        return base
+    if name == "N1D":
+        return base.unsqueeze(1)
+    if name == "1ND":
+        return base.unsqueeze(0)
+    raise AssertionError(name)
+
+
+@pytest.mark.parametrize("layout", ["ND", "N1D", "1ND"])
+@torch.no_grad()
+def test_real_fla_entry_point_routes_native_with_parity(layout):
+    torch.manual_seed(20260828)
+    n_rows, n_channels = 3, 257
+    x = _layout(
+        torch.randn(n_rows, n_channels, device="cuda", dtype=torch.bfloat16) * 0.25,
+        layout,
+    )
+    weight = torch.randn(n_channels, 4, device="cuda", dtype=torch.bfloat16) * 0.25
+    initial_state = torch.randn(n_rows, n_channels, 4, device="cuda", dtype=torch.bfloat16) * 0.25
+    fla_state = initial_state.clone()
+    native_state = initial_state.clone()
+
+    expected, expected_cache = _REAL_UPDATE(
+        x,
+        fla_state,
+        residual=None,
+        weight=weight,
+        bias=None,
+        activation="silu",
+    )
+    assert expected_cache is fla_state
+
+    accelerate_fla(verbose=False, targets="shortconv")
+    actual, returned_cache = fla_ops.causal_conv1d_update(
+        x,
+        native_state,
+        residual=None,
+        weight=weight,
+        bias=None,
+        activation="silu",
+    )
+
+    assert is_accelerated("short_conv")
+    assert short_conv_last_path() == "native"
+    assert actual.shape == x.shape
+    assert returned_cache is native_state
+    torch.testing.assert_close(actual, expected, atol=_ATOL, rtol=_RTOL)
+    torch.testing.assert_close(
+        native_state.view(torch.int16),
+        fla_state.view(torch.int16),
+        rtol=0,
+        atol=0,
+    )
+
+
+@torch.no_grad()
+def test_real_short_convolution_module_step_consumes_patched_entry_point():
+    torch.manual_seed(20260829)
+    n_rows, n_channels = 3, 257
+    module = fla_short_conv.ShortConvolution(
+        hidden_size=n_channels,
+        kernel_size=4,
+        bias=False,
+        activation="silu",
+        backend="triton",
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    x = torch.randn(n_rows, 1, n_channels, device="cuda", dtype=torch.bfloat16) * 0.25
+    initial_state = torch.randn(n_rows, n_channels, 4, device="cuda", dtype=torch.bfloat16) * 0.25
+    fla_state = initial_state.clone()
+    native_state = initial_state.clone()
+
+    expected, expected_cache = module(
+        x,
+        cache=fla_state,
+        output_final_state=True,
+    )
+    assert expected_cache is fla_state
+
+    accelerate_fla(verbose=False, targets="short_conv")
+    actual, returned_cache = module(
+        x,
+        cache=native_state,
+        output_final_state=True,
+    )
+
+    assert short_conv_last_path() == "native"
+    assert returned_cache is native_state
+    torch.testing.assert_close(actual, expected, atol=_ATOL, rtol=_RTOL)
+    torch.testing.assert_close(
+        native_state.view(torch.int16),
+        fla_state.view(torch.int16),
+        rtol=0,
+        atol=0,
+    )

--- a/test/python/linear_attention/test_fla_short_conv_shim_unit.py
+++ b/test/python/linear_attention/test_fla_short_conv_shim_unit.py
@@ -72,6 +72,31 @@ def test_native_layouts_are_zero_copy_and_preserve_fla_shape_and_cache_identity(
     assert short_conv.last_path() == "native"
 
 
+def test_sm110_calls_original_once_without_native_and_preserves_cache_identity(monkeypatch):
+    x, weight, cache = _inputs()
+    fallback_calls = []
+    native_calls = []
+    monkeypatch.setattr(short_conv, "_is_cuda_tensor", lambda tensor: True)
+    monkeypatch.setattr(short_conv, "_device_capability", lambda device: (11, 0))
+    monkeypatch.setattr(short_conv, "_is_compiling", lambda: False)
+
+    def native(*args):
+        native_calls.append(args)
+        pytest.fail("SM110 must not enter the SM100 native route")
+
+    monkeypatch.setattr(short_conv, "_call_native", native)
+    wrapped = short_conv.make_causal_conv1d_update(_original_spy(fallback_calls))
+
+    output, returned_cache = wrapped(x, cache, weight=weight, activation="silu")
+
+    assert output.shape == x.shape
+    assert returned_cache is cache
+    assert len(fallback_calls) == 1
+    assert fallback_calls[0][1] is cache
+    assert native_calls == []
+    assert short_conv.last_path() == "fallback:non-sm100"
+
+
 @pytest.mark.parametrize(
     "mutation,reason",
     [

--- a/test/python/linear_attention/test_fla_short_conv_shim_unit.py
+++ b/test/python/linear_attention/test_fla_short_conv_shim_unit.py
@@ -51,8 +51,8 @@ def test_native_layouts_are_zero_copy_and_preserve_fla_shape_and_cache_identity(
     fallback_calls = []
     native_calls = []
 
-    def native(native_x, native_weight, native_cache):
-        native_calls.append((native_x, native_weight, native_cache))
+    def native(native_x, native_cache, native_weight):
+        native_calls.append((native_x, native_cache, native_weight))
         assert native_x.data_ptr() == x.data_ptr()
         return native_x.clone()
 
@@ -66,8 +66,8 @@ def test_native_layouts_are_zero_copy_and_preserve_fla_shape_and_cache_identity(
     assert len(native_calls) == 1
     assert native_calls[0][0].data_ptr() == x.data_ptr()
     assert native_calls[0][0].shape == (cache.shape[0], weight.shape[0])
-    assert native_calls[0][1] is weight
-    assert native_calls[0][2] is cache
+    assert native_calls[0][1] is cache
+    assert native_calls[0][2] is weight
     assert fallback_calls == []
     assert short_conv.last_path() == "native"
 

--- a/test/python/linear_attention/test_fla_short_conv_shim_unit.py
+++ b/test/python/linear_attention/test_fla_short_conv_shim_unit.py
@@ -57,6 +57,23 @@ def _original_spy(calls):
     return original
 
 
+def test_native_adapter_requests_silu_explicitly(monkeypatch):
+    import cudnn.ops
+
+    x, weight, cache = _inputs()
+    calls = []
+    sentinel = object()
+
+    def semantic_api(*args, **kwargs):
+        calls.append((args, kwargs))
+        return sentinel
+
+    monkeypatch.setattr(cudnn.ops, "causal_conv1d_update", semantic_api)
+
+    assert short_conv._call_native(x, cache, weight) is sentinel
+    assert calls == [((x, cache, weight), {"activation": "silu"})]
+
+
 @pytest.mark.parametrize("shape", [(3, 8), (3, 1, 8), (1, 3, 8)])
 def test_native_layouts_are_zero_copy_and_preserve_fla_shape_and_cache_identity(mock_supported_arch, monkeypatch, shape):
     x, weight, cache = _inputs(shape)

--- a/test/python/linear_attention/test_fla_short_conv_shim_unit.py
+++ b/test/python/linear_attention/test_fla_short_conv_shim_unit.py
@@ -10,18 +10,30 @@ import importlib
 import sys
 import types
 
+import cudnn.fla as fla_api
 import pytest
 import torch
-
-import cudnn.fla as fla_api
 
 short_conv = importlib.import_module("cudnn.fla.short_conv")
 
 pytestmark = pytest.mark.L0
 
+_SUPPORTED_COMPUTE_CAPABILITIES = (
+    (8, 0),
+    (8, 6),
+    (8, 7),
+    (8, 9),
+    (9, 0),
+    (10, 0),
+    (10, 3),
+    (11, 0),
+    (12, 0),
+    (12, 1),
+)
+
 
 @pytest.fixture
-def mock_sm100(monkeypatch):
+def mock_supported_arch(monkeypatch):
     monkeypatch.setattr(short_conv, "_is_cuda_tensor", lambda tensor: True)
     monkeypatch.setattr(short_conv, "_device_capability", lambda device: (10, 0))
     monkeypatch.setattr(short_conv, "_is_compiling", lambda: False)
@@ -46,7 +58,7 @@ def _original_spy(calls):
 
 
 @pytest.mark.parametrize("shape", [(3, 8), (3, 1, 8), (1, 3, 8)])
-def test_native_layouts_are_zero_copy_and_preserve_fla_shape_and_cache_identity(mock_sm100, monkeypatch, shape):
+def test_native_layouts_are_zero_copy_and_preserve_fla_shape_and_cache_identity(mock_supported_arch, monkeypatch, shape):
     x, weight, cache = _inputs(shape)
     fallback_calls = []
     native_calls = []
@@ -72,17 +84,37 @@ def test_native_layouts_are_zero_copy_and_preserve_fla_shape_and_cache_identity(
     assert short_conv.last_path() == "native"
 
 
-def test_sm110_calls_original_once_without_native_and_preserves_cache_identity(monkeypatch):
+@pytest.mark.parametrize("capability", _SUPPORTED_COMPUTE_CAPABILITIES)
+def test_supported_architectures_enter_native_route(monkeypatch, capability):
     x, weight, cache = _inputs()
     fallback_calls = []
     native_calls = []
     monkeypatch.setattr(short_conv, "_is_cuda_tensor", lambda tensor: True)
-    monkeypatch.setattr(short_conv, "_device_capability", lambda device: (11, 0))
+    monkeypatch.setattr(short_conv, "_device_capability", lambda device: capability)
+    monkeypatch.setattr(short_conv, "_is_compiling", lambda: False)
+    monkeypatch.setattr(short_conv, "_call_native", lambda *args: native_calls.append(args) or args[0].clone())
+    wrapped = short_conv.make_causal_conv1d_update(_original_spy(fallback_calls))
+
+    output, returned_cache = wrapped(x, cache, weight=weight, activation="silu")
+
+    assert output.shape == x.shape
+    assert returned_cache is cache
+    assert len(native_calls) == 1
+    assert fallback_calls == []
+    assert short_conv.last_path() == "native"
+
+
+def test_unlisted_arch_calls_original_once_without_native_and_preserves_cache_identity(monkeypatch):
+    x, weight, cache = _inputs()
+    fallback_calls = []
+    native_calls = []
+    monkeypatch.setattr(short_conv, "_is_cuda_tensor", lambda tensor: True)
+    monkeypatch.setattr(short_conv, "_device_capability", lambda device: (11, 1))
     monkeypatch.setattr(short_conv, "_is_compiling", lambda: False)
 
     def native(*args):
         native_calls.append(args)
-        pytest.fail("SM110 must not enter the SM100 native route")
+        pytest.fail("an unlisted architecture must not enter the native route")
 
     monkeypatch.setattr(short_conv, "_call_native", native)
     wrapped = short_conv.make_causal_conv1d_update(_original_spy(fallback_calls))
@@ -94,7 +126,7 @@ def test_sm110_calls_original_once_without_native_and_preserves_cache_identity(m
     assert len(fallback_calls) == 1
     assert fallback_calls[0][1] is cache
     assert native_calls == []
-    assert short_conv.last_path() == "fallback:non-sm100"
+    assert short_conv.last_path() == "fallback:unsupported-arch"
 
 
 @pytest.mark.parametrize(
@@ -112,7 +144,7 @@ def test_sm110_calls_original_once_without_native_and_preserves_cache_identity(m
         (lambda x, weight, cache: {"weight": weight[:, :3].contiguous()}, "shape"),
     ],
 )
-def test_unsupported_variants_call_original_unchanged(mock_sm100, monkeypatch, mutation, reason):
+def test_unsupported_variants_call_original_unchanged(mock_supported_arch, monkeypatch, mutation, reason):
     x, weight, cache = _inputs()
     args = {"x": x, "cache": cache, "residual": None, "weight": weight, "bias": None, "activation": "swish"}
     args.update(mutation(x, weight, cache))
@@ -138,7 +170,7 @@ def test_unsupported_variants_call_original_unchanged(mock_sm100, monkeypatch, m
 
 
 @pytest.mark.parametrize("error", [NotImplementedError, short_conv.cudnn.cudnnGraphNotSupportedError, ImportError])
-def test_typed_native_decline_falls_back(mock_sm100, monkeypatch, error):
+def test_typed_native_decline_falls_back(mock_supported_arch, monkeypatch, error):
     x, weight, cache = _inputs()
     fallback_calls = []
     monkeypatch.setattr(short_conv, "_call_native", lambda *unused: (_ for _ in ()).throw(error("declined")))
@@ -156,7 +188,7 @@ def test_typed_native_decline_falls_back(mock_sm100, monkeypatch, error):
     assert short_conv.last_path() == f"fallback:{error.__name__}"
 
 
-def test_unexpected_native_error_is_not_swallowed(mock_sm100, monkeypatch):
+def test_unexpected_native_error_is_not_swallowed(mock_supported_arch, monkeypatch):
     x, weight, cache = _inputs()
     fallback_calls = []
     monkeypatch.setattr(short_conv, "_call_native", lambda *unused: (_ for _ in ()).throw(RuntimeError("launch failed")))

--- a/test/python/linear_attention/test_fla_short_conv_shim_unit.py
+++ b/test/python/linear_attention/test_fla_short_conv_shim_unit.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU/mock contract tests for the opt-in FLA short-convolution shim."""
+
+from __future__ import annotations
+
+import functools
+import importlib
+import sys
+import types
+
+import pytest
+import torch
+
+import cudnn.fla as fla_api
+
+short_conv = importlib.import_module("cudnn.fla.short_conv")
+
+pytestmark = pytest.mark.L0
+
+
+@pytest.fixture
+def mock_sm100(monkeypatch):
+    monkeypatch.setattr(short_conv, "_is_cuda_tensor", lambda tensor: True)
+    monkeypatch.setattr(short_conv, "_device_capability", lambda device: (10, 0))
+    monkeypatch.setattr(short_conv, "_is_compiling", lambda: False)
+
+
+def _inputs(shape=(3, 8)):
+    x = torch.randn(shape, dtype=torch.bfloat16)
+    n_rows, n_channels = shape if len(shape) == 2 else (shape[0], shape[-1])
+    if len(shape) == 3 and shape[0] == 1:
+        n_rows = shape[1]
+    weight = torch.randn(n_channels, 4, dtype=torch.bfloat16)
+    cache = torch.randn(n_rows, n_channels, 4, dtype=torch.bfloat16)
+    return x, weight, cache
+
+
+def _original_spy(calls):
+    def original(x, cache, residual=None, weight=None, bias=None, activation=None):
+        calls.append((x, cache, residual, weight, bias, activation))
+        return x.clone(), cache
+
+    return original
+
+
+@pytest.mark.parametrize("shape", [(3, 8), (3, 1, 8), (1, 3, 8)])
+def test_native_layouts_are_zero_copy_and_preserve_fla_shape_and_cache_identity(mock_sm100, monkeypatch, shape):
+    x, weight, cache = _inputs(shape)
+    fallback_calls = []
+    native_calls = []
+
+    def native(native_x, native_weight, native_cache):
+        native_calls.append((native_x, native_weight, native_cache))
+        assert native_x.data_ptr() == x.data_ptr()
+        return native_x.clone()
+
+    monkeypatch.setattr(short_conv, "_call_native", native)
+    wrapped = short_conv.make_causal_conv1d_update(_original_spy(fallback_calls))
+
+    output, returned_cache = wrapped(x, cache, weight=weight, activation="silu")
+
+    assert output.shape == x.shape
+    assert returned_cache is cache
+    assert len(native_calls) == 1
+    assert native_calls[0][0].data_ptr() == x.data_ptr()
+    assert native_calls[0][0].shape == (cache.shape[0], weight.shape[0])
+    assert native_calls[0][1] is weight
+    assert native_calls[0][2] is cache
+    assert fallback_calls == []
+    assert short_conv.last_path() == "native"
+
+
+@pytest.mark.parametrize(
+    "mutation,reason",
+    [
+        (lambda x, weight, cache: {"residual": torch.zeros_like(x)}, "residual"),
+        (lambda x, weight, cache: {"weight": None}, "weight"),
+        (lambda x, weight, cache: {"bias": torch.zeros(weight.shape[0], dtype=weight.dtype)}, "bias"),
+        (lambda x, weight, cache: {"activation": None}, "activation"),
+        (lambda x, weight, cache: {"activation": "relu"}, "activation"),
+        (lambda x, weight, cache: {"x": x.float()}, "non-bf16"),
+        (lambda x, weight, cache: {"x": x.requires_grad_()}, "autograd"),
+        (lambda x, weight, cache: {"x": x[:, ::2]}, "noncontiguous"),
+        (lambda x, weight, cache: {"cache": cache[:2]}, "shape"),
+        (lambda x, weight, cache: {"weight": weight[:, :3].contiguous()}, "shape"),
+    ],
+)
+def test_unsupported_variants_call_original_unchanged(mock_sm100, monkeypatch, mutation, reason):
+    x, weight, cache = _inputs()
+    args = {"x": x, "cache": cache, "residual": None, "weight": weight, "bias": None, "activation": "swish"}
+    args.update(mutation(x, weight, cache))
+    fallback_calls = []
+    monkeypatch.setattr(short_conv, "_call_native", lambda *unused: pytest.fail("native path should have declined"))
+    wrapped = short_conv.make_causal_conv1d_update(_original_spy(fallback_calls))
+
+    output, returned_cache = wrapped(**args)
+
+    assert output.shape == args["x"].shape
+    assert returned_cache is args["cache"]
+    assert fallback_calls == [
+        (
+            args["x"],
+            args["cache"],
+            args["residual"],
+            args["weight"],
+            args["bias"],
+            args["activation"],
+        )
+    ]
+    assert short_conv.last_path() == f"fallback:{reason}"
+
+
+@pytest.mark.parametrize("error", [NotImplementedError, short_conv.cudnn.cudnnGraphNotSupportedError, ImportError])
+def test_typed_native_decline_falls_back(mock_sm100, monkeypatch, error):
+    x, weight, cache = _inputs()
+    fallback_calls = []
+    monkeypatch.setattr(short_conv, "_call_native", lambda *unused: (_ for _ in ()).throw(error("declined")))
+
+    output, returned_cache = short_conv.make_causal_conv1d_update(_original_spy(fallback_calls))(
+        x,
+        cache,
+        weight=weight,
+        activation="silu",
+    )
+
+    assert output.shape == x.shape
+    assert returned_cache is cache
+    assert len(fallback_calls) == 1
+    assert short_conv.last_path() == f"fallback:{error.__name__}"
+
+
+def test_unexpected_native_error_is_not_swallowed(mock_sm100, monkeypatch):
+    x, weight, cache = _inputs()
+    fallback_calls = []
+    monkeypatch.setattr(short_conv, "_call_native", lambda *unused: (_ for _ in ()).throw(RuntimeError("launch failed")))
+
+    with pytest.raises(RuntimeError, match="launch failed"):
+        short_conv.make_causal_conv1d_update(_original_spy(fallback_calls))(x, cache, weight=weight, activation="silu")
+
+    assert fallback_calls == []
+    assert short_conv.last_path() == "error:RuntimeError"
+
+
+def _fake_fla_short_conv_module():
+    module = types.ModuleType("fla.modules.conv.triton.ops")
+
+    def causal_conv1d_update(x, cache, residual=None, weight=None, bias=None, activation=None):
+        del residual, weight, bias, activation
+        return x, cache
+
+    causal_conv1d_update.__module__ = module.__name__
+    causal_conv1d_update.__qualname__ = "causal_conv1d_update"
+    module.causal_conv1d_update = causal_conv1d_update
+    return module
+
+
+def test_public_alias_rebind_and_restore(monkeypatch):
+    module = _fake_fla_short_conv_module()
+    original = module.causal_conv1d_update
+    captured_import = types.ModuleType("_cudnn_fla_short_conv_consumer")
+    captured_import.causal_conv1d_update = original
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setitem(sys.modules, captured_import.__name__, captured_import)
+    monkeypatch.setattr(fla_api, "_supports_short_conv_fla", lambda: True)
+    monkeypatch.setattr(fla_api, "_matches_short_conv_target", lambda target_module, target: True)
+    monkeypatch.setattr(fla_api, "_ORIGINALS", {})
+
+    fla_api.accelerate_fla(verbose=False, targets="shortconv")
+
+    replacement = module.causal_conv1d_update
+    assert replacement is not original
+    assert captured_import.causal_conv1d_update is replacement
+    assert fla_api.is_accelerated("short_conv")
+
+    fla_api.restore_fla(targets="short_conv")
+
+    assert module.causal_conv1d_update is original
+    assert captured_import.causal_conv1d_update is original
+    assert not fla_api.is_accelerated("shortconv")
+
+
+def test_public_activation_rejects_other_fla_version(monkeypatch):
+    module = _fake_fla_short_conv_module()
+    original = module.causal_conv1d_update
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setattr(fla_api, "_supports_short_conv_fla", lambda: False)
+    monkeypatch.setattr(fla_api, "_ORIGINALS", {})
+
+    with pytest.raises(ImportError, match=r"requires flash-linear-attention==0\.5\.2"):
+        fla_api.accelerate_fla(verbose=False, targets="short_conv")
+
+    assert module.causal_conv1d_update is original
+    assert not fla_api.is_accelerated("shortconv")
+
+
+def test_public_activation_rejects_replaced_target(monkeypatch):
+    module = _fake_fla_short_conv_module()
+    stock = module.causal_conv1d_update
+
+    @functools.wraps(stock)
+    def third_party(*args, **kwargs):
+        return args, kwargs
+
+    module.causal_conv1d_update = third_party
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setattr(fla_api, "_supports_short_conv_fla", lambda: True)
+    monkeypatch.setattr(fla_api, "_ORIGINALS", {})
+
+    with pytest.raises(ImportError, match="does not match the expected owning module"):
+        fla_api.accelerate_fla(verbose=False, targets="short_conv")
+
+    assert module.causal_conv1d_update is third_party
+    assert not fla_api.is_accelerated("shortconv")

--- a/test/python/linear_attention/test_fla_short_conv_shim_unit.py
+++ b/test/python/linear_attention/test_fla_short_conv_shim_unit.py
@@ -49,6 +49,18 @@ def _inputs(shape=(3, 8)):
     return x, weight, cache
 
 
+def _fused_projection_view(layout, *, n_rows=3, n_channels=8):
+    projection = torch.randn(n_rows, 3 * n_channels, dtype=torch.bfloat16)
+    x = projection[:, n_channels : 2 * n_channels]
+    if layout == "ND":
+        return x
+    if layout == "N1D":
+        return x.unsqueeze(1)
+    if layout == "1ND":
+        return x.unsqueeze(0)
+    raise AssertionError(layout)
+
+
 def _original_spy(calls):
     def original(x, cache, residual=None, weight=None, bias=None, activation=None):
         calls.append((x, cache, residual, weight, bias, activation))
@@ -99,6 +111,70 @@ def test_native_layouts_are_zero_copy_and_preserve_fla_shape_and_cache_identity(
     assert native_calls[0][2] is weight
     assert fallback_calls == []
     assert short_conv.last_path() == "native"
+
+
+@pytest.mark.parametrize("layout", ["ND", "N1D", "1ND"])
+def test_fused_projection_row_strides_are_zero_copy_and_route_native(mock_supported_arch, monkeypatch, layout):
+    x = _fused_projection_view(layout)
+    n_rows, n_channels = 3, 8
+    weight = torch.randn(n_channels, 4, dtype=torch.bfloat16)
+    cache = torch.randn(n_rows, n_channels, 4, dtype=torch.bfloat16)
+    fallback_calls = []
+    native_calls = []
+
+    def native(native_x, native_cache, native_weight):
+        native_calls.append((native_x, native_cache, native_weight))
+        assert native_x.data_ptr() == x.data_ptr()
+        assert native_x.stride() == (3 * n_channels, 1)
+        return native_x.clone()
+
+    monkeypatch.setattr(short_conv, "_call_native", native)
+    wrapped = short_conv.make_causal_conv1d_update(_original_spy(fallback_calls))
+
+    output, returned_cache = wrapped(x, cache, weight=weight, activation="silu")
+
+    assert output.shape == x.shape
+    assert returned_cache is cache
+    assert len(native_calls) == 1
+    assert native_calls[0][1] is cache
+    assert native_calls[0][2] is weight
+    assert fallback_calls == []
+    assert short_conv.last_path() == "native"
+
+
+@pytest.mark.parametrize("n_channels", [7, 10], ids=["d7", "d10"])
+def test_compact_rows_accept_channel_counts_not_divisible_by_eight(mock_supported_arch, n_channels):
+    x, weight, cache = _inputs((3, n_channels))
+
+    native_x = short_conv._native_input_view(x, weight, cache)
+
+    assert native_x.data_ptr() == x.data_ptr()
+    assert native_x.stride() == (n_channels, 1)
+
+
+@pytest.mark.parametrize(
+    "x,reason",
+    [
+        (torch.empty_strided((3, 8), (7, 1), dtype=torch.bfloat16), "noncontiguous"),
+        (torch.empty_strided((3, 10), (12, 1), dtype=torch.bfloat16), "alignment"),
+    ],
+    ids=["overlapping-rows", "misaligned-padded-rows"],
+)
+def test_unsupported_row_strides_fall_back_unchanged(mock_supported_arch, monkeypatch, x, reason):
+    n_rows, n_channels = x.shape
+    weight = torch.randn(n_channels, 4, dtype=torch.bfloat16)
+    cache = torch.randn(n_rows, n_channels, 4, dtype=torch.bfloat16)
+    fallback_calls = []
+    monkeypatch.setattr(short_conv, "_call_native", lambda *unused: pytest.fail("native path should have declined"))
+    wrapped = short_conv.make_causal_conv1d_update(_original_spy(fallback_calls))
+
+    output, returned_cache = wrapped(x, cache, weight=weight, activation="silu")
+
+    assert output.shape == x.shape
+    assert returned_cache is cache
+    assert len(fallback_calls) == 1
+    assert fallback_calls[0][0] is x
+    assert short_conv.last_path() == f"fallback:{reason}"
 
 
 @pytest.mark.parametrize("capability", _SUPPORTED_COMPUTE_CAPABILITIES)


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
- [ ] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions). The milestone is set; this token cannot read or set organization Projects.

## Affected area

FE OSS kernels or CuTeDSL

## Summary

Add an experimental semantic decode operation:

```python
output = cudnn.ops.causal_conv1d_update(
    x,
    conv_state,
    weight,
    bias=None,
    activation="silu",
    conv_state_indices=None,
)
```

The operation advances a mutable depthwise causal-convolution state for one token. The public API owns tensor meaning and mutation; compilation, architecture dispatch, output allocation, streams, and schedules remain private.

The current native implementation covers the BF16 width-four decode specialization used by short-convolution linear-attention blocks:

- `x[N,D]` with strides `(ld,1)`; compact `ld == D` accepts every `D`, while padded rows require `ld % 8 == 0`
- contiguous `weight[D,4]`, optional `bias[D]`, and contiguous mutable `conv_state[S,D,L]` with `L in {3,4}`
- identity or SiLU/Swish epilogue
- optional unique int32 `conv_state_indices[N]`; `-1` is a non-mutating padding row
- contiguous newly allocated `output[N,D]`
- inference only; autograd is rejected

The semantic signature reserves optional `cache_seqlens` circular-buffer metadata, but the current native kernel declines that mode explicitly. Unsupported widths, state lengths, dtypes, layouts, or features fail closed rather than being reinterpreted.

An opt-in `cudnn.fla.accelerate_fla(targets="short_conv")` adapter preserves FLA 0.5.2's input shape, returned cache identity, and fallback behavior. It normalizes `[N,D]`, `[N,1,D]`, and `[1,N,D]` to a zero-copy row-strided view, so a slice of a wider fused projection does not need an adapter-side materialization.

## Why

FE has bulk causal-convolution graph operations but no native one-token mutable-state update matching current linear-attention decode call sites. This fills that API and kernel gap. The row-stride contract is important for integration: projection outputs are commonly split as views with a logical width smaller than their leading dimension.

## Related issues

None.

## API and compatibility impact

Functional targets are the explicit allowlist SM80/86/87/89/90/100/103/110/120/121. Every admitted target currently uses the conservative one-row-per-CTA schedule. The allowlist is functional admission, not a claim that the same schedule is optimal on every architecture.

The kernel is independently implemented in this repository with CUTLASS/CuTe DSL, inline PTX, and in-tree FROST helpers. FLA 0.5.2 and Dao-AILab/causal-conv1d are behavioral and interface references only; no source from either implementation is included.

## B200 performance

The table compares the saved FLA 0.5.2 public callable with the live opt-in FE shim on the exact same row-strided input object, weight, and initial state in one process. Each row uses 51 AB/BA-interleaved samples after 10 warmups. The metric is CUDA-event elapsed time for a warmed CUDA Graph replay; Python dispatch, compilation, capture, output allocation, and state reset are outside the interval. Correctness, native-route, state-bit, cache-identity, and restore gates must all pass before timings are emitted.

Hardware/software: NVIDIA B200 SM100, CUDA 13.0, cuDNN 9.26.0, PyTorch 2.13.0, FLA 0.5.2.

| N | logical D | ld | FE replay | FLA replay | paired FLA / FE |
|---:|---:|---:|---:|---:|---:|
| 1 | 5120 | 8240 | 7.648 us | 7.648 us | 0.988x |
| 8 | 5120 | 8240 | 7.808 us | 7.680 us | 0.988x |
| 128 | 5120 | 8240 | 7.744 us | 7.744 us | 1.016x |
| 1 | 6144 | 8224 | 7.552 us | 7.520 us | 1.004x |
| 8 | 6144 | 8224 | 7.616 us | 7.520 us | 0.988x |
| 128 | 6144 | 8224 | 7.680 us | 8.768 us | 1.124x |

This is leaf-operation latency, not full-model latency. On these public call paths, steady-state eager host enqueue medians were 58.1--61.0 us for FE and 55.5--57.3 us for FLA; that metric includes Python validation/cache lookup/allocation/launch and is not device completion latency. The primary integration impact is enabling the zero-copy native route; the measured leaf result ranges from parity to a 1.124x speedup rather than implying an end-to-end model gain.

Reproduction:

```bash
python benchmark/fla_short_conv_shim_sm100.py \
  --shape 1x5120 --shape 8x5120 --shape 128x5120 \
  --shape 1x6144 --shape 8x6144 --shape 128x6144 \
  --leading-dimension 5120:8240 --leading-dimension 6144:8224 \
  --samples 51 --warmup 10 --output-json result.json
```

The benchmark runs on every functionally admitted target and records the actual hardware/software metadata; the table above makes only a B200 performance claim.

## Testing

- Latest B200 row-stride/API/FLA suite: `138 passed`.
- Earlier compact-path runtime suites on this PR: A100 SM80 `23 passed`, H200 SM90 `23 passed`, B200 SM100 `23 passed`, and L40S SM89 `19 passed`.
- Runtime reference and bitwise state-transition checks also passed on boards reporting SM103 and SM120.
- SM86, SM87, SM110, and SM121: compile validation only; no runtime or performance claim.
- Coverage includes L=3/L=4, bias and identity/SiLU, indexed and padding rows, invalid-index device assertions, row-strided projection views, exact runtime stride/cache identity, non-default streams, CUDA Graph capture/replay, FLA native routing/fallback/restore, and public benchmark contracts.
- Changed-file pre-commit and `git diff --check`: passed.

## Follow-up scope

Bulk `[B,T,D]` prefill/training, packed variable-length input, circular-buffer execution, speculative intermediate-state returns, backward, and architecture-specific schedule tuning remain separate work. Framework integration should use the semantic API through an explicit fail-closed backend and measure the complete route rather than infer an application-level gain from this leaf benchmark.

