### PR TITLE
Add native causal conv1d full-sequence and decode operations

### DIFF
--- a/benchmark/causal_conv1d_bulk_autograd_smoke.py
+++ b/benchmark/causal_conv1d_bulk_autograd_smoke.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""B200 smoke for the explicit dense causal-conv autograd prototype."""
+
+from pathlib import Path
+
+import cudnn
+import torch
+import torch.nn.functional as F
+
+SOURCE_CUDNN = Path(__file__).resolve().parents[1] / "python" / "cudnn"
+if str(SOURCE_CUDNN) not in cudnn.__path__:
+    cudnn.__path__.insert(0, str(SOURCE_CUDNN))
+
+from cudnn.causal_conv1d_bulk_sm100.autograd import (
+    CausalConv1dBulkAutogradPrototype,
+)
+
+
+def reference(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    tokens = x.shape[1]
+    z = F.conv1d(
+        x.transpose(1, 2),
+        weight.unsqueeze(1),
+        padding=3,
+        groups=x.shape[2],
+    )[
+        ..., :tokens
+    ].transpose(1, 2)
+    return F.silu(z)
+
+
+def metrics(actual: torch.Tensor, expected: torch.Tensor) -> dict[str, float]:
+    actual_float = actual.detach().float()
+    expected_float = expected.detach().float()
+    difference = actual_float - expected_float
+    return {
+        "max_abs": float(difference.abs().max()),
+        "rel_l2": float(torch.linalg.vector_norm(difference) / torch.linalg.vector_norm(expected_float)),
+    }
+
+
+def main() -> None:
+    generator = torch.Generator(device="cuda").manual_seed(20260829)
+    shape = (1, 257, 256)
+    x = (torch.randn(shape, device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25).requires_grad_()
+    weight = (torch.randn((shape[2], 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25).requires_grad_()
+    dy = torch.randn(shape, device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+
+    x_ref = x.detach().float().requires_grad_()
+    weight_ref = weight.detach().float().requires_grad_()
+    expected = reference(x_ref, weight_ref)
+    expected.backward(dy.float())
+
+    operation = CausalConv1dBulkAutogradPrototype(x, weight)
+    actual = operation(x, weight)
+    actual.backward(dy)
+    torch.cuda.synchronize()
+
+    results = {
+        "output": metrics(actual, expected),
+        "dx": metrics(x.grad, x_ref.grad),
+        "dw": metrics(weight.grad, weight_ref.grad),
+    }
+    torch.testing.assert_close(actual.float(), expected, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(x.grad.float(), x_ref.grad, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(weight.grad.float(), weight_ref.grad, atol=1e-1, rtol=5e-2)
+    print(
+        {
+            "device": torch.cuda.get_device_name(),
+            "shape": shape,
+            "schedule": operation.backward_backend.schedule,
+            "results": results,
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/causal_conv1d_bulk_bwd_perf.py
+++ b/benchmark/causal_conv1d_bulk_bwd_perf.py
@@ -1,0 +1,248 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Same-process schedule and FLA comparison for dense conv backward."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import statistics
+from pathlib import Path
+
+import cudnn
+import torch
+
+SOURCE_CUDNN = Path(__file__).resolve().parents[1] / "python" / "cudnn"
+if str(SOURCE_CUDNN) not in cudnn.__path__:
+    cudnn.__path__.insert(0, str(SOURCE_CUDNN))
+
+from cudnn.causal_conv1d_bulk_sm100.backward import (
+    compile_causal_conv1d_bulk_bwd_prototype,
+)
+from cudnn._causal_conv1d_arch import F32X2_COMPUTE_CAPABILITIES
+from fla.modules.conv.triton.ops import causal_conv1d_bwd as fla_bwd
+from fla.ops.utils import prepare_chunk_indices
+
+
+def capture(call, warmup):
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(warmup):
+            call()
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        outputs = call()
+    torch.cuda.synchronize()
+    return graph, outputs
+
+
+@torch.no_grad()
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tokens", type=int, default=8192)
+    parser.add_argument("--channels", type=int, default=2048)
+    parser.add_argument("--samples", type=int, default=31)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--bias", action="store_true")
+    parser.add_argument(
+        "--vec4-ab",
+        action="store_true",
+        help="time t128, v4-stream, FLA, and v2-cpasync where supported",
+    )
+    parser.add_argument(
+        "--packed",
+        action="store_true",
+        help="split B=1 into three uneven sequences using device cu_seqlens",
+    )
+    args = parser.parse_args()
+    generator = torch.Generator(device="cuda").manual_seed(20260829)
+    shape = (1, args.tokens, args.channels)
+    x = torch.randn(shape, device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    weight = torch.randn((args.channels, 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    bias = torch.randn((args.channels,), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25 if args.bias else None
+    dy = torch.randn(shape, device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    cu_seqlens = None
+    chunk_indices = None
+    if args.packed:
+        first = args.tokens // 4
+        second = first + args.tokens // 3
+        offsets = (0, first, second, args.tokens)
+        if first <= 0 or second >= args.tokens:
+            parser.error("--packed requires at least four tokens")
+        cu_seqlens = torch.tensor(offsets, device="cuda", dtype=torch.int32)
+        cu_seqlens_cpu = torch.tensor(offsets, dtype=torch.int32)
+        chunk_indices = prepare_chunk_indices(
+            cu_seqlens,
+            64,
+            cu_seqlens_cpu=cu_seqlens_cpu,
+        )
+
+    arms = {}
+    native_outputs = {}
+    native_keepalive = {}
+    native_plans = {}
+    native_schedule_skips = {}
+    vec4_supported = not args.packed and bias is None and args.channels % 512 == 0 and args.tokens >= 16
+    capability = torch.cuda.get_device_capability()
+    cpasync_supported = vec4_supported and args.tokens >= 64 and capability in F32X2_COMPUTE_CAPABILITIES
+    if args.vec4_ab and not vec4_supported:
+        parser.error("--vec4-ab requires dense no-bias input, T>=16, and D divisible by 512")
+    schedules = ["t128", "v4-stream"] if args.vec4_ab else ["t32", "t64", "t128", "t64-partial"]
+    if args.vec4_ab:
+        if cpasync_supported:
+            schedules.append("v2-cpasync")
+        else:
+            native_schedule_skips["v2-cpasync"] = f"requires T>=64 and packed-f32x2 support; got T={args.tokens}, capability={capability}"
+    if vec4_supported and not args.vec4_ab:
+        schedules.append("v4-stream")
+    for schedule in schedules:
+        backend = compile_causal_conv1d_bulk_bwd_prototype(
+            x,
+            weight,
+            dy,
+            cu_seqlens,
+            schedule=schedule,
+            bias=bias,
+        )
+        dx = torch.empty_like(x)
+        dw = torch.empty_like(weight, dtype=torch.float32)
+        db = torch.empty_like(bias, dtype=torch.float32) if bias is not None else None
+        workspace = torch.empty(backend.dweight_workspace_numel, device="cuda", dtype=torch.float32) if backend.dweight_workspace_numel else None
+        packed_tile_map = (
+            torch.empty(
+                backend.packed_tile_map_numel,
+                device="cuda",
+                dtype=torch.int32,
+            )
+            if backend.packed_tile_map_numel
+            else None
+        )
+        graph, _ = capture(
+            lambda backend=backend, dx=dx, dw=dw, db=db, workspace=workspace, packed_tile_map=packed_tile_map: (
+                backend.execute(
+                    x,
+                    weight,
+                    dy,
+                    dx,
+                    dw,
+                    cu_seqlens=cu_seqlens,
+                    packed_tile_map=packed_tile_map,
+                    dweight_workspace=workspace,
+                    bias=bias,
+                    db_accum=db,
+                )
+            ),
+            args.warmup,
+        )
+        arms[schedule] = graph
+        native_outputs[schedule] = (dx, dw, db, backend.dweight_workspace_bytes)
+        native_plans[schedule] = {
+            "kernel_variant": backend.kernel_variant,
+            "sm_count": backend.sm_count,
+            "tokens_per_cta": backend.tokens_per_cta,
+            "token_ctas": backend.num_dweight_partials,
+        }
+        # CUDA graphs retain raw addresses, not these Python owners. Keep every
+        # caller-owned buffer alive after later schedules replace loop locals.
+        native_keepalive[schedule] = (backend, workspace, packed_tile_map)
+
+    fla_graph, fla_outputs = capture(
+        lambda: fla_bwd(
+            x=x,
+            dy=dy,
+            dht=None,
+            weight=weight,
+            bias=bias,
+            activation="silu",
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        ),
+        args.warmup,
+    )
+    arms["fla"] = fla_graph
+    fla_dx, fla_dw, fla_db = fla_outputs[:3]
+
+    # Capture records work but does not guarantee that tensors allocated only
+    # inside the captured region contain a completed result.  Materialize one
+    # result from every arm before reading correctness outputs.
+    for graph in arms.values():
+        graph.replay()
+    torch.cuda.synchronize()
+
+    correctness = {}
+    for name, (dx, dw, db, workspace_bytes) in native_outputs.items():
+        dx_diff = dx.float() - fla_dx.float()
+        dw_diff = dw - fla_dw.float()
+        correctness[name] = {
+            "dx_max_abs": float(dx_diff.abs().max()),
+            "dx_rel_l2": float(torch.linalg.vector_norm(dx_diff) / torch.linalg.vector_norm(fla_dx.float())),
+            "dw_max_abs": float(dw_diff.abs().max()),
+            "dw_rel_l2": float(torch.linalg.vector_norm(dw_diff) / torch.linalg.vector_norm(fla_dw.float())),
+            "workspace_bytes": workspace_bytes,
+        }
+        if db is not None:
+            db_diff = db - fla_db.float()
+            correctness[name].update(
+                db_max_abs=float(db_diff.abs().max()),
+                db_rel_l2=float(torch.linalg.vector_norm(db_diff) / torch.linalg.vector_norm(fla_db.float())),
+            )
+            torch.testing.assert_close(db, fla_db.float(), atol=1e-1, rtol=5e-2)
+        torch.testing.assert_close(dx, fla_dx, atol=3e-2, rtol=3e-2)
+        torch.testing.assert_close(dw, fla_dw.float(), atol=1e-1, rtol=5e-2)
+
+    names = tuple(arms)
+    timings = {name: [] for name in names}
+    events = [(torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)) for _ in range(args.samples * len(names))]
+    for start, end in events:
+        start.record()
+        end.record()
+    torch.cuda.synchronize()
+    event_index = 0
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        for sample in range(args.samples):
+            order = names[sample % len(names) :] + names[: sample % len(names)]
+            pending = []
+            for name in order:
+                start, end = events[event_index]
+                event_index += 1
+                start.record()
+                arms[name].replay()
+                end.record()
+                pending.append((name, start, end))
+            torch.cuda.synchronize()
+            for name, start, end in pending:
+                timings[name].append(float(start.elapsed_time(end) * 1000.0))
+    finally:
+        if gc_was_enabled:
+            gc.enable()
+
+    summaries = {name: {"median_us": statistics.median(values), "samples_us": values} for name, values in timings.items()}
+    fastest_native = min(native_outputs, key=lambda name: summaries[name]["median_us"])
+    print(
+        json.dumps(
+            {
+                "device": torch.cuda.get_device_name(),
+                "shape": list(shape),
+                "bias": bias is not None,
+                "cu_seqlens": None if cu_seqlens is None else cu_seqlens.cpu().tolist(),
+                "native_plans": native_plans,
+                "native_schedule_skips": native_schedule_skips,
+                "correctness_vs_fla": correctness,
+                "timings": summaries,
+                "fastest_native": fastest_native,
+                "fla_over_fastest_native": summaries["fla"]["median_us"] / summaries[fastest_native]["median_us"],
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/causal_conv1d_bulk_bwd_smoke.py
+++ b/benchmark/causal_conv1d_bulk_bwd_smoke.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""ComputeLab compile and correctness smoke for dense causal-conv backward."""
+"""GPU compile and correctness smoke for dense causal-conv backward."""
 
 from pathlib import Path
 

--- a/benchmark/causal_conv1d_bulk_bwd_smoke.py
+++ b/benchmark/causal_conv1d_bulk_bwd_smoke.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""ComputeLab compile and correctness smoke for dense causal-conv backward."""
+
+from pathlib import Path
+
+import cudnn
+import torch
+import torch.nn.functional as F
+
+SOURCE_CUDNN = Path(__file__).resolve().parents[1] / "python" / "cudnn"
+if str(SOURCE_CUDNN) not in cudnn.__path__:
+    cudnn.__path__.insert(0, str(SOURCE_CUDNN))
+
+from cudnn.causal_conv1d_bulk_sm100.backward import (
+    compile_causal_conv1d_bulk_bwd_prototype,
+)
+from fla.modules.conv.triton.ops import causal_conv1d_bwd as fla_bwd
+
+
+def reference(x, weight, dy):
+    x_ref = x.float().requires_grad_()
+    weight_ref = weight.float().requires_grad_()
+    tokens = x.shape[1]
+    z = F.conv1d(
+        x_ref.transpose(1, 2),
+        weight_ref.unsqueeze(1),
+        padding=3,
+        groups=x.shape[2],
+    )[
+        ..., :tokens
+    ].transpose(1, 2)
+    F.silu(z).backward(dy.float())
+    return x_ref.grad, weight_ref.grad
+
+
+@torch.no_grad()
+def main():
+    generator = torch.Generator(device="cuda").manual_seed(20260829)
+    x = torch.randn((1, 257, 256), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    weight = torch.randn((256, 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    dy = torch.randn(x.shape, device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    with torch.enable_grad():
+        reference_dx, reference_dw = reference(x, weight, dy)
+
+    fla_dx, fla_dw = fla_bwd(
+        x=x,
+        dy=dy,
+        dht=None,
+        weight=weight,
+        activation="silu",
+    )[:2]
+    fla_dx_diff = fla_dx.float() - reference_dx
+    fla_dw_diff = fla_dw.float() - reference_dw
+    fla_metrics = {
+        "dx_max_abs": float(fla_dx_diff.abs().max()),
+        "dx_rel_l2": float(torch.linalg.vector_norm(fla_dx_diff) / torch.linalg.vector_norm(reference_dx)),
+        "dw_max_abs": float(fla_dw_diff.abs().max()),
+        "dw_rel_l2": float(torch.linalg.vector_norm(fla_dw_diff) / torch.linalg.vector_norm(reference_dw)),
+    }
+
+    rows = {}
+    for schedule in ("t32", "t64", "t128", "t64-partial"):
+        backend = compile_causal_conv1d_bulk_bwd_prototype(x, weight, dy, schedule=schedule)
+        dx = torch.empty_like(x)
+        dw = torch.empty_like(weight, dtype=torch.float32)
+        workspace = None
+        if backend.dweight_workspace_numel:
+            workspace = torch.empty(backend.dweight_workspace_numel, device="cuda", dtype=torch.float32)
+        backend.execute(x, weight, dy, dx, dw, dweight_workspace=workspace)
+        torch.cuda.synchronize()
+        dx_diff = dx.float() - reference_dx
+        dw_diff = dw - reference_dw
+        metrics = {
+            "dx_max_abs": float(dx_diff.abs().max()),
+            "dx_rel_l2": float(torch.linalg.vector_norm(dx_diff) / torch.linalg.vector_norm(reference_dx)),
+            "dw_max_abs": float(dw_diff.abs().max()),
+            "dw_rel_l2": float(torch.linalg.vector_norm(dw_diff) / torch.linalg.vector_norm(reference_dw)),
+            "workspace_bytes": backend.dweight_workspace_bytes,
+        }
+        torch.testing.assert_close(dx.float(), reference_dx, atol=5e-2, rtol=5e-2)
+        torch.testing.assert_close(dw, reference_dw, atol=1e-1, rtol=5e-2)
+        rows[schedule] = metrics
+    print(
+        {
+            "device": torch.cuda.get_device_name(),
+            "shape": list(x.shape),
+            "fla_vs_fp32": fla_metrics,
+            "results": rows,
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/causal_conv1d_bulk_packed_bwd_smoke.py
+++ b/benchmark/causal_conv1d_bulk_packed_bwd_smoke.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""B200 correctness smoke for packed causal-conv autograd backward."""
+
+from pathlib import Path
+
+import cudnn
+import torch
+import torch.nn.functional as F
+
+SOURCE_CUDNN = Path(__file__).resolve().parents[1] / "python" / "cudnn"
+if str(SOURCE_CUDNN) not in cudnn.__path__:
+    cudnn.__path__.insert(0, str(SOURCE_CUDNN))
+
+from cudnn.causal_conv1d_bulk_sm100.autograd import (
+    CausalConv1dBulkAutogradPrototype,
+)
+
+
+def dense_reference(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    tokens = x.shape[1]
+    z = F.conv1d(
+        x.transpose(1, 2),
+        weight.unsqueeze(1),
+        padding=3,
+        groups=x.shape[2],
+    )[
+        ..., :tokens
+    ].transpose(1, 2)
+    return F.silu(z)
+
+
+def packed_reference(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    offsets: tuple[int, ...],
+) -> torch.Tensor:
+    return torch.cat(
+        [dense_reference(x[:, start:end], weight) for start, end in zip(offsets[:-1], offsets[1:], strict=True)],
+        dim=1,
+    )
+
+
+def metrics(actual: torch.Tensor, expected: torch.Tensor) -> dict[str, float]:
+    actual_float = actual.detach().float()
+    expected_float = expected.detach().float()
+    difference = actual_float - expected_float
+    return {
+        "max_abs": float(difference.abs().max()),
+        "rel_l2": float(torch.linalg.vector_norm(difference) / torch.linalg.vector_norm(expected_float)),
+    }
+
+
+def main() -> None:
+    generator = torch.Generator(device="cuda").manual_seed(20260829)
+    shape = (1, 257, 256)
+    offsets = (0, 1, 5, 70, 257)
+    cu_seqlens = torch.tensor(offsets, device="cuda", dtype=torch.int32)
+    x = (torch.randn(shape, device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25).requires_grad_()
+    weight = (torch.randn((shape[2], 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25).requires_grad_()
+    dy = torch.randn(shape, device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+
+    x_ref = x.detach().float().requires_grad_()
+    weight_ref = weight.detach().float().requires_grad_()
+    expected = packed_reference(x_ref, weight_ref, offsets)
+    expected.backward(dy.float())
+
+    operation = CausalConv1dBulkAutogradPrototype(x, weight, cu_seqlens)
+    actual = operation(x, weight, cu_seqlens)
+    actual.backward(dy)
+    torch.cuda.synchronize()
+
+    results = {
+        "output": metrics(actual, expected),
+        "dx": metrics(x.grad, x_ref.grad),
+        "dw": metrics(weight.grad, weight_ref.grad),
+    }
+    torch.testing.assert_close(actual.float(), expected, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(x.grad.float(), x_ref.grad, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(weight.grad.float(), weight_ref.grad, atol=1e-1, rtol=5e-2)
+
+    backend = operation.backward_backend
+    alias_rejected = False
+    try:
+        backend.execute(
+            x.detach(),
+            weight.detach(),
+            dy,
+            x.detach(),
+            torch.empty_like(weight, dtype=torch.float32),
+            cu_seqlens=cu_seqlens,
+            packed_tile_map=torch.empty(
+                backend.packed_tile_map_numel,
+                device="cuda",
+                dtype=torch.int32,
+            ),
+        )
+    except ValueError as error:
+        alias_rejected = "must not overlap" in str(error)
+    if not alias_rejected:
+        raise AssertionError("packed backward accepted an X/dX storage alias")
+    print(
+        {
+            "device": torch.cuda.get_device_name(),
+            "shape": shape,
+            "offsets": offsets,
+            "schedule": operation.backward_backend.schedule,
+            "tile_map_bytes": operation.backward_backend.packed_tile_map_bytes,
+            "alias_rejected": alias_rejected,
+            "results": results,
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/causal_conv1d_update_bias_smoke.py
+++ b/benchmark/causal_conv1d_update_bias_smoke.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""ComputeLab correctness smoke for optional decode causal-conv bias."""
+"""GPU correctness smoke for optional decode causal-conv bias."""
 
 from pathlib import Path
 

--- a/benchmark/causal_conv1d_update_bias_smoke.py
+++ b/benchmark/causal_conv1d_update_bias_smoke.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""ComputeLab correctness smoke for optional decode causal-conv bias."""
+
+from pathlib import Path
+
+import cudnn
+import torch
+import torch.nn.functional as F
+
+SOURCE_CUDNN = Path(__file__).resolve().parents[1] / "python" / "cudnn"
+if str(SOURCE_CUDNN) not in cudnn.__path__:
+    cudnn.__path__.insert(0, str(SOURCE_CUDNN))
+
+from cudnn.ops import causal_conv1d_update  # noqa: E402
+
+
+@torch.no_grad()
+def main():
+    generator = torch.Generator(device="cuda").manual_seed(20260829)
+    x = torch.randn((128, 4096), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    weight = torch.randn((4096, 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    bias = torch.randn((4096,), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    initial_state = torch.randn((128, 4096, 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    rows = {}
+    for name, value in (("none", None), ("bias", bias)):
+        state = initial_state.clone()
+        expected_state = torch.cat((initial_state[..., 1:], x.unsqueeze(-1)), dim=-1)
+        accumulator = (expected_state.float() * weight.float().unsqueeze(0)).sum(-1)
+        if value is not None:
+            accumulator = accumulator + value.float()
+        expected = F.silu(accumulator).to(torch.bfloat16)
+        actual = causal_conv1d_update(x, state, weight, bias=value, activation="silu")
+        torch.testing.assert_close(actual, expected, atol=3e-2, rtol=3e-2)
+        torch.testing.assert_close(state.view(torch.int16), expected_state.view(torch.int16), atol=0, rtol=0)
+        rows[name] = float((actual.float() - expected.float()).abs().max())
+    print(
+        {
+            "device": torch.cuda.get_device_name(),
+            "shape": list(x.shape),
+            "max_abs": rows,
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/causal_conv1d_update_sm100.py
+++ b/benchmark/causal_conv1d_update_sm100.py
@@ -1,0 +1,514 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Decode microbenchmark for the causal-convolution update operation.
+
+This compares the direct low-level cuDNN Frontend API against FLA 0.5.2's
+public Triton update operation at representative Qwen3.5/Qwen3.8 decode
+shapes.  The official model applies one fused-QKV depthwise convolution before
+splitting Q, K, and V, so the benchmark uses the full convolution channel
+counts D={6144, 8192, 10240, 12288, 20480}; every model uses W=4.
+It is a single-process, same-input, AB/BA-interleaved comparison.  Both
+implementations are compiled and CUDA-graph-captured before timing; in
+particular, the ``torch.empty_like`` in FLA's wrapper runs during capture rather
+than between the timing events.  Every timed replay starts from the same state
+bits.
+
+The script deliberately refuses to print timing results unless both output and
+the final mutable cache pass an explicit FP32/BF16 reference gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import importlib.metadata
+import json
+import os
+import platform
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable, NamedTuple
+
+import cudnn
+import torch
+import torch.nn.functional as F
+
+# Execute the Python sources from this checkout while retaining the installed
+# package's compiled extension.  This mirrors the focused pytest overlay and
+# makes the source-hash route proof independent of site-package sync state.
+_SOURCE_CUDNN = Path(__file__).resolve().parents[1] / "python" / "cudnn"
+if str(_SOURCE_CUDNN) not in cudnn.__path__:
+    cudnn.__path__.insert(0, str(_SOURCE_CUDNN))
+
+from cudnn._causal_conv1d_arch import (
+    is_supported_causal_conv1d_update_compute_capability,
+    supported_causal_conv1d_update_compute_capabilities_text,
+)
+from cudnn.causal_conv1d_update_sm100 import _CausalConv1dUpdatePlan
+from fla.modules.conv.triton.ops import causal_conv1d_update as fla_causal_conv1d_update
+
+DEFAULT_BATCH_SIZES = (1, 8, 32, 128)
+DEFAULT_CHANNELS = (6144, 8192, 10240, 12288, 20480)
+DEFAULT_SHAPES = tuple((batch, channels) for channels in DEFAULT_CHANNELS for batch in DEFAULT_BATCH_SIZES)
+OUTPUT_ATOL = 3e-2
+OUTPUT_RTOL = 3e-2
+
+
+class CapturedArm(NamedTuple):
+    name: str
+    graph: torch.cuda.CUDAGraph
+    output: torch.Tensor
+    state: torch.Tensor
+
+
+def _parse_shape(value: str) -> tuple[int, int]:
+    try:
+        n_rows, n_channels = (int(piece) for piece in value.lower().split("x", maxsplit=1))
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError("shape must be N x D, for example 8x8192") from exc
+    if n_rows <= 0 or n_channels <= 0:
+        raise argparse.ArgumentTypeError("N and D must both be positive")
+    return n_rows, n_channels
+
+
+def _quantile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    position = fraction * (len(ordered) - 1)
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = position - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def _sha256(path: str | os.PathLike[str]) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(["git", "-C", str(repo), *args], text=True).strip()
+
+
+def _package_version(name: str) -> str:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return "not-installed"
+
+
+def _slurm_provenance() -> dict[str, str | None]:
+    """Return optional scheduler metadata without restricting where the benchmark runs."""
+
+    return {
+        "slurm_job_id": os.environ.get("SLURM_JOB_ID"),
+        "slurmd_node_name": os.environ.get("SLURMD_NODENAME"),
+    }
+
+
+def _module_path(module_name: str) -> Path:
+    module = sys.modules.get(module_name)
+    path = getattr(module, "__file__", None)
+    if path is None:
+        raise RuntimeError(f"cannot resolve source path for loaded module {module_name}")
+    return Path(path).resolve()
+
+
+def _nvidia_driver_for_uuid(device_uuid: str) -> str:
+    """Resolve the actual NVIDIA driver, matching the CUDA-visible GPU UUID."""
+
+    output = subprocess.check_output(
+        [
+            "nvidia-smi",
+            "--query-gpu=uuid,driver_version",
+            "--format=csv,noheader,nounits",
+        ],
+        text=True,
+    )
+    normalized_uuid = device_uuid.lower().removeprefix("gpu-")
+    for line in output.splitlines():
+        gpu_uuid, separator, driver_version = line.partition(",")
+        if separator and gpu_uuid.strip().lower().removeprefix("gpu-") == normalized_uuid:
+            return driver_version.strip()
+    raise RuntimeError(f"nvidia-smi did not report CUDA-visible GPU UUID {device_uuid}")
+
+
+def _capture(call: Callable[[], torch.Tensor | tuple[torch.Tensor, torch.Tensor]], *, warmup: int):
+    """Warm and capture ``call``; all Python allocation stays outside timing."""
+
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(warmup):
+            call()
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+    torch.cuda.synchronize()
+
+    capture_stream = torch.cuda.Stream()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=capture_stream):
+        result = call()
+    torch.cuda.synchronize()
+    return graph, result
+
+
+def _reference(x: torch.Tensor, weight: torch.Tensor, initial_state: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    final_state = torch.cat((initial_state[..., 1:], x.unsqueeze(-1)), dim=-1)
+    accumulator = (final_state.float() * weight.float().unsqueeze(0)).sum(dim=-1)
+    output = F.silu(accumulator).to(torch.bfloat16)
+    return output, final_state
+
+
+def _gate_arm(
+    arm: CapturedArm,
+    initial_state: torch.Tensor,
+    reference_output: torch.Tensor,
+    reference_state: torch.Tensor,
+) -> dict:
+    arm.state.copy_(initial_state)
+    arm.graph.replay()
+    torch.cuda.synchronize()
+
+    output_diff = (arm.output.float() - reference_output.float()).abs()
+    state_bits_equal = torch.equal(arm.state.view(torch.int16), reference_state.view(torch.int16))
+    output_close = torch.allclose(arm.output, reference_output, atol=OUTPUT_ATOL, rtol=OUTPUT_RTOL)
+    gate = {
+        "output_close": bool(output_close),
+        "output_max_abs": float(output_diff.max().item()),
+        "output_mean_abs": float(output_diff.mean().item()),
+        "state_bits_equal": bool(state_bits_equal),
+    }
+    if not output_close or not state_bits_equal:
+        raise AssertionError(f"{arm.name} correctness gate failed: {gate}")
+    return gate
+
+
+def _prime_events(event_pairs: list[tuple[torch.cuda.Event, torch.cuda.Event]]) -> None:
+    """Force lazy CUDA event creation before any measured interval."""
+
+    for start, end in event_pairs:
+        start.record()
+        end.record()
+    torch.cuda.synchronize()
+
+
+def _interleaved_samples(
+    native: CapturedArm,
+    fla: CapturedArm,
+    initial_state: torch.Tensor,
+    *,
+    samples: int,
+) -> tuple[list[float], list[float], list[str]]:
+    """Measure one graph replay per sample, alternating AB and BA order."""
+
+    arms = {native.name: native, fla.name: fla}
+    timings = {native.name: [], fla.name: []}
+    event_pairs = [(torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)) for _ in range(samples * 2)]
+    _prime_events(event_pairs)
+    orders = []
+    event_index = 0
+
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        for sample_index in range(samples):
+            order = (native.name, fla.name) if sample_index % 2 == 0 else (fla.name, native.name)
+            orders.append("/".join(order))
+            pending = []
+            for name in order:
+                arm = arms[name]
+                # This reset is ordered before the start event on the same
+                # stream, hence excluded from the measured interval.
+                arm.state.copy_(initial_state)
+                start, end = event_pairs[event_index]
+                event_index += 1
+                start.record()
+                arm.graph.replay()
+                end.record()
+                pending.append((name, start, end))
+            torch.cuda.synchronize()
+            for name, start, end in pending:
+                timings[name].append(float(start.elapsed_time(end) * 1000.0))
+    finally:
+        if gc_was_enabled:
+            gc.enable()
+
+    return timings[native.name], timings[fla.name], orders
+
+
+def _summary(samples_us: list[float]) -> dict:
+    return {
+        "median_us": statistics.median(samples_us),
+        "q25_us": _quantile(samples_us, 0.25),
+        "q75_us": _quantile(samples_us, 0.75),
+        "min_us": min(samples_us),
+        "max_us": max(samples_us),
+    }
+
+
+@torch.no_grad()
+def _benchmark_shape(n_rows: int, n_channels: int, *, samples: int, warmup: int, seed: int) -> dict:
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    x = (
+        torch.randn(
+            (n_rows, n_channels),
+            device="cuda",
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.25
+    )
+    weight = torch.randn((n_channels, 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    initial_state = (
+        torch.randn(
+            (n_rows, n_channels, 4),
+            device="cuda",
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.25
+    )
+    native_state = initial_state.clone()
+    fla_state = initial_state.clone()
+    native_output = torch.empty_like(x)
+
+    api = _CausalConv1dUpdatePlan(x, weight, native_state, native_output, activation="silu")
+    if not api.check_support():
+        raise RuntimeError("native check_support unexpectedly returned false")
+    api.compile()
+
+    def native_call() -> torch.Tensor:
+        return api.execute(x, weight, native_state, native_output)
+
+    def fla_call() -> tuple[torch.Tensor, torch.Tensor]:
+        # Use FLA's public Triton op directly.  Its real cache contract is
+        # [N, D, W], including the newest element, so W=4 here.
+        return fla_causal_conv1d_update(
+            x=x,
+            cache=fla_state,
+            residual=None,
+            weight=weight,
+            bias=None,
+            activation="silu",
+        )
+
+    native_graph, captured_native_output = _capture(native_call, warmup=warmup)
+    fla_graph, captured_fla = _capture(fla_call, warmup=warmup)
+    fla_output, returned_fla_state = captured_fla
+    if captured_native_output.data_ptr() != native_output.data_ptr():
+        raise AssertionError("native direct execute did not return its preallocated output")
+    if returned_fla_state.data_ptr() != fla_state.data_ptr():
+        raise AssertionError("FLA did not return the mutable cache passed by the benchmark")
+
+    native_arm = CapturedArm("native", native_graph, native_output, native_state)
+    fla_arm = CapturedArm("fla", fla_graph, fla_output, fla_state)
+    reference_output, reference_state = _reference(x, weight, initial_state)
+    correctness = {
+        "native": _gate_arm(native_arm, initial_state, reference_output, reference_state),
+        "fla": _gate_arm(fla_arm, initial_state, reference_output, reference_state),
+    }
+    cross_output_close = torch.allclose(native_output, fla_output, atol=OUTPUT_ATOL, rtol=OUTPUT_RTOL)
+    cross_state_bits_equal = torch.equal(native_state.view(torch.int16), fla_state.view(torch.int16))
+    correctness["native_vs_fla"] = {
+        "output_close": bool(cross_output_close),
+        "state_bits_equal": bool(cross_state_bits_equal),
+        "output_max_abs": float((native_output.float() - fla_output.float()).abs().max().item()),
+    }
+    if not cross_output_close or not cross_state_bits_equal:
+        raise AssertionError(f"native/FLA cross gate failed: {correctness['native_vs_fla']}")
+
+    # Graphs and events are warmed.  Every measured arm below is reset from the
+    # same immutable state, outside of its event pair.
+    for arm in (native_arm, fla_arm):
+        for _ in range(warmup):
+            arm.state.copy_(initial_state)
+            arm.graph.replay()
+    torch.cuda.synchronize()
+
+    native_samples, fla_samples, orders = _interleaved_samples(
+        native_arm,
+        fla_arm,
+        initial_state,
+        samples=samples,
+    )
+    native_summary = _summary(native_samples)
+    fla_summary = _summary(fla_samples)
+    paired_ratios = [fla_us / native_us for native_us, fla_us in zip(native_samples, fla_samples, strict=True)]
+    return {
+        "shape": {"N": n_rows, "D": n_channels, "W": 4},
+        "correctness": correctness,
+        "native": {**native_summary, "samples_us": native_samples},
+        "fla": {**fla_summary, "samples_us": fla_samples},
+        "ratio_of_medians_fla_over_native": fla_summary["median_us"] / native_summary["median_us"],
+        "paired_fla_over_native": {
+            "median": statistics.median(paired_ratios),
+            "min": min(paired_ratios),
+            "max": max(paired_ratios),
+            "samples": paired_ratios,
+        },
+        "sample_orders": orders,
+    }
+
+
+def _metadata(repo: Path, shapes: tuple[tuple[int, int], ...], args: argparse.Namespace) -> dict:
+    executed_native_api_path = _module_path(_CausalConv1dUpdatePlan.__module__)
+    executed_native_kernel_path = _module_path("cudnn.causal_conv1d_update_sm100.kernel")
+    repo_native_api_path = (repo / "python/cudnn/causal_conv1d_update_sm100/api.py").resolve()
+    repo_native_kernel_path = (repo / "python/cudnn/causal_conv1d_update_sm100/kernel.py").resolve()
+    native_api_sha256 = _sha256(executed_native_api_path)
+    native_kernel_sha256 = _sha256(executed_native_kernel_path)
+    if native_api_sha256 != _sha256(repo_native_api_path) or native_kernel_sha256 != _sha256(repo_native_kernel_path):
+        raise RuntimeError("executed native short-conv sources do not match this worktree")
+    fla_source_path = _module_path(fla_causal_conv1d_update.__module__)
+    fla_kernel_path = _module_path("fla.modules.conv.triton.kernels")
+    device = torch.cuda.current_device()
+    properties = torch.cuda.get_device_properties(device)
+    capability = tuple(torch.cuda.get_device_capability(device))
+    device_uuid = str(properties.uuid)
+    return {
+        "schema_version": 1,
+        "benchmark": "causal_conv1d_update_decode_sm100",
+        "timing_contract": "warm cache-hit CUDA-graph replay; one update per sample; compile, capture, allocation, and state reset outside events",
+        "comparison_contract": "single process; AB/BA interleaved; identical x/weight/initial state; BF16 N,D,W=4 no-bias SiLU",
+        "shape_contract": ("official Qwen3.5/Qwen3.8 fused-QKV short conv: one update over " "D in {6144,8192,10240,12288,20480}; W=4"),
+        "native_route": f"{_CausalConv1dUpdatePlan.__module__}.{_CausalConv1dUpdatePlan.__qualname__}.execute",
+        "fla_route": f"{fla_causal_conv1d_update.__module__}.{fla_causal_conv1d_update.__name__}",
+        "provenance": {
+            "benchmark": {
+                "path": str(Path(__file__).resolve()),
+                "sha256": _sha256(Path(__file__).resolve()),
+            },
+            "native_api": {
+                "executed_path": str(executed_native_api_path),
+                "repo_path": str(repo_native_api_path),
+                "sha256": native_api_sha256,
+            },
+            "native_kernel": {
+                "executed_path": str(executed_native_kernel_path),
+                "repo_path": str(repo_native_kernel_path),
+                "sha256": native_kernel_sha256,
+            },
+            "fla_op": {
+                "path": str(fla_source_path),
+                "sha256": _sha256(fla_source_path),
+                "license": "MIT",
+            },
+            "fla_kernel": {
+                "path": str(fla_kernel_path),
+                "sha256": _sha256(fla_kernel_path),
+                "license": "MIT",
+            },
+        },
+        "hardware": {
+            "name": properties.name,
+            "architecture": f"sm_{capability[0]}{capability[1]}",
+            "compute_capability": list(capability),
+            "device_index": device,
+            "uuid": device_uuid,
+            "driver": _nvidia_driver_for_uuid(device_uuid),
+            "total_memory_bytes": properties.total_memory,
+        },
+        "slurm": _slurm_provenance(),
+        "software": {
+            "python": platform.python_version(),
+            "torch": torch.__version__,
+            "cuda": torch.version.cuda,
+            "torch_cudnn": torch.backends.cudnn.version(),
+            "cudnn_frontend": cudnn.__version__,
+            "cudnn_backend": cudnn.backend_version(),
+            "cudnn_backend_string": cudnn.backend_version_string(),
+            "flash_linear_attention": _package_version("flash-linear-attention"),
+        },
+        "repository": {
+            "root": str(repo),
+            "head": _git(repo, "rev-parse", "HEAD"),
+            "branch": _git(repo, "branch", "--show-current"),
+            "dirty": bool(_git(repo, "status", "--porcelain")),
+        },
+        "parameters": {
+            "samples": args.samples,
+            "warmup": args.warmup,
+            "seed": args.seed,
+            "shapes": [list(shape) for shape in shapes],
+        },
+    }
+
+
+def _validate_environment() -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is unavailable")
+    capability = tuple(torch.cuda.get_device_capability())
+    if not is_supported_causal_conv1d_update_compute_capability(capability):
+        raise RuntimeError(
+            "benchmark requires a functionally supported causal-conv compute capability "
+            f"({supported_causal_conv1d_update_compute_capabilities_text()}), found {capability[0]}.{capability[1]}"
+        )
+    if _CausalConv1dUpdatePlan.__module__ != "cudnn.causal_conv1d_update_sm100.api":
+        raise RuntimeError(f"unexpected native route: {_CausalConv1dUpdatePlan.__module__}")
+    if fla_causal_conv1d_update.__module__ != "fla.modules.conv.triton.ops":
+        raise RuntimeError(f"unexpected FLA route: {fla_causal_conv1d_update.__module__}")
+    if _package_version("flash-linear-attention") != "0.5.2":
+        raise RuntimeError("this controlled comparison requires flash-linear-attention==0.5.2")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--shape",
+        action="append",
+        type=_parse_shape,
+        help="N x D; repeat for multiple shapes (default: Qwen decode matrix)",
+    )
+    parser.add_argument(
+        "--samples",
+        type=int,
+        default=51,
+        help="timed samples per implementation and shape",
+    )
+    parser.add_argument("--warmup", type=int, default=10, help="warm replays before measurement")
+    parser.add_argument("--seed", type=int, default=20260828)
+    parser.add_argument("--output-json", type=Path, help="also write the complete result to this file")
+    args = parser.parse_args()
+    if args.samples < 3:
+        parser.error("--samples must be at least 3")
+    if args.warmup < 1:
+        parser.error("--warmup must be positive")
+    shapes = tuple(args.shape) if args.shape else DEFAULT_SHAPES
+
+    _validate_environment()
+    repo = Path(__file__).resolve().parents[1]
+    result = _metadata(repo, shapes, args)
+    result["results"] = []
+    for shape_index, (n_rows, n_channels) in enumerate(shapes):
+        row = _benchmark_shape(
+            n_rows,
+            n_channels,
+            samples=args.samples,
+            warmup=args.warmup,
+            seed=args.seed + shape_index,
+        )
+        result["results"].append(row)
+        print(
+            f"N={n_rows:3d} D={n_channels:4d}: native={row['native']['median_us']:.3f} us, "
+            f"FLA={row['fla']['median_us']:.3f} us, paired FLA/native={row['paired_fla_over_native']['median']:.3f}x",
+            flush=True,
+        )
+
+    encoded = json.dumps(result, indent=2, sort_keys=True)
+    print("RESULT_JSON_BEGIN")
+    print(encoded)
+    print("RESULT_JSON_END")
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(encoded + "\n")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmark/fla_short_conv_shim_sm100.py
+++ b/benchmark/fla_short_conv_shim_sm100.py
@@ -1,0 +1,705 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exact FLA-shim benchmark for the causal-convolution decode update.
+
+This benchmark measures the public callable installed by
+``cudnn.fla.accelerate_fla(targets="short_conv")`` against the saved FLA 0.5.2
+public callable.  It patches once, keeps both arms resident in one process, and
+restores once after all measurements.  No target toggling occurs in a sample.
+
+Two intentionally separate steady-state metrics are reported:
+
+* ``graph_replay_us`` is CUDA-event elapsed time for one warmed CUDA-graph
+  replay.  Python dispatch, output allocation, compilation, and state reset are
+  outside the replay interval.
+* ``eager_host_enqueue_us`` is host wall time from entering the public Python
+  callable until it returns after enqueuing the update.  The stream is drained
+  before each sample and synchronized after the timer.  This includes Python
+  validation, cache lookup, output allocation, and launch overhead, but it is
+  explicitly *not* kernel time or completed device latency.
+
+Timing is fail-closed unless the exact monkeypatch route is proven and both
+arms pass full-output FP32-reference, bitwise-state, cache-identity, and cross
+implementation gates.  The timed Qwen decode layout is ``[N, 1, D]`` for
+``N={1,8,32,128}``, ``D={6144,8192,10240,12288,20480}``, and ``W=4``.  These
+are the fused-QKV channel counts used by published Qwen3.5/Qwen3.8 models;
+Q, K, and V are split only after the convolution.  Optional ``D:ld`` leading
+dimensions reproduce zero-copy slices from a wider fused projection and feed
+the exact same row-strided view to FLA and the shim.  The other admitted input
+layouts, ``[N,D]`` and ``[1,N,D]``, receive additional correctness/route smoke
+coverage at ``D=8192``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import platform
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Callable, NamedTuple
+
+import torch
+
+# Import the shared timing/reference helpers from the adjacent low-level
+# benchmark without relying on ``benchmark`` being an installed package.
+_BENCHMARK_DIR = Path(__file__).resolve().parent
+if str(_BENCHMARK_DIR) not in sys.path:
+    sys.path.insert(0, str(_BENCHMARK_DIR))
+import causal_conv1d_update_sm100 as _base
+import cudnn
+import cudnn.fla as cudnn_fla
+import fla.modules.conv.triton.ops as fla_ops
+
+DEFAULT_SHAPES = _base.DEFAULT_SHAPES
+SMOKE_N = 8
+SMOKE_D = 8192
+
+
+def _parse_leading_dimension(value: str) -> tuple[int, int]:
+    try:
+        n_channels, leading_dimension = (int(piece) for piece in value.split(":", maxsplit=1))
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError("leading dimension must be D:ld, for example 5120:8240") from exc
+    if n_channels <= 0 or leading_dimension < n_channels:
+        raise argparse.ArgumentTypeError(f"leading dimension must satisfy D > 0 and ld >= D, got D={n_channels}, ld={leading_dimension}")
+    return n_channels, leading_dimension
+
+
+class EagerArm(NamedTuple):
+    name: str
+    call: Callable[[], tuple[torch.Tensor, torch.Tensor]]
+    state: torch.Tensor
+
+
+def _callable_code_path(function: Callable) -> Path:
+    code = getattr(function, "__code__", None)
+    filename = getattr(code, "co_filename", None)
+    if filename is None:
+        raise RuntimeError(f"cannot resolve code source for {function!r}")
+    return Path(filename).resolve()
+
+
+def _tensor_gate(
+    name: str,
+    output: torch.Tensor,
+    state: torch.Tensor,
+    reference_output: torch.Tensor,
+    reference_state: torch.Tensor,
+) -> dict:
+    output_diff = (output.float() - reference_output.float()).abs()
+    output_close = torch.allclose(output, reference_output, atol=_base.OUTPUT_ATOL, rtol=_base.OUTPUT_RTOL)
+    state_bits_equal = torch.equal(state.view(torch.int16), reference_state.view(torch.int16))
+    gate = {
+        "output_close": bool(output_close),
+        "output_max_abs": float(output_diff.max().item()),
+        "output_mean_abs": float(output_diff.mean().item()),
+        "state_bits_equal": bool(state_bits_equal),
+    }
+    if not output_close or not state_bits_equal:
+        raise AssertionError(f"{name} correctness gate failed: {gate}")
+    return gate
+
+
+def _cross_gate(
+    lhs_name: str,
+    lhs_output: torch.Tensor,
+    lhs_state: torch.Tensor,
+    rhs_name: str,
+    rhs_output: torch.Tensor,
+    rhs_state: torch.Tensor,
+) -> dict:
+    output_close = torch.allclose(lhs_output, rhs_output, atol=_base.OUTPUT_ATOL, rtol=_base.OUTPUT_RTOL)
+    state_bits_equal = torch.equal(lhs_state.view(torch.int16), rhs_state.view(torch.int16))
+    gate = {
+        "output_close": bool(output_close),
+        "output_max_abs": float((lhs_output.float() - rhs_output.float()).abs().max().item()),
+        "state_bits_equal": bool(state_bits_equal),
+    }
+    if not output_close or not state_bits_equal:
+        raise AssertionError(f"{lhs_name}/{rhs_name} cross gate failed: {gate}")
+    return gate
+
+
+def _reference_for_layout(x: torch.Tensor, weight: torch.Tensor, initial_state: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    n_rows, n_channels = initial_state.shape[:2]
+    output, final_state = _base._reference(x.view(n_rows, n_channels), weight, initial_state)
+    return output.view(x.shape), final_state
+
+
+def _make_inputs(
+    n_rows: int,
+    n_channels: int,
+    *,
+    layout: str,
+    seed: int,
+    leading_dimension: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    leading_dimension = n_channels if leading_dimension is None else leading_dimension
+    if leading_dimension < n_channels:
+        raise ValueError(f"leading dimension must be at least D={n_channels}, got ld={leading_dimension}")
+    if leading_dimension != n_channels and layout != "N1D":
+        raise ValueError("row-strided timed inputs currently require the N1D layout")
+
+    if layout == "N1D" and leading_dimension != n_channels:
+        # Mirror a prefix slice from Megatron's wider [1,N,ld] fused
+        # projection.  Transpose produces [N,1,ld]; slicing the logical D
+        # channels then normalizes to the exact FE stride (ld,1) with no copy.
+        storage = (
+            torch.randn(
+                (1, n_rows, leading_dimension),
+                device="cuda",
+                dtype=torch.bfloat16,
+                generator=generator,
+            )
+            * 0.25
+        )
+        x = storage.transpose(0, 1)[..., :n_channels]
+    else:
+        flat_x = (
+            torch.randn(
+                (n_rows, n_channels),
+                device="cuda",
+                dtype=torch.bfloat16,
+                generator=generator,
+            )
+            * 0.25
+        )
+        if layout == "N1D":
+            x = flat_x.view(n_rows, 1, n_channels)
+        elif layout == "ND":
+            x = flat_x
+        elif layout == "1ND":
+            x = flat_x.view(1, n_rows, n_channels)
+        else:
+            raise ValueError(f"unknown layout {layout!r}")
+    weight = torch.randn((n_channels, 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    initial_state = torch.randn((n_rows, n_channels, 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    return x, weight, initial_state
+
+
+def _make_call(
+    function: Callable,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    state: torch.Tensor,
+) -> Callable[[], tuple[torch.Tensor, torch.Tensor]]:
+    def call() -> tuple[torch.Tensor, torch.Tensor]:
+        return function(
+            x=x,
+            cache=state,
+            residual=None,
+            weight=weight,
+            bias=None,
+            activation="silu",
+        )
+
+    return call
+
+
+def _gate_eager_arm(
+    arm: EagerArm,
+    initial_state: torch.Tensor,
+    reference_output: torch.Tensor,
+    reference_state: torch.Tensor,
+    *,
+    require_native_route: bool,
+) -> tuple[torch.Tensor, dict]:
+    arm.state.copy_(initial_state)
+    output, returned_state = arm.call()
+    if returned_state is not arm.state:
+        raise AssertionError(f"{arm.name} did not return the exact mutable cache object")
+    if output.shape != reference_output.shape:
+        raise AssertionError(f"{arm.name} output shape mismatch: expected {reference_output.shape}, got {output.shape}")
+    if require_native_route and cudnn_fla.short_conv_last_path() != "native":
+        raise AssertionError(f"exact shim did not take the native route: {cudnn_fla.short_conv_last_path()}")
+    torch.cuda.synchronize()
+    gate = _tensor_gate(arm.name, output, arm.state, reference_output, reference_state)
+    gate["cache_identity"] = True
+    gate["output_shape_preserved"] = True
+    if require_native_route:
+        gate["shim_route"] = "native"
+    return output, gate
+
+
+def _warm_eager(arms: tuple[EagerArm, EagerArm], initial_state: torch.Tensor, *, warmup: int) -> None:
+    for arm in arms:
+        for _ in range(warmup):
+            arm.state.copy_(initial_state)
+            output, returned_state = arm.call()
+            if returned_state is not arm.state:
+                raise AssertionError(f"{arm.name} did not return the exact mutable cache object")
+            if arm.name == "shim" and cudnn_fla.short_conv_last_path() != "native":
+                raise AssertionError(f"exact shim warmup did not take the native route: {cudnn_fla.short_conv_last_path()}")
+            del output, returned_state
+        torch.cuda.synchronize()
+
+
+def _interleaved_eager_host_samples(
+    shim: EagerArm,
+    fla: EagerArm,
+    initial_state: torch.Tensor,
+    *,
+    samples: int,
+) -> tuple[list[float], list[float], list[str]]:
+    """Measure warm public-call host enqueue latency; never label it kernel time."""
+
+    arms = {shim.name: shim, fla.name: fla}
+    timings = {shim.name: [], fla.name: []}
+    orders = []
+
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        for sample_index in range(samples):
+            order = (shim.name, fla.name) if sample_index % 2 == 0 else (fla.name, shim.name)
+            orders.append("/".join(order))
+            for name in order:
+                arm = arms[name]
+                arm.state.copy_(initial_state)
+                # Drain the reset and any prior work outside the timed region.
+                torch.cuda.synchronize()
+                start_ns = time.perf_counter_ns()
+                output, returned_state = arm.call()
+                elapsed_us = (time.perf_counter_ns() - start_ns) / 1000.0
+                if returned_state is not arm.state:
+                    raise AssertionError(f"{name} did not return the exact mutable cache object")
+                if name == shim.name and cudnn_fla.short_conv_last_path() != "native":
+                    raise AssertionError(f"exact shim eager sample did not take the native route: {cudnn_fla.short_conv_last_path()}")
+                timings[name].append(elapsed_us)
+                # Completion and output lifetime are deliberately outside the
+                # host-enqueue timer.
+                torch.cuda.synchronize()
+                del output, returned_state
+    finally:
+        if gc_was_enabled:
+            gc.enable()
+
+    return timings[shim.name], timings[fla.name], orders
+
+
+def _benchmark_shape(
+    shim_function: Callable,
+    original_fla: Callable,
+    n_rows: int,
+    n_channels: int,
+    *,
+    samples: int,
+    warmup: int,
+    seed: int,
+    leading_dimension: int,
+) -> dict:
+    x, weight, initial_state = _make_inputs(
+        n_rows,
+        n_channels,
+        layout="N1D",
+        seed=seed,
+        leading_dimension=leading_dimension,
+    )
+    reference_output, reference_state = _reference_for_layout(x, weight, initial_state)
+
+    shim_graph_state = initial_state.clone()
+    fla_graph_state = initial_state.clone()
+    shim_graph_call = _make_call(shim_function, x, weight, shim_graph_state)
+    fla_graph_call = _make_call(original_fla, x, weight, fla_graph_state)
+
+    shim_graph, captured_shim = _base._capture(shim_graph_call, warmup=warmup)
+    shim_output, returned_shim_state = captured_shim
+    if returned_shim_state is not shim_graph_state:
+        raise AssertionError("captured exact shim did not return the exact mutable cache object")
+    if shim_output.shape != x.shape:
+        raise AssertionError(f"captured exact shim output shape mismatch: expected {x.shape}, got {shim_output.shape}")
+    if cudnn_fla.short_conv_last_path() != "native":
+        raise AssertionError(f"exact shim capture did not take the native route: {cudnn_fla.short_conv_last_path()}")
+
+    fla_graph, captured_fla = _base._capture(fla_graph_call, warmup=warmup)
+    fla_output, returned_fla_state = captured_fla
+    if returned_fla_state is not fla_graph_state:
+        raise AssertionError("captured FLA did not return the exact mutable cache object")
+    if fla_output.shape != x.shape:
+        raise AssertionError(f"captured FLA output shape mismatch: expected {x.shape}, got {fla_output.shape}")
+
+    shim_graph_arm = _base.CapturedArm("shim", shim_graph, shim_output, shim_graph_state)
+    fla_graph_arm = _base.CapturedArm("fla", fla_graph, fla_output, fla_graph_state)
+    shim_graph_gate = _base._gate_arm(shim_graph_arm, initial_state, reference_output, reference_state)
+    shim_graph_gate.update(cache_identity=True, output_shape_preserved=True, shim_route_at_capture="native")
+    fla_graph_gate = _base._gate_arm(fla_graph_arm, initial_state, reference_output, reference_state)
+    fla_graph_gate.update(cache_identity=True, output_shape_preserved=True)
+    graph_correctness = {"shim": shim_graph_gate, "fla": fla_graph_gate}
+    graph_correctness["shim_vs_fla"] = _cross_gate(
+        "shim",
+        shim_output,
+        shim_graph_state,
+        "fla",
+        fla_output,
+        fla_graph_state,
+    )
+
+    for arm in (shim_graph_arm, fla_graph_arm):
+        for _ in range(warmup):
+            arm.state.copy_(initial_state)
+            arm.graph.replay()
+    torch.cuda.synchronize()
+
+    shim_graph_samples, fla_graph_samples, graph_orders = _base._interleaved_samples(
+        shim_graph_arm,
+        fla_graph_arm,
+        initial_state,
+        samples=samples,
+    )
+    shim_graph_summary = _base._summary(shim_graph_samples)
+    fla_graph_summary = _base._summary(fla_graph_samples)
+    graph_paired = [fla_us / shim_us for shim_us, fla_us in zip(shim_graph_samples, fla_graph_samples, strict=True)]
+
+    shim_eager_state = initial_state.clone()
+    fla_eager_state = initial_state.clone()
+    shim_eager_arm = EagerArm("shim", _make_call(shim_function, x, weight, shim_eager_state), shim_eager_state)
+    fla_eager_arm = EagerArm("fla", _make_call(original_fla, x, weight, fla_eager_state), fla_eager_state)
+    _warm_eager((shim_eager_arm, fla_eager_arm), initial_state, warmup=warmup)
+    shim_eager_output, shim_eager_gate = _gate_eager_arm(
+        shim_eager_arm,
+        initial_state,
+        reference_output,
+        reference_state,
+        require_native_route=True,
+    )
+    fla_eager_output, fla_eager_gate = _gate_eager_arm(
+        fla_eager_arm,
+        initial_state,
+        reference_output,
+        reference_state,
+        require_native_route=False,
+    )
+    eager_correctness = {
+        "shim": shim_eager_gate,
+        "fla": fla_eager_gate,
+        "shim_vs_fla": _cross_gate(
+            "shim",
+            shim_eager_output,
+            shim_eager_state,
+            "fla",
+            fla_eager_output,
+            fla_eager_state,
+        ),
+    }
+    del shim_eager_output, fla_eager_output
+
+    shim_eager_samples, fla_eager_samples, eager_orders = _interleaved_eager_host_samples(
+        shim_eager_arm,
+        fla_eager_arm,
+        initial_state,
+        samples=samples,
+    )
+    shim_eager_summary = _base._summary(shim_eager_samples)
+    fla_eager_summary = _base._summary(fla_eager_samples)
+    eager_paired = [fla_us / shim_us for shim_us, fla_us in zip(shim_eager_samples, fla_eager_samples, strict=True)]
+
+    return {
+        "shape": {
+            "layout": "N1D",
+            "x": list(x.shape),
+            "x_stride": list(x.stride()),
+            "normalized_x_stride": list(x.view(n_rows, n_channels).stride()),
+            "leading_dimension": leading_dimension,
+            "data_pointer_mod_16": x.data_ptr() % 16,
+            "N": n_rows,
+            "D": n_channels,
+            "W": 4,
+        },
+        "correctness": {"graph": graph_correctness, "eager": eager_correctness},
+        "graph_replay_us": {
+            "shim": {**shim_graph_summary, "samples_us": shim_graph_samples},
+            "fla": {**fla_graph_summary, "samples_us": fla_graph_samples},
+            "paired_fla_over_shim": {
+                "median": statistics.median(graph_paired),
+                "min": min(graph_paired),
+                "max": max(graph_paired),
+                "samples": graph_paired,
+            },
+            "sample_orders": graph_orders,
+        },
+        "eager_host_enqueue_us": {
+            "shim": {**shim_eager_summary, "samples_us": shim_eager_samples},
+            "fla": {**fla_eager_summary, "samples_us": fla_eager_samples},
+            "paired_fla_over_shim": {
+                "median": statistics.median(eager_paired),
+                "min": min(eager_paired),
+                "max": max(eager_paired),
+                "samples": eager_paired,
+            },
+            "sample_orders": eager_orders,
+            "is_kernel_time": False,
+        },
+    }
+
+
+def _layout_smoke(
+    shim_function: Callable,
+    original_fla: Callable,
+    *,
+    layout: str,
+    seed: int,
+) -> dict:
+    x, weight, initial_state = _make_inputs(SMOKE_N, SMOKE_D, layout=layout, seed=seed)
+    reference_output, reference_state = _reference_for_layout(x, weight, initial_state)
+    shim_state = initial_state.clone()
+    fla_state = initial_state.clone()
+    shim_arm = EagerArm("shim", _make_call(shim_function, x, weight, shim_state), shim_state)
+    fla_arm = EagerArm("fla", _make_call(original_fla, x, weight, fla_state), fla_state)
+
+    shim_output, shim_gate = _gate_eager_arm(
+        shim_arm,
+        initial_state,
+        reference_output,
+        reference_state,
+        require_native_route=True,
+    )
+    fla_output, fla_gate = _gate_eager_arm(
+        fla_arm,
+        initial_state,
+        reference_output,
+        reference_state,
+        require_native_route=False,
+    )
+    cross = _cross_gate("shim", shim_output, shim_state, "fla", fla_output, fla_state)
+    return {
+        "layout": layout,
+        "shape": list(x.shape),
+        "shim": shim_gate,
+        "fla": fla_gate,
+        "shim_vs_fla": cross,
+        "cache_identity": {"shim": True, "fla": True},
+        "shim_route": "native",
+    }
+
+
+def _validate_environment() -> None:
+    _base._validate_environment()
+    if _base._package_version("flash-linear-attention") != "0.5.2":
+        raise RuntimeError("exact FLA short-conv shim benchmark requires flash-linear-attention==0.5.2")
+    if cudnn_fla.is_accelerated("short_conv"):
+        raise RuntimeError("short_conv was already accelerated before the benchmark; refusing ambiguous ownership")
+    if fla_ops.causal_conv1d_update is not _base.fla_causal_conv1d_update:
+        raise RuntimeError("FLA ops attribute changed before the benchmark could save the exact original callable")
+
+
+def _route_and_metadata(repo: Path, benchmark_path: Path, original_fla: Callable, shim_function: Callable) -> dict:
+    applied = cudnn_fla._ORIGINALS.get("short_conv")
+    if applied is None:
+        raise RuntimeError("short_conv registry has no applied patch after activation")
+    if applied.owner is not fla_ops or applied.original is not original_fla or applied.replacement is not shim_function:
+        raise RuntimeError("short_conv registry ownership does not match the live FLA ops attribute")
+    if fla_ops.causal_conv1d_update is not shim_function:
+        raise RuntimeError("live FLA ops attribute is not the registered exact shim replacement")
+    if getattr(shim_function, "__wrapped__", None) is not original_fla:
+        raise RuntimeError("exact shim does not wrap the saved FLA original")
+
+    repo_shim_path = (repo / "python/cudnn/fla/short_conv.py").resolve()
+    executed_shim_path = _base._module_path("cudnn.fla.short_conv")
+    shim_code_path = _callable_code_path(shim_function)
+    repo_base_benchmark_path = (repo / "benchmark/causal_conv1d_update_sm100.py").resolve()
+    executed_base_benchmark_path = Path(_base.__file__).resolve()
+    repo_registry_path = (repo / "python/cudnn/fla/__init__.py").resolve()
+    executed_registry_path = _base._module_path("cudnn.fla")
+    repo_native_api_path = (repo / "python/cudnn/causal_conv1d_update_sm100/api.py").resolve()
+    repo_native_kernel_path = (repo / "python/cudnn/causal_conv1d_update_sm100/kernel.py").resolve()
+    executed_native_api_path = _base._module_path("cudnn.causal_conv1d_update_sm100.api")
+    executed_native_kernel_path = _base._module_path("cudnn.causal_conv1d_update_sm100.kernel")
+
+    for name, executed, expected in (
+        ("shim module", executed_shim_path, repo_shim_path),
+        ("shim callable code", shim_code_path, repo_shim_path),
+        ("shared benchmark helpers", executed_base_benchmark_path, repo_base_benchmark_path),
+        ("FLA adapter registry", executed_registry_path, repo_registry_path),
+        ("native API", executed_native_api_path, repo_native_api_path),
+        ("native kernel", executed_native_kernel_path, repo_native_kernel_path),
+    ):
+        if _base._sha256(executed) != _base._sha256(expected):
+            raise RuntimeError(f"executed {name} source does not match this worktree: {executed} != {expected}")
+
+    fla_op_path = _base._module_path("fla.modules.conv.triton.ops")
+    fla_kernel_path = _base._module_path("fla.modules.conv.triton.kernels")
+    device = torch.cuda.current_device()
+    properties = torch.cuda.get_device_properties(device)
+    capability = tuple(torch.cuda.get_device_capability(device))
+    device_uuid = str(properties.uuid)
+    return {
+        "schema_version": 1,
+        "benchmark": "fla_short_conv_exact_shim_sm100",
+        "timing_contracts": {
+            "graph_replay_us": "warm cache-hit CUDA-graph replay; Python, compile, capture, allocation, and state reset outside CUDA events",
+            "eager_host_enqueue_us": "warm public-call host wall time through enqueue/return; includes Python validation, cache lookup, output allocation, and launch; pre-drained stream and post-timer synchronize; not kernel time",
+        },
+        "comparison_contract": "single process; patch once/restore once; saved FLA original versus live exact shim; AB/BA interleaved; identical BF16 x/weight/initial-state; W=4 no-bias SiLU",
+        "route_proof": {
+            "target": "short_conv",
+            "live_ops_attribute_is_registry_replacement": True,
+            "registry_owner_is_fla_ops_module": True,
+            "replacement_wraps_saved_original": True,
+            "is_accelerated": cudnn_fla.is_accelerated("short_conv"),
+            "shim_code_path": str(shim_code_path),
+            "last_path_required_per_eager_call_and_at_capture": "native",
+            "restored_after_measurement": False,
+        },
+        "provenance": {
+            "benchmark": {"path": str(benchmark_path), "sha256": _base._sha256(benchmark_path)},
+            "shared_benchmark_helpers": {
+                "path": str(executed_base_benchmark_path),
+                "sha256": _base._sha256(executed_base_benchmark_path),
+                "license": "Apache-2.0",
+            },
+            "shim": {"path": str(executed_shim_path), "sha256": _base._sha256(executed_shim_path), "license": "Apache-2.0"},
+            "adapter_registry": {
+                "path": str(executed_registry_path),
+                "sha256": _base._sha256(executed_registry_path),
+                "license": "Apache-2.0",
+            },
+            "native_api": {"path": str(executed_native_api_path), "sha256": _base._sha256(executed_native_api_path)},
+            "native_kernel": {"path": str(executed_native_kernel_path), "sha256": _base._sha256(executed_native_kernel_path)},
+            "fla_op": {"path": str(fla_op_path), "sha256": _base._sha256(fla_op_path), "license": "MIT"},
+            "fla_kernel": {"path": str(fla_kernel_path), "sha256": _base._sha256(fla_kernel_path), "license": "MIT"},
+        },
+        "hardware": {
+            "name": properties.name,
+            "architecture": f"sm_{capability[0]}{capability[1]}",
+            "compute_capability": list(capability),
+            "device_index": device,
+            "uuid": device_uuid,
+            "driver": _base._nvidia_driver_for_uuid(device_uuid),
+            "total_memory_bytes": properties.total_memory,
+        },
+        "slurm": _base._slurm_provenance(),
+        "software": {
+            "python": platform.python_version(),
+            "torch": torch.__version__,
+            "cuda": torch.version.cuda,
+            "torch_cudnn": torch.backends.cudnn.version(),
+            "cudnn_frontend": cudnn.__version__,
+            "cudnn_backend": cudnn.backend_version(),
+            "cudnn_backend_string": cudnn.backend_version_string(),
+            "flash_linear_attention": _base._package_version("flash-linear-attention"),
+        },
+        "repository": {
+            "root": str(repo),
+            "head": _base._git(repo, "rev-parse", "HEAD"),
+            "branch": _base._git(repo, "branch", "--show-current"),
+            "dirty": bool(_base._git(repo, "status", "--porcelain")),
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--shape",
+        action="append",
+        type=_base._parse_shape,
+        help="N x D; repeat for multiple timed N1D shapes (default: Qwen decode matrix)",
+    )
+    parser.add_argument(
+        "--leading-dimension",
+        action="append",
+        type=_parse_leading_dimension,
+        default=[],
+        metavar="D:LD",
+        help=("use row stride LD for every timed shape with logical width D; " "repeat for multiple widths (default: compact LD=D)"),
+    )
+    parser.add_argument("--samples", type=int, default=51, help="timed samples per arm, metric, and shape")
+    parser.add_argument("--warmup", type=int, default=10, help="warm calls/replays before measurement")
+    parser.add_argument("--seed", type=int, default=20260828)
+    parser.add_argument("--output-json", type=Path, help="also write the complete result to this file")
+    args = parser.parse_args()
+    if args.samples < 3:
+        parser.error("--samples must be at least 3")
+    if args.warmup < 1:
+        parser.error("--warmup must be positive")
+    shapes = tuple(args.shape) if args.shape else DEFAULT_SHAPES
+    leading_dimensions = {}
+    for n_channels, leading_dimension in args.leading_dimension:
+        if n_channels in leading_dimensions:
+            parser.error(f"duplicate --leading-dimension for D={n_channels}")
+        if leading_dimension > n_channels and leading_dimension % 8 != 0:
+            parser.error(f"padded leading dimension must be divisible by 8 BF16 elements, got D={n_channels}, ld={leading_dimension}")
+        leading_dimensions[n_channels] = leading_dimension
+    unused_leading_dimensions = set(leading_dimensions) - {n_channels for _, n_channels in shapes}
+    if unused_leading_dimensions:
+        parser.error("--leading-dimension provided for widths absent from --shape: " + ", ".join(str(value) for value in sorted(unused_leading_dimensions)))
+
+    _validate_environment()
+    repo = Path(__file__).resolve().parents[1]
+    benchmark_path = Path(__file__).resolve()
+    original_fla = fla_ops.causal_conv1d_update
+    patched = False
+    result = None
+    try:
+        cudnn_fla.accelerate_fla(verbose=False, targets="short_conv")
+        patched = True
+        shim_function = fla_ops.causal_conv1d_update
+        result = _route_and_metadata(repo, benchmark_path, original_fla, shim_function)
+        result["parameters"] = {
+            "samples": args.samples,
+            "warmup": args.warmup,
+            "seed": args.seed,
+            "timed_layout": "N1D",
+            "shapes": [list(shape) for shape in shapes],
+            "leading_dimensions": {str(n_channels): leading_dimensions.get(n_channels, n_channels) for n_channels in sorted({shape[1] for shape in shapes})},
+            "smoke": {"layouts": ["ND", "1ND"], "N": SMOKE_N, "D": SMOKE_D, "W": 4},
+        }
+        result["layout_smoke"] = [
+            _layout_smoke(shim_function, original_fla, layout="ND", seed=args.seed + 1000),
+            _layout_smoke(shim_function, original_fla, layout="1ND", seed=args.seed + 1001),
+        ]
+        result["results"] = []
+        for shape_index, (n_rows, n_channels) in enumerate(shapes):
+            row = _benchmark_shape(
+                shim_function,
+                original_fla,
+                n_rows,
+                n_channels,
+                samples=args.samples,
+                warmup=args.warmup,
+                seed=args.seed + shape_index,
+                leading_dimension=leading_dimensions.get(n_channels, n_channels),
+            )
+            result["results"].append(row)
+    finally:
+        if patched:
+            cudnn_fla.restore_fla(targets="short_conv")
+            if fla_ops.causal_conv1d_update is not original_fla:
+                raise RuntimeError("restore_fla did not restore the exact saved FLA original")
+
+    if result is None:
+        raise RuntimeError("benchmark produced no result")
+    result["route_proof"]["restored_after_measurement"] = True
+    # Emit timings only after every gate passed and the original FLA callable
+    # was restored, so a partial/failed run cannot be mistaken for a result.
+    for row in result["results"]:
+        n_rows, n_channels = row["shape"]["N"], row["shape"]["D"]
+        leading_dimension = row["shape"]["leading_dimension"]
+        print(
+            f"N={n_rows:3d} D={n_channels:5d} ld={leading_dimension:5d}: "
+            f"graph shim={row['graph_replay_us']['shim']['median_us']:.3f} us, "
+            f"FLA={row['graph_replay_us']['fla']['median_us']:.3f} us, "
+            f"paired={row['graph_replay_us']['paired_fla_over_shim']['median']:.3f}x; "
+            f"eager-host shim={row['eager_host_enqueue_us']['shim']['median_us']:.3f} us, "
+            f"FLA={row['eager_host_enqueue_us']['fla']['median_us']:.3f} us, "
+            f"paired={row['eager_host_enqueue_us']['paired_fla_over_shim']['median']:.3f}x",
+            flush=True,
+        )
+    encoded = json.dumps(result, indent=2, sort_keys=True)
+    print("RESULT_JSON_BEGIN")
+    print(encoded)
+    print("RESULT_JSON_END")
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(encoded + "\n")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/fe-oss-apis/causal_conv1d.md
+++ b/docs/fe-oss-apis/causal_conv1d.md
@@ -1,0 +1,62 @@
+# Causal Conv1d
+
+`cudnn.ops.causal_conv1d` is the model-facing full-sequence operation. Its
+tensor and state semantics match the commonly consumed `causal-conv1d`
+interface:
+
+- `x[B, D, T]`
+- `weight[D, W]` and optional `bias[D]`
+- reserved `seq_idx[B, T]` compatibility keyword (currently only `None` is
+  accepted)
+- optional packed `cu_seqlens[N + 1]` (mutually exclusive with `seq_idx`)
+- dense and `seq_idx` state: optional `initial_states[B, D, W - 1]` and
+  returned `final_states[B, D, W - 1]`
+- packed state: optional `initial_states[N, D, W - 1]` and returned
+  `final_states[N, D, W - 1]`, where `N = len(cu_seqlens) - 1`
+
+Model implementations that already own contiguous `[B, T, D]` storage pass
+its `transpose(1, 2)` view. The public shape stays `[B, D, T]`, while the
+current native implementation receives the original contiguous storage
+without a copy.
+
+```python
+from cudnn.ops import causal_conv1d
+
+output = causal_conv1d(x, weight, bias, activation="silu")
+output, final_states = causal_conv1d(
+    x,
+    weight,
+    bias,
+    initial_states=initial_states,
+    return_final_states=True,
+    activation="silu",
+)
+```
+
+The returned width-four ``final_states[B, D, 3]`` can be passed directly to
+``cudnn.ops.causal_conv1d_update`` for the next token. The update operation
+mutates that state in place; no layout conversion is required.
+
+The result is an ordinary Tensor or tuple. Kernel compilation, architecture
+class names, schedule choice, workspace allocation, intermediate result
+wrappers, and CUDA stream handles are backend details.
+
+The current optimized route covers dense and `cu_seqlens`-packed BF16-activation
+width-four SiLU forward and backward, including mathematical `W - 1` initial
+and final state. Weights may be BF16, or FP32 for the bias-free contract used by
+GLM linear-attention blocks; an FP32 weight with bias declines explicitly. The
+implementation adapts state to a private full-width buffer without exposing its
+storage or layout. `seq_idx` remains reserved and declines explicitly until a
+matching backend exists.
+
+Packed `cu_seqlens` values are validated on the device to avoid a host read.
+Malformed metadata—including a first offset other than zero, a final offset
+other than the runtime token total, non-increasing offsets, or an empty
+sequence—executes a device trap. The resulting sticky CUDA failure is not a
+recoverable Python exception; the process must discard that CUDA context before
+continuing GPU work.
+
+The current backward implementation accumulates dweight with FP32 atomics, so
+its dweight result is not bitwise reproducible across launches, even when
+PyTorch deterministic algorithms are enabled. A deterministic dweight route
+is not currently exposed by this semantic operation.

--- a/docs/fe-oss-apis/causal_conv1d.md
+++ b/docs/fe-oss-apis/causal_conv1d.md
@@ -43,11 +43,17 @@ wrappers, and CUDA stream handles are backend details.
 
 The current optimized route covers dense and `cu_seqlens`-packed BF16-activation
 width-four SiLU forward and backward, including mathematical `W - 1` initial
-and final state. Weights may be BF16, or FP32 for the bias-free contract used by
-GLM linear-attention blocks; an FP32 weight with bias declines explicitly. The
-implementation adapts state to a private full-width buffer without exposing its
-storage or layout. `seq_idx` remains reserved and declines explicitly until a
-matching backend exists.
+and final state. Weights may be BF16, or FP32 without bias (BF16 activations
+with an FP32 depthwise filter); the FP32-weight epilogue is only tested without
+bias, so an FP32 weight with bias declines explicitly. The implementation adapts
+state to a private full-width buffer without exposing its storage or layout.
+`seq_idx` remains reserved and declines explicitly until a matching backend
+exists.
+
+`final_states_out` must not share memory with `x`, `weight`, `bias`,
+`cu_seqlens`, or `initial_states`. The final state is written after the forward
+and the inputs are saved for backward, so an aliased output would corrupt them;
+overlapping storage is rejected with `ValueError`.
 
 Packed `cu_seqlens` values are validated on the device to avoid a host read.
 Malformed metadata—including a first offset other than zero, a final offset
@@ -56,7 +62,9 @@ sequence—executes a device trap. The resulting sticky CUDA failure is not a
 recoverable Python exception; the process must discard that CUDA context before
 continuing GPU work.
 
-The current backward implementation accumulates dweight with FP32 atomics, so
-its dweight result is not bitwise reproducible across launches, even when
-PyTorch deterministic algorithms are enabled. A deterministic dweight route
-is not currently exposed by this semantic operation.
+The backward honors `torch.use_deterministic_algorithms`. By default dweight
+accumulates with FP32 atomics and is not bitwise reproducible across launches.
+When deterministic algorithms are enabled, bias-free calls select a deterministic
+dweight route (unique FP32 partials followed by a fixed-order reduction). Calls
+with `bias` have no deterministic dbias route: they raise `RuntimeError`, or warn
+and run with atomics under `warn_only=True`, mirroring PyTorch's own semantics.

--- a/docs/fe-oss-apis/causal_conv1d.md
+++ b/docs/fe-oss-apis/causal_conv1d.md
@@ -9,8 +9,8 @@ interface:
 - reserved `seq_idx[B, T]` compatibility keyword (currently only `None` is
   accepted)
 - optional packed `cu_seqlens[N + 1]` (mutually exclusive with `seq_idx`)
-- dense and `seq_idx` state: optional `initial_states[B, D, W - 1]` and
-  returned `final_states[B, D, W - 1]`
+- dense state: optional `initial_states[B, D, W - 1]` and returned
+  `final_states[B, D, W - 1]`
 - packed state: optional `initial_states[N, D, W - 1]` and returned
   `final_states[N, D, W - 1]`, where `N = len(cu_seqlens) - 1`
 

--- a/docs/fe-oss-apis/causal_conv1d_update.md
+++ b/docs/fe-oss-apis/causal_conv1d_update.md
@@ -114,7 +114,7 @@ the state or weight meanings. The current public implementation rejects 3D
   compact storage is accepted for both lengths, and `L=3` additionally accepts
   the channel-last `(3 * D, 1, D)` stride returned by full-sequence prefill
 - `bias`: optional contiguous BF16 `[D]`
-- `cache_seqlens`: must be omitted
+- `cache_seqlens`: must be `None` or omitted
 - `conv_state_indices`: optional contiguous CUDA int32 `[N]`
 - output: contiguous BF16 `[N, D]`
 - activation: identity or SiLU
@@ -128,7 +128,7 @@ sufficient for this operation. The optional FLA 0.5.2 adapter treats the
 resulting `ImportError` as a typed decline and executes FLA's original path.
 
 Runtime correctness was validated on A100 SM80, L40S SM89, H200 SM90, B200
-SM100, a GB110 board reporting SM103, and RTX 5080 SM120. SM86, SM87, SM110,
+SM100, an SM103 board, and RTX 5080 SM120. SM86, SM87, SM110,
 and SM121 have compile-only validation. The SM110 path is functional support,
 not a training-performance claim.
 

--- a/docs/fe-oss-apis/causal_conv1d_update.md
+++ b/docs/fe-oss-apis/causal_conv1d_update.md
@@ -1,0 +1,161 @@
+# Causal Conv1d Decode Update
+
+**This FE-OSS API is experimental and subject to change.**
+
+`cudnn.ops.causal_conv1d_update` advances a mutable depthwise
+causal-convolution cache in place and returns the output for one decode step.
+The semantic tensor contract uses `weight[D, W]` and `conv_state[S, D, L]`,
+where `L >= W - 1`. The first native implementation targets the width-four
+short convolution used by GDN/KDA-style linear-attention blocks. Compilation,
+architecture dispatch, output ownership, streams, and kernel schedules remain
+private implementation details.
+
+Use [`cudnn.ops.causal_conv1d`](causal_conv1d.md) for full-sequence prefill or
+training. Its width-four final state can be passed directly to this operation.
+
+Without circular-buffer metadata, row `n`, channel `d`, and selected cache
+slot `s` are updated as follows:
+
+```text
+history = concat(conv_state[s, d, :], x[n, d])
+conv_state[s, d, :] = history[-L:]
+acc[n, d] = sum_j history[-W + j] * weight[d, j] + bias[d]
+output[n, d] = activation(acc[n, d])
+```
+
+The bias is zero when omitted. `activation=None` and `"identity"` return the
+accumulator directly; `"silu"` and `"swish"` select the same fused SiLU
+specialization. Identity and SiLU compile as separate kernels, so the unused
+activation work is absent from the identity path.
+
+When `conv_state_indices` is omitted, row `n` selects slot `n`. When it is
+present, `s = conv_state_indices[n]`. A value of `-1` denotes a padding row:
+its output is zero and it does not mutate `conv_state`. Other selected slots
+must be in range and unique within the decode batch because `conv_state` is
+mutated; repeated padding rows are allowed.
+
+`cache_seqlens` is a reserved compatibility keyword. The current operation
+accepts only `None` and raises `NotImplementedError` otherwise. A future
+implementation may use it for circular-buffer state without changing the
+public signature.
+
+## Python API
+
+```python
+import torch
+import cudnn
+
+x = torch.randn(8, 2048, device="cuda", dtype=torch.bfloat16)
+weight = torch.randn(2048, 4, device="cuda", dtype=torch.bfloat16)
+conv_state = torch.randn(8, 2048, 4, device="cuda", dtype=torch.bfloat16)
+
+output = cudnn.ops.causal_conv1d_update(
+    x,
+    conv_state,
+    weight,
+    bias=None,
+    activation="silu",
+)
+```
+
+The signature is:
+
+```python
+cudnn.ops.causal_conv1d_update(
+    x,
+    conv_state,
+    weight,
+    bias=None,
+    activation=None,
+    *,
+    cache_seqlens=None,
+    conv_state_indices=None,
+) -> torch.Tensor
+```
+
+`conv_state` is mutated in place and the return value is an ordinary newly
+allocated Tensor, not a wrapper result. The operation registers the mutation
+with `torch.library`, including its FakeTensor contract. It is inference-only;
+autograd inputs are rejected.
+
+The fourth and fifth positional arguments remain `bias` and `activation`.
+State-routing metadata is keyword-only. The first call for a supported device,
+shape, optional-input signature, and activation performs JIT compilation.
+Warm the exact signature before latency measurement or CUDA Graph capture.
+
+## Semantic tensor contract
+
+- `x`: BF16 `[N, D]` for one decode token, with strides `(ld, 1)`; compact
+  `ld == D` accepts every `D`, while padded `ld > D` requires `ld % 8 == 0`
+  so every row starts at a 16-byte-aligned address
+- `weight`: `[D, W]`
+- `conv_state`: `[S, D, L]`, updated in place, with `L >= W - 1`; compact
+  storage is accepted, and an `L=3` state returned by
+  `cudnn.ops.causal_conv1d` is accepted without copying
+- `bias`: optional `[D]`
+- `cache_seqlens`: reserved compatibility keyword; currently must be `None`
+- `conv_state_indices`: optional int32 `[N]` state-slot selection; `-1` is padding
+- output: `[N, D]`
+
+A future multi-token extension can admit `x[N, D, Tstep]` without changing
+the state or weight meanings. The current public implementation rejects 3D
+`x` rather than silently interpreting its layout.
+
+## Current native implementation
+
+- GPU: compute capabilities 8.0, 8.6, 8.7, 8.9, 9.0, 10.0, 10.3, 11.0,
+  12.0, and 12.1; the portable one-row schedule is used on every admitted
+  target
+- performance-characterized GPU: B200 SM100
+- `x`: BF16 `[N, D]` with strides `(ld, 1)`; compact `ld == D` accepts every
+  channel count, and padded `ld > D` requires `ld % 8 == 0`
+- `weight`: contiguous BF16 `[D, 4]`
+- `conv_state`: BF16 `[S, D, L]` with `L` equal to 3 or 4, updated in place;
+  compact storage is accepted for both lengths, and `L=3` additionally accepts
+  the channel-last `(3 * D, 1, D)` stride returned by full-sequence prefill
+- `bias`: optional contiguous BF16 `[D]`
+- `cache_seqlens`: must be omitted
+- `conv_state_indices`: optional contiguous CUDA int32 `[N]`
+- output: contiguous BF16 `[N, D]`
+- activation: identity or SiLU
+- autograd: unsupported
+- pointer alignment: 16 bytes for BF16 tensors and 4 bytes for indices
+
+The native kernel requires CUTLASS DSL 4.7 or newer for the inline-PTX
+integration it imports. The package-wide `cutedsl` extra keeps its broader
+`>=4.5` floor for unrelated APIs; installing only that minimum is not
+sufficient for this operation. The optional FLA 0.5.2 adapter treats the
+resulting `ImportError` as a typed decline and executes FLA's original path.
+
+Runtime correctness was validated on A100 SM80, L40S SM89, H200 SM90, B200
+SM100, a GB110 board reporting SM103, and RTX 5080 SM120. SM86, SM87, SM110,
+and SM121 have compile-only validation. The SM110 path is functional support,
+not a training-performance claim.
+
+For width four, `L=3` is the standard `W - 1` final state handed off by
+prefill; it uses a functionally correct stride-aware scalar state-access
+specialization and therefore needs no layout conversion.
+`L=4` retains the original vectorized fast path used by GDN/KDA decode. Other
+semantically valid widths and state lengths, circular-buffer updates,
+multi-token updates, speculative intermediate-state returns, prefill, and
+training currently raise a clear unsupported-configuration error. The indexed
+path is functional paged-state support; its duplicate-index validation is not
+performance-characterized as a fast path. For the current native path, the
+kernel checks indices on device and traps on values below `-1`, out-of-range
+slots, or duplicate non-padding slots;
+the resulting CUDA error is asynchronous and the failed update is not
+transactional.
+
+## Semantic provenance and benchmarking
+
+Behavioral references are FLA 0.5.2 `ShortConvolution.step` (MIT) and the
+public `causal_conv1d_update` contract from Dao-AILab/causal-conv1d at revision
+`cd81f0413cad2fc1e6f17e785ac39f59aae690cd` (BSD-3-Clause). No source from
+either project is included. The implementation uses CUTLASS/CuTe DSL, inline
+PTX, and in-tree NVIDIA FROST primitives.
+
+Use `benchmark/causal_conv1d_update_sm100.py` for route-proof, correctness, and
+an interleaved comparison against FLA. It intentionally uses the private
+preallocated plan so kernel timing does not include public output allocation
+or custom-op dispatch. The benchmark records the actual GPU architecture and
+software environment; Slurm metadata is optional.

--- a/docs/fe-oss-apis/fla.md
+++ b/docs/fe-oss-apis/fla.md
@@ -118,4 +118,13 @@ pip install "nvidia-cudnn-frontend[cutedsl]"
 The `cutedsl` extra supplies the optional CUTLASS DSL and CUDA Python
 dependencies required by the native `gated_mlp` and `short_conv` targets. To
 require the native `short_conv` route instead of its typed fallback, also
-ensure `nvidia-cutlass-dsl[cu13]>=4.7` is installed.
+ensure CUTLASS DSL 4.7 or newer is installed using the package variant that
+matches the CUDA Toolkit:
+
+```bash
+# CUDA Toolkit 12.9
+pip install "nvidia-cutlass-dsl>=4.7"
+
+# CUDA Toolkit 13.3
+pip install "nvidia-cutlass-dsl[cu13]>=4.7"
+```

--- a/docs/fe-oss-apis/fla.md
+++ b/docs/fe-oss-apis/fla.md
@@ -20,8 +20,11 @@ cudnn.fla.accelerate_fla()
 # Incrementally opt the dense FLA GatedMLP into the fused cuDNN SwiGLU MLP.
 cudnn.fla.accelerate_fla(targets="gated_mlp")
 
-# A string or iterable is accepted; "gdn" and "mlp" are aliases.
-cudnn.fla.accelerate_fla(targets=("gdn", "gated_mlp"))
+# Opt FLA 0.5.2 decode short convolution into the native update.
+cudnn.fla.accelerate_fla(targets="short_conv")
+
+# A string or iterable is accepted; "gdn", "mlp", and "shortconv" are aliases.
+cudnn.fla.accelerate_fla(targets=("gdn", "gated_mlp", "shortconv"))
 ```
 
 `accelerate_fla(verbose=True, *, targets=None)` is incremental and idempotent.
@@ -39,6 +42,47 @@ custom linears, other dtypes/layouts/devices, or graph compilation execute the
 original FLA method. Typed unsupported-kernel declines also fall back;
 unexpected binding, allocation, or launch errors propagate.
 
+The opt-in `short_conv` target patches
+`fla.modules.conv.triton.ops.causal_conv1d_update` and preserves FLA 0.5.2's
+public call and return contract:
+
+```python
+y, cache = causal_conv1d_update(
+    x, cache, residual=None, weight=weight, bias=None, activation="silu"
+)
+```
+
+The native route is deliberately restricted to inference on compute
+capabilities 8.0, 8.6, 8.7, 8.9, 9.0, 10.0, 10.3, 11.0, 12.0, and 12.1 with BF16, a
+contiguous `[N, D, 4]` cache, contiguous `[D, 4]` weights, no residual or bias,
+and `silu`/`swish`. Every admitted architecture uses the same one-row
+functional schedule. Input layouts `[N, D]`, `[N, 1, D]`, and `[1, N, D]` are
+normalized to `[N, D]` with zero-copy views. Compact X rows accept every D;
+padded `(ld, 1)` rows, including slices of wider fused projections, require `ld > D`
+and `ld % 8 == 0`. Output shape and cache object identity are preserved.
+Everything else executes the saved original FLA callable. Typed
+unsupported-kernel declines fall back, while unexpected native binding,
+allocation, and launch failures propagate.
+
+The current native kernel requires CUTLASS DSL 4.7 or newer. If only the
+package-wide `cutedsl>=4.5` minimum is present and the native import is
+unavailable, the adapter catches that typed `ImportError` and executes FLA's
+original path. Hardware correctness coverage is SM80, SM89, SM90, and SM100;
+the native kernel is additionally runtime-validated on SM103 and SM120.
+SM86, SM87, SM110, and SM121 are compile-validated only. The SM110 kernel
+cross-compiles with CUTLASS DSL 4.7, but no SM110 hardware execution is claimed.
+
+The cuDNN adapter and native kernel are independent NVIDIA implementations.
+They use FLA's documented interface and observable depthwise causal-convolution
+semantics for compatibility; no FLA Triton kernel source is incorporated or
+translated.
+
+Use `benchmark/fla_short_conv_shim_sm100.py` for an exact patched-callable
+comparison. It runs on every functionally admitted target, records the actual
+hardware and software metadata, reports CUDA-graph replay separately from
+steady-state eager host enqueue time, and refuses to emit timings until route,
+output, mutable-state, cache-identity, and restore gates pass.
+
 ## Inspect and restore
 
 ```python
@@ -49,8 +93,10 @@ cudnn.fla.is_accelerated("gated_mlp") # one target ("mlp" also works)
 
 cudnn.fla.mlp_last_path()  # "native", "fallback:<reason>", or "error:<type>"
 cudnn.fla.last_path()      # most recent Gated Delta Rule route
+cudnn.fla.short_conv_last_path() # most recent short-convolution route
 
 cudnn.fla.restore_fla(targets="gated_mlp") # restore only the MLP target
+cudnn.fla.restore_fla(targets="shortconv") # alias for the short-conv target
 cudnn.fla.restore_fla()                    # restore every target owned by cuDNN
 ```
 
@@ -61,13 +107,15 @@ per-thread state.
 
 ## Installation
 
-Install FLA separately. The dense MLP adapter is version-gated to the validated
-release:
+Install FLA separately. The dense MLP and short-convolution adapters are
+version-gated to the validated release:
 
 ```bash
 pip install flash-linear-attention==0.5.2
 pip install "nvidia-cudnn-frontend[cutedsl]"
 ```
 
-The `cutedsl` extra supplies the optional dependencies required by the fused
-GEMM path used by the native `gated_mlp` target.
+The `cutedsl` extra supplies the optional CUTLASS DSL and CUDA Python
+dependencies required by the native `gated_mlp` and `short_conv` targets. To
+require the native `short_conv` route instead of its typed fallback, also
+ensure `nvidia-cutlass-dsl[cu13]>=4.7` is installed.

--- a/docs/fe-oss-apis/overview.md
+++ b/docs/fe-oss-apis/overview.md
@@ -9,6 +9,7 @@ The GEMM CuTeDSL APIs are type-erased and torch-lazy: torch is imported only whe
 - **proj_rope_mxfp8**: JAX eager support on both input paths with `w_out_in=True` (the transposed [in, out] weight view is torch-only), plus the `jax.jit`-compatible `gemm_proj_rope_mxfp8_jax_sm100` entry point.
 
 This folder documents the Python FE APIs implemented under `python/cudnn`. For details on currently implemented operations, see:
+- [Causal Conv1d](causal_conv1d.md) and [Decode Update](causal_conv1d_update.md)
 - [FLA Integration Shims](fla.md)
 - [GEMM + Amax](gemm_fusions/gemm_amax.md)
 - [GEMM + RoPE + MXFP8 Projection](gemm_fusions/gemm_proj_rope_mxfp8.md)
@@ -56,6 +57,11 @@ pip install --group jax     # jax >= 0.5 (XLA entry points via cutlass.jax, ship
 After installation, you can import the APIs directly from the `cudnn` package, i.e. `from cudnn import {your_operation}`
 
 ## API Usage
+
+The causal-convolution family exposes semantic PyTorch operations only through
+`cudnn.ops.causal_conv1d` and `cudnn.ops.causal_conv1d_update`; they return
+ordinary tensors and keep prepared kernel objects private. The wrapper and
+class conventions below apply to prepared frontend-only kernel APIs.
 
 Most compiler-style operations expose the following two APIs. Functional
 autograd integrations such as BSA and Flex Attention instead document their

--- a/python/cudnn/README.md
+++ b/python/cudnn/README.md
@@ -61,6 +61,7 @@ To add a new frontend-only API, follow these steps:
 4. Add a sample usage/test file in `test/python/fe_api/`.
 
 **Currently implemented frontend-only APIs**:
+- `cudnn.ops.causal_conv1d` (full-sequence forward/backward) and `cudnn.ops.causal_conv1d_update` (one-token mutable update)
 - `GEMM + Amax`
 - `RMSNorm + RHT + Amax`
 - `GEMM + SwiGLU`

--- a/python/cudnn/_causal_conv1d_arch.py
+++ b/python/cudnn/_causal_conv1d_arch.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal functional and schedule policy for the causal-convolution family."""
+
+FUNCTIONAL_COMPUTE_CAPABILITIES = frozenset(
+    {
+        (8, 0),
+        (8, 6),
+        (8, 7),
+        (8, 9),
+        (9, 0),
+        (10, 0),
+        (10, 3),
+        (11, 0),
+        (12, 0),
+        (12, 1),
+    }
+)
+F32X2_COMPUTE_CAPABILITIES = frozenset(
+    {
+        (10, 0),
+        (10, 3),
+        (11, 0),
+        (12, 0),
+        (12, 1),
+    }
+)
+
+# The update route currently admits the same functional targets as the bulk
+# route. Keep this semantic alias so diagnostics remain operation-specific even
+# if the two implementations diverge later.
+SUPPORTED_CAUSAL_CONV1D_UPDATE_COMPUTE_CAPABILITIES = FUNCTIONAL_COMPUTE_CAPABILITIES
+
+
+def is_functional_arch(compute_capability: tuple[int, int]) -> bool:
+    return compute_capability in FUNCTIONAL_COMPUTE_CAPABILITIES
+
+
+def uses_vec8_schedule(compute_capability: tuple[int, int], n_channels: int) -> bool:
+    return compute_capability in F32X2_COMPUTE_CAPABILITIES and n_channels % 8 == 0
+
+
+def is_supported_causal_conv1d_update_compute_capability(
+    compute_capability: tuple[int, int],
+) -> bool:
+    """Return whether the operation admits this functional target."""
+
+    return is_functional_arch(compute_capability)
+
+
+def supported_causal_conv1d_update_compute_capabilities_text() -> str:
+    """Return the functional allowlist in a stable diagnostic format."""
+
+    return ", ".join(f"{major}.{minor}" for major, minor in sorted(SUPPORTED_CAUSAL_CONV1D_UPDATE_COMPUTE_CAPABILITIES))

--- a/python/cudnn/causal_conv1d_bulk_sm100/__init__.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/__init__.py
@@ -3,16 +3,30 @@
 
 """Private native backends for :func:`cudnn.ops.causal_conv1d`.
 
-The imports below are retained as implementation and test seams.  They are
-deliberately absent from the package's public export list; model code should
-use ``cudnn.ops``.
+The lifecycle symbols remain available as explicit implementation and test
+seams, but loading one backend must not import the others. They are deliberately
+absent from the package's public export list; model code should use
+``cudnn.ops``.
 """
 
-from .api import CausalConv1dBulkFwdSm100, causal_conv1d_bulk_fwd_wrapper_sm100
-from .autograd import CausalConv1dBulkAutogradPrototype
-from .backward import (
-    CausalConv1dBulkBwdPrototype,
-    compile_causal_conv1d_bulk_bwd_prototype,
-)
+from importlib import import_module
+
+_LAZY_BACKEND_ATTRIBUTES = {
+    "CausalConv1dBulkFwdSm100": ".api",
+    "causal_conv1d_bulk_fwd_wrapper_sm100": ".api",
+    "CausalConv1dBulkAutogradPrototype": ".autograd",
+    "CausalConv1dBulkBwdPrototype": ".backward",
+    "compile_causal_conv1d_bulk_bwd_prototype": ".backward",
+}
+
+
+def __getattr__(name: str):
+    module_name = _LAZY_BACKEND_ATTRIBUTES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(module_name, __name__), name)
+    globals()[name] = value
+    return value
+
 
 __all__: list[str] = []

--- a/python/cudnn/causal_conv1d_bulk_sm100/__init__.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/__init__.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Private native backends for :func:`cudnn.ops.causal_conv1d`.
+
+The imports below are retained as implementation and test seams.  They are
+deliberately absent from the package's public export list; model code should
+use ``cudnn.ops``.
+"""
+
+from .api import CausalConv1dBulkFwdSm100, causal_conv1d_bulk_fwd_wrapper_sm100
+from .autograd import CausalConv1dBulkAutogradPrototype
+from .backward import (
+    CausalConv1dBulkBwdPrototype,
+    compile_causal_conv1d_bulk_bwd_prototype,
+)
+
+__all__: list[str] = []

--- a/python/cudnn/causal_conv1d_bulk_sm100/api.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/api.py
@@ -12,7 +12,7 @@ correctness-first scalar schedule. Model code should use
 
 from contextlib import contextmanager
 import threading
-from typing import Iterator, Optional
+from typing import Iterator, Optional, Union
 
 from cuda.bindings import driver as cuda
 import cutlass
@@ -119,14 +119,14 @@ class CausalConv1dBulkFwdSm100(APIBase):
 
     def __init__(
         self,
-        sample_x: torch.Tensor,
-        sample_weight: torch.Tensor,
-        sample_output: torch.Tensor,
-        sample_cu_seqlens: Optional[torch.Tensor] = None,
-        sample_initial_state: Optional[torch.Tensor] = None,
-        sample_final_state: Optional[torch.Tensor] = None,
+        sample_x: Union[torch.Tensor, TensorDesc],
+        sample_weight: Union[torch.Tensor, TensorDesc],
+        sample_output: Union[torch.Tensor, TensorDesc],
+        sample_cu_seqlens: Optional[Union[torch.Tensor, TensorDesc]] = None,
+        sample_initial_state: Optional[Union[torch.Tensor, TensorDesc]] = None,
+        sample_final_state: Optional[Union[torch.Tensor, TensorDesc]] = None,
         *,
-        sample_bias: Optional[torch.Tensor] = None,
+        sample_bias: Optional[Union[torch.Tensor, TensorDesc]] = None,
     ):
         super().__init__()
         self._warn_experimental_api()
@@ -136,16 +136,16 @@ class CausalConv1dBulkFwdSm100(APIBase):
             ("sample_weight", sample_weight),
             ("sample_output", sample_output),
         ):
-            if not isinstance(sample, torch.Tensor):
-                raise TypeError(f"{name} must be a torch.Tensor, got {type(sample).__name__}")
+            if not isinstance(sample, (torch.Tensor, TensorDesc)):
+                raise TypeError(f"{name} must be a torch.Tensor or TensorDesc, got {type(sample).__name__}")
         for name, sample in (
             ("sample_bias", sample_bias),
             ("sample_cu_seqlens", sample_cu_seqlens),
             ("sample_initial_state", sample_initial_state),
             ("sample_final_state", sample_final_state),
         ):
-            if sample is not None and not isinstance(sample, torch.Tensor):
-                raise TypeError(f"{name} must be a torch.Tensor, got {type(sample).__name__}")
+            if sample is not None and not isinstance(sample, (torch.Tensor, TensorDesc)):
+                raise TypeError(f"{name} must be a torch.Tensor or TensorDesc, got {type(sample).__name__}")
 
         self.x_desc = self._make_tensor_desc(sample_x, name="sample_x")
         self.weight_desc = self._make_tensor_desc(sample_weight, name="sample_weight")
@@ -158,19 +158,21 @@ class CausalConv1dBulkFwdSm100(APIBase):
         # TensorDesc intentionally does not retain sample storage.  Preserve
         # only the pointer remainders backing the alignment promises made to
         # CuTe during compilation.
-        self._sample_alignment_remainders = {
-            "X": sample_x.data_ptr() % 16,
-            "Weight": sample_weight.data_ptr() % 16,
-            "Output": sample_output.data_ptr() % 16,
-        }
-        if sample_cu_seqlens is not None:
-            self._sample_alignment_remainders["cu_seqlens"] = sample_cu_seqlens.data_ptr() % 4
-        if sample_bias is not None:
-            self._sample_alignment_remainders["Bias"] = sample_bias.data_ptr() % 16
-        if sample_initial_state is not None:
-            self._sample_alignment_remainders["Initial state"] = sample_initial_state.data_ptr() % 16
-        if sample_final_state is not None:
-            self._sample_alignment_remainders["Final state"] = sample_final_state.data_ptr() % 16
+        # Metadata-only samples have no pointer to validate. Defer their
+        # alignment check to the live tensors passed to execute().
+        self._sample_alignment_remainders = {}
+        for name, sample, alignment in (
+            ("X", sample_x, 16),
+            ("Weight", sample_weight, 16),
+            ("Output", sample_output, 16),
+            ("cu_seqlens", sample_cu_seqlens, 4),
+            ("Bias", sample_bias, 16),
+            ("Initial state", sample_initial_state, 16),
+            ("Final state", sample_final_state, 16),
+        ):
+            data_ptr = getattr(sample, "data_ptr", None)
+            if callable(data_ptr):
+                self._sample_alignment_remainders[name] = data_ptr() % alignment
 
         self.batch_size = None
         self.sample_sequence_length = None

--- a/python/cudnn/causal_conv1d_bulk_sm100/api.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/api.py
@@ -1,0 +1,717 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Private FE-OSS backend for portable bulk causal convolution.
+
+The internal class retains its historical ``Sm100`` suffix. SM100 uses the
+measured vector schedule, other listed targets at SM100 or newer use the same
+instruction-compatible path, and supported pre-Blackwell targets use the
+correctness-first scalar schedule. Model code should use
+``cudnn.ops.causal_conv1d`` rather than this lifecycle API.
+"""
+
+from contextlib import contextmanager
+import threading
+from typing import Iterator, Optional
+
+from cuda.bindings import driver as cuda
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.runtime import make_fake_stream
+import torch
+
+from cudnn.api_base import APIBase, TensorDesc, TupleDict
+from cudnn._causal_conv1d_arch import (
+    FUNCTIONAL_COMPUTE_CAPABILITIES,
+    is_functional_arch,
+    uses_vec8_schedule,
+)
+from cudnn.frost.buffers import CUTEDSL_MIN_VERSION, cutedsl_state, cutedsl_too_old
+
+_API_CACHE = {}
+_API_CACHE_LOCK = threading.Lock()
+_API_CACHE_CAPACITY = 128
+_INT32_MAX = 2**31 - 1
+# Kernels form ``tile_end = first_token + 16`` in Int32.  Reserve the
+# largest possible tile overrun so that every accepted launch stays defined.
+_MAX_TOTAL_TOKENS = _INT32_MAX - 15
+# Packed kernels use ``(lower + upper) // 2`` during their device-side search.
+_MAX_PACKED_SEQUENCES = _INT32_MAX // 2
+_MAX_SCALAR_GRID_CHANNELS = 256 * 65535
+
+
+@contextmanager
+def _torch_stream_context(
+    current_stream: Optional[cuda.CUstream],
+    device: torch.device,
+) -> Iterator[None]:
+    """Run wrapper-owned PyTorch allocations on the launch stream."""
+
+    if current_stream is None:
+        yield
+        return
+
+    launch_stream = _as_torch_stream(current_stream, device)
+    with torch.cuda.stream(launch_stream):
+        yield
+
+
+def _as_torch_stream(current_stream: cuda.CUstream, device: torch.device) -> torch.cuda.Stream:
+    """Resolve a concrete driver handle to the matching PyTorch stream."""
+
+    handle = int(current_stream)
+    torch_current = torch.cuda.current_stream(device)
+    torch_default = torch.cuda.default_stream(device)
+    if handle in (0, 1, torch_default.cuda_stream):
+        return torch_default
+    if handle == 2:
+        raise ValueError("causal_conv1d_bulk_sm100 does not support the " "CU_STREAM_PER_THREAD sentinel; pass a concrete stream handle")
+    if handle == torch_current.cuda_stream:
+        return torch_current
+    return torch.cuda.ExternalStream(handle, device=device)
+
+
+def _record_streams(
+    tensors: tuple[Optional[torch.Tensor], ...],
+    consumer: Optional[torch.cuda.Stream],
+) -> None:
+    """Keep raw-pointer operands alive through an explicit-stream launch."""
+
+    if consumer is None:
+        return
+    for tensor in tensors:
+        if tensor is not None:
+            tensor.record_stream(consumer)
+
+
+def _require_storage_alignment(tensor: torch.Tensor, alignment: int, name: str) -> None:
+    remainder = tensor.data_ptr() % alignment
+    if remainder:
+        raise ValueError(f"{name} data pointer must be {alignment}-byte aligned, " f"got address modulo {alignment} = {remainder}")
+
+
+def _tensors_overlap(lhs: torch.Tensor, rhs: torch.Tensor) -> bool:
+    """Return whether two exact-contiguous tensors share any device bytes.
+
+    ``torch._C._overlaps`` only compares PyTorch Storage identity.  DLPack can
+    wrap the same device address in a distinct Storage, so use the byte spans
+    guaranteed by this API's exact-contiguous tensor contract instead.
+    """
+
+    lhs_begin = lhs.data_ptr()
+    rhs_begin = rhs.data_ptr()
+    lhs_end = lhs_begin + lhs.numel() * lhs.element_size()
+    rhs_end = rhs_begin + rhs.numel() * rhs.element_size()
+    return lhs_begin < rhs_end and rhs_begin < lhs_end
+
+
+class CausalConv1dBulkFwdSm100(APIBase):
+    """Compile and execute BF16 width-four bulk causal convolution.
+
+    The native layout is contiguous ``x[B, T, D]`` and ``weight[D, 4]``.
+    Dense mode treats each batch row as a sequence.  Packed mode requires
+    ``B == 1`` and a CUDA int32 ``cu_seqlens[N + 1]`` tensor.  Optional initial
+    and final states use the full-width ``[N, D, 4]`` decode-cache layout.
+
+    An optional contiguous BF16 ``bias[D]`` is added before SiLU.  The operation
+    remains inference-only until the matching backward primitive exists.
+    """
+
+    def __init__(
+        self,
+        sample_x: torch.Tensor,
+        sample_weight: torch.Tensor,
+        sample_output: torch.Tensor,
+        sample_cu_seqlens: Optional[torch.Tensor] = None,
+        sample_initial_state: Optional[torch.Tensor] = None,
+        sample_final_state: Optional[torch.Tensor] = None,
+        *,
+        sample_bias: Optional[torch.Tensor] = None,
+    ):
+        super().__init__()
+        self._warn_experimental_api()
+
+        for name, sample in (
+            ("sample_x", sample_x),
+            ("sample_weight", sample_weight),
+            ("sample_output", sample_output),
+        ):
+            if not isinstance(sample, torch.Tensor):
+                raise TypeError(f"{name} must be a torch.Tensor, got {type(sample).__name__}")
+        for name, sample in (
+            ("sample_bias", sample_bias),
+            ("sample_cu_seqlens", sample_cu_seqlens),
+            ("sample_initial_state", sample_initial_state),
+            ("sample_final_state", sample_final_state),
+        ):
+            if sample is not None and not isinstance(sample, torch.Tensor):
+                raise TypeError(f"{name} must be a torch.Tensor, got {type(sample).__name__}")
+
+        self.x_desc = self._make_tensor_desc(sample_x, name="sample_x")
+        self.weight_desc = self._make_tensor_desc(sample_weight, name="sample_weight")
+        self.bias_desc = self._make_tensor_desc(sample_bias, name="sample_bias")
+        self.output_desc = self._make_tensor_desc(sample_output, name="sample_output")
+        self.cu_seqlens_desc = self._make_tensor_desc(sample_cu_seqlens, name="sample_cu_seqlens")
+        self.initial_state_desc = self._make_tensor_desc(sample_initial_state, name="sample_initial_state")
+        self.final_state_desc = self._make_tensor_desc(sample_final_state, name="sample_final_state")
+
+        # TensorDesc intentionally does not retain sample storage.  Preserve
+        # only the pointer remainders backing the alignment promises made to
+        # CuTe during compilation.
+        self._sample_alignment_remainders = {
+            "X": sample_x.data_ptr() % 16,
+            "Weight": sample_weight.data_ptr() % 16,
+            "Output": sample_output.data_ptr() % 16,
+        }
+        if sample_cu_seqlens is not None:
+            self._sample_alignment_remainders["cu_seqlens"] = sample_cu_seqlens.data_ptr() % 4
+        if sample_bias is not None:
+            self._sample_alignment_remainders["Bias"] = sample_bias.data_ptr() % 16
+        if sample_initial_state is not None:
+            self._sample_alignment_remainders["Initial state"] = sample_initial_state.data_ptr() % 16
+        if sample_final_state is not None:
+            self._sample_alignment_remainders["Final state"] = sample_final_state.data_ptr() % 16
+
+        self.batch_size = None
+        self.sample_sequence_length = None
+        self.n_channels = None
+        self.num_sequences = None
+        self.compute_capability = None
+        self.use_vec8_schedule = None
+        self.is_packed = sample_cu_seqlens is not None
+
+    @staticmethod
+    def _require_rank(desc: TensorDesc, rank: int, name: str) -> None:
+        if desc.ndim != rank:
+            raise ValueError(f"{name} must be {rank}D, got shape {desc.shape}")
+
+    @staticmethod
+    def _require_cuda(desc: TensorDesc, name: str) -> None:
+        if desc.device.type != "cuda":
+            raise ValueError(f"{name} must be a CUDA tensor, got device {desc.device}")
+
+    def check_support(self) -> bool:
+        cutedsl_installed, cutedsl_version = cutedsl_state()
+        cutedsl_floor = ".".join(str(component) for component in CUTEDSL_MIN_VERSION)
+        self._runtime_error_if(
+            not cutedsl_installed,
+            "causal_conv1d_bulk_sm100 requires the cutedsl extra " f"(nvidia-cutlass-dsl>={cutedsl_floor})",
+        )
+        if cutedsl_too_old(cutedsl_version):
+            self._runtime_error_if(
+                True,
+                f"causal_conv1d_bulk_sm100 requires nvidia-cutlass-dsl>={cutedsl_floor}; " f"found {cutedsl_version[1]}",
+            )
+
+        self._require_rank(self.x_desc, 3, "X")
+        self._require_rank(self.weight_desc, 2, "Weight")
+        self._require_rank(self.output_desc, 3, "Output")
+        if self.bias_desc is not None:
+            self._require_rank(self.bias_desc, 1, "Bias")
+        if self.cu_seqlens_desc is not None:
+            self._require_rank(self.cu_seqlens_desc, 1, "cu_seqlens")
+        if self.initial_state_desc is not None:
+            self._require_rank(self.initial_state_desc, 3, "Initial state")
+        if self.final_state_desc is not None:
+            self._require_rank(self.final_state_desc, 3, "Final state")
+
+        batch_size, sequence_length, n_channels = self.x_desc.shape
+        self._value_error_if(batch_size <= 0, f"B must be positive, got {batch_size}")
+        self._value_error_if(sequence_length <= 0, f"T must be positive, got {sequence_length}")
+        self._value_error_if(n_channels <= 0, f"D must be positive, got {n_channels}")
+        self._value_error_if(batch_size > _INT32_MAX, f"B exceeds the Int32 limit: {batch_size}")
+        self._value_error_if(sequence_length > _INT32_MAX, f"T exceeds the Int32 limit: {sequence_length}")
+        self._value_error_if(
+            batch_size * sequence_length > _MAX_TOTAL_TOKENS,
+            f"B*T exceeds the safe Int32 tiled-indexing limit: {batch_size * sequence_length}",
+        )
+        self._value_error_if(n_channels > _MAX_SCALAR_GRID_CHANNELS, f"D exceeds the supported CUDA grid limit: {n_channels}")
+
+        if self.cu_seqlens_desc is None:
+            num_sequences = batch_size
+        else:
+            self._value_error_if(batch_size != 1, f"Packed X must have B=1, got B={batch_size}")
+            self._value_error_if(
+                self.cu_seqlens_desc.shape[0] < 2,
+                "Packed cu_seqlens must contain at least a start and end offset",
+            )
+            num_sequences = self.cu_seqlens_desc.shape[0] - 1
+            self._value_error_if(
+                num_sequences > _MAX_PACKED_SEQUENCES,
+                f"Packed N exceeds the safe Int32 search limit: {num_sequences}",
+            )
+            self._value_error_if(
+                num_sequences > batch_size * sequence_length,
+                f"Packed N={num_sequences} cannot exceed total_T={batch_size * sequence_length} " "when every sequence must be non-empty",
+            )
+
+        self._check_tensor_shape(self.weight_desc, (n_channels, 4), "Weight")
+        if self.bias_desc is not None:
+            self._check_tensor_shape(self.bias_desc, (n_channels,), "Bias")
+        self._check_tensor_shape(self.output_desc, (batch_size, sequence_length, n_channels), "Output")
+        if self.cu_seqlens_desc is not None:
+            self._check_tensor_shape(self.cu_seqlens_desc, (num_sequences + 1,), "cu_seqlens")
+        if self.initial_state_desc is not None:
+            self._check_tensor_shape(self.initial_state_desc, (num_sequences, n_channels, 4), "Initial state")
+        if self.final_state_desc is not None:
+            self._check_tensor_shape(self.final_state_desc, (num_sequences, n_channels, 4), "Final state")
+
+        self._check_tensor_stride(
+            self.x_desc,
+            stride=(sequence_length * n_channels, n_channels, 1),
+            name="X",
+            extra_error_msg="X must be [B, T, D] contiguous",
+        )
+        self._check_tensor_stride(
+            self.weight_desc,
+            stride=(4, 1),
+            name="Weight",
+            extra_error_msg="Weight must be [D, 4] contiguous",
+        )
+        if self.bias_desc is not None:
+            self._check_tensor_stride(
+                self.bias_desc,
+                stride=(1,),
+                name="Bias",
+                extra_error_msg="Bias must be [D] contiguous",
+            )
+        self._check_tensor_stride(
+            self.output_desc,
+            stride=(sequence_length * n_channels, n_channels, 1),
+            name="Output",
+            extra_error_msg="Output must be [B, T, D] contiguous",
+        )
+        if self.cu_seqlens_desc is not None:
+            self._check_tensor_stride(self.cu_seqlens_desc, stride=(1,), name="cu_seqlens")
+        for name, desc in (("Initial state", self.initial_state_desc), ("Final state", self.final_state_desc)):
+            if desc is not None:
+                self._check_tensor_stride(
+                    desc,
+                    stride=(n_channels * 4, 4, 1),
+                    name=name,
+                    extra_error_msg=f"{name} must be [N, D, 4] contiguous",
+                )
+
+        for name, desc in (
+            ("X", self.x_desc),
+            ("Output", self.output_desc),
+            ("Initial state", self.initial_state_desc),
+            ("Final state", self.final_state_desc),
+        ):
+            if desc is not None:
+                self._check_dtype(desc, dtype=torch.bfloat16, name=name)
+        self._value_error_if(
+            self.weight_desc.dtype not in (torch.bfloat16, torch.float32),
+            "Weight must have dtype torch.bfloat16 or torch.float32, " f"got {self.weight_desc.dtype}",
+        )
+        if self.bias_desc is not None:
+            self._value_error_if(
+                self.weight_desc.dtype != torch.bfloat16,
+                "FP32 Weight is currently supported only when Bias is omitted",
+            )
+            self._check_dtype(self.bias_desc, dtype=torch.bfloat16, name="Bias")
+        if self.cu_seqlens_desc is not None:
+            self._check_dtype(self.cu_seqlens_desc, dtype=torch.int32, name="cu_seqlens")
+
+        for name, remainder in self._sample_alignment_remainders.items():
+            alignment = 4 if name == "cu_seqlens" else 16
+            self._value_error_if(
+                remainder != 0,
+                f"{name} data pointer must be {alignment}-byte aligned, " f"got address modulo {alignment} = {remainder}",
+            )
+
+        descs = [
+            ("X", self.x_desc),
+            ("Weight", self.weight_desc),
+            ("Bias", self.bias_desc),
+            ("Output", self.output_desc),
+            ("cu_seqlens", self.cu_seqlens_desc),
+            ("Initial state", self.initial_state_desc),
+            ("Final state", self.final_state_desc),
+        ]
+        for name, desc in descs:
+            if desc is None:
+                continue
+            self._require_cuda(desc, name)
+            self._value_error_if(desc.device != self.x_desc.device, f"{name} must be on {self.x_desc.device}, got {desc.device}")
+
+        self._runtime_error_if(not torch.cuda.is_available(), "CUDA is not available")
+        compute_capability = torch.cuda.get_device_capability(self.x_desc.device)
+        self._runtime_error_if(
+            not is_functional_arch(compute_capability),
+            "CausalConv1dBulkFwdSm100 does not support compute capability "
+            f"{compute_capability[0]}.{compute_capability[1]}; supported capabilities are "
+            f"{sorted(FUNCTIONAL_COMPUTE_CAPABILITIES)}",
+        )
+        use_vec8_schedule = uses_vec8_schedule(compute_capability, n_channels)
+        if not use_vec8_schedule:
+            self._value_error_if(
+                batch_size * sequence_length * n_channels > _INT32_MAX,
+                "The scalar schedule requires X and Output to contain at most " f"{_INT32_MAX} elements",
+            )
+            if self.initial_state_desc is not None or self.final_state_desc is not None:
+                self._value_error_if(
+                    num_sequences * n_channels * 4 > _INT32_MAX,
+                    "The scalar schedule requires each state tensor to contain at most " f"{_INT32_MAX} elements",
+                )
+
+        self.batch_size = batch_size
+        self.sample_sequence_length = sequence_length
+        self.n_channels = n_channels
+        self.num_sequences = num_sequences
+        self.compute_capability = compute_capability
+        self.use_vec8_schedule = use_vec8_schedule
+        self._is_supported = True
+        return True
+
+    def compile(self) -> None:
+        self._ensure_support_checked()
+        if self._compiled_kernel is not None:
+            return
+
+        # Import only after check_support's explicit 4.7 gate. The kernel's
+        # packed math helpers do not exist in the package-wide 4.5 DSL floor.
+        from .kernel import CausalConv1dBulkForwardKernel
+
+        valid_tokens = cute.sym_int(divisibility=1)
+        fake_x = self._make_fake_cute_tensor(
+            dtype=self.x_desc.dtype,
+            shape=(valid_tokens, self.n_channels),
+            stride=(self.n_channels, 1),
+            assumed_align=16,
+        )
+        fake_weight = self._make_fake_cute_tensor_from_desc(self.weight_desc, assumed_align=16)
+        fake_bias = self._make_fake_cute_tensor_from_desc(self.bias_desc, assumed_align=16)
+        fake_initial_state = self._make_fake_cute_tensor_from_desc(self.initial_state_desc, assumed_align=16)
+        fake_cu_seqlens = self._make_fake_cute_tensor_from_desc(self.cu_seqlens_desc, assumed_align=4)
+        fake_output = self._make_fake_cute_tensor(
+            dtype=self.output_desc.dtype,
+            shape=(valid_tokens, self.n_channels),
+            stride=(self.n_channels, 1),
+            assumed_align=16,
+        )
+        fake_final_state = self._make_fake_cute_tensor_from_desc(self.final_state_desc, assumed_align=16)
+        fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
+
+        kernel = CausalConv1dBulkForwardKernel(use_vec8=self.use_vec8_schedule)
+        dense_tokens_per_sequence = self.sample_sequence_length if not self.is_packed else 0
+        with torch.cuda.device(self.x_desc.device):
+            self._compiled_kernel = cute.compile(
+                kernel,
+                fake_x,
+                fake_weight,
+                fake_bias,
+                fake_initial_state,
+                fake_cu_seqlens,
+                fake_output,
+                fake_final_state,
+                cutlass.Int32(self.num_sequences),
+                cutlass.Int32(dense_tokens_per_sequence),
+                cutlass.Int32(self.n_channels),
+                fake_stream,
+                options="--enable-tvm-ffi --generate-line-info",
+            )
+
+    @staticmethod
+    def _validate_runtime_static_tensor(tensor: torch.Tensor, desc: TensorDesc, name: str) -> None:
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(f"{name} must be a torch.Tensor, got {type(tensor).__name__}")
+        if tuple(tensor.shape) != desc.shape:
+            raise ValueError(f"{name} shape mismatch: expected {desc.shape}, got {tuple(tensor.shape)}")
+        if tuple(tensor.stride()) != desc.stride:
+            raise ValueError(f"{name} stride mismatch: expected {desc.stride}, got {tuple(tensor.stride())}")
+        if tensor.dtype != desc.dtype:
+            raise TypeError(f"{name} dtype mismatch: expected {desc.dtype}, got {tensor.dtype}")
+        if tensor.device != desc.device:
+            raise ValueError(f"{name} device mismatch: expected {desc.device}, got {tensor.device}")
+
+    def _validate_runtime_x_or_output(self, tensor: torch.Tensor, name: str) -> int:
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(f"{name} must be a torch.Tensor, got {type(tensor).__name__}")
+        if tensor.ndim != 3:
+            raise ValueError(f"{name} must be 3D, got shape {tuple(tensor.shape)}")
+        batch_size, sequence_length, n_channels = tensor.shape
+        if batch_size != self.batch_size or n_channels != self.n_channels:
+            raise ValueError(f"{name} shape mismatch: expected B={self.batch_size}, D={self.n_channels}, " f"got {tuple(tensor.shape)}")
+        if sequence_length <= 0:
+            raise ValueError(f"{name} T must be positive, got {sequence_length}")
+        if batch_size * sequence_length > _MAX_TOTAL_TOKENS:
+            raise ValueError(f"{name} B*T exceeds the safe Int32 tiled-indexing limit")
+        if not self.use_vec8_schedule and batch_size * sequence_length * n_channels > _INT32_MAX:
+            raise ValueError(f"The scalar schedule requires {name} to contain at most {_INT32_MAX} elements")
+        expected_stride = (sequence_length * n_channels, n_channels, 1)
+        if tuple(tensor.stride()) != expected_stride:
+            raise ValueError(f"{name} must be [B, T, D] contiguous, got stride {tuple(tensor.stride())}")
+        if tensor.dtype != torch.bfloat16:
+            raise TypeError(f"{name} dtype mismatch: expected torch.bfloat16, got {tensor.dtype}")
+        if tensor.device != self.x_desc.device:
+            raise ValueError(f"{name} device mismatch: expected {self.x_desc.device}, got {tensor.device}")
+        return sequence_length
+
+    def execute(
+        self,
+        x_tensor: torch.Tensor,
+        weight_tensor: torch.Tensor,
+        output_tensor: torch.Tensor,
+        cu_seqlens_tensor: Optional[torch.Tensor] = None,
+        initial_state_tensor: Optional[torch.Tensor] = None,
+        final_state_tensor: Optional[torch.Tensor] = None,
+        current_stream: Optional[cuda.CUstream] = None,
+        *,
+        bias_tensor: Optional[torch.Tensor] = None,
+    ) -> TupleDict:
+        self._runtime_error_if(
+            self._compiled_kernel is None,
+            "CausalConv1dBulkFwdSm100 kernel not compiled; call compile() first",
+        )
+
+        sequence_length = self._validate_runtime_x_or_output(x_tensor, "X")
+        output_sequence_length = self._validate_runtime_x_or_output(output_tensor, "Output")
+        if output_sequence_length != sequence_length:
+            raise ValueError(f"Output T must match X T={sequence_length}, got {output_sequence_length}")
+        if self.is_packed and self.num_sequences > self.batch_size * sequence_length:
+            raise ValueError(
+                f"Packed N={self.num_sequences} cannot exceed runtime total_T={self.batch_size * sequence_length} " "when every sequence must be non-empty"
+            )
+        self._validate_runtime_static_tensor(weight_tensor, self.weight_desc, "Weight")
+
+        optional_tensors = (
+            ("Bias", bias_tensor, self.bias_desc),
+            ("cu_seqlens", cu_seqlens_tensor, self.cu_seqlens_desc),
+            ("Initial state", initial_state_tensor, self.initial_state_desc),
+            ("Final state", final_state_tensor, self.final_state_desc),
+        )
+        for name, tensor, desc in optional_tensors:
+            if (tensor is None) != (desc is None):
+                raise ValueError(f"{name} presence must match the compiled signature")
+            if tensor is not None:
+                self._validate_runtime_static_tensor(tensor, desc, name)
+
+        for name, tensor, alignment in (
+            ("X", x_tensor, 16),
+            ("Weight", weight_tensor, 16),
+            ("Bias", bias_tensor, 16),
+            ("Output", output_tensor, 16),
+            ("cu_seqlens", cu_seqlens_tensor, 4),
+            ("Initial state", initial_state_tensor, 16),
+            ("Final state", final_state_tensor, 16),
+        ):
+            if tensor is not None:
+                _require_storage_alignment(tensor, alignment, name)
+
+        grad_inputs = [x_tensor, weight_tensor]
+        if bias_tensor is not None:
+            grad_inputs.append(bias_tensor)
+        if initial_state_tensor is not None:
+            grad_inputs.append(initial_state_tensor)
+        if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in grad_inputs):
+            raise RuntimeError("causal_conv1d_bulk_fwd is inference-only; call it under torch.no_grad()")
+
+        read_tensors = [x_tensor, weight_tensor]
+        if bias_tensor is not None:
+            read_tensors.append(bias_tensor)
+        if cu_seqlens_tensor is not None:
+            read_tensors.append(cu_seqlens_tensor)
+        if initial_state_tensor is not None:
+            read_tensors.append(initial_state_tensor)
+        for tensor in read_tensors:
+            if _tensors_overlap(output_tensor, tensor):
+                raise ValueError("Output must not overlap an input tensor")
+        if final_state_tensor is not None:
+            for tensor in [*read_tensors, output_tensor]:
+                if _tensors_overlap(final_state_tensor, tensor):
+                    raise ValueError("Final state must not overlap another input or output tensor")
+
+        if current_stream is None:
+            consumer_stream = torch.cuda.current_stream(x_tensor.device)
+            launch_stream = cuda.CUstream(consumer_stream.cuda_stream)
+        else:
+            consumer_stream = _as_torch_stream(current_stream, x_tensor.device)
+            launch_stream = current_stream
+
+        flat_x = x_tensor.view(-1, self.n_channels)
+        flat_output = output_tensor.view(-1, self.n_channels)
+        dense_tokens_per_sequence = sequence_length if not self.is_packed else 0
+        self._compiled_kernel(
+            flat_x,
+            weight_tensor,
+            bias_tensor,
+            initial_state_tensor,
+            cu_seqlens_tensor,
+            flat_output,
+            final_state_tensor,
+            cutlass.Int32(self.num_sequences),
+            cutlass.Int32(dense_tokens_per_sequence),
+            cutlass.Int32(self.n_channels),
+            launch_stream,
+        )
+        _record_streams(
+            (
+                x_tensor,
+                weight_tensor,
+                bias_tensor,
+                output_tensor,
+                cu_seqlens_tensor,
+                initial_state_tensor,
+                final_state_tensor,
+            ),
+            consumer_stream,
+        )
+        return TupleDict(output_tensor=output_tensor, final_state_tensor=final_state_tensor)
+
+
+def _cache_key(
+    x_tensor: torch.Tensor,
+    weight_tensor: torch.Tensor,
+    bias_tensor: Optional[torch.Tensor],
+    cu_seqlens_tensor: Optional[torch.Tensor],
+    initial_state_tensor: Optional[torch.Tensor],
+    output_final_state: bool,
+):
+    if not isinstance(x_tensor, torch.Tensor):
+        raise TypeError(f"X must be a torch.Tensor, got {type(x_tensor).__name__}")
+    if x_tensor.ndim != 3:
+        raise ValueError(f"X must be 3D, got shape {tuple(x_tensor.shape)}")
+    batch_size, sequence_length, n_channels = x_tensor.shape
+    if batch_size <= 0 or sequence_length <= 0 or n_channels <= 0:
+        raise ValueError(f"X dimensions must be positive, got shape {tuple(x_tensor.shape)}")
+    total_tokens = batch_size * sequence_length
+    if total_tokens > _MAX_TOTAL_TOKENS:
+        raise ValueError(f"X B*T exceeds the safe Int32 tiled-indexing limit: {total_tokens}")
+    if n_channels > _MAX_SCALAR_GRID_CHANNELS:
+        raise ValueError(f"X D exceeds the supported CUDA grid limit: {n_channels}")
+    if cu_seqlens_tensor is None:
+        num_sequences = batch_size
+    else:
+        if not isinstance(cu_seqlens_tensor, torch.Tensor):
+            raise TypeError("cu_seqlens must be a torch.Tensor or None, " f"got {type(cu_seqlens_tensor).__name__}")
+        if cu_seqlens_tensor.ndim != 1:
+            raise ValueError(f"cu_seqlens must be 1D, got shape {tuple(cu_seqlens_tensor.shape)}")
+        if batch_size != 1:
+            raise ValueError(f"Packed X must have B=1, got B={batch_size}")
+        if cu_seqlens_tensor.shape[0] < 2:
+            raise ValueError("Packed cu_seqlens must contain at least a start and end offset")
+        num_sequences = cu_seqlens_tensor.shape[0] - 1
+        if num_sequences > _MAX_PACKED_SEQUENCES:
+            raise ValueError(f"Packed N exceeds the safe Int32 search limit: {num_sequences}")
+        if num_sequences > total_tokens:
+            raise ValueError(f"Packed N={num_sequences} cannot exceed total_T={total_tokens} " "when every sequence must be non-empty")
+    compute_capability = torch.cuda.get_device_capability(x_tensor.device)
+    use_vec8_schedule = uses_vec8_schedule(compute_capability, n_channels)
+    if not use_vec8_schedule:
+        if x_tensor.numel() > _INT32_MAX:
+            raise ValueError(f"The scalar schedule requires X to contain at most {_INT32_MAX} elements")
+        if (initial_state_tensor is not None or output_final_state) and num_sequences * n_channels * 4 > _INT32_MAX:
+            raise ValueError(f"The scalar schedule requires each state tensor to contain at most {_INT32_MAX} elements")
+    return (
+        x_tensor.device.type,
+        x_tensor.device.index,
+        compute_capability,
+        use_vec8_schedule,
+        weight_tensor.dtype,
+        batch_size,
+        num_sequences,
+        n_channels,
+        bias_tensor is not None,
+        cu_seqlens_tensor is not None,
+        initial_state_tensor is not None,
+        bool(output_final_state),
+    )
+
+
+def causal_conv1d_bulk_fwd_wrapper_sm100(
+    x_tensor: torch.Tensor,
+    weight_tensor: torch.Tensor,
+    cu_seqlens_tensor: Optional[torch.Tensor] = None,
+    initial_state_tensor: Optional[torch.Tensor] = None,
+    *,
+    output_final_state: bool = False,
+    current_stream: Optional[cuda.CUstream] = None,
+    bias_tensor: Optional[torch.Tensor] = None,
+) -> TupleDict:
+    """Run the BF16 width-four bulk causal-convolution forward.
+
+    The result always contains ``output_tensor`` and ``final_state_tensor`` in
+    that order.  When ``output_final_state`` is false, the latter is a BF16
+    CUDA sentinel with shape ``(0,)``.  Packed metadata is consumed on device;
+    it must start at zero, end at ``total_T``, and be strictly increasing.
+    """
+
+    for name, tensor in (("X", x_tensor), ("Weight", weight_tensor)):
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(f"{name} must be a torch.Tensor, got {type(tensor).__name__}")
+    if initial_state_tensor is not None and not isinstance(initial_state_tensor, torch.Tensor):
+        raise TypeError("Initial state must be a torch.Tensor or None, " f"got {type(initial_state_tensor).__name__}")
+    if bias_tensor is not None and not isinstance(bias_tensor, torch.Tensor):
+        raise TypeError("Bias must be a torch.Tensor or None, " f"got {type(bias_tensor).__name__}")
+    if not isinstance(output_final_state, bool):
+        raise TypeError(f"output_final_state must be bool, got {type(output_final_state).__name__}")
+    if not x_tensor.is_cuda:
+        raise ValueError(f"X must be a CUDA tensor, got device {x_tensor.device}")
+
+    grad_inputs = [x_tensor, weight_tensor]
+    if bias_tensor is not None:
+        grad_inputs.append(bias_tensor)
+    if initial_state_tensor is not None:
+        grad_inputs.append(initial_state_tensor)
+    if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in grad_inputs):
+        raise RuntimeError("causal_conv1d_bulk_fwd is inference-only; call it under torch.no_grad()")
+
+    key = _cache_key(
+        x_tensor,
+        weight_tensor,
+        bias_tensor,
+        cu_seqlens_tensor,
+        initial_state_tensor,
+        output_final_state,
+    )
+    if cu_seqlens_tensor is None:
+        num_sequences = x_tensor.shape[0]
+    else:
+        num_sequences = cu_seqlens_tensor.shape[0] - 1
+
+    with torch.cuda.device(x_tensor.device), _torch_stream_context(current_stream, x_tensor.device):
+        output_tensor = torch.empty_like(x_tensor, memory_format=torch.contiguous_format)
+        if output_final_state:
+            n_channels = x_tensor.shape[2]
+            final_state_tensor = torch.empty(
+                (num_sequences, n_channels, 4),
+                dtype=torch.bfloat16,
+                device=x_tensor.device,
+            )
+        else:
+            final_state_tensor = torch.empty((0,), dtype=torch.bfloat16, device=x_tensor.device)
+
+        api = _API_CACHE.get(key)
+        if api is None:
+            with _API_CACHE_LOCK:
+                api = _API_CACHE.get(key)
+                if api is None:
+                    api = CausalConv1dBulkFwdSm100(
+                        sample_x=x_tensor,
+                        sample_weight=weight_tensor,
+                        sample_output=output_tensor,
+                        sample_bias=bias_tensor,
+                        sample_cu_seqlens=cu_seqlens_tensor,
+                        sample_initial_state=initial_state_tensor,
+                        sample_final_state=final_state_tensor if output_final_state else None,
+                    )
+                    api.check_support()
+                    api.compile()
+                    if len(_API_CACHE) >= _API_CACHE_CAPACITY:
+                        _API_CACHE.pop(next(iter(_API_CACHE)))
+                    _API_CACHE[key] = api
+
+        result = api.execute(
+            x_tensor=x_tensor,
+            weight_tensor=weight_tensor,
+            output_tensor=output_tensor,
+            cu_seqlens_tensor=cu_seqlens_tensor,
+            initial_state_tensor=initial_state_tensor,
+            final_state_tensor=final_state_tensor if output_final_state else None,
+            current_stream=current_stream,
+            bias_tensor=bias_tensor,
+        )
+        if not output_final_state:
+            result["final_state_tensor"] = final_state_tensor
+        return result

--- a/python/cudnn/causal_conv1d_bulk_sm100/api.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/api.py
@@ -5,7 +5,7 @@
 
 The internal class retains its historical ``Sm100`` suffix. SM100 uses the
 measured vector schedule, other listed targets at SM100 or newer use the same
-instruction-compatible path, and supported pre-Blackwell targets use the
+instruction-compatible path, and supported pre-SM100 targets use the
 correctness-first scalar schedule. Model code should use
 ``cudnn.ops.causal_conv1d`` rather than this lifecycle API.
 """

--- a/python/cudnn/causal_conv1d_bulk_sm100/autograd.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/autograd.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exact-shape dense and packed training prototype for causal conv.
+
+This module intentionally stays separate from the inference API while the
+backward schedules are being compared.  Construction compiles the exact-shape
+backward once; calls then expose an ordinary PyTorch autograd edge. Packed
+calls consume device ``cu_seqlens`` and optional BF16 channel bias. Bias-free
+calls may retain their width-four filter in FP32. Optional
+full-width initial/final state uses the same prefill-to-decode ABI as forward;
+width variants remain outside this experiment.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from cudnn.api_base import TupleDict
+
+from .api import causal_conv1d_bulk_fwd_wrapper_sm100
+from .backward import (
+    CausalConv1dBulkBwdPrototype,
+    compile_causal_conv1d_bulk_bwd_prototype,
+)
+
+
+class _CausalConv1dBulkAutogradFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+        backend,
+        bias: torch.Tensor | None,
+        initial_state: torch.Tensor | None,
+        output_final_state: bool,
+    ):
+        result = causal_conv1d_bulk_fwd_wrapper_sm100(
+            x,
+            weight,
+            cu_seqlens_tensor=cu_seqlens,
+            bias_tensor=bias,
+            initial_state_tensor=initial_state,
+            output_final_state=output_final_state,
+        )
+        saved = [x, weight]
+        if bias is not None:
+            saved.append(bias)
+        if cu_seqlens is not None:
+            saved.append(cu_seqlens)
+        if initial_state is not None:
+            saved.append(initial_state)
+        ctx.save_for_backward(*saved)
+        ctx.has_bias = bias is not None
+        ctx.has_cu_seqlens = cu_seqlens is not None
+        ctx.has_initial_state = initial_state is not None
+        ctx.output_final_state = output_final_state
+        ctx.backend = backend
+        if output_final_state:
+            return result["output_tensor"], result["final_state_tensor"]
+        return result["output_tensor"]
+
+    @staticmethod
+    def backward(ctx, dy: torch.Tensor, d_final_state: torch.Tensor | None = None):
+        x, weight = ctx.saved_tensors[:2]
+        saved_index = 2
+        bias = None
+        if ctx.has_bias:
+            bias = ctx.saved_tensors[saved_index]
+            saved_index += 1
+        cu_seqlens = None
+        if ctx.has_cu_seqlens:
+            cu_seqlens = ctx.saved_tensors[saved_index]
+            saved_index += 1
+        initial_state = ctx.saved_tensors[saved_index] if ctx.has_initial_state else None
+        backend: CausalConv1dBulkBwdPrototype = ctx.backend
+        dy = dy.contiguous()
+        if ctx.output_final_state:
+            if d_final_state is None:
+                raise RuntimeError("autograd did not materialize the required d_final_state")
+            d_final_state = d_final_state.contiguous()
+        elif d_final_state is not None:
+            raise RuntimeError("received d_final_state for a forward without final-state output")
+        dx = torch.empty_like(x, memory_format=torch.contiguous_format)
+        dw_accum = torch.empty(
+            weight.shape,
+            dtype=torch.float32,
+            device=weight.device,
+        )
+        db_accum = None
+        if bias is not None:
+            db_accum = torch.empty(
+                bias.shape,
+                dtype=torch.float32,
+                device=bias.device,
+            )
+        d_initial_state = None
+        if initial_state is not None:
+            d_initial_state = torch.empty_like(initial_state, memory_format=torch.contiguous_format)
+        workspace = None
+        if backend.dweight_workspace_numel:
+            workspace = torch.empty(
+                backend.dweight_workspace_numel,
+                dtype=torch.float32,
+                device=weight.device,
+            )
+        packed_tile_map = None
+        if backend.packed_tile_map_numel:
+            packed_tile_map = torch.empty(
+                backend.packed_tile_map_numel,
+                dtype=torch.int32,
+                device=weight.device,
+            )
+        backend.execute(
+            x,
+            weight,
+            dy,
+            dx,
+            dw_accum,
+            cu_seqlens=cu_seqlens,
+            packed_tile_map=packed_tile_map,
+            dweight_workspace=workspace,
+            bias=bias,
+            db_accum=db_accum,
+            initial_state=initial_state,
+            d_final_state=d_final_state,
+            d_initial_state=d_initial_state,
+        )
+        db = db_accum.to(bias.dtype) if db_accum is not None else None
+        return dx, dw_accum.to(weight.dtype), None, None, db, d_initial_state, None
+
+
+class CausalConv1dBulkAutogradPrototype:
+    """One exact-shape dense or packed BF16 training callable."""
+
+    def __init__(
+        self,
+        sample_x: torch.Tensor,
+        sample_weight: torch.Tensor,
+        sample_cu_seqlens: torch.Tensor | None = None,
+        *,
+        schedule: str = "auto",
+        sample_bias: torch.Tensor | None = None,
+        sample_initial_state: torch.Tensor | None = None,
+        output_final_state: bool = False,
+    ) -> None:
+        if not isinstance(output_final_state, bool):
+            raise TypeError(f"output_final_state must be bool, got {type(output_final_state).__name__}")
+        sample_dy = torch.empty_like(sample_x, memory_format=torch.contiguous_format)
+        sample_d_final_state = None
+        if output_final_state:
+            num_sequences = sample_x.shape[0] if sample_cu_seqlens is None else sample_cu_seqlens.shape[0] - 1
+            sample_d_final_state = torch.empty(
+                (num_sequences, sample_x.shape[2], 4),
+                dtype=sample_x.dtype,
+                device=sample_x.device,
+            )
+        self.backward_backend = compile_causal_conv1d_bulk_bwd_prototype(
+            sample_x,
+            sample_weight,
+            sample_dy,
+            sample_cu_seqlens,
+            schedule=schedule,
+            bias=sample_bias,
+            initial_state=sample_initial_state,
+            d_final_state=sample_d_final_state,
+        )
+        self.output_final_state = output_final_state
+
+    @property
+    def dweight_workspace_bytes(self) -> int:
+        return self.backward_backend.dweight_workspace_bytes
+
+    @property
+    def total_workspace_bytes(self) -> int:
+        return self.backward_backend.total_workspace_bytes
+
+    def __call__(
+        self,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
+        *,
+        bias: torch.Tensor | None = None,
+        initial_state: torch.Tensor | None = None,
+        output_final_state: bool | None = None,
+    ) -> torch.Tensor | TupleDict:
+        self.backward_backend._validate_runtime_tensor(x, self.backward_backend.x_desc, "X")
+        self.backward_backend._validate_runtime_tensor(weight, self.backward_backend.weight_desc, "Weight")
+        if (cu_seqlens is None) != (self.backward_backend.cu_seqlens_desc is None):
+            raise ValueError("cu_seqlens presence must match the compiled signature")
+        if cu_seqlens is not None:
+            assert self.backward_backend.cu_seqlens_desc is not None
+            self.backward_backend._validate_runtime_tensor(cu_seqlens, self.backward_backend.cu_seqlens_desc, "cu_seqlens")
+        if (bias is None) != (self.backward_backend.bias_desc is None):
+            raise ValueError("Bias presence must match the compiled signature")
+        if bias is not None:
+            assert self.backward_backend.bias_desc is not None
+            self.backward_backend._validate_runtime_tensor(bias, self.backward_backend.bias_desc, "Bias")
+        if (initial_state is None) != (self.backward_backend.initial_state_desc is None):
+            raise ValueError("Initial state presence must match the compiled signature")
+        if initial_state is not None:
+            assert self.backward_backend.initial_state_desc is not None
+            self.backward_backend._validate_runtime_tensor(initial_state, self.backward_backend.initial_state_desc, "Initial state")
+        if output_final_state is None:
+            output_final_state = self.output_final_state
+        elif not isinstance(output_final_state, bool):
+            raise TypeError(f"output_final_state must be bool or None, got {type(output_final_state).__name__}")
+        if output_final_state != self.output_final_state:
+            raise ValueError("output_final_state must match the compiled signature")
+        result = _CausalConv1dBulkAutogradFunction.apply(
+            x,
+            weight,
+            cu_seqlens,
+            self.backward_backend,
+            bias,
+            initial_state,
+            output_final_state,
+        )
+        if output_final_state:
+            output, final_state = result
+            return TupleDict(output_tensor=output, final_state_tensor=final_state)
+        return result
+
+
+__all__ = ["CausalConv1dBulkAutogradPrototype"]

--- a/python/cudnn/causal_conv1d_bulk_sm100/autograd.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/autograd.py
@@ -145,6 +145,7 @@ class CausalConv1dBulkAutogradPrototype:
         sample_bias: torch.Tensor | None = None,
         sample_initial_state: torch.Tensor | None = None,
         output_final_state: bool = False,
+        deterministic: bool = False,
     ) -> None:
         if not isinstance(output_final_state, bool):
             raise TypeError(f"output_final_state must be bool, got {type(output_final_state).__name__}")
@@ -166,6 +167,7 @@ class CausalConv1dBulkAutogradPrototype:
             bias=sample_bias,
             initial_state=sample_initial_state,
             d_final_state=sample_d_final_state,
+            deterministic=deterministic,
         )
         self.output_final_state = output_final_state
 

--- a/python/cudnn/causal_conv1d_bulk_sm100/backward.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/backward.py
@@ -1,0 +1,873 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Experimental bulk causal-convolution backward API.
+
+The prototype covers the same contiguous BF16, width-four, fused-SiLU data
+slice as the forward API. It supports dense [B, T, D] input and packed
+[1, total_T, D] input with device cu_seqlens. Optional BF16 bias [D] produces
+an FP32 dbias accumulator. Optional BF16 initial state [N, D, 4] produces a
+BF16 d_initial_state, and an optional BF16 upstream d_final_state contributes
+to both dX and d_initial_state. Residual and other widths are intentionally
+outside this surface.
+
+Compilation is exact-shape. Packed metadata values stay on device: a small
+pre-kernel validates the prefix sums and builds a bounded per-sequence tile
+map, after which the dense backward math is reused without cross-sequence
+reads. The default schedules accumulate dweight with FP32 atomics; partial
+schedules use caller-owned FP32 partials and a second reduction. The atomic
+schedules do not produce bitwise-reproducible dweight, even when PyTorch
+deterministic algorithms are enabled; request ``t64-partial`` when reproducible
+dweight is required. ``v4-stream`` is a dense, bias-free FE-native schedule
+derived from the operator math: each thread streams four adjacent channels,
+and a single occupancy formula chooses its token tile instead of maintaining a
+config zoo.
+``v2-cpasync`` keeps the same workspace/reducer ABI while using four G8 shared-
+memory stages, packed-FP32x2 math, and a fast-tanh SiLU derivative on capable
+architectures. Its token grid is derived from the live SM count.
+Optional dbias uses one FP32 atomic per token-tile and channel in the scalar
+schedules.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import torch
+from cuda.bindings import driver as cuda
+from cutlass import cute
+from cutlass.cute.runtime import make_fake_stream
+
+from cudnn._causal_conv1d_arch import (
+    F32X2_COMPUTE_CAPABILITIES,
+    FUNCTIONAL_COMPUTE_CAPABILITIES,
+    is_functional_arch,
+)
+from cudnn.api_base import APIBase, TensorDesc
+from cudnn.frost.buffers import CUTEDSL_MIN_VERSION, cutedsl_state, cutedsl_too_old
+
+from .api import (
+    _INT32_MAX,
+    _MAX_PACKED_SEQUENCES,
+    _MAX_SCALAR_GRID_CHANNELS,
+    _as_torch_stream,
+    _record_streams,
+    _require_storage_alignment,
+    _tensors_overlap,
+)
+
+_WIDTH = 4
+_DWEIGHT_ATOMIC = "atomic"
+_DWEIGHT_PARTIAL = "partial"
+_AUTO_SCHEDULE = "auto"
+_SCALAR_KERNEL = "scalar"
+_VEC4_STREAM_KERNEL = "vec4-stream"
+_VEC2_CPASYNC_KERNEL = "vec2-cpasync"
+_VEC4_CHANNELS_PER_CTA = 128 * 4
+_VEC4_TARGET_CTAS_PER_SM = 5
+_VEC2_CPASYNC_CHANNELS_PER_CTA = 128 * 2
+_VEC2_CPASYNC_TOKENS_PER_STAGE = 8
+_VEC2_CPASYNC_TARGET_CTAS_PER_SM = 4
+_VEC2_CPASYNC_MIN_TOKENS = 64
+
+
+class _BulkBwdSchedule(NamedTuple):
+    threads: int
+    tokens_per_cta: int
+    dweight_mode: str
+    reduction_threads: int = 256
+    kernel_variant: str = _SCALAR_KERNEL
+
+
+_SCHEDULES = {
+    "t32": _BulkBwdSchedule(256, 32, _DWEIGHT_ATOMIC),
+    "t64": _BulkBwdSchedule(256, 64, _DWEIGHT_ATOMIC),
+    "t128": _BulkBwdSchedule(256, 128, _DWEIGHT_ATOMIC),
+    "t64-partial": _BulkBwdSchedule(256, 64, _DWEIGHT_PARTIAL),
+    # tokens_per_cta is shape/device-derived during check_support().
+    "v4-stream": _BulkBwdSchedule(128, 0, _DWEIGHT_PARTIAL, 128, _VEC4_STREAM_KERNEL),
+    "v2-cpasync": _BulkBwdSchedule(128, 0, _DWEIGHT_PARTIAL, 128, _VEC2_CPASYNC_KERNEL),
+}
+
+
+def select_bulk_bwd_schedule(total_tokens: int) -> str:
+    """Choose the measured atomic schedule for the dense prototype.
+
+    Both returned schedules use FP32 atomics, so dweight is not bitwise
+    reproducible across launches, including when PyTorch deterministic
+    algorithms are enabled. Request ``t64-partial`` explicitly when
+    reproducible dweight is required.
+    """
+
+    return "t128" if total_tokens >= 16384 else "t64"
+
+
+def _align_vec2_cpasync_tile(tokens_per_cta: int) -> int:
+    """Round K up so every staged token after the three-token prime is G8."""
+
+    staged_tokens = max(0, tokens_per_cta - 3)
+    return 3 + (staged_tokens + _VEC2_CPASYNC_TOKENS_PER_STAGE - 1) // _VEC2_CPASYNC_TOKENS_PER_STAGE * _VEC2_CPASYNC_TOKENS_PER_STAGE
+
+
+def _plan_vec2_cpasync(sequence_length: int, n_channels: int, sm_count: int) -> tuple[int, int]:
+    """Derive the cp.async token grid from live SM count and exact shape."""
+
+    channel_ctas = n_channels // _VEC2_CPASYNC_CHANNELS_PER_CTA
+    resident_cta_budget = sm_count * _VEC2_CPASYNC_TARGET_CTAS_PER_SM
+    target_token_ctas = max(1, min(sequence_length // 32, resident_cta_budget // channel_ctas))
+    tokens_per_cta = _align_vec2_cpasync_tile((sequence_length + target_token_ctas - 1) // target_token_ctas)
+    token_ctas = (sequence_length + tokens_per_cta - 1) // tokens_per_cta
+    while channel_ctas * token_ctas > resident_cta_budget and token_ctas > 1:
+        tokens_per_cta = _align_vec2_cpasync_tile(tokens_per_cta + 1)
+        token_ctas = (sequence_length + tokens_per_cta - 1) // tokens_per_cta
+    # Every CTA primes exactly three tokens before entering the staged loop.
+    # Grow K in whole G8 stages if an arbitrary T would otherwise leave a
+    # one- or two-token final CTA. This can only reduce the grid, so the
+    # resident-wave budget established above remains valid.
+    while token_ctas > 1 and sequence_length - (token_ctas - 1) * tokens_per_cta < 3:
+        tokens_per_cta += _VEC2_CPASYNC_TOKENS_PER_STAGE
+        token_ctas = (sequence_length + tokens_per_cta - 1) // tokens_per_cta
+    return token_ctas, tokens_per_cta
+
+
+class CausalConv1dBulkBwdPrototype(APIBase):
+    """Compile one exact-shape dense or packed BF16+SiLU backward."""
+
+    def __init__(
+        self,
+        sample_x: torch.Tensor,
+        sample_weight: torch.Tensor,
+        sample_dy: torch.Tensor,
+        sample_cu_seqlens: torch.Tensor | None = None,
+        *,
+        schedule: str = _AUTO_SCHEDULE,
+        sample_bias: torch.Tensor | None = None,
+        sample_initial_state: torch.Tensor | None = None,
+        sample_d_final_state: torch.Tensor | None = None,
+    ) -> None:
+        super().__init__()
+        self._warn_experimental_api()
+        for name, sample in (
+            ("sample_x", sample_x),
+            ("sample_weight", sample_weight),
+            ("sample_dy", sample_dy),
+        ):
+            if not isinstance(sample, torch.Tensor):
+                raise TypeError(f"{name} must be a torch.Tensor, got {type(sample).__name__}")
+        if sample_cu_seqlens is not None and not isinstance(sample_cu_seqlens, torch.Tensor):
+            raise TypeError("sample_cu_seqlens must be a torch.Tensor or None, " f"got {type(sample_cu_seqlens).__name__}")
+        if sample_initial_state is not None and not isinstance(sample_initial_state, torch.Tensor):
+            raise TypeError("sample_initial_state must be a torch.Tensor or None, " f"got {type(sample_initial_state).__name__}")
+        if sample_d_final_state is not None and not isinstance(sample_d_final_state, torch.Tensor):
+            raise TypeError("sample_d_final_state must be a torch.Tensor or None, " f"got {type(sample_d_final_state).__name__}")
+        if sample_bias is not None and not isinstance(sample_bias, torch.Tensor):
+            raise TypeError(f"sample_bias must be a torch.Tensor or None, got {type(sample_bias).__name__}")
+        choices = (_AUTO_SCHEDULE, *_SCHEDULES)
+        if schedule not in choices:
+            raise ValueError(f"unknown schedule {schedule!r}; choose one of {choices}")
+        self.requested_schedule = schedule
+        self.schedule: str | None = None
+
+        self.x_desc = self._make_tensor_desc(sample_x, name="sample_x")
+        self.weight_desc = self._make_tensor_desc(sample_weight, name="sample_weight")
+        self.dy_desc = self._make_tensor_desc(sample_dy, name="sample_dy")
+        self.cu_seqlens_desc = self._make_tensor_desc(sample_cu_seqlens, name="sample_cu_seqlens")
+        self.initial_state_desc = self._make_tensor_desc(sample_initial_state, name="sample_initial_state")
+        self.d_final_state_desc = self._make_tensor_desc(sample_d_final_state, name="sample_d_final_state")
+        self.bias_desc = self._make_tensor_desc(sample_bias, name="sample_bias")
+        self._sample_alignment_remainders = {
+            "X": sample_x.data_ptr() % 16,
+            "Weight": sample_weight.data_ptr() % 16,
+            "dY": sample_dy.data_ptr() % 16,
+        }
+        if sample_cu_seqlens is not None:
+            self._sample_alignment_remainders["cu_seqlens"] = sample_cu_seqlens.data_ptr() % 4
+        if sample_initial_state is not None:
+            self._sample_alignment_remainders["Initial state"] = sample_initial_state.data_ptr() % 16
+        if sample_d_final_state is not None:
+            self._sample_alignment_remainders["dFinal state"] = sample_d_final_state.data_ptr() % 16
+        if sample_bias is not None:
+            self._sample_alignment_remainders["Bias"] = sample_bias.data_ptr() % 16
+
+        self.is_packed = sample_cu_seqlens is not None
+        self.batch_size: int | None = None
+        self.sequence_length: int | None = None
+        self.n_channels: int | None = None
+        self.num_sequences: int | None = None
+        self.total_tokens: int | None = None
+        self.threads: int | None = None
+        self.tokens_per_cta: int | None = None
+        self.dweight_mode: str | None = None
+        self.reduction_threads: int | None = None
+        self.kernel_variant: str | None = None
+        self.tiles_per_sequence: int | None = None
+        self.packed_tile_capacity = 0
+        self.num_dweight_partials: int | None = None
+        self.compute_capability: tuple[int, int] | None = None
+        self.sm_count: int | None = None
+
+    @staticmethod
+    def _require_rank(desc: TensorDesc, rank: int, name: str) -> None:
+        if desc.ndim != rank:
+            raise ValueError(f"{name} must be {rank}D, got shape {desc.shape}")
+
+    @staticmethod
+    def _require_cuda(desc: TensorDesc, name: str) -> None:
+        if desc.device.type != "cuda":
+            raise ValueError(f"{name} must be a CUDA tensor, got device {desc.device}")
+
+    @property
+    def packed_tile_map_numel(self) -> int:
+        """Number of int32 elements in the device-built packed tile map."""
+
+        return self.packed_tile_capacity * _WIDTH
+
+    @property
+    def packed_tile_map_bytes(self) -> int:
+        return self.packed_tile_map_numel * 4
+
+    @property
+    def dweight_workspace_numel(self) -> int:
+        """Number of FP32 elements required by the selected dweight mode."""
+
+        if self.dweight_mode != _DWEIGHT_PARTIAL:
+            return 0
+        assert self.num_dweight_partials is not None
+        assert self.n_channels is not None
+        return self.num_dweight_partials * self.n_channels * _WIDTH
+
+    @property
+    def dweight_workspace_bytes(self) -> int:
+        return self.dweight_workspace_numel * 4
+
+    @property
+    def total_workspace_bytes(self) -> int:
+        """Total caller-owned tile-map and dweight workspace in bytes."""
+
+        return self.packed_tile_map_bytes + self.dweight_workspace_bytes
+
+    def check_support(self) -> bool:
+        cutedsl_installed, cutedsl_version = cutedsl_state()
+        cutedsl_floor = ".".join(str(component) for component in CUTEDSL_MIN_VERSION)
+        self._runtime_error_if(
+            not cutedsl_installed,
+            "causal_conv1d_bulk backward requires the cutedsl extra " f"(nvidia-cutlass-dsl>={cutedsl_floor})",
+        )
+        if cutedsl_too_old(cutedsl_version):
+            self._runtime_error_if(
+                True,
+                "causal_conv1d_bulk backward requires " f"nvidia-cutlass-dsl>={cutedsl_floor}; found {cutedsl_version[1]}",
+            )
+
+        self._require_rank(self.x_desc, 3, "X")
+        self._require_rank(self.weight_desc, 2, "Weight")
+        self._require_rank(self.dy_desc, 3, "dY")
+        if self.bias_desc is not None:
+            self._require_rank(self.bias_desc, 1, "Bias")
+        if self.cu_seqlens_desc is not None:
+            self._require_rank(self.cu_seqlens_desc, 1, "cu_seqlens")
+        if self.initial_state_desc is not None:
+            self._require_rank(self.initial_state_desc, 3, "Initial state")
+        if self.d_final_state_desc is not None:
+            self._require_rank(self.d_final_state_desc, 3, "dFinal state")
+
+        batch_size, sequence_length, n_channels = self.x_desc.shape
+        self._value_error_if(batch_size <= 0, f"B must be positive, got {batch_size}")
+        self._value_error_if(sequence_length <= 0, f"T must be positive, got {sequence_length}")
+        self._value_error_if(n_channels <= 0, f"D must be positive, got {n_channels}")
+        total_tokens = batch_size * sequence_length
+        self._value_error_if(batch_size > _INT32_MAX, f"B exceeds the Int32 limit: {batch_size}")
+        self._value_error_if(
+            sequence_length > _INT32_MAX,
+            f"T exceeds the Int32 limit: {sequence_length}",
+        )
+        self._value_error_if(
+            total_tokens > _INT32_MAX,
+            f"B*T exceeds the Int32 limit: {total_tokens}",
+        )
+        self._value_error_if(
+            n_channels > _MAX_SCALAR_GRID_CHANNELS,
+            f"D exceeds the supported CUDA grid limit: {n_channels}",
+        )
+
+        if self.cu_seqlens_desc is None:
+            num_sequences = batch_size
+        else:
+            self._value_error_if(batch_size != 1, f"Packed X must have B=1, got B={batch_size}")
+            self._value_error_if(
+                self.cu_seqlens_desc.shape[0] < 2,
+                "Packed cu_seqlens must contain at least a start and end offset",
+            )
+            num_sequences = self.cu_seqlens_desc.shape[0] - 1
+            self._value_error_if(
+                num_sequences > _MAX_PACKED_SEQUENCES,
+                f"Packed N exceeds the safe Int32 limit: {num_sequences}",
+            )
+            self._value_error_if(
+                num_sequences > total_tokens,
+                f"Packed N={num_sequences} cannot exceed total_T={total_tokens} " "when every sequence must be non-empty",
+            )
+
+        self._check_tensor_shape(self.weight_desc, (n_channels, _WIDTH), "Weight")
+        self._check_tensor_shape(self.dy_desc, (batch_size, sequence_length, n_channels), "dY")
+        if self.bias_desc is not None:
+            self._check_tensor_shape(self.bias_desc, (n_channels,), "Bias")
+        if self.cu_seqlens_desc is not None:
+            self._check_tensor_shape(self.cu_seqlens_desc, (num_sequences + 1,), "cu_seqlens")
+        state_shape = (num_sequences, n_channels, _WIDTH)
+        if self.initial_state_desc is not None:
+            self._check_tensor_shape(self.initial_state_desc, state_shape, "Initial state")
+        if self.d_final_state_desc is not None:
+            self._check_tensor_shape(self.d_final_state_desc, state_shape, "dFinal state")
+
+        expected_data_stride = (sequence_length * n_channels, n_channels, 1)
+        self._check_tensor_stride(
+            self.x_desc,
+            stride=expected_data_stride,
+            name="X",
+            extra_error_msg="X must be [B, T, D] contiguous",
+        )
+        self._check_tensor_stride(
+            self.dy_desc,
+            stride=expected_data_stride,
+            name="dY",
+            extra_error_msg="dY must be [B, T, D] contiguous",
+        )
+        self._check_tensor_stride(
+            self.weight_desc,
+            stride=(_WIDTH, 1),
+            name="Weight",
+            extra_error_msg="Weight must be [D, 4] contiguous",
+        )
+        if self.bias_desc is not None:
+            self._check_tensor_stride(
+                self.bias_desc,
+                stride=(1,),
+                name="Bias",
+                extra_error_msg="Bias must be [D] contiguous",
+            )
+        if self.cu_seqlens_desc is not None:
+            self._check_tensor_stride(self.cu_seqlens_desc, stride=(1,), name="cu_seqlens")
+        for name, desc in (
+            ("Initial state", self.initial_state_desc),
+            ("dFinal state", self.d_final_state_desc),
+        ):
+            if desc is not None:
+                self._check_tensor_stride(
+                    desc,
+                    stride=(n_channels * _WIDTH, _WIDTH, 1),
+                    name=name,
+                    extra_error_msg=f"{name} must be [N, D, 4] contiguous",
+                )
+
+        for name, desc in (
+            ("X", self.x_desc),
+            ("dY", self.dy_desc),
+            ("Initial state", self.initial_state_desc),
+            ("dFinal state", self.d_final_state_desc),
+        ):
+            if desc is not None:
+                self._check_dtype(desc, dtype=torch.bfloat16, name=name)
+        self._value_error_if(
+            self.weight_desc.dtype not in (torch.bfloat16, torch.float32),
+            "Weight must have dtype torch.bfloat16 or torch.float32, " f"got {self.weight_desc.dtype}",
+        )
+        if self.bias_desc is not None:
+            self._value_error_if(
+                self.weight_desc.dtype != torch.bfloat16,
+                "FP32 Weight is currently supported only when Bias is omitted",
+            )
+            self._check_dtype(self.bias_desc, dtype=torch.bfloat16, name="Bias")
+        if self.cu_seqlens_desc is not None:
+            self._check_dtype(self.cu_seqlens_desc, dtype=torch.int32, name="cu_seqlens")
+
+        for name, remainder in self._sample_alignment_remainders.items():
+            alignment = 4 if name == "cu_seqlens" else 16
+            self._value_error_if(
+                remainder != 0,
+                f"{name} data pointer must be {alignment}-byte aligned, " f"got address modulo {alignment} = {remainder}",
+            )
+
+        for name, desc in (
+            ("X", self.x_desc),
+            ("Weight", self.weight_desc),
+            ("Bias", self.bias_desc),
+            ("dY", self.dy_desc),
+            ("cu_seqlens", self.cu_seqlens_desc),
+            ("Initial state", self.initial_state_desc),
+            ("dFinal state", self.d_final_state_desc),
+        ):
+            if desc is None:
+                continue
+            self._require_cuda(desc, name)
+            self._value_error_if(
+                desc.device != self.x_desc.device,
+                f"{name} must be on {self.x_desc.device}, got {desc.device}",
+            )
+
+        self._runtime_error_if(not torch.cuda.is_available(), "CUDA is not available")
+        compute_capability = torch.cuda.get_device_capability(self.x_desc.device)
+        self._runtime_error_if(
+            not is_functional_arch(compute_capability),
+            "CausalConv1dBulkBwdPrototype does not support compute capability "
+            f"{compute_capability[0]}.{compute_capability[1]}; supported capabilities are "
+            f"{sorted(FUNCTIONAL_COMPUTE_CAPABILITIES)}",
+        )
+        self._value_error_if(
+            total_tokens * n_channels > _INT32_MAX,
+            "The scalar backward schedule requires X, dY, and dX to contain at most " f"{_INT32_MAX} elements",
+        )
+        if self.initial_state_desc is not None or self.d_final_state_desc is not None:
+            self._value_error_if(
+                num_sequences * n_channels * _WIDTH > _INT32_MAX,
+                "The scalar backward schedule requires each state tensor to contain at most " f"{_INT32_MAX} elements",
+            )
+
+        schedule_extent = total_tokens if self.is_packed else sequence_length
+        auto_streaming = (
+            self.requested_schedule == _AUTO_SCHEDULE
+            and not self.is_packed
+            and batch_size == 1
+            and self.bias_desc is None
+            and self.initial_state_desc is None
+            and self.d_final_state_desc is None
+            and n_channels % _VEC4_CHANNELS_PER_CTA == 0
+            and sequence_length >= 8192
+        )
+        if auto_streaming:
+            schedule = "v2-cpasync" if compute_capability in F32X2_COMPUTE_CAPABILITIES else "v4-stream"
+        else:
+            schedule = select_bulk_bwd_schedule(schedule_extent) if self.requested_schedule == _AUTO_SCHEDULE else self.requested_schedule
+        config = _SCHEDULES[schedule]
+        kernel_variant = config.kernel_variant
+        sm_count = None
+        if config.kernel_variant in (_VEC4_STREAM_KERNEL, _VEC2_CPASYNC_KERNEL):
+            self._value_error_if(self.is_packed, f"{schedule} currently supports dense input only")
+            self._value_error_if(batch_size != 1, f"{schedule} requires B=1, got B={batch_size}")
+            self._value_error_if(self.bias_desc is not None, f"{schedule} does not yet support bias/dbias")
+            self._value_error_if(
+                self.initial_state_desc is not None or self.d_final_state_desc is not None,
+                f"{schedule} does not yet support initial-state or final-state gradients",
+            )
+            if config.kernel_variant == _VEC2_CPASYNC_KERNEL:
+                self._value_error_if(
+                    compute_capability not in F32X2_COMPUTE_CAPABILITIES,
+                    f"v2-cpasync requires packed-f32x2 support, got compute capability {compute_capability}",
+                )
+                self._value_error_if(
+                    n_channels % _VEC2_CPASYNC_CHANNELS_PER_CTA != 0,
+                    f"v2-cpasync requires D divisible by {_VEC2_CPASYNC_CHANNELS_PER_CTA}, got D={n_channels}",
+                )
+                self._value_error_if(
+                    sequence_length < _VEC2_CPASYNC_MIN_TOKENS,
+                    f"v2-cpasync requires T>={_VEC2_CPASYNC_MIN_TOKENS}, got T={sequence_length}",
+                )
+                sm_count = torch.cuda.get_device_properties(self.x_desc.device).multi_processor_count
+                tiles_per_sequence, tokens_per_cta = _plan_vec2_cpasync(sequence_length, n_channels, sm_count)
+                last_tile_tokens = sequence_length - (tiles_per_sequence - 1) * tokens_per_cta
+                self._value_error_if(last_tile_tokens < 3, f"v2-cpasync planner produced an unsafe final tile of {last_tile_tokens} tokens")
+            else:
+                self._value_error_if(
+                    n_channels % _VEC4_CHANNELS_PER_CTA != 0,
+                    f"v4-stream requires D divisible by {_VEC4_CHANNELS_PER_CTA}, got D={n_channels}",
+                )
+                self._value_error_if(sequence_length < 16, f"v4-stream requires T>=16, got T={sequence_length}")
+                sm_count = torch.cuda.get_device_properties(self.x_desc.device).multi_processor_count
+                channel_ctas = n_channels // _VEC4_CHANNELS_PER_CTA
+                target_token_ctas = max(1, round(sm_count * _VEC4_TARGET_CTAS_PER_SM / channel_ctas))
+                target_token_ctas = min(sequence_length // 16, target_token_ctas)
+                tokens_per_cta = ((sequence_length + target_token_ctas - 1) // target_token_ctas + 7) // 8 * 8
+                # The streaming kernel primes three dz values per tile. Fold a
+                # one- or two-token remainder into the preceding tile instead
+                # of admitting an undersized final tile.
+                while sequence_length - ((sequence_length - 1) // tokens_per_cta) * tokens_per_cta < 3:
+                    tokens_per_cta += 1
+                tiles_per_sequence = (sequence_length + tokens_per_cta - 1) // tokens_per_cta
+            packed_tile_capacity = 0
+            num_dweight_partials = tiles_per_sequence
+        else:
+            tokens_per_cta = config.tokens_per_cta
+            tiles_per_sequence = (sequence_length - 1) // tokens_per_cta + 1
+            if self.is_packed:
+                # Tight shape-only upper bound for sum_i ceil(length_i / K) when
+                # every sequence is non-empty. It avoids a host read of offsets.
+                packed_tile_capacity = num_sequences + (total_tokens - num_sequences) // tokens_per_cta
+                num_dweight_partials = packed_tile_capacity
+            else:
+                packed_tile_capacity = 0
+                num_dweight_partials = batch_size * tiles_per_sequence
+
+        self.schedule = schedule
+        self.threads = config.threads
+        self.tokens_per_cta = tokens_per_cta
+        self.dweight_mode = config.dweight_mode
+        self.reduction_threads = config.reduction_threads
+        self.kernel_variant = kernel_variant
+        self.batch_size = batch_size
+        self.sequence_length = sequence_length
+        self.n_channels = n_channels
+        self.num_sequences = num_sequences
+        self.total_tokens = total_tokens
+        self.tiles_per_sequence = tiles_per_sequence
+        self.packed_tile_capacity = packed_tile_capacity
+        self.num_dweight_partials = num_dweight_partials
+        self.compute_capability = compute_capability
+        self.sm_count = sm_count
+        self._is_supported = True
+        return True
+
+    def compile(self) -> None:
+        self._ensure_support_checked()
+        if self._compiled_kernel is not None:
+            return
+        assert self.total_tokens is not None
+        assert self.n_channels is not None
+        assert self.batch_size is not None
+        assert self.sequence_length is not None
+        assert self.num_sequences is not None
+        assert self.threads is not None
+        assert self.tokens_per_cta is not None
+        assert self.reduction_threads is not None
+
+        fake_x = self._make_fake_cute_tensor(
+            dtype=torch.bfloat16,
+            shape=(self.total_tokens, self.n_channels),
+            stride=(self.n_channels, 1),
+            assumed_align=16,
+        )
+        fake_weight = self._make_fake_cute_tensor_from_desc(self.weight_desc, assumed_align=16)
+        fake_bias = self._make_fake_cute_tensor_from_desc(self.bias_desc, assumed_align=16)
+        fake_dy = self._make_fake_cute_tensor(
+            dtype=torch.bfloat16,
+            shape=(self.total_tokens, self.n_channels),
+            stride=(self.n_channels, 1),
+            assumed_align=16,
+        )
+        fake_dx = self._make_fake_cute_tensor(
+            dtype=torch.bfloat16,
+            shape=(self.total_tokens, self.n_channels),
+            stride=(self.n_channels, 1),
+            assumed_align=16,
+        )
+        fake_dw = self._make_fake_cute_tensor(
+            dtype=torch.float32,
+            shape=(self.n_channels, _WIDTH),
+            stride=(_WIDTH, 1),
+            assumed_align=16,
+        )
+        fake_db = None
+        if self.bias_desc is not None:
+            fake_db = self._make_fake_cute_tensor(
+                dtype=torch.float32,
+                shape=(self.n_channels,),
+                stride=(1,),
+                assumed_align=16,
+            )
+        fake_dw_partials = None
+        if self.dweight_mode == _DWEIGHT_PARTIAL:
+            fake_dw_partials = self._make_fake_cute_tensor(
+                dtype=torch.float32,
+                shape=(self.dweight_workspace_numel,),
+                stride=(1,),
+                assumed_align=16,
+            )
+        fake_cu_seqlens = self._make_fake_cute_tensor_from_desc(self.cu_seqlens_desc, assumed_align=4)
+        fake_initial_state = self._make_fake_cute_tensor_from_desc(self.initial_state_desc, assumed_align=16)
+        fake_d_final_state = self._make_fake_cute_tensor_from_desc(self.d_final_state_desc, assumed_align=16)
+        fake_d_initial_state = None
+        if self.initial_state_desc is not None:
+            fake_d_initial_state = self._make_fake_cute_tensor_from_desc(self.initial_state_desc, assumed_align=16)
+        fake_packed_tile_map = None
+        if self.is_packed:
+            fake_packed_tile_map = self._make_fake_cute_tensor(
+                dtype=torch.int32,
+                shape=(self.packed_tile_map_numel,),
+                stride=(1,),
+                assumed_align=16,
+            )
+        fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
+        if self.kernel_variant == _VEC2_CPASYNC_KERNEL:
+            from .backward_kernel_vec2_cpasync import CausalConv1dBulkBackwardVec2CpAsyncKernel
+
+            kernel = CausalConv1dBulkBackwardVec2CpAsyncKernel(
+                sequence_length=self.sequence_length,
+                n_channels=self.n_channels,
+                tokens_per_cta=self.tokens_per_cta,
+                n_token_tiles=self.num_dweight_partials,
+                reduction_threads=self.reduction_threads,
+            )
+        elif self.kernel_variant == _VEC4_STREAM_KERNEL:
+            from .backward_kernel_vec4 import CausalConv1dBulkBackwardVec4Kernel
+
+            kernel = CausalConv1dBulkBackwardVec4Kernel(
+                sequence_length=self.sequence_length,
+                n_channels=self.n_channels,
+                tokens_per_cta=self.tokens_per_cta,
+                n_token_tiles=self.num_dweight_partials,
+                reduction_threads=self.reduction_threads,
+            )
+        else:
+            from .backward_kernel import CausalConv1dBulkBackwardKernel
+
+            kernel = CausalConv1dBulkBackwardKernel(
+                batch_size=self.batch_size,
+                sequence_length=self.sequence_length,
+                num_sequences=self.num_sequences,
+                packed_tile_capacity=self.packed_tile_capacity,
+                threads=self.threads,
+                tokens_per_cta=self.tokens_per_cta,
+                use_dweight_partials=self.dweight_mode == _DWEIGHT_PARTIAL,
+                reduction_threads=self.reduction_threads,
+            )
+        with torch.cuda.device(self.x_desc.device):
+            self._compiled_kernel = cute.compile(
+                kernel,
+                fake_x,
+                fake_weight,
+                fake_bias,
+                fake_dy,
+                fake_dx,
+                fake_dw,
+                fake_db,
+                fake_dw_partials,
+                fake_cu_seqlens,
+                fake_initial_state,
+                fake_d_final_state,
+                fake_d_initial_state,
+                fake_packed_tile_map,
+                fake_stream,
+                options="--enable-tvm-ffi --generate-line-info",
+            )
+
+    @staticmethod
+    def _validate_runtime_tensor(tensor: torch.Tensor, desc: TensorDesc, name: str) -> None:
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(f"{name} must be a torch.Tensor, got {type(tensor).__name__}")
+        if tuple(tensor.shape) != desc.shape:
+            raise ValueError(f"{name} shape mismatch: expected {desc.shape}, got {tuple(tensor.shape)}")
+        if tuple(tensor.stride()) != desc.stride:
+            raise ValueError(f"{name} stride mismatch: expected {desc.stride}, got {tuple(tensor.stride())}")
+        if tensor.dtype != desc.dtype:
+            raise TypeError(f"{name} dtype mismatch: expected {desc.dtype}, got {tensor.dtype}")
+        if tensor.device != desc.device:
+            raise ValueError(f"{name} device mismatch: expected {desc.device}, got {tensor.device}")
+
+    def execute(
+        self,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        dy: torch.Tensor,
+        dx: torch.Tensor,
+        dw_accum: torch.Tensor,
+        *,
+        cu_seqlens: torch.Tensor | None = None,
+        packed_tile_map: torch.Tensor | None = None,
+        dweight_workspace: torch.Tensor | None = None,
+        current_stream: cuda.CUstream | None = None,
+        bias: torch.Tensor | None = None,
+        db_accum: torch.Tensor | None = None,
+        initial_state: torch.Tensor | None = None,
+        d_final_state: torch.Tensor | None = None,
+        d_initial_state: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self._compiled_kernel is None:
+            raise RuntimeError("compile() must be called before execute()")
+        self._validate_runtime_tensor(x, self.x_desc, "X")
+        self._validate_runtime_tensor(weight, self.weight_desc, "Weight")
+        self._validate_runtime_tensor(dy, self.dy_desc, "dY")
+        self._validate_runtime_tensor(dx, self.x_desc, "dX")
+        if (bias is None) != (self.bias_desc is None):
+            raise ValueError("Bias presence must match the compiled signature")
+        if bias is not None:
+            assert self.bias_desc is not None
+            self._validate_runtime_tensor(bias, self.bias_desc, "Bias")
+        if (db_accum is None) != (self.bias_desc is None):
+            raise ValueError("dBias accumulator presence must match the compiled signature")
+        assert self.n_channels is not None
+        expected_dw = (self.n_channels, _WIDTH)
+        if not isinstance(dw_accum, torch.Tensor):
+            raise TypeError("dW accumulator must be a torch.Tensor, " f"got {type(dw_accum).__name__}")
+        if tuple(dw_accum.shape) != expected_dw or tuple(dw_accum.stride()) != (_WIDTH, 1) or dw_accum.dtype != torch.float32 or dw_accum.device != x.device:
+            raise ValueError(f"dW accumulator must be contiguous FP32 {expected_dw} on {x.device}")
+        if db_accum is not None:
+            if not isinstance(db_accum, torch.Tensor):
+                raise TypeError("dBias accumulator must be a torch.Tensor, " f"got {type(db_accum).__name__}")
+            if (
+                tuple(db_accum.shape) != (self.n_channels,)
+                or tuple(db_accum.stride()) != (1,)
+                or db_accum.dtype != torch.float32
+                or db_accum.device != x.device
+            ):
+                raise ValueError(f"dBias accumulator must be contiguous FP32 ({self.n_channels},) on {x.device}")
+
+        for name, tensor, desc in (
+            ("Initial state", initial_state, self.initial_state_desc),
+            ("dFinal state", d_final_state, self.d_final_state_desc),
+        ):
+            if (tensor is None) != (desc is None):
+                raise ValueError(f"{name} presence must match the compiled signature")
+            if tensor is not None:
+                assert desc is not None
+                self._validate_runtime_tensor(tensor, desc, name)
+        if (d_initial_state is None) != (self.initial_state_desc is None):
+            raise ValueError("dInitial state presence must match the compiled initial-state signature")
+        if d_initial_state is not None:
+            assert self.initial_state_desc is not None
+            self._validate_runtime_tensor(d_initial_state, self.initial_state_desc, "dInitial state")
+
+        if (cu_seqlens is None) != (self.cu_seqlens_desc is None):
+            raise ValueError("cu_seqlens presence must match the compiled signature")
+        if cu_seqlens is not None:
+            assert self.cu_seqlens_desc is not None
+            self._validate_runtime_tensor(cu_seqlens, self.cu_seqlens_desc, "cu_seqlens")
+
+        if self.is_packed:
+            if packed_tile_map is None:
+                raise ValueError(f"packed backward requires {self.packed_tile_map_bytes} bytes " "of int32 tile-map workspace")
+            if (
+                packed_tile_map.dtype != torch.int32
+                or not packed_tile_map.is_contiguous()
+                or packed_tile_map.numel() != self.packed_tile_map_numel
+                or packed_tile_map.device != x.device
+            ):
+                raise ValueError("packed tile map must be contiguous int32 " f"[{self.packed_tile_map_numel}] on {x.device}")
+        elif packed_tile_map is not None:
+            raise ValueError("dense backward does not consume a packed tile map")
+
+        if self.dweight_mode == _DWEIGHT_PARTIAL:
+            if dweight_workspace is None:
+                raise ValueError(f"schedule {self.schedule!r} requires " f"{self.dweight_workspace_bytes} bytes of FP32 dweight workspace")
+            if (
+                dweight_workspace.dtype != torch.float32
+                or not dweight_workspace.is_contiguous()
+                or dweight_workspace.numel() != self.dweight_workspace_numel
+                or dweight_workspace.device != x.device
+            ):
+                raise ValueError("dweight workspace must be contiguous FP32 " f"[{self.dweight_workspace_numel}] on {x.device}")
+        elif dweight_workspace is not None:
+            raise ValueError(f"schedule {self.schedule!r} does not consume dweight workspace")
+
+        named_tensors = (
+            ("X", x, False),
+            ("Weight", weight, False),
+            ("Bias", bias, False),
+            ("dY", dy, False),
+            ("Initial state", initial_state, False),
+            ("dFinal state", d_final_state, False),
+            ("cu_seqlens", cu_seqlens, False),
+            ("dX", dx, True),
+            ("dW accumulator", dw_accum, True),
+            ("dBias accumulator", db_accum, True),
+            ("dInitial state", d_initial_state, True),
+            ("Packed tile map", packed_tile_map, True),
+            ("dW workspace", dweight_workspace, True),
+        )
+        for index, (left_name, left, left_writable) in enumerate(named_tensors):
+            if left is None:
+                continue
+            for right_name, right, right_writable in named_tensors[index + 1 :]:
+                if right is None or not (left_writable or right_writable):
+                    continue
+                if _tensors_overlap(left, right):
+                    raise ValueError(f"{left_name} and {right_name} must not overlap")
+
+        for name, tensor, alignment in (
+            ("X", x, 16),
+            ("Weight", weight, 16),
+            ("Bias", bias, 16),
+            ("dY", dy, 16),
+            ("Initial state", initial_state, 16),
+            ("dFinal state", d_final_state, 16),
+            ("dX", dx, 16),
+            ("dW accumulator", dw_accum, 16),
+            ("dBias accumulator", db_accum, 16),
+            ("dInitial state", d_initial_state, 16),
+            ("cu_seqlens", cu_seqlens, 4),
+            ("Packed tile map", packed_tile_map, 16),
+            ("dW workspace", dweight_workspace, 16),
+        ):
+            if tensor is not None:
+                _require_storage_alignment(tensor, alignment, name)
+
+        if current_stream is None:
+            torch_stream = torch.cuda.current_stream(x.device)
+            launch_stream = cuda.CUstream(torch_stream.cuda_stream)
+        else:
+            launch_stream = current_stream
+            torch_stream = _as_torch_stream(current_stream, x.device)
+        if self.dweight_mode == _DWEIGHT_ATOMIC or db_accum is not None:
+            with torch.cuda.stream(torch_stream):
+                if self.dweight_mode == _DWEIGHT_ATOMIC:
+                    dw_accum.zero_()
+                if db_accum is not None:
+                    db_accum.zero_()
+        self._compiled_kernel(
+            x.view(-1, self.n_channels),
+            weight,
+            bias,
+            dy.view(-1, self.n_channels),
+            dx.view(-1, self.n_channels),
+            dw_accum,
+            db_accum,
+            dweight_workspace,
+            cu_seqlens,
+            initial_state,
+            d_final_state,
+            d_initial_state,
+            packed_tile_map,
+            launch_stream,
+        )
+        _record_streams(
+            (
+                x,
+                weight,
+                bias,
+                dy,
+                initial_state,
+                d_final_state,
+                dx,
+                dw_accum,
+                db_accum,
+                d_initial_state,
+                cu_seqlens,
+                packed_tile_map,
+                dweight_workspace,
+            ),
+            torch_stream,
+        )
+        return dx, dw_accum
+
+
+def compile_causal_conv1d_bulk_bwd_prototype(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    dy: torch.Tensor,
+    cu_seqlens: torch.Tensor | None = None,
+    *,
+    schedule: str = _AUTO_SCHEDULE,
+    bias: torch.Tensor | None = None,
+    initial_state: torch.Tensor | None = None,
+    d_final_state: torch.Tensor | None = None,
+) -> CausalConv1dBulkBwdPrototype:
+    """Construct, support-check, and compile an exact-shape prototype."""
+
+    api = CausalConv1dBulkBwdPrototype(
+        x,
+        weight,
+        dy,
+        sample_cu_seqlens=cu_seqlens,
+        sample_initial_state=initial_state,
+        sample_d_final_state=d_final_state,
+        schedule=schedule,
+        sample_bias=bias,
+    )
+    api.check_support()
+    api.compile()
+    return api
+
+
+__all__ = [
+    "CausalConv1dBulkBwdPrototype",
+    "compile_causal_conv1d_bulk_bwd_prototype",
+    "select_bulk_bwd_schedule",
+]

--- a/python/cudnn/causal_conv1d_bulk_sm100/backward.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/backward.py
@@ -15,10 +15,11 @@ Compilation is exact-shape. Packed metadata values stay on device: a small
 pre-kernel validates the prefix sums and builds a bounded per-sequence tile
 map, after which the dense backward math is reused without cross-sequence
 reads. The default schedules accumulate dweight with FP32 atomics; partial
-schedules use caller-owned FP32 partials and a second reduction. The atomic
-schedules do not produce bitwise-reproducible dweight, even when PyTorch
-deterministic algorithms are enabled; request ``t64-partial`` when reproducible
-dweight is required. ``v4-stream`` is a dense, bias-free FE-native schedule
+schedules use caller-owned FP32 partials and a second reduction. With
+``deterministic=True`` (the semantic op passes torch's deterministic-algorithms
+mode) ``auto`` selects a partial schedule, and any remaining atomic
+accumulation (an explicit atomic schedule, or dbias) raises, or warns under
+torch's warn-only mode. ``v4-stream`` is a dense, bias-free FE-native schedule
 derived from the operator math: each thread streams four adjacent channels,
 and a single occupancy formula chooses its token tile instead of maintaining a
 config zoo.
@@ -31,6 +32,7 @@ schedules.
 
 from __future__ import annotations
 
+import warnings
 from typing import NamedTuple
 
 import torch
@@ -94,12 +96,21 @@ def select_bulk_bwd_schedule(total_tokens: int) -> str:
     """Choose the measured atomic schedule for the dense prototype.
 
     Both returned schedules use FP32 atomics, so dweight is not bitwise
-    reproducible across launches, including when PyTorch deterministic
-    algorithms are enabled. Request ``t64-partial`` explicitly when
-    reproducible dweight is required.
+    reproducible across launches. ``check_support`` substitutes
+    ``t64-partial`` when the caller requests deterministic execution.
     """
 
     return "t128" if total_tokens >= 16384 else "t64"
+
+
+def _alert_nondeterministic(reason: str) -> None:
+    """Mirror torch deterministic-mode semantics: strict raises, warn-only warns."""
+
+    message = f"causal_conv1d backward is not deterministic: {reason}; " "torch.use_deterministic_algorithms(True) is set"
+    if torch.is_deterministic_algorithms_warn_only_enabled():
+        warnings.warn(message, RuntimeWarning, stacklevel=2)
+    else:
+        raise RuntimeError(message)
 
 
 def _align_vec2_cpasync_tile(tokens_per_cta: int) -> int:
@@ -144,9 +155,13 @@ class CausalConv1dBulkBwdPrototype(APIBase):
         sample_bias: torch.Tensor | None = None,
         sample_initial_state: torch.Tensor | None = None,
         sample_d_final_state: torch.Tensor | None = None,
+        deterministic: bool = False,
     ) -> None:
         super().__init__()
         self._warn_experimental_api()
+        if not isinstance(deterministic, bool):
+            raise TypeError(f"deterministic must be bool, got {type(deterministic).__name__}")
+        self.deterministic = deterministic
         for name, sample in (
             ("sample_x", sample_x),
             ("sample_weight", sample_weight),
@@ -436,9 +451,16 @@ class CausalConv1dBulkBwdPrototype(APIBase):
         )
         if auto_streaming:
             schedule = "v2-cpasync" if compute_capability in F32X2_COMPUTE_CAPABILITIES else "v4-stream"
+        elif self.requested_schedule == _AUTO_SCHEDULE:
+            schedule = "t64-partial" if self.deterministic else select_bulk_bwd_schedule(schedule_extent)
         else:
-            schedule = select_bulk_bwd_schedule(schedule_extent) if self.requested_schedule == _AUTO_SCHEDULE else self.requested_schedule
+            schedule = self.requested_schedule
         config = _SCHEDULES[schedule]
+        if self.deterministic:
+            if config.dweight_mode == _DWEIGHT_ATOMIC:
+                _alert_nondeterministic(f"schedule {schedule!r} accumulates dweight with FP32 atomics")
+            if self.bias_desc is not None:
+                _alert_nondeterministic("dbias accumulates with FP32 atomics")
         kernel_variant = config.kernel_variant
         sm_count = None
         if config.kernel_variant in (_VEC4_STREAM_KERNEL, _VEC2_CPASYNC_KERNEL):
@@ -848,6 +870,7 @@ def compile_causal_conv1d_bulk_bwd_prototype(
     bias: torch.Tensor | None = None,
     initial_state: torch.Tensor | None = None,
     d_final_state: torch.Tensor | None = None,
+    deterministic: bool = False,
 ) -> CausalConv1dBulkBwdPrototype:
     """Construct, support-check, and compile an exact-shape prototype."""
 
@@ -860,6 +883,7 @@ def compile_causal_conv1d_bulk_bwd_prototype(
         sample_d_final_state=d_final_state,
         schedule=schedule,
         sample_bias=bias,
+        deterministic=deterministic,
     )
     api.check_support()
     api.compile()

--- a/python/cudnn/causal_conv1d_bulk_sm100/backward_kernel.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/backward_kernel.py
@@ -1,0 +1,531 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CUTLASS DSL prototype for dense and packed width-four conv backward.
+
+This kernel is derived directly from the convolution and SiLU derivatives.  It
+does not contain source from FLA, causal-conv1d, or another external kernel.
+
+The prototype covers contiguous BF16 ``[B, T, D]`` and packed ``[1, total_T,
+D]`` with device int32 ``cu_seqlens``. It supports optional BF16 channel bias,
+full-width initial state, and upstream final-state gradients. A thread owns one
+channel over a token tile. It streams the input once, keeps a four-element
+``dz`` window in registers, and writes ``dx`` without atomics. Packed CTAs are
+built on device and never cross sequence boundaries. Weight gradients have two
+compile-time candidates: direct FP32 atomics, or one unique FP32 partial per
+token-tile CTA followed by a second reduction kernel. Optional dbias reuses the
+per-thread dz stream and emits one FP32 atomic per tile/channel in either
+dweight mode. A separate one-thread-per-sequence/channel state kernel
+recomputes at most the first three ``dz`` values, writes ``d_initial_state``,
+and projects only the ``d_final_state`` lanes backed by initial state.
+Token-backed final-state gradients join ``dx`` in the main kernel before its
+single BF16 rounding. Token tile and reduction choices are a small static
+schedule, not an autotuner.
+
+Packed metadata validation is deliberately device-only. A prefix sum that
+does not start at zero, does not end at ``total_T``, is not strictly
+increasing, or describes an empty sequence executes a device ``trap``. This is
+an asynchronous, sticky CUDA failure rather than a recoverable Python
+exception; callers must discard the affected CUDA context before doing more
+work.
+"""
+
+from __future__ import annotations
+
+import cuda.bindings.driver as cuda
+import cutlass
+from cutlass import cute
+from cutlass.cute.arch.nvvm_wrappers import inline_ptx
+
+from cudnn.frost.tile_dsl.pointwise import sigmoid
+from cudnn.sdpa.utils import atomic_add_fp32
+
+WIDTH = 4
+PACKED_TILE_DESCRIPTOR_WIDTH = 4
+
+
+@cute.kernel
+def _build_packed_tile_map_kernel(
+    cu_seqlens: cute.Tensor,
+    tile_map: cute.Tensor,
+    num_sequences: cutlass.Int32,
+    total_tokens: cutlass.Int64,
+    tokens_per_cta: cutlass.Int32,
+    tile_capacity: cutlass.Int32,
+) -> None:
+    """Validate packed boundaries and serialize exact per-sequence tiles.
+
+    A descriptor is ``[sequence, start, end, tile_start]``. The capacity is the
+    tight shape-only upper bound ``N + floor((total-N)/BT)``; unused entries
+    are filled with empty tiles at ``total_tokens`` so the following launch
+    needs no host read or dynamic grid size.
+    """
+
+    if cute.arch.block_idx()[0] == cutlass.Int32(0) and cute.arch.thread_idx()[0] == cutlass.Int32(0):
+        inline_ptx(
+            "trap;",
+            predicate=cutlass.Int32(cu_seqlens[0]) != cutlass.Int32(0),
+        )
+        inline_ptx(
+            "trap;",
+            predicate=cutlass.Int32(cu_seqlens[num_sequences]) != total_tokens,
+        )
+
+        descriptor = cutlass.Int32(0)
+        sequence = cutlass.Int32(0)
+        while sequence < num_sequences:
+            sequence_start = cutlass.Int64(cu_seqlens[sequence])
+            sequence_end = cutlass.Int64(cu_seqlens[sequence + cutlass.Int32(1)])
+            inline_ptx("trap;", predicate=sequence_start < cutlass.Int64(0))
+            inline_ptx("trap;", predicate=sequence_end <= sequence_start)
+            inline_ptx("trap;", predicate=sequence_end > total_tokens)
+
+            tile_start = sequence_start
+            while tile_start < sequence_end:
+                inline_ptx("trap;", predicate=descriptor >= tile_capacity)
+                base = cutlass.Int64(descriptor) * cutlass.Int64(PACKED_TILE_DESCRIPTOR_WIDTH)
+                tile_map[base] = sequence
+                tile_map[base + cutlass.Int64(1)] = cutlass.Int32(sequence_start)
+                tile_map[base + cutlass.Int64(2)] = cutlass.Int32(sequence_end)
+                tile_map[base + cutlass.Int64(3)] = cutlass.Int32(tile_start)
+                descriptor += cutlass.Int32(1)
+                tile_start += cutlass.Int64(tokens_per_cta)
+            sequence += cutlass.Int32(1)
+
+        while descriptor < tile_capacity:
+            base = cutlass.Int64(descriptor) * cutlass.Int64(PACKED_TILE_DESCRIPTOR_WIDTH)
+            tile_map[base] = cutlass.Int32(0)
+            tile_map[base + cutlass.Int64(1)] = cutlass.Int32(total_tokens)
+            tile_map[base + cutlass.Int64(2)] = cutlass.Int32(total_tokens)
+            tile_map[base + cutlass.Int64(3)] = cutlass.Int32(total_tokens)
+            descriptor += cutlass.Int32(1)
+
+
+@cute.kernel
+def _causal_conv1d_bulk_bwd_kernel(
+    x: cute.Tensor,
+    weight: cute.Tensor,
+    bias: cute.Tensor | None,
+    dy: cute.Tensor,
+    dx: cute.Tensor,
+    dw_accum: cute.Tensor,
+    db_accum: cute.Tensor | None,
+    initial_state: cute.Tensor | None,
+    d_final_state: cute.Tensor | None,
+    packed_tile_map: cute.Tensor | None,
+    sequence_length: cutlass.Int32,
+    tokens_per_cta: cutlass.Int32,
+    n_channels: cutlass.Int32,
+    write_dweight_partials: cutlass.Constexpr[bool],
+) -> None:
+    """Fuse SiLU recompute, ``dx`` stencil, and partial ``dw`` reduction."""
+
+    tile_linear = cutlass.Int32(cute.arch.block_idx()[0])
+    channel_tile = cutlass.Int32(cute.arch.block_idx()[1])
+    tidx = cutlass.Int32(cute.arch.thread_idx()[0])
+    threads = cutlass.Int32(cute.arch.block_dim()[0])
+    channel = channel_tile * threads + tidx
+
+    sequence_start = cutlass.Int64(0)
+    sequence_end = cutlass.Int64(0)
+    tile_start = cutlass.Int64(0)
+    sequence = cutlass.Int32(0)
+    if cutlass.const_expr(packed_tile_map is None):
+        tiles_per_sequence = (sequence_length - cutlass.Int32(1)) // tokens_per_cta + cutlass.Int32(1)
+        sequence = tile_linear // tiles_per_sequence
+        tile_in_sequence = tile_linear - sequence * tiles_per_sequence
+        sequence_start = cutlass.Int64(sequence) * cutlass.Int64(sequence_length)
+        sequence_end = sequence_start + cutlass.Int64(sequence_length)
+        tile_start = sequence_start + cutlass.Int64(tile_in_sequence) * cutlass.Int64(tokens_per_cta)
+    else:
+        descriptor = cutlass.Int64(tile_linear) * cutlass.Int64(PACKED_TILE_DESCRIPTOR_WIDTH)
+        sequence = cutlass.Int32(packed_tile_map[descriptor])
+        sequence_start = cutlass.Int64(packed_tile_map[descriptor + cutlass.Int64(1)])
+        sequence_end = cutlass.Int64(packed_tile_map[descriptor + cutlass.Int64(2)])
+        tile_start = cutlass.Int64(packed_tile_map[descriptor + cutlass.Int64(3)])
+    tile_end = tile_start + cutlass.Int64(tokens_per_cta)
+    if tile_end > sequence_end:  # noqa: PLR1730 -- DSL values cannot use Python min().
+        tile_end = sequence_end
+
+    w0 = cutlass.Float32(0.0)
+    w1 = cutlass.Float32(0.0)
+    w2 = cutlass.Float32(0.0)
+    w3 = cutlass.Float32(0.0)
+    bias_value = cutlass.Float32(0.0)
+    if channel < n_channels:
+        w0 = weight[channel, 0].to(cutlass.Float32)
+        w1 = weight[channel, 1].to(cutlass.Float32)
+        w2 = weight[channel, 2].to(cutlass.Float32)
+        w3 = weight[channel, 3].to(cutlass.Float32)
+        if cutlass.const_expr(bias is not None):
+            bias_value = bias[channel].to(cutlass.Float32)
+
+    # Input history immediately before this tile. Reads never cross a dense
+    # batch-row boundary. Near a sequence start, the missing prefix comes from
+    # full-width initial-state lanes 1..3; without initial state it is zero.
+    h0 = cutlass.Float32(0.0)
+    h1 = cutlass.Float32(0.0)
+    h2 = cutlass.Float32(0.0)
+    if channel < n_channels:
+        local_tile_start = tile_start - sequence_start
+        if tile_start - cutlass.Int64(3) >= sequence_start:
+            h0 = x[tile_start - cutlass.Int64(3), channel].to(cutlass.Float32)
+        elif cutlass.const_expr(initial_state is not None):
+            h0 = initial_state[sequence, channel, cutlass.Int32(local_tile_start) + cutlass.Int32(1)].to(cutlass.Float32)
+        if tile_start - cutlass.Int64(2) >= sequence_start:
+            h1 = x[tile_start - cutlass.Int64(2), channel].to(cutlass.Float32)
+        elif cutlass.const_expr(initial_state is not None):
+            h1 = initial_state[sequence, channel, cutlass.Int32(local_tile_start) + cutlass.Int32(2)].to(cutlass.Float32)
+        if tile_start - cutlass.Int64(1) >= sequence_start:
+            h2 = x[tile_start - cutlass.Int64(1), channel].to(cutlass.Float32)
+        elif cutlass.const_expr(initial_state is not None):
+            h2 = initial_state[sequence, channel, cutlass.Int32(3)].to(cutlass.Float32)
+
+    # The queue contains dz[p-3:p].  Three zero priming iterations naturally
+    # delay the first dx write until all four contributing outputs are known.
+    dz0 = cutlass.Float32(0.0)
+    dz1 = cutlass.Float32(0.0)
+    dz2 = cutlass.Float32(0.0)
+    dw0 = cutlass.Float32(0.0)
+    dw1 = cutlass.Float32(0.0)
+    dw2 = cutlass.Float32(0.0)
+    dw3 = cutlass.Float32(0.0)
+    db = cutlass.Float32(0.0)
+
+    scan_start = tile_start
+    scan_end = tile_end + cutlass.Int64(3)
+    p = scan_start
+    while p < scan_end:
+        current = cutlass.Float32(0.0)
+        dz3 = cutlass.Float32(0.0)
+        valid_output = p < sequence_end
+        if channel < n_channels:
+            if valid_output:
+                current = x[p, channel].to(cutlass.Float32)
+                z = h0 * w0
+                z = z + h1 * w1
+                z = z + h2 * w2
+                z = z + current * w3
+                if cutlass.const_expr(bias is not None):
+                    z = z + bias_value
+                gate = sigmoid(z)
+                silu_grad = gate * (cutlass.Float32(1.0) + z * (cutlass.Float32(1.0) - gate))
+                dz3 = dy[p, channel].to(cutlass.Float32) * silu_grad
+
+            if p >= tile_start + cutlass.Int64(3):
+                q = p - cutlass.Int64(3)
+                if q < tile_end:
+                    dx_value = dz0 * w3 + dz1 * w2 + dz2 * w1 + dz3 * w0
+                    if cutlass.const_expr(d_final_state is not None):
+                        sequence_length_local = sequence_end - sequence_start
+                        final_lane = q - sequence_start + cutlass.Int64(WIDTH) - sequence_length_local
+                        if final_lane >= cutlass.Int64(0):
+                            if final_lane < cutlass.Int64(WIDTH):
+                                dx_value = dx_value + d_final_state[sequence, channel, cutlass.Int32(final_lane)].to(cutlass.Float32)
+                    dx[q, channel] = dx_value.to(cutlass.BFloat16)
+
+            # Each token belongs to exactly one CTA's weight-gradient range.
+            if p < tile_end:
+                dw0 = dw0 + dz3 * h0
+                dw1 = dw1 + dz3 * h1
+                dw2 = dw2 + dz3 * h2
+                dw3 = dw3 + dz3 * current
+                if cutlass.const_expr(db_accum is not None):
+                    db = db + dz3
+
+        h0 = h1
+        h1 = h2
+        h2 = current
+        dz0 = dz1
+        dz1 = dz2
+        dz2 = dz3
+        p += cutlass.Int64(1)
+
+    if channel < n_channels:
+        if cutlass.const_expr(db_accum is not None):
+            atomic_add_fp32(db, db_accum.iterator + channel)
+        if cutlass.const_expr(write_dweight_partials):
+            # tile_linear uniquely owns this [channel, tap] vector.  The
+            # follow-up kernel reduces the leading partial dimension.
+            partial_base = (cutlass.Int64(tile_linear) * cutlass.Int64(n_channels) + cutlass.Int64(channel)) * cutlass.Int64(WIDTH)
+            partial_address = dw_accum.iterator.toint() + partial_base * cutlass.Int64(4)
+            inline_ptx(
+                "st.global.v4.f32 [$0], {$1, $2, $3, $4};",
+                read_only_args=[partial_address, dw0, dw1, dw2, dw3],
+            )
+        else:
+            base = channel * cutlass.Int32(WIDTH)
+            atomic_add_fp32(dw0, dw_accum.iterator + base)
+            atomic_add_fp32(dw1, dw_accum.iterator + base + cutlass.Int32(1))
+            atomic_add_fp32(dw2, dw_accum.iterator + base + cutlass.Int32(2))
+            atomic_add_fp32(dw3, dw_accum.iterator + base + cutlass.Int32(3))
+
+
+@cute.kernel
+def _causal_conv1d_bulk_state_bwd_kernel(
+    x: cute.Tensor,
+    weight: cute.Tensor,
+    bias: cute.Tensor | None,
+    dy: cute.Tensor,
+    initial_state: cute.Tensor | None,
+    d_final_state: cute.Tensor | None,
+    d_initial_state: cute.Tensor | None,
+    cu_seqlens: cute.Tensor | None,
+    sequence_length: cutlass.Int32,
+    num_sequences: cutlass.Int32,
+    n_channels: cutlass.Int32,
+) -> None:
+    """Project the full-width state edge without token-tile atomics.
+
+    One thread owns one ``[sequence, channel]`` pair. It recomputes only the
+    first three output derivatives that can depend on initial state, then maps
+    the upstream final-state lanes backed by initial state to their unique
+    sources. Positive sequence lengths make initial-state lane zero
+    unobservable, so it is always written as zero.
+    """
+
+    sequence = cutlass.Int32(cute.arch.block_idx()[0])
+    channel = cutlass.Int32(cute.arch.block_idx()[1]) * cutlass.Int32(cute.arch.block_dim()[0]) + cutlass.Int32(cute.arch.thread_idx()[0])
+    if sequence < num_sequences and channel < n_channels:
+        sequence_start = cutlass.Int64(sequence) * cutlass.Int64(sequence_length)
+        sequence_end = sequence_start + cutlass.Int64(sequence_length)
+        if cutlass.const_expr(cu_seqlens is not None):
+            sequence_start = cutlass.Int64(cu_seqlens[sequence])
+            sequence_end = cutlass.Int64(cu_seqlens[sequence + cutlass.Int32(1)])
+        length = sequence_end - sequence_start
+
+        d_initial_1 = cutlass.Float32(0.0)
+        d_initial_2 = cutlass.Float32(0.0)
+        d_initial_3 = cutlass.Float32(0.0)
+
+        if cutlass.const_expr(d_initial_state is not None):
+            w0 = weight[channel, 0].to(cutlass.Float32)
+            w1 = weight[channel, 1].to(cutlass.Float32)
+            w2 = weight[channel, 2].to(cutlass.Float32)
+            w3 = weight[channel, 3].to(cutlass.Float32)
+            bias_value = cutlass.Float32(0.0)
+            if cutlass.const_expr(bias is not None):
+                bias_value = bias[channel].to(cutlass.Float32)
+
+            history_0 = initial_state[sequence, channel, cutlass.Int32(1)].to(cutlass.Float32)
+            history_1 = initial_state[sequence, channel, cutlass.Int32(2)].to(cutlass.Float32)
+            history_2 = initial_state[sequence, channel, cutlass.Int32(3)].to(cutlass.Float32)
+            state_grad_end = sequence_start + cutlass.Int64(3)
+            if state_grad_end > sequence_end:  # noqa: PLR1730 -- DSL values cannot use Python min().
+                state_grad_end = sequence_end
+
+            token = sequence_start
+            while token < state_grad_end:
+                current = x[token, channel].to(cutlass.Float32)
+                z = history_0 * w0
+                z = z + history_1 * w1
+                z = z + history_2 * w2
+                z = z + current * w3
+                if cutlass.const_expr(bias is not None):
+                    z = z + bias_value
+                gate = sigmoid(z)
+                silu_grad = gate * (cutlass.Float32(1.0) + z * (cutlass.Float32(1.0) - gate))
+                dz = dy[token, channel].to(cutlass.Float32) * silu_grad
+                relative = token - sequence_start
+                if relative == cutlass.Int64(0):
+                    d_initial_1 = d_initial_1 + dz * w0
+                    d_initial_2 = d_initial_2 + dz * w1
+                    d_initial_3 = d_initial_3 + dz * w2
+                elif relative == cutlass.Int64(1):
+                    d_initial_2 = d_initial_2 + dz * w0
+                    d_initial_3 = d_initial_3 + dz * w1
+                else:
+                    d_initial_3 = d_initial_3 + dz * w0
+                history_0 = history_1
+                history_1 = history_2
+                history_2 = current
+                token += cutlass.Int64(1)
+
+        if cutlass.const_expr(d_final_state is not None):
+            final_lane = cutlass.Int32(0)
+            while final_lane < cutlass.Int32(WIDTH):
+                grad = d_final_state[sequence, channel, final_lane].to(cutlass.Float32)
+                source = length + cutlass.Int64(final_lane)
+                if source < cutlass.Int64(WIDTH):
+                    if cutlass.const_expr(d_initial_state is not None):
+                        if source == cutlass.Int64(1):
+                            d_initial_1 = d_initial_1 + grad
+                        elif source == cutlass.Int64(2):
+                            d_initial_2 = d_initial_2 + grad
+                        else:
+                            d_initial_3 = d_initial_3 + grad
+                final_lane += cutlass.Int32(1)
+
+        if cutlass.const_expr(d_initial_state is not None):
+            d_initial_state[sequence, channel, cutlass.Int32(0)] = cutlass.Float32(0.0).to(cutlass.BFloat16)
+            d_initial_state[sequence, channel, cutlass.Int32(1)] = d_initial_1.to(cutlass.BFloat16)
+            d_initial_state[sequence, channel, cutlass.Int32(2)] = d_initial_2.to(cutlass.BFloat16)
+            d_initial_state[sequence, channel, cutlass.Int32(3)] = d_initial_3.to(cutlass.BFloat16)
+
+
+@cute.kernel
+def _reduce_dweight_partials_kernel(
+    dw_partials: cute.Tensor,
+    dw_accum: cute.Tensor,
+    n_partials: cutlass.Int32,
+    n_channels: cutlass.Int32,
+) -> None:
+    """Reduce one FP32 ``[partial, channel, 4]`` vector per thread."""
+
+    tidx = cutlass.Int32(cute.arch.thread_idx()[0])
+    channel = cutlass.Int32(cute.arch.block_idx()[0]) * cutlass.Int32(cute.arch.block_dim()[0]) + tidx
+    if channel < n_channels:
+        dw0 = cutlass.Float32(0.0)
+        dw1 = cutlass.Float32(0.0)
+        dw2 = cutlass.Float32(0.0)
+        dw3 = cutlass.Float32(0.0)
+        partial = cutlass.Int32(0)
+        while partial < n_partials:
+            partial_base = (cutlass.Int64(partial) * cutlass.Int64(n_channels) + cutlass.Int64(channel)) * cutlass.Int64(WIDTH)
+            partial_address = dw_partials.iterator.toint() + partial_base * cutlass.Int64(4)
+            value0, value1, value2, value3 = inline_ptx(
+                "ld.global.v4.f32 {$0, $1, $2, $3}, [$4];",
+                write_only_types=[cutlass.Float32] * WIDTH,
+                read_only_args=[partial_address],
+            )
+            dw0 = dw0 + value0
+            dw1 = dw1 + value1
+            dw2 = dw2 + value2
+            dw3 = dw3 + value3
+            partial += cutlass.Int32(1)
+
+        output_address = dw_accum.iterator.toint() + cutlass.Int64(channel) * cutlass.Int64(WIDTH * 4)
+        inline_ptx(
+            "st.global.v4.f32 [$0], {$1, $2, $3, $4};",
+            read_only_args=[output_address, dw0, dw1, dw2, dw3],
+        )
+
+
+class CausalConv1dBulkBackwardKernel:
+    """Launch dense or per-sequence packed tiles with one dweight policy."""
+
+    def __init__(
+        self,
+        *,
+        batch_size: int,
+        sequence_length: int,
+        num_sequences: int,
+        packed_tile_capacity: int,
+        threads: int = 256,
+        tokens_per_cta: int = 64,
+        use_dweight_partials: bool = False,
+        reduction_threads: int = 256,
+    ):
+        self.batch_size = batch_size
+        self.sequence_length = sequence_length
+        self.num_sequences = num_sequences
+        self.packed_tile_capacity = packed_tile_capacity
+        self.threads = threads
+        self.tokens_per_cta = tokens_per_cta
+        self.use_dweight_partials = use_dweight_partials
+        self.reduction_threads = reduction_threads
+
+    @cute.jit
+    def __call__(
+        self,
+        x: cute.Tensor,
+        weight: cute.Tensor,
+        bias: cute.Tensor | None,
+        dy: cute.Tensor,
+        dx: cute.Tensor,
+        dw_accum: cute.Tensor,
+        db_accum: cute.Tensor | None,
+        dw_partials: cute.Tensor | None,
+        cu_seqlens: cute.Tensor | None,
+        initial_state: cute.Tensor | None,
+        d_final_state: cute.Tensor | None,
+        d_initial_state: cute.Tensor | None,
+        packed_tile_map: cute.Tensor | None,
+        stream: cuda.CUstream,
+    ) -> None:
+        tiles_per_sequence = (self.sequence_length - 1) // self.tokens_per_cta + 1
+        n_partials = self.batch_size * tiles_per_sequence
+        if cutlass.const_expr(cu_seqlens is not None):
+            _build_packed_tile_map_kernel(
+                cu_seqlens,
+                packed_tile_map,
+                cutlass.Int32(self.num_sequences),
+                cutlass.Int64(self.batch_size * self.sequence_length),
+                cutlass.Int32(self.tokens_per_cta),
+                cutlass.Int32(self.packed_tile_capacity),
+            ).launch(
+                grid=(1, 1, 1),
+                block=(1, 1, 1),
+                stream=stream,
+            )
+            n_partials = self.packed_tile_capacity
+        if cutlass.const_expr(self.use_dweight_partials):
+            _causal_conv1d_bulk_bwd_kernel(
+                x,
+                weight,
+                bias,
+                dy,
+                dx,
+                dw_partials,
+                db_accum,
+                initial_state,
+                d_final_state,
+                packed_tile_map,
+                cutlass.Int32(self.sequence_length),
+                cutlass.Int32(self.tokens_per_cta),
+                cutlass.Int32(x.shape[1]),
+                True,
+            ).launch(
+                grid=(n_partials, cute.ceil_div(x.shape[1], self.threads), 1),
+                block=(self.threads, 1, 1),
+                stream=stream,
+            )
+            _reduce_dweight_partials_kernel(
+                dw_partials,
+                dw_accum,
+                cutlass.Int32(n_partials),
+                cutlass.Int32(x.shape[1]),
+            ).launch(
+                grid=(cute.ceil_div(x.shape[1], self.reduction_threads), 1, 1),
+                block=(self.reduction_threads, 1, 1),
+                stream=stream,
+            )
+        else:
+            _causal_conv1d_bulk_bwd_kernel(
+                x,
+                weight,
+                bias,
+                dy,
+                dx,
+                dw_accum,
+                db_accum,
+                initial_state,
+                d_final_state,
+                packed_tile_map,
+                cutlass.Int32(self.sequence_length),
+                cutlass.Int32(self.tokens_per_cta),
+                cutlass.Int32(x.shape[1]),
+                False,
+            ).launch(
+                grid=(n_partials, cute.ceil_div(x.shape[1], self.threads), 1),
+                block=(self.threads, 1, 1),
+                stream=stream,
+            )
+        if cutlass.const_expr(initial_state is not None):
+            _causal_conv1d_bulk_state_bwd_kernel(
+                x,
+                weight,
+                bias,
+                dy,
+                initial_state,
+                d_final_state,
+                d_initial_state,
+                cu_seqlens,
+                cutlass.Int32(self.sequence_length),
+                cutlass.Int32(self.num_sequences),
+                cutlass.Int32(x.shape[1]),
+            ).launch(
+                grid=(self.num_sequences, cute.ceil_div(x.shape[1], self.threads), 1),
+                block=(self.threads, 1, 1),
+                stream=stream,
+            )

--- a/python/cudnn/causal_conv1d_bulk_sm100/backward_kernel_vec2_cpasync.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/backward_kernel_vec2_cpasync.py
@@ -56,7 +56,7 @@ def _stream_step_vec2_fast_tanh(
     produce_dx: cutlass.Constexpr,
     masked: cutlass.Constexpr,
 ) -> None:
-    """Advance one token using Blackwell packed-f32x2 arithmetic."""
+    """Advance one token using SM100+ packed-f32x2 arithmetic."""
 
     fma2 = cute.arch.fma_packed_f32x2
     mul2 = cute.arch.mul_packed_f32x2

--- a/python/cudnn/causal_conv1d_bulk_sm100/backward_kernel_vec2_cpasync.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/backward_kernel_vec2_cpasync.py
@@ -1,0 +1,585 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""B200 vec2 cp.async specialization for dense width-four conv backward.
+
+This FE-native prototype extends the streaming backward design with a
+four-stage ``cp.async`` pipeline, packed-f32x2 arithmetic, and a fast-tanh SiLU
+derivative. It consumes the FE caller-owned FP32 partial workspace and reuses
+the existing deterministic 16-way FP32 reducer. It does not allocate or cache
+on execute and does not copy or call FLA or another external convolution
+kernel.
+
+Each 128-thread CTA owns 256 adjacent BF16 channels. Four G8 stages of X and
+dY occupy 32 KiB of shared memory while each thread walks one token tile. The
+main kernel writes one FP32 ``[token_tile, channel, tap]`` partial; the shared
+reducer in :mod:`backward_kernel_vec4` produces the API's FP32 dW accumulator.
+"""
+
+from __future__ import annotations
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.utils
+from cutlass import cute
+
+from .backward_kernel_vec4 import _REDUCTION_SPLITS, _reduce_dweight_vec4_partials_kernel
+
+_WIDTH = 4
+_VEC = 2
+_THREADS = 128
+_CHANNELS_PER_CTA = _THREADS * _VEC
+_TOKENS_PER_STAGE = 8
+_STAGES = 4
+_PACKED_PAIRS = _VEC // 2
+_CHANNEL_VECTORS_16B = _CHANNELS_PER_CTA // 8
+_ROWS_PER_COPY = _THREADS // _CHANNEL_VECTORS_16B
+_COPIES_PER_STAGE = _TOKENS_PER_STAGE // _ROWS_PER_COPY
+_SMEM_ELEMENTS = _STAGES * _TOKENS_PER_STAGE * _CHANNELS_PER_CTA
+_SMEM_BYTES = 2 * _SMEM_ELEMENTS * 2
+_DX_STAGE_STRIDE = (_VEC, 1)
+
+_F32 = cutlass.Float32
+
+
+@cute.jit
+def _stream_step_vec2_fast_tanh(
+    x_buffer,
+    dy_buffer,
+    weight,
+    x_history,
+    dz_history,
+    dweight_accum,
+    dx_buffer,
+    dy_mask: cutlass.Float32,
+    accumulate_dweight: cutlass.Constexpr,
+    produce_dx: cutlass.Constexpr,
+    masked: cutlass.Constexpr,
+) -> None:
+    """Advance one token using Blackwell packed-f32x2 arithmetic."""
+
+    fma2 = cute.arch.fma_packed_f32x2
+    mul2 = cute.arch.mul_packed_f32x2
+    add2 = cute.arch.add_packed_f32x2
+    one2 = (_F32(1.0), _F32(1.0))
+
+    for pair in cutlass.range_constexpr(_PACKED_PAIRS):
+        lane0 = 2 * pair
+        lane1 = lane0 + 1
+        current = (x_buffer[lane0].to(_F32), x_buffer[lane1].to(_F32))
+        dy_value = (dy_buffer[lane0].to(_F32), dy_buffer[lane1].to(_F32))
+        if cutlass.const_expr(masked):
+            dy_value = mul2(dy_value, (dy_mask, dy_mask))
+
+        # Weights are stored as w/2, so z_half is the preactivation divided by
+        # two. This lets one tanh.approx evaluate the full SiLU derivative.
+        z_half = mul2(
+            (x_history[0, lane0], x_history[0, lane1]),
+            (weight[0, lane0], weight[0, lane1]),
+        )
+        z_half = fma2(
+            (x_history[1, lane0], x_history[1, lane1]),
+            (weight[1, lane0], weight[1, lane1]),
+            z_half,
+        )
+        z_half = fma2(
+            (x_history[2, lane0], x_history[2, lane1]),
+            (weight[2, lane0], weight[2, lane1]),
+            z_half,
+        )
+        z_half = fma2(current, (weight[3, lane0], weight[3, lane1]), z_half)
+
+        tanh_half = (
+            cute.math.tanh(z_half[0], fastmath=True),
+            cute.math.tanh(z_half[1], fastmath=True),
+        )
+        one_minus_tanh_squared = fma2((-tanh_half[0], -tanh_half[1]), tanh_half, one2)
+        derivative_twice = fma2(z_half, one_minus_tanh_squared, add2(one2, tanh_half))
+        dz_twice = mul2(dy_value, derivative_twice)
+
+        if cutlass.const_expr(accumulate_dweight):
+            value = fma2(
+                dz_twice,
+                (x_history[0, lane0], x_history[0, lane1]),
+                (dweight_accum[0, lane0], dweight_accum[0, lane1]),
+            )
+            dweight_accum[0, lane0] = value[0]
+            dweight_accum[0, lane1] = value[1]
+            value = fma2(
+                dz_twice,
+                (x_history[1, lane0], x_history[1, lane1]),
+                (dweight_accum[1, lane0], dweight_accum[1, lane1]),
+            )
+            dweight_accum[1, lane0] = value[0]
+            dweight_accum[1, lane1] = value[1]
+            value = fma2(
+                dz_twice,
+                (x_history[2, lane0], x_history[2, lane1]),
+                (dweight_accum[2, lane0], dweight_accum[2, lane1]),
+            )
+            dweight_accum[2, lane0] = value[0]
+            dweight_accum[2, lane1] = value[1]
+            value = fma2(
+                dz_twice,
+                current,
+                (dweight_accum[3, lane0], dweight_accum[3, lane1]),
+            )
+            dweight_accum[3, lane0] = value[0]
+            dweight_accum[3, lane1] = value[1]
+
+        if cutlass.const_expr(produce_dx):
+            dx_value = mul2(
+                (dz_history[0, lane0], dz_history[0, lane1]),
+                (weight[3, lane0], weight[3, lane1]),
+            )
+            dx_value = fma2(
+                (dz_history[1, lane0], dz_history[1, lane1]),
+                (weight[2, lane0], weight[2, lane1]),
+                dx_value,
+            )
+            dx_value = fma2(
+                (dz_history[2, lane0], dz_history[2, lane1]),
+                (weight[1, lane0], weight[1, lane1]),
+                dx_value,
+            )
+            dx_value = fma2(dz_twice, (weight[0, lane0], weight[0, lane1]), dx_value)
+            dx_buffer[lane0] = dx_value[0].to(cutlass.BFloat16)
+            dx_buffer[lane1] = dx_value[1].to(cutlass.BFloat16)
+
+        x_history[0, lane0] = x_history[1, lane0]
+        x_history[0, lane1] = x_history[1, lane1]
+        x_history[1, lane0] = x_history[2, lane0]
+        x_history[1, lane1] = x_history[2, lane1]
+        x_history[2, lane0] = current[0]
+        x_history[2, lane1] = current[1]
+        dz_history[0, lane0] = dz_history[1, lane0]
+        dz_history[0, lane1] = dz_history[1, lane1]
+        dz_history[1, lane0] = dz_history[2, lane0]
+        dz_history[1, lane1] = dz_history[2, lane1]
+        dz_history[2, lane0] = dz_twice[0]
+        dz_history[2, lane1] = dz_twice[1]
+
+
+@cute.jit
+def _issue_cpasync_stage(
+    copy_atom,
+    global_x_16b,
+    global_dy_16b,
+    shared_x_16b,
+    shared_dy_16b,
+    stage: cutlass.Int32,
+    token_base: cutlass.Int32,
+    first_row: cutlass.Int32,
+    channel_vector: cutlass.Int32,
+    channel_base: cutlass.Int32,
+) -> None:
+    """Issue this thread's 16-byte X and dY copies for one G8 stage."""
+
+    for copy_index in cutlass.range_constexpr(_COPIES_PER_STAGE):
+        row = first_row + copy_index * _ROWS_PER_COPY
+        cute.copy(
+            copy_atom,
+            global_x_16b[(token_base + row, channel_base + channel_vector, None)],
+            shared_x_16b[(stage, row, channel_vector, None)],
+        )
+        cute.copy(
+            copy_atom,
+            global_dy_16b[(token_base + row, channel_base + channel_vector, None)],
+            shared_dy_16b[(stage, row, channel_vector, None)],
+        )
+
+
+@cute.kernel
+def _causal_conv1d_bulk_bwd_vec2_cpasync_kernel(
+    x: cute.Tensor,
+    weight: cute.Tensor,
+    dy: cute.Tensor,
+    dx: cute.Tensor,
+    dweight_partials: cute.Tensor,
+    sequence_length: cutlass.Int32,
+    tokens_per_cta: cutlass.Int32,
+    n_token_tiles: cutlass.Constexpr,
+    n_channels: cutlass.Constexpr,
+) -> None:
+    """Run one four-stage cp.async token tile by two channels per thread."""
+
+    thread = cutlass.Int32(cute.arch.thread_idx()[0])
+    channel_tile = cutlass.Int32(cute.arch.block_idx()[0])
+    token_tile = cutlass.Int32(cute.arch.block_idx()[1])
+
+    channel_vectors = n_channels // _VEC
+    data_layout = cute.make_layout(
+        (sequence_length, channel_vectors, _VEC),
+        stride=(n_channels, _VEC, 1),
+    )
+    global_x = cute.make_tensor(x.iterator, data_layout)
+    global_dy = cute.make_tensor(dy.iterator, data_layout)
+    global_dx = cute.make_tensor(dx.iterator, data_layout)
+    global_weight = cute.make_tensor(
+        weight.iterator,
+        cute.make_layout((channel_vectors, _WIDTH * _VEC), stride=(_WIDTH * _VEC, 1)),
+    )
+    global_partials = cute.make_tensor(
+        dweight_partials.iterator,
+        cute.make_layout(
+            (n_token_tiles, n_channels, _WIDTH),
+            stride=(n_channels * _WIDTH, _WIDTH, 1),
+        ),
+    )
+
+    packed_layout = cute.make_layout(
+        (sequence_length, n_channels // 8, 8),
+        stride=(n_channels, 8, 1),
+    )
+    # DLPack-backed tensors carry generic pointers; cp.async requires a
+    # global-address-space source and the API has already checked 16B alignment.
+    x_global_pointer = cute.make_ptr(
+        cutlass.BFloat16,
+        x.iterator.toint(),
+        cute.AddressSpace.gmem,
+        assumed_align=16,
+    )
+    dy_global_pointer = cute.make_ptr(
+        cutlass.BFloat16,
+        dy.iterator.toint(),
+        cute.AddressSpace.gmem,
+        assumed_align=16,
+    )
+    global_x_16b = cute.make_tensor(x_global_pointer, packed_layout)
+    global_dy_16b = cute.make_tensor(dy_global_pointer, packed_layout)
+
+    register_load = cute.make_copy_atom(
+        cute.nvgpu.CopyG2ROp(),
+        cutlass.BFloat16,
+        num_bits_per_copy=_VEC * 16,
+        invariant=True,
+    )
+    cpasync_load = cute.make_copy_atom(
+        cute.nvgpu.cpasync.CopyG2SOp(
+            cache_mode=cute.nvgpu.common.LoadCacheMode.GLOBAL,
+        ),
+        cutlass.BFloat16,
+        num_bits_per_copy=128,
+    )
+
+    smem = cutlass.utils.SmemAllocator()
+    shared_x_raw = smem.allocate_tensor(
+        cutlass.BFloat16,
+        cute.make_layout(_SMEM_ELEMENTS),
+        byte_alignment=16,
+    )
+    shared_dy_raw = smem.allocate_tensor(
+        cutlass.BFloat16,
+        cute.make_layout(_SMEM_ELEMENTS),
+        byte_alignment=16,
+    )
+    shared_16b_layout = cute.make_layout(
+        (_STAGES, _TOKENS_PER_STAGE, _CHANNEL_VECTORS_16B, 8),
+        stride=(_TOKENS_PER_STAGE * _CHANNELS_PER_CTA, _CHANNELS_PER_CTA, 8, 1),
+    )
+    shared_vec2_layout = cute.make_layout(
+        (_STAGES, _TOKENS_PER_STAGE, _THREADS, _VEC),
+        stride=(_TOKENS_PER_STAGE * _CHANNELS_PER_CTA, _CHANNELS_PER_CTA, _VEC, 1),
+    )
+    shared_x_16b = cute.make_tensor(shared_x_raw.iterator, shared_16b_layout)
+    shared_dy_16b = cute.make_tensor(shared_dy_raw.iterator, shared_16b_layout)
+    shared_x_vec2 = cute.make_tensor(shared_x_raw.iterator, shared_vec2_layout)
+    shared_dy_vec2 = cute.make_tensor(shared_dy_raw.iterator, shared_vec2_layout)
+
+    channel_vector = channel_tile * (_CHANNELS_PER_CTA // _VEC) + thread
+    channel_base = channel_tile * _CHANNEL_VECTORS_16B
+    first_row = thread // _CHANNEL_VECTORS_16B
+    channel_vector_16b = thread % _CHANNEL_VECTORS_16B
+
+    token_start = token_tile * tokens_per_cta
+    token_end = token_start + tokens_per_cta
+    if token_end > sequence_length:
+        token_end = sequence_length
+    last_full_stage_start = sequence_length - _TOKENS_PER_STAGE
+
+    x_history = cute.make_rmem_tensor((3, _VEC), _F32)
+    dz_history = cute.make_rmem_tensor((3, _VEC), _F32)
+    dweight_accum = cute.make_rmem_tensor((_WIDTH, _VEC), _F32)
+    weight_values = cute.make_rmem_tensor((_WIDTH, _VEC), _F32)
+    x_buffer = cute.make_rmem_tensor((_VEC,), cutlass.BFloat16)
+    dy_buffer = cute.make_rmem_tensor((_VEC,), cutlass.BFloat16)
+    dx_buffer = cute.make_rmem_tensor((_VEC,), cutlass.BFloat16)
+    dx_stage = cute.make_rmem_tensor(
+        cute.make_layout(
+            (_TOKENS_PER_STAGE, _VEC),
+            stride=_DX_STAGE_STRIDE,
+        ),
+        cutlass.BFloat16,
+    )
+
+    for history in cutlass.range_constexpr(3):
+        for lane in cutlass.range_constexpr(_VEC):
+            x_history[history, lane] = _F32(0.0)
+            dz_history[history, lane] = _F32(0.0)
+    for tap in cutlass.range_constexpr(_WIDTH):
+        for lane in cutlass.range_constexpr(_VEC):
+            dweight_accum[tap, lane] = _F32(0.0)
+
+    packed_weight = cute.make_rmem_tensor((_WIDTH * _VEC,), weight.element_type)
+    cute.autovec_copy(global_weight[(channel_vector, None)], packed_weight)
+    for lane in cutlass.range_constexpr(_VEC):
+        for tap in cutlass.range_constexpr(_WIDTH):
+            weight_values[tap, lane] = packed_weight[_WIDTH * lane + tap].to(_F32) * _F32(0.5)
+
+    staged_start = token_start + 3
+    staged_tokens = token_end - staged_start
+    full_stages = staged_tokens // _TOKENS_PER_STAGE
+
+    # Fill three stages before the serial three-token prime.
+    for stage in cutlass.range_constexpr(_STAGES - 1):
+        if stage < full_stages:
+            issue_start = staged_start + stage * _TOKENS_PER_STAGE
+            if issue_start > last_full_stage_start:
+                issue_start = last_full_stage_start
+            _issue_cpasync_stage(
+                cpasync_load,
+                global_x_16b,
+                global_dy_16b,
+                shared_x_16b,
+                shared_dy_16b,
+                stage,
+                issue_start,
+                first_row,
+                channel_vector_16b,
+                channel_base,
+            )
+        cute.arch.cp_async_commit_group()
+
+    # Coalesce the three halo and three prime-token register loads before any
+    # arithmetic to preserve the schedule's latency-hiding structure.
+    prologue_layout = cute.make_layout((3, _VEC), stride=(_VEC, 1))
+    halo_x = cute.make_rmem_tensor(prologue_layout, cutlass.BFloat16)
+    prime_x = cute.make_rmem_tensor(prologue_layout, cutlass.BFloat16)
+    prime_dy = cute.make_rmem_tensor(prologue_layout, cutlass.BFloat16)
+    halo_start = token_start - 3
+    if halo_start < 0:
+        halo_start = cutlass.Int32(0)
+    for index in cutlass.range_constexpr(3):
+        cute.copy(register_load, global_x[(halo_start + index, channel_vector, None)], halo_x[(index, None)])
+        cute.copy(register_load, global_x[(token_start + index, channel_vector, None)], prime_x[(index, None)])
+        cute.copy(register_load, global_dy[(token_start + index, channel_vector, None)], prime_dy[(index, None)])
+
+    if token_start >= 3:
+        for index in cutlass.range_constexpr(3):
+            for lane in cutlass.range_constexpr(_VEC):
+                x_history[index, lane] = halo_x[index, lane].to(_F32)
+
+    one = _F32(1.0)
+    for index in cutlass.range_constexpr(3):
+        _stream_step_vec2_fast_tanh(
+            prime_x[(index, None)],
+            prime_dy[(index, None)],
+            weight_values,
+            x_history,
+            dz_history,
+            dweight_accum,
+            dx_buffer,
+            one,
+            True,
+            False,
+            False,
+        )
+
+    stage = cutlass.Int32(0)
+    next_stage = cutlass.Int32(_STAGES - 1)
+    for stage_index in cutlass.range(full_stages, unroll=1):
+        cute.arch.cp_async_wait_group(_STAGES - 2)
+        cute.arch.barrier()
+        stage_start = staged_start + stage_index * _TOKENS_PER_STAGE
+        for token in cutlass.range_constexpr(_TOKENS_PER_STAGE):
+            cute.autovec_copy(shared_x_vec2[(stage, token, thread, None)], x_buffer)
+            cute.autovec_copy(shared_dy_vec2[(stage, token, thread, None)], dy_buffer)
+            _stream_step_vec2_fast_tanh(
+                x_buffer,
+                dy_buffer,
+                weight_values,
+                x_history,
+                dz_history,
+                dweight_accum,
+                dx_buffer,
+                one,
+                True,
+                True,
+                False,
+            )
+            cute.autovec_copy(dx_buffer, dx_stage[(token, None)])
+
+        # This stage was last read one iteration ago; the top-of-loop barrier
+        # already separates that read from the following refill.
+        if stage_index + (_STAGES - 1) < full_stages:
+            issue_start = stage_start + (_STAGES - 1) * _TOKENS_PER_STAGE
+            if issue_start > last_full_stage_start:
+                issue_start = last_full_stage_start
+            _issue_cpasync_stage(
+                cpasync_load,
+                global_x_16b,
+                global_dy_16b,
+                shared_x_16b,
+                shared_dy_16b,
+                next_stage,
+                issue_start,
+                first_row,
+                channel_vector_16b,
+                channel_base,
+            )
+        cute.arch.cp_async_commit_group()
+        # Keep arithmetic and token ownership unchanged, but issue each G8
+        # stage's adjacent dX stores together after the next cp.async refill.
+        for token in cutlass.range_constexpr(_TOKENS_PER_STAGE):
+            cute.autovec_copy(
+                dx_stage[(token, None)],
+                global_dx[(stage_start + token - 3, channel_vector, None)],
+            )
+        stage = stage + 1
+        if stage == _STAGES:
+            stage = cutlass.Int32(0)
+        next_stage = next_stage + 1
+        if next_stage == _STAGES:
+            next_stage = cutlass.Int32(0)
+
+    tail_start = staged_start + full_stages * _TOKENS_PER_STAGE
+    for index in cutlass.range(staged_tokens - full_stages * _TOKENS_PER_STAGE, unroll=1):
+        cute.copy(register_load, global_x[(tail_start + index, channel_vector, None)], x_buffer)
+        cute.copy(register_load, global_dy[(tail_start + index, channel_vector, None)], dy_buffer)
+        _stream_step_vec2_fast_tanh(
+            x_buffer,
+            dy_buffer,
+            weight_values,
+            x_history,
+            dz_history,
+            dweight_accum,
+            dx_buffer,
+            one,
+            True,
+            True,
+            False,
+        )
+        cute.autovec_copy(dx_buffer, global_dx[(tail_start + index - 3, channel_vector, None)])
+
+    # Drain dz[token_end:token_end+3], masking the sequence boundary. These
+    # values finish this tile's final three dX values but never contribute dW.
+    for index in cutlass.range_constexpr(3):
+        source_token = token_end + index
+        mask = _F32(0.0)
+        clamped_token = sequence_length - 1
+        if source_token < sequence_length:
+            mask = _F32(1.0)
+            clamped_token = source_token
+        cute.copy(register_load, global_x[(clamped_token, channel_vector, None)], x_buffer)
+        cute.copy(register_load, global_dy[(clamped_token, channel_vector, None)], dy_buffer)
+        _stream_step_vec2_fast_tanh(
+            x_buffer,
+            dy_buffer,
+            weight_values,
+            x_history,
+            dz_history,
+            dweight_accum,
+            dx_buffer,
+            mask,
+            False,
+            True,
+            True,
+        )
+        cute.autovec_copy(dx_buffer, global_dx[(token_end + index - 3, channel_vector, None)])
+
+    # dz and weights were each scaled by two in opposite directions. Apply the
+    # remaining 0.5 once while materializing the exact FP32 dW partial.
+    channel_partial = cute.make_rmem_tensor((_WIDTH,), _F32)
+    for lane in cutlass.range_constexpr(_VEC):
+        for tap in cutlass.range_constexpr(_WIDTH):
+            channel_partial[tap] = dweight_accum[tap, lane] * _F32(0.5)
+        cute.autovec_copy(
+            channel_partial,
+            global_partials[(token_tile, channel_vector * _VEC + lane, None)],
+        )
+
+
+class CausalConv1dBulkBackwardVec2CpAsyncKernel:
+    """Launch the B200 cp.async main kernel and existing FP32 reducer."""
+
+    def __init__(
+        self,
+        *,
+        sequence_length: int,
+        n_channels: int,
+        tokens_per_cta: int,
+        n_token_tiles: int,
+        reduction_threads: int,
+    ) -> None:
+        if sequence_length < 3:
+            raise ValueError(f"sequence_length must be at least 3, got {sequence_length}")
+        if n_channels % _CHANNELS_PER_CTA != 0:
+            raise ValueError(f"n_channels must be divisible by {_CHANNELS_PER_CTA}, got {n_channels}")
+        if tokens_per_cta < 3 or (tokens_per_cta - 3) % _TOKENS_PER_STAGE != 0:
+            raise ValueError(f"tokens_per_cta must be at least 3 and congruent to 3 modulo {_TOKENS_PER_STAGE}, got {tokens_per_cta}")
+        expected_tiles = (sequence_length + tokens_per_cta - 1) // tokens_per_cta
+        if n_token_tiles != expected_tiles:
+            raise ValueError(f"n_token_tiles mismatch: expected {expected_tiles}, got {n_token_tiles}")
+        last_tile_tokens = sequence_length - (n_token_tiles - 1) * tokens_per_cta
+        if last_tile_tokens < 3:
+            raise ValueError(f"the final token tile must contain at least 3 tokens, got {last_tile_tokens}")
+        if reduction_threads <= 0 or reduction_threads % _REDUCTION_SPLITS != 0:
+            raise ValueError(f"reduction_threads must be positive and divisible by {_REDUCTION_SPLITS}, got {reduction_threads}")
+        channels_per_reduction_block = reduction_threads // _REDUCTION_SPLITS
+        if n_channels % channels_per_reduction_block != 0:
+            raise ValueError(f"n_channels must be divisible by {channels_per_reduction_block}, got {n_channels}")
+
+        self.sequence_length = sequence_length
+        self.n_channels = n_channels
+        self.tokens_per_cta = tokens_per_cta
+        self.n_token_tiles = n_token_tiles
+        self.reduction_threads = reduction_threads
+
+    @cute.jit
+    def __call__(
+        self,
+        x: cute.Tensor,
+        weight: cute.Tensor,
+        bias: cute.Tensor | None,
+        dy: cute.Tensor,
+        dx: cute.Tensor,
+        dw_accum: cute.Tensor,
+        db_accum: cute.Tensor | None,
+        dweight_partials: cute.Tensor,
+        cu_seqlens: cute.Tensor | None,
+        initial_state: cute.Tensor | None,
+        d_final_state: cute.Tensor | None,
+        d_initial_state: cute.Tensor | None,
+        packed_tile_map: cute.Tensor | None,
+        stream: cuda.CUstream,
+    ) -> None:
+        _causal_conv1d_bulk_bwd_vec2_cpasync_kernel(
+            x,
+            weight,
+            dy,
+            dx,
+            dweight_partials,
+            cutlass.Int32(self.sequence_length),
+            cutlass.Int32(self.tokens_per_cta),
+            self.n_token_tiles,
+            self.n_channels,
+        ).launch(
+            grid=(self.n_channels // _CHANNELS_PER_CTA, self.n_token_tiles, 1),
+            block=(_THREADS, 1, 1),
+            stream=stream,
+            smem=_SMEM_BYTES,
+        )
+        _reduce_dweight_vec4_partials_kernel(
+            dweight_partials,
+            dw_accum,
+            cutlass.Int32(self.n_token_tiles),
+            self.n_channels,
+            self.reduction_threads // _REDUCTION_SPLITS,
+        ).launch(
+            grid=(self.n_channels // (self.reduction_threads // _REDUCTION_SPLITS), 1, 1),
+            block=(self.reduction_threads // _REDUCTION_SPLITS, _REDUCTION_SPLITS, 1),
+            stream=stream,
+        )
+
+
+__all__ = ["CausalConv1dBulkBackwardVec2CpAsyncKernel"]

--- a/python/cudnn/causal_conv1d_bulk_sm100/backward_kernel_vec4.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/backward_kernel_vec4.py
@@ -1,0 +1,398 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dense vec4 streaming width-four conv backward prototype.
+
+This FE-native implementation was independently derived from the convolution
+and SiLU derivatives; it does not copy or call FLA, causal-conv1d, or another
+external kernel. It consumes caller-owned workspace and performs no
+execute-time allocation.
+
+Each thread owns four adjacent channels and walks one token tile. Three input
+and dz values stay in registers, so each output gradient is written without an
+atomic. A unique FP32 ``[token_tile, channel, tap]`` partial is followed by one
+deterministic reduction kernel. The reducer assigns 16 split lanes to each
+channel, then combines their FP32 sums through shared memory.
+"""
+
+from __future__ import annotations
+
+import cuda.bindings.driver as cuda
+import cutlass
+from cutlass import cute
+
+from cudnn.frost.tile_dsl.pointwise import sigmoid
+
+_WIDTH = 4
+_VEC = 4
+_THREADS = 128
+_CHANNELS_PER_CTA = _THREADS * _VEC
+_TOKEN_GROUP = 4
+_REDUCTION_SPLITS = 16
+
+
+@cute.jit
+def _stream_step(
+    x_buffer,
+    dy_buffer,
+    dx_buffer,
+    group_index: cutlass.Constexpr,
+    weight,
+    x_history,
+    dz_history,
+    dw_accum,
+    dy_mask: cutlass.Float32,
+    accumulate_dweight: cutlass.Constexpr,
+    produce_dx: cutlass.Constexpr,
+    masked: cutlass.Constexpr,
+) -> None:
+    """Advance one token for four adjacent channels."""
+
+    for lane in cutlass.range_constexpr(_VEC):
+        current = x_buffer[group_index, lane].to(cutlass.Float32)
+        dy_value = dy_buffer[group_index, lane].to(cutlass.Float32)
+        if cutlass.const_expr(masked):
+            dy_value = dy_value * dy_mask
+
+        z = x_history[0, lane] * weight[0, lane]
+        z = z + x_history[1, lane] * weight[1, lane]
+        z = z + x_history[2, lane] * weight[2, lane]
+        z = z + current * weight[3, lane]
+        gate = sigmoid(z)
+        dz = dy_value * (gate + z * (gate * (cutlass.Float32(1.0) - gate)))
+
+        if cutlass.const_expr(accumulate_dweight):
+            dw_accum[0, lane] = dw_accum[0, lane] + dz * x_history[0, lane]
+            dw_accum[1, lane] = dw_accum[1, lane] + dz * x_history[1, lane]
+            dw_accum[2, lane] = dw_accum[2, lane] + dz * x_history[2, lane]
+            dw_accum[3, lane] = dw_accum[3, lane] + dz * current
+
+        if cutlass.const_expr(produce_dx):
+            dx_value = dz_history[0, lane] * weight[3, lane]
+            dx_value = dx_value + dz_history[1, lane] * weight[2, lane]
+            dx_value = dx_value + dz_history[2, lane] * weight[1, lane]
+            dx_value = dx_value + dz * weight[0, lane]
+            dx_buffer[group_index, lane] = dx_value.to(cutlass.BFloat16)
+
+        x_history[0, lane] = x_history[1, lane]
+        x_history[1, lane] = x_history[2, lane]
+        x_history[2, lane] = current
+        dz_history[0, lane] = dz_history[1, lane]
+        dz_history[1, lane] = dz_history[2, lane]
+        dz_history[2, lane] = dz
+
+
+@cute.kernel
+def _causal_conv1d_bulk_bwd_vec4_kernel(
+    x: cute.Tensor,
+    weight: cute.Tensor,
+    dy: cute.Tensor,
+    dx: cute.Tensor,
+    dw_partials: cute.Tensor,
+    sequence_length: cutlass.Int32,
+    tokens_per_cta: cutlass.Int32,
+    n_token_tiles: cutlass.Int32,
+    n_channels: cutlass.Constexpr,
+) -> None:
+    """Stream one token tile by four channels per thread."""
+
+    tidx = cutlass.Int32(cute.arch.thread_idx()[0])
+    channel_tile = cutlass.Int32(cute.arch.block_idx()[0])
+    token_tile = cutlass.Int32(cute.arch.block_idx()[1])
+
+    channel_vectors = n_channels // _VEC
+    data_layout = cute.make_layout(
+        (sequence_length, channel_vectors, _VEC),
+        stride=(n_channels, _VEC, 1),
+    )
+    global_x = cute.make_tensor(x.iterator, data_layout)
+    global_dy = cute.make_tensor(dy.iterator, data_layout)
+    global_dx = cute.make_tensor(dx.iterator, data_layout)
+    global_weight = cute.make_tensor(
+        weight.iterator,
+        cute.make_layout((channel_vectors, _WIDTH * _VEC), stride=(_WIDTH * _VEC, 1)),
+    )
+    global_partials = cute.make_tensor(
+        dw_partials.iterator,
+        cute.make_layout(
+            (n_token_tiles, n_channels, _WIDTH),
+            stride=(n_channels * _WIDTH, _WIDTH, 1),
+        ),
+    )
+
+    load_atom = cute.make_copy_atom(
+        cute.nvgpu.CopyG2ROp(),
+        cutlass.BFloat16,
+        num_bits_per_copy=_VEC * 16,
+        invariant=True,
+    )
+    channel_vector = channel_tile * (_CHANNELS_PER_CTA // _VEC) + tidx
+    token_start = token_tile * tokens_per_cta
+    token_end = token_start + tokens_per_cta
+    if token_end > sequence_length:
+        token_end = sequence_length
+
+    x_history = cute.make_rmem_tensor((3, _VEC), cutlass.Float32)
+    dz_history = cute.make_rmem_tensor((3, _VEC), cutlass.Float32)
+    dw_accum = cute.make_rmem_tensor((_WIDTH, _VEC), cutlass.Float32)
+    weight_values = cute.make_rmem_tensor((_WIDTH, _VEC), cutlass.Float32)
+    group_layout = cute.make_layout((_TOKEN_GROUP, _VEC), stride=(_VEC, 1))
+    x_buffer = cute.make_rmem_tensor(group_layout, cutlass.BFloat16)
+    dy_buffer = cute.make_rmem_tensor(group_layout, cutlass.BFloat16)
+    dx_buffer = cute.make_rmem_tensor(group_layout, cutlass.BFloat16)
+
+    for history in cutlass.range_constexpr(3):
+        for lane in cutlass.range_constexpr(_VEC):
+            x_history[history, lane] = cutlass.Float32(0.0)
+            dz_history[history, lane] = cutlass.Float32(0.0)
+    for tap in cutlass.range_constexpr(_WIDTH):
+        for lane in cutlass.range_constexpr(_VEC):
+            dw_accum[tap, lane] = cutlass.Float32(0.0)
+
+    packed_weight = cute.make_rmem_tensor((_WIDTH * _VEC,), weight.element_type)
+    cute.autovec_copy(global_weight[(channel_vector, None)], packed_weight)
+    for lane in cutlass.range_constexpr(_VEC):
+        for tap in cutlass.range_constexpr(_WIDTH):
+            weight_values[tap, lane] = packed_weight[_WIDTH * lane + tap].to(cutlass.Float32)
+
+    if token_start >= cutlass.Int32(3):
+        for history in cutlass.range_constexpr(3):
+            cute.copy(
+                load_atom,
+                global_x[(token_start - cutlass.Int32(3) + history, channel_vector, None)],
+                x_buffer[(0, None)],
+            )
+            for lane in cutlass.range_constexpr(_VEC):
+                x_history[history, lane] = x_buffer[0, lane].to(cutlass.Float32)
+
+    one = cutlass.Float32(1.0)
+
+    # Prime dz[token_start:token_start+3]. The neighboring token tile owns the
+    # three dx values preceding this tile.
+    for prime in cutlass.range_constexpr(3):
+        cute.copy(load_atom, global_x[(token_start + prime, channel_vector, None)], x_buffer[(0, None)])
+        cute.copy(load_atom, global_dy[(token_start + prime, channel_vector, None)], dy_buffer[(0, None)])
+        _stream_step(
+            x_buffer,
+            dy_buffer,
+            dx_buffer,
+            0,
+            weight_values,
+            x_history,
+            dz_history,
+            dw_accum,
+            one,
+            True,
+            False,
+            False,
+        )
+
+    steady_tokens = token_end - token_start - cutlass.Int32(3)
+    full_groups = steady_tokens // cutlass.Int32(_TOKEN_GROUP)
+    for group in cutlass.range(full_groups, unroll=1):
+        base = token_start + cutlass.Int32(3) + group * cutlass.Int32(_TOKEN_GROUP)
+        for index in cutlass.range_constexpr(_TOKEN_GROUP):
+            cute.copy(load_atom, global_x[(base + index, channel_vector, None)], x_buffer[(index, None)])
+            cute.copy(load_atom, global_dy[(base + index, channel_vector, None)], dy_buffer[(index, None)])
+        for index in cutlass.range_constexpr(_TOKEN_GROUP):
+            _stream_step(
+                x_buffer,
+                dy_buffer,
+                dx_buffer,
+                index,
+                weight_values,
+                x_history,
+                dz_history,
+                dw_accum,
+                one,
+                True,
+                True,
+                False,
+            )
+        for index in cutlass.range_constexpr(_TOKEN_GROUP):
+            cute.autovec_copy(dx_buffer[(index, None)], global_dx[(base + index - cutlass.Int32(3), channel_vector, None)])
+
+    tail_tokens = steady_tokens - full_groups * cutlass.Int32(_TOKEN_GROUP)
+    tail_start = token_start + cutlass.Int32(3) + full_groups * cutlass.Int32(_TOKEN_GROUP)
+    for index in cutlass.range(tail_tokens, unroll=1):
+        cute.copy(load_atom, global_x[(tail_start + index, channel_vector, None)], x_buffer[(0, None)])
+        cute.copy(load_atom, global_dy[(tail_start + index, channel_vector, None)], dy_buffer[(0, None)])
+        _stream_step(
+            x_buffer,
+            dy_buffer,
+            dx_buffer,
+            0,
+            weight_values,
+            x_history,
+            dz_history,
+            dw_accum,
+            one,
+            True,
+            True,
+            False,
+        )
+        cute.autovec_copy(dx_buffer[(0, None)], global_dx[(tail_start + index - cutlass.Int32(3), channel_vector, None)])
+
+    # Drain future dz values so the last three dx values owned by this tile
+    # receive all four convolution taps. Out-of-range future dy is masked.
+    for index in cutlass.range_constexpr(3):
+        source_token = token_end + index
+        mask = cutlass.Float32(0.0)
+        clamped_token = sequence_length - cutlass.Int32(1)
+        if source_token < sequence_length:
+            mask = cutlass.Float32(1.0)
+            clamped_token = source_token
+        cute.copy(load_atom, global_x[(clamped_token, channel_vector, None)], x_buffer[(0, None)])
+        cute.copy(load_atom, global_dy[(clamped_token, channel_vector, None)], dy_buffer[(0, None)])
+        _stream_step(
+            x_buffer,
+            dy_buffer,
+            dx_buffer,
+            0,
+            weight_values,
+            x_history,
+            dz_history,
+            dw_accum,
+            mask,
+            False,
+            True,
+            True,
+        )
+        cute.autovec_copy(dx_buffer[(0, None)], global_dx[(token_end + index - cutlass.Int32(3), channel_vector, None)])
+
+    channel_partial = cute.make_rmem_tensor((_WIDTH,), cutlass.Float32)
+    for lane in cutlass.range_constexpr(_VEC):
+        for tap in cutlass.range_constexpr(_WIDTH):
+            channel_partial[tap] = dw_accum[tap, lane]
+        cute.autovec_copy(
+            channel_partial,
+            global_partials[(token_tile, channel_vector * cutlass.Int32(_VEC) + lane, None)],
+        )
+
+
+@cute.kernel
+def _reduce_dweight_vec4_partials_kernel(
+    dw_partials: cute.Tensor,
+    dw_accum: cute.Tensor,
+    n_token_tiles: cutlass.Int32,
+    n_channels: cutlass.Constexpr,
+    channels_per_block: cutlass.Constexpr,
+) -> None:
+    """Reduce one FP32 four-tap vector per output channel."""
+
+    channel_lane = cutlass.Int32(cute.arch.thread_idx()[0])
+    split_lane = cutlass.Int32(cute.arch.thread_idx()[1])
+    channel = cutlass.Int32(cute.arch.block_idx()[0]) * cutlass.Int32(channels_per_block) + channel_lane
+    partials = cute.make_tensor(
+        dw_partials.iterator,
+        cute.make_layout(
+            (n_token_tiles, n_channels, _WIDTH),
+            stride=(n_channels * _WIDTH, _WIDTH, 1),
+        ),
+    )
+    output = cute.make_tensor(
+        dw_accum.iterator,
+        cute.make_layout((n_channels, _WIDTH), stride=(_WIDTH, 1)),
+    )
+    accum = cute.make_rmem_tensor((_WIDTH,), cutlass.Float32)
+    values = cute.make_rmem_tensor((_WIDTH,), cutlass.Float32)
+    for tap in cutlass.range_constexpr(_WIDTH):
+        accum[tap] = cutlass.Float32(0.0)
+
+    # Each split lane owns a strided range. This covers every token tile once
+    # for arbitrary n_token_tiles, including n_token_tiles < 16 and a final
+    # range shorter than the others.
+    for token_tile in cutlass.range(split_lane, n_token_tiles, _REDUCTION_SPLITS, unroll=1):
+        cute.autovec_copy(partials[(token_tile, channel, None)], values)
+        for tap in cutlass.range_constexpr(_WIDTH):
+            accum[tap] = accum[tap] + values[tap]
+
+    smem = cutlass.utils.SmemAllocator()
+    split_partials = smem.allocate_tensor(
+        cutlass.Float32,
+        cute.make_layout(
+            (_REDUCTION_SPLITS, channels_per_block, _WIDTH),
+            stride=(channels_per_block * _WIDTH, _WIDTH, 1),
+        ),
+        byte_alignment=16,
+    )
+    cute.autovec_copy(accum, split_partials[(split_lane, channel_lane, None)])
+    cute.arch.barrier()
+
+    if split_lane == 0:
+        for tap in cutlass.range_constexpr(_WIDTH):
+            accum[tap] = cutlass.Float32(0.0)
+        for reduction_split in cutlass.range_constexpr(_REDUCTION_SPLITS):
+            cute.autovec_copy(split_partials[(reduction_split, channel_lane, None)], values)
+            for tap in cutlass.range_constexpr(_WIDTH):
+                accum[tap] = accum[tap] + values[tap]
+        cute.autovec_copy(accum, output[(channel, None)])
+
+
+class CausalConv1dBulkBackwardVec4Kernel:
+    """Launch the dense vec4 streaming kernel and deterministic reduction."""
+
+    def __init__(
+        self,
+        *,
+        sequence_length: int,
+        n_channels: int,
+        tokens_per_cta: int,
+        n_token_tiles: int,
+        reduction_threads: int,
+    ) -> None:
+        if reduction_threads <= 0 or reduction_threads % _REDUCTION_SPLITS != 0:
+            raise ValueError(f"reduction_threads must be positive and divisible by {_REDUCTION_SPLITS}, got {reduction_threads}")
+        channels_per_reduction_block = reduction_threads // _REDUCTION_SPLITS
+        if n_channels % channels_per_reduction_block != 0:
+            raise ValueError(f"n_channels must be divisible by {channels_per_reduction_block}, got {n_channels}")
+        self.sequence_length = sequence_length
+        self.n_channels = n_channels
+        self.tokens_per_cta = tokens_per_cta
+        self.n_token_tiles = n_token_tiles
+        self.reduction_threads = reduction_threads
+
+    @cute.jit
+    def __call__(
+        self,
+        x: cute.Tensor,
+        weight: cute.Tensor,
+        bias: cute.Tensor | None,
+        dy: cute.Tensor,
+        dx: cute.Tensor,
+        dw_accum: cute.Tensor,
+        db_accum: cute.Tensor | None,
+        dw_partials: cute.Tensor,
+        cu_seqlens: cute.Tensor | None,
+        initial_state: cute.Tensor | None,
+        d_final_state: cute.Tensor | None,
+        d_initial_state: cute.Tensor | None,
+        packed_tile_map: cute.Tensor | None,
+        stream: cuda.CUstream,
+    ) -> None:
+        _causal_conv1d_bulk_bwd_vec4_kernel(
+            x,
+            weight,
+            dy,
+            dx,
+            dw_partials,
+            cutlass.Int32(self.sequence_length),
+            cutlass.Int32(self.tokens_per_cta),
+            cutlass.Int32(self.n_token_tiles),
+            self.n_channels,
+        ).launch(
+            grid=(self.n_channels // _CHANNELS_PER_CTA, self.n_token_tiles, 1),
+            block=(_THREADS, 1, 1),
+            stream=stream,
+        )
+        _reduce_dweight_vec4_partials_kernel(
+            dw_partials,
+            dw_accum,
+            cutlass.Int32(self.n_token_tiles),
+            self.n_channels,
+            self.reduction_threads // _REDUCTION_SPLITS,
+        ).launch(
+            grid=(self.n_channels // (self.reduction_threads // _REDUCTION_SPLITS), 1, 1),
+            block=(self.reduction_threads // _REDUCTION_SPLITS, _REDUCTION_SPLITS, 1),
+            stream=stream,
+        )

--- a/python/cudnn/causal_conv1d_bulk_sm100/kernel.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/kernel.py
@@ -554,7 +554,7 @@ class CausalConv1dBulkForwardKernel:
 
     ``use_vec8`` is selected from the exact compilation target.  Its packed
     FP32 arithmetic requires SM100-or-newer instructions; the scalar schedule
-    is the functional fallback on supported pre-Blackwell architectures. Both
+    is the functional fallback on supported pre-SM100 architectures. Both
     BF16 and FP32 filter specializations accumulate in FP32.
     """
 

--- a/python/cudnn/causal_conv1d_bulk_sm100/kernel.py
+++ b/python/cudnn/causal_conv1d_bulk_sm100/kernel.py
@@ -1,0 +1,623 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Correctness-first bulk causal-convolution forward kernels.
+
+This is an independent CuTe DSL implementation of the width-four, BF16,
+depthwise causal-convolution contract documented by cuDNN Frontend.  FLA's
+short-convolution module and Dao-AILab's public causal-conv1d API were consulted
+only as semantic and interface references; no external kernel source is
+included here.
+
+The kernel consumes contiguous, flattened ``[total_tokens, D]`` input and
+output views.  A dense launch derives sequence boundaries from the host-provided
+``tokens_per_sequence`` scalar.  A packed launch reads ``cu_seqlens`` in the
+kernel, so neither compilation nor execution needs a device-to-host metadata
+read.  Optional initial and final states use the full ``[N, D, 4]`` layout that
+can be handed directly to the decode-update primitive.
+
+The schedule deliberately stays small and auditable.  Channel extents divisible
+by eight use a 128-thread fast path in which each thread owns eight adjacent
+channels and moves each input/output row as one aligned 16-byte transaction.
+The fallback keeps the original scalar 256-channel schedule for arbitrary
+channel tails.  Both schedules retain a rolling three-value causal window, so
+every subsequent output loads only the current token.  The CTA derives its
+first sequence interval once and advances it whenever the token loop crosses a
+boundary, resetting the window from that sequence's initial state or zeros.
+Thus a packed tile may safely straddle any number of sequences.  Packed
+launches first run a one-CTA device validator which traps unless the prefix
+sums start at zero, end at the runtime token total, and are strictly increasing.
+
+Callers must provide non-overlapping input, output, and state storage.  In
+particular, in-place output is unsafe because token CTAs execute independently
+and may still need earlier input tokens.
+"""
+
+from typing import Optional
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.arch.nvvm_wrappers import inline_ptx
+
+from cudnn.frost.tile_dsl.pointwise import (
+    f16x2_to_f32,
+    ffma2,
+    fmul2,
+    fp32_to_fp16,
+    opaque_f32_zero,
+    sigmoid,
+    sigmoid2,
+)
+
+THREADS = 256
+TOKENS_PER_CTA = 16
+VEC_THREADS = 128
+VEC_CHANNELS_PER_THREAD = 8
+VEC_CHANNELS_PER_CTA = VEC_THREADS * VEC_CHANNELS_PER_THREAD
+VEC_TOKENS_PER_CTA = 8
+WIDTH = 4
+
+
+@cute.jit
+def _load_bf16x8(address):
+    """Load eight aligned BF16 values as four packed words."""
+
+    word_0, word_1, word_2, word_3 = inline_ptx(
+        "ld.global.v4.b32 {$0, $1, $2, $3}, [$4];",
+        write_only_types=[cutlass.Int32, cutlass.Int32, cutlass.Int32, cutlass.Int32],
+        read_only_args=[address],
+    )
+    value_0, value_1 = f16x2_to_f32(word_0, dtype=cutlass.BFloat16)
+    value_2, value_3 = f16x2_to_f32(word_1, dtype=cutlass.BFloat16)
+    value_4, value_5 = f16x2_to_f32(word_2, dtype=cutlass.BFloat16)
+    value_6, value_7 = f16x2_to_f32(word_3, dtype=cutlass.BFloat16)
+    return value_0, value_1, value_2, value_3, value_4, value_5, value_6, value_7
+
+
+@cute.jit
+def _load_f32x4(address):
+    """Load one aligned four-tap FP32 weight row."""
+
+    return inline_ptx(
+        "ld.global.v4.f32 {$0, $1, $2, $3}, [$4];",
+        write_only_types=[cutlass.Float32] * WIDTH,
+        read_only_args=[address],
+    )
+
+
+@cute.jit
+def _store_bf16x8(address, value_0, value_1, value_2, value_3, value_4, value_5, value_6, value_7):
+    """Store eight BF16 values with one aligned 16-byte transaction."""
+
+    word_0 = fp32_to_fp16(value_0, value_1, dtype=cutlass.BFloat16)
+    word_1 = fp32_to_fp16(value_2, value_3, dtype=cutlass.BFloat16)
+    word_2 = fp32_to_fp16(value_4, value_5, dtype=cutlass.BFloat16)
+    word_3 = fp32_to_fp16(value_6, value_7, dtype=cutlass.BFloat16)
+    inline_ptx(
+        "st.global.v4.b32 [$0], {$1, $2, $3, $4};",
+        read_only_args=[address, word_0, word_1, word_2, word_3],
+    )
+
+
+@cute.kernel
+def _validate_cu_seqlens_kernel(
+    cu_seqlens: cute.Tensor,
+    num_sequences: cutlass.Int32,
+    total_tokens: cutlass.Int32,
+) -> None:
+    """Fail closed on malformed packed boundaries without a host read.
+
+    The CUDA error is asynchronous and, like the decode-update index guards,
+    is intentionally implemented with PTX ``trap``.  The validator and the
+    convolution launch on the same stream, so an invalid metadata launch cannot
+    proceed into tensor reads on that stream.
+    """
+
+    tidx = cutlass.Int32(cute.arch.thread_idx()[0])
+    if tidx == cutlass.Int32(0):
+        inline_ptx(
+            "trap;",
+            predicate=cutlass.Int32(cu_seqlens[0]) != cutlass.Int32(0),
+        )
+        inline_ptx(
+            "trap;",
+            predicate=cutlass.Int32(cu_seqlens[num_sequences]) != total_tokens,
+        )
+
+    boundary = tidx
+    while boundary < num_sequences:
+        left = cutlass.Int32(cu_seqlens[boundary])
+        right = cutlass.Int32(cu_seqlens[boundary + cutlass.Int32(1)])
+        inline_ptx("trap;", predicate=right <= left)
+        boundary += cutlass.Int32(THREADS)
+
+
+@cute.kernel
+def _causal_conv1d_bulk_fwd_kernel(
+    x: cute.Tensor,
+    weight: cute.Tensor,
+    bias: Optional[cute.Tensor],
+    initial_state: Optional[cute.Tensor],
+    cu_seqlens: Optional[cute.Tensor],
+    output: cute.Tensor,
+    final_state: Optional[cute.Tensor],
+    num_sequences: cutlass.Int32,
+    tokens_per_sequence: cutlass.Int32,
+    n_channels: cutlass.Int32,
+) -> None:
+    """Emit one token tile by 256 channels and final states at sequence ends.
+
+    ``cu_seqlens`` is ``None``-specialized for dense input.  For packed input,
+    lane zero of each warp performs one device-side binary search at the tile
+    start and broadcasts the resulting sequence interval.  The token loop
+    advances that interval at boundaries.  Every causal read is guarded by the
+    local position inside the current interval, preventing reads from a
+    preceding packed sequence.  A channel thread keeps its four weights and a
+    three-value causal window in registers across the token tile.
+    """
+
+    token_tile = cutlass.Int32(cute.arch.block_idx()[0])
+    channel_tile = cutlass.Int32(cute.arch.block_idx()[1])
+    tidx = cutlass.Int32(cute.arch.thread_idx()[0])
+    channel = channel_tile * cutlass.Int32(THREADS) + tidx
+    first_token = token_tile * cutlass.Int32(TOKENS_PER_CTA)
+    total_tokens = cutlass.Int32(x.shape[0])
+
+    weight_0 = cutlass.Float32(0.0)
+    weight_1 = cutlass.Float32(0.0)
+    weight_2 = cutlass.Float32(0.0)
+    weight_3 = cutlass.Float32(0.0)
+    bias_value = cutlass.Float32(0.0)
+    if channel < n_channels:
+        # Vectorize the naturally contiguous four-tap weight row.  The public
+        # model contract admits BF16 weights and the BF16-activation/FP32-weight
+        # combination used by GLM. Both specializations compute in FP32.
+        weight_element = cutlass.Int64(channel) * cutlass.Int64(weight.stride[0])
+        if cutlass.const_expr(weight.element_type == cutlass.Float32):
+            weight_address = weight.iterator.toint() + weight_element * cutlass.Int64(4)
+            weight_0, weight_1, weight_2, weight_3 = _load_f32x4(weight_address)
+        else:
+            weight_address = weight.iterator.toint() + weight_element * cutlass.Int64(2)
+            weight_01, weight_23 = inline_ptx(
+                "ld.global.v2.b32 {$0, $1}, [$2];",
+                write_only_types=[cutlass.Int32, cutlass.Int32],
+                read_only_args=[weight_address],
+            )
+            weight_0, weight_1 = f16x2_to_f32(weight_01, dtype=cutlass.BFloat16)
+            weight_2, weight_3 = f16x2_to_f32(weight_23, dtype=cutlass.BFloat16)
+        if cutlass.const_expr(bias is not None):
+            bias_value = bias[channel].to(cutlass.Float32)
+
+    sequence = cutlass.Int32(0)
+    sequence_start = cutlass.Int32(0)
+    sequence_end = cutlass.Int32(0)
+    if cutlass.const_expr(cu_seqlens is None):
+        sequence = first_token // tokens_per_sequence
+        sequence_start = sequence * tokens_per_sequence
+        sequence_end = sequence_start + tokens_per_sequence
+    else:
+        # All lanes in a warp process the same token tile.  Search once per
+        # warp and broadcast before the channel-tail predicate, so all lanes
+        # named by shuffle_sync's mask participate.
+        if cute.arch.lane_idx() == cutlass.Int32(0):
+            lower = cutlass.Int32(0)
+            upper = num_sequences
+            while lower + cutlass.Int32(1) < upper:
+                middle = (lower + upper) // cutlass.Int32(2)
+                if first_token < cutlass.Int32(cu_seqlens[middle]):
+                    upper = middle
+                else:
+                    lower = middle
+            sequence = lower
+            sequence_start = cutlass.Int32(cu_seqlens[sequence])
+            sequence_end = cutlass.Int32(cu_seqlens[sequence + cutlass.Int32(1)])
+
+        sequence = cute.arch.shuffle_sync(sequence, 0)
+        sequence_start = cute.arch.shuffle_sync(sequence_start, 0)
+        sequence_end = cute.arch.shuffle_sync(sequence_end, 0)
+
+    history_0 = cutlass.Float32(0.0)
+    history_1 = cutlass.Float32(0.0)
+    history_2 = cutlass.Float32(0.0)
+    if channel < n_channels:
+        local_first_token = first_token - sequence_start
+
+        # Initialize the three visible values immediately preceding the tile.
+        # Near a sequence start, the missing prefix comes from initial-state
+        # lanes 1..3; without initial state it remains zero.
+        if local_first_token >= cutlass.Int32(3):
+            history_0 = x[first_token - cutlass.Int32(3), channel].to(cutlass.Float32)
+        elif cutlass.const_expr(initial_state is not None):
+            history_0 = initial_state[sequence, channel, local_first_token + cutlass.Int32(1)].to(cutlass.Float32)
+
+        if local_first_token >= cutlass.Int32(2):
+            history_1 = x[first_token - cutlass.Int32(2), channel].to(cutlass.Float32)
+        elif cutlass.const_expr(initial_state is not None):
+            history_1 = initial_state[sequence, channel, local_first_token + cutlass.Int32(2)].to(cutlass.Float32)
+
+        if local_first_token >= cutlass.Int32(1):
+            history_2 = x[first_token - cutlass.Int32(1), channel].to(cutlass.Float32)
+        elif cutlass.const_expr(initial_state is not None):
+            history_2 = initial_state[sequence, channel, cutlass.Int32(3)].to(cutlass.Float32)
+
+    tile_end = first_token + cutlass.Int32(TOKENS_PER_CTA)
+    if tile_end > total_tokens:
+        tile_end = total_tokens
+
+    token = first_token
+    while token < tile_end:
+        # Strictly positive sequence lengths guarantee that incrementing one
+        # interval is sufficient when the unit-stride token loop hits an end.
+        if token == sequence_end:
+            sequence += cutlass.Int32(1)
+            sequence_start = sequence_end
+            if cutlass.const_expr(cu_seqlens is None):
+                sequence_end += tokens_per_sequence
+            else:
+                sequence_end = cutlass.Int32(cu_seqlens[sequence + cutlass.Int32(1)])
+
+            if channel < n_channels:
+                history_0 = cutlass.Float32(0.0)
+                history_1 = cutlass.Float32(0.0)
+                history_2 = cutlass.Float32(0.0)
+                if cutlass.const_expr(initial_state is not None):
+                    history_0 = initial_state[sequence, channel, cutlass.Int32(1)].to(cutlass.Float32)
+                    history_1 = initial_state[sequence, channel, cutlass.Int32(2)].to(cutlass.Float32)
+                    history_2 = initial_state[sequence, channel, cutlass.Int32(3)].to(cutlass.Float32)
+
+        if channel < n_channels:
+            current = x[token, channel].to(cutlass.Float32)
+            acc = history_0 * weight_0
+            acc = acc + history_1 * weight_1
+            acc = acc + history_2 * weight_2
+            acc = acc + current * weight_3
+            if cutlass.const_expr(bias is not None):
+                acc = acc + bias_value
+            output[token, channel] = (acc * sigmoid(acc)).to(cutlass.BFloat16)
+
+            if cutlass.const_expr(final_state is not None):
+                if token + cutlass.Int32(1) == sequence_end:
+                    final_state[sequence, channel, cutlass.Int32(0)] = history_0.to(cutlass.BFloat16)
+                    final_state[sequence, channel, cutlass.Int32(1)] = history_1.to(cutlass.BFloat16)
+                    final_state[sequence, channel, cutlass.Int32(2)] = history_2.to(cutlass.BFloat16)
+                    final_state[sequence, channel, cutlass.Int32(3)] = current.to(cutlass.BFloat16)
+
+            history_0 = history_1
+            history_1 = history_2
+            history_2 = current
+
+        token += cutlass.Int32(1)
+
+
+@cute.kernel
+def _causal_conv1d_bulk_vec8_fwd_kernel(
+    x: cute.Tensor,
+    weight: cute.Tensor,
+    bias: Optional[cute.Tensor],
+    initial_state: Optional[cute.Tensor],
+    cu_seqlens: Optional[cute.Tensor],
+    output: cute.Tensor,
+    final_state: Optional[cute.Tensor],
+    num_sequences: cutlass.Int32,
+    tokens_per_sequence: cutlass.Int32,
+    n_channels: cutlass.Int32,
+) -> None:
+    """Emit eight-token tiles with one aligned eight-channel vector per thread.
+
+    This specialization is launched only when the compile-time channel extent
+    is divisible by eight.  The API guarantees 16-byte base alignment and all
+    row strides are then multiples of eight BF16 elements.  Consequently every
+    valid vector below is aligned; ``channel_base < n_channels`` also proves the
+    entire eight-channel group is in bounds.
+    """
+
+    token_tile = cutlass.Int32(cute.arch.block_idx()[0])
+    channel_tile = cutlass.Int32(cute.arch.block_idx()[1])
+    tidx = cutlass.Int32(cute.arch.thread_idx()[0])
+    channel_base = channel_tile * cutlass.Int32(VEC_CHANNELS_PER_CTA) + tidx * cutlass.Int32(VEC_CHANNELS_PER_THREAD)
+    first_token = token_tile * cutlass.Int32(VEC_TOKENS_PER_CTA)
+    total_tokens = cutlass.Int32(x.shape[0])
+    valid_channel_group = channel_base < n_channels
+
+    # Four FP32 vectors are the four causal taps for eight channels.  Weight
+    # storage is [D, 4], so each 16-byte load naturally covers two complete
+    # adjacent channel rows and is transposed into the tap-major registers.
+    weight_0 = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
+    weight_1 = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
+    weight_2 = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
+    weight_3 = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
+    bias_values = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
+    zero = opaque_f32_zero()
+    for channel_offset in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD):
+        weight_0[channel_offset] = zero
+        weight_1[channel_offset] = zero
+        weight_2[channel_offset] = zero
+        weight_3[channel_offset] = zero
+        bias_values[channel_offset] = zero
+
+    if valid_channel_group:
+        if cutlass.const_expr(weight.element_type == cutlass.Float32):
+            for channel_offset in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD):
+                channel = channel_base + cutlass.Int32(channel_offset)
+                weight_element = cutlass.Int64(channel) * cutlass.Int64(weight.stride[0])
+                values = _load_f32x4(weight.iterator.toint() + weight_element * cutlass.Int64(4))
+                weight_0[channel_offset] = values[0]
+                weight_1[channel_offset] = values[1]
+                weight_2[channel_offset] = values[2]
+                weight_3[channel_offset] = values[3]
+        else:
+            for channel_pair in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD // 2):
+                pair_channel = channel_base + cutlass.Int32(2 * channel_pair)
+                weight_element = cutlass.Int64(pair_channel) * cutlass.Int64(weight.stride[0])
+                weight_address = weight.iterator.toint() + weight_element * cutlass.Int64(2)
+                values = _load_bf16x8(weight_address)
+                channel_offset = 2 * channel_pair
+                weight_0[channel_offset] = values[0]
+                weight_1[channel_offset] = values[1]
+                weight_2[channel_offset] = values[2]
+                weight_3[channel_offset] = values[3]
+                weight_0[channel_offset + 1] = values[4]
+                weight_1[channel_offset + 1] = values[5]
+                weight_2[channel_offset + 1] = values[6]
+                weight_3[channel_offset + 1] = values[7]
+        if cutlass.const_expr(bias is not None):
+            values = _load_bf16x8(bias.iterator.toint() + cutlass.Int64(channel_base) * cutlass.Int64(2))
+            for channel_offset in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD):
+                bias_values[channel_offset] = values[channel_offset]
+
+    sequence = cutlass.Int32(0)
+    sequence_start = cutlass.Int32(0)
+    sequence_end = cutlass.Int32(0)
+    if cutlass.const_expr(cu_seqlens is None):
+        sequence = first_token // tokens_per_sequence
+        sequence_start = sequence * tokens_per_sequence
+        sequence_end = sequence_start + tokens_per_sequence
+    else:
+        # Search and shuffle before the channel predicate: even threads whose
+        # vector falls beyond the final channel tile must participate in the
+        # full-warp shuffle mask.
+        if cute.arch.lane_idx() == cutlass.Int32(0):
+            lower = cutlass.Int32(0)
+            upper = num_sequences
+            while lower + cutlass.Int32(1) < upper:
+                middle = (lower + upper) // cutlass.Int32(2)
+                if first_token < cutlass.Int32(cu_seqlens[middle]):
+                    upper = middle
+                else:
+                    lower = middle
+            sequence = lower
+            sequence_start = cutlass.Int32(cu_seqlens[sequence])
+            sequence_end = cutlass.Int32(cu_seqlens[sequence + cutlass.Int32(1)])
+
+        sequence = cute.arch.shuffle_sync(sequence, 0)
+        sequence_start = cute.arch.shuffle_sync(sequence_start, 0)
+        sequence_end = cute.arch.shuffle_sync(sequence_end, 0)
+
+    history_0 = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
+    history_1 = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
+    history_2 = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
+    current = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
+    output_values = cutlass.Array(cutlass.Float32, VEC_CHANNELS_PER_THREAD, alignment=16)
+    for channel_offset in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD):
+        history_0[channel_offset] = zero
+        history_1[channel_offset] = zero
+        history_2[channel_offset] = zero
+        current[channel_offset] = zero
+        output_values[channel_offset] = zero
+
+    if valid_channel_group:
+        local_first_token = first_token - sequence_start
+
+        if local_first_token >= cutlass.Int32(3):
+            x_element = cutlass.Int64(first_token - cutlass.Int32(3)) * cutlass.Int64(x.stride[0]) + cutlass.Int64(channel_base)
+            values = _load_bf16x8(x.iterator.toint() + x_element * cutlass.Int64(2))
+            for channel_offset in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD):
+                history_0[channel_offset] = values[channel_offset]
+
+        if local_first_token >= cutlass.Int32(2):
+            x_element = cutlass.Int64(first_token - cutlass.Int32(2)) * cutlass.Int64(x.stride[0]) + cutlass.Int64(channel_base)
+            values = _load_bf16x8(x.iterator.toint() + x_element * cutlass.Int64(2))
+            for channel_offset in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD):
+                history_1[channel_offset] = values[channel_offset]
+
+        if local_first_token >= cutlass.Int32(1):
+            x_element = cutlass.Int64(first_token - cutlass.Int32(1)) * cutlass.Int64(x.stride[0]) + cutlass.Int64(channel_base)
+            values = _load_bf16x8(x.iterator.toint() + x_element * cutlass.Int64(2))
+            for channel_offset in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD):
+                history_2[channel_offset] = values[channel_offset]
+
+        # A single 16-byte state load per channel pair provides all four taps.
+        # Only the missing prefix is copied; input rows already loaded above
+        # remain authoritative farther into a sequence.
+        if cutlass.const_expr(initial_state is not None):
+            if local_first_token < cutlass.Int32(3):
+                for channel_pair in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD // 2):
+                    pair_channel = channel_base + cutlass.Int32(2 * channel_pair)
+                    state_element = cutlass.Int64(sequence) * cutlass.Int64(initial_state.stride[0]) + cutlass.Int64(pair_channel) * cutlass.Int64(
+                        initial_state.stride[1]
+                    )
+                    values = _load_bf16x8(initial_state.iterator.toint() + state_element * cutlass.Int64(2))
+                    channel_offset = 2 * channel_pair
+                    if local_first_token == cutlass.Int32(0):
+                        history_0[channel_offset] = values[1]
+                        history_1[channel_offset] = values[2]
+                        history_2[channel_offset] = values[3]
+                        history_0[channel_offset + 1] = values[5]
+                        history_1[channel_offset + 1] = values[6]
+                        history_2[channel_offset + 1] = values[7]
+                    elif local_first_token == cutlass.Int32(1):
+                        history_0[channel_offset] = values[2]
+                        history_1[channel_offset] = values[3]
+                        history_0[channel_offset + 1] = values[6]
+                        history_1[channel_offset + 1] = values[7]
+                    else:
+                        history_0[channel_offset] = values[3]
+                        history_0[channel_offset + 1] = values[7]
+
+    tile_end = first_token + cutlass.Int32(VEC_TOKENS_PER_CTA)
+    if tile_end > total_tokens:
+        tile_end = total_tokens
+
+    # This must remain a genuine runtime loop.  A constexpr-bounded Python
+    # while expands every token body and sharply inflates PTX/SASS and register
+    # liveness for larger token tiles.
+    for token in cutlass.range(first_token, tile_end, 1, unroll=1):
+        if token == sequence_end:
+            sequence += cutlass.Int32(1)
+            sequence_start = sequence_end
+            if cutlass.const_expr(cu_seqlens is None):
+                sequence_end += tokens_per_sequence
+            else:
+                sequence_end = cutlass.Int32(cu_seqlens[sequence + cutlass.Int32(1)])
+
+            if valid_channel_group:
+                for channel_offset in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD):
+                    history_0[channel_offset] = zero
+                    history_1[channel_offset] = zero
+                    history_2[channel_offset] = zero
+                if cutlass.const_expr(initial_state is not None):
+                    for channel_pair in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD // 2):
+                        pair_channel = channel_base + cutlass.Int32(2 * channel_pair)
+                        state_element = cutlass.Int64(sequence) * cutlass.Int64(initial_state.stride[0]) + cutlass.Int64(pair_channel) * cutlass.Int64(
+                            initial_state.stride[1]
+                        )
+                        values = _load_bf16x8(initial_state.iterator.toint() + state_element * cutlass.Int64(2))
+                        channel_offset = 2 * channel_pair
+                        history_0[channel_offset] = values[1]
+                        history_1[channel_offset] = values[2]
+                        history_2[channel_offset] = values[3]
+                        history_0[channel_offset + 1] = values[5]
+                        history_1[channel_offset + 1] = values[6]
+                        history_2[channel_offset + 1] = values[7]
+
+        if valid_channel_group:
+            x_element = cutlass.Int64(token) * cutlass.Int64(x.stride[0]) + cutlass.Int64(channel_base)
+            values = _load_bf16x8(x.iterator.toint() + x_element * cutlass.Int64(2))
+            for channel_offset in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD):
+                current[channel_offset] = values[channel_offset]
+
+            for channel_pair in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD // 2):
+                lo = 2 * channel_pair
+                hi = lo + 1
+                acc_lo, acc_hi = fmul2(history_0[lo], history_0[hi], weight_0[lo], weight_0[hi])
+                acc_lo, acc_hi = ffma2(history_1[lo], history_1[hi], weight_1[lo], weight_1[hi], acc_lo, acc_hi)
+                acc_lo, acc_hi = ffma2(history_2[lo], history_2[hi], weight_2[lo], weight_2[hi], acc_lo, acc_hi)
+                acc_lo, acc_hi = ffma2(current[lo], current[hi], weight_3[lo], weight_3[hi], acc_lo, acc_hi)
+                if cutlass.const_expr(bias is not None):
+                    acc_lo = acc_lo + bias_values[lo]
+                    acc_hi = acc_hi + bias_values[hi]
+                gate_lo, gate_hi = sigmoid2(acc_lo, acc_hi)
+                output_values[lo], output_values[hi] = fmul2(acc_lo, acc_hi, gate_lo, gate_hi)
+
+            output_element = cutlass.Int64(token) * cutlass.Int64(output.stride[0]) + cutlass.Int64(channel_base)
+            _store_bf16x8(
+                output.iterator.toint() + output_element * cutlass.Int64(2),
+                output_values[0],
+                output_values[1],
+                output_values[2],
+                output_values[3],
+                output_values[4],
+                output_values[5],
+                output_values[6],
+                output_values[7],
+            )
+
+            if cutlass.const_expr(final_state is not None):
+                if token + cutlass.Int32(1) == sequence_end:
+                    for channel_pair in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD // 2):
+                        pair_channel = channel_base + cutlass.Int32(2 * channel_pair)
+                        state_element = cutlass.Int64(sequence) * cutlass.Int64(final_state.stride[0]) + cutlass.Int64(pair_channel) * cutlass.Int64(
+                            final_state.stride[1]
+                        )
+                        channel_offset = 2 * channel_pair
+                        _store_bf16x8(
+                            final_state.iterator.toint() + state_element * cutlass.Int64(2),
+                            history_0[channel_offset],
+                            history_1[channel_offset],
+                            history_2[channel_offset],
+                            current[channel_offset],
+                            history_0[channel_offset + 1],
+                            history_1[channel_offset + 1],
+                            history_2[channel_offset + 1],
+                            current[channel_offset + 1],
+                        )
+
+            for channel_offset in cutlass.range_constexpr(VEC_CHANNELS_PER_THREAD):
+                history_0[channel_offset] = history_1[channel_offset]
+                history_1[channel_offset] = history_2[channel_offset]
+                history_2[channel_offset] = current[channel_offset]
+
+
+class CausalConv1dBulkForwardKernel:
+    """Host launcher for the BF16-activation, width-four forward slice.
+
+    ``use_vec8`` is selected from the exact compilation target.  Its packed
+    FP32 arithmetic requires SM100-or-newer instructions; the scalar schedule
+    is the functional fallback on supported pre-Blackwell architectures. Both
+    BF16 and FP32 filter specializations accumulate in FP32.
+    """
+
+    def __init__(self, *, use_vec8: bool = True):
+        self.use_vec8 = use_vec8
+
+    @cute.jit
+    def __call__(
+        self,
+        x: cute.Tensor,
+        weight: cute.Tensor,
+        bias: Optional[cute.Tensor],
+        initial_state: Optional[cute.Tensor],
+        cu_seqlens: Optional[cute.Tensor],
+        output: cute.Tensor,
+        final_state: Optional[cute.Tensor],
+        num_sequences: cutlass.Int32,
+        tokens_per_sequence: cutlass.Int32,
+        n_channels: cutlass.Int32,
+        stream: cuda.CUstream,
+    ) -> None:
+        if cutlass.const_expr(cu_seqlens is not None):
+            _validate_cu_seqlens_kernel(
+                cu_seqlens,
+                num_sequences,
+                cutlass.Int32(x.shape[0]),
+            ).launch(
+                grid=(1, 1, 1),
+                block=(THREADS, 1, 1),
+                stream=stream,
+            )
+
+        if cutlass.const_expr(self.use_vec8 and x.shape[1] % VEC_CHANNELS_PER_THREAD == 0):
+            _causal_conv1d_bulk_vec8_fwd_kernel(
+                x,
+                weight,
+                bias,
+                initial_state,
+                cu_seqlens,
+                output,
+                final_state,
+                num_sequences,
+                tokens_per_sequence,
+                n_channels,
+            ).launch(
+                grid=(cute.ceil_div(x.shape[0], VEC_TOKENS_PER_CTA), cute.ceil_div(x.shape[1], VEC_CHANNELS_PER_CTA), 1),
+                block=(VEC_THREADS, 1, 1),
+                stream=stream,
+            )
+        else:
+            _causal_conv1d_bulk_fwd_kernel(
+                x,
+                weight,
+                bias,
+                initial_state,
+                cu_seqlens,
+                output,
+                final_state,
+                num_sequences,
+                tokens_per_sequence,
+                n_channels,
+            ).launch(
+                grid=(cute.ceil_div(x.shape[0], TOKENS_PER_CTA), cute.ceil_div(x.shape[1], THREADS), 1),
+                block=(THREADS, 1, 1),
+                stream=stream,
+            )

--- a/python/cudnn/causal_conv1d_update_sm100/__init__.py
+++ b/python/cudnn/causal_conv1d_update_sm100/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Private implementation package for :mod:`cudnn.ops` causal-conv update."""
+
+from .api import _causal_conv1d_update as _causal_conv1d_update
+from .api import _CausalConv1dUpdatePlan as _CausalConv1dUpdatePlan
+
+__all__ = []

--- a/python/cudnn/causal_conv1d_update_sm100/api.py
+++ b/python/cudnn/causal_conv1d_update_sm100/api.py
@@ -1,0 +1,582 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Private prepared implementation for causal-convolution decode update.
+
+The model-facing API lives at :func:`cudnn.ops.causal_conv1d_update`. This
+module owns compilation, preallocated output execution, and explicit-stream
+support used by focused benchmarks; none of those mechanics are public API.
+"""
+
+import threading
+from contextlib import contextmanager
+from typing import Iterator, Optional, Union
+
+import cutlass
+import cutlass.cute as cute
+import torch
+from cuda.bindings import driver as cuda
+from cutlass.cute.runtime import make_fake_stream
+
+from cudnn._causal_conv1d_arch import (
+    is_supported_causal_conv1d_update_compute_capability,
+    supported_causal_conv1d_update_compute_capabilities_text,
+)
+from cudnn.api_base import APIBase, TensorDesc
+
+from .kernel import _CausalConv1dUpdateKernel
+
+_API_CACHE = {}
+_API_CACHE_LOCK = threading.Lock()
+_API_CACHE_CAPACITY = 128
+
+
+@contextmanager
+def _torch_stream_context(
+    current_stream: Optional[cuda.CUstream],
+    device: torch.device,
+) -> Iterator[None]:
+    """Run PyTorch allocations on the CUDA stream used by the kernel."""
+
+    if current_stream is None:
+        yield
+        return
+
+    launch_stream = _as_torch_stream(current_stream, device)
+    with torch.cuda.stream(launch_stream):
+        yield
+
+
+def _as_torch_stream(current_stream: cuda.CUstream, device: torch.device) -> torch.cuda.Stream:
+    """Resolve a concrete driver handle to the matching PyTorch stream."""
+
+    handle = int(current_stream)
+    torch_current = torch.cuda.current_stream(device)
+    torch_default = torch.cuda.default_stream(device)
+    if handle in (0, 1, torch_default.cuda_stream):
+        return torch_default
+    if handle == 2:
+        # CU_STREAM_PER_THREAD cannot be represented safely as a PyTorch
+        # ExternalStream on every supported build.
+        raise ValueError("causal_conv1d_update helpers do not support the " "CU_STREAM_PER_THREAD sentinel; pass a concrete stream handle")
+    if handle == torch_current.cuda_stream:
+        return torch_current
+    return torch.cuda.ExternalStream(handle, device=device)
+
+
+def _record_streams(
+    tensors: tuple[Optional[torch.Tensor], ...],
+    consumer: Optional[torch.cuda.Stream],
+) -> None:
+    """Keep raw-pointer operands alive through an explicit-stream launch."""
+
+    if consumer is None:
+        return
+    for tensor in tensors:
+        if tensor is not None:
+            tensor.record_stream(consumer)
+
+
+def _require_storage_alignment(tensor: torch.Tensor, alignment: int, name: str) -> None:
+    """Enforce the runtime alignment promised to CuTe during compilation."""
+
+    remainder = tensor.data_ptr() % alignment
+    if remainder:
+        raise ValueError(f"{name} data pointer must be {alignment}-byte aligned, " f"got address modulo {alignment} = {remainder}")
+
+
+def _tensor_byte_span(tensor: torch.Tensor) -> tuple[int, int]:
+    """Return the conservative byte span of one positive-stride tensor."""
+
+    begin = tensor.data_ptr()
+    if tensor.numel() == 0:
+        return begin, begin
+
+    # Most operands are contiguous. X may be row-strided and the W-1 state may
+    # be a channel-last transpose, so retain the general positive-stride path
+    # for those public layouts.
+    is_contiguous = getattr(tensor, "is_contiguous", None)
+    if is_contiguous is not None and is_contiguous():
+        return begin, begin + tensor.numel() * tensor.element_size()
+
+    shape = tuple(tensor.shape)
+    stride = tuple(tensor.stride())
+    last_element = 0
+    for dim, axis_stride in zip(shape, stride):
+        if dim > 1 and axis_stride <= 0:
+            raise ValueError("alias validation requires positive strides, " f"got shape {shape}, strides {stride}")
+        last_element += (dim - 1) * axis_stride
+    return begin, begin + (last_element + 1) * tensor.element_size()
+
+
+def _byte_spans_overlap(lhs: tuple[int, int], rhs: tuple[int, int]) -> bool:
+    lhs_begin, lhs_end = lhs
+    rhs_begin, rhs_end = rhs
+    if lhs_begin == lhs_end or rhs_begin == rhs_end:
+        return False
+    return lhs_begin < rhs_end and rhs_begin < lhs_end
+
+
+def _tensors_overlap(lhs: torch.Tensor, rhs: torch.Tensor) -> bool:
+    """Return whether two positive-stride tensor spans share device bytes.
+
+    ``torch._C._overlaps`` only compares PyTorch Storage identity. DLPack can
+    wrap the same device address in a distinct Storage, so compare byte spans
+    derived from shape and stride.  The span conservatively includes padding
+    between rows of a strided tensor.
+    """
+
+    return _byte_spans_overlap(_tensor_byte_span(lhs), _tensor_byte_span(rhs))
+
+
+class _CausalConv1dUpdatePlan(APIBase):
+    """Compile and execute BF16 K=4 causal-convolution decode.
+
+    Every compute capability admitted by the decode architecture policy uses
+    the same functional schedule.
+
+    This inference-only API advances ``state`` in place and writes ``output``.
+    It deliberately supports one narrow contract:
+
+    * ``x``: BF16 ``[N, D]`` with strides ``(ld, 1)``; compact rows admit any
+      ``D``, while padded rows require ``ld > D`` and ``ld % 8 == 0``
+    * ``output``: contiguous ``[N, D]`` BF16
+    * ``weight``: contiguous ``[D, 4]`` BF16
+    * ``state``: BF16 ``[S, D, L]`` with ``L`` in ``{3, 4}``, mutated in
+      place; compact storage is accepted for both lengths and the exact
+      channel-last prefill handoff is accepted for ``L=3``
+    * optional ``state_indices``: contiguous CUDA ``int32[N]``
+    * optional ``bias``: contiguous ``[D]`` BF16
+    * ``activation``: compile-time ``"identity"`` or ``"silu"``
+
+    Indexed slots must be ``-1`` or in ``[0, S)``.  ``-1`` marks a padding row
+    whose output is zero and whose state is untouched.  Non-padding slots must
+    be unique.  The kernel checks these properties on device and executes a
+    PTX trap on violation, so invalid mutable routing never silently races.
+    The CUDA error is asynchronous and the failed launch is not transactional.
+    """
+
+    def __init__(
+        self,
+        sample_x: Union[torch.Tensor, TensorDesc],
+        sample_weight: Union[torch.Tensor, TensorDesc],
+        sample_state: Union[torch.Tensor, TensorDesc],
+        sample_output: Union[torch.Tensor, TensorDesc],
+        sample_state_indices: Optional[Union[torch.Tensor, TensorDesc]] = None,
+        sample_bias: Optional[Union[torch.Tensor, TensorDesc]] = None,
+        *,
+        activation: str = "identity",
+    ):
+        super().__init__()
+        self._warn_experimental_api()
+
+        self.x_desc = self._make_tensor_desc(sample_x, name="sample_x")
+        self.weight_desc = self._make_tensor_desc(sample_weight, name="sample_weight")
+        self.state_desc = self._make_tensor_desc(sample_state, name="sample_state")
+        self.output_desc = self._make_tensor_desc(sample_output, name="sample_output")
+        self.state_indices_desc = self._make_tensor_desc(sample_state_indices, name="sample_state_indices")
+        self.bias_desc = self._make_tensor_desc(sample_bias, name="sample_bias")
+        if activation not in ("identity", "silu"):
+            raise ValueError(f"activation must be 'identity' or 'silu', got {activation!r}")
+        self.activation = activation
+
+        # TensorDesc deliberately does not retain sample tensors.  Preserve
+        # only the pointer remainders needed to validate the assumed alignment
+        # passed to make_fake_cute_tensor_from_desc().  Metadata-only samples
+        # defer this check to the live tensors validated by execute().
+        self._sample_alignment_remainders = {}
+        for name, sample, alignment in (
+            ("X", sample_x, 16),
+            ("Weight", sample_weight, 16),
+            ("State", sample_state, 16),
+            ("Output", sample_output, 16),
+            ("State indices", sample_state_indices, 4),
+            ("Bias", sample_bias, 16),
+        ):
+            data_ptr = getattr(sample, "data_ptr", None)
+            if callable(data_ptr):
+                self._sample_alignment_remainders[name] = data_ptr() % alignment
+
+        self.n_rows = None
+        self.n_channels = None
+        self.n_slots = None
+        self.state_len = None
+
+    @staticmethod
+    def _require_rank(desc: TensorDesc, rank: int, name: str) -> None:
+        if desc.ndim != rank:
+            raise ValueError(f"{name} must be {rank}D, got shape {desc.shape}")
+
+    @staticmethod
+    def _require_cuda(desc: TensorDesc, name: str) -> None:
+        if desc.device.type != "cuda":
+            raise ValueError(f"{name} must be a CUDA tensor, got device {desc.device}")
+
+    def check_support(self) -> bool:
+        self._require_rank(self.x_desc, 2, "X")
+        self._require_rank(self.weight_desc, 2, "Weight")
+        self._require_rank(self.state_desc, 3, "State")
+        self._require_rank(self.output_desc, 2, "Output")
+        if self.bias_desc is not None:
+            self._require_rank(self.bias_desc, 1, "Bias")
+        if self.state_indices_desc is not None:
+            self._require_rank(self.state_indices_desc, 1, "State indices")
+
+        n_rows, n_channels = self.x_desc.shape
+        n_slots = self.state_desc.shape[0]
+        state_len = self.state_desc.shape[2]
+        self._value_error_if(n_rows <= 0, f"N must be positive, got {n_rows}")
+        self._value_error_if(n_channels <= 0, f"D must be positive, got {n_channels}")
+        self._value_error_if(n_slots <= 0, f"S must be positive, got {n_slots}")
+        self._value_error_if(n_rows > 2**31 - 1, f"N exceeds the Int32 launch limit: {n_rows}")
+        self._value_error_if(n_slots > 2**31 - 1, f"S exceeds the Int32 indexing limit: {n_slots}")
+        self._value_error_if(
+            n_channels > 256 * 65535,
+            f"D exceeds the CUDA grid-y limit for 256-channel tiles: {n_channels}",
+        )
+        self._value_error_if(
+            state_len not in (3, 4),
+            f"State length must be 3 or 4 for width-four decode, got L={state_len}",
+        )
+
+        self._check_tensor_shape(self.weight_desc, (n_channels, 4), "Weight")
+        self._check_tensor_shape(self.state_desc, (n_slots, n_channels, state_len), "State")
+        self._check_tensor_shape(self.output_desc, (n_rows, n_channels), "Output")
+        if self.bias_desc is not None:
+            self._check_tensor_shape(self.bias_desc, (n_channels,), "Bias")
+        if self.state_indices_desc is None:
+            self._value_error_if(
+                n_slots < n_rows,
+                f"State needs at least N slots when state_indices is omitted, got S={n_slots}, N={n_rows}",
+            )
+        else:
+            self._check_tensor_shape(self.state_indices_desc, (n_rows,), "State indices")
+
+        x_row_stride, x_channel_stride = self.x_desc.stride
+        self._value_error_if(
+            x_channel_stride != 1,
+            f"X must have row-major strides (ld, 1), got {self.x_desc.stride}",
+        )
+        self._value_error_if(
+            x_row_stride < n_channels,
+            f"X row stride ld must be at least D={n_channels}, got ld={x_row_stride}",
+        )
+        self._value_error_if(
+            x_row_stride > n_channels and x_row_stride % 8 != 0,
+            "Padded X rows must start at 16-byte-aligned BF16 addresses " f"(ld % 8 == 0), got D={n_channels}, ld={x_row_stride}",
+        )
+        self._check_tensor_stride(
+            self.weight_desc,
+            stride=(4, 1),
+            name="Weight",
+            extra_error_msg="Weight must be row-major contiguous",
+        )
+        compact_state_stride = (n_channels * state_len, state_len, 1)
+        channel_last_state_stride = (n_channels * state_len, 1, n_channels)
+        state_stride_supported = self.state_desc.stride == compact_state_stride or (state_len == 3 and self.state_desc.stride == channel_last_state_stride)
+        self._value_error_if(
+            not state_stride_supported,
+            "State must be compact [S, D, L], or for L=3 a [S, 3, D]-backed " f"transpose; got strides {self.state_desc.stride}",
+        )
+        self._check_tensor_stride(
+            self.output_desc,
+            stride=(n_channels, 1),
+            name="Output",
+            extra_error_msg="Output must be row-major contiguous",
+        )
+        if self.bias_desc is not None:
+            self._check_tensor_stride(
+                self.bias_desc,
+                stride=(1,),
+                name="Bias",
+                extra_error_msg="Bias must be contiguous",
+            )
+        if self.state_indices_desc is not None:
+            self._check_tensor_stride(
+                self.state_indices_desc,
+                stride=(1,),
+                name="State indices",
+                extra_error_msg="State indices must be contiguous",
+            )
+
+        self._check_dtype(self.x_desc, dtype=torch.bfloat16, name="X")
+        self._check_dtype(self.weight_desc, dtype=torch.bfloat16, name="Weight")
+        self._check_dtype(self.state_desc, dtype=torch.bfloat16, name="State")
+        self._check_dtype(self.output_desc, dtype=torch.bfloat16, name="Output")
+        if self.bias_desc is not None:
+            self._check_dtype(self.bias_desc, dtype=torch.bfloat16, name="Bias")
+        if self.state_indices_desc is not None:
+            self._check_dtype(self.state_indices_desc, dtype=torch.int32, name="State indices")
+
+        for name, remainder in self._sample_alignment_remainders.items():
+            alignment = 4 if name == "State indices" else 16
+            self._value_error_if(
+                remainder != 0,
+                f"{name} data pointer must be {alignment}-byte aligned, " f"got address modulo {alignment} = {remainder}",
+            )
+
+        descs = [
+            ("X", self.x_desc),
+            ("Weight", self.weight_desc),
+            ("State", self.state_desc),
+            ("Output", self.output_desc),
+        ]
+        if self.bias_desc is not None:
+            descs.append(("Bias", self.bias_desc))
+        if self.state_indices_desc is not None:
+            descs.append(("State indices", self.state_indices_desc))
+        for name, desc in descs:
+            self._require_cuda(desc, name)
+            self._value_error_if(
+                desc.device != self.x_desc.device,
+                f"{name} must be on {self.x_desc.device}, got {desc.device}",
+            )
+
+        self._runtime_error_if(not torch.cuda.is_available(), "CUDA is not available")
+        compute_capability = torch.cuda.get_device_capability(self.x_desc.device)
+        self._runtime_error_if(
+            not is_supported_causal_conv1d_update_compute_capability(compute_capability),
+            "causal_conv1d_update supports compute capabilities "
+            f"{supported_causal_conv1d_update_compute_capabilities_text()}, "
+            f"found {compute_capability[0]}.{compute_capability[1]}",
+        )
+
+        self.n_rows = n_rows
+        self.n_channels = n_channels
+        self.n_slots = n_slots
+        self.state_len = state_len
+        self._is_supported = True
+        return True
+
+    def compile(self) -> None:
+        self._ensure_support_checked()
+        if self._compiled_kernel is not None:
+            return
+
+        fake_x = self._make_fake_cute_tensor_from_desc(self.x_desc, assumed_align=16)
+        fake_weight = self._make_fake_cute_tensor_from_desc(self.weight_desc, assumed_align=16)
+        fake_bias = self._make_fake_cute_tensor_from_desc(self.bias_desc, assumed_align=16)
+        fake_state = self._make_fake_cute_tensor_from_desc(self.state_desc, assumed_align=16)
+        fake_output = self._make_fake_cute_tensor_from_desc(self.output_desc, assumed_align=16)
+        fake_state_indices = self._make_fake_cute_tensor_from_desc(self.state_indices_desc, assumed_align=4)
+        fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
+
+        kernel = _CausalConv1dUpdateKernel(
+            apply_silu=self.activation == "silu",
+            state_len=self.state_len,
+        )
+        # CuTe DSL targets the current CUDA device.  Honor the sample tensor's
+        # device even when a multi-GPU caller has another device current.
+        with torch.cuda.device(self.x_desc.device):
+            self._compiled_kernel = cute.compile(
+                kernel,
+                fake_x,
+                fake_weight,
+                fake_bias,
+                fake_state,
+                fake_output,
+                fake_state_indices,
+                cutlass.Int32(self.n_slots),
+                cutlass.Int32(self.n_channels),
+                fake_stream,
+                options="--enable-tvm-ffi --generate-line-info",
+            )
+
+    @staticmethod
+    def _validate_runtime_tensor(tensor: torch.Tensor, desc: TensorDesc, name: str) -> None:
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(f"{name} must be a torch.Tensor, got {type(tensor).__name__}")
+        if tuple(tensor.shape) != desc.shape:
+            raise ValueError(f"{name} shape mismatch: expected {desc.shape}, got {tuple(tensor.shape)}")
+        if tuple(tensor.stride()) != desc.stride:
+            raise ValueError(f"{name} stride mismatch: expected {desc.stride}, got {tuple(tensor.stride())}")
+        if tensor.dtype != desc.dtype:
+            raise TypeError(f"{name} dtype mismatch: expected {desc.dtype}, got {tensor.dtype}")
+        if tensor.device != desc.device:
+            raise ValueError(f"{name} device mismatch: expected {desc.device}, got {tensor.device}")
+
+    def execute(
+        self,
+        x_tensor: torch.Tensor,
+        weight_tensor: torch.Tensor,
+        state_tensor: torch.Tensor,
+        output_tensor: torch.Tensor,
+        state_indices_tensor: Optional[torch.Tensor] = None,
+        current_stream: Optional[cuda.CUstream] = None,
+        bias_tensor: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        self._runtime_error_if(
+            self._compiled_kernel is None,
+            "causal_conv1d_update plan not compiled; call compile() first",
+        )
+
+        self._validate_runtime_tensor(x_tensor, self.x_desc, "X")
+        self._validate_runtime_tensor(weight_tensor, self.weight_desc, "Weight")
+        self._validate_runtime_tensor(state_tensor, self.state_desc, "State")
+        self._validate_runtime_tensor(output_tensor, self.output_desc, "Output")
+        if (bias_tensor is None) != (self.bias_desc is None):
+            raise ValueError("bias presence must match the compiled signature")
+        if bias_tensor is not None:
+            self._validate_runtime_tensor(bias_tensor, self.bias_desc, "Bias")
+        if (state_indices_tensor is None) != (self.state_indices_desc is None):
+            raise ValueError("state_indices presence must match the compiled signature")
+        if state_indices_tensor is not None:
+            self._validate_runtime_tensor(
+                state_indices_tensor,
+                self.state_indices_desc,
+                "State indices",
+            )
+
+        operands = (
+            ("X", x_tensor, 16),
+            ("Weight", weight_tensor, 16),
+            ("State", state_tensor, 16),
+            ("Output", output_tensor, 16),
+            ("Bias", bias_tensor, 16),
+            ("State indices", state_indices_tensor, 4),
+        )
+        spans = {}
+        for name, tensor, alignment in operands:
+            if tensor is not None:
+                _require_storage_alignment(tensor, alignment, name)
+                spans[name] = _tensor_byte_span(tensor)
+
+        grad_tensors = (
+            x_tensor,
+            weight_tensor,
+            state_tensor,
+            output_tensor,
+            bias_tensor,
+        )
+        if torch.is_grad_enabled() and any(tensor is not None and tensor.requires_grad for tensor in grad_tensors):
+            raise RuntimeError("causal_conv1d_update is inference-only; call it under torch.no_grad()")
+        for owner, other in (
+            ("State", "X"),
+            ("State", "Weight"),
+            ("State", "Output"),
+            ("State", "Bias"),
+            ("State", "State indices"),
+            ("Output", "X"),
+            ("Output", "Weight"),
+            ("Output", "Bias"),
+            ("Output", "State indices"),
+        ):
+            if other in spans and _byte_spans_overlap(spans[owner], spans[other]):
+                raise ValueError(f"{owner} must not overlap {other}")
+
+        if current_stream is None:
+            consumer_stream = torch.cuda.current_stream(x_tensor.device)
+            launch_stream = cuda.CUstream(consumer_stream.cuda_stream)
+        else:
+            consumer_stream = _as_torch_stream(current_stream, x_tensor.device)
+            launch_stream = current_stream
+
+        self._compiled_kernel(
+            x_tensor,
+            weight_tensor,
+            bias_tensor,
+            state_tensor,
+            output_tensor,
+            state_indices_tensor,
+            cutlass.Int32(self.n_slots),
+            cutlass.Int32(self.n_channels),
+            launch_stream,
+        )
+        _record_streams(
+            (
+                x_tensor,
+                weight_tensor,
+                bias_tensor,
+                state_tensor,
+                output_tensor,
+                state_indices_tensor,
+            ),
+            consumer_stream,
+        )
+        return output_tensor
+
+
+def _cache_key(
+    x_tensor: torch.Tensor,
+    state_tensor: torch.Tensor,
+    weight_tensor: torch.Tensor,
+    state_indices_tensor: Optional[torch.Tensor],
+    bias_tensor: Optional[torch.Tensor],
+    activation: str,
+):
+    return (
+        x_tensor.device.type,
+        x_tensor.device.index,
+        tuple(x_tensor.shape),
+        tuple(x_tensor.stride()),
+        tuple(weight_tensor.shape),
+        tuple(state_tensor.shape),
+        tuple(state_tensor.stride()),
+        state_indices_tensor is not None,
+        bias_tensor is not None,
+        activation,
+    )
+
+
+def _causal_conv1d_update(
+    x: torch.Tensor,
+    conv_state: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    activation: str = "identity",
+    *,
+    conv_state_indices: Optional[torch.Tensor] = None,
+    current_stream: Optional[cuda.CUstream] = None,
+) -> torch.Tensor:
+    """Private allocating route used by the public custom op and FLA adapter.
+
+    ``conv_state`` is updated in place. ``activation`` is already normalized
+    to ``"identity"`` or ``"silu"`` by the public semantic API. Explicit
+    streams remain private because the public PyTorch operation follows the
+    current-stream convention.
+    """
+
+    for name, tensor in (("X", x), ("Weight", weight), ("State", conv_state)):
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(f"{name} must be a torch.Tensor, got {type(tensor).__name__}")
+    if conv_state_indices is not None and not isinstance(conv_state_indices, torch.Tensor):
+        raise TypeError("State indices must be a torch.Tensor or None, " f"got {type(conv_state_indices).__name__}")
+    if bias is not None and not isinstance(bias, torch.Tensor):
+        raise TypeError("Bias must be a torch.Tensor or None, " f"got {type(bias).__name__}")
+    if activation not in ("identity", "silu"):
+        raise ValueError(f"activation must be 'identity' or 'silu', got {activation!r}")
+    if not x.is_cuda:
+        raise ValueError(f"X must be a CUDA tensor, got device {x.device}")
+    key = _cache_key(x, conv_state, weight, conv_state_indices, bias, activation)
+
+    with torch.cuda.device(x.device), _torch_stream_context(current_stream, x.device):
+        output = torch.empty_like(x, memory_format=torch.contiguous_format)
+        api = _API_CACHE.get(key)
+        if api is None:
+            with _API_CACHE_LOCK:
+                api = _API_CACHE.get(key)
+                if api is None:
+                    api = _CausalConv1dUpdatePlan(
+                        sample_x=x,
+                        sample_weight=weight,
+                        sample_state=conv_state,
+                        sample_output=output,
+                        sample_state_indices=conv_state_indices,
+                        sample_bias=bias,
+                        activation=activation,
+                    )
+                    api.check_support()
+                    api.compile()
+                    if len(_API_CACHE) >= _API_CACHE_CAPACITY:
+                        _API_CACHE.pop(next(iter(_API_CACHE)))
+                    _API_CACHE[key] = api
+
+        return api.execute(
+            x_tensor=x,
+            weight_tensor=weight,
+            state_tensor=conv_state,
+            output_tensor=output,
+            state_indices_tensor=conv_state_indices,
+            current_stream=current_stream,
+            bias_tensor=bias,
+        )

--- a/python/cudnn/causal_conv1d_update_sm100/kernel.py
+++ b/python/cudnn/causal_conv1d_update_sm100/kernel.py
@@ -1,0 +1,389 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""BF16 causal-convolution decode update kernel.
+
+The state transition follows the public ``causal_conv1d_update`` contract used
+by FLA's ``ShortConvolution.step``: append the current token to the history,
+retain the configured state length, take a four-wide depthwise dot product,
+then optionally apply SiLU. No source from either behavioral reference below
+is included. This implementation uses CUTLASS/CuTe DSL, inline PTX, and in-tree
+NVIDIA FROST primitives.
+
+Semantic references consulted:
+
+* fla-org/flash-linear-attention, ``fla/modules/conv/short_conv.py`` and
+  ``fla/modules/conv/triton/kernels.py`` (MIT), FLA 0.5.2.
+* Dao-AILab/causal-conv1d's public ``causal_conv1d_update`` API contract
+  (BSD-3-Clause), revision ``cd81f0413cad2fc1e6f17e785ac39f59aae690cd``.
+
+Only the four-wide, BF16, optional-bias inference specialization lives here.
+State length four keeps the original vectorized path. State length three, the
+standard ``W - 1`` prefill handoff, uses a separate scalar state specialization.
+Identity and SiLU are separate compile-time specializations.
+The input is addressed through its compiled ``(ld, 1)`` strides, including a
+16-byte-row-aligned padded leading dimension. The three-element mutable state
+uses its compiled strides so full-sequence prefill can hand off channel-last
+storage without a copy; the four-element state retains its compact vectorized
+path.
+One decode row is assigned to each CTA on every admitted architecture. This is
+an independent FE-native implementation using the original inline-PTX data
+path.
+"""
+
+from typing import Optional
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.arch.nvvm_wrappers import inline_ptx
+
+from cudnn.frost.tile_dsl.pointwise import f16x2_to_f32, sigmoid
+
+THREADS = 256
+
+
+@cute.kernel
+def _causal_conv1d_update_kernel(
+    x: cute.Tensor,
+    weight: cute.Tensor,
+    bias: Optional[cute.Tensor],
+    state: cute.Tensor,
+    output: cute.Tensor,
+    state_indices: Optional[cute.Tensor],
+    n_slots: cutlass.Int32,
+    n_channels: cutlass.Int32,
+    apply_silu: cutlass.Constexpr[bool],
+) -> None:
+    """Advance one 256-channel tile of a state row and emit its output tile.
+
+    ``state_indices`` is optional-specialized.  ``-1`` is a padding row: it
+    writes a zero output and does not mutate state.  Other indexed calls trap
+    on an out-of-range or duplicate slot before that CTA writes state.
+    Rejecting duplicates makes the mutation deterministic rather than allowing
+    two decode rows to race on the same mutable cache slot.
+    """
+
+    row = cutlass.Int32(cute.arch.block_idx()[0])
+    channel_tile = cutlass.Int32(cute.arch.block_idx()[1])
+    tidx = cutlass.Int32(cute.arch.thread_idx()[0])
+
+    slot = row
+    if cutlass.const_expr(state_indices is not None):
+        slot = cutlass.Int32(state_indices[row])
+        if tidx == cutlass.Int32(0):
+            # CuTe's testing assert lowers away in release device builds.  PTX
+            # trap is the fail-closed primitive here and is covered by GPU
+            # subprocess tests for every invalid-index class.
+            inline_ptx("trap;", predicate=slot < cutlass.Int32(-1))
+            inline_ptx("trap;", predicate=slot >= n_slots)
+
+            # Decode batches are small.  A lane-zero scan keeps the operation
+            # single-kernel while failing closed on duplicate mutable slots.
+            # Padding rows do not own state, so repeated -1 entries are valid.
+            if slot >= cutlass.Int32(0) and channel_tile == cutlass.Int32(0):
+                # A trap in the first channel tile aborts the whole launch;
+                # repeating this O(N^2) scan in every channel tile adds no
+                # validation coverage.
+                previous_row = cutlass.Int32(0)
+                while previous_row < row:
+                    inline_ptx(
+                        "trap;",
+                        predicate=cutlass.Int32(state_indices[previous_row]) == slot,
+                    )
+                    previous_row += cutlass.Int32(1)
+        cute.arch.barrier()
+
+    if cutlass.const_expr(state_indices is not None):
+        is_padding = slot == cutlass.Int32(-1)
+        if is_padding:
+            # Keep all later pointer arithmetic in range.  Loads from slot zero
+            # are harmless because the indexed padding branch suppresses the
+            # state store and observable convolution result.
+            slot = cutlass.Int32(0)
+
+    channel = channel_tile * cutlass.Int32(THREADS) + tidx
+    if channel < n_channels:
+        state_element = cutlass.Int64(slot) * cutlass.Int64(state.stride[0]) + cutlass.Int64(channel) * cutlass.Int64(state.stride[1])
+        state_address = state.iterator.toint() + state_element * cutlass.Int64(2)
+        weight_address = weight.iterator.toint() + cutlass.Int64(channel) * cutlass.Int64(weight.stride[0]) * cutlass.Int64(2)
+        x_element = cutlass.Int64(row) * cutlass.Int64(x.stride[0]) + cutlass.Int64(channel) * cutlass.Int64(x.stride[1])
+        x_address = x.iterator.toint() + x_element * cutlass.Int64(2)
+
+        state_01, state_23 = inline_ptx(
+            "ld.global.v2.b32 {$0, $1}, [$2];",
+            write_only_types=[cutlass.Int32, cutlass.Int32],
+            read_only_args=[state_address],
+        )
+        weight_01, weight_23 = inline_ptx(
+            "ld.global.v2.b32 {$0, $1}, [$2];",
+            write_only_types=[cutlass.Int32, cutlass.Int32],
+            read_only_args=[weight_address],
+        )
+        x_bits = inline_ptx(
+            "ld.global.u16 $0, [$1];",
+            write_only_types=[cutlass.Uint16],
+            read_only_args=[x_address],
+        )
+
+        _state_0, state_1 = f16x2_to_f32(state_01, dtype=cutlass.BFloat16)
+        state_2, state_3 = f16x2_to_f32(state_23, dtype=cutlass.BFloat16)
+        weight_0, weight_1 = f16x2_to_f32(weight_01, dtype=cutlass.BFloat16)
+        weight_2, weight_3 = f16x2_to_f32(weight_23, dtype=cutlass.BFloat16)
+        bias_value = cutlass.Float32(0.0)
+        if cutlass.const_expr(bias is not None):
+            bias_value = bias[channel].to(cutlass.Float32)
+        x_f32 = inline_ptx(
+            "{ .reg .b16 x; mov.b16 x, $1; mov.b32 $0, {0, x}; }",
+            write_only_types=[cutlass.Float32],
+            read_only_args=[x_bits],
+        )
+
+        # The updated state is [old_1, old_2, old_3, x].  Pack from the raw
+        # BF16 words so the shift and append are bitwise, including signed zero
+        # and NaN payloads; only the output path converts through FP32.
+        updated_01, updated_23 = inline_ptx(
+            "{ .reg .b16 s0, s1, s2, s3, xv; " "mov.b32 {s0, s1}, $2; mov.b32 {s2, s3}, $3; mov.b16 xv, $4; " "mov.b32 $0, {s1, s2}; mov.b32 $1, {s3, xv}; }",
+            write_only_types=[cutlass.Int32, cutlass.Int32],
+            read_only_args=[state_01, state_23, x_bits],
+        )
+        if cutlass.const_expr(state_indices is not None):
+            if not is_padding:
+                inline_ptx(
+                    "st.global.v2.b32 [$0], {$1, $2};",
+                    read_only_args=[state_address, updated_01, updated_23],
+                )
+        else:
+            inline_ptx(
+                "st.global.v2.b32 [$0], {$1, $2};",
+                read_only_args=[state_address, updated_01, updated_23],
+            )
+
+        acc = state_1 * weight_0
+        acc = acc + state_2 * weight_1
+        acc = acc + state_3 * weight_2
+        acc = acc + x_f32 * weight_3
+        acc = acc + bias_value
+        if cutlass.const_expr(apply_silu):
+            acc = acc * sigmoid(acc)
+
+        if cutlass.const_expr(state_indices is not None):
+            if is_padding:
+                output[row, channel] = cutlass.Float32(0.0).to(cutlass.BFloat16)
+            else:
+                output[row, channel] = acc.to(cutlass.BFloat16)
+        else:
+            output[row, channel] = acc.to(cutlass.BFloat16)
+
+
+@cute.kernel
+def _causal_conv1d_update_l3_kernel(
+    x: cute.Tensor,
+    weight: cute.Tensor,
+    bias: Optional[cute.Tensor],
+    state: cute.Tensor,
+    output: cute.Tensor,
+    state_indices: Optional[cute.Tensor],
+    n_slots: cutlass.Int32,
+    n_channels: cutlass.Int32,
+    apply_silu: cutlass.Constexpr[bool],
+) -> None:
+    """Advance a three-element ``W - 1`` state for one decode token.
+
+    This specialization deliberately uses scalar state loads and stores. The
+    four-element kernel above retains its original vector load/store path.
+    """
+
+    row = cutlass.Int32(cute.arch.block_idx()[0])
+    channel_tile = cutlass.Int32(cute.arch.block_idx()[1])
+    tidx = cutlass.Int32(cute.arch.thread_idx()[0])
+
+    slot = row
+    if cutlass.const_expr(state_indices is not None):
+        slot = cutlass.Int32(state_indices[row])
+        if tidx == cutlass.Int32(0):
+            inline_ptx("trap;", predicate=slot < cutlass.Int32(-1))
+            inline_ptx("trap;", predicate=slot >= n_slots)
+            if slot >= cutlass.Int32(0) and channel_tile == cutlass.Int32(0):
+                # A trap in the first channel tile aborts the whole launch;
+                # repeating this O(N^2) scan in every channel tile adds no
+                # validation coverage.
+                previous_row = cutlass.Int32(0)
+                while previous_row < row:
+                    inline_ptx(
+                        "trap;",
+                        predicate=cutlass.Int32(state_indices[previous_row]) == slot,
+                    )
+                    previous_row += cutlass.Int32(1)
+        cute.arch.barrier()
+
+    if cutlass.const_expr(state_indices is not None):
+        is_padding = slot == cutlass.Int32(-1)
+        if is_padding:
+            slot = cutlass.Int32(0)
+
+    channel = channel_tile * cutlass.Int32(THREADS) + tidx
+    if channel < n_channels:
+        state_element = cutlass.Int64(slot) * cutlass.Int64(state.stride[0]) + cutlass.Int64(channel) * cutlass.Int64(state.stride[1])
+        state_address = state.iterator.toint() + state_element * cutlass.Int64(2)
+        state_token_stride_bytes = cutlass.Int64(state.stride[2]) * cutlass.Int64(2)
+        state_1_address = state_address + state_token_stride_bytes
+        state_2_address = state_address + cutlass.Int64(2) * state_token_stride_bytes
+        weight_address = weight.iterator.toint() + cutlass.Int64(channel) * cutlass.Int64(weight.stride[0]) * cutlass.Int64(2)
+        x_element = cutlass.Int64(row) * cutlass.Int64(x.stride[0]) + cutlass.Int64(channel) * cutlass.Int64(x.stride[1])
+        x_address = x.iterator.toint() + x_element * cutlass.Int64(2)
+
+        state_0_bits = inline_ptx(
+            "ld.global.u16 $0, [$1];",
+            write_only_types=[cutlass.Uint16],
+            read_only_args=[state_address],
+        )
+        state_1_bits = inline_ptx(
+            "ld.global.u16 $0, [$1];",
+            write_only_types=[cutlass.Uint16],
+            read_only_args=[state_1_address],
+        )
+        state_2_bits = inline_ptx(
+            "ld.global.u16 $0, [$1];",
+            write_only_types=[cutlass.Uint16],
+            read_only_args=[state_2_address],
+        )
+        weight_01, weight_23 = inline_ptx(
+            "ld.global.v2.b32 {$0, $1}, [$2];",
+            write_only_types=[cutlass.Int32, cutlass.Int32],
+            read_only_args=[weight_address],
+        )
+        x_bits = inline_ptx(
+            "ld.global.u16 $0, [$1];",
+            write_only_types=[cutlass.Uint16],
+            read_only_args=[x_address],
+        )
+
+        state_0 = inline_ptx(
+            "{ .reg .b16 x; mov.b16 x, $1; mov.b32 $0, {0, x}; }",
+            write_only_types=[cutlass.Float32],
+            read_only_args=[state_0_bits],
+        )
+        state_1 = inline_ptx(
+            "{ .reg .b16 x; mov.b16 x, $1; mov.b32 $0, {0, x}; }",
+            write_only_types=[cutlass.Float32],
+            read_only_args=[state_1_bits],
+        )
+        state_2 = inline_ptx(
+            "{ .reg .b16 x; mov.b16 x, $1; mov.b32 $0, {0, x}; }",
+            write_only_types=[cutlass.Float32],
+            read_only_args=[state_2_bits],
+        )
+        weight_0, weight_1 = f16x2_to_f32(weight_01, dtype=cutlass.BFloat16)
+        weight_2, weight_3 = f16x2_to_f32(weight_23, dtype=cutlass.BFloat16)
+        bias_value = cutlass.Float32(0.0)
+        if cutlass.const_expr(bias is not None):
+            bias_value = bias[channel].to(cutlass.Float32)
+        x_f32 = inline_ptx(
+            "{ .reg .b16 x; mov.b16 x, $1; mov.b32 $0, {0, x}; }",
+            write_only_types=[cutlass.Float32],
+            read_only_args=[x_bits],
+        )
+
+        # Preserve BF16 payload bits in the state transition [old_1, old_2, x].
+        # A compact three-element channel row is only two-byte aligned for odd
+        # channels, while the prefill handoff strides across token planes. Every
+        # state access is therefore deliberately scalar and uses the compiled
+        # token stride.
+        if cutlass.const_expr(state_indices is not None):
+            if not is_padding:
+                inline_ptx(
+                    "st.global.u16 [$0], $1;",
+                    read_only_args=[state_address, state_1_bits],
+                )
+                inline_ptx(
+                    "st.global.u16 [$0], $1;",
+                    read_only_args=[state_1_address, state_2_bits],
+                )
+                inline_ptx(
+                    "st.global.u16 [$0], $1;",
+                    read_only_args=[state_2_address, x_bits],
+                )
+        else:
+            inline_ptx(
+                "st.global.u16 [$0], $1;",
+                read_only_args=[state_address, state_1_bits],
+            )
+            inline_ptx(
+                "st.global.u16 [$0], $1;",
+                read_only_args=[state_1_address, state_2_bits],
+            )
+            inline_ptx(
+                "st.global.u16 [$0], $1;",
+                read_only_args=[state_2_address, x_bits],
+            )
+
+        acc = state_0 * weight_0
+        acc = acc + state_1 * weight_1
+        acc = acc + state_2 * weight_2
+        acc = acc + x_f32 * weight_3
+        acc = acc + bias_value
+        if cutlass.const_expr(apply_silu):
+            acc = acc * sigmoid(acc)
+
+        if cutlass.const_expr(state_indices is not None):
+            if is_padding:
+                output[row, channel] = cutlass.Float32(0.0).to(cutlass.BFloat16)
+            else:
+                output[row, channel] = acc.to(cutlass.BFloat16)
+        else:
+            output[row, channel] = acc.to(cutlass.BFloat16)
+
+
+class _CausalConv1dUpdateKernel:
+    """Host launcher for the portable one-row decode specialization."""
+
+    def __init__(self, *, apply_silu: bool, state_len: int):
+        self.apply_silu = apply_silu
+        self.state_len = state_len
+
+    @cute.jit
+    def __call__(
+        self,
+        x: cute.Tensor,
+        weight: cute.Tensor,
+        bias: Optional[cute.Tensor],
+        state: cute.Tensor,
+        output: cute.Tensor,
+        state_indices: Optional[cute.Tensor],
+        n_slots: cutlass.Int32,
+        n_channels: cutlass.Int32,
+        stream: cuda.CUstream,
+    ) -> None:
+        if cutlass.const_expr(self.state_len == 4):
+            _causal_conv1d_update_kernel(
+                x,
+                weight,
+                bias,
+                state,
+                output,
+                state_indices,
+                n_slots,
+                n_channels,
+                self.apply_silu,
+            ).launch(
+                grid=(x.shape[0], cute.ceil_div(x.shape[1], THREADS), 1),
+                block=(THREADS, 1, 1),
+                stream=stream,
+            )
+        else:
+            _causal_conv1d_update_l3_kernel(
+                x,
+                weight,
+                bias,
+                state,
+                output,
+                state_indices,
+                n_slots,
+                n_channels,
+                self.apply_silu,
+            ).launch(
+                grid=(x.shape[0], cute.ceil_div(x.shape[1], THREADS), 1),
+                block=(THREADS, 1, 1),
+                stream=stream,
+            )

--- a/python/cudnn/fla/__init__.py
+++ b/python/cudnn/fla/__init__.py
@@ -6,13 +6,15 @@
 ``accelerate_fla()`` monkeypatches FLA entry points cuDNN can serve and
 transparently calls the original implementation for unsupported configurations.
 The backward-compatible no-argument call enables the linear-attention targets
-(``gated_delta_rule`` and ``kda``).  The dense MLP adapter is intentionally
-opt-in because it has a narrower FLA 0.5.2/local-module contract::
+(``gated_delta_rule`` and ``kda``).  The dense MLP and decode short-convolution
+adapters are intentionally opt-in because they have narrower FLA 0.5.2
+contracts::
 
     import cudnn.fla
 
     cudnn.fla.accelerate_fla()                    # GDN + KDA, as before
     cudnn.fla.accelerate_fla(targets="gated_mlp") # incremental MLP opt-in
+    cudnn.fla.accelerate_fla(targets="short_conv") # decode short-conv opt-in
 
 Targets can be enabled and restored independently.  Every adapter is
 fail-closed: an incompatible installed FLA target rejects explicit activation,
@@ -32,8 +34,18 @@ from .gated_mlp import last_path as mlp_last_path
 from .gated_mlp import make_gated_mlp_forward
 from .gated_mlp import _supports_installed_fla
 from .kda import make_chunk_kda
+from .short_conv import last_path as short_conv_last_path
+from .short_conv import make_causal_conv1d_update
+from .short_conv import _supports_installed_fla as _supports_short_conv_fla
 
-__all__ = ["accelerate_fla", "is_accelerated", "last_path", "mlp_last_path", "restore_fla"]
+__all__ = [
+    "accelerate_fla",
+    "is_accelerated",
+    "last_path",
+    "mlp_last_path",
+    "restore_fla",
+    "short_conv_last_path",
+]
 
 
 @dataclass(frozen=True)
@@ -74,6 +86,29 @@ def _gated_mlp_replacement(module, owner, original):
     return make_gated_mlp_forward(original, owner, swiglu_linear_cls)
 
 
+def _matches_short_conv_target(module, original) -> bool:
+    """Match the owned FLA 0.5.2 entry point without pinning wrapper internals."""
+
+    return (
+        callable(original)
+        and module.__dict__.get("causal_conv1d_update") is original
+        and getattr(original, "__module__", None) == module.__name__
+        and getattr(original, "__name__", None) == "causal_conv1d_update"
+        and getattr(original, "__qualname__", None) == "causal_conv1d_update"
+        and getattr(original, "_torchdynamo_disable", None) is True
+        and getattr(original, "_torchdynamo_orig_callable", None) is getattr(original, "__wrapped__", None)
+    )
+
+
+def _short_conv_replacement(module, owner, original):
+    del owner
+    if not _supports_short_conv_fla():
+        raise ImportError("the cuDNN short-conv shim requires flash-linear-attention==0.5.2")
+    if not _matches_short_conv_target(module, original):
+        raise ImportError("FLA causal_conv1d_update does not match the expected owning module")
+    return make_causal_conv1d_update(original)
+
+
 _TARGETS = {
     "gated_delta_rule": _PatchSpec(
         "fla.ops.gated_delta_rule",
@@ -92,8 +127,14 @@ _TARGETS = {
         owner_attribute="GatedMLP",
         default=False,
     ),
+    "short_conv": _PatchSpec(
+        "fla.modules.conv.triton.ops",
+        "causal_conv1d_update",
+        _short_conv_replacement,
+        default=False,
+    ),
 }
-_ALIASES = {"gdn": "gated_delta_rule", "mlp": "gated_mlp"}
+_ALIASES = {"gdn": "gated_delta_rule", "mlp": "gated_mlp", "shortconv": "short_conv"}
 _DEFAULT_TARGETS = tuple(name for name, spec in _TARGETS.items() if spec.default)
 _ORIGINALS: dict[str, _AppliedPatch] = {}
 
@@ -158,7 +199,9 @@ def accelerate_fla(verbose: bool = True, *, targets: str | Iterable[str] | None 
 
     ``targets=None`` preserves the original behavior and enables only GDN/KDA.
     Use ``targets="gated_mlp"`` (or the ``"mlp"`` alias) for the opt-in dense
-    MLP adapter.  A string or iterable of strings is accepted.
+    MLP adapter, and ``targets="short_conv"`` (or ``"shortconv"``) for the
+    FLA 0.5.2 decode short-convolution adapter.  A string or iterable of
+    strings is accepted.
     """
     requested = _normalize_targets(targets, default=_DEFAULT_TARGETS)
     available = {target for target in requested if is_accelerated(target)}

--- a/python/cudnn/fla/short_conv.py
+++ b/python/cudnn/fla/short_conv.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""cuDNN acceleration for FLA 0.5.2's decode short-convolution entry point.
+
+This adapter was implemented independently against FLA's public call contract.
+It does not include or translate FLA's Triton kernel implementation.  The
+supported path only normalizes FLA's decode layouts into zero-copy 2D views and
+calls :func:`cudnn.ops.causal_conv1d_update`; every other configuration calls the
+original FLA function unchanged.
+"""
+
+from __future__ import annotations
+
+import functools
+from importlib import metadata
+
+import torch
+
+import cudnn
+from cudnn._causal_conv1d_arch import (
+    is_supported_causal_conv1d_update_compute_capability,
+)
+
+_SUPPORTED_FLA_VERSION = "0.5.2"
+_DECLINE_ERRORS = (NotImplementedError, cudnn.cudnnGraphNotSupportedError, ImportError)
+_LAST = {"path": None}
+
+
+def last_path() -> str | None:
+    """Return the route taken by the most recent shimmed call."""
+
+    return _LAST["path"]
+
+
+def _installed_fla_version() -> str | None:
+    try:
+        return metadata.version("flash-linear-attention")
+    except metadata.PackageNotFoundError:
+        return None
+
+
+def _supports_installed_fla() -> bool:
+    return _installed_fla_version() == _SUPPORTED_FLA_VERSION
+
+
+def _is_cuda_tensor(tensor: torch.Tensor) -> bool:
+    return tensor.is_cuda
+
+
+def _device_capability(device: torch.device) -> tuple[int, int]:
+    return torch.cuda.get_device_capability(device)
+
+
+def _is_compiling() -> bool:
+    compiler = getattr(torch, "compiler", None)
+    if compiler is not None and compiler.is_compiling():
+        return True
+    dynamo = getattr(torch, "_dynamo", None)
+    return bool(dynamo is not None and dynamo.is_compiling())
+
+
+def _call_native(x: torch.Tensor, cache: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    # Resolve lazily so importing cudnn.fla does not import the optional
+    # CuTeDSL stack or compile a kernel.
+    from cudnn.ops import causal_conv1d_update
+
+    return causal_conv1d_update(x, cache, weight, activation="silu")
+
+
+def _native_input_view(x: torch.Tensor, weight: torch.Tensor, cache: torch.Tensor) -> torch.Tensor:
+    """Validate the native contract and return a zero-copy row-strided ``[N, D]`` view."""
+
+    if type(x) is not torch.Tensor or type(weight) is not torch.Tensor or type(cache) is not torch.Tensor:
+        raise ValueError("tensor-subclass")
+    if _is_compiling():
+        raise ValueError("compile")
+    if not (x.dtype == weight.dtype == cache.dtype == torch.bfloat16):
+        raise ValueError("non-bf16")
+    if not (_is_cuda_tensor(x) and _is_cuda_tensor(weight) and _is_cuda_tensor(cache)):
+        raise ValueError("non-cuda")
+    if not (x.device == weight.device == cache.device):
+        raise ValueError("device")
+    if not is_supported_causal_conv1d_update_compute_capability(_device_capability(x.device)):
+        raise ValueError("unsupported-arch")
+    if not (weight.is_contiguous() and cache.is_contiguous()):
+        raise ValueError("noncontiguous")
+
+    if x.ndim == 2:
+        n_rows, n_channels = x.shape
+    elif x.ndim == 3 and x.shape[1] == 1:
+        n_rows, _, n_channels = x.shape
+    elif x.ndim == 3 and x.shape[0] == 1:
+        _, n_rows, n_channels = x.shape
+    else:
+        raise ValueError("shape")
+    if n_rows <= 0 or n_channels <= 0:
+        raise ValueError("shape")
+
+    # Each admitted 3D layout only adds a singleton dimension, so view() is a
+    # zero-copy normalization.  Preserve X's leading dimension: fused QKV
+    # projections commonly expose each slice as (3 * D, 1), which the native
+    # kernel addresses directly without an adapter-side copy.
+    try:
+        native_x = x.view(n_rows, n_channels)
+    except RuntimeError as error:
+        raise ValueError("noncontiguous") from error
+    row_stride, channel_stride = native_x.stride()
+    if channel_stride != 1 or row_stride < n_channels:
+        raise ValueError("noncontiguous")
+    if row_stride > n_channels and row_stride % 8 != 0:
+        raise ValueError("alignment")
+
+    if tuple(weight.shape) != (n_channels, 4) or tuple(cache.shape) != (n_rows, n_channels, 4):
+        raise ValueError("shape")
+    if x.data_ptr() % 16 or weight.data_ptr() % 16 or cache.data_ptr() % 16:
+        raise ValueError("alignment")
+    if torch.is_grad_enabled() and any(tensor.requires_grad for tensor in (x, weight, cache)):
+        raise ValueError("autograd")
+
+    # The singleton layout and explicit stride checks above make this a true
+    # view; no adapter-side allocation, gather, or copy is permitted here.
+    return native_x
+
+
+def make_causal_conv1d_update(real_fn):
+    """Wrap FLA's public decode update with a narrow cuDNN native path."""
+
+    @functools.wraps(real_fn)
+    def causal_conv1d_update(
+        x,
+        cache,
+        residual=None,
+        weight=None,
+        bias=None,
+        activation=None,
+    ):
+        def fallback(reason):
+            _LAST["path"] = f"fallback:{reason}"
+            return real_fn(
+                x,
+                cache,
+                residual=residual,
+                weight=weight,
+                bias=bias,
+                activation=activation,
+            )
+
+        if residual is not None:
+            return fallback("residual")
+        if weight is None:
+            return fallback("weight")
+        if bias is not None:
+            return fallback("bias")
+        if activation not in ("silu", "swish"):
+            return fallback("activation")
+
+        try:
+            native_x = _native_input_view(x, weight, cache)
+        except (TypeError, ValueError) as error:
+            return fallback(str(error) or type(error).__name__)
+
+        try:
+            native_y = _call_native(native_x, cache, weight)
+        except _DECLINE_ERRORS as error:
+            return fallback(type(error).__name__)
+        except Exception as error:
+            # Binding/allocation/launch failures are not evidence that the
+            # configuration is unsupported.  Surface them to the caller.
+            _LAST["path"] = f"error:{type(error).__name__}"
+            raise
+
+        _LAST["path"] = "native"
+        return native_y.view(x.shape), cache
+
+    return causal_conv1d_update
+
+
+__all__ = ["last_path", "make_causal_conv1d_update"]

--- a/python/cudnn/ops/__init__.py
+++ b/python/cudnn/ops/__init__.py
@@ -16,6 +16,7 @@ _LAZY_EXPORTS = {
     "causal_conv1d": (".causal_conv1d", "causal_conv1d"),
     "causal_conv1d_nwh": (".causal_conv1d", "causal_conv1d_nwh"),
     "b2b_causal_conv1d": (".causal_conv1d", "b2b_causal_conv1d"),
+    "causal_conv1d_update": ("._causal_conv1d_update", "causal_conv1d_update"),
     "fft_causal_conv1d": (".fft_causal_conv1d", "fft_causal_conv1d"),
 }
 

--- a/python/cudnn/ops/_causal_conv1d_update.py
+++ b/python/cudnn/ops/_causal_conv1d_update.py
@@ -1,0 +1,332 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model-facing causal-convolution decode update implementation."""
+
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+
+def _normalize_activation(activation: Optional[str]) -> str:
+    if activation is None or activation == "identity":
+        return "identity"
+    if activation in ("silu", "swish"):
+        return "silu"
+    raise ValueError("activation must be None, 'identity', 'silu', or 'swish', " f"got {activation!r}")
+
+
+def _validate_x_stride(x: Tensor) -> None:
+    """Validate the native BF16 ``[N, D]`` row-strided input contract.
+
+    Compact rows retain the legacy behavior for every channel count.  Padded
+    rows are admitted only when every row begins at a 16-byte boundary; BF16
+    therefore requires an eight-element-aligned leading dimension.
+    """
+
+    n_channels = x.shape[1]
+    row_stride, channel_stride = x.stride()
+    if channel_stride != 1:
+        raise ValueError(f"x must have row-major strides (ld, 1), got {tuple(x.stride())}")
+    if row_stride < n_channels:
+        raise ValueError(f"x row stride ld must be at least D={n_channels}, got ld={row_stride}")
+    if row_stride > n_channels and row_stride % 8 != 0:
+        raise ValueError("padded x rows must start at 16-byte-aligned BF16 addresses " f"(ld % 8 == 0), got D={n_channels}, ld={row_stride}")
+
+
+def _has_supported_conv_state_layout(conv_state: Tensor) -> bool:
+    """Recognize the two state layouts consumed by the native family.
+
+    Decode caches commonly use compact ``[S, D, L]`` storage.  Full-sequence
+    prefill returns its ``W - 1`` state as a zero-copy ``[S, D, 3]`` transpose
+    backed by contiguous ``[S, 3, D]`` storage.  Admit that exact handoff
+    layout without opening the kernel contract to arbitrary striding.
+    """
+
+    if conv_state.is_contiguous():
+        return True
+    if conv_state.ndim != 3 or conv_state.shape[2] != 3:
+        return False
+    n_slots, n_channels, state_len = conv_state.shape
+    return tuple(conv_state.stride()) == (n_channels * state_len, 1, n_channels)
+
+
+def _validate_semantic_contract(
+    x: Tensor,
+    conv_state: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor],
+    cache_seqlens: Optional[Tensor],
+    conv_state_indices: Optional[Tensor],
+) -> None:
+    if x.ndim != 2:
+        raise ValueError(f"x must have shape [N, D], got {tuple(x.shape)}")
+    if conv_state.ndim != 3:
+        raise ValueError(f"conv_state must have shape [S, D, L], got {tuple(conv_state.shape)}")
+    if weight.ndim != 2:
+        raise ValueError(f"weight must have shape [D, W], got {tuple(weight.shape)}")
+
+    n_rows, n_channels = x.shape
+    n_slots = conv_state.shape[0]
+    if n_rows <= 0:
+        raise ValueError(f"x row count N must be positive, got N={n_rows}")
+    if n_channels <= 0:
+        raise ValueError(f"x channel count D must be positive, got D={n_channels}")
+    if n_slots <= 0:
+        raise ValueError(f"conv_state slot count S must be positive, got S={n_slots}")
+    width = weight.shape[1]
+    state_len = conv_state.shape[2]
+    if width < 1:
+        raise ValueError(f"weight width W must be positive, got W={width}")
+    if weight.shape[0] != n_channels:
+        raise ValueError(f"weight must have shape [D, W] with D={n_channels}, got {tuple(weight.shape)}")
+    if conv_state.shape[1] != n_channels:
+        raise ValueError(f"conv_state must have shape [S, D, L] with D={n_channels}, got {tuple(conv_state.shape)}")
+    if state_len < width - 1:
+        raise ValueError(f"conv_state length L must satisfy L >= W - 1, got L={state_len}, W={width}")
+    if bias is not None and tuple(bias.shape) != (n_channels,):
+        raise ValueError(f"bias must have shape {(n_channels,)}, got {tuple(bias.shape)}")
+    if conv_state_indices is None:
+        if n_slots < n_rows:
+            raise ValueError(f"conv_state needs at least N slots when conv_state_indices is omitted, got S={n_slots}, N={n_rows}")
+    elif tuple(conv_state_indices.shape) != (n_rows,):
+        raise ValueError(f"conv_state_indices must have shape {(n_rows,)}, got {tuple(conv_state_indices.shape)}")
+    if cache_seqlens is not None and tuple(cache_seqlens.shape) != (n_rows,):
+        raise ValueError(f"cache_seqlens must have shape {(n_rows,)}, got {tuple(cache_seqlens.shape)}")
+
+    tensors = (("x", x), ("conv_state", conv_state), ("weight", weight), ("bias", bias))
+    for name, tensor in tensors:
+        if tensor is None:
+            continue
+        if tensor.dtype != torch.bfloat16:
+            raise TypeError(f"{name} must have dtype torch.bfloat16, got {tensor.dtype}")
+        if name == "x":
+            _validate_x_stride(tensor)
+        elif name == "conv_state":
+            if not _has_supported_conv_state_layout(tensor):
+                raise ValueError(
+                    "conv_state must be contiguous [S, D, L], or for L=3 a "
+                    "[S, 3, D]-backed transpose with strides (3 * D, 1, D); "
+                    f"got shape {tuple(tensor.shape)}, strides {tuple(tensor.stride())}"
+                )
+        elif not tensor.is_contiguous():
+            raise ValueError(f"{name} must be contiguous")
+        if tensor.device != x.device:
+            raise ValueError(f"{name} must be on {x.device}, got {tensor.device}")
+    for name, tensor in (
+        ("cache_seqlens", cache_seqlens),
+        ("conv_state_indices", conv_state_indices),
+    ):
+        if tensor is None:
+            continue
+        if tensor.dtype != torch.int32:
+            raise TypeError(f"{name} must have dtype torch.int32, got {tensor.dtype}")
+        if not tensor.is_contiguous():
+            raise ValueError(f"{name} must be contiguous")
+        if tensor.device != x.device:
+            raise ValueError(f"{name} must be on {x.device}, got {tensor.device}")
+
+
+def _require_native_subset(
+    x: Tensor,
+    conv_state: Tensor,
+    weight: Tensor,
+    cache_seqlens: Optional[Tensor],
+) -> None:
+    """Decline semantic configurations the current native kernel cannot run."""
+
+    width = weight.shape[1]
+    state_len = conv_state.shape[2]
+    if width != 4 or state_len not in (3, 4) or cache_seqlens is not None:
+        circular = "present" if cache_seqlens is not None else "omitted"
+        raise NotImplementedError(
+            "the current native causal_conv1d_update kernel supports only one-token "
+            "x[N, D], weight[D, 4], conv_state[S, D, L] with L in {3, 4}, "
+            "and cache_seqlens=None; "
+            f"got x{tuple(x.shape)}, weight{tuple(weight.shape)}, "
+            f"conv_state{tuple(conv_state.shape)}, cache_seqlens={circular}"
+        )
+
+
+def _validated_native_update(
+    x: Tensor,
+    conv_state: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor],
+    activation: str,
+    cache_seqlens: Optional[Tensor],
+    conv_state_indices: Optional[Tensor],
+) -> Tensor:
+    """Validate the semantic contract and enter the prepared native route."""
+
+    _validate_semantic_contract(x, conv_state, weight, bias, cache_seqlens, conv_state_indices)
+    _require_native_subset(x, conv_state, weight, cache_seqlens)
+
+    from cudnn.causal_conv1d_update_sm100 import _causal_conv1d_update
+
+    return _causal_conv1d_update(
+        x,
+        conv_state,
+        weight,
+        bias,
+        activation,
+        conv_state_indices=conv_state_indices,
+    )
+
+
+def _is_compiling() -> bool:
+    compiler = getattr(torch, "compiler", None)
+    if compiler is not None and compiler.is_compiling():
+        return True
+    dynamo = getattr(torch, "_dynamo", None)
+    return bool(dynamo is not None and dynamo.is_compiling())
+
+
+def _can_use_eager_native_fast_path(
+    x: Tensor,
+    conv_state: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor],
+    cache_seqlens: Optional[Tensor],
+    conv_state_indices: Optional[Tensor],
+) -> bool:
+    """Keep dispatch-aware tensors on the custom op while avoiding it in plain eager mode."""
+
+    if _is_compiling() or not x.is_cuda or cache_seqlens is not None:
+        return False
+    dispatch_stack_length = getattr(torch._C, "_len_torch_dispatch_stack", None)
+    torch_function_mode_enabled = getattr(torch._C, "_is_torch_function_mode_enabled", None)
+    if dispatch_stack_length is None or dispatch_stack_length() != 0:
+        return False
+    if torch_function_mode_enabled is None or torch_function_mode_enabled():
+        return False
+    if type(x) is not torch.Tensor or type(conv_state) is not torch.Tensor:
+        return False
+    if type(weight) is not torch.Tensor:
+        return False
+    if bias is not None and type(bias) is not torch.Tensor:
+        return False
+    return conv_state_indices is None or type(conv_state_indices) is torch.Tensor
+
+
+@torch.library.custom_op(
+    "cudnn::_causal_conv1d_update",
+    mutates_args=("conv_state",),
+    device_types="cuda",
+)
+def _causal_conv1d_update_primitive(
+    x: Tensor,
+    conv_state: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor],
+    activation: str,
+    cache_seqlens: Optional[Tensor],
+    conv_state_indices: Optional[Tensor],
+) -> Tensor:
+    activation = _normalize_activation(activation)
+    return _validated_native_update(
+        x,
+        conv_state,
+        weight,
+        bias,
+        activation,
+        cache_seqlens,
+        conv_state_indices,
+    )
+
+
+@torch.library.register_fake("cudnn::_causal_conv1d_update")
+def _causal_conv1d_update_fake(
+    x: Tensor,
+    conv_state: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor],
+    activation: str,
+    cache_seqlens: Optional[Tensor],
+    conv_state_indices: Optional[Tensor],
+) -> Tensor:
+    _normalize_activation(activation)
+    _validate_semantic_contract(x, conv_state, weight, bias, cache_seqlens, conv_state_indices)
+    _require_native_subset(x, conv_state, weight, cache_seqlens)
+    return torch.empty_like(x, memory_format=torch.contiguous_format)
+
+
+def causal_conv1d_update(
+    x: Tensor,
+    conv_state: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor] = None,
+    activation: Optional[str] = None,
+    *,
+    cache_seqlens: Optional[Tensor] = None,
+    conv_state_indices: Optional[Tensor] = None,
+) -> Tensor:
+    r"""Advance a mutable causal-convolution state for one decode step.
+
+    ``conv_state`` is mutated in place. The returned Tensor is newly allocated
+    and has the same shape and dtype as ``x``. ``activation=None`` and
+    ``"identity"`` select the identity epilogue; ``"silu"`` and ``"swish"``
+    select the same compile-time SiLU specialization.
+
+    Args:
+        x: CUDA BF16 tensor with shape ``[N, D]`` and strides ``(ld, 1)``.
+            Compact ``ld == D`` is supported for every ``D``. Padded
+            ``ld > D`` must be divisible by eight so each BF16 row starts at a
+            16-byte-aligned address.
+        conv_state: CUDA BF16 tensor with shape ``[S, D, L]``, where
+            ``L >= W - 1``. Compact storage is accepted. For ``L=3``, the
+            channel-last view returned by :func:`cudnn.ops.causal_conv1d` is
+            also accepted directly.
+        weight: Contiguous CUDA BF16 tensor with shape ``[D, W]``.
+        bias: Optional contiguous CUDA BF16 tensor with shape ``[D]``.
+        activation: ``None``, ``"identity"``, ``"silu"``, or ``"swish"``.
+        cache_seqlens: Reserved compatibility keyword. The current
+            implementation accepts only ``None``.
+        conv_state_indices: Optional contiguous CUDA int32 tensor with shape
+            ``[N]`` selecting unique state slots.
+
+    Returns:
+        A contiguous CUDA BF16 Tensor with shape ``[N, D]``.
+    """
+
+    for name, tensor in (("x", x), ("conv_state", conv_state), ("weight", weight)):
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(f"{name} must be a torch.Tensor, got {type(tensor).__name__}")
+    if bias is not None and not isinstance(bias, torch.Tensor):
+        raise TypeError(f"bias must be a torch.Tensor or None, got {type(bias).__name__}")
+    if cache_seqlens is not None and not isinstance(cache_seqlens, torch.Tensor):
+        raise TypeError(f"cache_seqlens must be a torch.Tensor or None, got {type(cache_seqlens).__name__}")
+    if conv_state_indices is not None and not isinstance(conv_state_indices, torch.Tensor):
+        raise TypeError("conv_state_indices must be a torch.Tensor or None, " f"got {type(conv_state_indices).__name__}")
+    if not x.is_cuda and x.device.type != "meta":
+        raise ValueError(f"x must be a CUDA tensor, got {x.device}")
+
+    normalized_activation = _normalize_activation(activation)
+    grad_tensors = (x, conv_state, weight, bias)
+    if torch.is_grad_enabled() and any(tensor is not None and tensor.requires_grad for tensor in grad_tensors):
+        raise RuntimeError("causal_conv1d_update is inference-only; call it under torch.no_grad()")
+
+    if _can_use_eager_native_fast_path(x, conv_state, weight, bias, cache_seqlens, conv_state_indices):
+        return _validated_native_update(
+            x,
+            conv_state,
+            weight,
+            bias,
+            normalized_activation,
+            cache_seqlens,
+            conv_state_indices,
+        )
+
+    return torch.ops.cudnn._causal_conv1d_update(
+        x,
+        conv_state,
+        weight,
+        bias,
+        normalized_activation,
+        cache_seqlens,
+        conv_state_indices,
+    )
+
+
+__all__ = ["causal_conv1d_update"]

--- a/python/cudnn/ops/_causal_conv1d_update.py
+++ b/python/cudnn/ops/_causal_conv1d_update.py
@@ -48,7 +48,7 @@ def _has_supported_conv_state_layout(conv_state: Tensor) -> bool:
         return True
     if conv_state.ndim != 3 or conv_state.shape[2] != 3:
         return False
-    n_slots, n_channels, state_len = conv_state.shape
+    _, n_channels, state_len = conv_state.shape
     return tuple(conv_state.stride()) == (n_channels * state_len, 1, n_channels)
 
 

--- a/python/cudnn/ops/causal_conv1d.py
+++ b/python/cudnn/ops/causal_conv1d.py
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Optional, Tuple
+import threading
+from collections import OrderedDict
+from contextvars import ContextVar
+from typing import List, Optional, Tuple, Union
 
 import torch
 from torch import Tensor
@@ -37,6 +40,16 @@ def _activation_to_int(activation: str) -> int:
     return _ACTIVATION_TO_INT[activation]
 
 
+def _match_causal_conv1d_output_layout(output: Tensor, public_x: Tensor) -> Tensor:
+    """Preserve the input's dense memory format across backend selection."""
+
+    if output.stride() == public_x.stride():
+        return output
+    result = torch.empty_like(public_x)
+    result.copy_(output)
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Forward primitive
 # ---------------------------------------------------------------------------
@@ -59,6 +72,12 @@ def _fwd_primitive(x: Tensor, weight: Tensor, bias: Tensor, activation: str) -> 
     if not (x.dtype == weight.dtype == bias.dtype):
         raise TypeError(f"Dtype mismatch: x.dtype={x.dtype}, weight.dtype={weight.dtype}, " f"bias.dtype={bias.dtype} (all must match)")
 
+    # The backend ABI is contiguous BDT, but the public operation preserves
+    # the input's dense memory format.  In particular, model code commonly
+    # passes a BDT transpose view backed by contiguous BTD storage.  Keep that
+    # observable layout stable whether this generic primitive or the native
+    # channel-last route is selected.
+    public_x = x
     x = x.contiguous()
     weight = weight.contiguous()
     bias = bias.contiguous()
@@ -72,7 +91,7 @@ def _fwd_primitive(x: Tensor, weight: Tensor, bias: Tensor, activation: str) -> 
     if bias.shape[0] != dim:
         raise ValueError(f"Bias mismatch: x has dim={dim} but bias has shape {bias.shape} " f"(expected bias.shape[0]={dim})")
 
-    y = torch.empty_like(x)
+    y_contiguous = torch.empty_like(x)
 
     import cudnn
 
@@ -81,7 +100,7 @@ def _fwd_primitive(x: Tensor, weight: Tensor, bias: Tensor, activation: str) -> 
         x.data_ptr(),
         weight.data_ptr(),
         bias.data_ptr(),
-        y.data_ptr(),
+        y_contiguous.data_ptr(),
         batch,
         dim,
         seq_len,
@@ -89,7 +108,7 @@ def _fwd_primitive(x: Tensor, weight: Tensor, bias: Tensor, activation: str) -> 
         _dtype_to_int(x.dtype),
         _activation_to_int(activation),
     )
-    return y
+    return _match_causal_conv1d_output_layout(y_contiguous, public_x)
 
 
 @torch.library.register_fake("cudnn::causal_conv1d_fwd_primitive")
@@ -200,47 +219,520 @@ torch.library.register_autograd(
 
 
 # ---------------------------------------------------------------------------
-# Public API
+# Public semantic API and private bulk-backend adapter
 # ---------------------------------------------------------------------------
+
+
+_CAUSAL_CONV1D_TRAINING_CACHE_CAPACITY = 64
+_CAUSAL_CONV1D_TRAINING_CACHE = OrderedDict()
+_CAUSAL_CONV1D_TRAINING_CACHE_LOCK = threading.Lock()
+_CAUSAL_CONV1D_LAST_ROUTE: ContextVar[Optional[str]] = ContextVar(
+    "_CAUSAL_CONV1D_LAST_ROUTE",
+    default=None,
+)
+
+
+def _get_causal_conv1d_last_route() -> Optional[str]:
+    """Return this context's most recent successful eager public route.
+
+    Compiled calls do not touch this diagnostic, so they leave the previous
+    eager value unchanged instead of adding ContextVar operations to the graph.
+    """
+
+    return _CAUSAL_CONV1D_LAST_ROUTE.get()
+
+
+def _reset_causal_conv1d_last_route() -> None:
+    if not torch.compiler.is_compiling():
+        _CAUSAL_CONV1D_LAST_ROUTE.set(None)
+
+
+def _record_causal_conv1d_route(route: str) -> None:
+    if not torch.compiler.is_compiling():
+        _CAUSAL_CONV1D_LAST_ROUTE.set(route)
+
+
+def _causal_conv1d_native_route(
+    x: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor],
+    initial_state: Optional[Tensor] = None,
+) -> str:
+    differentiable = (x, weight, bias, initial_state)
+    if torch.is_grad_enabled() and any(tensor is not None and tensor.requires_grad for tensor in differentiable):
+        return "native-autograd"
+    return "native-inference"
+
+
+def _tensor_plan_signature(tensor: Optional[Tensor]):
+    if tensor is None:
+        return None
+    return (
+        tuple(tensor.shape),
+        tuple(tensor.stride()),
+        tensor.dtype,
+        tensor.device,
+    )
+
+
+def _causal_conv1d_training_key(
+    x_btd: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor],
+    cu_seqlens: Optional[Tensor],
+    initial_state: Optional[Tensor] = None,
+    output_final_state: bool = False,
+):
+    """Key every plan-time field consumed by the exact-shape training backend.
+
+    The routed backend is fixed to BF16 width-four SiLU. Tensor signatures key
+    its remaining specializations: dense versus packed presence, packed N,
+    bias and state presence, final-state output, shapes, strides, dtypes, and
+    device. Device properties key the architecture-dependent schedule. Runtime
+    ``cu_seqlens`` values are intentionally absent because the kernel consumes
+    them on device.
+    """
+
+    properties = torch.cuda.get_device_properties(x_btd.device)
+    return (
+        "bf16-width4-silu",
+        "packed" if cu_seqlens is not None else "dense",
+        _tensor_plan_signature(x_btd),
+        _tensor_plan_signature(weight),
+        _tensor_plan_signature(bias),
+        _tensor_plan_signature(cu_seqlens),
+        _tensor_plan_signature(initial_state),
+        bool(output_final_state),
+        (properties.major, properties.minor),
+        properties.multi_processor_count,
+    )
+
+
+def _compile_causal_conv1d_training_backend(
+    x_btd: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor],
+    cu_seqlens: Optional[Tensor],
+    initial_state: Optional[Tensor] = None,
+    output_final_state: bool = False,
+):
+    from cudnn.causal_conv1d_bulk_sm100.autograd import (
+        CausalConv1dBulkAutogradPrototype as _TrainingBackend,
+    )
+
+    return _TrainingBackend(
+        x_btd,
+        weight,
+        cu_seqlens,
+        sample_bias=bias,
+        sample_initial_state=initial_state,
+        output_final_state=output_final_state,
+    )
+
+
+def _get_causal_conv1d_training_backend(
+    x_btd: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor],
+    cu_seqlens: Optional[Tensor],
+    initial_state: Optional[Tensor] = None,
+    output_final_state: bool = False,
+):
+    key = _causal_conv1d_training_key(
+        x_btd,
+        weight,
+        bias,
+        cu_seqlens,
+        initial_state,
+        output_final_state,
+    )
+    with _CAUSAL_CONV1D_TRAINING_CACHE_LOCK:
+        backend = _CAUSAL_CONV1D_TRAINING_CACHE.get(key)
+        if backend is not None:
+            _CAUSAL_CONV1D_TRAINING_CACHE.move_to_end(key)
+            return backend
+
+        backend = _compile_causal_conv1d_training_backend(
+            x_btd,
+            weight,
+            bias,
+            cu_seqlens,
+            initial_state,
+            output_final_state,
+        )
+        _CAUSAL_CONV1D_TRAINING_CACHE[key] = backend
+        if len(_CAUSAL_CONV1D_TRAINING_CACHE) > _CAUSAL_CONV1D_TRAINING_CACHE_CAPACITY:
+            _CAUSAL_CONV1D_TRAINING_CACHE.popitem(last=False)
+        return backend
+
+
+def _run_causal_conv1d_bulk_backend(
+    x_btd: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor],
+    cu_seqlens: Optional[Tensor],
+    *,
+    initial_state: Optional[Tensor] = None,
+    output_final_state: bool = False,
+) -> Union[Tensor, Tuple[Tensor, Tensor]]:
+    """Run the current backend without exporting its lifecycle or result type."""
+
+    if _causal_conv1d_native_route(x_btd, weight, bias, initial_state) == "native-autograd":
+        backend = _get_causal_conv1d_training_backend(
+            x_btd,
+            weight,
+            bias,
+            cu_seqlens,
+            initial_state,
+            output_final_state,
+        )
+        result = backend(
+            x_btd,
+            weight,
+            cu_seqlens,
+            bias=bias,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+        )
+        if output_final_state:
+            return result["output_tensor"], result["final_state_tensor"]
+        return result
+
+    from cudnn.causal_conv1d_bulk_sm100.api import (
+        causal_conv1d_bulk_fwd_wrapper_sm100 as _forward_backend,
+    )
+
+    result = _forward_backend(
+        x_btd,
+        weight,
+        cu_seqlens_tensor=cu_seqlens,
+        initial_state_tensor=initial_state,
+        output_final_state=output_final_state,
+        bias_tensor=bias,
+    )
+    if output_final_state:
+        return result["output_tensor"], result["final_state_tensor"]
+    return result["output_tensor"]
+
+
+def _can_route_causal_conv1d_bulk(
+    x: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor],
+    cu_seqlens: Optional[Tensor],
+    activation: str,
+) -> bool:
+    """Whether the current BF16 width-four backend is a transparent route."""
+
+    if torch.compiler.is_compiling() or activation != "silu":
+        return False
+    if not isinstance(x, torch.Tensor) or not isinstance(weight, torch.Tensor):
+        return False
+    if bias is not None and not isinstance(bias, torch.Tensor):
+        return False
+    if cu_seqlens is not None and not isinstance(cu_seqlens, torch.Tensor):
+        return False
+    if x.ndim != 3 or weight.ndim != 2:
+        return False
+
+    batch, channels, tokens = x.shape
+    if batch <= 0 or channels <= 0 or tokens <= 0 or tuple(weight.shape) != (channels, 4):
+        return False
+    if bias is not None and tuple(bias.shape) != (channels,):
+        return False
+    if cu_seqlens is not None:
+        if batch != 1 or cu_seqlens.ndim != 1 or cu_seqlens.shape[0] < 2:
+            return False
+        if cu_seqlens.dtype != torch.int32 or not cu_seqlens.is_contiguous():
+            return False
+    if x.dtype != torch.bfloat16 or weight.dtype not in (
+        torch.bfloat16,
+        torch.float32,
+    ):
+        return False
+    # The current mixed-weight specialization targets the exact GLM contract:
+    # BF16 activations, FP32 depthwise weights, and no bias.  Keep other mixed
+    # combinations out of the route until their epilogue contract is tested.
+    if weight.dtype == torch.float32 and bias is not None:
+        return False
+    if bias is not None and bias.dtype != torch.bfloat16:
+        return False
+    tensors = (x, weight) if bias is None else (x, weight, bias)
+    if not x.is_cuda or any(tensor.device != x.device for tensor in tensors[1:]):
+        return False
+    if cu_seqlens is not None and cu_seqlens.device != x.device:
+        return False
+
+    x_btd = x.transpose(1, 2)
+    if not x_btd.is_contiguous() or x_btd.data_ptr() != x.data_ptr():
+        return False
+    if not weight.is_contiguous() or (bias is not None and not bias.is_contiguous()):
+        return False
+    if any(tensor.data_ptr() % 16 for tensor in tensors):
+        return False
+
+    try:
+        from cudnn._causal_conv1d_arch import is_functional_arch
+        from cudnn.frost.buffers import cutedsl_state, cutedsl_too_old
+
+        installed, version = cutedsl_state()
+        capability = torch.cuda.get_device_capability(x.device)
+    except (AttributeError, ImportError, OSError, RuntimeError):
+        return False
+    return installed and not cutedsl_too_old(version) and is_functional_arch(capability)
+
+
+def _normalize_causal_conv1d_activation(activation: Optional[str]) -> str:
+    if activation is None or activation == "identity":
+        return "identity"
+    if activation in ("silu", "swish"):
+        return "silu"
+    raise NotImplementedError("activation must be None, 'identity', 'silu', or 'swish'")
+
+
+def _validate_causal_conv1d_sequence_contract(
+    x: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor],
+    seq_idx: Optional[Tensor],
+    cu_seqlens: Optional[Tensor],
+    initial_states: Optional[Tensor],
+    return_final_states: bool,
+    final_states_out: Optional[Tensor],
+) -> None:
+    """Validate sequence and mathematical-state semantics only.
+
+    Physical layout requirements belong to a private backend route.  Keeping
+    them out of this validator prevents the current kernel schedule from
+    becoming part of the public operation contract.
+    """
+
+    if not isinstance(return_final_states, bool):
+        raise TypeError(f"return_final_states must be bool, got {type(return_final_states).__name__}")
+    if final_states_out is not None and not return_final_states:
+        raise ValueError("final_states_out requires return_final_states=True")
+    if seq_idx is not None and cu_seqlens is not None:
+        raise ValueError("seq_idx and cu_seqlens are mutually exclusive")
+    if seq_idx is not None and return_final_states:
+        raise ValueError("seq_idx and return_final_states are mutually exclusive")
+    for name, tensor in (("x", x), ("weight", weight)):
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(f"{name} must be a torch.Tensor, got {type(tensor).__name__}")
+    for name, tensor in (
+        ("bias", bias),
+        ("seq_idx", seq_idx),
+        ("cu_seqlens", cu_seqlens),
+        ("initial_states", initial_states),
+        ("final_states_out", final_states_out),
+    ):
+        if tensor is not None and not isinstance(tensor, torch.Tensor):
+            raise TypeError(f"{name} must be a torch.Tensor or None, got {type(tensor).__name__}")
+
+    if x.ndim != 3:
+        raise ValueError(f"x must have shape [B, D, T], got {tuple(x.shape)}")
+    if weight.ndim != 2:
+        raise ValueError(f"weight must have shape [D, W], got {tuple(weight.shape)}")
+    batch, channels, tokens = x.shape
+    if weight.shape[0] != channels:
+        raise ValueError(f"weight must have shape [D, W] with D={channels}, got {tuple(weight.shape)}")
+    width = weight.shape[1]
+    if width < 2:
+        raise ValueError(f"weight width must be at least two, got W={width}")
+    if bias is not None and tuple(bias.shape) != (channels,):
+        raise ValueError(f"bias must have shape {(channels,)}, got {tuple(bias.shape)}")
+    if seq_idx is not None and tuple(seq_idx.shape) != (batch, tokens):
+        raise ValueError(f"seq_idx must have shape {(batch, tokens)}, got {tuple(seq_idx.shape)}")
+    if cu_seqlens is not None:
+        if batch != 1:
+            raise ValueError(f"packed x must have B=1, got B={batch}")
+        if cu_seqlens.ndim != 1 or cu_seqlens.shape[0] < 2:
+            raise ValueError("cu_seqlens must have shape [N + 1] with N >= 1")
+        state_batch = cu_seqlens.shape[0] - 1
+    else:
+        state_batch = batch
+
+    state_shape = (state_batch, channels, width - 1)
+    for name, state in (("initial_states", initial_states), ("final_states_out", final_states_out)):
+        if state is not None and tuple(state.shape) != state_shape:
+            raise ValueError(f"{name} must have shape {state_shape}, got {tuple(state.shape)}")
+        if state is not None and state.dtype != x.dtype:
+            raise TypeError(f"{name} dtype must match x dtype {x.dtype}, got {state.dtype}")
+        if state is not None and state.device != x.device:
+            raise ValueError(f"{name} device must match x device {x.device}, got {state.device}")
+
+
+def _to_causal_conv1d_full_width_state(initial_states: Optional[Tensor]) -> Optional[Tensor]:
+    """Translate public ``W - 1`` history to the backend's private ``W`` cache.
+
+    The backend shifts before filtering the current token.  Prepending one
+    unobservable lane therefore makes ``[0, h0, h1, h2]`` become
+    ``[h0, h1, h2, x0]`` for the first width-four convolution window.
+    """
+
+    if initial_states is None:
+        return None
+    padding = torch.zeros_like(initial_states[..., :1])
+    return torch.cat((padding, initial_states), dim=-1)
+
+
+def _from_causal_conv1d_full_width_state(
+    final_state: Tensor,
+    final_states_out: Optional[Tensor],
+) -> Tensor:
+    """Copy the private ``W`` cache into independent public ``W - 1`` storage."""
+
+    mathematical_state = final_state[..., 1:]
+    if final_states_out is None:
+        # Match the channel-last state allocation used by the consumed API and
+        # avoid returning a view whose stride/storage exposes the private lane.
+        batch, channels, history = mathematical_state.shape
+        final_states_out = torch.empty(
+            (batch, history, channels),
+            dtype=mathematical_state.dtype,
+            device=mathematical_state.device,
+        ).transpose(1, 2)
+    final_states_out.copy_(mathematical_state)
+    return final_states_out
+
+
+def _run_causal_conv1d_sequence_backend(
+    x: Tensor,
+    weight: Tensor,
+    bias: Optional[Tensor],
+    activation: str,
+    seq_idx: Optional[Tensor],
+    cu_seqlens: Optional[Tensor],
+    initial_states: Optional[Tensor],
+    return_final_states: bool,
+    final_states_out: Optional[Tensor],
+) -> Tuple[Tensor, Optional[Tensor]]:
+    """Adapt mathematical state to the private width-four backend ABI."""
+
+    if seq_idx is not None:
+        raise NotImplementedError("the current backend does not yet implement seq_idx")
+    if not _can_route_causal_conv1d_bulk(x, weight, bias, cu_seqlens, activation):
+        raise NotImplementedError("the current backend cannot execute this stateful causal_conv1d call")
+
+    full_width_initial_state = _to_causal_conv1d_full_width_state(initial_states)
+    result = _run_causal_conv1d_bulk_backend(
+        x.transpose(1, 2),
+        weight,
+        bias,
+        cu_seqlens,
+        initial_state=full_width_initial_state,
+        output_final_state=return_final_states,
+    )
+    if return_final_states:
+        output_btd, full_width_final_state = result
+        public_final_state = _from_causal_conv1d_full_width_state(
+            full_width_final_state,
+            final_states_out,
+        )
+    else:
+        output_btd = result
+        public_final_state = None
+    output = _match_causal_conv1d_output_layout(output_btd.transpose(1, 2), x)
+    return output, public_final_state
 
 
 def causal_conv1d(
     x: Tensor,
     weight: Tensor,
     bias: Optional[Tensor] = None,
-    activation: str = "identity",
-) -> Tensor:
-    r"""Depthwise causal 1D convolution with optional activation.
+    activation: Optional[str] = None,
+    *,
+    seq_idx: Optional[Tensor] = None,
+    cu_seqlens: Optional[Tensor] = None,
+    initial_states: Optional[Tensor] = None,
+    return_final_states: bool = False,
+    final_states_out: Optional[Tensor] = None,
+) -> Union[Tensor, Tuple[Tensor, Tensor]]:
+    r"""Apply depthwise causal convolution to ``x[B, D, T]``.
 
-    Computes a depthwise 1D convolution with causal (left-only) padding
-    and optional fused activation::
+    The semantic contract follows the commonly consumed ``causal-conv1d``
+    interface: packed offsets prevent cross-sequence filtering, and optional
+    initial/final histories contain exactly ``W - 1`` samples. A channel-last
+    physical allocation can be passed as its zero-copy ``[B, D, T]`` transpose
+    view. ``seq_idx`` is a reserved compatibility keyword and currently must be
+    ``None``; it and ``cu_seqlens`` are mutually exclusive.
 
-        y = activation(conv1d_causal(x, weight) + bias)
+    Kernel compilation, schedule selection, workspace allocation, result
+    wrappers, architecture class names, and CUDA stream handles are private.
+    The result is a Tensor, or ``(output, final_states)`` when requested.
 
-    Causal padding: ``(kernel_size - 1)`` on the left, ``0`` on the right.
-    Each channel is convolved independently with its own 1D filter.
-
-    Supports ``torch.compile`` and ``torch.autograd`` — backward is handled
-    automatically when inputs require gradients.
-
-    Args:
-        x (torch.Tensor): Input tensor of shape ``(batch, dim, seq_len)``.
-            Must be BF16, FP16, FP32, or FP64. Must be contiguous and on CUDA.
-        weight (torch.Tensor): Filter tensor of shape ``(dim, kernel_size)``.
-            Same dtype as *x*. ``kernel_size`` must be between 2 and 256,
-            inclusive.
-        bias (torch.Tensor | None): Optional bias of shape ``(dim,)``.
-            Same dtype as *x*. Defaults to zeros if ``None``.
-        activation (str): ``"identity"`` (default) or ``"silu"``.
-
-    Returns:
-        torch.Tensor: Output of shape ``(batch, dim, seq_len)``, same dtype as *x*.
+    The current optimized route implements dense and ``cu_seqlens``-packed
+    BF16 width-four SiLU with forward and backward. Dense bias-free calls also
+    accept FP32 weights, matching models which retain the depthwise filter in
+    FP32 while their activations remain BF16. Unsupported optional modes fail
+    explicitly without changing the public state shape to match a backend
+    cache convention.
     """
-    if activation not in _ACTIVATION_TO_INT:
-        raise ValueError(f"Unsupported activation '{activation}'. Supported: 'identity', 'silu'.")
+
+    _reset_causal_conv1d_last_route()
+    normalized_activation = _normalize_causal_conv1d_activation(activation)
+    if seq_idx is not None and cu_seqlens is not None:
+        raise ValueError("seq_idx and cu_seqlens are mutually exclusive")
+    state_or_seq_idx_call = seq_idx is not None or initial_states is not None or return_final_states or final_states_out is not None
+    if state_or_seq_idx_call:
+        _validate_causal_conv1d_sequence_contract(
+            x,
+            weight,
+            bias,
+            seq_idx,
+            cu_seqlens,
+            initial_states,
+            return_final_states,
+            final_states_out,
+        )
+        output, final_states = _run_causal_conv1d_sequence_backend(
+            x,
+            weight,
+            bias,
+            normalized_activation,
+            seq_idx,
+            cu_seqlens,
+            initial_states,
+            return_final_states,
+            final_states_out,
+        )
+        if return_final_states:
+            assert final_states is not None
+            _record_causal_conv1d_route(_causal_conv1d_native_route(x, weight, bias, initial_states))
+            return output, final_states
+        _record_causal_conv1d_route(_causal_conv1d_native_route(x, weight, bias, initial_states))
+        return output
+
+    if cu_seqlens is not None:
+        _validate_causal_conv1d_sequence_contract(
+            x,
+            weight,
+            bias,
+            None,
+            cu_seqlens,
+            None,
+            False,
+            None,
+        )
+        if not _can_route_causal_conv1d_bulk(x, weight, bias, cu_seqlens, normalized_activation):
+            raise NotImplementedError("the current backend cannot execute this cu_seqlens-packed causal_conv1d call")
+        x_btd = x.transpose(1, 2)
+        output = _run_causal_conv1d_bulk_backend(x_btd, weight, bias, cu_seqlens).transpose(1, 2)
+        _record_causal_conv1d_route(_causal_conv1d_native_route(x, weight, bias))
+        return output
+
+    if _can_route_causal_conv1d_bulk(x, weight, bias, None, normalized_activation):
+        output_btd = _run_causal_conv1d_bulk_backend(x.transpose(1, 2), weight, bias, None)
+        output = output_btd.transpose(1, 2)
+        _record_causal_conv1d_route(_causal_conv1d_native_route(x, weight, bias))
+        return output
+
+    if x.dtype == torch.bfloat16 and weight.dtype == torch.float32:
+        raise NotImplementedError("BF16 activation with FP32 weight requires the native channel-last " "width-four SiLU route")
     if bias is None:
         bias = torch.zeros(weight.shape[0], device=x.device, dtype=x.dtype)
-    return torch.ops.cudnn.causal_conv1d_fwd_primitive(x, weight, bias, activation)
+    output = torch.ops.cudnn.causal_conv1d_fwd_primitive(x, weight, bias, normalized_activation)
+    _record_causal_conv1d_route("generic-cudnn")
+    return output
 
 
 # ===========================================================================

--- a/python/cudnn/ops/causal_conv1d.py
+++ b/python/cudnn/ops/causal_conv1d.py
@@ -282,13 +282,15 @@ def _causal_conv1d_training_key(
     cu_seqlens: Optional[Tensor],
     initial_state: Optional[Tensor] = None,
     output_final_state: bool = False,
+    deterministic: bool = False,
 ):
     """Key every plan-time field consumed by the exact-shape training backend.
 
     The routed backend is fixed to BF16 width-four SiLU. Tensor signatures key
     its remaining specializations: dense versus packed presence, packed N,
     bias and state presence, final-state output, shapes, strides, dtypes, and
-    device. Device properties key the architecture-dependent schedule. Runtime
+    device. Device properties key the architecture-dependent schedule, and the
+    torch deterministic-algorithms mode keys the dweight schedule. Runtime
     ``cu_seqlens`` values are intentionally absent because the kernel consumes
     them on device.
     """
@@ -303,6 +305,7 @@ def _causal_conv1d_training_key(
         _tensor_plan_signature(cu_seqlens),
         _tensor_plan_signature(initial_state),
         bool(output_final_state),
+        bool(deterministic),
         (properties.major, properties.minor),
         properties.multi_processor_count,
     )
@@ -315,6 +318,7 @@ def _compile_causal_conv1d_training_backend(
     cu_seqlens: Optional[Tensor],
     initial_state: Optional[Tensor] = None,
     output_final_state: bool = False,
+    deterministic: bool = False,
 ):
     from cudnn.causal_conv1d_bulk_sm100.autograd import (
         CausalConv1dBulkAutogradPrototype as _TrainingBackend,
@@ -327,6 +331,7 @@ def _compile_causal_conv1d_training_backend(
         sample_bias=bias,
         sample_initial_state=initial_state,
         output_final_state=output_final_state,
+        deterministic=deterministic,
     )
 
 
@@ -337,6 +342,7 @@ def _get_causal_conv1d_training_backend(
     cu_seqlens: Optional[Tensor],
     initial_state: Optional[Tensor] = None,
     output_final_state: bool = False,
+    deterministic: bool = False,
 ):
     key = _causal_conv1d_training_key(
         x_btd,
@@ -345,6 +351,7 @@ def _get_causal_conv1d_training_backend(
         cu_seqlens,
         initial_state,
         output_final_state,
+        deterministic,
     )
     with _CAUSAL_CONV1D_TRAINING_CACHE_LOCK:
         backend = _CAUSAL_CONV1D_TRAINING_CACHE.get(key)
@@ -359,6 +366,7 @@ def _get_causal_conv1d_training_backend(
             cu_seqlens,
             initial_state,
             output_final_state,
+            deterministic,
         )
         _CAUSAL_CONV1D_TRAINING_CACHE[key] = backend
         if len(_CAUSAL_CONV1D_TRAINING_CACHE) > _CAUSAL_CONV1D_TRAINING_CACHE_CAPACITY:
@@ -385,6 +393,7 @@ def _run_causal_conv1d_bulk_backend(
             cu_seqlens,
             initial_state,
             output_final_state,
+            torch.are_deterministic_algorithms_enabled(),
         )
         result = backend(
             x_btd,
@@ -450,9 +459,8 @@ def _can_route_causal_conv1d_bulk(
         torch.float32,
     ):
         return False
-    # The current mixed-weight specialization targets the exact GLM contract:
-    # BF16 activations, FP32 depthwise weights, and no bias.  Keep other mixed
-    # combinations out of the route until their epilogue contract is tested.
+    # The FP32-weight epilogue is only tested without bias; other mixed-dtype
+    # combinations stay off the route until their epilogue contract is tested.
     if weight.dtype == torch.float32 and bias is not None:
         return False
     if bias is not None and bias.dtype != torch.bfloat16:
@@ -559,6 +567,36 @@ def _validate_causal_conv1d_sequence_contract(
             raise TypeError(f"{name} dtype must match x dtype {x.dtype}, got {state.dtype}")
         if state is not None and state.device != x.device:
             raise ValueError(f"{name} device must match x device {x.device}, got {state.device}")
+    if final_states_out is not None:
+        # The final state is written after the forward, and autograd saves the
+        # inputs for backward, so an aliased output would corrupt them.
+        for name, tensor in (
+            ("x", x),
+            ("weight", weight),
+            ("bias", bias),
+            ("cu_seqlens", cu_seqlens),
+            ("initial_states", initial_states),
+        ):
+            if tensor is not None and _tensors_share_memory(final_states_out, tensor):
+                raise ValueError(f"final_states_out must not share memory with {name}")
+
+
+def _tensor_byte_span(tensor: Tensor) -> Tuple[int, int]:
+    """Half-open device byte range addressed by a possibly strided view."""
+
+    begin = tensor.data_ptr()
+    if tensor.numel() == 0:
+        return begin, begin
+    last_offset = sum((size - 1) * stride for size, stride in zip(tensor.shape, tensor.stride()))
+    return begin, begin + (last_offset + 1) * tensor.element_size()
+
+
+def _tensors_share_memory(lhs: Tensor, rhs: Tensor) -> bool:
+    if lhs.device != rhs.device:
+        return False
+    lhs_begin, lhs_end = _tensor_byte_span(lhs)
+    rhs_begin, rhs_end = _tensor_byte_span(rhs)
+    return lhs_begin < rhs_end and rhs_begin < lhs_end
 
 
 def _to_causal_conv1d_full_width_state(initial_states: Optional[Tensor]) -> Optional[Tensor]:
@@ -662,10 +700,14 @@ def causal_conv1d(
 
     The current optimized route implements dense and ``cu_seqlens``-packed
     BF16 width-four SiLU with forward and backward. Dense bias-free calls also
-    accept FP32 weights, matching models which retain the depthwise filter in
-    FP32 while their activations remain BF16. Unsupported optional modes fail
-    explicitly without changing the public state shape to match a backend
-    cache convention.
+    accept an FP32 depthwise filter with BF16 activations. Unsupported optional
+    modes fail explicitly without changing the public state shape to match a
+    backend cache convention.
+
+    ``final_states_out`` must not share memory with any input. The backward
+    honors ``torch.use_deterministic_algorithms``: bias-free calls switch to a
+    deterministic dweight schedule, while calls with ``bias`` raise (or warn
+    under ``warn_only=True``) because dbias accumulates with FP32 atomics.
     """
 
     _reset_causal_conv1d_last_route()

--- a/test/python/fe_api/causal_conv1d_bulk/benchmark_causal_conv1d_bulk_sm100.py
+++ b/test/python/fe_api/causal_conv1d_bulk/benchmark_causal_conv1d_bulk_sm100.py
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Interleaved benchmark for the bulk causal-convolution forward slice.
+
+This script is intentionally not a pytest test.  It runs on every functionally
+supported architecture; the operation's support check remains authoritative.
+
+The ``fe_execute`` arm uses caller-preallocated output tensors, whereas FLA's
+direct API allocates its outputs internally. CUDA events also include any GPU
+idle gap while the host enqueues work between the two events. Therefore this
+script reports direct-API event elapsed, not pure per-kernel active cycles;
+obtain the latter from same-process CUPTI/Nsight kernel durations. The
+wrapper/public arm is the more symmetric allocation-inclusive comparison.
+"""
+
+import argparse
+import json
+import os
+import platform
+import statistics
+
+import torch
+from cudnn._causal_conv1d_arch import is_functional_arch
+
+
+def _validate_environment():
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is unavailable")
+    properties = torch.cuda.get_device_properties(torch.cuda.current_device())
+    capability = (properties.major, properties.minor)
+    if not is_functional_arch(capability):
+        raise RuntimeError("Bulk causal conv1d does not support compute capability " f"{capability[0]}.{capability[1]} on {properties.name}")
+    return properties, capability
+
+
+def _slurm_metadata(environ=None):
+    environ = os.environ if environ is None else environ
+    fields = {
+        "job_id": environ.get("SLURM_JOB_ID"),
+        "node_name": environ.get("SLURMD_NODENAME"),
+    }
+    return {name: value for name, value in fields.items() if value}
+
+
+def _event_us(fn, inner: int) -> float:
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(inner):
+        fn()
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) * 1000.0 / inner
+
+
+def _interleaved_medians(functions, *, warmup: int, rounds: int, inner: int):
+    names = list(functions)
+    for _ in range(warmup):
+        for name in names:
+            functions[name]()
+    torch.cuda.synchronize()
+
+    samples = {name: [] for name in names}
+    for round_index in range(rounds):
+        order = names if round_index % 2 == 0 else list(reversed(names))
+        for name in order:
+            samples[name].append(_event_us(functions[name], inner))
+    return {
+        name: {
+            "median_us": statistics.median(values),
+            "min_us": min(values),
+            "max_us": max(values),
+            "samples_us": values,
+        }
+        for name, values in samples.items()
+    }
+
+
+@torch.no_grad()
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tokens", type=int, default=8192)
+    parser.add_argument("--channels", type=int, default=8192)
+    parser.add_argument("--packed-sequences", type=int, default=0)
+    parser.add_argument("--state", action="store_true")
+    parser.add_argument("--final-state", action="store_true")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--rounds", type=int, default=21)
+    parser.add_argument("--inner", type=int, default=5)
+    args = parser.parse_args()
+
+    properties, capability = _validate_environment()
+
+    from cudnn.causal_conv1d_bulk_sm100 import (
+        CausalConv1dBulkFwdSm100,
+        causal_conv1d_bulk_fwd_wrapper_sm100,
+    )
+    from fla.modules.conv.causal_conv1d import causal_conv1d as fla_causal_conv1d
+    from fla.modules.conv.triton.ops import causal_conv1d_fwd as fla_causal_conv1d_fwd
+    from fla.ops.utils import prepare_chunk_indices
+
+    torch.manual_seed(20260828)
+    x = torch.randn(1, args.tokens, args.channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(args.channels, 4, device="cuda", dtype=torch.bfloat16)
+
+    cu_seqlens = None
+    chunk_indices = None
+    num_sequences = 1
+    if args.packed_sequences:
+        if args.tokens % args.packed_sequences:
+            raise ValueError("--tokens must be divisible by --packed-sequences")
+        num_sequences = args.packed_sequences
+        length = args.tokens // num_sequences
+        cu_seqlens = torch.arange(
+            0,
+            args.tokens + 1,
+            length,
+            dtype=torch.int32,
+            device="cuda",
+        )
+        chunk_indices = prepare_chunk_indices(cu_seqlens, 64)
+
+    initial_state = None
+    if args.state:
+        initial_state = torch.randn(num_sequences, args.channels, 4, device="cuda", dtype=torch.bfloat16)
+
+    output = torch.empty_like(x)
+    final_state = torch.empty(num_sequences, args.channels, 4, device="cuda", dtype=torch.bfloat16) if args.final_state else None
+    fe_api = CausalConv1dBulkFwdSm100(
+        sample_x=x,
+        sample_weight=weight,
+        sample_output=output,
+        sample_cu_seqlens=cu_seqlens,
+        sample_initial_state=initial_state,
+        sample_final_state=final_state,
+    )
+    fe_api.check_support()
+    fe_api.compile()
+
+    def fe_execute():
+        return fe_api.execute(
+            x,
+            weight,
+            output,
+            cu_seqlens_tensor=cu_seqlens,
+            initial_state_tensor=initial_state,
+            final_state_tensor=final_state,
+        )
+
+    def fe_wrapper():
+        return causal_conv1d_bulk_fwd_wrapper_sm100(
+            x,
+            weight,
+            cu_seqlens_tensor=cu_seqlens,
+            initial_state_tensor=initial_state,
+            output_final_state=args.final_state,
+        )
+
+    def fla_direct():
+        return fla_causal_conv1d_fwd(
+            x=x,
+            weight=weight,
+            bias=None,
+            residual=None,
+            initial_state=initial_state,
+            output_final_state=args.final_state,
+            activation="silu",
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
+
+    def fla_public():
+        return fla_causal_conv1d(
+            x=x,
+            weight=weight,
+            initial_state=initial_state,
+            output_final_state=args.final_state,
+            activation="silu",
+            backend="triton",
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
+
+    # Compile/autotune before checking or timing. This validates the exact
+    # external implementation used by the benchmark but is not the independent
+    # oracle used by the permanent correctness suite.
+    fe_result = fe_wrapper()
+    fla_result = fla_public()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(fe_result["output_tensor"], fla_result[0], atol=3e-2, rtol=3e-2)
+    if args.final_state:
+        torch.testing.assert_close(fe_result["final_state_tensor"], fla_result[1], atol=0, rtol=0)
+
+    timings = _interleaved_medians(
+        {
+            "fe_execute": fe_execute,
+            "fla_direct": fla_direct,
+            "fe_wrapper": fe_wrapper,
+            "fla_public": fla_public,
+        },
+        warmup=args.warmup,
+        rounds=args.rounds,
+        inner=args.inner,
+    )
+    timings["ratios"] = {
+        "fla_direct_over_fe_execute": timings["fla_direct"]["median_us"] / timings["fe_execute"]["median_us"],
+        "fla_public_over_fe_wrapper": timings["fla_public"]["median_us"] / timings["fe_wrapper"]["median_us"],
+    }
+    timings["shape"] = {
+        "tokens": args.tokens,
+        "channels": args.channels,
+        "packed_sequences": args.packed_sequences,
+        "initial_state": args.state,
+        "final_state": args.final_state,
+    }
+    timings["hardware"] = {
+        "device": properties.name,
+        "compute_capability": list(capability),
+        "total_memory_bytes": properties.total_memory,
+    }
+    timings["software"] = {
+        "python": platform.python_version(),
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+    }
+    slurm = _slurm_metadata()
+    if slurm:
+        timings["slurm"] = slurm
+    print(json.dumps(timings, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/python/fe_api/causal_conv1d_bulk/conftest.py
+++ b/test/python/fe_api/causal_conv1d_bulk/conftest.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Overlay this checkout's Python modules onto a prebuilt frontend package."""
+
+from pathlib import Path
+
+import cudnn
+
+_SOURCE_CUDNN = Path(__file__).resolve().parents[4] / "python" / "cudnn"
+if str(_SOURCE_CUDNN) not in cudnn.__path__:
+    cudnn.__path__.insert(0, str(_SOURCE_CUDNN))

--- a/test/python/fe_api/causal_conv1d_bulk/reference.py
+++ b/test/python/fe_api/causal_conv1d_bulk/reference.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""PyTorch references for width-four causal convolution."""
+
+from typing import Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+
+def causal_conv1d_bulk_reference(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    *,
+    bias: Optional[torch.Tensor] = None,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    initial_state: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Return an FP32-compute reference and the full-width final state.
+
+    ``x`` has native NWH layout ``[B, T, D]``.  When ``cu_seqlens`` is
+    present, ``B`` is one and its token dimension contains the packed
+    sequences.  State shifts are performed in the input dtype; only the
+    four-term convolution and SiLU use FP32.
+    """
+
+    if x.ndim != 3:
+        raise ValueError(f"x must be 3D, got {tuple(x.shape)}")
+    if weight.shape != (x.shape[-1], 4):
+        raise ValueError(f"weight must have shape {(x.shape[-1], 4)}, got {tuple(weight.shape)}")
+    if bias is not None and bias.shape != (x.shape[-1],):
+        raise ValueError(f"bias must have shape {(x.shape[-1],)}, got {tuple(bias.shape)}")
+
+    batch, tokens, channels = x.shape
+    if cu_seqlens is None:
+        num_sequences = batch
+        ranges = [(row, 0, tokens) for row in range(batch)]
+    else:
+        if batch != 1:
+            raise ValueError("packed x must have B=1")
+        offsets = [int(offset) for offset in cu_seqlens.detach().cpu().tolist()]
+        num_sequences = len(offsets) - 1
+        ranges = [(0, offsets[sequence], offsets[sequence + 1]) for sequence in range(num_sequences)]
+
+    if initial_state is None:
+        state = torch.zeros((num_sequences, channels, 4), device=x.device, dtype=x.dtype)
+    else:
+        if initial_state.shape != (num_sequences, channels, 4):
+            raise ValueError(f"initial_state must have shape {(num_sequences, channels, 4)}, got {tuple(initial_state.shape)}")
+        state = initial_state.clone()
+
+    output = torch.empty_like(x)
+    weight_fp32 = weight.float()
+    bias_fp32 = bias.float() if bias is not None else None
+    for sequence, (row, begin, end) in enumerate(ranges):
+        sequence_state = state[sequence]
+        for token in range(begin, end):
+            sequence_state = torch.cat((sequence_state[:, 1:], x[row, token].unsqueeze(-1)), dim=-1)
+            preactivation = (sequence_state.float() * weight_fp32).sum(dim=-1)
+            if bias_fp32 is not None:
+                preactivation = preactivation + bias_fp32
+            output[row, token] = F.silu(preactivation).to(x.dtype)
+        state[sequence] = sequence_state
+
+    return output, state
+
+
+def causal_conv1d_update_reference(
+    x: torch.Tensor,
+    state: torch.Tensor,
+    weight: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Reference one decode update using the bulk operation's state ABI."""
+
+    output, final_state = causal_conv1d_bulk_reference(
+        x.unsqueeze(1),
+        weight,
+        initial_state=state,
+    )
+    return output[:, 0], final_state

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_backward_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_backward_contract_unit.py
@@ -198,7 +198,13 @@ def test_v2_cpasync_uses_live_sm_count_and_preserves_explicit_vec4(monkeypatch):
 
 def test_v2_cpasync_planner_is_safe_for_arbitrary_t_d_and_sm(monkeypatch):
     backward, *_ = _load_backward()
-    for sequence_length in range(64, 32769):
+    stage = backward._VEC2_CPASYNC_TOKENS_PER_STAGE
+    sequence_lengths = sorted(
+        set(range(64, 32769, 97))
+        | {64, 65, 66, 8241, 8242, 8243, 16383, 16384, 16385, 32767, 32768}
+        | {3 + stage * multiple for multiple in (8, 9, 10, 127, 128, 129, 1023, 1024, 1025, 4095)}
+    )
+    for sequence_length in sequence_lengths:
         for n_channels in (512, 1024, 2048, 4096, 8192, 16384):
             channel_ctas = n_channels // backward._VEC2_CPASYNC_CHANNELS_PER_CTA
             for sm_count in (40, 60, 80, 100, 120, 148, 160):

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_backward_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_backward_contract_unit.py
@@ -1,0 +1,586 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host contract for the exact-shape backward prototype."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.L0
+
+
+def _load_backward():
+    try:
+        from cudnn.causal_conv1d_bulk_sm100 import (
+            CausalConv1dBulkAutogradPrototype,
+            CausalConv1dBulkBwdPrototype,
+            backward,
+            compile_causal_conv1d_bulk_bwd_prototype,
+        )
+    except (ImportError, OSError) as error:
+        pytest.skip(f"CuTe DSL dependencies unavailable: {error}")
+    return (
+        backward,
+        CausalConv1dBulkAutogradPrototype,
+        CausalConv1dBulkBwdPrototype,
+        compile_causal_conv1d_bulk_bwd_prototype,
+    )
+
+
+def _support_checked_api(
+    monkeypatch,
+    *,
+    batch=1,
+    tokens=257,
+    channels=8,
+    num_sequences=None,
+    schedule="t64",
+    capability=(10, 0),
+    sm_count=148,
+    with_bias=False,
+    with_initial_state=False,
+    with_d_final_state=False,
+    weight_dtype=torch.bfloat16,
+):
+    backward, _, api_class, _ = _load_backward()
+    x = torch.empty(batch, tokens, channels, dtype=torch.bfloat16)
+    weight = torch.empty(channels, 4, dtype=weight_dtype)
+    dy = torch.empty_like(x)
+    bias = torch.zeros(channels, dtype=torch.bfloat16) if with_bias else None
+    cu_seqlens = None
+    if num_sequences is not None:
+        cu_seqlens = torch.empty(num_sequences + 1, dtype=torch.int32)
+    state_sequences = batch if num_sequences is None else num_sequences
+    initial_state = torch.zeros(state_sequences, channels, 4, dtype=torch.bfloat16) if with_initial_state else None
+    d_final_state = torch.zeros(state_sequences, channels, 4, dtype=torch.bfloat16) if with_d_final_state else None
+    api = api_class(
+        x,
+        weight,
+        dy,
+        sample_cu_seqlens=cu_seqlens,
+        schedule=schedule,
+        sample_bias=bias,
+        sample_initial_state=initial_state,
+        sample_d_final_state=d_final_state,
+    )
+    monkeypatch.setattr(backward, "cutedsl_state", lambda: (True, None))
+    monkeypatch.setattr(api, "_require_cuda", lambda desc, name: None)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: capability)
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda device=None: SimpleNamespace(multi_processor_count=sm_count))
+    api.check_support()
+    return api, x, weight, dy, cu_seqlens, bias, initial_state, d_final_state
+
+
+def test_auto_schedule_uses_the_measured_t64_t128_cutover():
+    backward, *_ = _load_backward()
+    assert backward.select_bulk_bwd_schedule(8192) == "t64"
+    assert backward.select_bulk_bwd_schedule(16383) == "t64"
+    assert backward.select_bulk_bwd_schedule(16384) == "t128"
+    assert backward.select_bulk_bwd_schedule(32768) == "t128"
+
+
+def test_backward_support_accepts_bias_free_fp32_weight(monkeypatch):
+    api, _, weight, *_ = _support_checked_api(
+        monkeypatch,
+        weight_dtype=torch.float32,
+    )
+    assert api.weight_desc.dtype == torch.float32
+    assert weight.dtype == torch.float32
+
+
+def test_auto_schedule_uses_per_sequence_t_for_dense_and_total_t_for_packed(monkeypatch):
+    dense, *_ = _support_checked_api(
+        monkeypatch,
+        batch=2,
+        tokens=8192,
+        schedule="auto",
+    )
+    assert dense.schedule == "t64"
+
+    packed, *_ = _support_checked_api(
+        monkeypatch,
+        tokens=16384,
+        num_sequences=3,
+        schedule="auto",
+    )
+    assert packed.schedule == "t128"
+
+    streaming, *_ = _support_checked_api(
+        monkeypatch,
+        tokens=8192,
+        channels=512,
+        schedule="auto",
+    )
+    assert streaming.schedule == "v2-cpasync"
+    assert streaming.kernel_variant == "vec2-cpasync"
+
+
+@pytest.mark.parametrize("state_kwarg", ("with_initial_state", "with_d_final_state"))
+def test_auto_schedule_keeps_state_gradients_on_scalar_kernel(monkeypatch, state_kwarg):
+    api, *_ = _support_checked_api(
+        monkeypatch,
+        tokens=8192,
+        channels=512,
+        schedule="auto",
+        **{state_kwarg: True},
+    )
+    assert api.schedule == "t64"
+    assert api.kernel_variant == "scalar"
+
+
+def test_vec4_stream_uses_one_sm_scaled_tile_formula(monkeypatch):
+    api, *_ = _support_checked_api(
+        monkeypatch,
+        tokens=16384,
+        channels=8192,
+        schedule="v4-stream",
+    )
+
+    assert api.kernel_variant == "vec4-stream"
+    assert api.sm_count == 148
+    assert api.tokens_per_cta == 360
+    assert api.tiles_per_sequence == 46
+    assert api.num_dweight_partials == 46
+    assert api.dweight_workspace_bytes == 46 * 8192 * 4 * 4
+
+    short_tail, *_ = _support_checked_api(
+        monkeypatch,
+        tokens=49,
+        channels=512,
+        schedule="v4-stream",
+    )
+    assert short_tail.tokens_per_cta == 25
+    assert short_tail.tiles_per_sequence == 2
+
+
+def test_v2_cpasync_uses_live_sm_count_and_preserves_explicit_vec4(monkeypatch):
+    cpasync, *_ = _support_checked_api(
+        monkeypatch,
+        tokens=16384,
+        channels=8192,
+        schedule="v2-cpasync",
+        sm_count=148,
+    )
+    assert cpasync.schedule == "v2-cpasync"
+    assert cpasync.kernel_variant == "vec2-cpasync"
+    assert cpasync.sm_count == 148
+    assert cpasync.tokens_per_cta == 915
+    assert cpasync.tiles_per_sequence == 18
+    assert cpasync.num_dweight_partials == 18
+    assert cpasync.dweight_workspace_bytes == 18 * 8192 * 4 * 4
+
+    fewer_sms, *_ = _support_checked_api(
+        monkeypatch,
+        tokens=16384,
+        channels=8192,
+        schedule="v2-cpasync",
+        capability=(10, 3),
+        sm_count=80,
+    )
+    assert fewer_sms.kernel_variant == "vec2-cpasync"
+    assert fewer_sms.tokens_per_cta == 1643
+    assert fewer_sms.tiles_per_sequence == 10
+
+    vec4, *_ = _support_checked_api(
+        monkeypatch,
+        tokens=16384,
+        channels=8192,
+        schedule="v4-stream",
+        sm_count=148,
+    )
+    assert vec4.kernel_variant == "vec4-stream"
+    assert vec4.tokens_per_cta == 360
+    assert vec4.tiles_per_sequence == 46
+
+
+def test_v2_cpasync_planner_is_safe_for_arbitrary_t_d_and_sm(monkeypatch):
+    backward, *_ = _load_backward()
+    for sequence_length in range(64, 32769):
+        for n_channels in (512, 1024, 2048, 4096, 8192, 16384):
+            channel_ctas = n_channels // backward._VEC2_CPASYNC_CHANNELS_PER_CTA
+            for sm_count in (40, 60, 80, 100, 120, 148, 160):
+                token_ctas, tokens_per_cta = backward._plan_vec2_cpasync(sequence_length, n_channels, sm_count)
+                last_tile_tokens = sequence_length - (token_ctas - 1) * tokens_per_cta
+                assert tokens_per_cta >= 3
+                assert (tokens_per_cta - 3) % backward._VEC2_CPASYNC_TOKENS_PER_STAGE == 0
+                assert token_ctas == (sequence_length + tokens_per_cta - 1) // tokens_per_cta
+                assert (token_ctas - 1) * tokens_per_cta < sequence_length <= token_ctas * tokens_per_cta
+                assert last_tile_tokens >= 3
+                assert channel_ctas * token_ctas <= sm_count * backward._VEC2_CPASYNC_TARGET_CTAS_PER_SM
+
+
+def test_v2_cpasync_burst_store_uses_compact_row_major_staging():
+    from cudnn.causal_conv1d_bulk_sm100.backward_kernel_vec2_cpasync import (
+        _DX_STAGE_STRIDE,
+    )
+
+    assert _DX_STAGE_STRIDE == (2, 1)
+
+
+def test_v2_cpasync_rejects_arch_without_packed_f32x2(monkeypatch):
+    with pytest.raises(ValueError, match="requires packed-f32x2 support"):
+        _support_checked_api(
+            monkeypatch,
+            tokens=8192,
+            channels=512,
+            schedule="v2-cpasync",
+            capability=(9, 0),
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    (
+        {"with_bias": True},
+        {"with_initial_state": True},
+        {"with_d_final_state": True},
+        {"num_sequences": 2},
+    ),
+)
+def test_auto_schedule_keeps_cpasync_unsupported_contracts_on_general_kernels(monkeypatch, kwargs):
+    api, *_ = _support_checked_api(
+        monkeypatch,
+        tokens=8192,
+        channels=512,
+        schedule="auto",
+        **kwargs,
+    )
+    assert api.kernel_variant == "scalar"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"batch": 2, "tokens": 64, "channels": 512}, "requires B=1"),
+        ({"tokens": 64, "channels": 512, "num_sequences": 2}, "dense input only"),
+        ({"tokens": 64, "channels": 513}, "D divisible by 512"),
+        ({"tokens": 64, "channels": 512, "with_bias": True}, "does not yet support bias"),
+        ({"tokens": 64, "channels": 512, "with_initial_state": True}, "does not yet support initial-state"),
+        ({"tokens": 64, "channels": 512, "with_d_final_state": True}, "does not yet support initial-state"),
+        ({"tokens": 15, "channels": 512}, "requires T>=16"),
+    ],
+)
+def test_vec4_stream_rejects_unimplemented_contracts(monkeypatch, kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        _support_checked_api(monkeypatch, schedule="v4-stream", **kwargs)
+
+
+def test_packed_capacity_is_the_tight_shape_only_bound(monkeypatch):
+    atomic, *_ = _support_checked_api(
+        monkeypatch,
+        tokens=257,
+        channels=8,
+        num_sequences=4,
+        schedule="t64",
+    )
+    assert atomic.packed_tile_capacity == 4 + (257 - 4) // 64 == 7
+    assert atomic.packed_tile_map_numel == 28
+    assert atomic.packed_tile_map_bytes == 112
+    assert atomic.dweight_workspace_bytes == 0
+    assert atomic.total_workspace_bytes == 112
+
+    partial, *_ = _support_checked_api(
+        monkeypatch,
+        tokens=257,
+        channels=8,
+        num_sequences=4,
+        schedule="t64-partial",
+    )
+    assert partial.num_dweight_partials == 7
+    assert partial.dweight_workspace_bytes == 7 * 8 * 4 * 4
+    assert partial.total_workspace_bytes == 112 + 7 * 8 * 4 * 4
+
+
+def test_dense_backward_needs_no_tile_map(monkeypatch):
+    api, *_ = _support_checked_api(
+        monkeypatch,
+        batch=2,
+        tokens=65,
+        channels=8,
+        schedule="t64-partial",
+    )
+    assert api.tiles_per_sequence == 2
+    assert api.num_dweight_partials == 4
+    assert api.packed_tile_map_bytes == 0
+    assert api.total_workspace_bytes == api.dweight_workspace_bytes
+
+
+@pytest.mark.parametrize("schedule", ["bad", "", "T64"])
+def test_unknown_schedule_fails_at_construction(schedule):
+    _, _, api_class, _ = _load_backward()
+    x = torch.zeros(1, 2, 8, dtype=torch.bfloat16)
+    with pytest.raises(ValueError, match="unknown schedule"):
+        api_class(x, torch.zeros(8, 4, dtype=x.dtype), x, schedule=schedule)
+
+
+def test_packed_requires_one_row_and_no_more_sequences_than_tokens(monkeypatch):
+    backward, _, api_class, _ = _load_backward()
+    monkeypatch.setattr(backward, "cutedsl_state", lambda: (True, None))
+
+    x = torch.zeros(2, 2, 8, dtype=torch.bfloat16)
+    api = api_class(
+        x,
+        torch.zeros(8, 4, dtype=x.dtype),
+        torch.zeros_like(x),
+        torch.empty(2, dtype=torch.int32),
+    )
+    with pytest.raises(ValueError, match="Packed X must have B=1"):
+        api.check_support()
+
+    x = x[:1]
+    api = api_class(
+        x,
+        torch.zeros(8, 4, dtype=x.dtype),
+        torch.zeros_like(x),
+        torch.empty(4, dtype=torch.int32),
+    )
+    with pytest.raises(ValueError, match="cannot exceed total_T"):
+        api.check_support()
+
+
+def test_backward_rejects_wrong_packed_metadata_dtype(monkeypatch):
+    backward, _, api_class, _ = _load_backward()
+    monkeypatch.setattr(backward, "cutedsl_state", lambda: (True, None))
+    x = torch.zeros(1, 4, 8, dtype=torch.bfloat16)
+    api = api_class(
+        x,
+        torch.zeros(8, 4, dtype=x.dtype),
+        torch.zeros_like(x),
+        torch.empty(2, dtype=torch.int64),
+    )
+    with pytest.raises(ValueError, match="cu_seqlens dtype mismatch"):
+        api.check_support()
+
+
+def test_backward_uses_the_shared_architecture_allowlist(monkeypatch):
+    with pytest.raises(RuntimeError, match="does not support compute capability"):
+        _support_checked_api(monkeypatch, capability=(10, 1))
+
+
+@pytest.mark.parametrize("case", ["rank", "shape", "dtype", "stride", "alignment"])
+def test_backward_rejects_invalid_bias_contract(monkeypatch, case):
+    backward, _, api_class, _ = _load_backward()
+    x = torch.zeros(1, 4, 8, dtype=torch.bfloat16)
+    weight = torch.zeros(8, 4, dtype=torch.bfloat16)
+    if case == "rank":
+        bias = torch.zeros(1, 8, dtype=torch.bfloat16)
+    elif case == "shape":
+        bias = torch.zeros(7, dtype=torch.bfloat16)
+    elif case == "dtype":
+        bias = torch.zeros(8, dtype=torch.float32)
+    elif case == "stride":
+        bias = torch.zeros(8, 2, dtype=torch.bfloat16)[:, 0]
+    elif case == "alignment":
+        bias = torch.zeros(9, dtype=torch.bfloat16)[1:]
+    else:
+        raise AssertionError(f"unhandled case {case}")
+    api = api_class(x, weight, torch.zeros_like(x), sample_bias=bias)
+    monkeypatch.setattr(backward, "cutedsl_state", lambda: (True, None))
+
+    with pytest.raises(ValueError, match="Bias"):
+        api.check_support()
+
+
+def test_backward_rejects_non_tensor_bias():
+    _, _, api_class, _ = _load_backward()
+    x = torch.zeros(1, 4, 8, dtype=torch.bfloat16)
+    with pytest.raises(TypeError, match=r"sample_bias must be a torch\.Tensor or None"):
+        api_class(x, torch.zeros(8, 4, dtype=x.dtype), torch.zeros_like(x), sample_bias=object())
+
+
+def test_bias_and_dbias_presence_match_the_compiled_signature(monkeypatch):
+    with_bias, x, weight, dy, _, bias, *_ = _support_checked_api(monkeypatch, tokens=17, with_bias=True)
+    with_bias._compiled_kernel = object()
+    dx = torch.empty_like(x)
+    dw = torch.empty_like(weight, dtype=torch.float32)
+    db = torch.empty(weight.shape[0], dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="Bias presence must match"):
+        with_bias.execute(x, weight, dy, dx, dw)
+    with pytest.raises(ValueError, match="dBias accumulator presence must match"):
+        with_bias.execute(x, weight, dy, dx, dw, bias=bias)
+    with pytest.raises(TypeError, match=r"dBias accumulator must be a torch\.Tensor"):
+        with_bias.execute(x, weight, dy, dx, dw, bias=bias, db_accum=object())
+    with pytest.raises(ValueError, match="dBias accumulator must be contiguous FP32"):
+        with_bias.execute(x, weight, dy, dx, dw, bias=bias, db_accum=torch.empty(weight.shape[0] + 1, dtype=torch.float32))
+
+    without_bias, *_ = _support_checked_api(monkeypatch, tokens=17)
+    without_bias._compiled_kernel = object()
+    with pytest.raises(ValueError, match="Bias presence must match"):
+        without_bias.execute(x, weight, dy, dx, dw, bias=bias, db_accum=db)
+
+
+def test_dbias_reuses_dweight_schedule_without_extra_workspace(monkeypatch):
+    without_bias, *_ = _support_checked_api(monkeypatch, tokens=257, channels=8, num_sequences=4, schedule="t64-partial")
+    with_bias, *_ = _support_checked_api(monkeypatch, tokens=257, channels=8, num_sequences=4, schedule="t64-partial", with_bias=True)
+
+    assert with_bias.dweight_workspace_bytes == without_bias.dweight_workspace_bytes
+    assert with_bias.total_workspace_bytes == without_bias.total_workspace_bytes
+
+
+def test_dbias_accumulator_must_not_overlap_dweight(monkeypatch):
+    api, x, weight, dy, _, bias, *_ = _support_checked_api(monkeypatch, tokens=17, with_bias=True)
+    api._compiled_kernel = object()
+    dw = torch.empty_like(weight, dtype=torch.float32)
+    db_alias = dw.view(-1)[: weight.shape[0]]
+
+    with pytest.raises(ValueError, match="dW accumulator and dBias accumulator must not overlap"):
+        api.execute(x, weight, dy, torch.empty_like(x), dw, bias=bias, db_accum=db_alias)
+
+
+def test_state_presence_is_an_exact_compile_signature(monkeypatch):
+    api, x, weight, dy, _, bias, initial_state, d_final_state = _support_checked_api(
+        monkeypatch,
+        tokens=4,
+        with_bias=True,
+        with_initial_state=True,
+        with_d_final_state=True,
+    )
+    api._compiled_kernel = object()
+    dx = torch.empty_like(x)
+    dw = torch.empty_like(weight, dtype=torch.float32)
+    db = torch.empty(weight.shape[0], dtype=torch.float32)
+    d_initial_state = torch.empty_like(initial_state)
+
+    with pytest.raises(ValueError, match="Initial state presence must match"):
+        api.execute(
+            x,
+            weight,
+            dy,
+            dx,
+            dw,
+            bias=bias,
+            db_accum=db,
+            d_final_state=d_final_state,
+            d_initial_state=d_initial_state,
+        )
+    with pytest.raises(ValueError, match="dFinal state presence must match"):
+        api.execute(
+            x,
+            weight,
+            dy,
+            dx,
+            dw,
+            bias=bias,
+            db_accum=db,
+            initial_state=initial_state,
+            d_initial_state=d_initial_state,
+        )
+    with pytest.raises(ValueError, match="dInitial state presence must match"):
+        api.execute(
+            x,
+            weight,
+            dy,
+            dx,
+            dw,
+            bias=bias,
+            db_accum=db,
+            initial_state=initial_state,
+            d_final_state=d_final_state,
+        )
+
+
+def test_state_gradient_output_must_not_overlap_inputs(monkeypatch):
+    api, x, weight, dy, _, _, initial_state, _ = _support_checked_api(
+        monkeypatch,
+        tokens=4,
+        with_initial_state=True,
+    )
+    api._compiled_kernel = object()
+
+    with pytest.raises(ValueError, match="Initial state and dInitial state must not overlap"):
+        api.execute(
+            x,
+            weight,
+            dy,
+            torch.empty_like(x),
+            torch.empty_like(weight, dtype=torch.float32),
+            initial_state=initial_state,
+            d_initial_state=initial_state,
+        )
+
+
+def test_execute_keeps_the_stateless_two_tuple_abi(monkeypatch):
+    backward, *_ = _load_backward()
+    api, x, weight, dy, *_ = _support_checked_api(
+        monkeypatch,
+        tokens=17,
+        schedule="t64-partial",
+    )
+    launches = []
+    api._compiled_kernel = lambda *args: launches.append(args)
+    monkeypatch.setattr(backward, "_as_torch_stream", lambda current_stream, device: object())
+    monkeypatch.setattr(backward, "_record_streams", lambda tensors, stream: None)
+    dx = torch.empty_like(x)
+    dw = torch.empty_like(weight, dtype=torch.float32)
+    workspace = torch.empty(api.dweight_workspace_numel, dtype=torch.float32)
+
+    result = api.execute(
+        x,
+        weight,
+        dy,
+        dx,
+        dw,
+        dweight_workspace=workspace,
+        current_stream=object(),
+    )
+
+    assert len(result) == 2
+    assert result[0] is dx
+    assert result[1] is dw
+    assert len(launches) == 1
+
+
+def test_execute_rejects_input_output_alias_before_launch(monkeypatch):
+    api, x, weight, dy, cu_seqlens, _, *_ = _support_checked_api(
+        monkeypatch,
+        tokens=17,
+        channels=8,
+        num_sequences=2,
+    )
+    api._compiled_kernel = object()
+    tile_map = torch.empty(api.packed_tile_map_numel, dtype=torch.int32)
+    dw = torch.empty_like(weight, dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="X and dX must not overlap"):
+        api.execute(
+            x,
+            weight,
+            dy,
+            x,
+            dw,
+            cu_seqlens=cu_seqlens,
+            packed_tile_map=tile_map,
+        )
+    with pytest.raises(ValueError, match="dY and dX must not overlap"):
+        api.execute(
+            x,
+            weight,
+            dy,
+            dy,
+            dw,
+            cu_seqlens=cu_seqlens,
+            packed_tile_map=tile_map,
+        )
+
+
+def test_packed_execute_requires_tile_map_even_for_atomic_schedule(monkeypatch):
+    api, x, weight, dy, cu_seqlens, _, *_ = _support_checked_api(
+        monkeypatch,
+        tokens=17,
+        channels=8,
+        num_sequences=2,
+    )
+    api._compiled_kernel = object()
+    with pytest.raises(ValueError, match="tile-map workspace"):
+        api.execute(
+            x,
+            weight,
+            dy,
+            torch.empty_like(x),
+            torch.empty_like(weight, dtype=torch.float32),
+            cu_seqlens=cu_seqlens,
+        )

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_backward_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_backward_contract_unit.py
@@ -43,6 +43,7 @@ def _support_checked_api(
     with_initial_state=False,
     with_d_final_state=False,
     weight_dtype=torch.bfloat16,
+    deterministic=False,
 ):
     backward, _, api_class, _ = _load_backward()
     x = torch.empty(batch, tokens, channels, dtype=torch.bfloat16)
@@ -64,6 +65,7 @@ def _support_checked_api(
         sample_bias=bias,
         sample_initial_state=initial_state,
         sample_d_final_state=d_final_state,
+        deterministic=deterministic,
     )
     monkeypatch.setattr(backward, "cutedsl_state", lambda: (True, None))
     monkeypatch.setattr(api, "_require_cuda", lambda desc, name: None)
@@ -590,3 +592,48 @@ def test_packed_execute_requires_tile_map_even_for_atomic_schedule(monkeypatch):
             torch.empty_like(weight, dtype=torch.float32),
             cu_seqlens=cu_seqlens,
         )
+
+
+def test_default_auto_schedule_still_accumulates_dweight_with_atomics(monkeypatch):
+    backward, *_ = _load_backward()
+    api, *_ = _support_checked_api(monkeypatch, schedule="auto")
+    assert api.dweight_mode == backward._DWEIGHT_ATOMIC
+
+
+@pytest.mark.parametrize("kwargs", [{}, {"num_sequences": 4}, {"with_initial_state": True, "with_d_final_state": True}])
+def test_deterministic_auto_schedule_uses_partial_dweight(monkeypatch, kwargs):
+    backward, *_ = _load_backward()
+    api, *_ = _support_checked_api(monkeypatch, schedule="auto", deterministic=True, **kwargs)
+    assert api.dweight_mode == backward._DWEIGHT_PARTIAL
+    assert api.dweight_workspace_numel > 0
+
+
+def test_deterministic_auto_keeps_the_partial_streaming_schedule(monkeypatch):
+    backward, *_ = _load_backward()
+    api, *_ = _support_checked_api(monkeypatch, tokens=8192, channels=512, schedule="auto", deterministic=True)
+    assert api.dweight_mode == backward._DWEIGHT_PARTIAL
+
+
+@pytest.mark.parametrize(
+    "kwargs, reason",
+    [
+        ({"schedule": "t64"}, "dweight with FP32 atomics"),
+        ({"schedule": "auto", "with_bias": True}, "dbias accumulates"),
+    ],
+)
+def test_deterministic_strict_mode_rejects_remaining_atomics(monkeypatch, kwargs, reason):
+    with pytest.raises(RuntimeError, match=reason):
+        _support_checked_api(monkeypatch, deterministic=True, **kwargs)
+
+
+def test_deterministic_warn_only_mode_warns_and_keeps_atomic_dbias(monkeypatch):
+    backward, *_ = _load_backward()
+    previous = torch.are_deterministic_algorithms_enabled()
+    previous_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
+    torch.use_deterministic_algorithms(True, warn_only=True)
+    try:
+        with pytest.warns(RuntimeWarning, match="dbias accumulates"):
+            api, *_ = _support_checked_api(monkeypatch, schedule="auto", with_bias=True, deterministic=True)
+    finally:
+        torch.use_deterministic_algorithms(previous, warn_only=previous_warn_only)
+    assert api.dweight_mode == backward._DWEIGHT_PARTIAL

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_backward_sm100.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_backward_sm100.py
@@ -47,7 +47,7 @@ def _reference(
     if offsets is None:
         return _dense_reference(x, weight, bias)
     return torch.cat(
-        [_dense_reference(x[:, start:end], weight, bias) for start, end in zip(offsets[:-1], offsets[1:], strict=True)],
+        [_dense_reference(x[:, start:end], weight, bias) for start, end in zip(offsets[:-1], offsets[1:])],
         dim=1,
     )
 

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_backward_sm100.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_backward_sm100.py
@@ -1,0 +1,390 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GPU correctness for the experimental bulk backward."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn.functional as F
+from cudnn._causal_conv1d_arch import F32X2_COMPUTE_CAPABILITIES, is_functional_arch
+from fe_api.causal_conv1d_bulk.reference import causal_conv1d_bulk_reference
+
+pytestmark = pytest.mark.L1
+
+
+def _load_autograd_prototype():
+    try:
+        from cudnn.causal_conv1d_bulk_sm100 import (
+            CausalConv1dBulkAutogradPrototype,
+        )
+    except (ImportError, OSError) as error:
+        pytest.skip(f"CuTe DSL dependencies unavailable: {error}")
+    return CausalConv1dBulkAutogradPrototype
+
+
+def _dense_reference(x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None) -> torch.Tensor:
+    tokens = x.shape[1]
+    preactivation = F.conv1d(
+        x.transpose(1, 2),
+        weight.unsqueeze(1),
+        bias,
+        padding=3,
+        groups=x.shape[2],
+    )[
+        ..., :tokens
+    ].transpose(1, 2)
+    return F.silu(preactivation)
+
+
+def _reference(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    offsets: tuple[int, ...] | None,
+) -> torch.Tensor:
+    if offsets is None:
+        return _dense_reference(x, weight, bias)
+    return torch.cat(
+        [_dense_reference(x[:, start:end], weight, bias) for start, end in zip(offsets[:-1], offsets[1:], strict=True)],
+        dim=1,
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize(
+    ("shape", "offsets", "schedule", "with_bias"),
+    [
+        ((2, 65, 8), None, "t64", False),
+        ((1, 70, 8), (0, 1, 3, 6, 70), "t64", False),
+        ((1, 70, 8), (0, 1, 3, 6, 70), "t64-partial", False),
+        ((2, 65, 8), None, "t64", True),
+        ((1, 70, 8), (0, 1, 3, 6, 70), "t64", True),
+        ((1, 70, 8), (0, 1, 3, 6, 70), "t64-partial", True),
+        ((1, 16384, 8), None, "auto", True),
+        ((1, 64, 512), None, "v4-stream", False),
+        ((1, 49, 512), None, "v4-stream", False),
+        ((1, 65, 256), None, "v2-cpasync", False),
+        # This shape exposes a one-token final tile unless the planner folds it
+        # into the preceding G8 tile.
+        ((1, 8242, 2048), None, "v2-cpasync", False),
+    ],
+)
+def test_stateless_backward_matches_independent_recurrence(shape, offsets, schedule, with_bias):
+    capability = torch.cuda.get_device_capability()
+    if not is_functional_arch(capability):
+        pytest.skip(f"unsupported compute capability {capability}")
+    if schedule == "v2-cpasync" and capability not in F32X2_COMPUTE_CAPABILITIES:
+        pytest.skip(f"packed-f32x2 is unsupported on compute capability {capability}")
+
+    prototype = _load_autograd_prototype()
+    generator = torch.Generator(device="cuda").manual_seed(20260829)
+    x = (torch.randn(shape, device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25).requires_grad_()
+    weight = (
+        torch.randn(
+            (shape[2], 4),
+            device="cuda",
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.25
+    ).requires_grad_()
+    bias = (torch.randn(shape[2], device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25).requires_grad_() if with_bias else None
+    dy = torch.randn(shape, device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    cu_seqlens = None if offsets is None else torch.tensor(offsets, device="cuda", dtype=torch.int32)
+
+    reference_x = x.detach().float().requires_grad_()
+    reference_weight = weight.detach().float().requires_grad_()
+    reference_bias = bias.detach().float().requires_grad_() if bias is not None else None
+    expected = _reference(reference_x, reference_weight, reference_bias, offsets)
+    expected.backward(dy.float())
+
+    operation = prototype(x, weight, cu_seqlens, schedule=schedule, sample_bias=bias)
+    actual = operation(x, weight, cu_seqlens, bias=bias)
+    actual.backward(dy)
+
+    torch.testing.assert_close(actual.float(), expected, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(x.grad.float(), reference_x.grad, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(weight.grad.float(), reference_weight.grad, atol=1e-1, rtol=5e-2)
+    if bias is not None:
+        torch.testing.assert_close(bias.grad.float(), reference_bias.grad, atol=1e-1, rtol=5e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize(
+    ("shape", "schedule"),
+    [
+        ((1, 64, 512), "v4-stream"),
+        ((1, 8192, 256), "v2-cpasync"),
+    ],
+)
+def test_streaming_backward_supports_fp32_weight(shape, schedule):
+    capability = torch.cuda.get_device_capability()
+    if not is_functional_arch(capability):
+        pytest.skip(f"unsupported compute capability {capability}")
+    if schedule == "v2-cpasync" and capability not in F32X2_COMPUTE_CAPABILITIES:
+        pytest.skip(f"packed-f32x2 is unsupported on compute capability {capability}")
+
+    prototype = _load_autograd_prototype()
+    generator = torch.Generator(device="cuda").manual_seed(20260903)
+    x = (
+        torch.randn(
+            shape,
+            device="cuda",
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.25
+    ).requires_grad_()
+    weight = (
+        torch.randn(
+            (shape[2], 4),
+            device="cuda",
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * 0.25
+    ).requires_grad_()
+    dy = (
+        torch.randn(
+            shape,
+            device="cuda",
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.25
+    )
+
+    reference_x = x.detach().float().requires_grad_()
+    reference_weight = weight.detach().requires_grad_()
+    expected = _dense_reference(reference_x, reference_weight, None)
+    expected.backward(dy.float())
+
+    operation = prototype(x, weight, schedule=schedule)
+    actual = operation(x, weight)
+    actual.backward(dy)
+
+    assert operation.backward_backend.kernel_variant in (
+        "vec4-stream",
+        "vec2-cpasync",
+    )
+    assert weight.grad.dtype == torch.float32
+    torch.testing.assert_close(actual.float(), expected, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(x.grad.float(), reference_x.grad, atol=1.25e-1, rtol=5e-2)
+    torch.testing.assert_close(weight.grad, reference_weight.grad, atol=2.0, rtol=5e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_vec2_cpasync_fast_tanh_extremes_and_exact_cancellation():
+    capability = torch.cuda.get_device_capability()
+    if capability not in F32X2_COMPUTE_CAPABILITIES:
+        pytest.skip(f"packed-f32x2 is unsupported on compute capability {capability}")
+
+    prototype = _load_autograd_prototype()
+    shape = (1, 64, 512)
+    x = torch.empty(shape, device="cuda", dtype=torch.bfloat16)
+    weight = torch.zeros((shape[2], 4), device="cuda", dtype=torch.bfloat16)
+    with torch.no_grad():
+        levels = torch.tensor((-32.0, -16.0, -8.0, -4.0, -1.0, 0.0, 1.0, 4.0, 8.0, 16.0, 32.0), device="cuda", dtype=torch.bfloat16)
+        x[..., :256] = levels.repeat((shape[1] * 256 + levels.numel() - 1) // levels.numel())[: shape[1] * 256].view(shape[1], 256)
+        weight[:256, 3] = 1.0
+
+        # For every interior token these four terms cancel z and dX exactly:
+        # z = 96 - 96 + 64 - 64 and dX = -64 + 64 - 96 + 96.
+        x[..., 256:] = 1.0
+        weight[256:, 0] = 96.0
+        weight[256:, 1] = -96.0
+        weight[256:, 2] = 64.0
+        weight[256:, 3] = -64.0
+    x.requires_grad_()
+    weight.requires_grad_()
+    dy = torch.full_like(x, 1.359375)
+
+    reference_x = x.detach().float().requires_grad_()
+    reference_weight = weight.detach().float().requires_grad_()
+    expected = _dense_reference(reference_x, reference_weight, None)
+    expected.backward(dy.float())
+
+    operation = prototype(x, weight, schedule="v2-cpasync")
+    assert operation.backward_backend.kernel_variant == "vec2-cpasync"
+    actual = operation(x, weight)
+    actual.backward(dy)
+
+    assert torch.isfinite(x.grad).all()
+    assert torch.isfinite(weight.grad).all()
+    torch.testing.assert_close(x.grad.float(), reference_x.grad, atol=1.25e-1, rtol=5e-2)
+    torch.testing.assert_close(weight.grad.float(), reference_weight.grad, atol=2.0, rtol=5e-2)
+    torch.testing.assert_close(x.grad[0, 3:61, 256:], torch.zeros_like(x.grad[0, 3:61, 256:]), atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize(
+    ("shape", "offsets", "schedule", "with_bias"),
+    [
+        ((2, 1, 8), None, "t64", False),
+        ((2, 2, 8), None, "t64", True),
+        ((2, 3, 8), None, "t64-partial", False),
+        ((2, 4, 8), None, "t64-partial", True),
+        ((1, 10, 8), (0, 1, 3, 6, 10), "t64", True),
+        ((1, 10, 8), (0, 1, 3, 6, 10), "t64-partial", False),
+    ],
+)
+def test_stateful_backward_matches_tail4_recurrence(shape, offsets, schedule, with_bias):
+    """Exercise every positive short-sequence boundary and both dw schedules."""
+
+    capability = torch.cuda.get_device_capability()
+    if not is_functional_arch(capability):
+        pytest.skip(f"unsupported compute capability {capability}")
+
+    prototype = _load_autograd_prototype()
+    generator = torch.Generator(device="cuda").manual_seed(20260830 + shape[1] + int(with_bias))
+    num_sequences = shape[0] if offsets is None else len(offsets) - 1
+    x = (torch.randn(shape, device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25).requires_grad_()
+    weight = (torch.randn((shape[2], 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25).requires_grad_()
+    bias = (torch.randn(shape[2], device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25).requires_grad_() if with_bias else None
+    initial_state = (torch.randn((num_sequences, shape[2], 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25).requires_grad_()
+    dy = torch.randn(shape, device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    d_final_state = torch.randn(initial_state.shape, device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    cu_seqlens = None if offsets is None else torch.tensor(offsets, device="cuda", dtype=torch.int32)
+
+    reference_x = x.detach().float().requires_grad_()
+    reference_weight = weight.detach().float().requires_grad_()
+    reference_bias = bias.detach().float().requires_grad_() if bias is not None else None
+    reference_initial_state = initial_state.detach().float().requires_grad_()
+    expected_output, expected_final_state = causal_conv1d_bulk_reference(
+        reference_x,
+        reference_weight,
+        bias=reference_bias,
+        cu_seqlens=cu_seqlens,
+        initial_state=reference_initial_state,
+    )
+    torch.autograd.backward(
+        (expected_output, expected_final_state),
+        (dy.float(), d_final_state.float()),
+    )
+
+    operation = prototype(
+        x,
+        weight,
+        cu_seqlens,
+        schedule=schedule,
+        sample_bias=bias,
+        sample_initial_state=initial_state,
+        output_final_state=True,
+    )
+    actual = operation(
+        x,
+        weight,
+        cu_seqlens,
+        bias=bias,
+        initial_state=initial_state,
+        output_final_state=True,
+    )
+    torch.autograd.backward(
+        (actual["output_tensor"], actual["final_state_tensor"]),
+        (dy, d_final_state),
+    )
+
+    torch.testing.assert_close(actual["output_tensor"].float(), expected_output, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(actual["final_state_tensor"].float(), expected_final_state, atol=0, rtol=0)
+    torch.testing.assert_close(x.grad.float(), reference_x.grad, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(weight.grad.float(), reference_weight.grad, atol=1e-1, rtol=5e-2)
+    torch.testing.assert_close(initial_state.grad.float(), reference_initial_state.grad, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(initial_state.grad[..., 0], torch.zeros_like(initial_state.grad[..., 0]), atol=0, rtol=0)
+    if bias is not None:
+        torch.testing.assert_close(bias.grad.float(), reference_bias.grad, atol=1e-1, rtol=5e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_final_state_gradient_without_initial_state_reaches_only_surviving_tokens():
+    capability = torch.cuda.get_device_capability()
+    if not is_functional_arch(capability):
+        pytest.skip(f"unsupported compute capability {capability}")
+
+    prototype = _load_autograd_prototype()
+    generator = torch.Generator(device="cuda").manual_seed(20260831)
+    shape = (1, 6, 8)
+    offsets = (0, 1, 3, 6)
+    x = (torch.randn(shape, device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25).requires_grad_()
+    weight = (torch.randn((shape[2], 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25).requires_grad_()
+    dy = torch.randn(shape, device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    d_final_state = torch.randn((len(offsets) - 1, shape[2], 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    cu_seqlens = torch.tensor(offsets, device="cuda", dtype=torch.int32)
+
+    reference_x = x.detach().float().requires_grad_()
+    reference_weight = weight.detach().float().requires_grad_()
+    expected_output, expected_final_state = causal_conv1d_bulk_reference(
+        reference_x,
+        reference_weight,
+        cu_seqlens=cu_seqlens,
+    )
+    torch.autograd.backward((expected_output, expected_final_state), (dy.float(), d_final_state.float()))
+
+    operation = prototype(x, weight, cu_seqlens, output_final_state=True)
+    actual = operation(x, weight, cu_seqlens, output_final_state=True)
+    torch.autograd.backward((actual["output_tensor"], actual["final_state_tensor"]), (dy, d_final_state))
+
+    torch.testing.assert_close(x.grad.float(), reference_x.grad, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(weight.grad.float(), reference_weight.grad, atol=1e-1, rtol=5e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_final_state_gradient_is_accumulated_before_the_single_bf16_dx_cast():
+    capability = torch.cuda.get_device_capability()
+    if not is_functional_arch(capability):
+        pytest.skip(f"unsupported compute capability {capability}")
+
+    prototype = _load_autograd_prototype()
+    x = torch.zeros((1, 1, 8), device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    weight = torch.zeros((8, 4), device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    with torch.no_grad():
+        weight[:, 3] = 96.0
+    dy = torch.full_like(x, 1.359375)
+    d_final_state = torch.zeros((1, 8, 4), device="cuda", dtype=torch.bfloat16)
+    d_final_state[..., 3] = -65.0
+
+    operation = prototype(x, weight, output_final_state=True)
+    actual = operation(x, weight, output_final_state=True)
+    torch.autograd.backward(
+        (actual["output_tensor"], actual["final_state_tensor"]),
+        (dy, d_final_state),
+    )
+
+    # At z=0, SiLU'=0.5: 1.359375 * 0.5 * 96 - 65 = 0.25.
+    torch.testing.assert_close(x.grad, torch.full_like(x, 0.25), atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_initial_state_gradient_without_final_state_output():
+    capability = torch.cuda.get_device_capability()
+    if not is_functional_arch(capability):
+        pytest.skip(f"unsupported compute capability {capability}")
+
+    prototype = _load_autograd_prototype()
+    generator = torch.Generator(device="cuda").manual_seed(20260901)
+    shape = (1, 3, 8)
+    x = (torch.randn(shape, device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25).requires_grad_()
+    weight = (torch.randn((shape[2], 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25).requires_grad_()
+    initial_state = (torch.randn((shape[0], shape[2], 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25).requires_grad_()
+    dy = torch.randn(shape, device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+
+    reference_x = x.detach().float().requires_grad_()
+    reference_weight = weight.detach().float().requires_grad_()
+    reference_initial_state = initial_state.detach().float().requires_grad_()
+    expected_output, _ = causal_conv1d_bulk_reference(
+        reference_x,
+        reference_weight,
+        initial_state=reference_initial_state,
+    )
+    expected_output.backward(dy.float())
+
+    operation = prototype(x, weight, sample_initial_state=initial_state)
+    actual = operation(x, weight, initial_state=initial_state)
+    assert isinstance(actual, torch.Tensor)
+    actual.backward(dy)
+
+    torch.testing.assert_close(x.grad.float(), reference_x.grad, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(weight.grad.float(), reference_weight.grad, atol=1e-1, rtol=5e-2)
+    torch.testing.assert_close(initial_state.grad.float(), reference_initial_state.grad, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(initial_state.grad[..., 0], torch.zeros_like(initial_state.grad[..., 0]), atol=0, rtol=0)

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_contract_unit.py
@@ -1,0 +1,370 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host-visible contract checks that do not compile a CuTe kernel."""
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.L0
+
+
+def _load_private_backend():
+    try:
+        import cudnn.causal_conv1d_bulk_sm100 as bulk
+    except (ImportError, OSError) as error:
+        pytest.skip(f"CuTe DSL dependencies unavailable: {error}")
+    return bulk, bulk.CausalConv1dBulkFwdSm100, bulk.causal_conv1d_bulk_fwd_wrapper_sm100
+
+
+def _load_benchmark_module():
+    path = Path(__file__).with_name("benchmark_causal_conv1d_bulk_sm100.py")
+    spec = importlib.util.spec_from_file_location("_causal_conv1d_bulk_benchmark_contract", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_operation_package_does_not_publish_backend_lifecycle():
+    bulk, api_class, wrapper = _load_private_backend()
+    assert bulk.__all__ == []
+    # Backend contract tests can reach private implementation seams by an
+    # explicit module path; wildcard users and generated API docs cannot.
+    assert bulk.CausalConv1dBulkFwdSm100 is api_class
+    assert bulk.causal_conv1d_bulk_fwd_wrapper_sm100 is wrapper
+
+
+@pytest.mark.parametrize(
+    "capability",
+    [
+        (8, 0),
+        (8, 6),
+        (8, 7),
+        (8, 9),
+        (9, 0),
+        (10, 0),
+        (10, 3),
+        (11, 0),
+        (12, 0),
+        (12, 1),
+    ],
+)
+def test_benchmark_accepts_functional_gpu_without_slurm(monkeypatch, capability):
+    benchmark = _load_benchmark_module()
+    properties = SimpleNamespace(
+        major=capability[0],
+        minor=capability[1],
+        name="Customer GPU",
+    )
+    requested_devices = []
+
+    def get_device_properties(device):
+        requested_devices.append(device)
+        return properties
+
+    monkeypatch.setattr(benchmark.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(benchmark.torch.cuda, "current_device", lambda: 3)
+    monkeypatch.setattr(benchmark.torch.cuda, "get_device_properties", get_device_properties)
+
+    assert benchmark._validate_environment() == (properties, capability)
+    assert requested_devices == [3]
+    assert benchmark._slurm_metadata({}) == {}
+
+
+def test_benchmark_rejects_unsupported_gpu(monkeypatch):
+    benchmark = _load_benchmark_module()
+    properties = SimpleNamespace(major=10, minor=1, name="Unsupported GPU")
+    monkeypatch.setattr(benchmark.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(benchmark.torch.cuda, "current_device", lambda: 3)
+    monkeypatch.setattr(benchmark.torch.cuda, "get_device_properties", lambda device=None: properties)
+
+    with pytest.raises(RuntimeError, match=r"does not support compute capability 10\.1"):
+        benchmark._validate_environment()
+
+
+def test_benchmark_requires_cuda(monkeypatch):
+    benchmark = _load_benchmark_module()
+    monkeypatch.setattr(benchmark.torch.cuda, "is_available", lambda: False)
+
+    with pytest.raises(RuntimeError, match="CUDA is unavailable"):
+        benchmark._validate_environment()
+
+
+def test_benchmark_slurm_metadata_is_optional():
+    benchmark = _load_benchmark_module()
+
+    assert benchmark._slurm_metadata({}) == {}
+    assert benchmark._slurm_metadata({"SLURM_JOB_ID": "123", "SLURMD_NODENAME": "gpu-node"}) == {
+        "job_id": "123",
+        "node_name": "gpu-node",
+    }
+
+
+def test_support_rejects_the_package_wide_4_5_dsl_floor(monkeypatch):
+    _, api_class, _ = _load_private_backend()
+    import cudnn.causal_conv1d_bulk_sm100.api as api_module
+
+    x = torch.zeros(1, 2, 8, dtype=torch.bfloat16)
+    weight = torch.zeros(8, 4, dtype=torch.bfloat16)
+    output = torch.empty_like(x)
+    api = api_class(x, weight, output)
+    monkeypatch.setattr(api_module, "cutedsl_state", lambda: (True, ("nvidia-cutlass-dsl", "4.5.0")))
+
+    with pytest.raises(RuntimeError, match=r"nvidia-cutlass-dsl>=4\.7\.0; found 4\.5\.0"):
+        api.check_support()
+
+
+def test_support_accepts_a_source_dsl_without_distribution_metadata(monkeypatch):
+    _, api_class, _ = _load_private_backend()
+    import cudnn.causal_conv1d_bulk_sm100.api as api_module
+
+    x = torch.zeros(1, 2, 8, dtype=torch.bfloat16)
+    weight = torch.zeros(8, 4, dtype=torch.bfloat16)
+    bias = torch.zeros(8, dtype=torch.bfloat16)
+    output = torch.empty_like(x)
+    api = api_class(x, weight, output, sample_bias=bias)
+    monkeypatch.setattr(api_module, "cutedsl_state", lambda: (True, None))
+    monkeypatch.setattr(api, "_require_cuda", lambda desc, name: None)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: (10, 0))
+
+    assert api.check_support()
+    assert api.bias_desc.shape == (8,)
+
+
+def test_support_accepts_fp32_weight_only_without_bias(monkeypatch):
+    _, api_class, _ = _load_private_backend()
+    import cudnn.causal_conv1d_bulk_sm100.api as api_module
+
+    x = torch.zeros(1, 2, 8, dtype=torch.bfloat16)
+    weight = torch.zeros(8, 4, dtype=torch.float32)
+    output = torch.empty_like(x)
+    api = api_class(x, weight, output)
+    monkeypatch.setattr(api_module, "cutedsl_state", lambda: (True, None))
+    monkeypatch.setattr(api, "_require_cuda", lambda desc, name: None)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: (10, 0))
+
+    assert api.check_support()
+    assert api.weight_desc.dtype == torch.float32
+
+    with_bias = api_class(
+        x,
+        weight,
+        output,
+        sample_bias=torch.zeros(8, dtype=torch.float32),
+    )
+    monkeypatch.setattr(api_module, "cutedsl_state", lambda: (True, None))
+    with pytest.raises(ValueError, match="only when Bias is omitted"):
+        with_bias.check_support()
+
+
+@pytest.mark.parametrize("case", ["rank", "shape", "dtype", "stride", "alignment"])
+def test_support_rejects_invalid_bias_contract(monkeypatch, case):
+    _, api_class, _ = _load_private_backend()
+    import cudnn.causal_conv1d_bulk_sm100.api as api_module
+
+    x = torch.zeros(1, 2, 8, dtype=torch.bfloat16)
+    weight = torch.zeros(8, 4, dtype=torch.bfloat16)
+    output = torch.empty_like(x)
+    if case == "rank":
+        bias = torch.zeros(1, 8, dtype=torch.bfloat16)
+    elif case == "shape":
+        bias = torch.zeros(7, dtype=torch.bfloat16)
+    elif case == "dtype":
+        bias = torch.zeros(8, dtype=torch.float32)
+    elif case == "stride":
+        bias = torch.zeros(8, 2, dtype=torch.bfloat16)[:, 0]
+    elif case == "alignment":
+        bias = torch.zeros(9, dtype=torch.bfloat16)[1:]
+    else:
+        raise AssertionError(f"unhandled case {case}")
+
+    api = api_class(x, weight, output, sample_bias=bias)
+    monkeypatch.setattr(api_module, "cutedsl_state", lambda: (True, None))
+
+    with pytest.raises(ValueError, match="Bias"):
+        api.check_support()
+
+
+def test_bias_presence_must_match_the_compiled_signature(monkeypatch):
+    _, api_class, _ = _load_private_backend()
+    import cudnn.causal_conv1d_bulk_sm100.api as api_module
+
+    x = torch.zeros(1, 2, 8, dtype=torch.bfloat16)
+    weight = torch.zeros(8, 4, dtype=torch.bfloat16)
+    bias = torch.zeros(8, dtype=torch.bfloat16)
+    output = torch.empty_like(x)
+    monkeypatch.setattr(api_module, "cutedsl_state", lambda: (True, None))
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: (10, 0))
+
+    with_bias = api_class(x, weight, output, sample_bias=bias)
+    monkeypatch.setattr(with_bias, "_require_cuda", lambda desc, name: None)
+    assert with_bias.check_support()
+    with_bias._compiled_kernel = object()
+    with pytest.raises(ValueError, match="Bias presence must match"):
+        with_bias.execute(x, weight, output)
+
+    without_bias = api_class(x, weight, output)
+    monkeypatch.setattr(without_bias, "_require_cuda", lambda desc, name: None)
+    assert without_bias.check_support()
+    without_bias._compiled_kernel = object()
+    with pytest.raises(ValueError, match="Bias presence must match"):
+        without_bias.execute(x, weight, output, bias_tensor=bias)
+
+
+def test_constructor_and_wrapper_reject_non_tensor_bias():
+    _, api_class, wrapper = _load_private_backend()
+    x = torch.zeros(1, 2, 8, dtype=torch.bfloat16)
+    weight = torch.zeros(8, 4, dtype=torch.bfloat16)
+    output = torch.empty_like(x)
+
+    with pytest.raises(TypeError, match=r"sample_bias must be a torch\.Tensor"):
+        api_class(x, weight, output, sample_bias=object())
+    with pytest.raises(TypeError, match=r"Bias must be a torch\.Tensor or None"):
+        wrapper(x, weight, bias_tensor=object())
+
+
+@pytest.mark.parametrize(
+    "capability,n_channels,expected_vec8",
+    [
+        ((8, 0), 8, False),
+        ((8, 6), 8, False),
+        ((8, 7), 8, False),
+        ((8, 9), 8, False),
+        ((9, 0), 8, False),
+        ((10, 0), 8, True),
+        ((10, 0), 7, False),
+        ((10, 3), 8, True),
+        ((11, 0), 8, True),
+        ((12, 0), 8, True),
+        ((12, 1), 8, True),
+    ],
+)
+def test_support_selects_schedule_from_exact_arch(monkeypatch, capability, n_channels, expected_vec8):
+    _, api_class, _ = _load_private_backend()
+    import cudnn.causal_conv1d_bulk_sm100.api as api_module
+
+    x = torch.zeros(1, 2, n_channels, dtype=torch.bfloat16)
+    weight = torch.zeros(n_channels, 4, dtype=torch.bfloat16)
+    output = torch.empty_like(x)
+    api = api_class(x, weight, output)
+    monkeypatch.setattr(api_module, "cutedsl_state", lambda: (True, None))
+    monkeypatch.setattr(api, "_require_cuda", lambda desc, name: None)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: capability)
+
+    assert api.check_support()
+    assert api.compute_capability == capability
+    assert api.use_vec8_schedule is expected_vec8
+
+
+@pytest.mark.parametrize("capability", [(7, 5), (10, 1), (11, 1)])
+def test_support_rejects_unlisted_arch(monkeypatch, capability):
+    _, api_class, _ = _load_private_backend()
+    import cudnn.causal_conv1d_bulk_sm100.api as api_module
+
+    x = torch.zeros(1, 2, 8, dtype=torch.bfloat16)
+    weight = torch.zeros(8, 4, dtype=torch.bfloat16)
+    output = torch.empty_like(x)
+    api = api_class(x, weight, output)
+    monkeypatch.setattr(api_module, "cutedsl_state", lambda: (True, None))
+    monkeypatch.setattr(api, "_require_cuda", lambda desc, name: None)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: capability)
+
+    with pytest.raises(RuntimeError, match="does not support compute capability"):
+        api.check_support()
+
+
+def test_constructor_rejects_metadata_only_tensor_descriptors():
+    _, api_class, _ = _load_private_backend()
+    from cudnn.api_base import TensorDesc
+
+    sample_x = TensorDesc(
+        dtype=torch.bfloat16,
+        shape=(1, 2, 8),
+        stride=(16, 8, 1),
+        stride_order=(2, 1, 0),
+        device=torch.device("cuda"),
+    )
+    weight = torch.zeros(8, 4, dtype=torch.bfloat16)
+    output = torch.zeros(1, 2, 8, dtype=torch.bfloat16)
+
+    with pytest.raises(TypeError, match=r"sample_x must be a torch.Tensor, got TensorDesc"):
+        api_class(sample_x, weight, output)
+
+
+@pytest.mark.parametrize("missing_name", ["sample_x", "sample_weight", "sample_output"])
+def test_constructor_rejects_none_for_required_samples(missing_name):
+    _, api_class, _ = _load_private_backend()
+    samples = {
+        "sample_x": torch.zeros(1, 2, 8, dtype=torch.bfloat16),
+        "sample_weight": torch.zeros(8, 4, dtype=torch.bfloat16),
+        "sample_output": torch.zeros(1, 2, 8, dtype=torch.bfloat16),
+    }
+    samples[missing_name] = None
+
+    with pytest.raises(TypeError, match=rf"{missing_name} must be a torch.Tensor, got NoneType"):
+        api_class(**samples)
+
+
+@pytest.mark.L1
+def test_top_level_exports_only_the_semantic_api_from_a_clean_source_package(tmp_path):
+    # The suite normally overlays this operation onto a prebuilt frontend. Use
+    # a fresh interpreter and this checkout's __init__.py to exercise the
+    # top-level lazy-export route that a built wheel installs.
+    _load_private_backend()
+    import cudnn
+
+    source = Path(__file__).resolve().parents[4] / "python" / "cudnn"
+    probe = tmp_path / "cudnn"
+    shutil.copytree(source, probe)
+    compiled_modules = list(Path(cudnn.__file__).resolve().parent.glob("_compiled_module*.so"))
+    if len(compiled_modules) != 1:
+        pytest.skip(f"expected one compiled module next to {cudnn.__file__}, found {len(compiled_modules)}")
+    try:
+        (probe / compiled_modules[0].name).symlink_to(compiled_modules[0])
+    except OSError as error:
+        pytest.skip(f"cannot link the compiled module into the probe package: {error}")
+
+    script = """
+import cudnn
+from cudnn.ops import causal_conv1d
+
+assert callable(causal_conv1d)
+for name in (
+    "CausalConv1dBulkAutogradPrototype",
+    "CausalConv1dBulkBwdPrototype",
+    "CausalConv1dBulkFwdSm100",
+    "causal_conv1d_bulk_fwd_wrapper_sm100",
+    "compile_causal_conv1d_bulk_bwd_prototype",
+):
+    assert name not in dir(cudnn)
+    try:
+        getattr(cudnn, name)
+    except AttributeError:
+        pass
+    else:
+        raise AssertionError(f"{name} leaked through the public cudnn namespace")
+"""
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = os.pathsep.join((str(tmp_path), environment.get("PYTHONPATH", ""))).rstrip(os.pathsep)
+    subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+    )

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_contract_unit.py
@@ -287,8 +287,9 @@ def test_support_rejects_unlisted_arch(monkeypatch, capability):
         api.check_support()
 
 
-def test_constructor_rejects_metadata_only_tensor_descriptors():
+def test_support_accepts_metadata_only_tensor_descriptors(monkeypatch):
     _, api_class, _ = _load_private_backend()
+    import cudnn.causal_conv1d_bulk_sm100.api as api_module
     from cudnn.api_base import TensorDesc
 
     sample_x = TensorDesc(
@@ -298,11 +299,27 @@ def test_constructor_rejects_metadata_only_tensor_descriptors():
         stride_order=(2, 1, 0),
         device=torch.device("cuda"),
     )
-    weight = torch.zeros(8, 4, dtype=torch.bfloat16)
-    output = torch.zeros(1, 2, 8, dtype=torch.bfloat16)
+    sample_weight = TensorDesc(
+        dtype=torch.bfloat16,
+        shape=(8, 4),
+        stride=(4, 1),
+        stride_order=(1, 0),
+        device=torch.device("cuda"),
+    )
+    sample_output = TensorDesc(
+        dtype=torch.bfloat16,
+        shape=(1, 2, 8),
+        stride=(16, 8, 1),
+        stride_order=(2, 1, 0),
+        device=torch.device("cuda"),
+    )
+    api = api_class(sample_x, sample_weight, sample_output)
+    monkeypatch.setattr(api_module, "cutedsl_state", lambda: (True, None))
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: (10, 0))
 
-    with pytest.raises(TypeError, match=r"sample_x must be a torch.Tensor, got TensorDesc"):
-        api_class(sample_x, weight, output)
+    assert api.check_support()
+    assert api._sample_alignment_remainders == {}
 
 
 @pytest.mark.parametrize("missing_name", ["sample_x", "sample_weight", "sample_output"])
@@ -315,7 +332,7 @@ def test_constructor_rejects_none_for_required_samples(missing_name):
     }
     samples[missing_name] = None
 
-    with pytest.raises(TypeError, match=rf"{missing_name} must be a torch.Tensor, got NoneType"):
+    with pytest.raises(TypeError, match=rf"{missing_name} must be a torch.Tensor or TensorDesc, got NoneType"):
         api_class(**samples)
 
 

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_contract_unit.py
@@ -14,8 +14,6 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-pytestmark = pytest.mark.L0
-
 
 def _load_private_backend():
     try:
@@ -34,6 +32,7 @@ def _load_benchmark_module():
     return module
 
 
+@pytest.mark.L0
 def test_operation_package_does_not_publish_backend_lifecycle():
     bulk, api_class, wrapper = _load_private_backend()
     assert bulk.__all__ == []
@@ -43,6 +42,7 @@ def test_operation_package_does_not_publish_backend_lifecycle():
     assert bulk.causal_conv1d_bulk_fwd_wrapper_sm100 is wrapper
 
 
+@pytest.mark.L0
 @pytest.mark.parametrize(
     "capability",
     [
@@ -80,6 +80,7 @@ def test_benchmark_accepts_functional_gpu_without_slurm(monkeypatch, capability)
     assert benchmark._slurm_metadata({}) == {}
 
 
+@pytest.mark.L0
 def test_benchmark_rejects_unsupported_gpu(monkeypatch):
     benchmark = _load_benchmark_module()
     properties = SimpleNamespace(major=10, minor=1, name="Unsupported GPU")
@@ -91,6 +92,7 @@ def test_benchmark_rejects_unsupported_gpu(monkeypatch):
         benchmark._validate_environment()
 
 
+@pytest.mark.L0
 def test_benchmark_requires_cuda(monkeypatch):
     benchmark = _load_benchmark_module()
     monkeypatch.setattr(benchmark.torch.cuda, "is_available", lambda: False)
@@ -99,6 +101,7 @@ def test_benchmark_requires_cuda(monkeypatch):
         benchmark._validate_environment()
 
 
+@pytest.mark.L0
 def test_benchmark_slurm_metadata_is_optional():
     benchmark = _load_benchmark_module()
 
@@ -109,6 +112,7 @@ def test_benchmark_slurm_metadata_is_optional():
     }
 
 
+@pytest.mark.L0
 def test_support_rejects_the_package_wide_4_5_dsl_floor(monkeypatch):
     _, api_class, _ = _load_private_backend()
     import cudnn.causal_conv1d_bulk_sm100.api as api_module
@@ -123,6 +127,7 @@ def test_support_rejects_the_package_wide_4_5_dsl_floor(monkeypatch):
         api.check_support()
 
 
+@pytest.mark.L0
 def test_support_accepts_a_source_dsl_without_distribution_metadata(monkeypatch):
     _, api_class, _ = _load_private_backend()
     import cudnn.causal_conv1d_bulk_sm100.api as api_module
@@ -141,6 +146,7 @@ def test_support_accepts_a_source_dsl_without_distribution_metadata(monkeypatch)
     assert api.bias_desc.shape == (8,)
 
 
+@pytest.mark.L0
 def test_support_accepts_fp32_weight_only_without_bias(monkeypatch):
     _, api_class, _ = _load_private_backend()
     import cudnn.causal_conv1d_bulk_sm100.api as api_module
@@ -168,6 +174,7 @@ def test_support_accepts_fp32_weight_only_without_bias(monkeypatch):
         with_bias.check_support()
 
 
+@pytest.mark.L0
 @pytest.mark.parametrize("case", ["rank", "shape", "dtype", "stride", "alignment"])
 def test_support_rejects_invalid_bias_contract(monkeypatch, case):
     _, api_class, _ = _load_private_backend()
@@ -196,6 +203,7 @@ def test_support_rejects_invalid_bias_contract(monkeypatch, case):
         api.check_support()
 
 
+@pytest.mark.L0
 def test_bias_presence_must_match_the_compiled_signature(monkeypatch):
     _, api_class, _ = _load_private_backend()
     import cudnn.causal_conv1d_bulk_sm100.api as api_module
@@ -223,6 +231,7 @@ def test_bias_presence_must_match_the_compiled_signature(monkeypatch):
         without_bias.execute(x, weight, output, bias_tensor=bias)
 
 
+@pytest.mark.L0
 def test_constructor_and_wrapper_reject_non_tensor_bias():
     _, api_class, wrapper = _load_private_backend()
     x = torch.zeros(1, 2, 8, dtype=torch.bfloat16)
@@ -235,6 +244,7 @@ def test_constructor_and_wrapper_reject_non_tensor_bias():
         wrapper(x, weight, bias_tensor=object())
 
 
+@pytest.mark.L0
 @pytest.mark.parametrize(
     "capability,n_channels,expected_vec8",
     [
@@ -269,6 +279,7 @@ def test_support_selects_schedule_from_exact_arch(monkeypatch, capability, n_cha
     assert api.use_vec8_schedule is expected_vec8
 
 
+@pytest.mark.L0
 @pytest.mark.parametrize("capability", [(7, 5), (10, 1), (11, 1)])
 def test_support_rejects_unlisted_arch(monkeypatch, capability):
     _, api_class, _ = _load_private_backend()
@@ -287,6 +298,7 @@ def test_support_rejects_unlisted_arch(monkeypatch, capability):
         api.check_support()
 
 
+@pytest.mark.L0
 def test_support_accepts_metadata_only_tensor_descriptors(monkeypatch):
     _, api_class, _ = _load_private_backend()
     import cudnn.causal_conv1d_bulk_sm100.api as api_module
@@ -322,6 +334,7 @@ def test_support_accepts_metadata_only_tensor_descriptors(monkeypatch):
     assert api._sample_alignment_remainders == {}
 
 
+@pytest.mark.L0
 @pytest.mark.parametrize("missing_name", ["sample_x", "sample_weight", "sample_output"])
 def test_constructor_rejects_none_for_required_samples(missing_name):
     _, api_class, _ = _load_private_backend()

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_sm100.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_sm100.py
@@ -1,0 +1,600 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""L0 GPU correctness for the bulk causal-convolution forward API."""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+import torch
+from cuda.bindings import driver as cuda
+
+from fe_api.causal_conv1d_bulk.reference import (
+    causal_conv1d_bulk_reference,
+    causal_conv1d_update_reference,
+)
+
+_SUPPORTED_COMPUTE_CAPABILITIES = {
+    (8, 0),
+    (8, 6),
+    (8, 7),
+    (8, 9),
+    (9, 0),
+    (10, 0),
+    (10, 3),
+    (11, 0),
+    (12, 0),
+    (12, 1),
+}
+
+
+def _is_supported_arch() -> bool:
+    return torch.cuda.is_available() and torch.cuda.get_device_capability() in _SUPPORTED_COMPUTE_CAPABILITIES
+
+
+pytestmark = [
+    pytest.mark.L0,
+    pytest.mark.gpu_exclusive,
+    pytest.mark.xdist_group(name="gpu_exclusive"),
+    pytest.mark.skipif(not _is_supported_arch(), reason="requires a supported SM80-or-newer architecture"),
+]
+
+
+def _load_wrapper():
+    try:
+        from cudnn.frost.buffers import cutedsl_state, cutedsl_too_old
+        from cudnn.causal_conv1d_bulk_sm100 import causal_conv1d_bulk_fwd_wrapper_sm100
+    except (ImportError, OSError) as error:
+        pytest.skip(f"CuTe DSL dependencies unavailable: {error}")
+    installed, version = cutedsl_state()
+    if not installed or cutedsl_too_old(version):
+        pytest.skip("causal_conv1d_bulk_sm100 requires nvidia-cutlass-dsl>=4.7.0")
+    return causal_conv1d_bulk_fwd_wrapper_sm100
+
+
+def _load_class():
+    try:
+        from cudnn.frost.buffers import cutedsl_state, cutedsl_too_old
+        from cudnn.causal_conv1d_bulk_sm100 import CausalConv1dBulkFwdSm100
+    except (ImportError, OSError) as error:
+        pytest.skip(f"CuTe DSL dependencies unavailable: {error}")
+    installed, version = cutedsl_state()
+    if not installed or cutedsl_too_old(version):
+        pytest.skip("causal_conv1d_bulk_sm100 requires nvidia-cutlass-dsl>=4.7.0")
+    return CausalConv1dBulkFwdSm100
+
+
+def _assert_state_bits_equal(actual: torch.Tensor, expected: torch.Tensor) -> None:
+    torch.testing.assert_close(actual.view(torch.int16), expected.view(torch.int16), rtol=0, atol=0)
+
+
+@torch.no_grad()
+def test_dense_channel_tail_without_state_has_stable_outputs():
+    from cudnn.api_base import TupleDict
+
+    wrapper = _load_wrapper()
+    torch.manual_seed(101)
+    x = torch.randn(2, 7, 259, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(259, 4, device="cuda", dtype=torch.bfloat16)
+    expected, _ = causal_conv1d_bulk_reference(x, weight)
+
+    result = wrapper(x, weight, output_final_state=False)
+
+    assert isinstance(result, TupleDict)
+    assert list(result.keys()) == ["output_tensor", "final_state_tensor"]
+    assert result[0] is result["output_tensor"]
+    assert result[1] is result["final_state_tensor"]
+    torch.testing.assert_close(result["output_tensor"], expected, atol=3e-2, rtol=3e-2)
+    assert result["final_state_tensor"].shape == (0,)
+    assert result["final_state_tensor"].dtype == torch.bfloat16
+    assert result["final_state_tensor"].device == x.device
+    assert result["final_state_tensor"].is_contiguous()
+
+    # T is intentionally absent from the wrapper cache key: one symbolic
+    # compile must safely serve a different runtime token extent.
+    x2 = torch.randn(2, 11, 259, device="cuda", dtype=torch.bfloat16)
+    expected2, _ = causal_conv1d_bulk_reference(x2, weight)
+    result2 = wrapper(x2, weight, output_final_state=False)
+    torch.testing.assert_close(result2["output_tensor"], expected2, atol=3e-2, rtol=3e-2)
+
+    with torch.enable_grad(), pytest.raises(RuntimeError, match="inference-only"):
+        wrapper(x.detach().requires_grad_(True), weight)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("channels,packed", [(264, False), (263, True)])
+def test_optional_bias_matches_reference_for_vec8_and_scalar_paths(channels, packed):
+    wrapper = _load_wrapper()
+    torch.manual_seed(109 + channels)
+    x = torch.randn(1, 11, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(channels, device="cuda", dtype=torch.bfloat16)
+    cu_seqlens = torch.tensor((0, 3, 11), device="cuda", dtype=torch.int32) if packed else None
+    expected, _ = causal_conv1d_bulk_reference(
+        x,
+        weight,
+        bias=bias,
+        cu_seqlens=cu_seqlens,
+    )
+
+    result = wrapper(
+        x,
+        weight,
+        cu_seqlens_tensor=cu_seqlens,
+        bias_tensor=bias,
+    )
+
+    torch.testing.assert_close(result["output_tensor"], expected, atol=3e-2, rtol=3e-2)
+
+
+@torch.no_grad()
+def test_dense_class_nonzero_state_final_state_and_decode_recurrence():
+    api_class = _load_class()
+    torch.manual_seed(102)
+    batch, tokens, channels = 2, 3, 257
+    x = torch.randn(batch, tokens, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    initial_state = torch.randn(batch, channels, 4, device="cuda", dtype=torch.bfloat16)
+    initial_state_before = initial_state.clone()
+    expected, expected_final = causal_conv1d_bulk_reference(x, weight, initial_state=initial_state)
+
+    output = torch.empty_like(x)
+    final_state = torch.empty_like(initial_state)
+    api = api_class(
+        sample_x=x,
+        sample_weight=weight,
+        sample_output=output,
+        sample_initial_state=initial_state,
+        sample_final_state=final_state,
+    )
+    assert api.check_support()
+    api.compile()
+    result = api.execute(
+        x_tensor=x,
+        weight_tensor=weight,
+        output_tensor=output,
+        initial_state_tensor=initial_state,
+        final_state_tensor=final_state,
+    )
+
+    assert list(result.keys()) == ["output_tensor", "final_state_tensor"]
+    assert result["output_tensor"] is output
+    assert result["final_state_tensor"] is final_state
+    torch.testing.assert_close(result["output_tensor"], expected, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(result["final_state_tensor"], expected_final)
+    _assert_state_bits_equal(initial_state, initial_state_before)
+
+    # The full-width state needs no repacking before the next decode token.
+    next_x = torch.randn(batch, channels, device="cuda", dtype=torch.bfloat16)
+    expected_next, expected_after_decode = causal_conv1d_update_reference(next_x, expected_final, weight)
+    actual_next, actual_after_decode = causal_conv1d_update_reference(next_x, result["final_state_tensor"], weight)
+    torch.testing.assert_close(actual_next, expected_next, atol=0, rtol=0)
+    _assert_state_bits_equal(actual_after_decode, expected_after_decode)
+
+    # The combined causal-convolution feature must expose decode through the
+    # public semantic operation, not through its private backend package.
+    from cudnn.ops import causal_conv1d_update
+
+    decode_state = result["final_state_tensor"].clone()
+    decode_output = causal_conv1d_update(next_x, decode_state, weight, activation="silu")
+    torch.testing.assert_close(decode_output, expected_next, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(decode_state, expected_after_decode)
+
+    # The preallocated class API revalidates outputs and aliases at execute,
+    # rather than trusting the descriptors used for compilation.
+    with pytest.raises(ValueError, match="Output T must match X"):
+        api.execute(
+            x,
+            weight,
+            torch.empty(batch, tokens + 1, channels, device="cuda", dtype=x.dtype),
+            initial_state_tensor=initial_state,
+            final_state_tensor=final_state,
+        )
+    with pytest.raises(TypeError, match="Output dtype mismatch"):
+        api.execute(x, weight, output.float(), initial_state_tensor=initial_state, final_state_tensor=final_state)
+    with pytest.raises(ValueError, match=r"Output must be.*contiguous"):
+        api.execute(
+            x,
+            weight,
+            torch.empty(batch, tokens, channels * 2, device="cuda", dtype=x.dtype)[..., ::2],
+            initial_state_tensor=initial_state,
+            final_state_tensor=final_state,
+        )
+    with pytest.raises(ValueError, match="Final state presence must match"):
+        api.execute(x, weight, output, initial_state_tensor=initial_state)
+    with pytest.raises(ValueError, match="Final state stride mismatch"):
+        api.execute(
+            x,
+            weight,
+            output,
+            initial_state_tensor=initial_state,
+            final_state_tensor=torch.empty(batch, channels, 8, device="cuda", dtype=x.dtype)[..., ::2],
+        )
+    with pytest.raises(ValueError, match="Output must not overlap"):
+        api.execute(x, weight, x, initial_state_tensor=initial_state, final_state_tensor=final_state)
+    with pytest.raises(ValueError, match="Final state must not overlap"):
+        api.execute(x, weight, output, initial_state_tensor=initial_state, final_state_tensor=initial_state)
+    dlpack_output_alias = torch.from_dlpack(x)
+    assert dlpack_output_alias.data_ptr() == x.data_ptr()
+    with pytest.raises(ValueError, match="Output must not overlap"):
+        api.execute(x, weight, dlpack_output_alias, initial_state_tensor=initial_state, final_state_tensor=final_state)
+    dlpack_final_alias = torch.from_dlpack(initial_state)
+    assert dlpack_final_alias.data_ptr() == initial_state.data_ptr()
+    with pytest.raises(ValueError, match="Final state must not overlap"):
+        api.execute(x, weight, output, initial_state_tensor=initial_state, final_state_tensor=dlpack_final_alias)
+    with torch.enable_grad(), pytest.raises(RuntimeError, match="inference-only"):
+        api.execute(x.detach().requires_grad_(True), weight, output, initial_state_tensor=initial_state, final_state_tensor=final_state)
+
+
+@torch.no_grad()
+def test_vec8_dense_initial_and_final_state_match_reference():
+    wrapper = _load_wrapper()
+    torch.manual_seed(104)
+    batch, tokens, channels = 2, 9, 264
+    x = torch.randn(batch, tokens, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    initial_state = torch.randn(batch, channels, 4, device="cuda", dtype=torch.bfloat16)
+    initial_state_before = initial_state.clone()
+    expected, expected_final = causal_conv1d_bulk_reference(x, weight, initial_state=initial_state)
+
+    result = wrapper(
+        x,
+        weight,
+        initial_state_tensor=initial_state,
+        output_final_state=True,
+    )
+
+    torch.testing.assert_close(result["output_tensor"], expected, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(result["final_state_tensor"], expected_final)
+    _assert_state_bits_equal(initial_state, initial_state_before)
+
+    # The vec8 specialization must retain the same symbolic-T cache contract
+    # as the scalar fallback, including execution on a caller-owned stream.
+    x2 = torch.randn(batch, 13, channels, device="cuda", dtype=torch.bfloat16)
+    expected2, expected_final2 = causal_conv1d_bulk_reference(x2, weight, initial_state=initial_state)
+    launch_stream = torch.cuda.Stream()
+    torch.cuda.current_stream().synchronize()
+    result2 = wrapper(
+        x2,
+        weight,
+        initial_state_tensor=initial_state,
+        output_final_state=True,
+        current_stream=cuda.CUstream(launch_stream.cuda_stream),
+    )
+    launch_stream.synchronize()
+    torch.testing.assert_close(result2["output_tensor"], expected2, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(result2["final_state_tensor"], expected_final2)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "use_initial_state,output_final_state",
+    [(False, True), (True, False)],
+)
+def test_optional_state_presence_compile_specializations(use_initial_state, output_final_state):
+    wrapper = _load_wrapper()
+    torch.manual_seed(107 + int(use_initial_state))
+    batch, tokens, channels = 2, 5, 264
+    x = torch.randn(batch, tokens, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    initial_state = torch.randn(batch, channels, 4, device="cuda", dtype=torch.bfloat16) if use_initial_state else None
+    initial_state_before = initial_state.clone() if initial_state is not None else None
+    expected, expected_final = causal_conv1d_bulk_reference(x, weight, initial_state=initial_state)
+
+    result = wrapper(
+        x,
+        weight,
+        initial_state_tensor=initial_state,
+        output_final_state=output_final_state,
+    )
+
+    torch.testing.assert_close(result["output_tensor"], expected, atol=3e-2, rtol=3e-2)
+    if output_final_state:
+        _assert_state_bits_equal(result["final_state_tensor"], expected_final)
+    else:
+        assert result["final_state_tensor"].shape == (0,)
+    if initial_state is not None:
+        _assert_state_bits_equal(initial_state, initial_state_before)
+
+
+@torch.no_grad()
+def test_packed_unequal_sequences_do_not_bleed_across_boundaries():
+    wrapper = _load_wrapper()
+    torch.manual_seed(103)
+    lengths = (17, 2, 14)  # Crosses scalar token tiles and includes T < width.
+    channels = 263
+    total_tokens = sum(lengths)
+    x = torch.randn(1, total_tokens, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    cu_seqlens = torch.tensor((0, 17, 19, 33), device="cuda", dtype=torch.int32)
+    initial_state = torch.randn(len(lengths), channels, 4, device="cuda", dtype=torch.bfloat16)
+    initial_state_before = initial_state.clone()
+    expected, expected_final = causal_conv1d_bulk_reference(
+        x,
+        weight,
+        cu_seqlens=cu_seqlens,
+        initial_state=initial_state,
+    )
+
+    result = wrapper(
+        x,
+        weight,
+        cu_seqlens_tensor=cu_seqlens,
+        initial_state_tensor=initial_state,
+        output_final_state=True,
+    )
+
+    torch.testing.assert_close(result["output_tensor"], expected, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(result["final_state_tensor"], expected_final)
+    _assert_state_bits_equal(initial_state, initial_state_before)
+
+    # The first output of each sequence must depend on its own initial state,
+    # never on the token immediately before the packed boundary.
+    for sequence, begin in enumerate(cu_seqlens[:-1].tolist()):
+        one_token, _ = causal_conv1d_bulk_reference(
+            x[:, begin : begin + 1],
+            weight,
+            initial_state=initial_state[sequence : sequence + 1],
+        )
+        torch.testing.assert_close(result["output_tensor"][:, begin : begin + 1], one_token, atol=3e-2, rtol=3e-2)
+
+    # Packed N/D/state presence form the compile signature, while total_T and
+    # the boundary values remain runtime inputs. Reuse this scalar compiled
+    # object at a second legal T with different cross-tile boundaries.
+    lengths2 = (8, 1, 12)
+    x2 = torch.randn(1, sum(lengths2), channels, device="cuda", dtype=torch.bfloat16)
+    cu_seqlens2 = torch.tensor((0, 8, 9, 21), device="cuda", dtype=torch.int32)
+    expected2, expected_final2 = causal_conv1d_bulk_reference(
+        x2,
+        weight,
+        cu_seqlens=cu_seqlens2,
+        initial_state=initial_state,
+    )
+    result2 = wrapper(
+        x2,
+        weight,
+        cu_seqlens_tensor=cu_seqlens2,
+        initial_state_tensor=initial_state,
+        output_final_state=True,
+    )
+    torch.testing.assert_close(result2["output_tensor"], expected2, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(result2["final_state_tensor"], expected_final2)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("pass_explicit_handle", [False, True])
+def test_side_stream_launch_records_temporary_operand_lifetimes(pass_explicit_handle):
+    # A raw CuTe launch is invisible to PyTorch's allocator. Delay a side-stream
+    # launch, drop every read operand, then pressure the matching allocation
+    # buckets on the default stream. This covers both an explicit handle and
+    # current_stream=None while a non-default torch stream is current.
+    if not hasattr(torch.cuda, "_sleep"):
+        pytest.skip("torch.cuda._sleep is unavailable")
+
+    wrapper = _load_wrapper()
+    torch.manual_seed(106)
+    batch, tokens, channels = 2, 13, 264
+    warm_x = torch.randn(batch, tokens, channels, device="cuda", dtype=torch.bfloat16)
+    warm_weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    warm_state = torch.randn(batch, channels, 4, device="cuda", dtype=torch.bfloat16)
+    wrapper(warm_x, warm_weight, initial_state_tensor=warm_state, output_final_state=True)
+    torch.cuda.synchronize()
+
+    ephemeral_x = torch.randn(batch, tokens, channels, device="cuda", dtype=torch.bfloat16)
+    ephemeral_weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    ephemeral_state = torch.randn(batch, channels, 4, device="cuda", dtype=torch.bfloat16)
+    expected, expected_final = causal_conv1d_bulk_reference(
+        ephemeral_x,
+        ephemeral_weight,
+        initial_state=ephemeral_state,
+    )
+    torch.cuda.current_stream().synchronize()
+
+    delayed_stream = torch.cuda.Stream()
+    with torch.cuda.stream(delayed_stream):
+        torch.cuda._sleep(100_000_000)
+        delayed_result = wrapper(
+            ephemeral_x,
+            ephemeral_weight,
+            initial_state_tensor=ephemeral_state,
+            output_final_state=True,
+            current_stream=cuda.CUstream(delayed_stream.cuda_stream) if pass_explicit_handle else None,
+        )
+
+    del ephemeral_x, ephemeral_weight, ephemeral_state
+    poison = []
+    for _ in range(8):
+        poison.extend(
+            (
+                torch.full((batch, tokens, channels), float("nan"), device="cuda", dtype=torch.bfloat16),
+                torch.full((channels, 4), float("nan"), device="cuda", dtype=torch.bfloat16),
+                torch.full((batch, channels, 4), float("nan"), device="cuda", dtype=torch.bfloat16),
+            )
+        )
+    delayed_stream.synchronize()
+    torch.testing.assert_close(delayed_result["output_tensor"], expected, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(delayed_result["final_state_tensor"], expected_final)
+
+
+@torch.no_grad()
+def test_vec8_packed_short_sequences_match_reference_and_final_state_bits():
+    wrapper = _load_wrapper()
+    torch.manual_seed(105)
+    lengths = (1, 2, 3, 4, 5)
+    channels = 264
+    x = torch.randn(1, sum(lengths), channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    cu_seqlens = torch.tensor((0, 1, 3, 6, 10, 15), device="cuda", dtype=torch.int32)
+    initial_state = torch.randn(len(lengths), channels, 4, device="cuda", dtype=torch.bfloat16)
+    initial_state_before = initial_state.clone()
+    expected, expected_final = causal_conv1d_bulk_reference(
+        x,
+        weight,
+        cu_seqlens=cu_seqlens,
+        initial_state=initial_state,
+    )
+
+    result = wrapper(
+        x,
+        weight,
+        cu_seqlens_tensor=cu_seqlens,
+        initial_state_tensor=initial_state,
+        output_final_state=True,
+    )
+
+    torch.testing.assert_close(result["output_tensor"], expected, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(result["final_state_tensor"], expected_final)
+    _assert_state_bits_equal(initial_state, initial_state_before)
+
+    # N is part of the cache key but T is symbolic. Rebinding this cached packed
+    # signature to fewer tokens than positive sequences must fail on the host,
+    # before the device-side metadata validator can trap.
+    too_short_x = torch.randn(1, 3, channels, device="cuda", dtype=torch.bfloat16)
+    too_short_cu = torch.tensor((0, 1, 2, 3, 3, 3), device="cuda", dtype=torch.int32)
+    with pytest.raises(ValueError, match="cannot exceed total_T"):
+        wrapper(
+            too_short_x,
+            weight,
+            cu_seqlens_tensor=too_short_cu,
+            initial_state_tensor=initial_state,
+            output_final_state=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "x-rank",
+        "weight-shape",
+        "x-dtype",
+        "unsupported-weight-dtype",
+        "x-stride",
+        "weight-stride",
+        "packed-batch",
+        "packed-too-many-sequences",
+        "cu-too-short",
+        "cu-dtype",
+        "cu-stride",
+        "state-shape",
+        "state-dtype",
+        "state-stride",
+        "cu-device",
+    ],
+)
+def test_invalid_public_contract_is_rejected_before_launch(case):
+    wrapper = _load_wrapper()
+    x = torch.zeros(1, 4, 8, device="cuda", dtype=torch.bfloat16)
+    weight = torch.zeros(8, 4, device="cuda", dtype=torch.bfloat16)
+    cu_seqlens = None
+    initial_state = None
+
+    if case == "x-rank":
+        x = x.squeeze(0)
+    elif case == "weight-shape":
+        weight = weight[:, :3]
+    elif case == "x-dtype":
+        x = x.float()
+    elif case == "unsupported-weight-dtype":
+        weight = weight.half()
+    elif case == "x-stride":
+        x = torch.empty(1, 8, 4, device="cuda", dtype=x.dtype).transpose(1, 2)
+    elif case == "weight-stride":
+        weight = torch.empty(8, 8, device="cuda", dtype=weight.dtype)[:, ::2]
+    elif case == "packed-batch":
+        x = x.expand(2, -1, -1).contiguous()
+        cu_seqlens = torch.tensor([0, 4], device="cuda", dtype=torch.int32)
+    elif case == "packed-too-many-sequences":
+        cu_seqlens = torch.arange(6, device="cuda", dtype=torch.int32)
+    elif case == "cu-too-short":
+        cu_seqlens = torch.empty(0, device="cuda", dtype=torch.int32)
+    elif case == "cu-dtype":
+        cu_seqlens = torch.tensor([0, 4], device="cuda", dtype=torch.int64)
+    elif case == "cu-stride":
+        cu_seqlens = torch.tensor([0, -1, 4, -1], device="cuda", dtype=torch.int32)[::2]
+    elif case == "state-shape":
+        initial_state = torch.zeros(2, 8, 4, device="cuda", dtype=x.dtype)
+    elif case == "state-dtype":
+        initial_state = torch.zeros(1, 8, 4, device="cuda", dtype=torch.float32)
+    elif case == "state-stride":
+        initial_state = torch.empty(1, 8, 8, device="cuda", dtype=x.dtype)[:, :, ::2]
+    elif case == "cu-device":
+        cu_seqlens = torch.tensor([0, 4], device="cpu", dtype=torch.int32)
+    else:
+        raise AssertionError(f"unhandled case {case}")
+
+    with pytest.raises((TypeError, ValueError, RuntimeError)):
+        wrapper(
+            x,
+            weight,
+            cu_seqlens_tensor=cu_seqlens,
+            initial_state_tensor=initial_state,
+            output_final_state=True,
+        )
+
+
+_DEVICE_ASSERT_WORKER = r"""
+import os
+import sys
+
+import torch
+import cudnn
+
+case = sys.argv[1]
+source_cudnn = sys.argv[2]
+cudnn.__path__.insert(0, source_cudnn)
+
+from cudnn.causal_conv1d_bulk_sm100 import CausalConv1dBulkFwdSm100
+
+torch.manual_seed(19)
+n_channels = 257
+x = torch.randn(1, 6, n_channels, device="cuda", dtype=torch.bfloat16)
+weight = torch.randn(n_channels, 4, device="cuda", dtype=torch.bfloat16)
+output = torch.empty_like(x)
+valid_cu = torch.tensor([0, 2, 4, 6], device="cuda", dtype=torch.int32)
+api = CausalConv1dBulkFwdSm100(x, weight, output, sample_cu_seqlens=valid_cu)
+api.check_support()
+api.compile()
+api.execute(x, weight, output, cu_seqlens_tensor=valid_cu)
+torch.cuda.synchronize()
+
+invalid_cu = {
+    "start_nonzero": [1, 2, 4, 6],
+    "end_mismatch": [0, 2, 4, 5],
+    "non_increasing": [0, 4, 3, 6],
+}[case]
+invalid_cu = torch.tensor(invalid_cu, device="cuda", dtype=torch.int32)
+
+try:
+    api.execute(x, weight, output, cu_seqlens_tensor=invalid_cu)
+    torch.cuda.synchronize()
+except Exception as error:
+    print(f"EXPECTED_DEVICE_FAILURE:{case}:{type(error).__name__}:{error}", flush=True)
+    os._exit(0)
+
+print(f"MISSING_DEVICE_FAILURE:{case}", flush=True)
+os._exit(9)
+"""
+
+
+@pytest.mark.parametrize("case", ["start_nonzero", "end_mismatch", "non_increasing"])
+def test_invalid_cu_seqlens_fail_closed_in_fresh_process(case):
+    # A PTX trap poisons its CUDA context, so isolate each metadata class and
+    # first prove that the same compiled object accepts valid boundaries.
+    _load_class()
+    source_cudnn = Path(__file__).resolve().parents[4] / "python" / "cudnn"
+    environment = os.environ.copy()
+    environment["PYTHONNOUSERSITE"] = "1"
+    result = subprocess.run(
+        [sys.executable, "-c", _DEVICE_ASSERT_WORKER, case, str(source_cudnn)],
+        cwd=Path(__file__).resolve().parents[4],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    diagnostics = result.stdout + result.stderr
+    assert result.returncode == 0, diagnostics
+    assert f"EXPECTED_DEVICE_FAILURE:{case}:" in diagnostics, diagnostics

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_semantic_api_sm100.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_semantic_api_sm100.py
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""L1 GPU correctness for the model-facing causal-conv state adapter."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from fe_api.causal_conv1d_bulk.reference import causal_conv1d_bulk_reference
+
+pytestmark = [
+    pytest.mark.L1,
+    pytest.mark.gpu_exclusive,
+    pytest.mark.xdist_group(name="gpu_exclusive"),
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required"),
+]
+
+
+def _require_native_route() -> None:
+    try:
+        from cudnn._causal_conv1d_arch import is_functional_arch
+        from cudnn.frost.buffers import cutedsl_state, cutedsl_too_old
+    except (ImportError, OSError) as error:
+        pytest.skip(f"CuTe DSL dependencies unavailable: {error}")
+    installed, version = cutedsl_state()
+    if not installed or cutedsl_too_old(version):
+        pytest.skip("causal_conv1d state requires nvidia-cutlass-dsl>=4.7.0")
+    capability = torch.cuda.get_device_capability()
+    if not is_functional_arch(capability):
+        pytest.skip(f"unsupported compute capability {capability}")
+
+
+def test_glm_mixed_fp32_weight_contract_matches_fp32_oracle() -> None:
+    """Keep the exact GLM D=24576 parameter and gradient dtypes native."""
+
+    _require_native_route()
+    from cudnn.ops.causal_conv1d import (
+        _get_causal_conv1d_last_route,
+        causal_conv1d,
+    )
+
+    generator = torch.Generator(device="cuda").manual_seed(20260903)
+    batch, tokens, channels = 1, 16, 24576
+    x_btd = (
+        torch.randn(
+            (batch, tokens, channels),
+            device="cuda",
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.25
+    ).requires_grad_()
+    weight = (
+        torch.randn(
+            (channels, 4),
+            device="cuda",
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * 0.25
+    ).requires_grad_()
+    dy_btd = (
+        torch.randn(
+            x_btd.shape,
+            device="cuda",
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.25
+    )
+
+    reference_x = x_btd.detach().float().requires_grad_()
+    reference_weight = weight.detach().requires_grad_()
+    expected_btd, _ = causal_conv1d_bulk_reference(
+        reference_x,
+        reference_weight,
+    )
+    expected_btd.backward(dy_btd.float())
+
+    actual = causal_conv1d(
+        x_btd.transpose(1, 2),
+        weight,
+        activation="silu",
+    )
+    assert _get_causal_conv1d_last_route() == "native-autograd"
+    actual.backward(dy_btd.transpose(1, 2))
+
+    assert actual.dtype == torch.bfloat16
+    assert x_btd.grad.dtype == torch.bfloat16
+    assert weight.grad.dtype == torch.float32
+    torch.testing.assert_close(actual.float(), expected_btd.transpose(1, 2), atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(x_btd.grad.float(), reference_x.grad, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(weight.grad, reference_weight.grad, atol=1e-1, rtol=5e-2)
+
+
+@pytest.mark.parametrize("packed", [False, True], ids=("dense", "packed"))
+def test_public_w_minus_one_state_matches_oracle_and_initial_gradient(
+    packed: bool,
+) -> None:
+    """Exercise public state shape, output/final values, and dInitial mapping."""
+
+    _require_native_route()
+    from cudnn.ops.causal_conv1d import (
+        _get_causal_conv1d_last_route,
+        causal_conv1d,
+    )
+
+    generator = torch.Generator(device="cuda").manual_seed(20260902 + int(packed))
+    batch, tokens, channels = (1, 6, 8) if packed else (2, 5, 8)
+    offsets = (0, 1, 3, 6) if packed else None
+    num_sequences = len(offsets) - 1 if offsets is not None else batch
+    cu_seqlens = None if offsets is None else torch.tensor(offsets, device="cuda", dtype=torch.int32)
+
+    x_btd = (
+        torch.randn(
+            (batch, tokens, channels),
+            device="cuda",
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.25
+    ).requires_grad_()
+    public_x = x_btd.transpose(1, 2)
+    weight = (torch.randn((channels, 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25).requires_grad_()
+    bias = (torch.randn(channels, device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25).requires_grad_()
+    initial_backing = torch.randn(
+        (num_sequences, 3, channels),
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    initial_states = (initial_backing * 0.25).transpose(1, 2).detach().requires_grad_()
+    final_states_out = torch.empty(
+        (num_sequences, 3, channels),
+        device="cuda",
+        dtype=torch.bfloat16,
+    ).transpose(1, 2)
+    dy_btd = torch.randn(x_btd.shape, device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    d_final_states = (
+        torch.randn(
+            initial_states.shape,
+            device="cuda",
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.25
+    )
+
+    reference_x = x_btd.detach().float().requires_grad_()
+    reference_weight = weight.detach().float().requires_grad_()
+    reference_bias = bias.detach().float().requires_grad_()
+    reference_initial_states = initial_states.detach().float().requires_grad_()
+    reference_full_state = torch.cat(
+        (torch.zeros_like(reference_initial_states[..., :1]), reference_initial_states),
+        dim=-1,
+    )
+    expected_btd, expected_full_final = causal_conv1d_bulk_reference(
+        reference_x,
+        reference_weight,
+        bias=reference_bias,
+        cu_seqlens=cu_seqlens,
+        initial_state=reference_full_state,
+    )
+    expected_final_states = expected_full_final[..., 1:]
+    d_full_final = torch.cat(
+        (torch.zeros_like(d_final_states[..., :1]), d_final_states),
+        dim=-1,
+    )
+    torch.autograd.backward(
+        (expected_btd, expected_full_final),
+        (dy_btd.float(), d_full_final.float()),
+    )
+
+    actual, actual_final_states = causal_conv1d(
+        public_x,
+        weight,
+        bias,
+        "silu",
+        cu_seqlens=cu_seqlens,
+        initial_states=initial_states,
+        return_final_states=True,
+        final_states_out=final_states_out,
+    )
+    assert _get_causal_conv1d_last_route() == "native-autograd"
+    torch.autograd.backward(
+        (actual, actual_final_states),
+        (dy_btd.transpose(1, 2), d_final_states),
+    )
+
+    assert actual.shape == public_x.shape
+    assert actual.stride() == public_x.stride()
+    assert actual_final_states is final_states_out
+    assert actual_final_states.shape == (num_sequences, channels, 3)
+    torch.testing.assert_close(actual.float(), expected_btd.transpose(1, 2), atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(actual_final_states.float(), expected_final_states, atol=0, rtol=0)
+    torch.testing.assert_close(initial_states.grad.float(), reference_initial_states.grad, atol=5e-2, rtol=5e-2)
+
+
+def test_public_inference_separates_bf16_and_fp32_weight_plans() -> None:
+    """A same-shape FP32 call must not reuse the preceding BF16 plan."""
+
+    _require_native_route()
+    from cudnn.ops.causal_conv1d import (
+        _get_causal_conv1d_last_route,
+        causal_conv1d,
+    )
+
+    generator = torch.Generator(device="cuda").manual_seed(20260904)
+    x_btd = torch.randn((1, 8, 16), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    weight_bf16 = torch.randn((16, 4), device="cuda", dtype=torch.bfloat16, generator=generator) * 0.25
+    weight_fp32 = torch.randn((16, 4), device="cuda", dtype=torch.float32, generator=generator) * 0.25
+
+    expected_bf16, _ = causal_conv1d_bulk_reference(x_btd, weight_bf16)
+    expected_fp32, _ = causal_conv1d_bulk_reference(x_btd, weight_fp32)
+
+    with torch.no_grad():
+        actual_bf16 = causal_conv1d(x_btd.transpose(1, 2), weight_bf16, activation="silu")
+        assert _get_causal_conv1d_last_route() == "native-inference"
+        actual_fp32 = causal_conv1d(x_btd.transpose(1, 2), weight_fp32, activation="silu")
+        assert _get_causal_conv1d_last_route() == "native-inference"
+
+    torch.testing.assert_close(actual_bf16.float(), expected_bf16.transpose(1, 2).float(), atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(actual_fp32.float(), expected_fp32.transpose(1, 2).float(), atol=3e-2, rtol=3e-2)

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_semantic_api_unit.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_semantic_api_unit.py
@@ -1,0 +1,613 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host-only checks for the model-facing causal-conv facade."""
+
+import ast
+import asyncio
+import functools
+import importlib.util
+import inspect
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.L0
+
+
+@functools.lru_cache(maxsize=1)
+def _ops_module():
+    source = Path(__file__).resolve().parents[4] / "python" / "cudnn" / "ops" / "causal_conv1d.py"
+    spec = importlib.util.spec_from_file_location("_causal_conv1d_semantic_contract", source)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_signature_matches_consumed_semantics_and_hides_backend_lifecycle():
+    signature = inspect.signature(_ops_module().causal_conv1d)
+
+    assert tuple(signature.parameters) == (
+        "x",
+        "weight",
+        "bias",
+        "activation",
+        "seq_idx",
+        "cu_seqlens",
+        "initial_states",
+        "return_final_states",
+        "final_states_out",
+    )
+    for name in (
+        "seq_idx",
+        "cu_seqlens",
+        "initial_states",
+        "return_final_states",
+        "final_states_out",
+    ):
+        assert signature.parameters[name].kind is inspect.Parameter.KEYWORD_ONLY
+    for forbidden in (
+        "wrapper",
+        "sm100",
+        "schedule",
+        "workspace",
+        "output",
+        "current_stream",
+        "plan",
+        "compile",
+    ):
+        assert forbidden not in signature.parameters
+
+
+def test_top_level_cudnn_does_not_export_experimental_backend_types():
+    source = Path(__file__).resolve().parents[4] / "python" / "cudnn" / "__init__.py"
+    tree = ast.parse(source.read_text())
+    lazy_imports = next(
+        ast.literal_eval(node.value)
+        for node in tree.body
+        if isinstance(node, ast.Assign) and any(isinstance(target, ast.Name) and target.id == "_LAZY_OPTIONAL_IMPORTS" for target in node.targets)
+    )
+    for name in (
+        "CausalConv1dBulkAutogradPrototype",
+        "CausalConv1dBulkBwdPrototype",
+        "CausalConv1dBulkFwdSm100",
+        "compile_causal_conv1d_bulk_bwd_prototype",
+        "causal_conv1d_bulk_fwd_wrapper_sm100",
+    ):
+        assert name not in lazy_imports
+
+
+def test_ops_surface_adds_only_the_semantic_causal_conv_name():
+    source = Path(__file__).resolve().parents[4] / "python" / "cudnn" / "ops" / "__init__.py"
+    tree = ast.parse(source.read_text())
+    lazy_exports = next(
+        ast.literal_eval(node.value)
+        for node in tree.body
+        if isinstance(node, ast.Assign) and any(isinstance(target, ast.Name) and target.id == "_LAZY_EXPORTS" for target in node.targets)
+    )
+
+    assert lazy_exports["causal_conv1d"] == (".causal_conv1d", "causal_conv1d")
+    assert "_get_causal_conv1d_last_route" not in lazy_exports
+    assert not any(token in name.lower() for name in lazy_exports for token in ("bulk", "wrapper", "sm100", "prototype"))
+
+
+def test_primary_docs_do_not_promote_legacy_or_backend_api_names():
+    docs = Path(__file__).resolve().parents[4] / "docs" / "fe-oss-apis" / "causal_conv1d.md"
+    text = docs.read_text()
+
+    assert "`cudnn.ops.causal_conv1d`" in text
+    for forbidden in (
+        "causal_conv1d_nwh",
+        "causal_conv1d_bulk",
+        "CausalConv1dBulk",
+        "wrapper_sm100",
+    ):
+        assert forbidden not in text
+
+
+def test_dense_native_route_is_bdt_public_and_btd_zero_copy(monkeypatch):
+    module = _ops_module()
+    backing = torch.randn(2, 5, 8, dtype=torch.bfloat16)
+    x = backing.transpose(1, 2)
+    weight = torch.randn(8, 4, dtype=torch.bfloat16)
+    observed = {}
+
+    monkeypatch.setattr(module, "_can_route_causal_conv1d_bulk", lambda *args: True)
+
+    def run(x_btd, native_weight, bias, cu_seqlens):
+        observed.update(x_btd=x_btd, weight=native_weight, bias=bias)
+        assert cu_seqlens is None
+        return torch.empty_like(x_btd)
+
+    monkeypatch.setattr(module, "_run_causal_conv1d_bulk_backend", run)
+    output = module.causal_conv1d(x, weight, activation="silu")
+
+    assert output.shape == x.shape
+    assert output.stride() == x.stride()
+    assert observed["x_btd"].is_contiguous()
+    assert observed["x_btd"].data_ptr() == x.data_ptr()
+    assert observed["weight"] is weight
+    assert module._get_causal_conv1d_last_route() == "native-inference"
+
+
+def test_generic_backend_layout_adapter_preserves_channel_last_input_format():
+    module = _ops_module()
+    backing = torch.randn(2, 5, 8, dtype=torch.bfloat16)
+    public_x = backing.transpose(1, 2)
+    contiguous_output = torch.randn_like(public_x.contiguous())
+
+    output = module._match_causal_conv1d_output_layout(contiguous_output, public_x)
+
+    assert output.shape == public_x.shape
+    assert output.stride() == public_x.stride()
+    torch.testing.assert_close(output, contiguous_output)
+
+
+def test_mathematical_w_minus_one_state_returns_an_ordinary_tuple(monkeypatch):
+    module = _ops_module()
+    backing = torch.randn(2, 5, 8, dtype=torch.bfloat16)
+    x = backing.transpose(1, 2)
+    weight = torch.randn(8, 4, dtype=torch.bfloat16)
+    initial_states = torch.randn(2, 8, 3, dtype=torch.bfloat16)
+    final_states_out = torch.empty_like(initial_states)
+    semantic_output = torch.empty_like(x)
+    observed = {}
+
+    def run(
+        native_x,
+        native_weight,
+        bias,
+        activation,
+        seq_idx,
+        cu_seqlens,
+        native_initial,
+        return_final,
+        native_final,
+    ):
+        observed.update(
+            x=native_x,
+            weight=native_weight,
+            bias=bias,
+            activation=activation,
+            seq_idx=seq_idx,
+            cu_seqlens=cu_seqlens,
+            initial_states=native_initial,
+            return_final_states=return_final,
+            final_states_out=native_final,
+        )
+        return semantic_output, native_final
+
+    monkeypatch.setattr(module, "_run_causal_conv1d_sequence_backend", run)
+    result = module.causal_conv1d(
+        x,
+        weight,
+        initial_states=initial_states,
+        return_final_states=True,
+        final_states_out=final_states_out,
+        activation="silu",
+    )
+
+    assert type(result) is tuple
+    output, final_states = result
+    assert output.shape == x.shape
+    assert final_states is final_states_out
+    assert observed["x"] is x
+    assert observed["initial_states"] is initial_states
+
+
+def test_full_width_state_adapter_uses_private_storage_and_preserves_gradient():
+    module = _ops_module()
+    initial_states = torch.randn(2, 8, 3, dtype=torch.bfloat16, requires_grad=True)
+
+    full_width = module._to_causal_conv1d_full_width_state(initial_states)
+    assert full_width.shape == (2, 8, 4)
+    torch.testing.assert_close(full_width[..., 0], torch.zeros_like(full_width[..., 0]))
+    torch.testing.assert_close(full_width[..., 1:], initial_states)
+
+    public_final = module._from_causal_conv1d_full_width_state(full_width * 2, None)
+    assert public_final.shape == initial_states.shape
+    assert public_final.untyped_storage().nbytes() == public_final.numel() * public_final.element_size()
+    assert public_final.data_ptr() != full_width.data_ptr()
+    torch.testing.assert_close(public_final, initial_states * 2)
+
+    public_final.float().sum().backward()
+    torch.testing.assert_close(initial_states.grad, torch.full_like(initial_states, 2))
+
+
+@pytest.mark.parametrize("packed", [False, True])
+def test_sequence_backend_adapts_dense_and_packed_state_with_final_states_out_gradient(monkeypatch, packed):
+    module = _ops_module()
+    batch = 1 if packed else 2
+    backing = torch.randn(batch, 5, 8, dtype=torch.bfloat16)
+    x = backing.transpose(1, 2)
+    weight = torch.randn(8, 4, dtype=torch.bfloat16)
+    cu_seqlens = torch.tensor([0, 2, 5], dtype=torch.int32) if packed else None
+    state_rows = 2
+    initial_states = torch.randn(state_rows, 8, 3, dtype=torch.bfloat16, requires_grad=True)
+    final_states_out = torch.empty(state_rows, 3, 8, dtype=torch.bfloat16).transpose(1, 2)
+    observed = {}
+
+    monkeypatch.setattr(module, "_can_route_causal_conv1d_bulk", lambda *args: True)
+
+    def run(
+        x_btd,
+        native_weight,
+        bias,
+        native_cu_seqlens,
+        *,
+        initial_state,
+        output_final_state,
+    ):
+        observed.update(
+            x_btd=x_btd,
+            weight=native_weight,
+            cu_seqlens=native_cu_seqlens,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+        )
+        return x_btd.clone(), initial_state * 2
+
+    monkeypatch.setattr(module, "_run_causal_conv1d_bulk_backend", run)
+    output, final_states = module.causal_conv1d(
+        x,
+        weight,
+        activation="silu",
+        cu_seqlens=cu_seqlens,
+        initial_states=initial_states,
+        return_final_states=True,
+        final_states_out=final_states_out,
+    )
+
+    assert output.shape == x.shape
+    assert output.stride() == x.stride()
+    assert final_states is final_states_out
+    assert observed["cu_seqlens"] is cu_seqlens
+    assert observed["output_final_state"] is True
+    assert observed["initial_state"].shape == (state_rows, 8, 4)
+    torch.testing.assert_close(
+        observed["initial_state"][..., 0],
+        torch.zeros_like(observed["initial_state"][..., 0]),
+    )
+    torch.testing.assert_close(observed["initial_state"][..., 1:], initial_states)
+    torch.testing.assert_close(final_states, initial_states * 2)
+
+    final_states.float().sum().backward()
+    torch.testing.assert_close(initial_states.grad, torch.full_like(initial_states, 2))
+    assert module._get_causal_conv1d_last_route() == "native-autograd"
+
+
+def test_bulk_backend_training_dispatch_includes_internal_state(monkeypatch):
+    module = _ops_module()
+    x_btd = torch.randn(1, 5, 8, dtype=torch.bfloat16)
+    weight = torch.randn(8, 4, dtype=torch.bfloat16)
+    initial_state = torch.randn(1, 8, 4, dtype=torch.bfloat16, requires_grad=True)
+    observed = {}
+
+    class Backend:
+        def __call__(self, x, native_weight, cu_seqlens, **kwargs):
+            observed.update(x=x, weight=native_weight, cu_seqlens=cu_seqlens, **kwargs)
+            return {
+                "output_tensor": x.clone(),
+                "final_state_tensor": kwargs["initial_state"].clone(),
+            }
+
+    def get_backend(x, native_weight, bias, cu_seqlens, native_initial, output_final_state):
+        observed.update(cache_initial=native_initial, cache_final=output_final_state)
+        return Backend()
+
+    monkeypatch.setattr(module, "_get_causal_conv1d_training_backend", get_backend)
+    output, final_state = module._run_causal_conv1d_bulk_backend(
+        x_btd,
+        weight,
+        None,
+        None,
+        initial_state=initial_state,
+        output_final_state=True,
+    )
+
+    assert output.shape == x_btd.shape
+    assert final_state.shape == initial_state.shape
+    assert observed["cache_initial"] is initial_state
+    assert observed["initial_state"] is initial_state
+    assert observed["cache_final"] is True
+    assert observed["output_final_state"] is True
+
+
+def test_bulk_backend_inference_dispatch_includes_internal_state(monkeypatch):
+    module = _ops_module()
+    x_btd = torch.randn(1, 5, 8, dtype=torch.bfloat16)
+    weight = torch.randn(8, 4, dtype=torch.bfloat16)
+    initial_state = torch.randn(1, 8, 4, dtype=torch.bfloat16)
+    observed = {}
+
+    def forward(x, native_weight, **kwargs):
+        observed.update(x=x, weight=native_weight, **kwargs)
+        return {
+            "output_tensor": x.clone(),
+            "final_state_tensor": kwargs["initial_state_tensor"].clone(),
+        }
+
+    fake_api = SimpleNamespace(causal_conv1d_bulk_fwd_wrapper_sm100=forward)
+    monkeypatch.setitem(sys.modules, "cudnn.causal_conv1d_bulk_sm100.api", fake_api)
+    with torch.no_grad():
+        output, final_state = module._run_causal_conv1d_bulk_backend(
+            x_btd,
+            weight,
+            None,
+            None,
+            initial_state=initial_state,
+            output_final_state=True,
+        )
+
+    assert output.shape == x_btd.shape
+    assert final_state.shape == initial_state.shape
+    assert observed["initial_state_tensor"] is initial_state
+    assert observed["output_final_state"] is True
+
+
+def test_full_width_backend_cache_is_not_accepted_as_public_state():
+    module = _ops_module()
+    backing = torch.randn(1, 5, 8, dtype=torch.bfloat16)
+    x = backing.transpose(1, 2)
+    weight = torch.randn(8, 4, dtype=torch.bfloat16)
+    full_width_cache = torch.randn(1, 8, 4, dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match=r"initial_states must have shape \(1, 8, 3\)"):
+        module.causal_conv1d(x, weight, initial_states=full_width_cache, activation="silu")
+
+
+@pytest.mark.parametrize("with_seq_idx", [False, True])
+def test_dense_and_seq_idx_states_use_batch_rows(with_seq_idx):
+    module = _ops_module()
+    backing = torch.randn(2, 5, 8, dtype=torch.bfloat16)
+    x = backing.transpose(1, 2)
+    weight = torch.randn(8, 4, dtype=torch.bfloat16)
+    state = torch.randn(2, 8, 3, dtype=torch.bfloat16)
+    seq_idx = torch.zeros(2, 5, dtype=torch.int32) if with_seq_idx else None
+
+    result = module._validate_causal_conv1d_sequence_contract(
+        x,
+        weight,
+        None,
+        seq_idx,
+        None,
+        state,
+        False,
+        None,
+    )
+
+    assert result is None
+    with pytest.raises(ValueError, match=r"initial_states must have shape \(2, 8, 3\)"):
+        module._validate_causal_conv1d_sequence_contract(
+            x,
+            weight,
+            None,
+            seq_idx,
+            None,
+            torch.randn(1, 8, 3, dtype=torch.bfloat16),
+            False,
+            None,
+        )
+
+
+def test_packed_states_use_number_of_sequences_not_storage_batch():
+    module = _ops_module()
+    backing = torch.randn(1, 5, 8, dtype=torch.bfloat16)
+    x = backing.transpose(1, 2)
+    weight = torch.randn(8, 4, dtype=torch.bfloat16)
+    cu_seqlens = torch.tensor([0, 2, 5], dtype=torch.int32)
+    initial_states = torch.randn(2, 8, 3, dtype=torch.bfloat16)
+    final_states_out = torch.empty_like(initial_states)
+
+    result = module._validate_causal_conv1d_sequence_contract(
+        x,
+        weight,
+        None,
+        None,
+        cu_seqlens,
+        initial_states,
+        True,
+        final_states_out,
+    )
+
+    assert result is None
+    with pytest.raises(ValueError, match=r"initial_states must have shape \(2, 8, 3\)"):
+        module._validate_causal_conv1d_sequence_contract(
+            x,
+            weight,
+            None,
+            None,
+            cu_seqlens,
+            torch.randn(1, 8, 3, dtype=torch.bfloat16),
+            True,
+            final_states_out,
+        )
+
+
+def test_exact_shape_training_backend_is_private_and_reused(monkeypatch):
+    module = _ops_module()
+    module._CAUSAL_CONV1D_TRAINING_CACHE.clear()
+    x_btd = torch.randn(1, 5, 8, dtype=torch.bfloat16)
+    weight = torch.randn(8, 4, dtype=torch.bfloat16)
+    created = []
+    backend = object()
+
+    monkeypatch.setattr(module, "_causal_conv1d_training_key", lambda *args: ("same-shape",))
+    monkeypatch.setattr(
+        module,
+        "_compile_causal_conv1d_training_backend",
+        lambda *args: created.append(args) or backend,
+    )
+
+    assert module._get_causal_conv1d_training_backend(x_btd, weight, None, None) is backend
+    assert module._get_causal_conv1d_training_backend(x_btd, weight, None, None) is backend
+    assert len(created) == 1
+
+
+def test_training_cache_keys_every_routed_plan_field_but_not_packed_values(monkeypatch):
+    module = _ops_module()
+    properties = SimpleNamespace(major=10, minor=0, multi_processor_count=148)
+    monkeypatch.setattr(module.torch.cuda, "get_device_properties", lambda device: properties)
+
+    x_btd = torch.randn(1, 5, 8, dtype=torch.bfloat16)
+    weight = torch.randn(8, 4, dtype=torch.bfloat16)
+    bias = torch.randn(8, dtype=torch.bfloat16)
+    packed_a = torch.tensor([0, 2, 5], dtype=torch.int32)
+    packed_b = torch.tensor([0, 1, 5], dtype=torch.int32)
+    packed_more_sequences = torch.tensor([0, 1, 3, 5], dtype=torch.int32)
+    initial_state = torch.randn(1, 8, 4, dtype=torch.bfloat16)
+
+    dense_key = module._causal_conv1d_training_key(x_btd, weight, None, None)
+    biased_key = module._causal_conv1d_training_key(x_btd, weight, bias, None)
+    packed_a_key = module._causal_conv1d_training_key(x_btd, weight, None, packed_a)
+    packed_b_key = module._causal_conv1d_training_key(x_btd, weight, None, packed_b)
+    packed_more_sequences_key = module._causal_conv1d_training_key(x_btd, weight, None, packed_more_sequences)
+    initial_state_key = module._causal_conv1d_training_key(x_btd, weight, None, None, initial_state, False)
+    final_state_key = module._causal_conv1d_training_key(x_btd, weight, None, None, initial_state, True)
+    strided_weight = torch.empty(4, 8, dtype=torch.bfloat16).transpose(0, 1)
+    strided_weight_key = module._causal_conv1d_training_key(x_btd, strided_weight, None, None)
+
+    assert dense_key != biased_key
+    assert dense_key != packed_a_key
+    assert packed_a_key == packed_b_key
+    assert packed_a_key != packed_more_sequences_key
+    assert dense_key != initial_state_key
+    assert initial_state_key != final_state_key
+    assert dense_key != strided_weight_key
+
+
+def test_unmapped_state_and_seq_idx_modes_decline_explicitly():
+    module = _ops_module()
+    backing = torch.randn(1, 5, 8, dtype=torch.bfloat16)
+    x = backing.transpose(1, 2)
+    weight = torch.randn(8, 4, dtype=torch.bfloat16)
+    seq_idx = torch.zeros(1, 5, dtype=torch.int32)
+
+    with pytest.raises(NotImplementedError, match="does not yet implement"):
+        module.causal_conv1d(x, weight, seq_idx=seq_idx, activation="silu")
+
+
+def test_cu_seqlens_packed_route_returns_a_tensor_and_is_mutually_exclusive(
+    monkeypatch,
+):
+    module = _ops_module()
+    backing = torch.randn(1, 5, 8, dtype=torch.bfloat16)
+    x = backing.transpose(1, 2)
+    weight = torch.randn(8, 4, dtype=torch.bfloat16)
+    cu_seqlens = torch.tensor([0, 2, 5], dtype=torch.int32)
+    output_btd = torch.empty_like(backing)
+    observed = {}
+
+    monkeypatch.setattr(module, "_can_route_causal_conv1d_bulk", lambda *args: True)
+
+    def run(x_btd, native_weight, bias, native_cu_seqlens):
+        observed.update(x_btd=x_btd, weight=native_weight, cu_seqlens=native_cu_seqlens)
+        return output_btd
+
+    monkeypatch.setattr(module, "_run_causal_conv1d_bulk_backend", run)
+    output = module.causal_conv1d(x, weight, None, "silu", cu_seqlens=cu_seqlens)
+
+    assert type(output) is torch.Tensor
+    assert output.shape == x.shape
+    assert observed["x_btd"].data_ptr() == x.data_ptr()
+    assert observed["cu_seqlens"] is cu_seqlens
+    assert module._get_causal_conv1d_last_route() == "native-inference"
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        module.causal_conv1d(
+            x,
+            weight,
+            None,
+            "silu",
+            seq_idx=torch.zeros(1, 5, dtype=torch.int32),
+            cu_seqlens=cu_seqlens,
+        )
+
+
+def test_generic_route_is_recorded_only_after_success(monkeypatch):
+    module = _ops_module()
+    x = torch.randn(2, 8, 5)
+    weight = torch.randn(8, 3)
+    expected = torch.empty_like(x)
+
+    monkeypatch.setattr(module, "_can_route_causal_conv1d_bulk", lambda *args: False)
+    monkeypatch.setattr(
+        module.torch.ops.cudnn,
+        "causal_conv1d_fwd_primitive",
+        lambda *args: expected,
+    )
+
+    assert module.causal_conv1d(x, weight) is expected
+    assert module._get_causal_conv1d_last_route() == "generic-cudnn"
+
+    with pytest.raises(NotImplementedError, match="activation must"):
+        module.causal_conv1d(x, weight, activation="relu")
+    assert module._get_causal_conv1d_last_route() is None
+
+
+def test_mixed_fp32_weight_declines_explicitly_when_native_layout_is_unavailable(
+    monkeypatch,
+):
+    module = _ops_module()
+    x = torch.randn(1, 8, 5, dtype=torch.bfloat16)
+    weight = torch.randn(8, 4, dtype=torch.float32)
+
+    monkeypatch.setattr(module, "_can_route_causal_conv1d_bulk", lambda *args: False)
+    with pytest.raises(NotImplementedError, match="BF16 activation with FP32 weight"):
+        module.causal_conv1d(x, weight, activation="silu")
+    assert module._get_causal_conv1d_last_route() is None
+
+
+def test_last_route_diagnostic_stays_out_of_torch_compile_graph(monkeypatch):
+    module = _ops_module()
+    x = torch.randn(2, 8, 5)
+    weight = torch.randn(8, 3)
+
+    monkeypatch.setattr(
+        module.torch.ops.cudnn,
+        "causal_conv1d_fwd_primitive",
+        lambda public_x, *args: public_x.clone(),
+    )
+    module._record_causal_conv1d_route("native-inference")
+
+    compiled = torch.compile(module.causal_conv1d, backend="eager", fullgraph=True)
+    output = compiled(x, weight)
+
+    torch.testing.assert_close(output, x)
+    # Compiled calls neither graph-break on ContextVar nor replace the most
+    # recent eager route with a trace-time observation.
+    assert module._get_causal_conv1d_last_route() == "native-inference"
+
+
+def test_last_route_diagnostic_is_thread_and_async_context_local():
+    module = _ops_module()
+    module._record_causal_conv1d_route("generic-cudnn")
+    barrier = threading.Barrier(2)
+
+    def thread_worker(route):
+        assert module._get_causal_conv1d_last_route() is None
+        module._record_causal_conv1d_route(route)
+        barrier.wait()
+        return module._get_causal_conv1d_last_route()
+
+    routes = ("native-inference", "native-autograd")
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        assert tuple(pool.map(thread_worker, routes)) == routes
+    assert module._get_causal_conv1d_last_route() == "generic-cudnn"
+
+    async def async_worker(route):
+        module._record_causal_conv1d_route(route)
+        await asyncio.sleep(0)
+        return module._get_causal_conv1d_last_route()
+
+    async def run_async_workers():
+        return await asyncio.gather(*(async_worker(route) for route in routes))
+
+    assert tuple(asyncio.run(run_async_workers())) == routes
+    assert module._get_causal_conv1d_last_route() == "generic-cudnn"

--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_semantic_api_unit.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_semantic_api_unit.py
@@ -297,8 +297,8 @@ def test_bulk_backend_training_dispatch_includes_internal_state(monkeypatch):
                 "final_state_tensor": kwargs["initial_state"].clone(),
             }
 
-    def get_backend(x, native_weight, bias, cu_seqlens, native_initial, output_final_state):
-        observed.update(cache_initial=native_initial, cache_final=output_final_state)
+    def get_backend(x, native_weight, bias, cu_seqlens, native_initial, output_final_state, deterministic):
+        observed.update(cache_initial=native_initial, cache_final=output_final_state, deterministic=deterministic)
         return Backend()
 
     monkeypatch.setattr(module, "_get_causal_conv1d_training_backend", get_backend)
@@ -611,3 +611,70 @@ def test_last_route_diagnostic_is_thread_and_async_context_local():
 
     assert tuple(asyncio.run(run_async_workers())) == routes
     assert module._get_causal_conv1d_last_route() == "generic-cudnn"
+
+
+@pytest.mark.parametrize("alias", ["x", "weight", "initial_states"])
+def test_final_states_out_must_not_share_memory_with_inputs(alias):
+    module = _ops_module()
+    backing = torch.randn(2, 5, 8, dtype=torch.bfloat16)
+    x = backing.transpose(1, 2)
+    weight = torch.randn(8, 4, dtype=torch.bfloat16)
+    initial_states = torch.randn(2, 8, 3, dtype=torch.bfloat16)
+    if alias == "x":
+        final_states_out = x[..., :3]
+    elif alias == "weight":
+        final_states_out = weight.as_strided((2, 8, 3), (0, 4, 1))
+    else:
+        final_states_out = initial_states
+
+    with pytest.raises(ValueError, match=f"final_states_out must not share memory with {alias}"):
+        module.causal_conv1d(
+            x,
+            weight,
+            activation="silu",
+            initial_states=initial_states,
+            return_final_states=True,
+            final_states_out=final_states_out,
+        )
+
+
+def test_shared_memory_check_uses_addressed_byte_spans_not_storage_identity():
+    module = _ops_module()
+    storage = torch.empty(2 * 2 * 8 * 3, dtype=torch.bfloat16)
+    first = storage[: 2 * 8 * 3].view(2, 8, 3)
+    second = storage[2 * 8 * 3 :].view(2, 8, 3)
+    shifted = storage[1 : 2 * 8 * 3 + 1].view(2, 8, 3)
+
+    assert not module._tensors_share_memory(first, second)
+    assert module._tensors_share_memory(first, shifted)
+    assert module._tensors_share_memory(first, first.transpose(1, 2))
+
+
+def test_training_dispatch_keys_and_forwards_torch_deterministic_mode(monkeypatch):
+    module = _ops_module()
+    properties = SimpleNamespace(major=10, minor=0, multi_processor_count=148)
+    monkeypatch.setattr(module.torch.cuda, "get_device_properties", lambda device: properties)
+    x_btd = torch.randn(1, 5, 8, dtype=torch.bfloat16)
+    weight = torch.randn(8, 4, dtype=torch.bfloat16, requires_grad=True)
+
+    default_key = module._causal_conv1d_training_key(x_btd, weight, None, None)
+    deterministic_key = module._causal_conv1d_training_key(x_btd, weight, None, None, None, False, True)
+    assert default_key != deterministic_key
+
+    observed = []
+
+    def get_backend(x, native_weight, bias, cu_seqlens, initial_state, output_final_state, deterministic):
+        observed.append(deterministic)
+        return lambda *args, **kwargs: x.clone()
+
+    monkeypatch.setattr(module, "_get_causal_conv1d_training_backend", get_backend)
+    previous = torch.are_deterministic_algorithms_enabled()
+    previous_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
+    try:
+        torch.use_deterministic_algorithms(False)
+        module._run_causal_conv1d_bulk_backend(x_btd, weight, None, None)
+        torch.use_deterministic_algorithms(True, warn_only=True)
+        module._run_causal_conv1d_bulk_backend(x_btd, weight, None, None)
+    finally:
+        torch.use_deterministic_algorithms(previous, warn_only=previous_warn_only)
+    assert observed == [False, True]

--- a/test/python/fe_api/causal_conv1d_update/conftest.py
+++ b/test/python/fe_api/causal_conv1d_update/conftest.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Overlay this checkout's Python modules onto a prebuilt frontend package."""
+
+from pathlib import Path
+
+import cudnn
+
+_SOURCE_CUDNN = Path(__file__).resolve().parents[4] / "python" / "cudnn"
+if str(_SOURCE_CUDNN) not in cudnn.__path__:
+    cudnn.__path__.insert(0, str(_SOURCE_CUDNN))

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_prefill_decode_seam_sm100.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_prefill_decode_seam_sm100.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public full-sequence to decode state-handoff correctness."""
+
+import pytest
+import torch
+import torch.nn.functional as F
+from fe_api.causal_conv1d_bulk.reference import causal_conv1d_bulk_reference
+
+pytestmark = [
+    pytest.mark.L1,
+    pytest.mark.gpu_exclusive,
+    pytest.mark.xdist_group(name="gpu_exclusive"),
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required"),
+]
+
+
+def _require_native_route() -> None:
+    try:
+        from cudnn._causal_conv1d_arch import is_functional_arch
+        from cudnn.frost.buffers import cutedsl_state, cutedsl_too_old
+    except (ImportError, OSError) as error:
+        pytest.skip(f"CuTe DSL dependencies unavailable: {error}")
+    installed, version = cutedsl_state()
+    if not installed or cutedsl_too_old(version):
+        pytest.skip("causal_conv1d state requires nvidia-cutlass-dsl>=4.7.0")
+    capability = torch.cuda.get_device_capability()
+    if not is_functional_arch(capability):
+        pytest.skip(f"unsupported compute capability {capability}")
+
+
+def _reference_update(
+    x: torch.Tensor,
+    state: torch.Tensor,
+    weight: torch.Tensor,
+    *,
+    bias: torch.Tensor | None = None,
+    state_indices: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    rows = x.shape[0]
+    slots = torch.arange(rows, device=x.device, dtype=torch.long) if state_indices is None else state_indices.long()
+    valid = slots >= 0
+    output = torch.zeros_like(x)
+    expected_state = state.clone()
+    if valid.any():
+        valid_slots = slots[valid]
+        selected = state.index_select(0, valid_slots)
+        history = torch.cat((selected, x[valid].unsqueeze(-1)), dim=-1)
+        window = history[..., -weight.shape[-1] :]
+        accumulator = (window.float() * weight.float().unsqueeze(0)).sum(dim=-1)
+        if bias is not None:
+            accumulator = accumulator + bias.float()
+        output[valid] = F.silu(accumulator).to(torch.bfloat16)
+        expected_state.index_copy_(0, valid_slots, history[..., -state.shape[-1] :])
+    return output, expected_state
+
+
+def _assert_state_bits_equal(actual: torch.Tensor, expected: torch.Tensor) -> None:
+    torch.testing.assert_close(
+        actual.contiguous().view(torch.int16),
+        expected.contiguous().view(torch.int16),
+        rtol=0,
+        atol=0,
+    )
+
+
+def _state_identity(state: torch.Tensor) -> tuple[int, tuple[int, ...], int]:
+    return state.data_ptr(), tuple(state.stride()), state.storage_offset()
+
+
+@torch.no_grad()
+def test_dense_default_and_caller_owned_states_feed_decode_without_repacking() -> None:
+    _require_native_route()
+    from cudnn.ops import causal_conv1d, causal_conv1d_update
+
+    torch.manual_seed(20260901)
+    batch, tokens, channels = 2, 5, 257
+    x_btd = torch.randn(batch, tokens, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(channels, device="cuda", dtype=torch.bfloat16)
+    next_x = torch.randn(batch, channels, device="cuda", dtype=torch.bfloat16)
+
+    _, state = causal_conv1d(
+        x_btd.transpose(1, 2),
+        weight,
+        bias,
+        "silu",
+        return_final_states=True,
+    )
+    assert state.shape == (batch, channels, 3)
+    _assert_state_bits_equal(state, x_btd[:, -3:, :].transpose(1, 2))
+
+    expected_output, expected_state = _reference_update(next_x, state, weight, bias=bias)
+    identity = _state_identity(state)
+    actual_output = causal_conv1d_update(next_x, state, weight, bias, activation="silu")
+    assert _state_identity(state) == identity
+    torch.testing.assert_close(actual_output, expected_output, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(state, expected_state)
+
+    # A compact caller-owned output for the same shape must also feed the
+    # public update directly.
+    compact_state = torch.empty(batch, channels, 3, device="cuda", dtype=torch.bfloat16)
+    _, returned_state = causal_conv1d(
+        x_btd.transpose(1, 2),
+        weight,
+        bias,
+        "silu",
+        return_final_states=True,
+        final_states_out=compact_state,
+    )
+    assert returned_state is compact_state
+    expected_output, expected_state = _reference_update(next_x, compact_state, weight, bias=bias)
+    identity = _state_identity(compact_state)
+    actual_output = causal_conv1d_update(next_x, compact_state, weight, bias, activation="silu")
+    assert _state_identity(compact_state) == identity
+    torch.testing.assert_close(actual_output, expected_output, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(compact_state, expected_state)
+
+
+@torch.no_grad()
+def test_packed_default_state_feeds_indexed_decode_without_repacking() -> None:
+    _require_native_route()
+    from cudnn.ops import causal_conv1d, causal_conv1d_update
+
+    torch.manual_seed(20260902)
+    tokens, channels = 8, 257
+    x_btd = torch.randn(1, tokens, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    cu_seqlens = torch.tensor([0, 2, 5, 8], device="cuda", dtype=torch.int32)
+
+    _, state = causal_conv1d(
+        x_btd.transpose(1, 2),
+        weight,
+        activation="silu",
+        cu_seqlens=cu_seqlens,
+        return_final_states=True,
+    )
+    assert state.shape == (3, channels, 3)
+    _, expected_full_state = causal_conv1d_bulk_reference(x_btd, weight, cu_seqlens=cu_seqlens)
+    _assert_state_bits_equal(state, expected_full_state[..., 1:])
+
+    next_x = torch.randn(3, channels, device="cuda", dtype=torch.bfloat16)
+    state_indices = torch.tensor([2, -1, 0], device="cuda", dtype=torch.int32)
+    expected_output, expected_state = _reference_update(next_x, state, weight, state_indices=state_indices)
+    untouched_slot = state[1].clone()
+    identity = _state_identity(state)
+    actual_output = causal_conv1d_update(
+        next_x,
+        state,
+        weight,
+        activation="silu",
+        conv_state_indices=state_indices,
+    )
+
+    assert _state_identity(state) == identity
+    torch.testing.assert_close(actual_output, expected_output, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(actual_output[1], torch.zeros_like(actual_output[1]), rtol=0, atol=0)
+    _assert_state_bits_equal(state[1], untouched_slot)
+    _assert_state_bits_equal(state, expected_state)

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_prefill_decode_seam_sm100.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_prefill_decode_seam_sm100.py
@@ -72,7 +72,8 @@ def _state_identity(state: torch.Tensor) -> tuple[int, tuple[int, ...], int]:
 @torch.no_grad()
 def test_dense_default_and_caller_owned_states_feed_decode_without_repacking() -> None:
     _require_native_route()
-    from cudnn.ops import causal_conv1d, causal_conv1d_update
+    from cudnn.ops import causal_conv1d_update
+    from cudnn.ops.causal_conv1d import causal_conv1d
 
     torch.manual_seed(20260901)
     batch, tokens, channels = 2, 5, 257
@@ -121,7 +122,8 @@ def test_dense_default_and_caller_owned_states_feed_decode_without_repacking() -
 @torch.no_grad()
 def test_packed_default_state_feeds_indexed_decode_without_repacking() -> None:
     _require_native_route()
-    from cudnn.ops import causal_conv1d, causal_conv1d_update
+    from cudnn.ops import causal_conv1d_update
+    from cudnn.ops.causal_conv1d import causal_conv1d
 
     torch.manual_seed(20260902)
     tokens, channels = 8, 257

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_benchmark_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_benchmark_contract_unit.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host-contract tests for the causal-convolution benchmark environment gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.L0
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _fake_benchmark_dependencies(monkeypatch):
+    packages = {}
+    for name in ("fla", "fla.modules", "fla.modules.conv", "fla.modules.conv.triton"):
+        package = types.ModuleType(name)
+        package.__path__ = []
+        packages[name] = package
+        monkeypatch.setitem(sys.modules, name, package)
+
+    ops = types.ModuleType("fla.modules.conv.triton.ops")
+
+    def causal_conv1d_update(x, cache, residual=None, weight=None, bias=None, activation=None):
+        del residual, weight, bias, activation
+        return x, cache
+
+    causal_conv1d_update.__module__ = ops.__name__
+    ops.causal_conv1d_update = causal_conv1d_update
+    monkeypatch.setitem(sys.modules, ops.__name__, ops)
+
+    packages["fla"].modules = packages["fla.modules"]
+    packages["fla.modules"].conv = packages["fla.modules.conv"]
+    packages["fla.modules.conv"].triton = packages["fla.modules.conv.triton"]
+    packages["fla.modules.conv.triton"].ops = ops
+
+    native = types.ModuleType("cudnn.causal_conv1d_update_sm100")
+
+    class _CausalConv1dUpdatePlan:
+        pass
+
+    _CausalConv1dUpdatePlan.__module__ = "cudnn.causal_conv1d_update_sm100.api"
+    native._CausalConv1dUpdatePlan = _CausalConv1dUpdatePlan
+    monkeypatch.setitem(sys.modules, native.__name__, native)
+
+
+def _load_benchmark(monkeypatch):
+    _fake_benchmark_dependencies(monkeypatch)
+    benchmark_path = _REPO_ROOT / "benchmark" / "causal_conv1d_update_sm100.py"
+    module_name = "_test_causal_conv1d_update_sm100_benchmark"
+    spec = importlib.util.spec_from_file_location(module_name, benchmark_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    try:
+        spec.loader.exec_module(module)
+    except ImportError as exc:
+        pytest.skip(f"CuTe DSL benchmark dependencies unavailable: {exc}")
+    return module
+
+
+def test_benchmark_accepts_supported_cuda_without_slurm(monkeypatch):
+    benchmark = _load_benchmark(monkeypatch)
+    monkeypatch.setattr(benchmark.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(benchmark.torch.cuda, "get_device_capability", lambda device=None: (10, 0))
+    monkeypatch.setattr(benchmark, "_package_version", lambda unused: "0.5.2")
+    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+    monkeypatch.delenv("SLURMD_NODENAME", raising=False)
+
+    benchmark._validate_environment()
+
+    assert benchmark._slurm_provenance() == {
+        "slurm_job_id": None,
+        "slurmd_node_name": None,
+    }
+
+
+def test_benchmark_records_available_slurm_provenance(monkeypatch):
+    benchmark = _load_benchmark(monkeypatch)
+    monkeypatch.setenv("SLURM_JOB_ID", "12345")
+    monkeypatch.setenv("SLURMD_NODENAME", "customer-node-7")
+
+    assert benchmark._slurm_provenance() == {
+        "slurm_job_id": "12345",
+        "slurmd_node_name": "customer-node-7",
+    }
+
+
+def test_benchmark_rejects_unavailable_or_unsupported_cuda(monkeypatch):
+    benchmark = _load_benchmark(monkeypatch)
+    monkeypatch.setattr(benchmark, "_package_version", lambda unused: "0.5.2")
+    monkeypatch.setattr(benchmark.torch.cuda, "is_available", lambda: False)
+    with pytest.raises(RuntimeError, match="CUDA is unavailable"):
+        benchmark._validate_environment()
+
+    monkeypatch.setattr(benchmark.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(benchmark.torch.cuda, "get_device_capability", lambda device=None: (11, 1))
+    with pytest.raises(RuntimeError, match="functionally supported causal-conv compute capability"):
+        benchmark._validate_environment()

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Observable host contracts for the public decode-update operation."""
+
+import inspect
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.L0
+
+
+def _meta_inputs(
+    *,
+    n_rows: int = 2,
+    n_channels: int = 8,
+    n_slots: int = 3,
+    state_len: int = 4,
+    width: int = 4,
+):
+    x = torch.empty(n_rows, n_channels, device="meta", dtype=torch.bfloat16)
+    state = torch.empty(n_slots, n_channels, state_len, device="meta", dtype=torch.bfloat16)
+    weight = torch.empty(n_channels, width, device="meta", dtype=torch.bfloat16)
+    return x, state, weight
+
+
+def _channel_fast_state(n_slots: int, n_channels: int, state_len: int):
+    return torch.empty(
+        n_slots,
+        state_len,
+        n_channels,
+        device="meta",
+        dtype=torch.bfloat16,
+    ).transpose(1, 2)
+
+
+def test_only_cudnn_ops_exports_the_semantic_api(tmp_path):
+    """Check the source package in a fresh interpreter, not conftest's overlay."""
+
+    import cudnn
+
+    source = Path(__file__).resolve().parents[4] / "python" / "cudnn"
+    probe = tmp_path / "cudnn"
+    shutil.copytree(source, probe)
+    compiled_modules = list(Path(cudnn.__file__).resolve().parent.glob("_compiled_module*.so"))
+    if len(compiled_modules) != 1:
+        pytest.skip(f"expected one compiled module next to {cudnn.__file__}, " f"found {len(compiled_modules)}")
+    try:
+        (probe / compiled_modules[0].name).symlink_to(compiled_modules[0])
+    except OSError as error:
+        pytest.skip(f"cannot link the compiled module into the probe package: {error}")
+
+    script = """
+import types
+import cudnn
+import cudnn.ops
+from cudnn.ops import causal_conv1d_update
+
+assert callable(causal_conv1d_update)
+assert not isinstance(causal_conv1d_update, types.ModuleType)
+assert cudnn.ops.causal_conv1d_update is causal_conv1d_update
+assert not hasattr(cudnn, "causal_conv1d_update")
+assert not hasattr(cudnn, "causal_conv1d_update_wrapper_sm100")
+assert not hasattr(cudnn, "CausalConv1dUpdateSm100")
+"""
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = os.pathsep.join((str(tmp_path), environment.get("PYTHONPATH", ""))).rstrip(os.pathsep)
+    subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_public_semantic_signature():
+    from cudnn.ops import causal_conv1d_update
+
+    parameters = inspect.signature(causal_conv1d_update).parameters
+    assert tuple(parameters) == (
+        "x",
+        "conv_state",
+        "weight",
+        "bias",
+        "activation",
+        "cache_seqlens",
+        "conv_state_indices",
+    )
+    assert parameters["bias"].default is None
+    assert parameters["activation"].default is None
+    for name in ("cache_seqlens", "conv_state_indices"):
+        assert parameters[name].kind is inspect.Parameter.KEYWORD_ONLY
+        assert parameters[name].default is None
+
+
+@pytest.mark.parametrize("state_len", [3, 4], ids=["w-minus-one", "legacy-four"])
+@pytest.mark.parametrize("activation", [None, "identity", "silu", "swish"])
+def test_public_meta_contract_preserves_output_metadata(state_len, activation):
+    from cudnn.ops import causal_conv1d_update
+
+    x, state, weight = _meta_inputs(state_len=state_len)
+    indices = torch.empty(x.shape[0], device="meta", dtype=torch.int32)
+    output = causal_conv1d_update(
+        x,
+        state,
+        weight,
+        activation=activation,
+        conv_state_indices=indices,
+    )
+
+    assert type(output) is torch.Tensor
+    assert output.shape == x.shape
+    assert output.dtype == x.dtype
+    assert output.device == x.device
+
+
+@pytest.mark.parametrize("channel_fast", [False, True])
+def test_public_accepts_both_prefill_handoff_and_compact_wminus1_state(
+    channel_fast,
+):
+    from cudnn.ops import causal_conv1d_update
+
+    x, compact_state, weight = _meta_inputs(state_len=3)
+    state = _channel_fast_state(compact_state.shape[0], x.shape[1], 3) if channel_fast else compact_state
+
+    output = causal_conv1d_update(x, state, weight, activation="silu")
+    assert output.shape == x.shape
+
+
+@pytest.mark.parametrize("n_channels,row_stride", [(10, 10), (10, 16)])
+def test_public_accepts_supported_input_row_strides(n_channels, row_stride):
+    from cudnn.ops import causal_conv1d_update
+
+    x = torch.empty_strided(
+        (2, n_channels),
+        (row_stride, 1),
+        device="meta",
+        dtype=torch.bfloat16,
+    )
+    state = torch.empty(2, n_channels, 3, device="meta", dtype=torch.bfloat16)
+    weight = torch.empty(n_channels, 4, device="meta", dtype=torch.bfloat16)
+
+    assert causal_conv1d_update(x, state, weight).shape == x.shape
+
+
+@pytest.mark.parametrize(
+    "stride,match",
+    [
+        ((20, 2), "row-major strides"),
+        ((7, 1), "at least D"),
+        ((12, 1), "16-byte-aligned"),
+    ],
+)
+def test_public_rejects_unsupported_input_row_strides(stride, match):
+    from cudnn.ops import causal_conv1d_update
+
+    x = torch.empty_strided((2, 10), stride, device="meta", dtype=torch.bfloat16)
+    state = torch.empty(2, 10, 3, device="meta", dtype=torch.bfloat16)
+    weight = torch.empty(10, 4, device="meta", dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match=match):
+        causal_conv1d_update(x, state, weight)
+
+
+def test_public_rejects_channel_fast_legacy_four_state():
+    from cudnn.ops import causal_conv1d_update
+
+    x, _, weight = _meta_inputs(state_len=4)
+    state = _channel_fast_state(3, x.shape[1], 4)
+    with pytest.raises(ValueError, match=r"contiguous.*or for L=3"):
+        causal_conv1d_update(x, state, weight)
+
+
+@pytest.mark.parametrize(
+    "state_len,width,has_cache",
+    [(2, 3, False), (5, 4, False), (4, 4, True)],
+    ids=["width-three", "state-length-five", "circular-buffer"],
+)
+def test_unimplemented_compatibility_modes_decline_explicitly(state_len, width, has_cache):
+    from cudnn.ops import causal_conv1d_update
+
+    x, state, weight = _meta_inputs(state_len=state_len, width=width)
+    cache_seqlens = torch.empty(x.shape[0], device="meta", dtype=torch.int32) if has_cache else None
+    with pytest.raises(NotImplementedError, match=r"current native.*supports only"):
+        causal_conv1d_update(x, state, weight, cache_seqlens=cache_seqlens)
+
+
+def test_multi_token_input_is_not_silently_interpreted():
+    from cudnn.ops import causal_conv1d_update
+
+    x = torch.empty(2, 8, 2, device="meta", dtype=torch.bfloat16)
+    state = torch.empty(2, 8, 4, device="meta", dtype=torch.bfloat16)
+    weight = torch.empty(8, 4, device="meta", dtype=torch.bfloat16)
+    with pytest.raises(ValueError, match=r"x must have shape \[N, D\]"):
+        causal_conv1d_update(x, state, weight)
+
+
+def test_public_rejects_invalid_activation_and_autograd():
+    from cudnn.ops import causal_conv1d_update
+
+    x, state, weight = _meta_inputs()
+    with pytest.raises(ValueError, match="activation"):
+        causal_conv1d_update(x, state, weight, activation="relu")
+
+    grad_x = x.requires_grad_()
+    with pytest.raises(RuntimeError, match="inference-only"):
+        causal_conv1d_update(grad_x, state, weight)

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
@@ -20,13 +20,10 @@ def _has_supported_gpu() -> bool:
     return torch.cuda.is_available() and is_supported_causal_conv1d_update_compute_capability(torch.cuda.get_device_capability())
 
 
-pytestmark = [
-    pytest.mark.L0,
-    pytest.mark.skipif(
-        not _has_supported_gpu(),
-        reason="requires a functionally supported GPU architecture",
-    ),
-]
+pytestmark = pytest.mark.skipif(
+    not _has_supported_gpu(),
+    reason="requires a functionally supported GPU architecture",
+)
 
 
 def _load_api():
@@ -89,6 +86,7 @@ def _padded_x(values, row_stride):
     return result
 
 
+@pytest.mark.L0
 @torch.no_grad()
 def test_nonzero_state_across_consecutive_steps():
     causal_conv1d_update = _load_api()
@@ -106,6 +104,7 @@ def test_nonzero_state_across_consecutive_steps():
         _assert_state_bits_equal(state, expected_state)
 
 
+@pytest.mark.L0
 @torch.no_grad()
 @pytest.mark.parametrize("state_len", [3, 4], ids=["w-minus-one", "legacy-four"])
 def test_padded_x_rows_match_reference(state_len):
@@ -128,6 +127,7 @@ def test_padded_x_rows_match_reference(state_len):
     _assert_state_bits_equal(state, expected_state)
 
 
+@pytest.mark.L0
 @torch.no_grad()
 @pytest.mark.parametrize("channels", [2048, 4096])
 def test_n128_representative_shape_correctness(channels):
@@ -145,6 +145,7 @@ def test_n128_representative_shape_correctness(channels):
     _assert_state_bits_equal(state, expected_state)
 
 
+@pytest.mark.L0
 @torch.no_grad()
 def test_paged_state_slots_and_untouched_rows():
     causal_conv1d_update = _load_api()
@@ -162,6 +163,7 @@ def test_paged_state_slots_and_untouched_rows():
     _assert_state_bits_equal(state, expected_state)
 
 
+@pytest.mark.L0
 @torch.no_grad()
 @pytest.mark.parametrize("state_len", [3, 4], ids=["w-minus-one", "legacy-four"])
 def test_padding_state_indices_write_zero_and_do_not_mutate_state(state_len):
@@ -196,6 +198,7 @@ def test_padding_state_indices_write_zero_and_do_not_mutate_state(state_len):
     _assert_state_bits_equal(state, expected_state)
 
 
+@pytest.mark.L0
 @torch.no_grad()
 def test_channel_fast_wminus1_state_matches_next_causal_output():
     causal_conv1d_update = _load_api()
@@ -217,6 +220,7 @@ def test_channel_fast_wminus1_state_matches_next_causal_output():
     _assert_state_bits_equal(state, expected_state)
 
 
+@pytest.mark.L0
 @torch.no_grad()
 def test_public_api_returns_an_ordinary_tensor():
     causal_conv1d_update = _load_api()
@@ -233,6 +237,7 @@ def test_public_api_returns_an_ordinary_tensor():
     _assert_state_bits_equal(state, expected_state)
 
 
+@pytest.mark.L0
 @torch.no_grad()
 @pytest.mark.parametrize("state_len", [3, 4], ids=["w-minus-one", "legacy-four"])
 def test_state_shift_and_append_are_bitwise(state_len):
@@ -263,6 +268,7 @@ def test_state_shift_and_append_are_bitwise(state_len):
     torch.testing.assert_close(state.view(torch.int16), expected_bits, rtol=0, atol=0)
 
 
+@pytest.mark.L0
 @torch.no_grad()
 def test_channel_fast_wminus1_state_shift_and_append_are_bitwise():
     causal_conv1d_update = _load_api()
@@ -293,6 +299,7 @@ def test_channel_fast_wminus1_state_shift_and_append_are_bitwise():
     torch.testing.assert_close(state.contiguous().view(torch.int16), expected_bits, rtol=0, atol=0)
 
 
+@pytest.mark.L0
 @torch.no_grad()
 def test_silu_special_values_and_channel_tail():
     causal_conv1d_update = _load_api()
@@ -332,6 +339,7 @@ def test_silu_special_values_and_channel_tail():
     assert torch.equal(torch.isnan(output), torch.isnan(expected))
 
 
+@pytest.mark.L0
 @torch.no_grad()
 def test_silu_and_swish_aliases_are_observably_identical():
     causal_conv1d_update = _load_api()
@@ -350,6 +358,7 @@ def test_silu_and_swish_aliases_are_observably_identical():
     _assert_state_bits_equal(silu_state, swish_state)
 
 
+@pytest.mark.L0
 @torch.no_grad()
 def test_public_torch_compile_fullgraph_observes_state_mutation():
     causal_conv1d_update = _load_api()
@@ -367,6 +376,7 @@ def test_public_torch_compile_fullgraph_observes_state_mutation():
     _assert_state_bits_equal(state, expected_state)
 
 
+@pytest.mark.L0
 @torch.no_grad()
 def test_public_cuda_graph_capture_and_replay_observe_state_mutation():
     causal_conv1d_update = _load_api()
@@ -400,6 +410,7 @@ def test_public_cuda_graph_capture_and_replay_observe_state_mutation():
     _assert_state_bits_equal(state, expected_state_2)
 
 
+@pytest.mark.L0
 @torch.no_grad()
 def test_public_call_respects_current_torch_stream():
     causal_conv1d_update = _load_api()
@@ -487,6 +498,7 @@ def test_invalid_state_indices_fail_closed_in_fresh_process(case):
     assert f"EXPECTED_DEVICE_FAILURE:{case}:" in diagnostics, diagnostics
 
 
+@pytest.mark.L0
 @torch.no_grad()
 @pytest.mark.parametrize(
     "mutate,match",

--- a/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
+++ b/test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_sm100.py
@@ -1,0 +1,529 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GPU correctness for the public causal-convolution decode update."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn.functional as F
+from cudnn._causal_conv1d_arch import (
+    is_supported_causal_conv1d_update_compute_capability,
+)
+
+
+def _has_supported_gpu() -> bool:
+    return torch.cuda.is_available() and is_supported_causal_conv1d_update_compute_capability(torch.cuda.get_device_capability())
+
+
+pytestmark = [
+    pytest.mark.L0,
+    pytest.mark.skipif(
+        not _has_supported_gpu(),
+        reason="requires a functionally supported GPU architecture",
+    ),
+]
+
+
+def _load_api():
+    try:
+        from cudnn.ops import causal_conv1d_update
+    except ImportError as error:
+        pytest.skip(f"CuTe DSL dependencies unavailable: {error}")
+    return causal_conv1d_update
+
+
+def _reference_step(
+    x,
+    weight,
+    state,
+    state_indices=None,
+    bias=None,
+    activation=None,
+):
+    """Explicit FP32 output oracle plus exact BF16 state transition."""
+
+    rows = x.shape[0]
+    slots = torch.arange(rows, device=x.device, dtype=torch.long) if state_indices is None else state_indices.long()
+    valid = slots >= 0
+    output = torch.zeros_like(x)
+    expected_state = state.clone()
+    if valid.any():
+        valid_slots = slots[valid]
+        selected = state.index_select(0, valid_slots)
+        history = torch.cat((selected, x[valid].unsqueeze(-1)), dim=-1)
+        updated = history[..., -state.shape[-1] :]
+        window = history[..., -weight.shape[-1] :]
+        accumulator = (window.float() * weight.float().unsqueeze(0)).sum(dim=-1)
+        if bias is not None:
+            accumulator = accumulator + bias.float()
+        if activation in ("silu", "swish"):
+            accumulator = F.silu(accumulator)
+        output[valid] = accumulator.to(torch.bfloat16)
+        expected_state.index_copy_(0, valid_slots, updated)
+    return output, expected_state
+
+
+def _assert_state_bits_equal(actual, expected):
+    torch.testing.assert_close(
+        actual.contiguous().view(torch.int16),
+        expected.contiguous().view(torch.int16),
+        rtol=0,
+        atol=0,
+    )
+
+
+def _padded_x(values, row_stride):
+    storage = torch.empty(
+        values.shape[0],
+        row_stride,
+        device=values.device,
+        dtype=values.dtype,
+    )
+    result = storage[:, : values.shape[1]]
+    result.copy_(values)
+    return result
+
+
+@torch.no_grad()
+def test_nonzero_state_across_consecutive_steps():
+    causal_conv1d_update = _load_api()
+    torch.manual_seed(0)
+    rows, channels = 3, 521
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(channels, device="cuda", dtype=torch.bfloat16)
+    state = torch.randn(rows, channels, 4, device="cuda", dtype=torch.bfloat16)
+
+    for _ in range(3):
+        x = torch.randn(rows, channels, device="cuda", dtype=torch.bfloat16)
+        expected_output, expected_state = _reference_step(x, weight, state, bias=bias, activation="silu")
+        output = causal_conv1d_update(x, state, weight, bias, activation="silu")
+        torch.testing.assert_close(output, expected_output, atol=3e-2, rtol=3e-2)
+        _assert_state_bits_equal(state, expected_state)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("state_len", [3, 4], ids=["w-minus-one", "legacy-four"])
+def test_padded_x_rows_match_reference(state_len):
+    causal_conv1d_update = _load_api()
+    torch.manual_seed(11 + state_len)
+    rows, channels, row_stride = 3, 10, 16
+    dense_x = torch.randn(rows, channels, device="cuda", dtype=torch.bfloat16)
+    x = _padded_x(dense_x, row_stride)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    state = torch.randn(rows, channels, state_len, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(channels, device="cuda", dtype=torch.bfloat16)
+    expected_output, expected_state = _reference_step(dense_x, weight, state, bias=bias, activation="silu")
+
+    output = causal_conv1d_update(x, state, weight, bias, activation="silu")
+
+    assert output.shape == dense_x.shape
+    assert output.dtype == dense_x.dtype
+    assert output.device == dense_x.device
+    torch.testing.assert_close(output, expected_output, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(state, expected_state)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("channels", [2048, 4096])
+def test_n128_representative_shape_correctness(channels):
+    causal_conv1d_update = _load_api()
+    torch.manual_seed(1)
+    rows = 128
+    x = torch.randn(rows, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    state = torch.randn(rows, channels, 4, device="cuda", dtype=torch.bfloat16)
+    expected_output, expected_state = _reference_step(x, weight, state)
+
+    output = causal_conv1d_update(x, state, weight)
+
+    torch.testing.assert_close(output, expected_output, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(state, expected_state)
+
+
+@torch.no_grad()
+def test_paged_state_slots_and_untouched_rows():
+    causal_conv1d_update = _load_api()
+    torch.manual_seed(4)
+    rows, slots, channels = 2, 4, 259
+    x = torch.randn(rows, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    state = torch.randn(slots, channels, 4, device="cuda", dtype=torch.bfloat16)
+    state_indices = torch.tensor([3, 1], device="cuda", dtype=torch.int32)
+    expected_output, expected_state = _reference_step(x, weight, state, state_indices)
+
+    output = causal_conv1d_update(x, state, weight, conv_state_indices=state_indices)
+
+    torch.testing.assert_close(output, expected_output, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(state, expected_state)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("state_len", [3, 4], ids=["w-minus-one", "legacy-four"])
+def test_padding_state_indices_write_zero_and_do_not_mutate_state(state_len):
+    causal_conv1d_update = _load_api()
+    torch.manual_seed(5 + state_len)
+    rows, slots, channels = 4, 5, 257
+    x = torch.randn(rows, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(channels, device="cuda", dtype=torch.bfloat16)
+    state = torch.randn(slots, channels, state_len, device="cuda", dtype=torch.bfloat16)
+    state_indices = torch.tensor([-1, 3, -1, 1], device="cuda", dtype=torch.int32)
+    expected_output, expected_state = _reference_step(
+        x,
+        weight,
+        state,
+        state_indices,
+        bias=bias,
+        activation="silu",
+    )
+
+    output = causal_conv1d_update(
+        x,
+        state,
+        weight,
+        bias,
+        activation="silu",
+        conv_state_indices=state_indices,
+    )
+
+    torch.testing.assert_close(output, expected_output, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(output[[0, 2]], torch.zeros_like(output[[0, 2]]), rtol=0, atol=0)
+    _assert_state_bits_equal(state, expected_state)
+
+
+@torch.no_grad()
+def test_channel_fast_wminus1_state_matches_next_causal_output():
+    causal_conv1d_update = _load_api()
+    torch.manual_seed(7)
+    rows, channels, prefix_len = 3, 259, 11
+    prefix = torch.randn(rows, channels, prefix_len, device="cuda", dtype=torch.bfloat16)
+    next_x = torch.randn(rows, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(channels, device="cuda", dtype=torch.bfloat16)
+    state = prefix[..., -3:].transpose(1, 2).contiguous().transpose(1, 2)
+    full_history = torch.cat((prefix, next_x.unsqueeze(-1)), dim=-1)
+    expected_window = full_history[..., -4:]
+    expected_output = F.silu((expected_window.float() * weight.float().unsqueeze(0)).sum(dim=-1) + bias.float()).to(torch.bfloat16)
+    expected_state = full_history[..., -3:]
+
+    output = causal_conv1d_update(next_x, state, weight, bias, activation="silu")
+
+    torch.testing.assert_close(output, expected_output, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(state, expected_state)
+
+
+@torch.no_grad()
+def test_public_api_returns_an_ordinary_tensor():
+    causal_conv1d_update = _load_api()
+    rows, channels = 2, 257
+    x = torch.randn(rows, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    state = torch.randn(rows, channels, 4, device="cuda", dtype=torch.bfloat16)
+    expected_output, expected_state = _reference_step(x, weight, state)
+
+    result = causal_conv1d_update(x, state, weight)
+
+    assert type(result) is torch.Tensor
+    torch.testing.assert_close(result, expected_output, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(state, expected_state)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("state_len", [3, 4], ids=["w-minus-one", "legacy-four"])
+def test_state_shift_and_append_are_bitwise(state_len):
+    causal_conv1d_update = _load_api()
+    torch.manual_seed(2)
+    rows, channels = 2, 257
+    state_bits = torch.randint(
+        -(2**15),
+        2**15,
+        (rows, channels, state_len),
+        device="cuda",
+        dtype=torch.int16,
+    )
+    x_bits = torch.randint(
+        -(2**15),
+        2**15,
+        (rows, channels),
+        device="cuda",
+        dtype=torch.int16,
+    )
+    state = state_bits.view(torch.bfloat16)
+    x = x_bits.view(torch.bfloat16)
+    weight = torch.zeros(channels, 4, device="cuda", dtype=torch.bfloat16)
+    expected_bits = torch.cat((state_bits, x_bits.unsqueeze(-1)), dim=-1)[..., -state_len:]
+
+    causal_conv1d_update(x, state, weight)
+
+    torch.testing.assert_close(state.view(torch.int16), expected_bits, rtol=0, atol=0)
+
+
+@torch.no_grad()
+def test_channel_fast_wminus1_state_shift_and_append_are_bitwise():
+    causal_conv1d_update = _load_api()
+    torch.manual_seed(3)
+    rows, channels = 2, 257
+    backing_bits = torch.randint(
+        -(2**15),
+        2**15,
+        (rows, 3, channels),
+        device="cuda",
+        dtype=torch.int16,
+    )
+    state = backing_bits.view(torch.bfloat16).transpose(1, 2)
+    initial_bits = state.contiguous().view(torch.int16)
+    x_bits = torch.randint(
+        -(2**15),
+        2**15,
+        (rows, channels),
+        device="cuda",
+        dtype=torch.int16,
+    )
+    x = x_bits.view(torch.bfloat16)
+    weight = torch.zeros(channels, 4, device="cuda", dtype=torch.bfloat16)
+    expected_bits = torch.cat((initial_bits, x_bits.unsqueeze(-1)), dim=-1)[..., -3:]
+
+    causal_conv1d_update(x, state, weight)
+
+    torch.testing.assert_close(state.contiguous().view(torch.int16), expected_bits, rtol=0, atol=0)
+
+
+@torch.no_grad()
+def test_silu_special_values_and_channel_tail():
+    causal_conv1d_update = _load_api()
+    values = torch.tensor(
+        [
+            -float("inf"),
+            -100.0,
+            -20.0,
+            -10.0,
+            -1.0,
+            -0.0,
+            0.0,
+            1.0,
+            10.0,
+            20.0,
+            100.0,
+            float("inf"),
+            float("nan"),
+        ],
+        device="cuda",
+        dtype=torch.float32,
+    ).to(torch.bfloat16)
+    channels = 257
+    x = values.repeat((channels + values.numel() - 1) // values.numel())[:channels]
+    x = x.unsqueeze(0)
+    state = torch.zeros(1, channels, 3, device="cuda", dtype=torch.bfloat16)
+    weight = torch.zeros(channels, 4, device="cuda", dtype=torch.bfloat16)
+    weight[:, 3] = 1
+    expected = F.silu(x.float()).to(torch.bfloat16)
+
+    output = causal_conv1d_update(x, state, weight, activation="silu")
+
+    finite = torch.isfinite(expected)
+    torch.testing.assert_close(output[finite], expected[finite], atol=3e-2, rtol=3e-2)
+    infinite = torch.isinf(expected)
+    torch.testing.assert_close(output[infinite], expected[infinite], rtol=0, atol=0)
+    assert torch.equal(torch.isnan(output), torch.isnan(expected))
+
+
+@torch.no_grad()
+def test_silu_and_swish_aliases_are_observably_identical():
+    causal_conv1d_update = _load_api()
+    torch.manual_seed(13)
+    rows, channels = 3, 257
+    x = torch.randn(rows, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    initial_state = torch.randn(rows, channels, 3, device="cuda", dtype=torch.bfloat16)
+    silu_state = initial_state.clone()
+    swish_state = initial_state.clone()
+
+    silu_output = causal_conv1d_update(x, silu_state, weight, activation="silu")
+    swish_output = causal_conv1d_update(x, swish_state, weight, activation="swish")
+
+    torch.testing.assert_close(silu_output, swish_output, rtol=0, atol=0)
+    _assert_state_bits_equal(silu_state, swish_state)
+
+
+@torch.no_grad()
+def test_public_torch_compile_fullgraph_observes_state_mutation():
+    causal_conv1d_update = _load_api()
+    torch.manual_seed(23)
+    rows, channels = 2, 257
+    x = torch.randn(rows, channels, device="cuda", dtype=torch.bfloat16)
+    state = torch.randn(rows, channels, 4, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    expected_output, expected_state = _reference_step(x, weight, state, activation="silu")
+
+    compiled_update = torch.compile(causal_conv1d_update, fullgraph=True)
+    output = compiled_update(x, state, weight, activation="silu")
+
+    torch.testing.assert_close(output, expected_output, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(state, expected_state)
+
+
+@torch.no_grad()
+def test_public_cuda_graph_capture_and_replay_observe_state_mutation():
+    causal_conv1d_update = _load_api()
+    torch.manual_seed(29)
+    rows, channels = 2, 257
+    x = torch.randn(rows, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    initial_state = torch.randn(rows, channels, 4, device="cuda", dtype=torch.bfloat16)
+    warmup_stream = torch.cuda.Stream()
+    with torch.cuda.stream(warmup_stream):
+        causal_conv1d_update(x, initial_state.clone(), weight, activation="silu")
+    warmup_stream.synchronize()
+
+    state = initial_state.clone()
+    expected_output, expected_state = _reference_step(x, weight, initial_state, activation="silu")
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output = causal_conv1d_update(x, state, weight, activation="silu")
+    captured_output.fill_(float("nan"))
+    torch.cuda.synchronize()
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(captured_output, expected_output, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(state, expected_state)
+
+    expected_output_2, expected_state_2 = _reference_step(x, weight, expected_state, activation="silu")
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(captured_output, expected_output_2, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(state, expected_state_2)
+
+
+@torch.no_grad()
+def test_public_call_respects_current_torch_stream():
+    causal_conv1d_update = _load_api()
+    torch.manual_seed(31)
+    rows, channels = 2, 257
+    x_real = torch.randn(rows, channels, device="cuda", dtype=torch.bfloat16)
+    state_real = torch.randn(rows, channels, 4, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    expected_output, expected_state = _reference_step(x_real, weight, state_real)
+    causal_conv1d_update(x_real, state_real.clone(), weight)
+    torch.cuda.synchronize()
+
+    x = torch.full_like(x_real, float("nan"))
+    state = torch.full_like(state_real, float("nan"))
+    side = torch.cuda.Stream()
+    with torch.cuda.stream(side):
+        torch.cuda._sleep(100_000_000)
+        x.copy_(x_real)
+        state.copy_(state_real)
+        output = causal_conv1d_update(x, state, weight)
+    side.synchronize()
+
+    assert not torch.isnan(output).any(), "kernel read poisoned data from another stream"
+    torch.testing.assert_close(output, expected_output, atol=3e-2, rtol=3e-2)
+    _assert_state_bits_equal(state, expected_state)
+
+
+_DEVICE_ASSERT_WORKER = r"""
+import os
+import sys
+
+import torch
+import cudnn
+
+case = sys.argv[1]
+source_cudnn = sys.argv[2]
+cudnn.__path__.insert(0, source_cudnn)
+
+from cudnn.ops import causal_conv1d_update
+
+torch.manual_seed(17)
+rows, channels, slots = 2, 257, 3
+x = torch.randn(rows, channels, device="cuda", dtype=torch.bfloat16)
+weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+state = torch.randn(slots, channels, 4, device="cuda", dtype=torch.bfloat16)
+valid_indices = torch.tensor([0, 1], device="cuda", dtype=torch.int32)
+causal_conv1d_update(x, state, weight, conv_state_indices=valid_indices)
+torch.cuda.synchronize()
+
+invalid_indices = {
+    "below_padding": [-2, 1],
+    "out_of_range": [0, slots],
+    "duplicate": [1, 1],
+}[case]
+invalid_indices = torch.tensor(invalid_indices, device="cuda", dtype=torch.int32)
+
+try:
+    causal_conv1d_update(x, state, weight, conv_state_indices=invalid_indices)
+    torch.cuda.synchronize()
+except Exception as error:
+    print(f"EXPECTED_DEVICE_FAILURE:{case}:{type(error).__name__}:{error}", flush=True)
+    os._exit(0)
+
+print(f"MISSING_DEVICE_FAILURE:{case}", flush=True)
+os._exit(9)
+"""
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize("case", ["below_padding", "out_of_range", "duplicate"])
+def test_invalid_state_indices_fail_closed_in_fresh_process(case):
+    source_cudnn = Path(__file__).resolve().parents[4] / "python" / "cudnn"
+    environment = os.environ.copy()
+    environment["PYTHONNOUSERSITE"] = "1"
+    result = subprocess.run(
+        [sys.executable, "-c", _DEVICE_ASSERT_WORKER, case, str(source_cudnn)],
+        cwd=Path(__file__).resolve().parents[4],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    diagnostics = result.stdout + result.stderr
+    assert result.returncode == 0, diagnostics
+    assert f"EXPECTED_DEVICE_FAILURE:{case}:" in diagnostics, diagnostics
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "mutate,match",
+    [
+        (lambda x, w, s, i: (x, w[:, :3].contiguous(), s, i), "supports only"),
+        (lambda x, w, s, i: (x, w.float(), s, i), "weight must have dtype"),
+        (lambda x, w, s, i: (x, w, s[..., :2].contiguous(), i), "L must satisfy"),
+        (lambda x, w, s, i: (x, w, s, i[:1]), "must have shape"),
+        (
+            lambda x, w, s, i: (
+                torch.empty_strided(
+                    x.shape,
+                    (x.shape[1] + 2, 1),
+                    device=x.device,
+                    dtype=x.dtype,
+                ),
+                w,
+                s,
+                i,
+            ),
+            "16-byte-aligned",
+        ),
+    ],
+)
+def test_bad_public_contracts_fail_closed(mutate, match):
+    causal_conv1d_update = _load_api()
+    rows, channels = 2, 10
+    x = torch.randn(rows, channels, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device="cuda", dtype=torch.bfloat16)
+    state = torch.randn(rows, channels, 4, device="cuda", dtype=torch.bfloat16)
+    indices = torch.arange(rows, device="cuda", dtype=torch.int32)
+    bad_x, bad_weight, bad_state, bad_indices = mutate(x, weight, state, indices)
+
+    with pytest.raises((TypeError, ValueError, NotImplementedError), match=match):
+        causal_conv1d_update(
+            bad_x,
+            bad_state,
+            bad_weight,
+            conv_state_indices=bad_indices,
+        )

--- a/test/python/linear_attention/conftest.py
+++ b/test/python/linear_attention/conftest.py
@@ -23,8 +23,11 @@ try:
     import cudnn
 
     _SRC_CUDNN = Path(__file__).resolve().parents[3] / "python" / "cudnn"
-    if _SRC_CUDNN.is_dir() and str(_SRC_CUDNN) not in cudnn.__path__:
-        cudnn.__path__.append(str(_SRC_CUDNN))
+    if _SRC_CUDNN.is_dir():
+        source_path = str(_SRC_CUDNN)
+        if source_path in cudnn.__path__:
+            cudnn.__path__.remove(source_path)
+        cudnn.__path__.insert(0, source_path)
 except ImportError:
     pass  # test_la.py skips via importorskip
 

--- a/test/python/linear_attention/test_fla_short_conv_compat.py
+++ b/test/python/linear_attention/test_fla_short_conv_compat.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Supported-GPU route and parity gates for the FLA short-convolution shim."""
+
+from __future__ import annotations
+
+from importlib import metadata
+
+import pytest
+import torch
+from cudnn._causal_conv1d_arch import (
+    is_supported_causal_conv1d_update_compute_capability,
+)
+
+fla_ops = pytest.importorskip("fla.modules.conv.triton.ops")
+fla_short_conv = pytest.importorskip("fla.modules.conv.short_conv")
+
+try:
+    _FLA_VERSION = metadata.version("flash-linear-attention")
+except metadata.PackageNotFoundError:
+    _FLA_VERSION = None
+
+from cudnn.fla import (
+    accelerate_fla,
+    is_accelerated,
+    restore_fla,
+    short_conv_last_path,
+)
+
+pytestmark = [
+    pytest.mark.L0,
+    pytest.mark.skipif(
+        not (torch.cuda.is_available() and is_supported_causal_conv1d_update_compute_capability(torch.cuda.get_device_capability())),
+        reason="the native decode short-convolution update requires a functionally supported GPU architecture",
+    ),
+    pytest.mark.skipif(
+        _FLA_VERSION != "0.5.2",
+        reason="the production short-convolution shim intentionally supports FLA 0.5.2 exactly",
+    ),
+]
+
+_REAL_UPDATE = fla_ops.causal_conv1d_update
+_ATOL = 3e-2
+_RTOL = 3e-2
+
+
+@pytest.fixture(autouse=True)
+def _restore_short_conv_patch():
+    restore_fla(targets="short_conv")
+    yield
+    restore_fla(targets="short_conv")
+    assert fla_ops.causal_conv1d_update is _REAL_UPDATE
+
+
+def _layout(base: torch.Tensor, name: str) -> torch.Tensor:
+    if name == "ND":
+        return base
+    if name == "N1D":
+        return base.unsqueeze(1)
+    if name == "1ND":
+        return base.unsqueeze(0)
+    raise AssertionError(name)
+
+
+@pytest.mark.parametrize("layout", ["ND", "N1D", "1ND"])
+@torch.no_grad()
+def test_real_fla_entry_point_routes_native_with_parity(layout):
+    torch.manual_seed(20260828)
+    n_rows, n_channels = 3, 257
+    x = _layout(
+        torch.randn(n_rows, n_channels, device="cuda", dtype=torch.bfloat16) * 0.25,
+        layout,
+    )
+    weight = torch.randn(n_channels, 4, device="cuda", dtype=torch.bfloat16) * 0.25
+    initial_state = torch.randn(n_rows, n_channels, 4, device="cuda", dtype=torch.bfloat16) * 0.25
+    fla_state = initial_state.clone()
+    native_state = initial_state.clone()
+
+    expected, expected_cache = _REAL_UPDATE(
+        x,
+        fla_state,
+        residual=None,
+        weight=weight,
+        bias=None,
+        activation="silu",
+    )
+    assert expected_cache is fla_state
+
+    accelerate_fla(verbose=False, targets="shortconv")
+    actual, returned_cache = fla_ops.causal_conv1d_update(
+        x,
+        native_state,
+        residual=None,
+        weight=weight,
+        bias=None,
+        activation="silu",
+    )
+
+    assert is_accelerated("short_conv")
+    assert short_conv_last_path() == "native"
+    assert actual.shape == x.shape
+    assert returned_cache is native_state
+    torch.testing.assert_close(actual, expected, atol=_ATOL, rtol=_RTOL)
+    torch.testing.assert_close(
+        native_state.view(torch.int16),
+        fla_state.view(torch.int16),
+        rtol=0,
+        atol=0,
+    )
+
+
+@torch.no_grad()
+def test_real_short_convolution_module_step_consumes_patched_entry_point():
+    torch.manual_seed(20260829)
+    n_rows, n_channels = 3, 257
+    module = fla_short_conv.ShortConvolution(
+        hidden_size=n_channels,
+        kernel_size=4,
+        bias=False,
+        activation="silu",
+        backend="triton",
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    x = torch.randn(n_rows, 1, n_channels, device="cuda", dtype=torch.bfloat16) * 0.25
+    initial_state = torch.randn(n_rows, n_channels, 4, device="cuda", dtype=torch.bfloat16) * 0.25
+    fla_state = initial_state.clone()
+    native_state = initial_state.clone()
+
+    expected, expected_cache = module(
+        x,
+        cache=fla_state,
+        output_final_state=True,
+    )
+    assert expected_cache is fla_state
+
+    accelerate_fla(verbose=False, targets="short_conv")
+    actual, returned_cache = module(
+        x,
+        cache=native_state,
+        output_final_state=True,
+    )
+
+    assert short_conv_last_path() == "native"
+    assert returned_cache is native_state
+    torch.testing.assert_close(actual, expected, atol=_ATOL, rtol=_RTOL)
+    torch.testing.assert_close(
+        native_state.view(torch.int16),
+        fla_state.view(torch.int16),
+        rtol=0,
+        atol=0,
+    )

--- a/test/python/linear_attention/test_fla_short_conv_shim_unit.py
+++ b/test/python/linear_attention/test_fla_short_conv_shim_unit.py
@@ -1,0 +1,366 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU/mock contract tests for the opt-in FLA short-convolution shim."""
+
+from __future__ import annotations
+
+import functools
+import importlib
+import sys
+import types
+
+import cudnn
+import cudnn.fla as fla_api
+import cudnn.ops as cudnn_ops
+import pytest
+import torch
+
+short_conv = importlib.import_module("cudnn.fla.short_conv")
+
+pytestmark = pytest.mark.L0
+
+_SUPPORTED_COMPUTE_CAPABILITIES = (
+    (8, 0),
+    (8, 6),
+    (8, 7),
+    (8, 9),
+    (9, 0),
+    (10, 0),
+    (10, 3),
+    (11, 0),
+    (12, 0),
+    (12, 1),
+)
+_FALLBACK_VALUE = -17.0
+
+
+@pytest.fixture(autouse=True)
+def _restore_short_conv_patch():
+    fla_api.restore_fla(targets="short_conv")
+    yield
+    fla_api.restore_fla(targets="short_conv")
+
+
+@pytest.fixture
+def supported_tensor_environment(monkeypatch):
+    monkeypatch.setattr(short_conv, "_is_cuda_tensor", lambda tensor: True)
+    monkeypatch.setattr(short_conv, "_device_capability", lambda device: (10, 0))
+    monkeypatch.setattr(short_conv, "_is_compiling", lambda: False)
+
+
+def _inputs(shape=(3, 8)):
+    x = torch.randn(shape, dtype=torch.bfloat16)
+    n_rows, n_channels = shape if len(shape) == 2 else (shape[0], shape[-1])
+    if len(shape) == 3 and shape[0] == 1:
+        n_rows = shape[1]
+    weight = torch.randn(n_channels, 4, dtype=torch.bfloat16)
+    cache = torch.randn(n_rows, n_channels, 4, dtype=torch.bfloat16)
+    return x, weight, cache
+
+
+def _fused_projection_view(layout, *, n_rows=3, n_channels=8):
+    projection = torch.randn(n_rows, 3 * n_channels, dtype=torch.bfloat16)
+    x = projection[:, n_channels : 2 * n_channels]
+    if layout == "ND":
+        return x
+    if layout == "N1D":
+        return x.unsqueeze(1)
+    if layout == "1ND":
+        return x.unsqueeze(0)
+    raise AssertionError(layout)
+
+
+def _install_fake_fla_module(monkeypatch, fallback_calls):
+    packages = {}
+    for name in ("fla", "fla.modules", "fla.modules.conv", "fla.modules.conv.triton"):
+        package = types.ModuleType(name)
+        package.__path__ = []
+        packages[name] = package
+        monkeypatch.setitem(sys.modules, name, package)
+
+    module = types.ModuleType("fla.modules.conv.triton.ops")
+
+    def original_callable(x, cache, residual=None, weight=None, bias=None, activation=None):
+        del residual, weight, bias, activation
+        return torch.full_like(x, _FALLBACK_VALUE), cache
+
+    def causal_conv1d_update(x, cache, residual=None, weight=None, bias=None, activation=None):
+        fallback_calls.append(1)
+        return original_callable(x, cache, residual=residual, weight=weight, bias=bias, activation=activation)
+
+    causal_conv1d_update.__module__ = module.__name__
+    causal_conv1d_update.__name__ = "causal_conv1d_update"
+    causal_conv1d_update.__qualname__ = "causal_conv1d_update"
+    causal_conv1d_update.__wrapped__ = original_callable
+    causal_conv1d_update._torchdynamo_disable = True
+    causal_conv1d_update._torchdynamo_orig_callable = original_callable
+    module.causal_conv1d_update = causal_conv1d_update
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+
+    packages["fla"].modules = packages["fla.modules"]
+    packages["fla.modules"].conv = packages["fla.modules.conv"]
+    packages["fla.modules.conv"].triton = packages["fla.modules.conv.triton"]
+    packages["fla.modules.conv.triton"].ops = module
+    return module, causal_conv1d_update
+
+
+def _activate_fake_fla(monkeypatch, fallback_calls):
+    monkeypatch.setattr(short_conv.metadata, "version", lambda distribution: "0.5.2")
+    module, original = _install_fake_fla_module(monkeypatch, fallback_calls)
+    fla_api.accelerate_fla(verbose=False, targets="short_conv")
+    assert fla_api.is_accelerated("short_conv")
+    return module, original
+
+
+def _install_native_spy(monkeypatch, native_calls):
+    def native_update(x, *args, **kwargs):
+        del args, kwargs
+        native_calls.append(1)
+        return x + 1
+
+    monkeypatch.setattr(cudnn_ops, "causal_conv1d_update", native_update)
+
+
+@pytest.mark.parametrize("shape", [(3, 8), (3, 1, 8), (1, 3, 8)])
+def test_public_shim_preserves_fla_shape_and_cache_identity(supported_tensor_environment, monkeypatch, shape):
+    x, weight, cache = _inputs(shape)
+    fallback_calls = []
+    native_calls = []
+    module, _ = _activate_fake_fla(monkeypatch, fallback_calls)
+    _install_native_spy(monkeypatch, native_calls)
+
+    output, returned_cache = module.causal_conv1d_update(x, cache, weight=weight, activation="silu")
+
+    assert output.shape == x.shape
+    torch.testing.assert_close(output, x + 1)
+    assert returned_cache is cache
+    assert native_calls == [1]
+    assert fallback_calls == []
+    assert fla_api.short_conv_last_path() == "native"
+
+
+@pytest.mark.parametrize("layout", ["ND", "N1D", "1ND"])
+def test_fused_projection_views_route_through_public_shim(supported_tensor_environment, monkeypatch, layout):
+    x = _fused_projection_view(layout)
+    n_rows, n_channels = 3, 8
+    weight = torch.randn(n_channels, 4, dtype=torch.bfloat16)
+    cache = torch.randn(n_rows, n_channels, 4, dtype=torch.bfloat16)
+    fallback_calls = []
+    native_calls = []
+    module, _ = _activate_fake_fla(monkeypatch, fallback_calls)
+    _install_native_spy(monkeypatch, native_calls)
+
+    output, returned_cache = module.causal_conv1d_update(x, cache, weight=weight, activation="silu")
+
+    assert output.shape == x.shape
+    torch.testing.assert_close(output, x + 1)
+    assert returned_cache is cache
+    assert native_calls == [1]
+    assert fallback_calls == []
+    assert fla_api.short_conv_last_path() == "native"
+
+
+@pytest.mark.parametrize("n_channels", [7, 10], ids=["d7", "d10"])
+def test_compact_rows_accept_channel_counts_not_divisible_by_eight(supported_tensor_environment, monkeypatch, n_channels):
+    x, weight, cache = _inputs((3, n_channels))
+    fallback_calls = []
+    native_calls = []
+    module, _ = _activate_fake_fla(monkeypatch, fallback_calls)
+    _install_native_spy(monkeypatch, native_calls)
+
+    output, returned_cache = module.causal_conv1d_update(x, cache, weight=weight, activation="silu")
+
+    torch.testing.assert_close(output, x + 1)
+    assert returned_cache is cache
+    assert native_calls == [1]
+    assert fallback_calls == []
+    assert fla_api.short_conv_last_path() == "native"
+
+
+@pytest.mark.parametrize(
+    "x,reason",
+    [
+        (torch.empty_strided((3, 8), (7, 1), dtype=torch.bfloat16), "noncontiguous"),
+        (torch.empty_strided((3, 10), (12, 1), dtype=torch.bfloat16), "alignment"),
+    ],
+    ids=["overlapping-rows", "misaligned-padded-rows"],
+)
+def test_unsupported_row_strides_fall_back(supported_tensor_environment, monkeypatch, x, reason):
+    n_rows, n_channels = x.shape
+    weight = torch.randn(n_channels, 4, dtype=torch.bfloat16)
+    cache = torch.randn(n_rows, n_channels, 4, dtype=torch.bfloat16)
+    fallback_calls = []
+    native_calls = []
+    module, _ = _activate_fake_fla(monkeypatch, fallback_calls)
+    _install_native_spy(monkeypatch, native_calls)
+
+    output, returned_cache = module.causal_conv1d_update(x, cache, weight=weight, activation="silu")
+
+    torch.testing.assert_close(output, torch.full_like(x, _FALLBACK_VALUE))
+    assert returned_cache is cache
+    assert fallback_calls == [1]
+    assert native_calls == []
+    assert fla_api.short_conv_last_path() == f"fallback:{reason}"
+
+
+@pytest.mark.parametrize("capability", _SUPPORTED_COMPUTE_CAPABILITIES)
+def test_supported_architectures_enter_native_route(monkeypatch, capability):
+    monkeypatch.setattr(short_conv, "_is_cuda_tensor", lambda tensor: True)
+    monkeypatch.setattr(short_conv, "_device_capability", lambda device: capability)
+    monkeypatch.setattr(short_conv, "_is_compiling", lambda: False)
+    x, weight, cache = _inputs()
+    fallback_calls = []
+    native_calls = []
+    module, _ = _activate_fake_fla(monkeypatch, fallback_calls)
+    _install_native_spy(monkeypatch, native_calls)
+
+    output, returned_cache = module.causal_conv1d_update(x, cache, weight=weight, activation="silu")
+
+    torch.testing.assert_close(output, x + 1)
+    assert returned_cache is cache
+    assert native_calls == [1]
+    assert fallback_calls == []
+    assert fla_api.short_conv_last_path() == "native"
+
+
+def test_unlisted_arch_calls_original_once_and_preserves_cache_identity(monkeypatch):
+    monkeypatch.setattr(short_conv, "_is_cuda_tensor", lambda tensor: True)
+    monkeypatch.setattr(short_conv, "_device_capability", lambda device: (11, 1))
+    monkeypatch.setattr(short_conv, "_is_compiling", lambda: False)
+    x, weight, cache = _inputs()
+    fallback_calls = []
+    native_calls = []
+    module, _ = _activate_fake_fla(monkeypatch, fallback_calls)
+    _install_native_spy(monkeypatch, native_calls)
+
+    output, returned_cache = module.causal_conv1d_update(x, cache, weight=weight, activation="silu")
+
+    torch.testing.assert_close(output, torch.full_like(x, _FALLBACK_VALUE))
+    assert returned_cache is cache
+    assert fallback_calls == [1]
+    assert native_calls == []
+    assert fla_api.short_conv_last_path() == "fallback:unsupported-arch"
+
+
+@pytest.mark.parametrize(
+    "mutation,reason",
+    [
+        (lambda x, weight, cache: {"residual": torch.zeros_like(x)}, "residual"),
+        (lambda x, weight, cache: {"weight": None}, "weight"),
+        (lambda x, weight, cache: {"bias": torch.zeros(weight.shape[0], dtype=weight.dtype)}, "bias"),
+        (lambda x, weight, cache: {"activation": None}, "activation"),
+        (lambda x, weight, cache: {"activation": "relu"}, "activation"),
+        (lambda x, weight, cache: {"x": x.float()}, "non-bf16"),
+        (lambda x, weight, cache: {"x": x.requires_grad_()}, "autograd"),
+        (lambda x, weight, cache: {"x": x[:, ::2]}, "noncontiguous"),
+        (lambda x, weight, cache: {"cache": cache[:2]}, "shape"),
+        (lambda x, weight, cache: {"weight": weight[:, :3].contiguous()}, "shape"),
+    ],
+)
+def test_unsupported_variants_call_original(supported_tensor_environment, monkeypatch, mutation, reason):
+    x, weight, cache = _inputs()
+    arguments = {"x": x, "cache": cache, "residual": None, "weight": weight, "bias": None, "activation": "swish"}
+    arguments.update(mutation(x, weight, cache))
+    fallback_calls = []
+    native_calls = []
+    module, _ = _activate_fake_fla(monkeypatch, fallback_calls)
+    _install_native_spy(monkeypatch, native_calls)
+
+    output, returned_cache = module.causal_conv1d_update(**arguments)
+
+    torch.testing.assert_close(output, torch.full_like(arguments["x"], _FALLBACK_VALUE))
+    assert returned_cache is arguments["cache"]
+    assert fallback_calls == [1]
+    assert native_calls == []
+    assert fla_api.short_conv_last_path() == f"fallback:{reason}"
+
+
+@pytest.mark.parametrize("error", [NotImplementedError, cudnn.cudnnGraphNotSupportedError, ImportError])
+def test_typed_native_decline_falls_back(supported_tensor_environment, monkeypatch, error):
+    x, weight, cache = _inputs()
+    fallback_calls = []
+    module, _ = _activate_fake_fla(monkeypatch, fallback_calls)
+
+    def decline(*args, **kwargs):
+        del args, kwargs
+        raise error("declined")
+
+    monkeypatch.setattr(cudnn_ops, "causal_conv1d_update", decline)
+
+    output, returned_cache = module.causal_conv1d_update(x, cache, weight=weight, activation="silu")
+
+    torch.testing.assert_close(output, torch.full_like(x, _FALLBACK_VALUE))
+    assert returned_cache is cache
+    assert fallback_calls == [1]
+    assert fla_api.short_conv_last_path() == f"fallback:{error.__name__}"
+
+
+def test_unexpected_native_error_is_not_swallowed(supported_tensor_environment, monkeypatch):
+    x, weight, cache = _inputs()
+    fallback_calls = []
+    module, _ = _activate_fake_fla(monkeypatch, fallback_calls)
+
+    def fail(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("launch failed")
+
+    monkeypatch.setattr(cudnn_ops, "causal_conv1d_update", fail)
+
+    with pytest.raises(RuntimeError, match="launch failed"):
+        module.causal_conv1d_update(x, cache, weight=weight, activation="silu")
+
+    assert fallback_calls == []
+    assert fla_api.short_conv_last_path() == "error:RuntimeError"
+
+
+def test_public_alias_rebind_and_restore(monkeypatch):
+    monkeypatch.setattr(short_conv.metadata, "version", lambda distribution: "0.5.2")
+    fallback_calls = []
+    module, original = _install_fake_fla_module(monkeypatch, fallback_calls)
+    captured_import = types.ModuleType("_cudnn_fla_short_conv_consumer")
+    captured_import.causal_conv1d_update = original
+    monkeypatch.setitem(sys.modules, captured_import.__name__, captured_import)
+
+    fla_api.accelerate_fla(verbose=False, targets="shortconv")
+
+    replacement = module.causal_conv1d_update
+    assert replacement is not original
+    assert captured_import.causal_conv1d_update is replacement
+    assert fla_api.is_accelerated("short_conv")
+
+    fla_api.restore_fla(targets="short_conv")
+
+    assert module.causal_conv1d_update is original
+    assert captured_import.causal_conv1d_update is original
+    assert not fla_api.is_accelerated("shortconv")
+
+
+def test_public_activation_rejects_other_fla_version(monkeypatch):
+    monkeypatch.setattr(short_conv.metadata, "version", lambda distribution: "9.9.9")
+    fallback_calls = []
+    module, original = _install_fake_fla_module(monkeypatch, fallback_calls)
+
+    with pytest.raises(ImportError, match=r"requires flash-linear-attention==0\.5\.2"):
+        fla_api.accelerate_fla(verbose=False, targets="short_conv")
+
+    assert module.causal_conv1d_update is original
+    assert not fla_api.is_accelerated("shortconv")
+
+
+def test_public_activation_rejects_replaced_target(monkeypatch):
+    monkeypatch.setattr(short_conv.metadata, "version", lambda distribution: "0.5.2")
+    fallback_calls = []
+    module, stock = _install_fake_fla_module(monkeypatch, fallback_calls)
+
+    @functools.wraps(stock)
+    def third_party(*args, **kwargs):
+        return args, kwargs
+
+    module.causal_conv1d_update = third_party
+
+    with pytest.raises(ImportError, match="does not match the expected owning module"):
+        fla_api.accelerate_fla(verbose=False, targets="short_conv")
+
+    assert module.causal_conv1d_update is third_party
+    assert not fla_api.is_accelerated("shortconv")


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
- [ ] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions). The milestone is set to `Frontend 1.29.0`; Project assignment is still required.

## Affected area

FE OSS kernels or CuTeDSL

## Summary

### Model-level context

On one NVIDIA B200, BF16 batch-one forward+backward proxies measured the following incumbent-to-optimized ratios with the broader optimized feature stack enabled:

| proxy scope | 8K tokens | 16K tokens | 32K tokens |
|---|---:|---:|---:|
| Qwen3.5-9B, 32-layer decoder backbone | **1.1530x** | **1.1722x** | **1.1931x** |
| Qwen3.8-27B, 64-layer decoder backbone | **1.1354x** | **1.1967x** | **1.0898x** |
| GLM-5.3-Flash, 34-layer KDA substack | **1.0732x** | **1.0950x** | **1.0966x** |
| Kimi-K3, official-count feature substack | **1.3567x** | **1.3238x** | **1.2189x** |

These are combined-stack proxy results, not marginal speedups attributable to this PR and not assembled-model throughput. Qwen also changes GDN, SwiGLU, and SDPA; GLM also changes KDA; Kimi also changes KDA and SiTU. Each proxy exercises the full-sequence causal-convolution path landed here.

This PR adds one semantic causal-convolution family:

- `cudnn.ops.causal_conv1d`: native BF16 width-four SiLU full-sequence forward/backward, dense or `cu_seqlens` packed, optional bias and mathematical `W - 1` initial/final state;
- a bias-free BF16-activation/FP32-weight specialization used by GLM linear-attention blocks;
- `cudnn.ops.causal_conv1d_update`: one-token inference with in-place state mutation, identity or SiLU, optional indexed state slots, and `-1` padding rows;
- zero-copy state handoff from full-sequence execution to update; and
- an opt-in FLA 0.5.2 short-convolution compatibility route.

The two native semantic operation entry points are public through `cudnn.ops`. The opt-in public compatibility surface also extends `cudnn.fla.accelerate_fla(targets="short_conv")` and exposes `short_conv_last_path` route telemetry. Compiled plans, schedules, workspaces, and the historically named `*_sm100` packages remain private implementation details. The kernels are independently derived from the convolution and SiLU equations; no external causal-convolution kernel source is included.

## Why

The existing generic cuDNN path accepts a broad convolution contract, but linear-attention short convolution has a narrower and performance-sensitive shape: width four, causal access, optional state, and model-native sequence-major storage. Generic planning and channels-first adaptation can erase an otherwise fast leaf kernel inside the real layer.

The native implementation consumes the model layout directly and specializes the short-width causal work. Full-sequence and update share one state-layout contract, so landing them together guarantees a direct prefill-to-update handoff. This remains a standalone semantic operation rather than a model-topology matcher in the graph API.

## Related issues

Supersedes #797 and #798.

## API and compatibility impact

`cudnn.ops.causal_conv1d` preserves the existing `[B, D, T]` API and adds keyword-only packed/state arguments. Existing dense/stateless calls retain the generic cuDNN route when they do not match the optimized contract. The native route covers BF16 width-four SiLU with optional BF16 bias, plus dense bias-free FP32 weights. `seq_idx` is reserved and currently declines explicitly.

Dense state is `[B, D, W - 1]`; packed state is `[N, D, W - 1]`, where `N = len(cu_seqlens) - 1`.

`cudnn.ops.causal_conv1d_update(x, conv_state, weight, bias=None, activation=None, *, cache_seqlens=None, conv_state_indices=None)` accepts BF16 one-token input `[N, D]`, mutates BF16 state `[S, D, L]` in place, and returns `[N, D]`. Width four is supported with `L` equal to three or four. The operation is inference-only; `cache_seqlens` is reserved and must be `None` or omitted.

Runtime correctness has been exercised on SM80, SM89, SM90, SM100, SM103, and SM120; SM86, SM87, SM110, and SM121 are compile-validated. Architecture is a schedule-selection dimension, not a semantic API gate. Performance claims in this PR are B200-only. The implementation requires `nvidia-cutlass-dsl >= 4.7.0`; users select the package variant matching their CUDA Toolkit.

## Testing

Current review head: `96c524644`. The latest commit changes architecture wording only; kernel code remains unchanged from `87f68dad3`.

- `pre-commit run --from-ref upstream/develop --to-ref HEAD`: passed.
- exact current-tree guardword scan over all 285 PR-changed paths: **285/285 passed**; Python compilation and diff checks also passed.
- focused host-visible contract suite with `-m L0`: `173 passed, 1 deselected`; the isolated contract module with `-m L1`: `1 passed, 42 deselected`.
- private-package lazy-import smoke: passed; requesting forward does not import autograd/backward.
- Python 3.9 grammar parse over repository Python files: passed.
- the three post-kernel review commits (`26cad8e03`, `658b27632`, `96c524644`) change documentation, import/API metadata contracts, test scheduling, and neutral architecture wording; kernel code is unchanged from `87f68dad3`.
- kernel-identical NVIDIA B200 L1 suite at `26cad8e03` across full-sequence forward/backward, update, and the prefill-to-update seam: `33 passed, 187 deselected`.

Focused host command:

```bash
python -m pytest -q -m L0 \
  test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_backward_contract_unit.py \
  test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_contract_unit.py \
  test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_semantic_api_unit.py \
  test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_benchmark_contract_unit.py \
  test/python/fe_api/causal_conv1d_update/test_causal_conv1d_update_contract_unit.py \
  test/python/linear_attention/test_fla_short_conv_shim_unit.py
```

B200 correctness command:

```bash
python -m pytest -q -m L1 \
  test/python/fe_api/causal_conv1d_bulk \
  test/python/fe_api/causal_conv1d_update \
  test/python/linear_attention/test_fla_short_conv_shim_unit.py
```

### B200 operator evidence

At the unchanged kernel head `87f68dad3553cb8f325af8038c77567267bff5fb`:

| scope | representative workload and timing boundary | result |
|---|---|---:|
| full-sequence forward | dense `T=8192, D=2048`; CUDA-event direct calls | prepared FE **26.618 us** vs direct FLA **64.922 us**, **2.439x**; allocation-inclusive FE **44.058 us** vs public FLA **89.146 us**, **2.023x** |
| backward | dense `B=1, T=8192, D=2048`; warmed CUDA Graph replay | native **28.032 us** vs FLA **130.592 us**, **4.659x** |
| update | `N=1, D=8192`; warmed CUDA Graph replay | FE **7.840 us** vs FLA **7.616 us**; order-sensitive and effectively tied |

Reproduction commands:

```bash
python test/python/fe_api/causal_conv1d_bulk/benchmark_causal_conv1d_bulk_sm100.py --tokens 8192 --channels 2048
python benchmark/causal_conv1d_bulk_bwd_perf.py --tokens 8192 --channels 2048
python benchmark/causal_conv1d_update_sm100.py --shape 1x8192
```

Compilation, capture, and allocation are outside the backward/update replay intervals. The full-sequence comparison uses equal contiguous `[1, T, D]` BF16 layouts. Update is reported as parity; its primary value here is native state compatibility rather than a speedup claim.

The focused NVIDIA B200 correctness suite at `87f68dad3` reported `88 passed, 1 warning`, covering public full-sequence forward/backward, update, the state seam, real FLA compatibility, non-default streams, CUDA Graph replay, and `torch.compile`/FakeTensor contracts. The internal `python_tests,frost` pipeline was also run for that SHA.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full-sequence causal convolution for dense and packed inputs, with bias, state handling, and gradient support.
  * Added single-token causal-convolution updates with mutable state, activations, bias, and indexed routing.
  * Added optimized BF16 execution paths for supported NVIDIA GPUs.
  * Added optional FLA short-convolution acceleration with safe fallback behavior.

* **Documentation**
  * Documented causal-convolution, decode-update, and FLA short-convolution APIs, limitations, and usage.

* **Tests & Benchmarks**
  * Added extensive correctness, compatibility, smoke-test, and performance coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->