### PR TITLE
Add experimental SM100-optimized bulk causal conv1d forward

### DIFF
--- a/docs/fe-oss-apis/causal_conv1d_bulk_contract.md
+++ b/docs/fe-oss-apis/causal_conv1d_bulk_contract.md
@@ -8,16 +8,17 @@ repacking when both are installed. The API is experimental.
 
 ## First native slice
 
-The first optimized slice is the model-relevant BF16, width-four, no-bias,
-fused-SiLU operation. Functional targets are the exact compute capabilities
-SM80, SM86, SM87, SM89, SM90, SM100, SM103, SM110, SM120, and SM121. The
-public class and wrapper retain their original `Sm100` suffix while this
-experimental API evolves.
+The first optimized slice is the model-relevant BF16, width-four, fused-SiLU
+operation with an optional per-channel bias. Functional targets are the exact
+compute capabilities SM80, SM86, SM87, SM89, SM90, SM100, SM103, SM110,
+SM120, and SM121. The public class and wrapper retain their original `Sm100`
+suffix while this experimental API evolves.
 
 - dense input: contiguous `x[B, T, D]`
 - packed input: contiguous `x[1, total_T, D]` plus contiguous CUDA int32
   `cu_seqlens[N + 1]`
 - filter: contiguous `weight[D, 4]`
+- optional channel bias: contiguous BF16 `bias[D]`
 - optional initial state: contiguous `initial_state[N, D, 4]`
 - output: contiguous `y`, with the same shape as `x`
 - optional final state: contiguous `final_state[N, D, 4]`
@@ -51,11 +52,13 @@ repacking:
 
 ```text
 state = [state[1], state[2], state[3], x_t]
-y_t = SiLU(sum_j state[j] * weight[j])
+preactivation_t[d] = sum_j state[d, j] * weight[d, j] + bias[d]
+y_t[d] = SiLU(preactivation_t[d])
 ```
 
-When `initial_state` is omitted, its observable lanes are zero. Returning a
-final state must not mutate the input state.
+The bias term is omitted when `bias=None`. When `initial_state` is omitted,
+its observable lanes are zero. Returning a final state must not mutate the
+input state.
 
 The high-level wrapper always returns a `TupleDict` in this stable order:
 
@@ -67,6 +70,7 @@ result = causal_conv1d_bulk_fwd_wrapper_sm100(
     weight,
     cu_seqlens_tensor=cu_seqlens,
     initial_state_tensor=initial_state,
+    bias_tensor=bias,  # optional contiguous BF16 [D]
     output_final_state=True,
 )
 y = result["output_tensor"]
@@ -80,18 +84,21 @@ The lower-level class API follows the common FE-OSS lifecycle: construct it
 from representative PyTorch tensors (metadata-only `TensorDesc` inputs are not
 accepted), call `check_support()`, call `compile()` once,
 then call `execute()` with preallocated output tensors. `B`, `D`, packed `N`,
-and optional-tensor presence are compile-signature properties; `T` is symbolic
-and may change between executions within the indexing limits above. Both APIs
-accept an explicit CUDA stream and do not synchronize it on a valid launch.
+and optional-tensor presence, including bias presence, are compile-signature
+properties; `T` is symbolic and may change between executions within the
+indexing limits above. The class constructor uses keyword-only `sample_bias`,
+and `execute()` requires the runtime `bias_tensor` presence to match it. Both
+APIs accept an explicit CUDA stream and do not synchronize it on a valid
+launch.
 
 ## Backward contract
 
 The matching backward is not implemented in this first slice. Its contract is
-to return gradients for `x`, `weight`, and `initial_state` when that input
-participates in autograd. If `final_state` contributes to the loss, backward
-also consumes its upstream gradient. This makes the prefill-to-decode state
-bridge differentiable instead of treating the state output as detached
-metadata.
+to return gradients for `x`, `weight`, optional `bias`, and `initial_state`
+when that input participates in autograd. If `final_state` contributes to the
+loss, backward also consumes its upstream gradient. This makes the
+prefill-to-decode state bridge differentiable instead of treating the state
+output as detached metadata.
 
 All four upstream final-state lanes must flow to the corresponding source in
 `tail_4(initial_state || x_sequence)`, including sequences of length one or
@@ -111,9 +118,10 @@ existing causal-convolution wrappers.
 The native primitive owns one explicit contract; adapters own ecosystem
 differences.
 
-- FLA uses `[B, T, D]`, `[D, W]`, `cu_seqlens`, and full-width `[N, D, W]`
-  cache tensors. The exact contiguous, alignment-compatible, no-bias,
-  no-residual, width-four BF16 SiLU/swish subset can be a zero-copy adapter.
+- FLA uses `[B, T, D]`, `[D, W]`, `cu_seqlens`, an optional `[D]` bias, and
+  full-width `[N, D, W]` cache tensors. The exact contiguous,
+  alignment-compatible, no-residual, width-four BF16 SiLU/swish subset can be
+  a zero-copy adapter when its optional bias is also contiguous BF16.
   Nonstandard QKV views, scheduling hints that cannot be safely ignored,
   duplicate/empty packed segments, or any broader option must retain FLA's
   original route.
@@ -154,15 +162,16 @@ packed boundaries or initial/final state pointers. A separate native path is
 therefore required rather than presenting a Python loop or per-sequence
 fallback as packed-kernel support.
 
-If bias or residual support is added later, the fixed semantic order is
-`residual + SiLU(conv + bias)`.
+Bias is added before SiLU. If residual support is added later, the fixed
+semantic order is `residual + SiLU(conv + bias)`.
 
 ## Delivery order
 
 1. Forward correctness for dense and packed inputs, including exact boundary
    and final-state tests. **Implemented.**
-2. Backward correctness for `dx`, `dweight`, `d_initial_state`, and upstream
-   `d_final_state`, including sequences shorter than the width.
+2. Backward correctness for `dx`, `dweight`, optional `dbias`,
+   `d_initial_state`, and upstream `d_final_state`, including sequences shorter
+   than the width.
 3. FLA and Transformers adapters with explicit route proof and fail-closed
    support checks.
 4. ComputeLab B200 optimization at representative sequence lengths 8192,
@@ -173,6 +182,6 @@ If bias or residual support is added later, the fixed semantic order is
 
 The first performance gate is parity with the best available FLA route while
 adding FE's packed-state forward; the matching backward remains next. FLA
-Triton itself already implements those features. Broader dtype, width, bias,
-and additional architecture support are follow-ups, not hidden fallback
-behavior.
+Triton itself already implements those features. Broader dtype, width,
+residual fusion, and additional architecture support are follow-ups, not
+hidden fallback behavior.

--- a/docs/fe-oss-apis/causal_conv1d_bulk_contract.md
+++ b/docs/fe-oss-apis/causal_conv1d_bulk_contract.md
@@ -134,6 +134,15 @@ differences.
 No external kernel source is to be copied into the implementation. External
 projects are semantic, interface, and performance references only.
 
+## Benchmark harness
+
+`test/python/fe_api/causal_conv1d_bulk/benchmark_causal_conv1d_bulk_sm100.py`
+runs the interleaved FE-versus-FLA comparison on every functional target. It
+requires CUDA and lets the native API perform the authoritative support check;
+neither ComputeLab nor Slurm is required. The JSON always records ordinary
+hardware and software metadata and includes Slurm job/node fields only when
+those environment variables are present.
+
 ## Existing path and gap
 
 `cudnn.ops.causal_conv1d_nwh` already provides dense `[B, T, D]` forward and

--- a/docs/fe-oss-apis/causal_conv1d_bulk_contract.md
+++ b/docs/fe-oss-apis/causal_conv1d_bulk_contract.md
@@ -71,7 +71,8 @@ When `output_final_state=False`, `final_state_tensor` is a CUDA BF16 sentinel
 with shape `(0,)`. An FLA adapter must translate that sentinel to `None`.
 
 The lower-level class API follows the common FE-OSS lifecycle: construct it
-from representative tensors, call `check_support()`, call `compile()` once,
+from representative PyTorch tensors (metadata-only `TensorDesc` inputs are not
+accepted), call `check_support()`, call `compile()` once,
 then call `execute()` with preallocated output tensors. `B`, `D`, packed `N`,
 and optional-tensor presence are compile-signature properties; `T` is symbolic
 and may change between executions within the indexing limits above. Both APIs

--- a/docs/fe-oss-apis/causal_conv1d_bulk_contract.md
+++ b/docs/fe-oss-apis/causal_conv1d_bulk_contract.md
@@ -1,8 +1,10 @@
-# Bulk Causal Conv1d Contract (Prototype)
+# Bulk Causal Conv1d Forward (SM100)
 
-This document fixes the contract for the bulk causal-convolution work that
-follows the SM100 decode-update primitive. It is a prototype plan, not a
-shipped API guarantee.
+`CausalConv1dBulkFwdSm100` and
+`causal_conv1d_bulk_fwd_wrapper_sm100` expose the first native bulk
+causal-convolution slice. Its full-width output state is designed to match the
+pending companion SM100 decode-update contract, so the two APIs need no state
+repacking when both are installed. The API is experimental.
 
 ## First native slice
 
@@ -17,14 +19,29 @@ fused-SiLU operation on SM100:
 - output: contiguous `y`, with the same shape as `x`
 - optional final state: contiguous `final_state[N, D, 4]`
 
+Every tensor is CUDA-resident. Data tensors are BF16 and must have a 16-byte
+aligned base pointer; `cu_seqlens` is int32 with a 4-byte aligned base pointer.
+This API requires `nvidia-cutlass-dsl>=4.7.0`; the frontend package's broader
+`cutedsl` extra deliberately retains its 4.5.0 floor for unrelated APIs.
+The first slice is inference-only and rejects requires-grad inputs while grad
+mode is enabled. There is no implicit dtype/layout conversion or fallback.
+Channel extents divisible by eight use an aligned 128-bit channel-vector fast
+path; other positive extents use a predicated scalar-tail path with the same
+public semantics.
+
 For dense input, `N == B`. For packed input, `B == 1`,
 `cu_seqlens[0] == 0`, `cu_seqlens[-1] == total_T`, and every sequence length
-is positive. Packed sequences must never read each other's tokens.
+is positive. Packed sequences must never read each other's tokens. `B` and `T`
+must each fit int32, `B*T <= 2^31 - 16`, and
+`N <= min(total_T, floor((2^31 - 1) / 2))`. The API also limits
+`D <= 256 * 65535`, preserving a representable scalar-fallback CUDA grid for
+every accepted channel extent. On that scalar path, each input/output or state
+tensor it indexes may contain at most `2^31 - 1` elements.
 
 The full-width state is intentional. For each token, the operation shifts the
 four-lane state left, appends the token, then filters the updated state. The
-returned final state can therefore be passed directly to the decode-update
-primitive without repacking:
+returned final state follows the intended decode-update recurrence without
+repacking:
 
 ```text
 state = [state[1], state[2], state[3], x_t]
@@ -34,13 +51,47 @@ y_t = SiLU(sum_j state[j] * weight[j])
 When `initial_state` is omitted, its observable lanes are zero. Returning a
 final state must not mutate the input state.
 
+The high-level wrapper always returns a `TupleDict` in this stable order:
+
+```python
+from cudnn import causal_conv1d_bulk_fwd_wrapper_sm100
+
+result = causal_conv1d_bulk_fwd_wrapper_sm100(
+    x,
+    weight,
+    cu_seqlens_tensor=cu_seqlens,
+    initial_state_tensor=initial_state,
+    output_final_state=True,
+)
+y = result["output_tensor"]
+final_state = result["final_state_tensor"]
+```
+
+When `output_final_state=False`, `final_state_tensor` is a CUDA BF16 sentinel
+with shape `(0,)`. An FLA adapter must translate that sentinel to `None`.
+
+The lower-level class API follows the common FE-OSS lifecycle: construct it
+from representative tensors, call `check_support()`, call `compile()` once,
+then call `execute()` with preallocated output tensors. `B`, `D`, packed `N`,
+and optional-tensor presence are compile-signature properties; `T` is symbolic
+and may change between executions within the indexing limits above. Both APIs
+accept an explicit CUDA stream and do not synchronize it on a valid launch.
+
 ## Backward contract
 
-Backward returns gradients for `x`, `weight`, and `initial_state` when that
-input participates in autograd. If `final_state` contributes to the loss,
-backward also consumes its upstream gradient. This makes the prefill-to-decode
-state bridge differentiable instead of treating the state output as detached
+The matching backward is not implemented in this first slice. Its contract is
+to return gradients for `x`, `weight`, and `initial_state` when that input
+participates in autograd. If `final_state` contributes to the loss, backward
+also consumes its upstream gradient. This makes the prefill-to-decode state
+bridge differentiable instead of treating the state output as detached
 metadata.
+
+All four upstream final-state lanes must flow to the corresponding source in
+`tail_4(initial_state || x_sequence)`, including sequences of length one or
+two. An independent recurrence, rather than an external kernel implementation,
+is the oracle for these tests. For every positive-length sequence,
+`d_initial_state[..., 0]` is zero because the first state update discards that
+lane.
 
 The implementation may recompute the four-term preactivation in backward.
 That policy is part of graph construction, not a requirement to save a large
@@ -54,15 +105,24 @@ The native primitive owns one explicit contract; adapters own ecosystem
 differences.
 
 - FLA uses `[B, T, D]`, `[D, W]`, `cu_seqlens`, and full-width `[N, D, W]`
-  cache tensors. Its supported no-bias width-four subset can be a zero-copy
-  adapter. Residual, other activations, widths, dtypes, or architectures must
-  retain FLA's original route.
-- Transformers Qwen3.5 uses a full-width convolution cache as well. Its fused
-  mixed-QKV channel width is a separate measured signature, not an assumption
-  that split Q/K/V measurements transfer to it.
-- Dao-AILab/causal-conv1d's bulk API uses `[B, D, T]` and a minimal
-  `[B, D, W-1]` state. Compatibility belongs in an adapter; the native API
-  will not weaken the direct prefill-to-decode bridge to copy that ABI.
+  cache tensors. The exact contiguous, alignment-compatible, no-bias,
+  no-residual, width-four BF16 SiLU/swish subset can be a zero-copy adapter.
+  Nonstandard QKV views, scheduling hints that cannot be safely ignored,
+  duplicate/empty packed segments, or any broader option must retain FLA's
+  original route.
+- Transformers Qwen3.5 calls a stateless bulk function with `[B, D, T]`; its
+  cache manager owns and mutates the full-width `[B, D, W]` cache before that
+  call. A function-level adapter can cover only stateless dense bulk. The
+  initial/final-state bridge requires a module/cache-level adapter that
+  preserves static cache addresses, and must fall back when `record_past=True`.
+  Qwen3.5 always applies one convolution to fused mixed QKV, so its channel
+  width is a separate measured signature rather than three split calls.
+- Dao-AILab/causal-conv1d's bulk API uses `[B, D, T]`, a minimal
+  `[B, D, W-1]` state, and optional `seq_idx[B, T]`. `seq_idx` is not
+  equivalent to `cu_seqlens`: it can describe multiple segments per batch row,
+  negative labels, and a contract incompatible with final-state output.
+  Compatibility belongs in an adapter; the native API will not weaken the
+  direct prefill-to-decode bridge to copy that ABI.
 
 No external kernel source is to be copied into the implementation. External
 projects are semantic, interface, and performance references only.
@@ -70,24 +130,32 @@ projects are semantic, interface, and performance references only.
 ## Existing path and gap
 
 `cudnn.ops.causal_conv1d_nwh` already provides dense `[B, T, D]` forward and
-backward through fixed-size backend bindings. Those bindings accept only
-`batch`, `dim`, `seq_len`, and `kernel_size`; they do not accept packed
-boundaries or initial/final state pointers. The new work therefore needs a
-separate native path rather than presenting a Python loop or per-sequence
+backward through fixed-size backend bindings, but its filter layout is
+`[W, D]`. The ecosystem-facing native API deliberately uses `[D, W]`; an
+adapter must not transpose and materialize the old layout on every call. The
+old bindings also accept only `batch`, `dim`, `seq_len`, and `kernel_size`, not
+packed boundaries or initial/final state pointers. A separate native path is
+therefore required rather than presenting a Python loop or per-sequence
 fallback as packed-kernel support.
+
+If bias or residual support is added later, the fixed semantic order is
+`residual + SiLU(conv + bias)`.
 
 ## Delivery order
 
 1. Forward correctness for dense and packed inputs, including exact boundary
-   and final-state tests.
+   and final-state tests. **Implemented.**
 2. Backward correctness for `dx`, `dweight`, `d_initial_state`, and upstream
    `d_final_state`, including sequences shorter than the width.
 3. FLA and Transformers adapters with explicit route proof and fail-closed
    support checks.
 4. ComputeLab B200 optimization at representative sequence lengths 8192,
-   16384, and 32768. Report direct kernel-active time separately from graph or
-   model-proxy latency, and compare arms in one interleaved process.
+   16384, and 32768. Report direct-API CUDA-event elapsed, profiler kernel
+   duration, and graph/model-proxy latency as distinct quantities, and compare
+   arms in one interleaved process.
+   **Prototype benchmarked; model routing remains a follow-up.**
 
 The first performance gate is parity with the best available FLA route while
-filling the packed-state/backward feature gap. Broader dtype, width, bias, and
-architecture support are follow-ups, not hidden fallback behavior.
+adding FE's packed-state forward; the matching backward remains next. FLA
+Triton itself already implements those features. Broader dtype, width, bias,
+and architecture support are follow-ups, not hidden fallback behavior.

--- a/docs/fe-oss-apis/causal_conv1d_bulk_contract.md
+++ b/docs/fe-oss-apis/causal_conv1d_bulk_contract.md
@@ -1,15 +1,18 @@
-# Bulk Causal Conv1d Forward (SM100)
+# Bulk Causal Conv1d Forward (SM100-optimized)
 
 `CausalConv1dBulkFwdSm100` and
 `causal_conv1d_bulk_fwd_wrapper_sm100` expose the first native bulk
 causal-convolution slice. Its full-width output state is designed to match the
-pending companion SM100 decode-update contract, so the two APIs need no state
+companion decode-update contract, so the two APIs need no state
 repacking when both are installed. The API is experimental.
 
 ## First native slice
 
 The first optimized slice is the model-relevant BF16, width-four, no-bias,
-fused-SiLU operation on SM100:
+fused-SiLU operation. Functional targets are the exact compute capabilities
+SM80, SM86, SM87, SM89, SM90, SM100, SM103, SM110, SM120, and SM121. The
+public class and wrapper retain their original `Sm100` suffix while this
+experimental API evolves.
 
 - dense input: contiguous `x[B, T, D]`
 - packed input: contiguous `x[1, total_T, D]` plus contiguous CUDA int32
@@ -25,9 +28,12 @@ This API requires `nvidia-cutlass-dsl>=4.7.0`; the frontend package's broader
 `cutedsl` extra deliberately retains its 4.5.0 floor for unrelated APIs.
 The first slice is inference-only and rejects requires-grad inputs while grad
 mode is enabled. There is no implicit dtype/layout conversion or fallback.
-Channel extents divisible by eight use an aligned 128-bit channel-vector fast
-path; other positive extents use a predicated scalar-tail path with the same
-public semantics.
+On SM100, SM103, SM110, SM120, and SM121, channel extents divisible by eight
+use an aligned 128-bit channel-vector fast path with packed FP32 arithmetic.
+SM80 through SM90, and every positive channel extent not divisible by eight,
+use a predicated scalar path with the same public semantics. Only SM100/B200
+has been performance-characterized; the other targets are functional support,
+not a cross-architecture performance claim.
 
 For dense input, `N == B`. For packed input, `B == 1`,
 `cu_seqlens[0] == 0`, `cu_seqlens[-1] == total_T`, and every sequence length
@@ -159,4 +165,5 @@ If bias or residual support is added later, the fixed semantic order is
 The first performance gate is parity with the best available FLA route while
 adding FE's packed-state forward; the matching backward remains next. FLA
 Triton itself already implements those features. Broader dtype, width, bias,
-and architecture support are follow-ups, not hidden fallback behavior.
+and additional architecture support are follow-ups, not hidden fallback
+behavior.

--- a/docs/fe-oss-apis/causal_conv1d_bulk_contract.md
+++ b/docs/fe-oss-apis/causal_conv1d_bulk_contract.md
@@ -1,0 +1,93 @@
+# Bulk Causal Conv1d Contract (Prototype)
+
+This document fixes the contract for the bulk causal-convolution work that
+follows the SM100 decode-update primitive. It is a prototype plan, not a
+shipped API guarantee.
+
+## First native slice
+
+The first optimized slice is the model-relevant BF16, width-four, no-bias,
+fused-SiLU operation on SM100:
+
+- dense input: contiguous `x[B, T, D]`
+- packed input: contiguous `x[1, total_T, D]` plus contiguous CUDA int32
+  `cu_seqlens[N + 1]`
+- filter: contiguous `weight[D, 4]`
+- optional initial state: contiguous `initial_state[N, D, 4]`
+- output: contiguous `y`, with the same shape as `x`
+- optional final state: contiguous `final_state[N, D, 4]`
+
+For dense input, `N == B`. For packed input, `B == 1`,
+`cu_seqlens[0] == 0`, `cu_seqlens[-1] == total_T`, and every sequence length
+is positive. Packed sequences must never read each other's tokens.
+
+The full-width state is intentional. For each token, the operation shifts the
+four-lane state left, appends the token, then filters the updated state. The
+returned final state can therefore be passed directly to the decode-update
+primitive without repacking:
+
+```text
+state = [state[1], state[2], state[3], x_t]
+y_t = SiLU(sum_j state[j] * weight[j])
+```
+
+When `initial_state` is omitted, its observable lanes are zero. Returning a
+final state must not mutate the input state.
+
+## Backward contract
+
+Backward returns gradients for `x`, `weight`, and `initial_state` when that
+input participates in autograd. If `final_state` contributes to the loss,
+backward also consumes its upstream gradient. This makes the prefill-to-decode
+state bridge differentiable instead of treating the state output as detached
+metadata.
+
+The implementation may recompute the four-term preactivation in backward.
+That policy is part of graph construction, not a requirement to save a large
+intermediate. BF16 parameter gradients may accumulate in FP32 internally, but
+the public autograd result follows the input parameter dtype, matching the
+existing causal-convolution wrappers.
+
+## Ecosystem adapters
+
+The native primitive owns one explicit contract; adapters own ecosystem
+differences.
+
+- FLA uses `[B, T, D]`, `[D, W]`, `cu_seqlens`, and full-width `[N, D, W]`
+  cache tensors. Its supported no-bias width-four subset can be a zero-copy
+  adapter. Residual, other activations, widths, dtypes, or architectures must
+  retain FLA's original route.
+- Transformers Qwen3.5 uses a full-width convolution cache as well. Its fused
+  mixed-QKV channel width is a separate measured signature, not an assumption
+  that split Q/K/V measurements transfer to it.
+- Dao-AILab/causal-conv1d's bulk API uses `[B, D, T]` and a minimal
+  `[B, D, W-1]` state. Compatibility belongs in an adapter; the native API
+  will not weaken the direct prefill-to-decode bridge to copy that ABI.
+
+No external kernel source is to be copied into the implementation. External
+projects are semantic, interface, and performance references only.
+
+## Existing path and gap
+
+`cudnn.ops.causal_conv1d_nwh` already provides dense `[B, T, D]` forward and
+backward through fixed-size backend bindings. Those bindings accept only
+`batch`, `dim`, `seq_len`, and `kernel_size`; they do not accept packed
+boundaries or initial/final state pointers. The new work therefore needs a
+separate native path rather than presenting a Python loop or per-sequence
+fallback as packed-kernel support.
+
+## Delivery order
+
+1. Forward correctness for dense and packed inputs, including exact boundary
+   and final-state tests.
+2. Backward correctness for `dx`, `dweight`, `d_initial_state`, and upstream
+   `d_final_state`, including sequences shorter than the width.
+3. FLA and Transformers adapters with explicit route proof and fail-closed
+   support checks.
+4. ComputeLab B200 optimization at representative sequence lengths 8192,
+   16384, and 32768. Report direct kernel-active time separately from graph or
+   model-proxy latency, and compare arms in one interleaved process.
+
+The first performance gate is parity with the best available FLA route while
+filling the packed-state/backward feature gap. Broader dtype, width, bias, and
+architecture support are follow-ups, not hidden fallback behavior.

--- a/docs/fe-oss-apis/overview.md
+++ b/docs/fe-oss-apis/overview.md
@@ -9,6 +9,7 @@ The GEMM CuTeDSL APIs are type-erased and torch-lazy: torch is imported only whe
 - **proj_rope_mxfp8**: JAX eager support on both input paths with `w_out_in=True` (the transposed [in, out] weight view is torch-only), plus the `jax.jit`-compatible `gemm_proj_rope_mxfp8_jax_sm100` entry point.
 
 This folder documents the Python FE APIs implemented under `python/cudnn`. For details on currently implemented operations, see:
+- [Bulk Causal Conv1d Forward (SM100)](causal_conv1d_bulk_contract.md)
 - [FLA Integration Shims](fla.md)
 - [GEMM + Amax](gemm_fusions/gemm_amax.md)
 - [GEMM + RoPE + MXFP8 Projection](gemm_fusions/gemm_proj_rope_mxfp8.md)

--- a/python/cudnn/README.md
+++ b/python/cudnn/README.md
@@ -61,6 +61,7 @@ To add a new frontend-only API, follow these steps:
 4. Add a sample usage/test file in `test/python/fe_api/`.
 
 **Currently implemented frontend-only APIs**:
+- `Bulk Causal Conv1d Forward (SM100)`
 - `GEMM + Amax`
 - `RMSNorm + RHT + Amax`
 - `GEMM + SwiGLU`

--- a/python/cudnn/README.md
+++ b/python/cudnn/README.md
@@ -61,7 +61,7 @@ To add a new frontend-only API, follow these steps:
 4. Add a sample usage/test file in `test/python/fe_api/`.
 
 **Currently implemented frontend-only APIs**:
-- `Bulk Causal Conv1d Forward (SM100)`
+- `Bulk Causal Conv1d Forward (SM100-optimized; functional SM80/86/87/89/90/100/103/110/120/121)`
 - `GEMM + Amax`
 - `RMSNorm + RHT + Amax`
 - `GEMM + SwiGLU`

--- a/python/cudnn/__init__.py
+++ b/python/cudnn/__init__.py
@@ -308,6 +308,11 @@ __all__ = [*_EAGER_PUBLIC_NAMES, "Graph", "wrapper"]
 _OPTIONAL_DEPENDENCY_INSTALL_HINT = "Install with 'pip install nvidia-cudnn-frontend[cutedsl]'"
 
 _LAZY_OPTIONAL_IMPORTS = {
+    "CausalConv1dBulkFwdSm100": (".causal_conv1d_bulk_sm100", "CausalConv1dBulkFwdSm100"),
+    "causal_conv1d_bulk_fwd_wrapper_sm100": (
+        ".causal_conv1d_bulk_sm100",
+        "causal_conv1d_bulk_fwd_wrapper_sm100",
+    ),
     "gnn": (".gnn", None),
     "BSA": (".block_sparse_attention", "BSA"),
     "block_sparse_attention_forward": (".block_sparse_attention", "block_sparse_attention_forward"),

--- a/python/cudnn/_causal_conv1d_bulk_arch.py
+++ b/python/cudnn/_causal_conv1d_bulk_arch.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Architecture policy for the experimental bulk causal-conv1d API."""
+
+FUNCTIONAL_COMPUTE_CAPABILITIES = frozenset(
+    {
+        (8, 0),
+        (8, 6),
+        (8, 7),
+        (8, 9),
+        (9, 0),
+        (10, 0),
+        (10, 3),
+        (11, 0),
+        (12, 0),
+        (12, 1),
+    }
+)
+F32X2_COMPUTE_CAPABILITIES = frozenset(
+    {
+        (10, 0),
+        (10, 3),
+        (11, 0),
+        (12, 0),
+        (12, 1),
+    }
+)
+
+
+def is_functional_arch(compute_capability: tuple[int, int]) -> bool:
+    return compute_capability in FUNCTIONAL_COMPUTE_CAPABILITIES
+
+
+def uses_vec8_schedule(compute_capability: tuple[int, int], n_channels: int) -> bool:
+    return compute_capability in F32X2_COMPUTE_CAPABILITIES and n_channels % 8 == 0

--- a/python/cudnn/causal_conv1d_bulk_sm100/__init__.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""SM100 bulk causal-convolution FE-OSS API."""
+"""SM100-optimized, portable bulk causal-convolution FE-OSS API."""
 
 from .api import CausalConv1dBulkFwdSm100, causal_conv1d_bulk_fwd_wrapper_sm100
 

--- a/python/cudnn/causal_conv1d_bulk_sm100/__init__.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SM100 bulk causal-convolution FE-OSS API."""
+
+from .api import CausalConv1dBulkFwdSm100, causal_conv1d_bulk_fwd_wrapper_sm100
+
+__all__ = [
+    "CausalConv1dBulkFwdSm100",
+    "causal_conv1d_bulk_fwd_wrapper_sm100",
+]

--- a/python/cudnn/causal_conv1d_bulk_sm100/api.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/api.py
@@ -117,6 +117,17 @@ class CausalConv1dBulkFwdSm100(APIBase):
         super().__init__()
         self._warn_experimental_api()
 
+        for name, sample in (
+            ("sample_x", sample_x),
+            ("sample_weight", sample_weight),
+            ("sample_output", sample_output),
+            ("sample_cu_seqlens", sample_cu_seqlens),
+            ("sample_initial_state", sample_initial_state),
+            ("sample_final_state", sample_final_state),
+        ):
+            if sample is not None and not isinstance(sample, torch.Tensor):
+                raise TypeError(f"{name} must be a torch.Tensor, got {type(sample).__name__}")
+
         self.x_desc = self._make_tensor_desc(sample_x, name="sample_x")
         self.weight_desc = self._make_tensor_desc(sample_weight, name="sample_weight")
         self.output_desc = self._make_tensor_desc(sample_output, name="sample_output")

--- a/python/cudnn/causal_conv1d_bulk_sm100/api.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/api.py
@@ -1,7 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Experimental FE-OSS API for SM100 bulk causal convolution."""
+"""Experimental FE-OSS API for portable bulk causal convolution.
+
+The public class retains its original ``Sm100`` suffix while this experimental
+API evolves. SM100 uses the measured vector schedule, other listed targets at
+SM100 or newer use the same instruction-compatible path, and supported
+pre-Blackwell targets use the correctness-first scalar schedule.
+"""
 
 from contextlib import contextmanager
 import threading
@@ -26,6 +32,37 @@ _MAX_TOTAL_TOKENS = _INT32_MAX - 15
 # Packed kernels use ``(lower + upper) // 2`` during their device-side search.
 _MAX_PACKED_SEQUENCES = _INT32_MAX // 2
 _MAX_SCALAR_GRID_CHANNELS = 256 * 65535
+_FUNCTIONAL_COMPUTE_CAPABILITIES = frozenset(
+    {
+        (8, 0),
+        (8, 6),
+        (8, 7),
+        (8, 9),
+        (9, 0),
+        (10, 0),
+        (10, 3),
+        (11, 0),
+        (12, 0),
+        (12, 1),
+    }
+)
+_F32X2_COMPUTE_CAPABILITIES = frozenset(
+    {
+        (10, 0),
+        (10, 3),
+        (11, 0),
+        (12, 0),
+        (12, 1),
+    }
+)
+
+
+def _is_functional_arch(compute_capability: tuple[int, int]) -> bool:
+    return compute_capability in _FUNCTIONAL_COMPUTE_CAPABILITIES
+
+
+def _uses_vec8_schedule(compute_capability: tuple[int, int], n_channels: int) -> bool:
+    return compute_capability in _F32X2_COMPUTE_CAPABILITIES and n_channels % 8 == 0
 
 
 @contextmanager
@@ -94,7 +131,7 @@ def _tensors_overlap(lhs: torch.Tensor, rhs: torch.Tensor) -> bool:
 
 
 class CausalConv1dBulkFwdSm100(APIBase):
-    """Compile and execute BF16 width-four bulk causal convolution on SM100.
+    """Compile and execute BF16 width-four bulk causal convolution.
 
     The native layout is contiguous ``x[B, T, D]`` and ``weight[D, 4]``.
     Dense mode treats each batch row as a sequence.  Packed mode requires
@@ -158,6 +195,8 @@ class CausalConv1dBulkFwdSm100(APIBase):
         self.sample_sequence_length = None
         self.n_channels = None
         self.num_sequences = None
+        self.compute_capability = None
+        self.use_vec8_schedule = None
         self.is_packed = sample_cu_seqlens is not None
 
     @staticmethod
@@ -222,17 +261,6 @@ class CausalConv1dBulkFwdSm100(APIBase):
                 num_sequences > batch_size * sequence_length,
                 f"Packed N={num_sequences} cannot exceed total_T={batch_size * sequence_length} " "when every sequence must be non-empty",
             )
-
-        if n_channels % 8 != 0:
-            self._value_error_if(
-                batch_size * sequence_length * n_channels > _INT32_MAX,
-                "The scalar-tail path requires X and Output to contain at most " f"{_INT32_MAX} elements",
-            )
-            if self.initial_state_desc is not None or self.final_state_desc is not None:
-                self._value_error_if(
-                    num_sequences * n_channels * 4 > _INT32_MAX,
-                    "The scalar-tail path requires each state tensor to contain at most " f"{_INT32_MAX} elements",
-                )
 
         self._check_tensor_shape(self.weight_desc, (n_channels, 4), "Weight")
         self._check_tensor_shape(self.output_desc, (batch_size, sequence_length, n_channels), "Output")
@@ -308,14 +336,29 @@ class CausalConv1dBulkFwdSm100(APIBase):
         self._runtime_error_if(not torch.cuda.is_available(), "CUDA is not available")
         compute_capability = torch.cuda.get_device_capability(self.x_desc.device)
         self._runtime_error_if(
-            compute_capability != (10, 0),
-            "CausalConv1dBulkFwdSm100 requires exactly SM100 " f"(compute capability 10.0), found {compute_capability[0]}.{compute_capability[1]}",
+            not _is_functional_arch(compute_capability),
+            "CausalConv1dBulkFwdSm100 does not support compute capability "
+            f"{compute_capability[0]}.{compute_capability[1]}; supported capabilities are "
+            f"{sorted(_FUNCTIONAL_COMPUTE_CAPABILITIES)}",
         )
+        use_vec8_schedule = _uses_vec8_schedule(compute_capability, n_channels)
+        if not use_vec8_schedule:
+            self._value_error_if(
+                batch_size * sequence_length * n_channels > _INT32_MAX,
+                "The scalar schedule requires X and Output to contain at most " f"{_INT32_MAX} elements",
+            )
+            if self.initial_state_desc is not None or self.final_state_desc is not None:
+                self._value_error_if(
+                    num_sequences * n_channels * 4 > _INT32_MAX,
+                    "The scalar schedule requires each state tensor to contain at most " f"{_INT32_MAX} elements",
+                )
 
         self.batch_size = batch_size
         self.sample_sequence_length = sequence_length
         self.n_channels = n_channels
         self.num_sequences = num_sequences
+        self.compute_capability = compute_capability
+        self.use_vec8_schedule = use_vec8_schedule
         self._is_supported = True
         return True
 
@@ -347,7 +390,7 @@ class CausalConv1dBulkFwdSm100(APIBase):
         fake_final_state = self._make_fake_cute_tensor_from_desc(self.final_state_desc, assumed_align=16)
         fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
 
-        kernel = CausalConv1dBulkForwardKernel()
+        kernel = CausalConv1dBulkForwardKernel(use_vec8=self.use_vec8_schedule)
         dense_tokens_per_sequence = self.sample_sequence_length if not self.is_packed else 0
         with torch.cuda.device(self.x_desc.device):
             self._compiled_kernel = cute.compile(
@@ -390,8 +433,8 @@ class CausalConv1dBulkFwdSm100(APIBase):
             raise ValueError(f"{name} T must be positive, got {sequence_length}")
         if batch_size * sequence_length > _MAX_TOTAL_TOKENS:
             raise ValueError(f"{name} B*T exceeds the safe Int32 tiled-indexing limit")
-        if n_channels % 8 != 0 and batch_size * sequence_length * n_channels > _INT32_MAX:
-            raise ValueError(f"The scalar-tail path requires {name} to contain at most {_INT32_MAX} elements")
+        if not self.use_vec8_schedule and batch_size * sequence_length * n_channels > _INT32_MAX:
+            raise ValueError(f"The scalar schedule requires {name} to contain at most {_INT32_MAX} elements")
         expected_stride = (sequence_length * n_channels, n_channels, 1)
         if tuple(tensor.stride()) != expected_stride:
             raise ValueError(f"{name} must be [B, T, D] contiguous, got stride {tuple(tensor.stride())}")
@@ -537,14 +580,18 @@ def _cache_key(
             raise ValueError(f"Packed N exceeds the safe Int32 search limit: {num_sequences}")
         if num_sequences > total_tokens:
             raise ValueError(f"Packed N={num_sequences} cannot exceed total_T={total_tokens} " "when every sequence must be non-empty")
-    if n_channels % 8 != 0:
+    compute_capability = torch.cuda.get_device_capability(x_tensor.device)
+    use_vec8_schedule = _uses_vec8_schedule(compute_capability, n_channels)
+    if not use_vec8_schedule:
         if x_tensor.numel() > _INT32_MAX:
-            raise ValueError(f"The scalar-tail path requires X to contain at most {_INT32_MAX} elements")
+            raise ValueError(f"The scalar schedule requires X to contain at most {_INT32_MAX} elements")
         if (initial_state_tensor is not None or output_final_state) and num_sequences * n_channels * 4 > _INT32_MAX:
-            raise ValueError(f"The scalar-tail path requires each state tensor to contain at most {_INT32_MAX} elements")
+            raise ValueError(f"The scalar schedule requires each state tensor to contain at most {_INT32_MAX} elements")
     return (
         x_tensor.device.type,
         x_tensor.device.index,
+        compute_capability,
+        use_vec8_schedule,
         batch_size,
         num_sequences,
         n_channels,
@@ -563,7 +610,7 @@ def causal_conv1d_bulk_fwd_wrapper_sm100(
     output_final_state: bool = False,
     current_stream: Optional[cuda.CUstream] = None,
 ) -> TupleDict:
-    """Run the SM100 BF16 width-four bulk causal-convolution forward.
+    """Run the BF16 width-four bulk causal-convolution forward.
 
     The result always contains ``output_tensor`` and ``final_state_tensor`` in
     that order.  When ``output_final_state`` is false, the latter is a BF16

--- a/python/cudnn/causal_conv1d_bulk_sm100/api.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/api.py
@@ -121,6 +121,10 @@ class CausalConv1dBulkFwdSm100(APIBase):
             ("sample_x", sample_x),
             ("sample_weight", sample_weight),
             ("sample_output", sample_output),
+        ):
+            if not isinstance(sample, torch.Tensor):
+                raise TypeError(f"{name} must be a torch.Tensor, got {type(sample).__name__}")
+        for name, sample in (
             ("sample_cu_seqlens", sample_cu_seqlens),
             ("sample_initial_state", sample_initial_state),
             ("sample_final_state", sample_final_state),

--- a/python/cudnn/causal_conv1d_bulk_sm100/api.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/api.py
@@ -1,0 +1,628 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Experimental FE-OSS API for SM100 bulk causal convolution."""
+
+from contextlib import contextmanager
+import threading
+from typing import Iterator, Optional
+
+from cuda.bindings import driver as cuda
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.runtime import make_fake_stream
+import torch
+
+from cudnn.api_base import APIBase, TensorDesc, TupleDict
+from cudnn.frost.buffers import CUTEDSL_MIN_VERSION, cutedsl_state, cutedsl_too_old
+
+_API_CACHE = {}
+_API_CACHE_LOCK = threading.Lock()
+_API_CACHE_CAPACITY = 128
+_INT32_MAX = 2**31 - 1
+# Kernels form ``tile_end = first_token + 16`` in Int32.  Reserve the
+# largest possible tile overrun so that every accepted launch stays defined.
+_MAX_TOTAL_TOKENS = _INT32_MAX - 15
+# Packed kernels use ``(lower + upper) // 2`` during their device-side search.
+_MAX_PACKED_SEQUENCES = _INT32_MAX // 2
+_MAX_SCALAR_GRID_CHANNELS = 256 * 65535
+
+
+@contextmanager
+def _torch_stream_context(
+    current_stream: Optional[cuda.CUstream],
+    device: torch.device,
+) -> Iterator[None]:
+    """Run wrapper-owned PyTorch allocations on the launch stream."""
+
+    if current_stream is None:
+        yield
+        return
+
+    launch_stream = _as_torch_stream(current_stream, device)
+    with torch.cuda.stream(launch_stream):
+        yield
+
+
+def _as_torch_stream(current_stream: cuda.CUstream, device: torch.device) -> torch.cuda.Stream:
+    """Resolve a concrete driver handle to the matching PyTorch stream."""
+
+    handle = int(current_stream)
+    torch_current = torch.cuda.current_stream(device)
+    torch_default = torch.cuda.default_stream(device)
+    if handle in (0, 1, torch_default.cuda_stream):
+        return torch_default
+    if handle == 2:
+        raise ValueError("causal_conv1d_bulk_sm100 does not support the " "CU_STREAM_PER_THREAD sentinel; pass a concrete stream handle")
+    if handle == torch_current.cuda_stream:
+        return torch_current
+    return torch.cuda.ExternalStream(handle, device=device)
+
+
+def _record_streams(
+    tensors: tuple[Optional[torch.Tensor], ...],
+    consumer: Optional[torch.cuda.Stream],
+) -> None:
+    """Keep raw-pointer operands alive through an explicit-stream launch."""
+
+    if consumer is None:
+        return
+    for tensor in tensors:
+        if tensor is not None:
+            tensor.record_stream(consumer)
+
+
+def _require_storage_alignment(tensor: torch.Tensor, alignment: int, name: str) -> None:
+    remainder = tensor.data_ptr() % alignment
+    if remainder:
+        raise ValueError(f"{name} data pointer must be {alignment}-byte aligned, " f"got address modulo {alignment} = {remainder}")
+
+
+def _tensors_overlap(lhs: torch.Tensor, rhs: torch.Tensor) -> bool:
+    """Return whether two exact-contiguous tensors share any device bytes.
+
+    ``torch._C._overlaps`` only compares PyTorch Storage identity.  DLPack can
+    wrap the same device address in a distinct Storage, so use the byte spans
+    guaranteed by this API's exact-contiguous tensor contract instead.
+    """
+
+    lhs_begin = lhs.data_ptr()
+    rhs_begin = rhs.data_ptr()
+    lhs_end = lhs_begin + lhs.numel() * lhs.element_size()
+    rhs_end = rhs_begin + rhs.numel() * rhs.element_size()
+    return lhs_begin < rhs_end and rhs_begin < lhs_end
+
+
+class CausalConv1dBulkFwdSm100(APIBase):
+    """Compile and execute BF16 width-four bulk causal convolution on SM100.
+
+    The native layout is contiguous ``x[B, T, D]`` and ``weight[D, 4]``.
+    Dense mode treats each batch row as a sequence.  Packed mode requires
+    ``B == 1`` and a CUDA int32 ``cu_seqlens[N + 1]`` tensor.  Optional initial
+    and final states use the full-width ``[N, D, 4]`` decode-cache layout.
+
+    This first slice has no bias and always applies SiLU.  It is inference-only
+    until the matching backward primitive is available.
+    """
+
+    def __init__(
+        self,
+        sample_x: torch.Tensor,
+        sample_weight: torch.Tensor,
+        sample_output: torch.Tensor,
+        sample_cu_seqlens: Optional[torch.Tensor] = None,
+        sample_initial_state: Optional[torch.Tensor] = None,
+        sample_final_state: Optional[torch.Tensor] = None,
+    ):
+        super().__init__()
+        self._warn_experimental_api()
+
+        self.x_desc = self._make_tensor_desc(sample_x, name="sample_x")
+        self.weight_desc = self._make_tensor_desc(sample_weight, name="sample_weight")
+        self.output_desc = self._make_tensor_desc(sample_output, name="sample_output")
+        self.cu_seqlens_desc = self._make_tensor_desc(sample_cu_seqlens, name="sample_cu_seqlens")
+        self.initial_state_desc = self._make_tensor_desc(sample_initial_state, name="sample_initial_state")
+        self.final_state_desc = self._make_tensor_desc(sample_final_state, name="sample_final_state")
+
+        # TensorDesc intentionally does not retain sample storage.  Preserve
+        # only the pointer remainders backing the alignment promises made to
+        # CuTe during compilation.
+        self._sample_alignment_remainders = {
+            "X": sample_x.data_ptr() % 16,
+            "Weight": sample_weight.data_ptr() % 16,
+            "Output": sample_output.data_ptr() % 16,
+        }
+        if sample_cu_seqlens is not None:
+            self._sample_alignment_remainders["cu_seqlens"] = sample_cu_seqlens.data_ptr() % 4
+        if sample_initial_state is not None:
+            self._sample_alignment_remainders["Initial state"] = sample_initial_state.data_ptr() % 16
+        if sample_final_state is not None:
+            self._sample_alignment_remainders["Final state"] = sample_final_state.data_ptr() % 16
+
+        self.batch_size = None
+        self.sample_sequence_length = None
+        self.n_channels = None
+        self.num_sequences = None
+        self.is_packed = sample_cu_seqlens is not None
+
+    @staticmethod
+    def _require_rank(desc: TensorDesc, rank: int, name: str) -> None:
+        if desc.ndim != rank:
+            raise ValueError(f"{name} must be {rank}D, got shape {desc.shape}")
+
+    @staticmethod
+    def _require_cuda(desc: TensorDesc, name: str) -> None:
+        if desc.device.type != "cuda":
+            raise ValueError(f"{name} must be a CUDA tensor, got device {desc.device}")
+
+    def check_support(self) -> bool:
+        cutedsl_installed, cutedsl_version = cutedsl_state()
+        cutedsl_floor = ".".join(str(component) for component in CUTEDSL_MIN_VERSION)
+        self._runtime_error_if(
+            not cutedsl_installed,
+            "causal_conv1d_bulk_sm100 requires the cutedsl extra " f"(nvidia-cutlass-dsl>={cutedsl_floor})",
+        )
+        if cutedsl_too_old(cutedsl_version):
+            self._runtime_error_if(
+                True,
+                f"causal_conv1d_bulk_sm100 requires nvidia-cutlass-dsl>={cutedsl_floor}; " f"found {cutedsl_version[1]}",
+            )
+
+        self._require_rank(self.x_desc, 3, "X")
+        self._require_rank(self.weight_desc, 2, "Weight")
+        self._require_rank(self.output_desc, 3, "Output")
+        if self.cu_seqlens_desc is not None:
+            self._require_rank(self.cu_seqlens_desc, 1, "cu_seqlens")
+        if self.initial_state_desc is not None:
+            self._require_rank(self.initial_state_desc, 3, "Initial state")
+        if self.final_state_desc is not None:
+            self._require_rank(self.final_state_desc, 3, "Final state")
+
+        batch_size, sequence_length, n_channels = self.x_desc.shape
+        self._value_error_if(batch_size <= 0, f"B must be positive, got {batch_size}")
+        self._value_error_if(sequence_length <= 0, f"T must be positive, got {sequence_length}")
+        self._value_error_if(n_channels <= 0, f"D must be positive, got {n_channels}")
+        self._value_error_if(batch_size > _INT32_MAX, f"B exceeds the Int32 limit: {batch_size}")
+        self._value_error_if(sequence_length > _INT32_MAX, f"T exceeds the Int32 limit: {sequence_length}")
+        self._value_error_if(
+            batch_size * sequence_length > _MAX_TOTAL_TOKENS,
+            f"B*T exceeds the safe Int32 tiled-indexing limit: {batch_size * sequence_length}",
+        )
+        self._value_error_if(n_channels > _MAX_SCALAR_GRID_CHANNELS, f"D exceeds the supported CUDA grid limit: {n_channels}")
+
+        if self.cu_seqlens_desc is None:
+            num_sequences = batch_size
+        else:
+            self._value_error_if(batch_size != 1, f"Packed X must have B=1, got B={batch_size}")
+            self._value_error_if(
+                self.cu_seqlens_desc.shape[0] < 2,
+                "Packed cu_seqlens must contain at least a start and end offset",
+            )
+            num_sequences = self.cu_seqlens_desc.shape[0] - 1
+            self._value_error_if(
+                num_sequences > _MAX_PACKED_SEQUENCES,
+                f"Packed N exceeds the safe Int32 search limit: {num_sequences}",
+            )
+            self._value_error_if(
+                num_sequences > batch_size * sequence_length,
+                f"Packed N={num_sequences} cannot exceed total_T={batch_size * sequence_length} " "when every sequence must be non-empty",
+            )
+
+        if n_channels % 8 != 0:
+            self._value_error_if(
+                batch_size * sequence_length * n_channels > _INT32_MAX,
+                "The scalar-tail path requires X and Output to contain at most " f"{_INT32_MAX} elements",
+            )
+            if self.initial_state_desc is not None or self.final_state_desc is not None:
+                self._value_error_if(
+                    num_sequences * n_channels * 4 > _INT32_MAX,
+                    "The scalar-tail path requires each state tensor to contain at most " f"{_INT32_MAX} elements",
+                )
+
+        self._check_tensor_shape(self.weight_desc, (n_channels, 4), "Weight")
+        self._check_tensor_shape(self.output_desc, (batch_size, sequence_length, n_channels), "Output")
+        if self.cu_seqlens_desc is not None:
+            self._check_tensor_shape(self.cu_seqlens_desc, (num_sequences + 1,), "cu_seqlens")
+        if self.initial_state_desc is not None:
+            self._check_tensor_shape(self.initial_state_desc, (num_sequences, n_channels, 4), "Initial state")
+        if self.final_state_desc is not None:
+            self._check_tensor_shape(self.final_state_desc, (num_sequences, n_channels, 4), "Final state")
+
+        self._check_tensor_stride(
+            self.x_desc,
+            stride=(sequence_length * n_channels, n_channels, 1),
+            name="X",
+            extra_error_msg="X must be [B, T, D] contiguous",
+        )
+        self._check_tensor_stride(
+            self.weight_desc,
+            stride=(4, 1),
+            name="Weight",
+            extra_error_msg="Weight must be [D, 4] contiguous",
+        )
+        self._check_tensor_stride(
+            self.output_desc,
+            stride=(sequence_length * n_channels, n_channels, 1),
+            name="Output",
+            extra_error_msg="Output must be [B, T, D] contiguous",
+        )
+        if self.cu_seqlens_desc is not None:
+            self._check_tensor_stride(self.cu_seqlens_desc, stride=(1,), name="cu_seqlens")
+        for name, desc in (("Initial state", self.initial_state_desc), ("Final state", self.final_state_desc)):
+            if desc is not None:
+                self._check_tensor_stride(
+                    desc,
+                    stride=(n_channels * 4, 4, 1),
+                    name=name,
+                    extra_error_msg=f"{name} must be [N, D, 4] contiguous",
+                )
+
+        for name, desc in (
+            ("X", self.x_desc),
+            ("Weight", self.weight_desc),
+            ("Output", self.output_desc),
+            ("Initial state", self.initial_state_desc),
+            ("Final state", self.final_state_desc),
+        ):
+            if desc is not None:
+                self._check_dtype(desc, dtype=torch.bfloat16, name=name)
+        if self.cu_seqlens_desc is not None:
+            self._check_dtype(self.cu_seqlens_desc, dtype=torch.int32, name="cu_seqlens")
+
+        for name, remainder in self._sample_alignment_remainders.items():
+            alignment = 4 if name == "cu_seqlens" else 16
+            self._value_error_if(
+                remainder != 0,
+                f"{name} data pointer must be {alignment}-byte aligned, " f"got address modulo {alignment} = {remainder}",
+            )
+
+        descs = [
+            ("X", self.x_desc),
+            ("Weight", self.weight_desc),
+            ("Output", self.output_desc),
+            ("cu_seqlens", self.cu_seqlens_desc),
+            ("Initial state", self.initial_state_desc),
+            ("Final state", self.final_state_desc),
+        ]
+        for name, desc in descs:
+            if desc is None:
+                continue
+            self._require_cuda(desc, name)
+            self._value_error_if(desc.device != self.x_desc.device, f"{name} must be on {self.x_desc.device}, got {desc.device}")
+
+        self._runtime_error_if(not torch.cuda.is_available(), "CUDA is not available")
+        compute_capability = torch.cuda.get_device_capability(self.x_desc.device)
+        self._runtime_error_if(
+            compute_capability != (10, 0),
+            "CausalConv1dBulkFwdSm100 requires exactly SM100 " f"(compute capability 10.0), found {compute_capability[0]}.{compute_capability[1]}",
+        )
+
+        self.batch_size = batch_size
+        self.sample_sequence_length = sequence_length
+        self.n_channels = n_channels
+        self.num_sequences = num_sequences
+        self._is_supported = True
+        return True
+
+    def compile(self) -> None:
+        self._ensure_support_checked()
+        if self._compiled_kernel is not None:
+            return
+
+        # Import only after check_support's explicit 4.7 gate. The kernel's
+        # packed math helpers do not exist in the package-wide 4.5 DSL floor.
+        from .kernel import CausalConv1dBulkForwardKernel
+
+        valid_tokens = cute.sym_int(divisibility=1)
+        fake_x = self._make_fake_cute_tensor(
+            dtype=self.x_desc.dtype,
+            shape=(valid_tokens, self.n_channels),
+            stride=(self.n_channels, 1),
+            assumed_align=16,
+        )
+        fake_weight = self._make_fake_cute_tensor_from_desc(self.weight_desc, assumed_align=16)
+        fake_initial_state = self._make_fake_cute_tensor_from_desc(self.initial_state_desc, assumed_align=16)
+        fake_cu_seqlens = self._make_fake_cute_tensor_from_desc(self.cu_seqlens_desc, assumed_align=4)
+        fake_output = self._make_fake_cute_tensor(
+            dtype=self.output_desc.dtype,
+            shape=(valid_tokens, self.n_channels),
+            stride=(self.n_channels, 1),
+            assumed_align=16,
+        )
+        fake_final_state = self._make_fake_cute_tensor_from_desc(self.final_state_desc, assumed_align=16)
+        fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
+
+        kernel = CausalConv1dBulkForwardKernel()
+        dense_tokens_per_sequence = self.sample_sequence_length if not self.is_packed else 0
+        with torch.cuda.device(self.x_desc.device):
+            self._compiled_kernel = cute.compile(
+                kernel,
+                fake_x,
+                fake_weight,
+                fake_initial_state,
+                fake_cu_seqlens,
+                fake_output,
+                fake_final_state,
+                cutlass.Int32(self.num_sequences),
+                cutlass.Int32(dense_tokens_per_sequence),
+                cutlass.Int32(self.n_channels),
+                fake_stream,
+                options="--enable-tvm-ffi --generate-line-info",
+            )
+
+    @staticmethod
+    def _validate_runtime_static_tensor(tensor: torch.Tensor, desc: TensorDesc, name: str) -> None:
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(f"{name} must be a torch.Tensor, got {type(tensor).__name__}")
+        if tuple(tensor.shape) != desc.shape:
+            raise ValueError(f"{name} shape mismatch: expected {desc.shape}, got {tuple(tensor.shape)}")
+        if tuple(tensor.stride()) != desc.stride:
+            raise ValueError(f"{name} stride mismatch: expected {desc.stride}, got {tuple(tensor.stride())}")
+        if tensor.dtype != desc.dtype:
+            raise TypeError(f"{name} dtype mismatch: expected {desc.dtype}, got {tensor.dtype}")
+        if tensor.device != desc.device:
+            raise ValueError(f"{name} device mismatch: expected {desc.device}, got {tensor.device}")
+
+    def _validate_runtime_x_or_output(self, tensor: torch.Tensor, name: str) -> int:
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(f"{name} must be a torch.Tensor, got {type(tensor).__name__}")
+        if tensor.ndim != 3:
+            raise ValueError(f"{name} must be 3D, got shape {tuple(tensor.shape)}")
+        batch_size, sequence_length, n_channels = tensor.shape
+        if batch_size != self.batch_size or n_channels != self.n_channels:
+            raise ValueError(f"{name} shape mismatch: expected B={self.batch_size}, D={self.n_channels}, " f"got {tuple(tensor.shape)}")
+        if sequence_length <= 0:
+            raise ValueError(f"{name} T must be positive, got {sequence_length}")
+        if batch_size * sequence_length > _MAX_TOTAL_TOKENS:
+            raise ValueError(f"{name} B*T exceeds the safe Int32 tiled-indexing limit")
+        if n_channels % 8 != 0 and batch_size * sequence_length * n_channels > _INT32_MAX:
+            raise ValueError(f"The scalar-tail path requires {name} to contain at most {_INT32_MAX} elements")
+        expected_stride = (sequence_length * n_channels, n_channels, 1)
+        if tuple(tensor.stride()) != expected_stride:
+            raise ValueError(f"{name} must be [B, T, D] contiguous, got stride {tuple(tensor.stride())}")
+        if tensor.dtype != torch.bfloat16:
+            raise TypeError(f"{name} dtype mismatch: expected torch.bfloat16, got {tensor.dtype}")
+        if tensor.device != self.x_desc.device:
+            raise ValueError(f"{name} device mismatch: expected {self.x_desc.device}, got {tensor.device}")
+        return sequence_length
+
+    def execute(
+        self,
+        x_tensor: torch.Tensor,
+        weight_tensor: torch.Tensor,
+        output_tensor: torch.Tensor,
+        cu_seqlens_tensor: Optional[torch.Tensor] = None,
+        initial_state_tensor: Optional[torch.Tensor] = None,
+        final_state_tensor: Optional[torch.Tensor] = None,
+        current_stream: Optional[cuda.CUstream] = None,
+    ) -> TupleDict:
+        self._runtime_error_if(
+            self._compiled_kernel is None,
+            "CausalConv1dBulkFwdSm100 kernel not compiled; call compile() first",
+        )
+
+        sequence_length = self._validate_runtime_x_or_output(x_tensor, "X")
+        output_sequence_length = self._validate_runtime_x_or_output(output_tensor, "Output")
+        if output_sequence_length != sequence_length:
+            raise ValueError(f"Output T must match X T={sequence_length}, got {output_sequence_length}")
+        if self.is_packed and self.num_sequences > self.batch_size * sequence_length:
+            raise ValueError(
+                f"Packed N={self.num_sequences} cannot exceed runtime total_T={self.batch_size * sequence_length} " "when every sequence must be non-empty"
+            )
+        self._validate_runtime_static_tensor(weight_tensor, self.weight_desc, "Weight")
+
+        optional_tensors = (
+            ("cu_seqlens", cu_seqlens_tensor, self.cu_seqlens_desc),
+            ("Initial state", initial_state_tensor, self.initial_state_desc),
+            ("Final state", final_state_tensor, self.final_state_desc),
+        )
+        for name, tensor, desc in optional_tensors:
+            if (tensor is None) != (desc is None):
+                raise ValueError(f"{name} presence must match the compiled signature")
+            if tensor is not None:
+                self._validate_runtime_static_tensor(tensor, desc, name)
+
+        for name, tensor, alignment in (
+            ("X", x_tensor, 16),
+            ("Weight", weight_tensor, 16),
+            ("Output", output_tensor, 16),
+            ("cu_seqlens", cu_seqlens_tensor, 4),
+            ("Initial state", initial_state_tensor, 16),
+            ("Final state", final_state_tensor, 16),
+        ):
+            if tensor is not None:
+                _require_storage_alignment(tensor, alignment, name)
+
+        grad_inputs = [x_tensor, weight_tensor]
+        if initial_state_tensor is not None:
+            grad_inputs.append(initial_state_tensor)
+        if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in grad_inputs):
+            raise RuntimeError("causal_conv1d_bulk_fwd is inference-only; call it under torch.no_grad()")
+
+        read_tensors = [x_tensor, weight_tensor]
+        if cu_seqlens_tensor is not None:
+            read_tensors.append(cu_seqlens_tensor)
+        if initial_state_tensor is not None:
+            read_tensors.append(initial_state_tensor)
+        for tensor in read_tensors:
+            if _tensors_overlap(output_tensor, tensor):
+                raise ValueError("Output must not overlap an input tensor")
+        if final_state_tensor is not None:
+            for tensor in [*read_tensors, output_tensor]:
+                if _tensors_overlap(final_state_tensor, tensor):
+                    raise ValueError("Final state must not overlap another input or output tensor")
+
+        if current_stream is None:
+            consumer_stream = torch.cuda.current_stream(x_tensor.device)
+            launch_stream = cuda.CUstream(consumer_stream.cuda_stream)
+        else:
+            consumer_stream = _as_torch_stream(current_stream, x_tensor.device)
+            launch_stream = current_stream
+
+        flat_x = x_tensor.view(-1, self.n_channels)
+        flat_output = output_tensor.view(-1, self.n_channels)
+        dense_tokens_per_sequence = sequence_length if not self.is_packed else 0
+        self._compiled_kernel(
+            flat_x,
+            weight_tensor,
+            initial_state_tensor,
+            cu_seqlens_tensor,
+            flat_output,
+            final_state_tensor,
+            cutlass.Int32(self.num_sequences),
+            cutlass.Int32(dense_tokens_per_sequence),
+            cutlass.Int32(self.n_channels),
+            launch_stream,
+        )
+        _record_streams(
+            (
+                x_tensor,
+                weight_tensor,
+                output_tensor,
+                cu_seqlens_tensor,
+                initial_state_tensor,
+                final_state_tensor,
+            ),
+            consumer_stream,
+        )
+        return TupleDict(output_tensor=output_tensor, final_state_tensor=final_state_tensor)
+
+
+def _cache_key(
+    x_tensor: torch.Tensor,
+    cu_seqlens_tensor: Optional[torch.Tensor],
+    initial_state_tensor: Optional[torch.Tensor],
+    output_final_state: bool,
+):
+    if not isinstance(x_tensor, torch.Tensor):
+        raise TypeError(f"X must be a torch.Tensor, got {type(x_tensor).__name__}")
+    if x_tensor.ndim != 3:
+        raise ValueError(f"X must be 3D, got shape {tuple(x_tensor.shape)}")
+    batch_size, sequence_length, n_channels = x_tensor.shape
+    if batch_size <= 0 or sequence_length <= 0 or n_channels <= 0:
+        raise ValueError(f"X dimensions must be positive, got shape {tuple(x_tensor.shape)}")
+    total_tokens = batch_size * sequence_length
+    if total_tokens > _MAX_TOTAL_TOKENS:
+        raise ValueError(f"X B*T exceeds the safe Int32 tiled-indexing limit: {total_tokens}")
+    if n_channels > _MAX_SCALAR_GRID_CHANNELS:
+        raise ValueError(f"X D exceeds the supported CUDA grid limit: {n_channels}")
+    if cu_seqlens_tensor is None:
+        num_sequences = batch_size
+    else:
+        if not isinstance(cu_seqlens_tensor, torch.Tensor):
+            raise TypeError("cu_seqlens must be a torch.Tensor or None, " f"got {type(cu_seqlens_tensor).__name__}")
+        if cu_seqlens_tensor.ndim != 1:
+            raise ValueError(f"cu_seqlens must be 1D, got shape {tuple(cu_seqlens_tensor.shape)}")
+        if batch_size != 1:
+            raise ValueError(f"Packed X must have B=1, got B={batch_size}")
+        if cu_seqlens_tensor.shape[0] < 2:
+            raise ValueError("Packed cu_seqlens must contain at least a start and end offset")
+        num_sequences = cu_seqlens_tensor.shape[0] - 1
+        if num_sequences > _MAX_PACKED_SEQUENCES:
+            raise ValueError(f"Packed N exceeds the safe Int32 search limit: {num_sequences}")
+        if num_sequences > total_tokens:
+            raise ValueError(f"Packed N={num_sequences} cannot exceed total_T={total_tokens} " "when every sequence must be non-empty")
+    if n_channels % 8 != 0:
+        if x_tensor.numel() > _INT32_MAX:
+            raise ValueError(f"The scalar-tail path requires X to contain at most {_INT32_MAX} elements")
+        if (initial_state_tensor is not None or output_final_state) and num_sequences * n_channels * 4 > _INT32_MAX:
+            raise ValueError(f"The scalar-tail path requires each state tensor to contain at most {_INT32_MAX} elements")
+    return (
+        x_tensor.device.type,
+        x_tensor.device.index,
+        batch_size,
+        num_sequences,
+        n_channels,
+        cu_seqlens_tensor is not None,
+        initial_state_tensor is not None,
+        bool(output_final_state),
+    )
+
+
+def causal_conv1d_bulk_fwd_wrapper_sm100(
+    x_tensor: torch.Tensor,
+    weight_tensor: torch.Tensor,
+    cu_seqlens_tensor: Optional[torch.Tensor] = None,
+    initial_state_tensor: Optional[torch.Tensor] = None,
+    *,
+    output_final_state: bool = False,
+    current_stream: Optional[cuda.CUstream] = None,
+) -> TupleDict:
+    """Run the SM100 BF16 width-four bulk causal-convolution forward.
+
+    The result always contains ``output_tensor`` and ``final_state_tensor`` in
+    that order.  When ``output_final_state`` is false, the latter is a BF16
+    CUDA sentinel with shape ``(0,)``.  Packed metadata is consumed on device;
+    it must start at zero, end at ``total_T``, and be strictly increasing.
+    """
+
+    for name, tensor in (("X", x_tensor), ("Weight", weight_tensor)):
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(f"{name} must be a torch.Tensor, got {type(tensor).__name__}")
+    if initial_state_tensor is not None and not isinstance(initial_state_tensor, torch.Tensor):
+        raise TypeError("Initial state must be a torch.Tensor or None, " f"got {type(initial_state_tensor).__name__}")
+    if not isinstance(output_final_state, bool):
+        raise TypeError(f"output_final_state must be bool, got {type(output_final_state).__name__}")
+    if not x_tensor.is_cuda:
+        raise ValueError(f"X must be a CUDA tensor, got device {x_tensor.device}")
+
+    grad_inputs = [x_tensor, weight_tensor]
+    if initial_state_tensor is not None:
+        grad_inputs.append(initial_state_tensor)
+    if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in grad_inputs):
+        raise RuntimeError("causal_conv1d_bulk_fwd is inference-only; call it under torch.no_grad()")
+
+    key = _cache_key(
+        x_tensor,
+        cu_seqlens_tensor,
+        initial_state_tensor,
+        output_final_state,
+    )
+    if cu_seqlens_tensor is None:
+        num_sequences = x_tensor.shape[0]
+    else:
+        num_sequences = cu_seqlens_tensor.shape[0] - 1
+
+    with torch.cuda.device(x_tensor.device), _torch_stream_context(current_stream, x_tensor.device):
+        output_tensor = torch.empty_like(x_tensor, memory_format=torch.contiguous_format)
+        if output_final_state:
+            n_channels = x_tensor.shape[2]
+            final_state_tensor = torch.empty(
+                (num_sequences, n_channels, 4),
+                dtype=torch.bfloat16,
+                device=x_tensor.device,
+            )
+        else:
+            final_state_tensor = torch.empty((0,), dtype=torch.bfloat16, device=x_tensor.device)
+
+        api = _API_CACHE.get(key)
+        if api is None:
+            with _API_CACHE_LOCK:
+                api = _API_CACHE.get(key)
+                if api is None:
+                    api = CausalConv1dBulkFwdSm100(
+                        sample_x=x_tensor,
+                        sample_weight=weight_tensor,
+                        sample_output=output_tensor,
+                        sample_cu_seqlens=cu_seqlens_tensor,
+                        sample_initial_state=initial_state_tensor,
+                        sample_final_state=final_state_tensor if output_final_state else None,
+                    )
+                    api.check_support()
+                    api.compile()
+                    if len(_API_CACHE) >= _API_CACHE_CAPACITY:
+                        _API_CACHE.pop(next(iter(_API_CACHE)))
+                    _API_CACHE[key] = api
+
+        result = api.execute(
+            x_tensor=x_tensor,
+            weight_tensor=weight_tensor,
+            output_tensor=output_tensor,
+            cu_seqlens_tensor=cu_seqlens_tensor,
+            initial_state_tensor=initial_state_tensor,
+            final_state_tensor=final_state_tensor if output_final_state else None,
+            current_stream=current_stream,
+        )
+        if not output_final_state:
+            result["final_state_tensor"] = final_state_tensor
+        return result

--- a/python/cudnn/causal_conv1d_bulk_sm100/api.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/api.py
@@ -20,6 +20,11 @@ from cutlass.cute.runtime import make_fake_stream
 import torch
 
 from cudnn.api_base import APIBase, TensorDesc, TupleDict
+from cudnn._causal_conv1d_bulk_arch import (
+    FUNCTIONAL_COMPUTE_CAPABILITIES,
+    is_functional_arch,
+    uses_vec8_schedule,
+)
 from cudnn.frost.buffers import CUTEDSL_MIN_VERSION, cutedsl_state, cutedsl_too_old
 
 _API_CACHE = {}
@@ -32,37 +37,6 @@ _MAX_TOTAL_TOKENS = _INT32_MAX - 15
 # Packed kernels use ``(lower + upper) // 2`` during their device-side search.
 _MAX_PACKED_SEQUENCES = _INT32_MAX // 2
 _MAX_SCALAR_GRID_CHANNELS = 256 * 65535
-_FUNCTIONAL_COMPUTE_CAPABILITIES = frozenset(
-    {
-        (8, 0),
-        (8, 6),
-        (8, 7),
-        (8, 9),
-        (9, 0),
-        (10, 0),
-        (10, 3),
-        (11, 0),
-        (12, 0),
-        (12, 1),
-    }
-)
-_F32X2_COMPUTE_CAPABILITIES = frozenset(
-    {
-        (10, 0),
-        (10, 3),
-        (11, 0),
-        (12, 0),
-        (12, 1),
-    }
-)
-
-
-def _is_functional_arch(compute_capability: tuple[int, int]) -> bool:
-    return compute_capability in _FUNCTIONAL_COMPUTE_CAPABILITIES
-
-
-def _uses_vec8_schedule(compute_capability: tuple[int, int], n_channels: int) -> bool:
-    return compute_capability in _F32X2_COMPUTE_CAPABILITIES and n_channels % 8 == 0
 
 
 @contextmanager
@@ -336,12 +310,12 @@ class CausalConv1dBulkFwdSm100(APIBase):
         self._runtime_error_if(not torch.cuda.is_available(), "CUDA is not available")
         compute_capability = torch.cuda.get_device_capability(self.x_desc.device)
         self._runtime_error_if(
-            not _is_functional_arch(compute_capability),
+            not is_functional_arch(compute_capability),
             "CausalConv1dBulkFwdSm100 does not support compute capability "
             f"{compute_capability[0]}.{compute_capability[1]}; supported capabilities are "
-            f"{sorted(_FUNCTIONAL_COMPUTE_CAPABILITIES)}",
+            f"{sorted(FUNCTIONAL_COMPUTE_CAPABILITIES)}",
         )
-        use_vec8_schedule = _uses_vec8_schedule(compute_capability, n_channels)
+        use_vec8_schedule = uses_vec8_schedule(compute_capability, n_channels)
         if not use_vec8_schedule:
             self._value_error_if(
                 batch_size * sequence_length * n_channels > _INT32_MAX,
@@ -581,7 +555,7 @@ def _cache_key(
         if num_sequences > total_tokens:
             raise ValueError(f"Packed N={num_sequences} cannot exceed total_T={total_tokens} " "when every sequence must be non-empty")
     compute_capability = torch.cuda.get_device_capability(x_tensor.device)
-    use_vec8_schedule = _uses_vec8_schedule(compute_capability, n_channels)
+    use_vec8_schedule = uses_vec8_schedule(compute_capability, n_channels)
     if not use_vec8_schedule:
         if x_tensor.numel() > _INT32_MAX:
             raise ValueError(f"The scalar schedule requires X to contain at most {_INT32_MAX} elements")

--- a/python/cudnn/causal_conv1d_bulk_sm100/api.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/api.py
@@ -112,8 +112,8 @@ class CausalConv1dBulkFwdSm100(APIBase):
     ``B == 1`` and a CUDA int32 ``cu_seqlens[N + 1]`` tensor.  Optional initial
     and final states use the full-width ``[N, D, 4]`` decode-cache layout.
 
-    This first slice has no bias and always applies SiLU.  It is inference-only
-    until the matching backward primitive is available.
+    An optional contiguous BF16 ``bias[D]`` is added before SiLU.  The operation
+    remains inference-only until the matching backward primitive exists.
     """
 
     def __init__(
@@ -124,6 +124,8 @@ class CausalConv1dBulkFwdSm100(APIBase):
         sample_cu_seqlens: Optional[torch.Tensor] = None,
         sample_initial_state: Optional[torch.Tensor] = None,
         sample_final_state: Optional[torch.Tensor] = None,
+        *,
+        sample_bias: Optional[torch.Tensor] = None,
     ):
         super().__init__()
         self._warn_experimental_api()
@@ -136,6 +138,7 @@ class CausalConv1dBulkFwdSm100(APIBase):
             if not isinstance(sample, torch.Tensor):
                 raise TypeError(f"{name} must be a torch.Tensor, got {type(sample).__name__}")
         for name, sample in (
+            ("sample_bias", sample_bias),
             ("sample_cu_seqlens", sample_cu_seqlens),
             ("sample_initial_state", sample_initial_state),
             ("sample_final_state", sample_final_state),
@@ -145,6 +148,7 @@ class CausalConv1dBulkFwdSm100(APIBase):
 
         self.x_desc = self._make_tensor_desc(sample_x, name="sample_x")
         self.weight_desc = self._make_tensor_desc(sample_weight, name="sample_weight")
+        self.bias_desc = self._make_tensor_desc(sample_bias, name="sample_bias")
         self.output_desc = self._make_tensor_desc(sample_output, name="sample_output")
         self.cu_seqlens_desc = self._make_tensor_desc(sample_cu_seqlens, name="sample_cu_seqlens")
         self.initial_state_desc = self._make_tensor_desc(sample_initial_state, name="sample_initial_state")
@@ -160,6 +164,8 @@ class CausalConv1dBulkFwdSm100(APIBase):
         }
         if sample_cu_seqlens is not None:
             self._sample_alignment_remainders["cu_seqlens"] = sample_cu_seqlens.data_ptr() % 4
+        if sample_bias is not None:
+            self._sample_alignment_remainders["Bias"] = sample_bias.data_ptr() % 16
         if sample_initial_state is not None:
             self._sample_alignment_remainders["Initial state"] = sample_initial_state.data_ptr() % 16
         if sample_final_state is not None:
@@ -199,6 +205,8 @@ class CausalConv1dBulkFwdSm100(APIBase):
         self._require_rank(self.x_desc, 3, "X")
         self._require_rank(self.weight_desc, 2, "Weight")
         self._require_rank(self.output_desc, 3, "Output")
+        if self.bias_desc is not None:
+            self._require_rank(self.bias_desc, 1, "Bias")
         if self.cu_seqlens_desc is not None:
             self._require_rank(self.cu_seqlens_desc, 1, "cu_seqlens")
         if self.initial_state_desc is not None:
@@ -237,6 +245,8 @@ class CausalConv1dBulkFwdSm100(APIBase):
             )
 
         self._check_tensor_shape(self.weight_desc, (n_channels, 4), "Weight")
+        if self.bias_desc is not None:
+            self._check_tensor_shape(self.bias_desc, (n_channels,), "Bias")
         self._check_tensor_shape(self.output_desc, (batch_size, sequence_length, n_channels), "Output")
         if self.cu_seqlens_desc is not None:
             self._check_tensor_shape(self.cu_seqlens_desc, (num_sequences + 1,), "cu_seqlens")
@@ -257,6 +267,13 @@ class CausalConv1dBulkFwdSm100(APIBase):
             name="Weight",
             extra_error_msg="Weight must be [D, 4] contiguous",
         )
+        if self.bias_desc is not None:
+            self._check_tensor_stride(
+                self.bias_desc,
+                stride=(1,),
+                name="Bias",
+                extra_error_msg="Bias must be [D] contiguous",
+            )
         self._check_tensor_stride(
             self.output_desc,
             stride=(sequence_length * n_channels, n_channels, 1),
@@ -277,6 +294,7 @@ class CausalConv1dBulkFwdSm100(APIBase):
         for name, desc in (
             ("X", self.x_desc),
             ("Weight", self.weight_desc),
+            ("Bias", self.bias_desc),
             ("Output", self.output_desc),
             ("Initial state", self.initial_state_desc),
             ("Final state", self.final_state_desc),
@@ -296,6 +314,7 @@ class CausalConv1dBulkFwdSm100(APIBase):
         descs = [
             ("X", self.x_desc),
             ("Weight", self.weight_desc),
+            ("Bias", self.bias_desc),
             ("Output", self.output_desc),
             ("cu_seqlens", self.cu_seqlens_desc),
             ("Initial state", self.initial_state_desc),
@@ -353,6 +372,7 @@ class CausalConv1dBulkFwdSm100(APIBase):
             assumed_align=16,
         )
         fake_weight = self._make_fake_cute_tensor_from_desc(self.weight_desc, assumed_align=16)
+        fake_bias = self._make_fake_cute_tensor_from_desc(self.bias_desc, assumed_align=16)
         fake_initial_state = self._make_fake_cute_tensor_from_desc(self.initial_state_desc, assumed_align=16)
         fake_cu_seqlens = self._make_fake_cute_tensor_from_desc(self.cu_seqlens_desc, assumed_align=4)
         fake_output = self._make_fake_cute_tensor(
@@ -371,6 +391,7 @@ class CausalConv1dBulkFwdSm100(APIBase):
                 kernel,
                 fake_x,
                 fake_weight,
+                fake_bias,
                 fake_initial_state,
                 fake_cu_seqlens,
                 fake_output,
@@ -427,6 +448,8 @@ class CausalConv1dBulkFwdSm100(APIBase):
         initial_state_tensor: Optional[torch.Tensor] = None,
         final_state_tensor: Optional[torch.Tensor] = None,
         current_stream: Optional[cuda.CUstream] = None,
+        *,
+        bias_tensor: Optional[torch.Tensor] = None,
     ) -> TupleDict:
         self._runtime_error_if(
             self._compiled_kernel is None,
@@ -444,6 +467,7 @@ class CausalConv1dBulkFwdSm100(APIBase):
         self._validate_runtime_static_tensor(weight_tensor, self.weight_desc, "Weight")
 
         optional_tensors = (
+            ("Bias", bias_tensor, self.bias_desc),
             ("cu_seqlens", cu_seqlens_tensor, self.cu_seqlens_desc),
             ("Initial state", initial_state_tensor, self.initial_state_desc),
             ("Final state", final_state_tensor, self.final_state_desc),
@@ -457,6 +481,7 @@ class CausalConv1dBulkFwdSm100(APIBase):
         for name, tensor, alignment in (
             ("X", x_tensor, 16),
             ("Weight", weight_tensor, 16),
+            ("Bias", bias_tensor, 16),
             ("Output", output_tensor, 16),
             ("cu_seqlens", cu_seqlens_tensor, 4),
             ("Initial state", initial_state_tensor, 16),
@@ -466,12 +491,16 @@ class CausalConv1dBulkFwdSm100(APIBase):
                 _require_storage_alignment(tensor, alignment, name)
 
         grad_inputs = [x_tensor, weight_tensor]
+        if bias_tensor is not None:
+            grad_inputs.append(bias_tensor)
         if initial_state_tensor is not None:
             grad_inputs.append(initial_state_tensor)
         if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in grad_inputs):
             raise RuntimeError("causal_conv1d_bulk_fwd is inference-only; call it under torch.no_grad()")
 
         read_tensors = [x_tensor, weight_tensor]
+        if bias_tensor is not None:
+            read_tensors.append(bias_tensor)
         if cu_seqlens_tensor is not None:
             read_tensors.append(cu_seqlens_tensor)
         if initial_state_tensor is not None:
@@ -497,6 +526,7 @@ class CausalConv1dBulkFwdSm100(APIBase):
         self._compiled_kernel(
             flat_x,
             weight_tensor,
+            bias_tensor,
             initial_state_tensor,
             cu_seqlens_tensor,
             flat_output,
@@ -510,6 +540,7 @@ class CausalConv1dBulkFwdSm100(APIBase):
             (
                 x_tensor,
                 weight_tensor,
+                bias_tensor,
                 output_tensor,
                 cu_seqlens_tensor,
                 initial_state_tensor,
@@ -522,6 +553,7 @@ class CausalConv1dBulkFwdSm100(APIBase):
 
 def _cache_key(
     x_tensor: torch.Tensor,
+    bias_tensor: Optional[torch.Tensor],
     cu_seqlens_tensor: Optional[torch.Tensor],
     initial_state_tensor: Optional[torch.Tensor],
     output_final_state: bool,
@@ -569,6 +601,7 @@ def _cache_key(
         batch_size,
         num_sequences,
         n_channels,
+        bias_tensor is not None,
         cu_seqlens_tensor is not None,
         initial_state_tensor is not None,
         bool(output_final_state),
@@ -583,6 +616,7 @@ def causal_conv1d_bulk_fwd_wrapper_sm100(
     *,
     output_final_state: bool = False,
     current_stream: Optional[cuda.CUstream] = None,
+    bias_tensor: Optional[torch.Tensor] = None,
 ) -> TupleDict:
     """Run the BF16 width-four bulk causal-convolution forward.
 
@@ -597,12 +631,16 @@ def causal_conv1d_bulk_fwd_wrapper_sm100(
             raise TypeError(f"{name} must be a torch.Tensor, got {type(tensor).__name__}")
     if initial_state_tensor is not None and not isinstance(initial_state_tensor, torch.Tensor):
         raise TypeError("Initial state must be a torch.Tensor or None, " f"got {type(initial_state_tensor).__name__}")
+    if bias_tensor is not None and not isinstance(bias_tensor, torch.Tensor):
+        raise TypeError("Bias must be a torch.Tensor or None, " f"got {type(bias_tensor).__name__}")
     if not isinstance(output_final_state, bool):
         raise TypeError(f"output_final_state must be bool, got {type(output_final_state).__name__}")
     if not x_tensor.is_cuda:
         raise ValueError(f"X must be a CUDA tensor, got device {x_tensor.device}")
 
     grad_inputs = [x_tensor, weight_tensor]
+    if bias_tensor is not None:
+        grad_inputs.append(bias_tensor)
     if initial_state_tensor is not None:
         grad_inputs.append(initial_state_tensor)
     if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in grad_inputs):
@@ -610,6 +648,7 @@ def causal_conv1d_bulk_fwd_wrapper_sm100(
 
     key = _cache_key(
         x_tensor,
+        bias_tensor,
         cu_seqlens_tensor,
         initial_state_tensor,
         output_final_state,
@@ -640,6 +679,7 @@ def causal_conv1d_bulk_fwd_wrapper_sm100(
                         sample_x=x_tensor,
                         sample_weight=weight_tensor,
                         sample_output=output_tensor,
+                        sample_bias=bias_tensor,
                         sample_cu_seqlens=cu_seqlens_tensor,
                         sample_initial_state=initial_state_tensor,
                         sample_final_state=final_state_tensor if output_final_state else None,
@@ -658,6 +698,7 @@ def causal_conv1d_bulk_fwd_wrapper_sm100(
             initial_state_tensor=initial_state_tensor,
             final_state_tensor=final_state_tensor if output_final_state else None,
             current_stream=current_stream,
+            bias_tensor=bias_tensor,
         )
         if not output_final_state:
             result["final_state_tensor"] = final_state_tensor

--- a/python/cudnn/causal_conv1d_bulk_sm100/kernel.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/kernel.py
@@ -1,0 +1,569 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Correctness-first SM100 bulk causal-convolution forward kernel.
+
+This is an independent CuTe DSL implementation of the width-four, BF16,
+depthwise causal-convolution contract documented by cuDNN Frontend.  FLA's
+short-convolution module and Dao-AILab's public causal-conv1d API were consulted
+only as semantic and interface references; no external kernel source is
+included here.
+
+The kernel consumes contiguous, flattened ``[total_tokens, D]`` input and
+output views.  A dense launch derives sequence boundaries from the host-provided
+``tokens_per_sequence`` scalar.  A packed launch reads ``cu_seqlens`` in the
+kernel, so neither compilation nor execution needs a device-to-host metadata
+read.  Optional initial and final states use the full ``[N, D, 4]`` layout that
+can be handed directly to the decode-update primitive.
+
+The schedule deliberately stays small and auditable.  Channel extents divisible
+by eight use a 128-thread fast path in which each thread owns eight adjacent
+channels and moves each input/output row as one aligned 16-byte transaction.
+The fallback keeps the original scalar 256-channel schedule for arbitrary
+channel tails.  Both schedules retain a rolling three-value causal window, so
+every subsequent output loads only the current token.  The CTA derives its
+first sequence interval once and advances it whenever the token loop crosses a
+boundary, resetting the window from that sequence's initial state or zeros.
+Thus a packed tile may safely straddle any number of sequences.  Packed
+launches first run a one-CTA device validator which traps unless the prefix
+sums start at zero, end at the runtime token total, and are strictly increasing.
+
+Callers must provide non-overlapping input, output, and state storage.  In
+particular, in-place output is unsafe because token CTAs execute independently
+and may still need earlier input tokens.
+"""
+
+from typing import Optional
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.arch.nvvm_wrappers import inline_ptx
+
+from cudnn.frost.tile_dsl.pointwise import (
+    f16x2_to_f32,
+    ffma2,
+    fmul2,
+    fp32_to_fp16,
+    opaque_f32_zero,
+    sigmoid,
+    sigmoid2,
+)
+
+THREADS = 256
+TOKENS_PER_CTA = 16
+VEC_THREADS = 128
+VEC_CHANNELS_PER_THREAD = 8
+VEC_CHANNELS_PER_CTA = VEC_THREADS * VEC_CHANNELS_PER_THREAD
+VEC_TOKENS_PER_CTA = 8
+WIDTH = 4
+
+
+@cute.jit
+def _load_bf16x8(address):
+    """Load eight aligned BF16 values as four packed words."""
+
+    word_0, word_1, word_2, word_3 = inline_ptx(
+        "ld.global.v4.b32 {$0, $1, $2, $3}, [$4];",
+        write_only_types=[cutlass.Int32, cutlass.Int32, cutlass.Int32, cutlass.Int32],
+        read_only_args=[address],
+    )
+    value_0, value_1 = f16x2_to_f32(word_0, dtype=cutlass.BFloat16)
+    value_2, value_3 = f16x2_to_f32(word_1, dtype=cutlass.BFloat16)
+    value_4, value_5 = f16x2_to_f32(word_2, dtype=cutlass.BFloat16)
+    value_6, value_7 = f16x2_to_f32(word_3, dtype=cutlass.BFloat16)
+    return value_0, value_1, value_2, value_3, value_4, value_5, value_6, value_7
+
+
+@cute.jit
+def _store_bf16x8(address, value_0, value_1, value_2, value_3, value_4, value_5, value_6, value_7):
+    """Store eight BF16 values with one aligned 16-byte transaction."""
+
+    word_0 = fp32_to_fp16(value_0, value_1, dtype=cutlass.BFloat16)
+    word_1 = fp32_to_fp16(value_2, value_3, dtype=cutlass.BFloat16)
+    word_2 = fp32_to_fp16(value_4, value_5, dtype=cutlass.BFloat16)
+    word_3 = fp32_to_fp16(value_6, value_7, dtype=cutlass.BFloat16)
+    inline_ptx(
+        "st.global.v4.b32 [$0], {$1, $2, $3, $4};",
+        read_only_args=[address, word_0, word_1, word_2, word_3],
+    )
+
+
+@cute.kernel
+def _validate_cu_seqlens_kernel(
+    cu_seqlens: cute.Tensor,
+    num_sequences: cutlass.Int32,
+    total_tokens: cutlass.Int32,
+) -> None:
+    """Fail closed on malformed packed boundaries without a host read.
+
+    The CUDA error is asynchronous and, like the decode-update index guards,
+    is intentionally implemented with PTX ``trap``.  The validator and the
+    convolution launch on the same stream, so an invalid metadata launch cannot
+    proceed into tensor reads on that stream.
+    """
+
+    tidx = cutlass.Int32(cute.arch.thread_idx()[0])
+    if tidx == cutlass.Int32(0):
+        inline_ptx(
+            "trap;",
+            predicate=cutlass.Int32(cu_seqlens[0]) != cutlass.Int32(0),
+        )
+        inline_ptx(
+            "trap;",
+            predicate=cutlass.Int32(cu_seqlens[num_sequences]) != total_tokens,
+        )
+
+    boundary = tidx
+    while boundary < num_sequences:
+        left = cutlass.Int32(cu_seqlens[boundary])
+        right = cutlass.Int32(cu_seqlens[boundary + cutlass.Int32(1)])
+        inline_ptx("trap;", predicate=right <= left)
+        boundary += cutlass.Int32(THREADS)
+
+
+@cute.kernel
+def _causal_conv1d_bulk_fwd_kernel(
+    x: cute.Tensor,
+    weight: cute.Tensor,
+    initial_state: Optional[cute.Tensor],
+    cu_seqlens: Optional[cute.Tensor],
+    output: cute.Tensor,
+    final_state: Optional[cute.Tensor],
+    num_sequences: cutlass.Int32,
+    tokens_per_sequence: cutlass.Int32,
+    n_channels: cutlass.Int32,
+) -> None:
+    """Emit one token tile by 256 channels and final states at sequence ends.
+
+    ``cu_seqlens`` is ``None``-specialized for dense input.  For packed input,
+    lane zero of each warp performs one device-side binary search at the tile
+    start and broadcasts the resulting sequence interval.  The token loop
+    advances that interval at boundaries.  Every causal read is guarded by the
+    local position inside the current interval, preventing reads from a
+    preceding packed sequence.  A channel thread keeps its four weights and a
+    three-value causal window in registers across the token tile.
+    """
+
+    token_tile = cutlass.Int32(cute.arch.block_idx()[0])
+    channel_tile = cutlass.Int32(cute.arch.block_idx()[1])
+    tidx = cutlass.Int32(cute.arch.thread_idx()[0])
+    channel = channel_tile * cutlass.Int32(THREADS) + tidx
+    first_token = token_tile * cutlass.Int32(TOKENS_PER_CTA)
+    total_tokens = cutlass.Int32(x.shape[0])
+
+    weight_0 = cutlass.Float32(0.0)
+    weight_1 = cutlass.Float32(0.0)
+    weight_2 = cutlass.Float32(0.0)
+    weight_3 = cutlass.Float32(0.0)
+    if channel < n_channels:
+        # Vectorize the naturally contiguous four-tap weight row.  Its address
+        # is always eight-byte aligned for contiguous BF16 [D, 4] storage.
+        weight_element = cutlass.Int64(channel) * cutlass.Int64(weight.stride[0])
+        weight_address = weight.iterator.toint() + weight_element * cutlass.Int64(2)
+        weight_01, weight_23 = inline_ptx(
+            "ld.global.v2.b32 {$0, $1}, [$2];",
+            write_only_types=[cutlass.Int32, cutlass.Int32],
+            read_only_args=[weight_address],
+        )
+        weight_0, weight_1 = f16x2_to_f32(weight_01, dtype=cutlass.BFloat16)
+        weight_2, weight_3 = f16x2_to_f32(weight_23, dtype=cutlass.BFloat16)
+
+    sequence = cutlass.Int32(0)
+    sequence_start = cutlass.Int32(0)
+    sequence_end = cutlass.Int32(0)
+    if cutlass.const_expr(cu_seqlens is None):
+        sequence = first_token // tokens_per_sequence
+        sequence_start = sequence * tokens_per_sequence
+        sequence_end = sequence_start + tokens_per_sequence
+    else:
+        # All lanes in a warp process the same token tile.  Search once per
+        # warp and broadcast before the channel-tail predicate, so all lanes
+        # named by shuffle_sync's mask participate.
+        if cute.arch.lane_idx() == cutlass.Int32(0):
+            lower = cutlass.Int32(0)
+            upper = num_sequences
+            while lower + cutlass.Int32(1) < upper:
+                middle = (lower + upper) // cutlass.Int32(2)
+                if first_token < cutlass.Int32(cu_seqlens[middle]):
+                    upper = middle
+                else:
+                    lower = middle
+            sequence = lower
+            sequence_start = cutlass.Int32(cu_seqlens[sequence])
+            sequence_end = cutlass.Int32(cu_seqlens[sequence + cutlass.Int32(1)])
+
+        sequence = cute.arch.shuffle_sync(sequence, 0)
+        sequence_start = cute.arch.shuffle_sync(sequence_start, 0)
+        sequence_end = cute.arch.shuffle_sync(sequence_end, 0)
+
+    history_0 = cutlass.Float32(0.0)
+    history_1 = cutlass.Float32(0.0)
+    history_2 = cutlass.Float32(0.0)
+    if channel < n_channels:
+        local_first_token = first_token - sequence_start
+
+        # Initialize the three visible values immediately preceding the tile.
+        # Near a sequence start, the missing prefix comes from initial-state
+        # lanes 1..3; without initial state it remains zero.
+        if local_first_token >= cutlass.Int32(3):
+            history_0 = x[first_token - cutlass.Int32(3), channel].to(cutlass.Float32)
+        elif cutlass.const_expr(initial_state is not None):
+            history_0 = initial_state[sequence, channel, local_first_token + cutlass.Int32(1)].to(cutlass.Float32)
+
+        if local_first_token >= cutlass.Int32(2):
+            history_1 = x[first_token - cutlass.Int32(2), channel].to(cutlass.Float32)
+        elif cutlass.const_expr(initial_state is not None):
+            history_1 = initial_state[sequence, channel, local_first_token + cutlass.Int32(2)].to(cutlass.Float32)
+
+        if local_first_token >= cutlass.Int32(1):
+            history_2 = x[first_token - cutlass.Int32(1), channel].to(cutlass.Float32)
+        elif cutlass.const_expr(initial_state is not None):
+            history_2 = initial_state[sequence, channel, cutlass.Int32(3)].to(cutlass.Float32)
+
+    tile_end = first_token + cutlass.Int32(TOKENS_PER_CTA)
+    if tile_end > total_tokens:
+        tile_end = total_tokens
+
+    token = first_token
+    while token < tile_end:
+        # Strictly positive sequence lengths guarantee that incrementing one
+        # interval is sufficient when the unit-stride token loop hits an end.
+        if token == sequence_end:
+            sequence += cutlass.Int32(1)
+            sequence_start = sequence_end
+            if cutlass.const_expr(cu_seqlens is None):
+                sequence_end += tokens_per_sequence
+            else:
+                sequence_end = cutlass.Int32(cu_seqlens[sequence + cutlass.Int32(1)])
+
+            if channel < n_channels:
+                history_0 = cutlass.Float32(0.0)
+                history_1 = cutlass.Float32(0.0)
+                history_2 = cutlass.Float32(0.0)
+                if cutlass.const_expr(initial_state is not None):
+                    history_0 = initial_state[sequence, channel, cutlass.Int32(1)].to(cutlass.Float32)
+                    history_1 = initial_state[sequence, channel, cutlass.Int32(2)].to(cutlass.Float32)
+                    history_2 = initial_state[sequence, channel, cutlass.Int32(3)].to(cutlass.Float32)
+
+        if channel < n_channels:
+            current = x[token, channel].to(cutlass.Float32)
+            acc = history_0 * weight_0
+            acc = acc + history_1 * weight_1
+            acc = acc + history_2 * weight_2
+            acc = acc + current * weight_3
+            output[token, channel] = (acc * sigmoid(acc)).to(cutlass.BFloat16)
+
+            if cutlass.const_expr(final_state is not None):
+                if token + cutlass.Int32(1) == sequence_end:
+                    final_state[sequence, channel, cutlass.Int32(0)] = history_0.to(cutlass.BFloat16)
+                    final_state[sequence, channel, cutlass.Int32(1)] = history_1.to(cutlass.BFloat16)
+                    final_state[sequence, channel, cutlass.Int32(2)] = history_2.to(cutlass.BFloat16)
+                    final_state[sequence, channel, cutlass.Int32(3)] = current.to(cutlass.BFloat16)
+
+            history_0 = history_1
+            history_1 = history_2
+            history_2 = current
+
+        token += cutlass.Int32(1)
+
+
+@cute.kernel
+def _causal_conv1d_bulk_vec8_fwd_kernel(
+    x: cute.Tensor,
+    weight: cute.Tensor,
+    initial_state: Optional[cute.Tensor],
+    cu_seqlens: Optional[cute.Tensor],
+    output: cute.Tensor,
+    final_state: Optional[cute.Tensor],
+    num_sequences: cutlass.Int32,
+    tokens_per_sequence: cutlass.Int32,
+    n_channels: cutlass.Int32,
+) -> None:
+    """Emit eight-token tiles with one aligned eight-channel vector per thread.
+
+    This specialization is launched only when the compile-time channel extent
+    is divisible by eight.  The API guarantees 16-byte base alignment and all
+    row strides are then multiples of eight BF16 elements.  Consequently every
+    valid vector below is aligned; ``channel_base < n_channels`` also proves the
+    entire eight-channel group is in bounds.
+    """
+
+    token_tile = cutlass.Int32(cute.arch.block_idx()[0])
+    channel_tile = cutlass.Int32(cute.arch.block_idx()[1])
+    tidx = cutlass.Int32(cute.arch.thread_idx()[0])
+    channel_base = channel_tile * cutlass.Int32(VEC_CHANNELS_PER_CTA) + tidx * cutlass.Int32(VEC_CHANNELS_PER_THREAD)
+    first_token = token_tile * cutlass.Int32(VEC_TOKENS_PER_CTA)
+    total_tokens = cutlass.Int32(x.shape[0])
+    valid_channel_group = channel_base < n_channels
+
+    # Four FP32 vectors are the four causal taps for eight channels.  Weight
+    # storage is [D, 4], so each 16-byte load naturally covers two complete
+    # adjacent channel rows and is transposed into the tap-major registers.
+    weight_0 = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
+    weight_1 = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
+    weight_2 = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
+    weight_3 = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
+    zero = opaque_f32_zero()
+    for channel_offset in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD):
+        weight_0[channel_offset] = zero
+        weight_1[channel_offset] = zero
+        weight_2[channel_offset] = zero
+        weight_3[channel_offset] = zero
+
+    if valid_channel_group:
+        for channel_pair in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD // 2):
+            pair_channel = channel_base + cutlass.Int32(2 * channel_pair)
+            weight_element = cutlass.Int64(pair_channel) * cutlass.Int64(weight.stride[0])
+            weight_address = weight.iterator.toint() + weight_element * cutlass.Int64(2)
+            values = _load_bf16x8(weight_address)
+            channel_offset = 2 * channel_pair
+            weight_0[channel_offset] = values[0]
+            weight_1[channel_offset] = values[1]
+            weight_2[channel_offset] = values[2]
+            weight_3[channel_offset] = values[3]
+            weight_0[channel_offset + 1] = values[4]
+            weight_1[channel_offset + 1] = values[5]
+            weight_2[channel_offset + 1] = values[6]
+            weight_3[channel_offset + 1] = values[7]
+
+    sequence = cutlass.Int32(0)
+    sequence_start = cutlass.Int32(0)
+    sequence_end = cutlass.Int32(0)
+    if cutlass.const_expr(cu_seqlens is None):
+        sequence = first_token // tokens_per_sequence
+        sequence_start = sequence * tokens_per_sequence
+        sequence_end = sequence_start + tokens_per_sequence
+    else:
+        # Search and shuffle before the channel predicate: even threads whose
+        # vector falls beyond the final channel tile must participate in the
+        # full-warp shuffle mask.
+        if cute.arch.lane_idx() == cutlass.Int32(0):
+            lower = cutlass.Int32(0)
+            upper = num_sequences
+            while lower + cutlass.Int32(1) < upper:
+                middle = (lower + upper) // cutlass.Int32(2)
+                if first_token < cutlass.Int32(cu_seqlens[middle]):
+                    upper = middle
+                else:
+                    lower = middle
+            sequence = lower
+            sequence_start = cutlass.Int32(cu_seqlens[sequence])
+            sequence_end = cutlass.Int32(cu_seqlens[sequence + cutlass.Int32(1)])
+
+        sequence = cute.arch.shuffle_sync(sequence, 0)
+        sequence_start = cute.arch.shuffle_sync(sequence_start, 0)
+        sequence_end = cute.arch.shuffle_sync(sequence_end, 0)
+
+    history_0 = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
+    history_1 = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
+    history_2 = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
+    current = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
+    output_values = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
+    for channel_offset in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD):
+        history_0[channel_offset] = zero
+        history_1[channel_offset] = zero
+        history_2[channel_offset] = zero
+        current[channel_offset] = zero
+        output_values[channel_offset] = zero
+
+    if valid_channel_group:
+        local_first_token = first_token - sequence_start
+
+        if local_first_token >= cutlass.Int32(3):
+            x_element = cutlass.Int64(first_token - cutlass.Int32(3)) * cutlass.Int64(x.stride[0]) + cutlass.Int64(channel_base)
+            values = _load_bf16x8(x.iterator.toint() + x_element * cutlass.Int64(2))
+            for channel_offset in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD):
+                history_0[channel_offset] = values[channel_offset]
+
+        if local_first_token >= cutlass.Int32(2):
+            x_element = cutlass.Int64(first_token - cutlass.Int32(2)) * cutlass.Int64(x.stride[0]) + cutlass.Int64(channel_base)
+            values = _load_bf16x8(x.iterator.toint() + x_element * cutlass.Int64(2))
+            for channel_offset in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD):
+                history_1[channel_offset] = values[channel_offset]
+
+        if local_first_token >= cutlass.Int32(1):
+            x_element = cutlass.Int64(first_token - cutlass.Int32(1)) * cutlass.Int64(x.stride[0]) + cutlass.Int64(channel_base)
+            values = _load_bf16x8(x.iterator.toint() + x_element * cutlass.Int64(2))
+            for channel_offset in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD):
+                history_2[channel_offset] = values[channel_offset]
+
+        # A single 16-byte state load per channel pair provides all four taps.
+        # Only the missing prefix is copied; input rows already loaded above
+        # remain authoritative farther into a sequence.
+        if cutlass.const_expr(initial_state is not None):
+            if local_first_token < cutlass.Int32(3):
+                for channel_pair in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD // 2):
+                    pair_channel = channel_base + cutlass.Int32(2 * channel_pair)
+                    state_element = cutlass.Int64(sequence) * cutlass.Int64(initial_state.stride[0]) + cutlass.Int64(pair_channel) * cutlass.Int64(
+                        initial_state.stride[1]
+                    )
+                    values = _load_bf16x8(initial_state.iterator.toint() + state_element * cutlass.Int64(2))
+                    channel_offset = 2 * channel_pair
+                    if local_first_token == cutlass.Int32(0):
+                        history_0[channel_offset] = values[1]
+                        history_1[channel_offset] = values[2]
+                        history_2[channel_offset] = values[3]
+                        history_0[channel_offset + 1] = values[5]
+                        history_1[channel_offset + 1] = values[6]
+                        history_2[channel_offset + 1] = values[7]
+                    elif local_first_token == cutlass.Int32(1):
+                        history_0[channel_offset] = values[2]
+                        history_1[channel_offset] = values[3]
+                        history_0[channel_offset + 1] = values[6]
+                        history_1[channel_offset + 1] = values[7]
+                    else:
+                        history_0[channel_offset] = values[3]
+                        history_0[channel_offset + 1] = values[7]
+
+    tile_end = first_token + cutlass.Int32(VEC_TOKENS_PER_CTA)
+    if tile_end > total_tokens:
+        tile_end = total_tokens
+
+    # This must remain a genuine runtime loop.  A constexpr-bounded Python
+    # while expands every token body and sharply inflates PTX/SASS and register
+    # liveness for larger token tiles.
+    for token in cutlass.range(first_token, tile_end, 1, unroll=1):
+        if token == sequence_end:
+            sequence += cutlass.Int32(1)
+            sequence_start = sequence_end
+            if cutlass.const_expr(cu_seqlens is None):
+                sequence_end += tokens_per_sequence
+            else:
+                sequence_end = cutlass.Int32(cu_seqlens[sequence + cutlass.Int32(1)])
+
+            if valid_channel_group:
+                for channel_offset in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD):
+                    history_0[channel_offset] = zero
+                    history_1[channel_offset] = zero
+                    history_2[channel_offset] = zero
+                if cutlass.const_expr(initial_state is not None):
+                    for channel_pair in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD // 2):
+                        pair_channel = channel_base + cutlass.Int32(2 * channel_pair)
+                        state_element = cutlass.Int64(sequence) * cutlass.Int64(initial_state.stride[0]) + cutlass.Int64(pair_channel) * cutlass.Int64(
+                            initial_state.stride[1]
+                        )
+                        values = _load_bf16x8(initial_state.iterator.toint() + state_element * cutlass.Int64(2))
+                        channel_offset = 2 * channel_pair
+                        history_0[channel_offset] = values[1]
+                        history_1[channel_offset] = values[2]
+                        history_2[channel_offset] = values[3]
+                        history_0[channel_offset + 1] = values[5]
+                        history_1[channel_offset + 1] = values[6]
+                        history_2[channel_offset + 1] = values[7]
+
+        if valid_channel_group:
+            x_element = cutlass.Int64(token) * cutlass.Int64(x.stride[0]) + cutlass.Int64(channel_base)
+            values = _load_bf16x8(x.iterator.toint() + x_element * cutlass.Int64(2))
+            for channel_offset in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD):
+                current[channel_offset] = values[channel_offset]
+
+            for channel_pair in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD // 2):
+                lo = 2 * channel_pair
+                hi = lo + 1
+                acc_lo, acc_hi = fmul2(history_0[lo], history_0[hi], weight_0[lo], weight_0[hi])
+                acc_lo, acc_hi = ffma2(history_1[lo], history_1[hi], weight_1[lo], weight_1[hi], acc_lo, acc_hi)
+                acc_lo, acc_hi = ffma2(history_2[lo], history_2[hi], weight_2[lo], weight_2[hi], acc_lo, acc_hi)
+                acc_lo, acc_hi = ffma2(current[lo], current[hi], weight_3[lo], weight_3[hi], acc_lo, acc_hi)
+                gate_lo, gate_hi = sigmoid2(acc_lo, acc_hi)
+                output_values[lo], output_values[hi] = fmul2(acc_lo, acc_hi, gate_lo, gate_hi)
+
+            output_element = cutlass.Int64(token) * cutlass.Int64(output.stride[0]) + cutlass.Int64(channel_base)
+            _store_bf16x8(
+                output.iterator.toint() + output_element * cutlass.Int64(2),
+                output_values[0],
+                output_values[1],
+                output_values[2],
+                output_values[3],
+                output_values[4],
+                output_values[5],
+                output_values[6],
+                output_values[7],
+            )
+
+            if cutlass.const_expr(final_state is not None):
+                if token + cutlass.Int32(1) == sequence_end:
+                    for channel_pair in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD // 2):
+                        pair_channel = channel_base + cutlass.Int32(2 * channel_pair)
+                        state_element = cutlass.Int64(sequence) * cutlass.Int64(final_state.stride[0]) + cutlass.Int64(pair_channel) * cutlass.Int64(
+                            final_state.stride[1]
+                        )
+                        channel_offset = 2 * channel_pair
+                        _store_bf16x8(
+                            final_state.iterator.toint() + state_element * cutlass.Int64(2),
+                            history_0[channel_offset],
+                            history_1[channel_offset],
+                            history_2[channel_offset],
+                            current[channel_offset],
+                            history_0[channel_offset + 1],
+                            history_1[channel_offset + 1],
+                            history_2[channel_offset + 1],
+                            current[channel_offset + 1],
+                        )
+
+            for channel_offset in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD):
+                history_0[channel_offset] = history_1[channel_offset]
+                history_1[channel_offset] = history_2[channel_offset]
+                history_2[channel_offset] = current[channel_offset]
+
+
+class CausalConv1dBulkForwardKernel:
+    """Host launcher for the fixed BF16, width-four SM100 forward slice."""
+
+    @cute.jit
+    def __call__(
+        self,
+        x: cute.Tensor,
+        weight: cute.Tensor,
+        initial_state: Optional[cute.Tensor],
+        cu_seqlens: Optional[cute.Tensor],
+        output: cute.Tensor,
+        final_state: Optional[cute.Tensor],
+        num_sequences: cutlass.Int32,
+        tokens_per_sequence: cutlass.Int32,
+        n_channels: cutlass.Int32,
+        stream: cuda.CUstream,
+    ) -> None:
+        if cutlass.const_expr(cu_seqlens is not None):
+            _validate_cu_seqlens_kernel(
+                cu_seqlens,
+                num_sequences,
+                cutlass.Int32(x.shape[0]),
+            ).launch(
+                grid=(1, 1, 1),
+                block=(THREADS, 1, 1),
+                stream=stream,
+            )
+
+        if cutlass.const_expr(x.shape[1] % VEC_CHANNELS_PER_THREAD == 0):
+            _causal_conv1d_bulk_vec8_fwd_kernel(
+                x,
+                weight,
+                initial_state,
+                cu_seqlens,
+                output,
+                final_state,
+                num_sequences,
+                tokens_per_sequence,
+                n_channels,
+            ).launch(
+                grid=(cute.ceil_div(x.shape[0], VEC_TOKENS_PER_CTA), cute.ceil_div(x.shape[1], VEC_CHANNELS_PER_CTA), 1),
+                block=(VEC_THREADS, 1, 1),
+                stream=stream,
+            )
+        else:
+            _causal_conv1d_bulk_fwd_kernel(
+                x,
+                weight,
+                initial_state,
+                cu_seqlens,
+                output,
+                final_state,
+                num_sequences,
+                tokens_per_sequence,
+                n_channels,
+            ).launch(
+                grid=(cute.ceil_div(x.shape[0], TOKENS_PER_CTA), cute.ceil_div(x.shape[1], THREADS), 1),
+                block=(THREADS, 1, 1),
+                stream=stream,
+            )

--- a/python/cudnn/causal_conv1d_bulk_sm100/kernel.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/kernel.py
@@ -126,6 +126,7 @@ def _validate_cu_seqlens_kernel(
 def _causal_conv1d_bulk_fwd_kernel(
     x: cute.Tensor,
     weight: cute.Tensor,
+    bias: Optional[cute.Tensor],
     initial_state: Optional[cute.Tensor],
     cu_seqlens: Optional[cute.Tensor],
     output: cute.Tensor,
@@ -156,6 +157,7 @@ def _causal_conv1d_bulk_fwd_kernel(
     weight_1 = cutlass.Float32(0.0)
     weight_2 = cutlass.Float32(0.0)
     weight_3 = cutlass.Float32(0.0)
+    bias_value = cutlass.Float32(0.0)
     if channel < n_channels:
         # Vectorize the naturally contiguous four-tap weight row.  Its address
         # is always eight-byte aligned for contiguous BF16 [D, 4] storage.
@@ -168,6 +170,8 @@ def _causal_conv1d_bulk_fwd_kernel(
         )
         weight_0, weight_1 = f16x2_to_f32(weight_01, dtype=cutlass.BFloat16)
         weight_2, weight_3 = f16x2_to_f32(weight_23, dtype=cutlass.BFloat16)
+        if cutlass.const_expr(bias is not None):
+            bias_value = bias[channel].to(cutlass.Float32)
 
     sequence = cutlass.Int32(0)
     sequence_start = cutlass.Int32(0)
@@ -252,6 +256,8 @@ def _causal_conv1d_bulk_fwd_kernel(
             acc = acc + history_1 * weight_1
             acc = acc + history_2 * weight_2
             acc = acc + current * weight_3
+            if cutlass.const_expr(bias is not None):
+                acc = acc + bias_value
             output[token, channel] = (acc * sigmoid(acc)).to(cutlass.BFloat16)
 
             if cutlass.const_expr(final_state is not None):
@@ -272,6 +278,7 @@ def _causal_conv1d_bulk_fwd_kernel(
 def _causal_conv1d_bulk_vec8_fwd_kernel(
     x: cute.Tensor,
     weight: cute.Tensor,
+    bias: Optional[cute.Tensor],
     initial_state: Optional[cute.Tensor],
     cu_seqlens: Optional[cute.Tensor],
     output: cute.Tensor,
@@ -304,12 +311,14 @@ def _causal_conv1d_bulk_vec8_fwd_kernel(
     weight_1 = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
     weight_2 = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
     weight_3 = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
+    bias_values = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
     zero = opaque_f32_zero()
     for channel_offset in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD):
         weight_0[channel_offset] = zero
         weight_1[channel_offset] = zero
         weight_2[channel_offset] = zero
         weight_3[channel_offset] = zero
+        bias_values[channel_offset] = zero
 
     if valid_channel_group:
         for channel_pair in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD // 2):
@@ -326,6 +335,10 @@ def _causal_conv1d_bulk_vec8_fwd_kernel(
             weight_1[channel_offset + 1] = values[5]
             weight_2[channel_offset + 1] = values[6]
             weight_3[channel_offset + 1] = values[7]
+        if cutlass.const_expr(bias is not None):
+            values = _load_bf16x8(bias.iterator.toint() + cutlass.Int64(channel_base) * cutlass.Int64(2))
+            for channel_offset in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD):
+                bias_values[channel_offset] = values[channel_offset]
 
     sequence = cutlass.Int32(0)
     sequence_start = cutlass.Int32(0)
@@ -465,6 +478,9 @@ def _causal_conv1d_bulk_vec8_fwd_kernel(
                 acc_lo, acc_hi = ffma2(history_1[lo], history_1[hi], weight_1[lo], weight_1[hi], acc_lo, acc_hi)
                 acc_lo, acc_hi = ffma2(history_2[lo], history_2[hi], weight_2[lo], weight_2[hi], acc_lo, acc_hi)
                 acc_lo, acc_hi = ffma2(current[lo], current[hi], weight_3[lo], weight_3[hi], acc_lo, acc_hi)
+                if cutlass.const_expr(bias is not None):
+                    acc_lo = acc_lo + bias_values[lo]
+                    acc_hi = acc_hi + bias_values[hi]
                 gate_lo, gate_hi = sigmoid2(acc_lo, acc_hi)
                 output_values[lo], output_values[hi] = fmul2(acc_lo, acc_hi, gate_lo, gate_hi)
 
@@ -523,6 +539,7 @@ class CausalConv1dBulkForwardKernel:
         self,
         x: cute.Tensor,
         weight: cute.Tensor,
+        bias: Optional[cute.Tensor],
         initial_state: Optional[cute.Tensor],
         cu_seqlens: Optional[cute.Tensor],
         output: cute.Tensor,
@@ -547,6 +564,7 @@ class CausalConv1dBulkForwardKernel:
             _causal_conv1d_bulk_vec8_fwd_kernel(
                 x,
                 weight,
+                bias,
                 initial_state,
                 cu_seqlens,
                 output,
@@ -563,6 +581,7 @@ class CausalConv1dBulkForwardKernel:
             _causal_conv1d_bulk_fwd_kernel(
                 x,
                 weight,
+                bias,
                 initial_state,
                 cu_seqlens,
                 output,

--- a/python/cudnn/causal_conv1d_bulk_sm100/kernel.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/kernel.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Correctness-first SM100 bulk causal-convolution forward kernel.
+"""Correctness-first bulk causal-convolution forward kernels.
 
 This is an independent CuTe DSL implementation of the width-four, BF16,
 depthwise causal-convolution contract documented by cuDNN Frontend.  FLA's
@@ -508,7 +508,15 @@ def _causal_conv1d_bulk_vec8_fwd_kernel(
 
 
 class CausalConv1dBulkForwardKernel:
-    """Host launcher for the fixed BF16, width-four SM100 forward slice."""
+    """Host launcher for the fixed BF16, width-four forward slice.
+
+    ``use_vec8`` is selected from the exact compilation target.  Its packed
+    FP32 arithmetic requires SM100-or-newer instructions; the scalar schedule
+    is the functional fallback on supported pre-Blackwell architectures.
+    """
+
+    def __init__(self, *, use_vec8: bool = True):
+        self.use_vec8 = use_vec8
 
     @cute.jit
     def __call__(
@@ -535,7 +543,7 @@ class CausalConv1dBulkForwardKernel:
                 stream=stream,
             )
 
-        if cutlass.const_expr(x.shape[1] % VEC_CHANNELS_PER_THREAD == 0):
+        if cutlass.const_expr(self.use_vec8 and x.shape[1] % VEC_CHANNELS_PER_THREAD == 0):
             _causal_conv1d_bulk_vec8_fwd_kernel(
                 x,
                 weight,

--- a/test/python/fe_api/causal_conv1d_bulk/benchmark_causal_conv1d_bulk_sm100.py
+++ b/test/python/fe_api/causal_conv1d_bulk/benchmark_causal_conv1d_bulk_sm100.py
@@ -1,11 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Interleaved B200 benchmark for the bulk causal-convolution forward slice.
+"""Interleaved benchmark for the bulk causal-convolution forward slice.
 
-This script is intentionally not a pytest test.  Run it through the repository's
-ComputeLab wrapper so quoted numbers come from a full NVIDIA B200 rather than a
-local engineering board.
+This script is intentionally not a pytest test.  It runs on every functionally
+supported architecture; the operation's support check remains authoritative.
 
 The ``fe_execute`` arm uses caller-preallocated output tensors, whereas FLA's
 direct API allocates its outputs internally. CUDA events also include any GPU
@@ -17,17 +16,31 @@ wrapper/public arm is the more symmetric allocation-inclusive comparison.
 
 import argparse
 import json
+import os
+import platform
 import statistics
 
 import torch
+from cudnn._causal_conv1d_bulk_arch import is_functional_arch
 
-from cudnn.causal_conv1d_bulk_sm100 import (
-    CausalConv1dBulkFwdSm100,
-    causal_conv1d_bulk_fwd_wrapper_sm100,
-)
-from fla.modules.conv.causal_conv1d import causal_conv1d as fla_causal_conv1d
-from fla.modules.conv.triton.ops import causal_conv1d_fwd as fla_causal_conv1d_fwd
-from fla.ops.utils import prepare_chunk_indices
+
+def _validate_environment():
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is unavailable")
+    properties = torch.cuda.get_device_properties(0)
+    capability = (properties.major, properties.minor)
+    if not is_functional_arch(capability):
+        raise RuntimeError("Bulk causal conv1d does not support compute capability " f"{capability[0]}.{capability[1]} on {properties.name}")
+    return properties, capability
+
+
+def _slurm_metadata(environ=None):
+    environ = os.environ if environ is None else environ
+    fields = {
+        "job_id": environ.get("SLURM_JOB_ID"),
+        "node_name": environ.get("SLURMD_NODENAME"),
+    }
+    return {name: value for name, value in fields.items() if value}
 
 
 def _event_us(fn, inner: int) -> float:
@@ -77,9 +90,15 @@ def main() -> None:
     parser.add_argument("--inner", type=int, default=5)
     args = parser.parse_args()
 
-    properties = torch.cuda.get_device_properties(0)
-    if (properties.major, properties.minor) != (10, 0) or properties.name != "NVIDIA B200":
-        raise RuntimeError("Performance measurements require a ComputeLab NVIDIA B200, got " f"{properties.name} SM{properties.major}{properties.minor}")
+    properties, capability = _validate_environment()
+
+    from cudnn.causal_conv1d_bulk_sm100 import (
+        CausalConv1dBulkFwdSm100,
+        causal_conv1d_bulk_fwd_wrapper_sm100,
+    )
+    from fla.modules.conv.causal_conv1d import causal_conv1d as fla_causal_conv1d
+    from fla.modules.conv.triton.ops import causal_conv1d_fwd as fla_causal_conv1d_fwd
+    from fla.ops.utils import prepare_chunk_indices
 
     torch.manual_seed(20260828)
     x = torch.randn(1, args.tokens, args.channels, device="cuda", dtype=torch.bfloat16)
@@ -195,7 +214,19 @@ def main() -> None:
         "initial_state": args.state,
         "final_state": args.final_state,
     }
-    timings["device"] = properties.name
+    timings["hardware"] = {
+        "device": properties.name,
+        "compute_capability": list(capability),
+        "total_memory_bytes": properties.total_memory,
+    }
+    timings["software"] = {
+        "python": platform.python_version(),
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+    }
+    slurm = _slurm_metadata()
+    if slurm:
+        timings["slurm"] = slurm
     print(json.dumps(timings, indent=2, sort_keys=True))
 
 

--- a/test/python/fe_api/causal_conv1d_bulk/benchmark_causal_conv1d_bulk_sm100.py
+++ b/test/python/fe_api/causal_conv1d_bulk/benchmark_causal_conv1d_bulk_sm100.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Interleaved B200 benchmark for the bulk causal-convolution forward slice.
+
+This script is intentionally not a pytest test.  Run it through the repository's
+ComputeLab wrapper so quoted numbers come from a full NVIDIA B200 rather than a
+local engineering board.
+
+The ``fe_execute`` arm uses caller-preallocated output tensors, whereas FLA's
+direct API allocates its outputs internally. CUDA events also include any GPU
+idle gap while the host enqueues work between the two events. Therefore this
+script reports direct-API event elapsed, not pure per-kernel active cycles;
+obtain the latter from same-process CUPTI/Nsight kernel durations. The
+wrapper/public arm is the more symmetric allocation-inclusive comparison.
+"""
+
+import argparse
+import json
+import statistics
+
+import torch
+
+from cudnn.causal_conv1d_bulk_sm100 import (
+    CausalConv1dBulkFwdSm100,
+    causal_conv1d_bulk_fwd_wrapper_sm100,
+)
+from fla.modules.conv.causal_conv1d import causal_conv1d as fla_causal_conv1d
+from fla.modules.conv.triton.ops import causal_conv1d_fwd as fla_causal_conv1d_fwd
+from fla.ops.utils import prepare_chunk_indices
+
+
+def _event_us(fn, inner: int) -> float:
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(inner):
+        fn()
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) * 1000.0 / inner
+
+
+def _interleaved_medians(functions, *, warmup: int, rounds: int, inner: int):
+    names = list(functions)
+    for _ in range(warmup):
+        for name in names:
+            functions[name]()
+    torch.cuda.synchronize()
+
+    samples = {name: [] for name in names}
+    for round_index in range(rounds):
+        order = names if round_index % 2 == 0 else list(reversed(names))
+        for name in order:
+            samples[name].append(_event_us(functions[name], inner))
+    return {
+        name: {
+            "median_us": statistics.median(values),
+            "min_us": min(values),
+            "max_us": max(values),
+            "samples_us": values,
+        }
+        for name, values in samples.items()
+    }
+
+
+@torch.no_grad()
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tokens", type=int, default=8192)
+    parser.add_argument("--channels", type=int, default=8192)
+    parser.add_argument("--packed-sequences", type=int, default=0)
+    parser.add_argument("--state", action="store_true")
+    parser.add_argument("--final-state", action="store_true")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--rounds", type=int, default=21)
+    parser.add_argument("--inner", type=int, default=5)
+    args = parser.parse_args()
+
+    properties = torch.cuda.get_device_properties(0)
+    if (properties.major, properties.minor) != (10, 0) or properties.name != "NVIDIA B200":
+        raise RuntimeError("Performance measurements require a ComputeLab NVIDIA B200, got " f"{properties.name} SM{properties.major}{properties.minor}")
+
+    torch.manual_seed(20260828)
+    x = torch.randn(1, args.tokens, args.channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(args.channels, 4, device="cuda", dtype=torch.bfloat16)
+
+    cu_seqlens = None
+    chunk_indices = None
+    num_sequences = 1
+    if args.packed_sequences:
+        if args.tokens % args.packed_sequences:
+            raise ValueError("--tokens must be divisible by --packed-sequences")
+        num_sequences = args.packed_sequences
+        length = args.tokens // num_sequences
+        cu_seqlens = torch.arange(
+            0,
+            args.tokens + 1,
+            length,
+            dtype=torch.int32,
+            device="cuda",
+        )
+        chunk_indices = prepare_chunk_indices(cu_seqlens, 64)
+
+    initial_state = None
+    if args.state:
+        initial_state = torch.randn(num_sequences, args.channels, 4, device="cuda", dtype=torch.bfloat16)
+
+    output = torch.empty_like(x)
+    final_state = torch.empty(num_sequences, args.channels, 4, device="cuda", dtype=torch.bfloat16) if args.final_state else None
+    fe_api = CausalConv1dBulkFwdSm100(
+        sample_x=x,
+        sample_weight=weight,
+        sample_output=output,
+        sample_cu_seqlens=cu_seqlens,
+        sample_initial_state=initial_state,
+        sample_final_state=final_state,
+    )
+    fe_api.check_support()
+    fe_api.compile()
+
+    def fe_execute():
+        return fe_api.execute(
+            x,
+            weight,
+            output,
+            cu_seqlens_tensor=cu_seqlens,
+            initial_state_tensor=initial_state,
+            final_state_tensor=final_state,
+        )
+
+    def fe_wrapper():
+        return causal_conv1d_bulk_fwd_wrapper_sm100(
+            x,
+            weight,
+            cu_seqlens_tensor=cu_seqlens,
+            initial_state_tensor=initial_state,
+            output_final_state=args.final_state,
+        )
+
+    def fla_direct():
+        return fla_causal_conv1d_fwd(
+            x=x,
+            weight=weight,
+            bias=None,
+            residual=None,
+            initial_state=initial_state,
+            output_final_state=args.final_state,
+            activation="silu",
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
+
+    def fla_public():
+        return fla_causal_conv1d(
+            x=x,
+            weight=weight,
+            initial_state=initial_state,
+            output_final_state=args.final_state,
+            activation="silu",
+            backend="triton",
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
+
+    # Compile/autotune before checking or timing. This validates the exact
+    # external implementation used by the benchmark but is not the independent
+    # oracle used by the permanent correctness suite.
+    fe_result = fe_wrapper()
+    fla_result = fla_public()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(fe_result["output_tensor"], fla_result[0], atol=3e-2, rtol=3e-2)
+    if args.final_state:
+        torch.testing.assert_close(fe_result["final_state_tensor"], fla_result[1], atol=0, rtol=0)
+
+    timings = _interleaved_medians(
+        {
+            "fe_execute": fe_execute,
+            "fla_direct": fla_direct,
+            "fe_wrapper": fe_wrapper,
+            "fla_public": fla_public,
+        },
+        warmup=args.warmup,
+        rounds=args.rounds,
+        inner=args.inner,
+    )
+    timings["ratios"] = {
+        "fla_direct_over_fe_execute": timings["fla_direct"]["median_us"] / timings["fe_execute"]["median_us"],
+        "fla_public_over_fe_wrapper": timings["fla_public"]["median_us"] / timings["fe_wrapper"]["median_us"],
+    }
+    timings["shape"] = {
+        "tokens": args.tokens,
+        "channels": args.channels,
+        "packed_sequences": args.packed_sequences,
+        "initial_state": args.state,
+        "final_state": args.final_state,
+    }
+    timings["device"] = properties.name
+    print(json.dumps(timings, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/python/fe_api/causal_conv1d_bulk/conftest.py
+++ b/test/python/fe_api/causal_conv1d_bulk/conftest.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Overlay this checkout's Python modules onto a prebuilt frontend package."""
+
+from pathlib import Path
+
+import cudnn
+
+_SOURCE_CUDNN = Path(__file__).resolve().parents[4] / "python" / "cudnn"
+if str(_SOURCE_CUDNN) not in cudnn.__path__:
+    cudnn.__path__.insert(0, str(_SOURCE_CUDNN))

--- a/test/python/fe_api/causal_conv1d_bulk/reference.py
+++ b/test/python/fe_api/causal_conv1d_bulk/reference.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""PyTorch references for width-four causal convolution."""
+
+from typing import Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+
+def causal_conv1d_bulk_reference(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    *,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    initial_state: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Return an FP32-compute reference and the full-width final state.
+
+    ``x`` has native NWH layout ``[B, T, D]``.  When ``cu_seqlens`` is
+    present, ``B`` is one and its token dimension contains the packed
+    sequences.  State shifts are performed in the input dtype; only the
+    four-term convolution and SiLU use FP32.
+    """
+
+    if x.ndim != 3:
+        raise ValueError(f"x must be 3D, got {tuple(x.shape)}")
+    if weight.shape != (x.shape[-1], 4):
+        raise ValueError(f"weight must have shape {(x.shape[-1], 4)}, got {tuple(weight.shape)}")
+
+    batch, tokens, channels = x.shape
+    if cu_seqlens is None:
+        num_sequences = batch
+        ranges = [(row, 0, tokens) for row in range(batch)]
+    else:
+        if batch != 1:
+            raise ValueError("packed x must have B=1")
+        offsets = [int(offset) for offset in cu_seqlens.detach().cpu().tolist()]
+        num_sequences = len(offsets) - 1
+        ranges = [(0, offsets[sequence], offsets[sequence + 1]) for sequence in range(num_sequences)]
+
+    if initial_state is None:
+        state = torch.zeros((num_sequences, channels, 4), device=x.device, dtype=x.dtype)
+    else:
+        if initial_state.shape != (num_sequences, channels, 4):
+            raise ValueError(f"initial_state must have shape {(num_sequences, channels, 4)}, got {tuple(initial_state.shape)}")
+        state = initial_state.clone()
+
+    output = torch.empty_like(x)
+    weight_fp32 = weight.float()
+    for sequence, (row, begin, end) in enumerate(ranges):
+        sequence_state = state[sequence]
+        for token in range(begin, end):
+            sequence_state = torch.cat((sequence_state[:, 1:], x[row, token].unsqueeze(-1)), dim=-1)
+            preactivation = (sequence_state.float() * weight_fp32).sum(dim=-1)
+            output[row, token] = F.silu(preactivation).to(x.dtype)
+        state[sequence] = sequence_state
+
+    return output, state
+
+
+def causal_conv1d_update_reference(
+    x: torch.Tensor,
+    state: torch.Tensor,
+    weight: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Reference one decode update using the bulk operation's state ABI."""
+
+    output, final_state = causal_conv1d_bulk_reference(
+        x.unsqueeze(1),
+        weight,
+        initial_state=state,
+    )
+    return output[:, 0], final_state

--- a/test/python/fe_api/causal_conv1d_bulk/reference.py
+++ b/test/python/fe_api/causal_conv1d_bulk/reference.py
@@ -13,6 +13,7 @@ def causal_conv1d_bulk_reference(
     x: torch.Tensor,
     weight: torch.Tensor,
     *,
+    bias: Optional[torch.Tensor] = None,
     cu_seqlens: Optional[torch.Tensor] = None,
     initial_state: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -28,6 +29,8 @@ def causal_conv1d_bulk_reference(
         raise ValueError(f"x must be 3D, got {tuple(x.shape)}")
     if weight.shape != (x.shape[-1], 4):
         raise ValueError(f"weight must have shape {(x.shape[-1], 4)}, got {tuple(weight.shape)}")
+    if bias is not None and bias.shape != (x.shape[-1],):
+        raise ValueError(f"bias must have shape {(x.shape[-1],)}, got {tuple(bias.shape)}")
 
     batch, tokens, channels = x.shape
     if cu_seqlens is None:
@@ -49,11 +52,14 @@ def causal_conv1d_bulk_reference(
 
     output = torch.empty_like(x)
     weight_fp32 = weight.float()
+    bias_fp32 = bias.float() if bias is not None else None
     for sequence, (row, begin, end) in enumerate(ranges):
         sequence_state = state[sequence]
         for token in range(begin, end):
             sequence_state = torch.cat((sequence_state[:, 1:], x[row, token].unsqueeze(-1)), dim=-1)
             preactivation = (sequence_state.float() * weight_fp32).sum(dim=-1)
+            if bias_fp32 is not None:
+                preactivation = preactivation + bias_fp32
             output[row, token] = F.silu(preactivation).to(x.dtype)
         state[sequence] = sequence_state
 

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_contract_unit.py
@@ -3,12 +3,14 @@
 
 """Host-visible contract checks that do not compile a CuTe kernel."""
 
+import importlib.util
 import inspect
 import os
-from pathlib import Path
 import shutil
 import subprocess
 import sys
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -22,6 +24,15 @@ def _load_public_api():
     except (ImportError, OSError) as error:
         pytest.skip(f"CuTe DSL dependencies unavailable: {error}")
     return bulk, bulk.CausalConv1dBulkFwdSm100, bulk.causal_conv1d_bulk_fwd_wrapper_sm100
+
+
+def _load_benchmark_module():
+    path = Path(__file__).with_name("benchmark_causal_conv1d_bulk_sm100.py")
+    spec = importlib.util.spec_from_file_location("_causal_conv1d_bulk_benchmark_contract", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_operation_package_exports_class_and_wrapper():
@@ -64,6 +75,63 @@ def test_public_signatures_keep_optional_state_and_packed_metadata_explicit():
         "current_stream",
     )
     assert inspect.signature(wrapper).parameters["output_final_state"].kind is inspect.Parameter.KEYWORD_ONLY
+
+
+@pytest.mark.parametrize(
+    "capability",
+    [
+        (8, 0),
+        (8, 6),
+        (8, 7),
+        (8, 9),
+        (9, 0),
+        (10, 0),
+        (10, 3),
+        (11, 0),
+        (12, 0),
+        (12, 1),
+    ],
+)
+def test_benchmark_accepts_functional_gpu_without_slurm(monkeypatch, capability):
+    benchmark = _load_benchmark_module()
+    properties = SimpleNamespace(
+        major=capability[0],
+        minor=capability[1],
+        name="Customer GPU",
+    )
+    monkeypatch.setattr(benchmark.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(benchmark.torch.cuda, "get_device_properties", lambda device=None: properties)
+
+    assert benchmark._validate_environment() == (properties, capability)
+    assert benchmark._slurm_metadata({}) == {}
+
+
+def test_benchmark_rejects_unsupported_gpu(monkeypatch):
+    benchmark = _load_benchmark_module()
+    properties = SimpleNamespace(major=10, minor=1, name="Unsupported GPU")
+    monkeypatch.setattr(benchmark.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(benchmark.torch.cuda, "get_device_properties", lambda device=None: properties)
+
+    with pytest.raises(RuntimeError, match="does not support compute capability 10.1"):
+        benchmark._validate_environment()
+
+
+def test_benchmark_requires_cuda(monkeypatch):
+    benchmark = _load_benchmark_module()
+    monkeypatch.setattr(benchmark.torch.cuda, "is_available", lambda: False)
+
+    with pytest.raises(RuntimeError, match="CUDA is unavailable"):
+        benchmark._validate_environment()
+
+
+def test_benchmark_slurm_metadata_is_optional():
+    benchmark = _load_benchmark_module()
+
+    assert benchmark._slurm_metadata({}) == {}
+    assert benchmark._slurm_metadata({"SLURM_JOB_ID": "123", "SLURMD_NODENAME": "gpu-node"}) == {
+        "job_id": "123",
+        "node_name": "gpu-node",
+    }
 
 
 def test_support_rejects_the_package_wide_4_5_dsl_floor(monkeypatch):

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_contract_unit.py
@@ -96,6 +96,24 @@ def test_support_accepts_a_source_dsl_without_distribution_metadata(monkeypatch)
     assert api.check_support()
 
 
+def test_constructor_rejects_metadata_only_tensor_descriptors():
+    _, api_class, _ = _load_public_api()
+    from cudnn.api_base import TensorDesc
+
+    sample_x = TensorDesc(
+        dtype=torch.bfloat16,
+        shape=(1, 2, 8),
+        stride=(16, 8, 1),
+        stride_order=(2, 1, 0),
+        device=torch.device("cuda"),
+    )
+    weight = torch.zeros(8, 4, dtype=torch.bfloat16)
+    output = torch.zeros(1, 2, 8, dtype=torch.bfloat16)
+
+    with pytest.raises(TypeError, match=r"sample_x must be a torch.Tensor, got TensorDesc"):
+        api_class(sample_x, weight, output)
+
+
 def test_top_level_lazy_exports_resolve_from_a_clean_source_package(tmp_path):
     # The suite normally overlays this operation onto a prebuilt frontend. Use
     # a fresh interpreter and this checkout's __init__.py to exercise the

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_contract_unit.py
@@ -45,7 +45,7 @@ def test_operation_package_exports_class_and_wrapper():
     assert bulk.causal_conv1d_bulk_fwd_wrapper_sm100 is wrapper
 
 
-def test_public_signatures_keep_optional_state_and_packed_metadata_explicit():
+def test_public_signatures_append_keyword_only_bias_without_moving_existing_parameters():
     _, api_class, wrapper = _load_public_api()
 
     assert tuple(inspect.signature(api_class).parameters) == (
@@ -55,6 +55,7 @@ def test_public_signatures_keep_optional_state_and_packed_metadata_explicit():
         "sample_cu_seqlens",
         "sample_initial_state",
         "sample_final_state",
+        "sample_bias",
     )
     assert tuple(inspect.signature(api_class.execute).parameters) == (
         "self",
@@ -65,6 +66,7 @@ def test_public_signatures_keep_optional_state_and_packed_metadata_explicit():
         "initial_state_tensor",
         "final_state_tensor",
         "current_stream",
+        "bias_tensor",
     )
     assert tuple(inspect.signature(wrapper).parameters) == (
         "x_tensor",
@@ -73,8 +75,12 @@ def test_public_signatures_keep_optional_state_and_packed_metadata_explicit():
         "initial_state_tensor",
         "output_final_state",
         "current_stream",
+        "bias_tensor",
     )
+    assert inspect.signature(api_class).parameters["sample_bias"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert inspect.signature(api_class.execute).parameters["bias_tensor"].kind is inspect.Parameter.KEYWORD_ONLY
     assert inspect.signature(wrapper).parameters["output_final_state"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert inspect.signature(wrapper).parameters["bias_tensor"].kind is inspect.Parameter.KEYWORD_ONLY
 
 
 @pytest.mark.parametrize(
@@ -154,14 +160,83 @@ def test_support_accepts_a_source_dsl_without_distribution_metadata(monkeypatch)
 
     x = torch.zeros(1, 2, 8, dtype=torch.bfloat16)
     weight = torch.zeros(8, 4, dtype=torch.bfloat16)
+    bias = torch.zeros(8, dtype=torch.bfloat16)
     output = torch.empty_like(x)
-    api = api_class(x, weight, output)
+    api = api_class(x, weight, output, sample_bias=bias)
     monkeypatch.setattr(api_module, "cutedsl_state", lambda: (True, None))
     monkeypatch.setattr(api, "_require_cuda", lambda desc, name: None)
     monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
     monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: (10, 0))
 
     assert api.check_support()
+    assert api.bias_desc.shape == (8,)
+
+
+@pytest.mark.parametrize("case", ["rank", "shape", "dtype", "stride", "alignment"])
+def test_support_rejects_invalid_bias_contract(monkeypatch, case):
+    _, api_class, _ = _load_public_api()
+    import cudnn.causal_conv1d_bulk_sm100.api as api_module
+
+    x = torch.zeros(1, 2, 8, dtype=torch.bfloat16)
+    weight = torch.zeros(8, 4, dtype=torch.bfloat16)
+    output = torch.empty_like(x)
+    if case == "rank":
+        bias = torch.zeros(1, 8, dtype=torch.bfloat16)
+    elif case == "shape":
+        bias = torch.zeros(7, dtype=torch.bfloat16)
+    elif case == "dtype":
+        bias = torch.zeros(8, dtype=torch.float32)
+    elif case == "stride":
+        bias = torch.zeros(8, 2, dtype=torch.bfloat16)[:, 0]
+    elif case == "alignment":
+        bias = torch.zeros(9, dtype=torch.bfloat16)[1:]
+    else:
+        raise AssertionError(f"unhandled case {case}")
+
+    api = api_class(x, weight, output, sample_bias=bias)
+    monkeypatch.setattr(api_module, "cutedsl_state", lambda: (True, None))
+
+    with pytest.raises(ValueError, match="Bias"):
+        api.check_support()
+
+
+def test_bias_presence_must_match_the_compiled_signature(monkeypatch):
+    _, api_class, _ = _load_public_api()
+    import cudnn.causal_conv1d_bulk_sm100.api as api_module
+
+    x = torch.zeros(1, 2, 8, dtype=torch.bfloat16)
+    weight = torch.zeros(8, 4, dtype=torch.bfloat16)
+    bias = torch.zeros(8, dtype=torch.bfloat16)
+    output = torch.empty_like(x)
+    monkeypatch.setattr(api_module, "cutedsl_state", lambda: (True, None))
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: (10, 0))
+
+    with_bias = api_class(x, weight, output, sample_bias=bias)
+    monkeypatch.setattr(with_bias, "_require_cuda", lambda desc, name: None)
+    assert with_bias.check_support()
+    with_bias._compiled_kernel = object()
+    with pytest.raises(ValueError, match="Bias presence must match"):
+        with_bias.execute(x, weight, output)
+
+    without_bias = api_class(x, weight, output)
+    monkeypatch.setattr(without_bias, "_require_cuda", lambda desc, name: None)
+    assert without_bias.check_support()
+    without_bias._compiled_kernel = object()
+    with pytest.raises(ValueError, match="Bias presence must match"):
+        without_bias.execute(x, weight, output, bias_tensor=bias)
+
+
+def test_constructor_and_wrapper_reject_non_tensor_bias():
+    _, api_class, wrapper = _load_public_api()
+    x = torch.zeros(1, 2, 8, dtype=torch.bfloat16)
+    weight = torch.zeros(8, 4, dtype=torch.bfloat16)
+    output = torch.empty_like(x)
+
+    with pytest.raises(TypeError, match="sample_bias must be a torch.Tensor"):
+        api_class(x, weight, output, sample_bias=object())
+    with pytest.raises(TypeError, match="Bias must be a torch.Tensor or None"):
+        wrapper(x, weight, bias_tensor=object())
 
 
 @pytest.mark.parametrize(

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_contract_unit.py
@@ -96,6 +96,58 @@ def test_support_accepts_a_source_dsl_without_distribution_metadata(monkeypatch)
     assert api.check_support()
 
 
+@pytest.mark.parametrize(
+    "capability,n_channels,expected_vec8",
+    [
+        ((8, 0), 8, False),
+        ((8, 6), 8, False),
+        ((8, 7), 8, False),
+        ((8, 9), 8, False),
+        ((9, 0), 8, False),
+        ((10, 0), 8, True),
+        ((10, 0), 7, False),
+        ((10, 3), 8, True),
+        ((11, 0), 8, True),
+        ((12, 0), 8, True),
+        ((12, 1), 8, True),
+    ],
+)
+def test_support_selects_schedule_from_exact_arch(monkeypatch, capability, n_channels, expected_vec8):
+    _, api_class, _ = _load_public_api()
+    import cudnn.causal_conv1d_bulk_sm100.api as api_module
+
+    x = torch.zeros(1, 2, n_channels, dtype=torch.bfloat16)
+    weight = torch.zeros(n_channels, 4, dtype=torch.bfloat16)
+    output = torch.empty_like(x)
+    api = api_class(x, weight, output)
+    monkeypatch.setattr(api_module, "cutedsl_state", lambda: (True, None))
+    monkeypatch.setattr(api, "_require_cuda", lambda desc, name: None)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: capability)
+
+    assert api.check_support()
+    assert api.compute_capability == capability
+    assert api.use_vec8_schedule is expected_vec8
+
+
+@pytest.mark.parametrize("capability", [(7, 5), (10, 1), (11, 1)])
+def test_support_rejects_unlisted_arch(monkeypatch, capability):
+    _, api_class, _ = _load_public_api()
+    import cudnn.causal_conv1d_bulk_sm100.api as api_module
+
+    x = torch.zeros(1, 2, 8, dtype=torch.bfloat16)
+    weight = torch.zeros(8, 4, dtype=torch.bfloat16)
+    output = torch.empty_like(x)
+    api = api_class(x, weight, output)
+    monkeypatch.setattr(api_module, "cutedsl_state", lambda: (True, None))
+    monkeypatch.setattr(api, "_require_cuda", lambda desc, name: None)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: capability)
+
+    with pytest.raises(RuntimeError, match="does not support compute capability"):
+        api.check_support()
+
+
 def test_constructor_rejects_metadata_only_tensor_descriptors():
     _, api_class, _ = _load_public_api()
     from cudnn.api_base import TensorDesc

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_contract_unit.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host-visible contract checks that do not compile a CuTe kernel."""
+
+import inspect
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.L0
+
+
+def _load_public_api():
+    try:
+        import cudnn.causal_conv1d_bulk_sm100 as bulk
+    except (ImportError, OSError) as error:
+        pytest.skip(f"CuTe DSL dependencies unavailable: {error}")
+    return bulk, bulk.CausalConv1dBulkFwdSm100, bulk.causal_conv1d_bulk_fwd_wrapper_sm100
+
+
+def test_operation_package_exports_class_and_wrapper():
+    bulk, api_class, wrapper = _load_public_api()
+    assert bulk.__all__ == [
+        "CausalConv1dBulkFwdSm100",
+        "causal_conv1d_bulk_fwd_wrapper_sm100",
+    ]
+    assert bulk.CausalConv1dBulkFwdSm100 is api_class
+    assert bulk.causal_conv1d_bulk_fwd_wrapper_sm100 is wrapper
+
+
+def test_public_signatures_keep_optional_state_and_packed_metadata_explicit():
+    _, api_class, wrapper = _load_public_api()
+
+    assert tuple(inspect.signature(api_class).parameters) == (
+        "sample_x",
+        "sample_weight",
+        "sample_output",
+        "sample_cu_seqlens",
+        "sample_initial_state",
+        "sample_final_state",
+    )
+    assert tuple(inspect.signature(api_class.execute).parameters) == (
+        "self",
+        "x_tensor",
+        "weight_tensor",
+        "output_tensor",
+        "cu_seqlens_tensor",
+        "initial_state_tensor",
+        "final_state_tensor",
+        "current_stream",
+    )
+    assert tuple(inspect.signature(wrapper).parameters) == (
+        "x_tensor",
+        "weight_tensor",
+        "cu_seqlens_tensor",
+        "initial_state_tensor",
+        "output_final_state",
+        "current_stream",
+    )
+    assert inspect.signature(wrapper).parameters["output_final_state"].kind is inspect.Parameter.KEYWORD_ONLY
+
+
+def test_support_rejects_the_package_wide_4_5_dsl_floor(monkeypatch):
+    _, api_class, _ = _load_public_api()
+    import cudnn.causal_conv1d_bulk_sm100.api as api_module
+
+    x = torch.zeros(1, 2, 8, dtype=torch.bfloat16)
+    weight = torch.zeros(8, 4, dtype=torch.bfloat16)
+    output = torch.empty_like(x)
+    api = api_class(x, weight, output)
+    monkeypatch.setattr(api_module, "cutedsl_state", lambda: (True, ("nvidia-cutlass-dsl", "4.5.0")))
+
+    with pytest.raises(RuntimeError, match=r"nvidia-cutlass-dsl>=4\.7\.0; found 4\.5\.0"):
+        api.check_support()
+
+
+def test_support_accepts_a_source_dsl_without_distribution_metadata(monkeypatch):
+    _, api_class, _ = _load_public_api()
+    import cudnn.causal_conv1d_bulk_sm100.api as api_module
+
+    x = torch.zeros(1, 2, 8, dtype=torch.bfloat16)
+    weight = torch.zeros(8, 4, dtype=torch.bfloat16)
+    output = torch.empty_like(x)
+    api = api_class(x, weight, output)
+    monkeypatch.setattr(api_module, "cutedsl_state", lambda: (True, None))
+    monkeypatch.setattr(api, "_require_cuda", lambda desc, name: None)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: (10, 0))
+
+    assert api.check_support()
+
+
+def test_top_level_lazy_exports_resolve_from_a_clean_source_package(tmp_path):
+    # The suite normally overlays this operation onto a prebuilt frontend. Use
+    # a fresh interpreter and this checkout's __init__.py to exercise the
+    # top-level lazy-export route that a built wheel installs.
+    _load_public_api()
+    import cudnn
+
+    source = Path(__file__).resolve().parents[4] / "python" / "cudnn"
+    probe = tmp_path / "cudnn"
+    shutil.copytree(source, probe)
+    compiled_modules = list(Path(cudnn.__file__).resolve().parent.glob("_compiled_module*.so"))
+    assert len(compiled_modules) == 1
+    (probe / compiled_modules[0].name).symlink_to(compiled_modules[0])
+
+    script = """
+import cudnn
+from cudnn import CausalConv1dBulkFwdSm100, causal_conv1d_bulk_fwd_wrapper_sm100
+from cudnn.causal_conv1d_bulk_sm100 import (
+    CausalConv1dBulkFwdSm100 as package_class,
+    causal_conv1d_bulk_fwd_wrapper_sm100 as package_wrapper,
+)
+
+assert CausalConv1dBulkFwdSm100 is package_class
+assert causal_conv1d_bulk_fwd_wrapper_sm100 is package_wrapper
+assert cudnn.CausalConv1dBulkFwdSm100 is package_class
+assert cudnn.causal_conv1d_bulk_fwd_wrapper_sm100 is package_wrapper
+"""
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = os.pathsep.join((str(tmp_path), environment.get("PYTHONPATH", ""))).rstrip(os.pathsep)
+    subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+    )

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_contract_unit.py
@@ -114,6 +114,20 @@ def test_constructor_rejects_metadata_only_tensor_descriptors():
         api_class(sample_x, weight, output)
 
 
+@pytest.mark.parametrize("missing_name", ["sample_x", "sample_weight", "sample_output"])
+def test_constructor_rejects_none_for_required_samples(missing_name):
+    _, api_class, _ = _load_public_api()
+    samples = {
+        "sample_x": torch.zeros(1, 2, 8, dtype=torch.bfloat16),
+        "sample_weight": torch.zeros(8, 4, dtype=torch.bfloat16),
+        "sample_output": torch.zeros(1, 2, 8, dtype=torch.bfloat16),
+    }
+    samples[missing_name] = None
+
+    with pytest.raises(TypeError, match=rf"{missing_name} must be a torch.Tensor, got NoneType"):
+        api_class(**samples)
+
+
 def test_top_level_lazy_exports_resolve_from_a_clean_source_package(tmp_path):
     # The suite normally overlays this operation onto a prebuilt frontend. Use
     # a fresh interpreter and this checkout's __init__.py to exercise the

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_sm100.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_sm100.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""L0 GPU correctness for the SM100 bulk causal-convolution forward API."""
+"""L0 GPU correctness for the bulk causal-convolution forward API."""
 
 import os
 from pathlib import Path
@@ -17,16 +17,29 @@ from fe_api.causal_conv1d_bulk.reference import (
     causal_conv1d_update_reference,
 )
 
+_SUPPORTED_COMPUTE_CAPABILITIES = {
+    (8, 0),
+    (8, 6),
+    (8, 7),
+    (8, 9),
+    (9, 0),
+    (10, 0),
+    (10, 3),
+    (11, 0),
+    (12, 0),
+    (12, 1),
+}
 
-def _is_sm100() -> bool:
-    return torch.cuda.is_available() and torch.cuda.get_device_capability() == (10, 0)
+
+def _is_supported_arch() -> bool:
+    return torch.cuda.is_available() and torch.cuda.get_device_capability() in _SUPPORTED_COMPUTE_CAPABILITIES
 
 
 pytestmark = [
     pytest.mark.L0,
     pytest.mark.gpu_exclusive,
     pytest.mark.xdist_group(name="gpu_exclusive"),
-    pytest.mark.skipif(not _is_sm100(), reason="requires exactly SM100 (compute capability 10.0)"),
+    pytest.mark.skipif(not _is_supported_arch(), reason="requires a supported SM80-or-newer architecture"),
 ]
 
 

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_sm100.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_sm100.py
@@ -159,7 +159,7 @@ def test_dense_class_nonzero_state_final_state_and_decode_recurrence():
         )
     with pytest.raises(TypeError, match="Output dtype mismatch"):
         api.execute(x, weight, output.float(), initial_state_tensor=initial_state, final_state_tensor=final_state)
-    with pytest.raises(ValueError, match="Output must be.*contiguous"):
+    with pytest.raises(ValueError, match=r"Output must be.*contiguous"):
         api.execute(
             x,
             weight,
@@ -547,6 +547,7 @@ os._exit(9)
 def test_invalid_cu_seqlens_fail_closed_in_fresh_process(case):
     # A PTX trap poisons its CUDA context, so isolate each metadata class and
     # first prove that the same compiled object accepts valid boundaries.
+    _load_class()
     source_cudnn = Path(__file__).resolve().parents[4] / "python" / "cudnn"
     environment = os.environ.copy()
     environment["PYTHONNOUSERSITE"] = "1"

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_sm100.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_sm100.py
@@ -105,6 +105,32 @@ def test_dense_channel_tail_without_state_has_stable_outputs():
 
 
 @torch.no_grad()
+@pytest.mark.parametrize("channels,packed", [(264, False), (263, True)])
+def test_optional_bias_matches_reference_for_vec8_and_scalar_paths(channels, packed):
+    wrapper = _load_wrapper()
+    torch.manual_seed(109 + channels)
+    x = torch.randn(1, 11, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(channels, device="cuda", dtype=torch.bfloat16)
+    cu_seqlens = torch.tensor((0, 3, 11), device="cuda", dtype=torch.int32) if packed else None
+    expected, _ = causal_conv1d_bulk_reference(
+        x,
+        weight,
+        bias=bias,
+        cu_seqlens=cu_seqlens,
+    )
+
+    result = wrapper(
+        x,
+        weight,
+        cu_seqlens_tensor=cu_seqlens,
+        bias_tensor=bias,
+    )
+
+    torch.testing.assert_close(result["output_tensor"], expected, atol=3e-2, rtol=3e-2)
+
+
+@torch.no_grad()
 def test_dense_class_nonzero_state_final_state_and_decode_recurrence():
     api_class = _load_class()
     torch.manual_seed(102)

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_sm100.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_sm100.py
@@ -1,0 +1,563 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""L0 GPU correctness for the SM100 bulk causal-convolution forward API."""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+import torch
+from cuda.bindings import driver as cuda
+
+from fe_api.causal_conv1d_bulk.reference import (
+    causal_conv1d_bulk_reference,
+    causal_conv1d_update_reference,
+)
+
+
+def _is_sm100() -> bool:
+    return torch.cuda.is_available() and torch.cuda.get_device_capability() == (10, 0)
+
+
+pytestmark = [
+    pytest.mark.L0,
+    pytest.mark.gpu_exclusive,
+    pytest.mark.xdist_group(name="gpu_exclusive"),
+    pytest.mark.skipif(not _is_sm100(), reason="requires exactly SM100 (compute capability 10.0)"),
+]
+
+
+def _load_wrapper():
+    try:
+        from cudnn.frost.buffers import cutedsl_state, cutedsl_too_old
+        from cudnn.causal_conv1d_bulk_sm100 import causal_conv1d_bulk_fwd_wrapper_sm100
+    except (ImportError, OSError) as error:
+        pytest.skip(f"CuTe DSL dependencies unavailable: {error}")
+    installed, version = cutedsl_state()
+    if not installed or cutedsl_too_old(version):
+        pytest.skip("causal_conv1d_bulk_sm100 requires nvidia-cutlass-dsl>=4.7.0")
+    return causal_conv1d_bulk_fwd_wrapper_sm100
+
+
+def _load_class():
+    try:
+        from cudnn.frost.buffers import cutedsl_state, cutedsl_too_old
+        from cudnn.causal_conv1d_bulk_sm100 import CausalConv1dBulkFwdSm100
+    except (ImportError, OSError) as error:
+        pytest.skip(f"CuTe DSL dependencies unavailable: {error}")
+    installed, version = cutedsl_state()
+    if not installed or cutedsl_too_old(version):
+        pytest.skip("causal_conv1d_bulk_sm100 requires nvidia-cutlass-dsl>=4.7.0")
+    return CausalConv1dBulkFwdSm100
+
+
+def _assert_state_bits_equal(actual: torch.Tensor, expected: torch.Tensor) -> None:
+    torch.testing.assert_close(actual.view(torch.int16), expected.view(torch.int16), rtol=0, atol=0)
+
+
+@torch.no_grad()
+def test_dense_channel_tail_without_state_has_stable_outputs():
+    from cudnn.api_base import TupleDict
+
+    wrapper = _load_wrapper()
+    torch.manual_seed(101)
+    x = torch.randn(2, 7, 259, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(259, 4, device="cuda", dtype=torch.bfloat16)
+    expected, _ = causal_conv1d_bulk_reference(x, weight)
+
+    result = wrapper(x, weight, output_final_state=False)
+
+    assert isinstance(result, TupleDict)
+    assert list(result.keys()) == ["output_tensor", "final_state_tensor"]
+    assert result[0] is result["output_tensor"]
+    assert result[1] is result["final_state_tensor"]
+    torch.testing.assert_close(result["output_tensor"], expected, atol=3e-2, rtol=3e-2)
+    assert result["final_state_tensor"].shape == (0,)
+    assert result["final_state_tensor"].dtype == torch.bfloat16
+    assert result["final_state_tensor"].device == x.device
+    assert result["final_state_tensor"].is_contiguous()
+
+    # T is intentionally absent from the wrapper cache key: one symbolic
+    # compile must safely serve a different runtime token extent.
+    x2 = torch.randn(2, 11, 259, device="cuda", dtype=torch.bfloat16)
+    expected2, _ = causal_conv1d_bulk_reference(x2, weight)
+    result2 = wrapper(x2, weight, output_final_state=False)
+    torch.testing.assert_close(result2["output_tensor"], expected2, atol=3e-2, rtol=3e-2)
+
+    with torch.enable_grad(), pytest.raises(RuntimeError, match="inference-only"):
+        wrapper(x.detach().requires_grad_(True), weight)
+
+
+@torch.no_grad()
+def test_dense_class_nonzero_state_final_state_and_decode_recurrence():
+    api_class = _load_class()
+    torch.manual_seed(102)
+    batch, tokens, channels = 2, 3, 257
+    x = torch.randn(batch, tokens, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    initial_state = torch.randn(batch, channels, 4, device="cuda", dtype=torch.bfloat16)
+    initial_state_before = initial_state.clone()
+    expected, expected_final = causal_conv1d_bulk_reference(x, weight, initial_state=initial_state)
+
+    output = torch.empty_like(x)
+    final_state = torch.empty_like(initial_state)
+    api = api_class(
+        sample_x=x,
+        sample_weight=weight,
+        sample_output=output,
+        sample_initial_state=initial_state,
+        sample_final_state=final_state,
+    )
+    assert api.check_support()
+    api.compile()
+    result = api.execute(
+        x_tensor=x,
+        weight_tensor=weight,
+        output_tensor=output,
+        initial_state_tensor=initial_state,
+        final_state_tensor=final_state,
+    )
+
+    assert list(result.keys()) == ["output_tensor", "final_state_tensor"]
+    assert result["output_tensor"] is output
+    assert result["final_state_tensor"] is final_state
+    torch.testing.assert_close(result["output_tensor"], expected, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(result["final_state_tensor"], expected_final)
+    _assert_state_bits_equal(initial_state, initial_state_before)
+
+    # The full-width state needs no repacking before the next decode token.
+    next_x = torch.randn(batch, channels, device="cuda", dtype=torch.bfloat16)
+    expected_next, expected_after_decode = causal_conv1d_update_reference(next_x, expected_final, weight)
+    actual_next, actual_after_decode = causal_conv1d_update_reference(next_x, result["final_state_tensor"], weight)
+    torch.testing.assert_close(actual_next, expected_next, atol=0, rtol=0)
+    _assert_state_bits_equal(actual_after_decode, expected_after_decode)
+
+    # Exercise the native decode implementation as well once that sibling API
+    # is present in the checkout (the bulk branch can precede it in CI).
+    try:
+        from cudnn.causal_conv1d_update_sm100 import causal_conv1d_update
+    except (ImportError, OSError):
+        causal_conv1d_update = None
+    if causal_conv1d_update is not None:
+        decode_state = result["final_state_tensor"].clone()
+        decode_output = causal_conv1d_update(next_x, decode_state, weight)
+        torch.testing.assert_close(decode_output, expected_next, atol=3e-2, rtol=3e-2)
+        _assert_state_bits_equal(decode_state, expected_after_decode)
+
+    # The preallocated class API revalidates outputs and aliases at execute,
+    # rather than trusting the descriptors used for compilation.
+    with pytest.raises(ValueError, match="Output T must match X"):
+        api.execute(
+            x,
+            weight,
+            torch.empty(batch, tokens + 1, channels, device="cuda", dtype=x.dtype),
+            initial_state_tensor=initial_state,
+            final_state_tensor=final_state,
+        )
+    with pytest.raises(TypeError, match="Output dtype mismatch"):
+        api.execute(x, weight, output.float(), initial_state_tensor=initial_state, final_state_tensor=final_state)
+    with pytest.raises(ValueError, match="Output must be.*contiguous"):
+        api.execute(
+            x,
+            weight,
+            torch.empty(batch, tokens, channels * 2, device="cuda", dtype=x.dtype)[..., ::2],
+            initial_state_tensor=initial_state,
+            final_state_tensor=final_state,
+        )
+    with pytest.raises(ValueError, match="Final state presence must match"):
+        api.execute(x, weight, output, initial_state_tensor=initial_state)
+    with pytest.raises(ValueError, match="Final state stride mismatch"):
+        api.execute(
+            x,
+            weight,
+            output,
+            initial_state_tensor=initial_state,
+            final_state_tensor=torch.empty(batch, channels, 8, device="cuda", dtype=x.dtype)[..., ::2],
+        )
+    with pytest.raises(ValueError, match="Output must not overlap"):
+        api.execute(x, weight, x, initial_state_tensor=initial_state, final_state_tensor=final_state)
+    with pytest.raises(ValueError, match="Final state must not overlap"):
+        api.execute(x, weight, output, initial_state_tensor=initial_state, final_state_tensor=initial_state)
+    dlpack_output_alias = torch.from_dlpack(x)
+    assert dlpack_output_alias.data_ptr() == x.data_ptr()
+    with pytest.raises(ValueError, match="Output must not overlap"):
+        api.execute(x, weight, dlpack_output_alias, initial_state_tensor=initial_state, final_state_tensor=final_state)
+    dlpack_final_alias = torch.from_dlpack(initial_state)
+    assert dlpack_final_alias.data_ptr() == initial_state.data_ptr()
+    with pytest.raises(ValueError, match="Final state must not overlap"):
+        api.execute(x, weight, output, initial_state_tensor=initial_state, final_state_tensor=dlpack_final_alias)
+    with torch.enable_grad(), pytest.raises(RuntimeError, match="inference-only"):
+        api.execute(x.detach().requires_grad_(True), weight, output, initial_state_tensor=initial_state, final_state_tensor=final_state)
+
+
+@torch.no_grad()
+def test_vec8_dense_initial_and_final_state_match_reference():
+    wrapper = _load_wrapper()
+    torch.manual_seed(104)
+    batch, tokens, channels = 2, 9, 264
+    x = torch.randn(batch, tokens, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    initial_state = torch.randn(batch, channels, 4, device="cuda", dtype=torch.bfloat16)
+    initial_state_before = initial_state.clone()
+    expected, expected_final = causal_conv1d_bulk_reference(x, weight, initial_state=initial_state)
+
+    result = wrapper(
+        x,
+        weight,
+        initial_state_tensor=initial_state,
+        output_final_state=True,
+    )
+
+    torch.testing.assert_close(result["output_tensor"], expected, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(result["final_state_tensor"], expected_final)
+    _assert_state_bits_equal(initial_state, initial_state_before)
+
+    # The vec8 specialization must retain the same symbolic-T cache contract
+    # as the scalar fallback, including execution on a caller-owned stream.
+    x2 = torch.randn(batch, 13, channels, device="cuda", dtype=torch.bfloat16)
+    expected2, expected_final2 = causal_conv1d_bulk_reference(x2, weight, initial_state=initial_state)
+    launch_stream = torch.cuda.Stream()
+    torch.cuda.current_stream().synchronize()
+    result2 = wrapper(
+        x2,
+        weight,
+        initial_state_tensor=initial_state,
+        output_final_state=True,
+        current_stream=cuda.CUstream(launch_stream.cuda_stream),
+    )
+    launch_stream.synchronize()
+    torch.testing.assert_close(result2["output_tensor"], expected2, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(result2["final_state_tensor"], expected_final2)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "use_initial_state,output_final_state",
+    [(False, True), (True, False)],
+)
+def test_optional_state_presence_compile_specializations(use_initial_state, output_final_state):
+    wrapper = _load_wrapper()
+    torch.manual_seed(107 + int(use_initial_state))
+    batch, tokens, channels = 2, 5, 264
+    x = torch.randn(batch, tokens, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    initial_state = torch.randn(batch, channels, 4, device="cuda", dtype=torch.bfloat16) if use_initial_state else None
+    initial_state_before = initial_state.clone() if initial_state is not None else None
+    expected, expected_final = causal_conv1d_bulk_reference(x, weight, initial_state=initial_state)
+
+    result = wrapper(
+        x,
+        weight,
+        initial_state_tensor=initial_state,
+        output_final_state=output_final_state,
+    )
+
+    torch.testing.assert_close(result["output_tensor"], expected, atol=3e-2, rtol=3e-2)
+    if output_final_state:
+        _assert_state_bits_equal(result["final_state_tensor"], expected_final)
+    else:
+        assert result["final_state_tensor"].shape == (0,)
+    if initial_state is not None:
+        _assert_state_bits_equal(initial_state, initial_state_before)
+
+
+@torch.no_grad()
+def test_packed_unequal_sequences_do_not_bleed_across_boundaries():
+    wrapper = _load_wrapper()
+    torch.manual_seed(103)
+    lengths = (17, 2, 14)  # Crosses scalar token tiles and includes T < width.
+    channels = 263
+    total_tokens = sum(lengths)
+    x = torch.randn(1, total_tokens, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    cu_seqlens = torch.tensor((0, 17, 19, 33), device="cuda", dtype=torch.int32)
+    initial_state = torch.randn(len(lengths), channels, 4, device="cuda", dtype=torch.bfloat16)
+    initial_state_before = initial_state.clone()
+    expected, expected_final = causal_conv1d_bulk_reference(
+        x,
+        weight,
+        cu_seqlens=cu_seqlens,
+        initial_state=initial_state,
+    )
+
+    result = wrapper(
+        x,
+        weight,
+        cu_seqlens_tensor=cu_seqlens,
+        initial_state_tensor=initial_state,
+        output_final_state=True,
+    )
+
+    torch.testing.assert_close(result["output_tensor"], expected, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(result["final_state_tensor"], expected_final)
+    _assert_state_bits_equal(initial_state, initial_state_before)
+
+    # The first output of each sequence must depend on its own initial state,
+    # never on the token immediately before the packed boundary.
+    for sequence, begin in enumerate(cu_seqlens[:-1].tolist()):
+        one_token, _ = causal_conv1d_bulk_reference(
+            x[:, begin : begin + 1],
+            weight,
+            initial_state=initial_state[sequence : sequence + 1],
+        )
+        torch.testing.assert_close(result["output_tensor"][:, begin : begin + 1], one_token, atol=3e-2, rtol=3e-2)
+
+    # Packed N/D/state presence form the compile signature, while total_T and
+    # the boundary values remain runtime inputs. Reuse this scalar compiled
+    # object at a second legal T with different cross-tile boundaries.
+    lengths2 = (8, 1, 12)
+    x2 = torch.randn(1, sum(lengths2), channels, device="cuda", dtype=torch.bfloat16)
+    cu_seqlens2 = torch.tensor((0, 8, 9, 21), device="cuda", dtype=torch.int32)
+    expected2, expected_final2 = causal_conv1d_bulk_reference(
+        x2,
+        weight,
+        cu_seqlens=cu_seqlens2,
+        initial_state=initial_state,
+    )
+    result2 = wrapper(
+        x2,
+        weight,
+        cu_seqlens_tensor=cu_seqlens2,
+        initial_state_tensor=initial_state,
+        output_final_state=True,
+    )
+    torch.testing.assert_close(result2["output_tensor"], expected2, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(result2["final_state_tensor"], expected_final2)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("pass_explicit_handle", [False, True])
+def test_side_stream_launch_records_temporary_operand_lifetimes(pass_explicit_handle):
+    # A raw CuTe launch is invisible to PyTorch's allocator. Delay a side-stream
+    # launch, drop every read operand, then pressure the matching allocation
+    # buckets on the default stream. This covers both an explicit handle and
+    # current_stream=None while a non-default torch stream is current.
+    if not hasattr(torch.cuda, "_sleep"):
+        pytest.skip("torch.cuda._sleep is unavailable")
+
+    wrapper = _load_wrapper()
+    torch.manual_seed(106)
+    batch, tokens, channels = 2, 13, 264
+    warm_x = torch.randn(batch, tokens, channels, device="cuda", dtype=torch.bfloat16)
+    warm_weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    warm_state = torch.randn(batch, channels, 4, device="cuda", dtype=torch.bfloat16)
+    wrapper(warm_x, warm_weight, initial_state_tensor=warm_state, output_final_state=True)
+    torch.cuda.synchronize()
+
+    ephemeral_x = torch.randn(batch, tokens, channels, device="cuda", dtype=torch.bfloat16)
+    ephemeral_weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    ephemeral_state = torch.randn(batch, channels, 4, device="cuda", dtype=torch.bfloat16)
+    expected, expected_final = causal_conv1d_bulk_reference(
+        ephemeral_x,
+        ephemeral_weight,
+        initial_state=ephemeral_state,
+    )
+    torch.cuda.current_stream().synchronize()
+
+    delayed_stream = torch.cuda.Stream()
+    with torch.cuda.stream(delayed_stream):
+        torch.cuda._sleep(100_000_000)
+        delayed_result = wrapper(
+            ephemeral_x,
+            ephemeral_weight,
+            initial_state_tensor=ephemeral_state,
+            output_final_state=True,
+            current_stream=cuda.CUstream(delayed_stream.cuda_stream) if pass_explicit_handle else None,
+        )
+
+    del ephemeral_x, ephemeral_weight, ephemeral_state
+    poison = []
+    for _ in range(8):
+        poison.extend(
+            (
+                torch.full((batch, tokens, channels), float("nan"), device="cuda", dtype=torch.bfloat16),
+                torch.full((channels, 4), float("nan"), device="cuda", dtype=torch.bfloat16),
+                torch.full((batch, channels, 4), float("nan"), device="cuda", dtype=torch.bfloat16),
+            )
+        )
+    delayed_stream.synchronize()
+    torch.testing.assert_close(delayed_result["output_tensor"], expected, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(delayed_result["final_state_tensor"], expected_final)
+
+
+@torch.no_grad()
+def test_vec8_packed_short_sequences_match_reference_and_final_state_bits():
+    wrapper = _load_wrapper()
+    torch.manual_seed(105)
+    lengths = (1, 2, 3, 4, 5)
+    channels = 264
+    x = torch.randn(1, sum(lengths), channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    cu_seqlens = torch.tensor((0, 1, 3, 6, 10, 15), device="cuda", dtype=torch.int32)
+    initial_state = torch.randn(len(lengths), channels, 4, device="cuda", dtype=torch.bfloat16)
+    initial_state_before = initial_state.clone()
+    expected, expected_final = causal_conv1d_bulk_reference(
+        x,
+        weight,
+        cu_seqlens=cu_seqlens,
+        initial_state=initial_state,
+    )
+
+    result = wrapper(
+        x,
+        weight,
+        cu_seqlens_tensor=cu_seqlens,
+        initial_state_tensor=initial_state,
+        output_final_state=True,
+    )
+
+    torch.testing.assert_close(result["output_tensor"], expected, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(result["final_state_tensor"], expected_final)
+    _assert_state_bits_equal(initial_state, initial_state_before)
+
+    # N is part of the cache key but T is symbolic. Rebinding this cached packed
+    # signature to fewer tokens than positive sequences must fail on the host,
+    # before the device-side metadata validator can trap.
+    too_short_x = torch.randn(1, 3, channels, device="cuda", dtype=torch.bfloat16)
+    too_short_cu = torch.tensor((0, 1, 2, 3, 3, 3), device="cuda", dtype=torch.int32)
+    with pytest.raises(ValueError, match="cannot exceed total_T"):
+        wrapper(
+            too_short_x,
+            weight,
+            cu_seqlens_tensor=too_short_cu,
+            initial_state_tensor=initial_state,
+            output_final_state=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "x-rank",
+        "weight-shape",
+        "x-dtype",
+        "weight-dtype",
+        "x-stride",
+        "weight-stride",
+        "packed-batch",
+        "packed-too-many-sequences",
+        "cu-too-short",
+        "cu-dtype",
+        "cu-stride",
+        "state-shape",
+        "state-dtype",
+        "state-stride",
+        "cu-device",
+    ],
+)
+def test_invalid_public_contract_is_rejected_before_launch(case):
+    wrapper = _load_wrapper()
+    x = torch.zeros(1, 4, 8, device="cuda", dtype=torch.bfloat16)
+    weight = torch.zeros(8, 4, device="cuda", dtype=torch.bfloat16)
+    cu_seqlens = None
+    initial_state = None
+
+    if case == "x-rank":
+        x = x.squeeze(0)
+    elif case == "weight-shape":
+        weight = weight[:, :3]
+    elif case == "x-dtype":
+        x = x.float()
+    elif case == "weight-dtype":
+        weight = weight.float()
+    elif case == "x-stride":
+        x = torch.empty(1, 8, 4, device="cuda", dtype=x.dtype).transpose(1, 2)
+    elif case == "weight-stride":
+        weight = torch.empty(8, 8, device="cuda", dtype=weight.dtype)[:, ::2]
+    elif case == "packed-batch":
+        x = x.expand(2, -1, -1).contiguous()
+        cu_seqlens = torch.tensor([0, 4], device="cuda", dtype=torch.int32)
+    elif case == "packed-too-many-sequences":
+        cu_seqlens = torch.arange(6, device="cuda", dtype=torch.int32)
+    elif case == "cu-too-short":
+        cu_seqlens = torch.empty(0, device="cuda", dtype=torch.int32)
+    elif case == "cu-dtype":
+        cu_seqlens = torch.tensor([0, 4], device="cuda", dtype=torch.int64)
+    elif case == "cu-stride":
+        cu_seqlens = torch.tensor([0, -1, 4, -1], device="cuda", dtype=torch.int32)[::2]
+    elif case == "state-shape":
+        initial_state = torch.zeros(2, 8, 4, device="cuda", dtype=x.dtype)
+    elif case == "state-dtype":
+        initial_state = torch.zeros(1, 8, 4, device="cuda", dtype=torch.float32)
+    elif case == "state-stride":
+        initial_state = torch.empty(1, 8, 8, device="cuda", dtype=x.dtype)[:, :, ::2]
+    elif case == "cu-device":
+        cu_seqlens = torch.tensor([0, 4], device="cpu", dtype=torch.int32)
+    else:
+        raise AssertionError(f"unhandled case {case}")
+
+    with pytest.raises((TypeError, ValueError, RuntimeError)):
+        wrapper(
+            x,
+            weight,
+            cu_seqlens_tensor=cu_seqlens,
+            initial_state_tensor=initial_state,
+            output_final_state=True,
+        )
+
+
+_DEVICE_ASSERT_WORKER = r"""
+import os
+import sys
+
+import torch
+import cudnn
+
+case = sys.argv[1]
+source_cudnn = sys.argv[2]
+cudnn.__path__.insert(0, source_cudnn)
+
+from cudnn.causal_conv1d_bulk_sm100 import CausalConv1dBulkFwdSm100
+
+torch.manual_seed(19)
+n_channels = 257
+x = torch.randn(1, 6, n_channels, device="cuda", dtype=torch.bfloat16)
+weight = torch.randn(n_channels, 4, device="cuda", dtype=torch.bfloat16)
+output = torch.empty_like(x)
+valid_cu = torch.tensor([0, 2, 4, 6], device="cuda", dtype=torch.int32)
+api = CausalConv1dBulkFwdSm100(x, weight, output, sample_cu_seqlens=valid_cu)
+api.check_support()
+api.compile()
+api.execute(x, weight, output, cu_seqlens_tensor=valid_cu)
+torch.cuda.synchronize()
+
+invalid_cu = {
+    "start_nonzero": [1, 2, 4, 6],
+    "end_mismatch": [0, 2, 4, 5],
+    "non_increasing": [0, 4, 3, 6],
+}[case]
+invalid_cu = torch.tensor(invalid_cu, device="cuda", dtype=torch.int32)
+
+try:
+    api.execute(x, weight, output, cu_seqlens_tensor=invalid_cu)
+    torch.cuda.synchronize()
+except Exception as error:
+    print(f"EXPECTED_DEVICE_FAILURE:{case}:{type(error).__name__}:{error}", flush=True)
+    os._exit(0)
+
+print(f"MISSING_DEVICE_FAILURE:{case}", flush=True)
+os._exit(9)
+"""
+
+
+@pytest.mark.parametrize("case", ["start_nonzero", "end_mismatch", "non_increasing"])
+def test_invalid_cu_seqlens_fail_closed_in_fresh_process(case):
+    # A PTX trap poisons its CUDA context, so isolate each metadata class and
+    # first prove that the same compiled object accepts valid boundaries.
+    source_cudnn = Path(__file__).resolve().parents[4] / "python" / "cudnn"
+    environment = os.environ.copy()
+    environment["PYTHONNOUSERSITE"] = "1"
+    result = subprocess.run(
+        [sys.executable, "-c", _DEVICE_ASSERT_WORKER, case, str(source_cudnn)],
+        cwd=Path(__file__).resolve().parents[4],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    diagnostics = result.stdout + result.stderr
+    assert result.returncode == 0, diagnostics
+    assert f"EXPECTED_DEVICE_FAILURE:{case}:" in diagnostics, diagnostics


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
- [ ] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions). The milestone is `Frontend 1.29.0`; the current token does not have Projects scope, so Project assignment remains for a maintainer.

## Affected area

FE OSS kernels or CuTeDSL.

## Summary

### Downstream model impact (combined attribution)

On B200, BF16 batch-one fprop+bprop all-on proxies containing this causal-convolution forward feature measured, at 8K/16K/32K respectively: Qwen3.5-9B 32-layer decoder backbone **1.1530x / 1.1722x / 1.1931x**; Qwen3.8-27B 64-layer decoder backbone **1.1354x / 1.1967x / 1.0898x**; GLM-5.3-Flash 34-layer KDA substack **1.0732x / 1.0950x / 1.0966x**; and the official-count Kimi-K3 feature substack **1.3567x / 1.3238x / 1.2189x**. These are combined results: Qwen also changes GDN, SwiGLU, and SDPA; GLM also changes KDA; Kimi also changes KDA and SiTU. They are not marginal speedups attributable to #798 or assembled-model results. Qwen and GLM contain this exact current head; Kimi uses a patch-equivalent rebased implementation.


Add an experimental, independent, SM100-optimized bulk causal-conv1d forward API and CuTeDSL kernel for the BF16, width-4, fused-SiLU operation used by short-convolution model blocks.

The implementation supports:

- dense `[B, T, D]` and packed `[1, total_T, D]` inputs;
- packed boundaries supplied as device-resident int32 cumulative sequence lengths;
- optional bias;
- optional full-width `[N, D, 4]` initial and final states;
- symbolic runtime `T` reuse for a compiled shape signature;
- a 128-bit vec8 fast path on the explicitly admitted SM100-family and newer targets, plus a compile-time-selected scalar fallback for supported SM80-SM90 targets;
- explicit/current PyTorch stream launch and allocator-lifetime recording;
- device-side validation that traps invalid packed boundaries before the convolution launch.

No external causal-conv kernel implementation was copied. FLA is used only as an independently installed interoperability/performance comparison in the manual benchmark; permanent correctness tests use the in-tree PyTorch reference.

## Why

The frontend has a decode-oriented causal-conv companion in #797, but no matching bulk/prefill primitive. This fills that forward feature gap with a standalone frontend implementation while keeping the contract narrow enough to validate and optimize independently.

## Related issues

Related to #797.

## API and compatibility impact

This adds the experimental `CausalConv1dBulkFwdSm100` class and `causal_conv1d_bulk_fwd_wrapper_sm100` convenience wrapper; the original suffix is retained while the API evolves. The exact functional targets are SM80/86/87/89/90/100/103/110/120/121. SM100/103/110/120/121 use the vec8 path when D is divisible by eight; SM80-SM90 use a compile-time scalar schedule. Unsupported architectures and inputs fail closed; there is no framework fallback, conversion, host synchronization, or backward implementation.

The API checks for `nvidia-cutlass-dsl >= 4.7` before lazily importing the kernel. The repository-wide dependency floor is unchanged. The optional state layout is intended to be compatible with the pending decode companion in #797; cross-API state tests remain conditional on that PR landing.

### Architecture policy and validation

Architecture admission and schedule selection are separate. The vec8 path contains `mul.f32x2` / `fma.rn.f32x2`, whose PTX target floor is SM100. Pre-Blackwell targets therefore compile only the ordinary-FP32 scalar kernel, even when `D % 8 == 0`. The gate is an explicit target allowlist rather than an open-ended `>=` comparison because the current DSL does not accept every numerical capability between listed targets.

The benchmark harness itself runs on every functional target, requires neither ComputeLab nor Slurm, and records ordinary hardware/software metadata plus optional Slurm fields.

No performance numbers were collected outside B200. Functional validation:

- ComputeLab A100 SM80, H200 SM90, and B200 SM100: complete GPU suite, 27 passed on each architecture.
- ComputeLab GB110 bring-up board SM103 and RTX 5080 SM120: dense vec8 and scalar state/final-state smoke tests passed against the independent reference.
- SM110 and SM121: API-equivalent CuTeDSL cross-compilation passed, including packed/state vec8; no runtime device was available, so these are compile-validated rather than runtime-validated.

### ComputeLab B200 performance

#### Equal-layout cuDNN backend NWH baseline (current head)

The exact clean current head `678e3570272ced7009eadb9603b4eb911b76cb8a` was rechecked on one NVIDIA B200 (SM100), PyTorch 2.13.0+cu130, cuDNN 9.26, and `nvidia-cutlass-dsl` 4.7.0. Both direct arms consume the same contiguous `[1, T, D]` BF16 input, implement width-four causal depthwise convolution plus SiLU, and write caller-preallocated output. Each number is the median of 15 alternating-order rounds with 10 calls per CUDA-event interval in one process. Ratios are `backend NWH / FE`, so values above 1 mean FE is faster.

| Signature | Shape | FE execute (us) | backend NWH direct (us) | Direct ratio | FE active (us) | backend NWH active (us) | Active ratio |
|---|---|---:|---:|---:|---:|---:|---:|
| `bias=None` | T8192 D8192 | 75.331 | 133.802 | 1.776x | 74.335 | 132.570 | 1.783x |
| `bias=None` | T16384 D8192 | 141.402 | 263.123 | 1.861x | 140.698 | 263.011 | 1.869x |
| `bias=None` | T32768 D8192 | 273.363 | 519.648 | 1.901x | 274.246 | 518.845 | 1.892x |
| `bias=None` | T16384 D12288 | 213.850 | 442.186 | 2.068x | 213.856 | 442.225 | 2.068x |

A separate same-process `torch.profiler`/CUPTI pass found exactly one kernel per arm per call and reproduced the CUDA-event ratios closely. This corroborates a kernel-throughput advantage rather than wrapper allocation or host-enqueue overhead. The profiler route was the FE vec8 kernel versus `cudnn_causal_conv1d_nwh_fwd_k4_silu_cutlass__bfloat16_t`. All shapes passed an independent FP32 reference; maximum absolute error divided by the reference range was below `0.00343`.

For `bias=None`, FE compiles the bias load/add out; the backend's public no-bias path supplies the all-zero bias buffer required by its ABI. A second equal-layout current-head run with a real nonzero BF16 bias gives the following signature-level result:

| Signature over the same four shapes | Direct NWH / FE range | CUPTI active NWH / FE range | Status |
|---|---:|---:|---|
| `bias=None` | 1.776-2.068x | 1.783-2.068x | reproduces the original rounded 1.8-2.1x result |
| nonzero bias | 1.619-1.916x | 1.631-1.914x | correct and still faster; bias specialization is a follow-up optimization |

The original 1.8-2.1x statement therefore applies specifically to `bias=None`; it is not used as a blanket claim for the nonzero-bias specialization.

#### FLA interoperability baseline

Measured on one NVIDIA B200 (SM100), PyTorch 2.13.0+cu130, cuDNN 9.26, `nvidia-cutlass-dsl` 4.7.0, and FLA 0.5.2. Each number is the median of 21 alternating-order rounds with 5 calls per CUDA-event interval in one process. These rows use `bias=None`. Ratios are `FLA / FE`, so values above 1 mean FE is faster.

| Shape | FE execute (us) | FLA direct (us) | Direct ratio | FE wrapper (us) | FLA public (us) | Public ratio |
|---|---:|---:|---:|---:|---:|---:|
| dense T8192 D8192 | 78.483 | 93.453 | 1.191x | 81.690 | 100.653 | 1.232x |
| dense T16384 D8192 | 144.710 | 169.427 | 1.171x | 147.872 | 174.125 | 1.178x |
| dense T32768 D8192 | 276.499 | 322.643 | 1.167x | 280.102 | 326.010 | 1.164x |
| dense state+final T16384 D8192 | 171.712 | 211.546 | 1.232x | 175.552 | 214.490 | 1.222x |
| packed N8 state+final T16384 D2048 | 55.827 | 109.907 | 1.969x | 60.832 | 136.134 | 2.238x |

These are direct-API CUDA-event elapsed measurements, not profiler-isolated kernel-active cycles or model end-to-end speedups. The FE direct arm uses caller-preallocated outputs while the FLA direct API allocates its outputs internally; the wrapper/public pair is the more symmetric allocation-inclusive comparison. CUDA events may also include device idle gaps while the host enqueues work.

A separate same-process `torch.profiler`/CUPTI capture isolates active kernel duration after the final stream-lifetime fix. Each implementation ran 20 direct-API plus 20 public-wrapper calls, yielding 40 launches of each kernel:

| Shape | FE active kernels (us) | FLA active kernels (us) | Kernel ratio |
|---|---:|---:|---:|
| dense T16384 D8192 | vec8 140.339 | conv 160.168 | 1.141x |
| packed N8 state+final T16384 D2048 | vec8 47.652 + validator 1.695 = 49.347 | conv 61.089 + state 2.303 = 63.392 | 1.285x |

These profiler ratios are also primitive-only and are intentionally reported separately from API elapsed and any future model-proxy result.

## Testing

- `pre-commit run --files <all changed files>`: passed (`black`, `black-jupyter`; clang-format not applicable).
- Focused host contract suite after the portable benchmark change: `36 passed`.
- ComputeLab B200 standalone benchmark smoke with `SLURM_JOB_ID` and `SLURMD_NODENAME` unset: completed successfully and omitted the optional Slurm object.
- Final review-fix ComputeLab B200 targeted suite: `36 passed, 1 warning in 35.94s` (job `4004734`).
- Current-head B200 equal-layout comparison: all no-bias and nonzero-bias shapes passed the independent FP32 reference; CUDA-event and one-kernel CUPTI ratios agree as reported above.
- Coverage includes dense/packed scalar and vec8 paths, bias on both schedules, state specializations, exact final-state bits, initial-state immutability, legal packed dynamic-T reuse, explicit/current side-stream allocator lifetime, DLPack alias rejection, and fresh-process device traps for invalid packed metadata.

GitHub CI does not exercise this SM100 GPU runtime path, so the ComputeLab result above is the relevant runtime validation.

Follow-ups are backward support, FLA/Transformers adapters with route proof, conditional cross-API state tests with #797, nonzero-bias specialization tuning, per-architecture tuning beyond the SM100 schedule, and model-proxy measurements after integration.
