### PR TITLE
feat(kda): preserve FP32 beta logits in fused sigmoid

### DIFF
--- a/python/cudnn/fla/kda.py
+++ b/python/cudnn/fla/kda.py
@@ -97,9 +97,11 @@ def _to_native(
         b = dt_bias.float().reshape(H, K)
         g = -a.exp() * F.softplus(g + b)
 
-    # beta is io-dtype logits when the kernel applies the sigmoid; post-activation beta rides as given.
-    if use_beta_sigmoid_in_kernel:
-        beta = beta.to(q.dtype)
+    # Preserve raw-logit precision for the fused sigmoid.  The current native
+    # kernels accept either the io dtype or float32 and return dBeta in the
+    # corresponding dtype; official Kimi passes float32 logits here.
+    if use_beta_sigmoid_in_kernel and beta.dtype not in (q.dtype, torch.float32):
+        raise _Decline(f"beta logits must be {q.dtype} or float32, got {beta.dtype}")
 
     def thd(t):
         return t.reshape(-1, *t.shape[2:])

--- a/python/cudnn/linear_attention/frost/kda_engine.py
+++ b/python/cudnn/linear_attention/frost/kda_engine.py
@@ -59,7 +59,7 @@ class KdaFrostEngine(BaseEngine):
         if not facts.gates_at_ho:
             raise NotImplementedError(f"KdaFrostEngine: g/beta must carry HO = max(q, v) heads ({facts.h_o})")
         fp32 = cudnn.data_type.FLOAT
-        beta_wants = (facts.io_dtype,) if facts.use_beta_sigmoid else (fp32, facts.io_dtype)
+        beta_wants = (fp32, facts.io_dtype)
         if facts.beta_dtype not in beta_wants + (None,):
             raise NotImplementedError(f"KdaFrostEngine: 'beta' must be {' or '.join(str(w) for w in beta_wants)}, got {facts.beta_dtype}")
         state_dtypes = (fp32, cudnn.data_type.BFLOAT16)

--- a/python/cudnn/linear_attention/ops/kda.py
+++ b/python/cudnn/linear_attention/ops/kda.py
@@ -359,7 +359,7 @@ def kda_fwd(
         raise ValueError(f"kimi_delta_attention: cu_seqlens must be int32 or int64; got {cu_seqlens.dtype}")
     cu = cu_seqlens
     check_dtype("g", g, (torch.float32, torch.bfloat16, torch.float16))
-    check_dtype("beta", beta, q.dtype if use_beta_sigmoid_in_kernel else (torch.float32, q.dtype))
+    check_dtype("beta", beta, (torch.float32, q.dtype))
     if safe_gate:
         if a_log is None or dt_bias is None:
             raise ValueError("kimi_delta_attention: safe_gate requires a_log and dt_bias")
@@ -658,7 +658,7 @@ def kda_bwd(
         raise ValueError(f"kimi_delta_attention: cu_seqlens must be int32 or int64; got {cu_seqlens.dtype}")
     cu = cu_seqlens
     check_dtype("g", g, (torch.float32, torch.bfloat16, torch.float16))
-    check_dtype("beta", beta, q.dtype if use_beta_sigmoid_in_kernel else (torch.float32, q.dtype))
+    check_dtype("beta", beta, (torch.float32, q.dtype))
     if safe_gate:
         if a_log is None or dt_bias is None:
             raise ValueError("kimi_delta_attention: safe_gate requires a_log and dt_bias")
@@ -985,7 +985,7 @@ def kimi_delta_attention(
 
     Dtypes are kernel-native and strict (callers convert).  ``g`` is float32,
     bfloat16 or float16 and ``dG`` comes back in the same dtype.  ``beta`` and
-    ``dBeta`` are float32 or the io dtype (io-dtype logits under
+    ``dBeta`` are float32 or the io dtype (raw logits of either dtype under
     ``use_beta_sigmoid_in_kernel``).  ``initial_state`` is float32 or bfloat16
     and ``final_state`` and the state gradients (``d_final_state``,
     ``d_initial_state``) follow it.
@@ -994,7 +994,8 @@ def kimi_delta_attention(
         g: per-key-channel log-space decay (``alpha = exp(g) in (0, 1]^K``),
             or raw pre-activation logits when ``safe_gate=True``.
         beta: per-token scalar write strength (float32 or the io dtype,
-            post-sigmoid), or io-dtype logits when ``use_beta_sigmoid_in_kernel=True``.
+            post-sigmoid), or float32/io-dtype logits when
+            ``use_beta_sigmoid_in_kernel=True``.
         cu_seqlens: ``[N+1]`` int32/int64 sequence boundaries over the packed tokens.
         scale: attention scale applied to ``q``. Defaults to ``1 / sqrt(K)``.
         initial_state: optional recurrent state (otherwise zero); float32 or

--- a/test/python/linear_attention/test_fla_compat.py
+++ b/test/python/linear_attention/test_fla_compat.py
@@ -254,7 +254,9 @@ def _kda_leaves(B, T, H, K, V, dtype, seed):
         "k": io(B, T, H, K),
         "v": io(B, T, H, V),
         "g": io(B, T, H, K),  # raw f_proj output (channel-wise), io dtype
-        "beta": io(B, T, H),
+        # Official Kimi preserves raw beta logits in FP32 until the fused
+        # sigmoid; exercise that exact adapter contract here.
+        "beta": torch.randn(B, T, H, generator=gen, device=dev).requires_grad_(True),
         "A_log": torch.log(torch.empty(H, device=dev).uniform_(1, 16)).requires_grad_(True),
         "dt_bias": (dt + torch.log(-torch.expm1(-dt))).detach().requires_grad_(True),
     }
@@ -291,7 +293,7 @@ def test_kda_parity_fused():
     def clone(src, dt):
         lv = {}
         for name, t in src.items():
-            fp32 = name in ("A_log", "dt_bias")
+            fp32 = name in ("beta", "A_log", "dt_bias")
             lv[name] = t.detach().clone().to(torch.float32 if fp32 else dt).requires_grad_(True)
         return lv
 
@@ -327,6 +329,7 @@ def test_kda_parity_fused():
     check("o", o_fla, o_cud, o_ref, KDA_SLACK)
     for n in ("q", "k", "v", "g", "beta", "A_log", "dt_bias"):
         check("d" + n, lv_fla[n].grad, lv_cud[n].grad, lv_ref[n].grad, KDA_GATE_SLACK if n in GATE_PARAMS else KDA_SLACK)
+    assert lv_cud["beta"].grad.dtype == torch.float32
 
 
 def test_fallback_is_transparent():

--- a/test/python/linear_attention/test_la.py
+++ b/test/python/linear_attention/test_la.py
@@ -1409,12 +1409,13 @@ def test_safe_gate_backward(backend, variant, gate_dtype):
         assert leaf.grad is not None and bool(torch.isfinite(leaf.grad).all()), name
 
 
-def test_beta_sigmoid_in_kernel(backend):
-    """KDA: io-dtype Beta logits with the in-kernel sigmoid match the
-    post-activation fp32 path."""
+@pytest.mark.parametrize("beta_dtype", [torch.float32, torch.bfloat16], ids=DTYPE_IDS.get)
+def test_beta_sigmoid_in_kernel(backend, beta_dtype):
+    """KDA: float32/io-dtype Beta logits with the in-kernel sigmoid match
+    the post-activation fp32 path."""
     case = make_case("kda", torch.bfloat16, T=256)
     set_seed(SEED + 11)
-    braw = torch.randn(1, case.T, case.HO, device="cuda").to(case.dtype)
+    braw = torch.randn(1, case.T, case.HO, device="cuda").to(beta_dtype)
     raw_case = case.clone(gates=dict(case.gates, beta=braw))
     eff_case = case.clone(gates=dict(case.gates, beta=braw.float().sigmoid()))
     o_raw, fs_raw = run_fwd(backend, raw_case, output_final_state=True, use_beta_sigmoid_in_kernel=True)
@@ -1423,14 +1424,18 @@ def test_beta_sigmoid_in_kernel(backend):
     assert rms_ratio(fs_raw, fs_eff) < 2e-2
 
 
-@pytest.mark.parametrize("variant", VARIANTS)
-def test_beta_sigmoid_backward(backend, variant):
+@pytest.mark.parametrize(
+    "variant,beta_dtype",
+    [(variant, torch.bfloat16) for variant in VARIANTS] + [("kda", torch.float32)],
+    ids=[*(f"{variant}-bf16" for variant in VARIANTS), "kda-fp32"],
+)
+def test_beta_sigmoid_backward(backend, variant, beta_dtype):
     """The in-kernel Beta sigmoid returns the gradient wrt the raw logit, so
     dbeta must equal the post-activation path's dbeta times s * (1 - s) at the
     io-rounded s the forward stores."""
     case = make_case(variant, torch.bfloat16, T=256)
     set_seed(SEED + 13)
-    braw = torch.randn_like(case.gates["beta"].float()).to(case.dtype)
+    braw = torch.randn_like(case.gates["beta"].float()).to(beta_dtype)
     s_io = torch.sigmoid(braw.float()).to(case.dtype)
 
     def dbeta(beta, **kw):
@@ -1441,6 +1446,7 @@ def test_beta_sigmoid_backward(backend, variant):
         with waive_unsupported(backend, variant):
             o, _ = pinned_op(backend, variant)(*args, case.cu, **kw)
             o.sum().backward()
+        assert leaf.grad.dtype == beta.dtype
         return leaf.grad.double()
 
     got = dbeta(braw, use_beta_sigmoid_in_kernel=True)


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
- [ ] I set the **Milestone** and **Projects** fields in the sidebar (milestone is set; a maintainer must add the GitHub Project).

## Affected area

Python API or bindings

## Summary

### Downstream model impact (combined attribution)

On B200, an official-count Kimi-K3 BF16 fprop+bprop feature-substack integration carrying patch-identical versions of both commits in this PR measured **1.3567x / 1.3238x / 1.2189x** at 8K/16K/32K, removing **26.3% / 24.5% / 18.0%** of the declared substack latency. The all-on arm combines merged #819 plus this raw-FP32-beta contract with three native causal-convolution calls and native SiTU; MLA is unchanged. This is not a marginal #802 or full-model result.


- Rebase the FP32-beta contract onto `develop` after #819, without carrying a duplicate KDA kernel implementation.
- Accept FP32 or I/O-dtype raw beta logits when KDA applies sigmoid inside the kernel, and return `dBeta` in the matching dtype.
- Preserve official Kimi's FP32 beta logits in the FLA adapter instead of rounding them to BF16.
- Cover both raw-beta dtypes in forward and backward tests, including the official fused Kimi call shape.

## Why

Official Kimi keeps raw beta logits in FP32 until the fused sigmoid. #819 generalized the FROST kernels to carry beta's element type, cache beta dtype, and return matching `dBeta`, but the public op validator, FROST engine admission check, and FLA adapter still rejected or rounded the official FP32 input. This PR closes that contract seam while reusing #819's implementation.

## Related issues

Related to #819.

## API and compatibility impact

This is a backward-compatible extension of the Python KDA contract. With fused beta sigmoid enabled, `beta` and `dBeta` may both be FP32 or both use the I/O dtype. Existing I/O-dtype callers and post-sigmoid FP32/I/O-dtype callers are unchanged. The adapter continues to fail closed for unsupported dtypes. This does not expand the existing architecture or software-version support of the FROST KDA path.

The feature itself is performance-neutral. In a current official-count Kimi feature-substack A/B, the optimized cuDNN arm with this contract and merged #819 measured `3839.153 -> 2829.813 ms` (`1.3567x`) at sequence 8192. That is the composed KDA + causal-conv + dense/shared SiTU result, not marginal speedup attributable to this PR.

## Testing

Latest `develop` plus this two-commit patch:

- `pre-commit run --files python/cudnn/fla/kda.py python/cudnn/linear_attention/frost/kda_engine.py python/cudnn/linear_attention/ops/kda.py test/python/linear_attention/test_fla_compat.py test/python/linear_attention/test_la.py`: passed.
- ComputeLab NVIDIA B200: `test_kda_parity_fused` plus every FROST `beta_sigmoid` case: `6 passed, 1174 deselected`. This covers FP32/BF16 raw-beta forward, matching-dtype `dBeta`, the official fused Kimi adapter route, and the FP32-calibrated output/all-gradient check.
- Official-count Kimi feature-substack at sequence 8192: seven alternating rounds, full output/input/all-parameter-gradient checks, native route proof, and the original 5% correctness caps all passed. The composed timing is reported above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded KDA support for mixed tensor dtypes, including FP16, BF16, and FP32 decay values, beta inputs, and initial states.
  * Added support for FP32 beta logits and gradients in fused sigmoid mode.
  * Added support for int64 sequence-length metadata.

* **Bug Fixes**
  * Improved dtype validation for forward and backward operations, including state and gradient matching.
  * Improved caching behavior across different tensor dtype combinations.

* **Tests**
  * Expanded coverage for dtype combinations, checkpointing, gradients, parity, validation, and repeatability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->