### PR TITLE
Fix FROST linear-attention compiled cache device identity

### DIFF
--- a/python/cudnn/linear_attention/frost/engine.py
+++ b/python/cudnn/linear_attention/frost/engine.py
@@ -75,6 +75,13 @@ class FrostLaPlan(CompiledPlan):
         return self.compiled.workspace_bytes()
 
     def execute(self, graph, variant_pack, ctx) -> None:
+        handle = ctx.handle
+        launch_device = handle.device.ordinal if hasattr(handle, "device") else variant_pack.device
+        if launch_device != self.compiled.device:
+            raise ValueError(
+                f"{self.compiled.plan_name}: plan was built for cuda:{self.compiled.device}, "
+                f"but the execution context targets cuda:{launch_device}; build one plan per device"
+            )
         ports = self.ports
         if ports is None:
             ports = self.ports = bind_ports(graph, variant_pack)

--- a/python/cudnn/linear_attention/frost/gdn2_engine.py
+++ b/python/cudnn/linear_attention/frost/gdn2_engine.py
@@ -118,6 +118,7 @@ class CompiledGdn2:
         self.table = None
         self.kcache = None
         self.plan_name = "Gdn2FrostEngine (GDN2)"
+        self.device = current_device()
         scale = node.params.get("scale")
         self.scale = float(scale) if scale is not None else 1.0 / math.sqrt(node.inputs["q"].dim[-1])
         self.use_qk_l2norm = bool(node.params.get("use_qk_l2norm", False))
@@ -139,7 +140,7 @@ class CompiledGdn2:
         B = node.inputs["cu_seqlens"].dim[0] - 1
         layout = WorkspaceLayout()
         self.off_scheduler = layout.add(8)
-        self.num_sm = multiprocessor_count(current_device())
+        self.num_sm = multiprocessor_count(self.device)
         self.n_tiles = B * HO
         self.n_heads_out = HO
         if self.split:
@@ -295,6 +296,8 @@ class CompiledGdn2:
             work_item_scratch=item_scratch,
             tensormap_workspace=tensormaps,
             **checkpoint_kwargs,
+            device=self.device,
+            num_sm=self.num_sm,
             stream=stream,
         )
         return None
@@ -317,6 +320,7 @@ class CompiledGdn2Bwd:
         self.kcache = None
         self.recompute_cache = None
         self.plan_name = "Gdn2FrostEngine (GDN2_BWD)"
+        self.device = current_device()
         from .common.gate_bwd import GATE_BWD_BLOCKS, channel_gate_bwd
         from .common.head_reduce import head_group_reduce
         from .common.host import tensormap_workspace_bytes
@@ -346,7 +350,7 @@ class CompiledGdn2Bwd:
         self.n_heads_out, self.total = HO, total
         layout = WorkspaceLayout()
         self.off_scheduler = layout.add(16)
-        self.num_sm = multiprocessor_count(current_device())
+        self.num_sm = multiprocessor_count(self.device)
         self.bwd_dynamic_scheduling = True
         self.batch_invariant = bool(node.params.get("batch_invariant", False))
         self.split = not self.batch_invariant
@@ -608,6 +612,8 @@ class CompiledGdn2Bwd:
                 work_item_scratch=region.get("item_scratch"),
                 order_in_prologue=True,
                 tensormap_workspace=region["recompute_tensormaps"],
+                device=self.device,
+                num_sm=self.num_sm,
                 stream=stream,
             )
 
@@ -653,6 +659,8 @@ class CompiledGdn2Bwd:
             work_item_scratch=region.get("item_scratch") if not self.order_in_recompute else None,
             order_in_prologue=not self.order_in_recompute,
             tensormap_workspace=region["bwd_tensormaps"],
+            device=self.device,
+            num_sm=self.num_sm,
             stream=stream,
         )
         if self.safe_gate:

--- a/python/cudnn/linear_attention/frost/gdn_engine.py
+++ b/python/cudnn/linear_attention/frost/gdn_engine.py
@@ -114,6 +114,7 @@ class CompiledGdn:
         self.table = None
         self.kcache = None
         self.plan_name = "GdnFrostEngine (GDN)"
+        self.device = current_device()
         from .common.l2norm import l2norm_qk
 
         self.l2norm_qk = l2norm_qk
@@ -142,7 +143,7 @@ class CompiledGdn:
         self.tensormap_words = tensormap_workspace_bytes(kernel_module, B) // 8
         self.off_tensormaps = layout.add(self.tensormap_words * 8)
         self.off_scheduler = layout.add(8)
-        self.num_sm = multiprocessor_count(current_device())
+        self.num_sm = multiprocessor_count(self.device)
         self.n_tiles = B * HO
         self.n_heads_out = HO
         if self.split:
@@ -301,6 +302,8 @@ class CompiledGdn:
             use_beta_sigmoid=self.use_beta_sigmoid,
             work_item_scratch=item_scratch,
             workspace=tensormaps,
+            device=self.device,
+            num_sm=self.num_sm,
             stream=stream,
         )
         return None
@@ -325,6 +328,7 @@ class CompiledGdnBwd:
         self.kcache = None
         self.recompute_cache = None
         self.plan_name = "GdnFrostEngine (GDN_BWD)"
+        self.device = current_device()
         from .common.gate_bwd import scalar_gate_bwd, scalar_gate_blocks
         from .common.head_reduce import head_group_reduce
         from .common.host import tensormap_workspace_bytes
@@ -351,7 +355,7 @@ class CompiledGdnBwd:
         self.has_state_checkpoints = "state_checkpoints" in node.inputs
         self.io_name = "float16" if node.inputs["q"].get_data_type().name == "HALF" else "bfloat16"
 
-        self.num_sm = multiprocessor_count(current_device())
+        self.num_sm = multiprocessor_count(self.device)
         self.bwd_dynamic_scheduling = True
         self.batch_invariant = bool(node.params.get("batch_invariant", False))
         self.split = not self.batch_invariant
@@ -619,6 +623,8 @@ class CompiledGdnBwd:
                 order_in_prologue=self.recompute_orders,
                 log_gate=True,
                 workspace=region["recompute_tensormaps"],
+                device=self.device,
+                num_sm=self.num_sm,
                 stream=stream,
             )
 
@@ -659,6 +665,8 @@ class CompiledGdnBwd:
             order_in_prologue=self.bwd_orders,
             log_gate=True,
             workspace=region["tensormaps"],
+            device=self.device,
+            num_sm=self.num_sm,
             stream=stream,
         )
         if self.safe_gate:

--- a/python/cudnn/linear_attention/frost/kda_engine.py
+++ b/python/cudnn/linear_attention/frost/kda_engine.py
@@ -113,6 +113,7 @@ class CompiledKda:
         self.table = None
         self.kcache = None
         self.plan_name = "KdaFrostEngine (KDA)"
+        self.device = current_device()
         scale = node.params.get("scale")
         self.scale = float(scale) if scale is not None else 1.0 / math.sqrt(node.inputs["q"].dim[-1])
         self.use_qk_l2norm = bool(node.params.get("use_qk_l2norm", False))
@@ -133,7 +134,7 @@ class CompiledKda:
         B = node.inputs["cu_seqlens"].dim[0] - 1
         layout = WorkspaceLayout()
         self.off_scheduler = layout.add(8)
-        self.num_sm = multiprocessor_count(current_device())
+        self.num_sm = multiprocessor_count(self.device)
         self.n_tiles = B * HO
         self.n_heads_out = HO
         if self.split:
@@ -284,6 +285,8 @@ class CompiledKda:
             work_item_scratch=item_scratch,
             tensormap_workspace=tensormaps,
             **checkpoint_kwargs,
+            device=self.device,
+            num_sm=self.num_sm,
             stream=stream,
         )
         return None
@@ -308,6 +311,7 @@ class CompiledKdaBwd:
         self.kcache = None
         self.recompute_cache = None
         self.plan_name = "KdaFrostEngine (KDA_BWD)"
+        self.device = current_device()
         from .common.gate_bwd import GATE_BWD_BLOCKS, channel_gate_bwd
         from .common.head_reduce import head_group_reduce
         from .common.host import tensormap_workspace_bytes
@@ -336,7 +340,7 @@ class CompiledKdaBwd:
         self.n_heads_out, self.total = HO, total
         layout = WorkspaceLayout()
         self.off_scheduler = layout.add(16)
-        self.num_sm = multiprocessor_count(current_device())
+        self.num_sm = multiprocessor_count(self.device)
         self.bwd_dynamic_scheduling = True
         self.batch_invariant = bool(node.params.get("batch_invariant", False))
         self.split = not self.batch_invariant
@@ -588,6 +592,8 @@ class CompiledKdaBwd:
                 work_item_scratch=region.get("item_scratch"),
                 order_in_prologue=True,
                 tensormap_workspace=region["recompute_tensormaps"],
+                device=self.device,
+                num_sm=self.num_sm,
                 stream=stream,
             )
 
@@ -630,6 +636,8 @@ class CompiledKdaBwd:
             work_item_scratch=region.get("item_scratch") if self.has_state_checkpoints else None,
             order_in_prologue=self.has_state_checkpoints,
             tensormap_workspace=region["bwd_tensormaps"],
+            device=self.device,
+            num_sm=self.num_sm,
             stream=stream,
         )
         if self.safe_gate:

--- a/python/cudnn/linear_attention/frost/kernel/gdn2_bprop_f16.py
+++ b/python/cudnn/linear_attention/frost/kernel/gdn2_bprop_f16.py
@@ -13,7 +13,6 @@ from ..common.beta_guard import beta_guard
 from ..common.split_k import ORDER_CAPACITY, ORDER_ELEMENTS, ORDER_THREADS, decode_work_item, order_body
 from ..common.host import get_dtype
 from cudnn.frost.buffers import data_ptr
-from cudnn.frost.device import current_device, multiprocessor_count
 from ..common.thd import TENSOR_MAP_QWORDS, emit_checkpoint_seq_descs, emit_seq_descs
 from .gdn2_bprop_config import CFG
 
@@ -4127,6 +4126,8 @@ def get_compiled_cache(
     dstate0_dtype_str: str,
     gate_dtype_str: str,
     cu_dtype_str: str,
+    device: int,
+    num_sm: int,
     HQ: int,
     HK: int,
     HV: int,
@@ -4181,6 +4182,8 @@ def chunk_gdn2_bwd_sm100(
     work_item_scratch=None,
     order_in_prologue: bool = False,
     tensormap_workspace,
+    device: int,
+    num_sm: int,
     stream,
 ) -> None:
     """Execute the Blackwell BT=16 chunked GDN-2 backward kernel.
@@ -4268,6 +4271,8 @@ def chunk_gdn2_bwd_sm100(
         str(d_initial_state.dtype) if d_initial_state is not None else "none",
         str(gate.dtype),
         str(cu_seqlens.dtype),
+        device,
+        num_sm,
         HQ,
         HK,
         HV,
@@ -4303,7 +4308,7 @@ def chunk_gdn2_bwd_sm100(
             k_ratio=HO // HK,
             v_ratio=HO // HV,
             n_heads_out=HO,
-            max_active_clusters=multiprocessor_count(current_device()),
+            max_active_clusters=num_sm,
             dynamic_scheduling=dynamic_scheduling,
         )
 

--- a/python/cudnn/linear_attention/frost/kernel/gdn2_prefill_f16.py
+++ b/python/cudnn/linear_attention/frost/kernel/gdn2_prefill_f16.py
@@ -30,7 +30,6 @@ from ..common.beta_guard import beta_guard
 from ..common.split_k import ORDER_CAPACITY, ORDER_ELEMENTS, ORDER_THREADS, decode_work_item, order_body
 from ..common.host import get_dtype
 from cudnn.frost.buffers import data_ptr
-from cudnn.frost.device import current_device, multiprocessor_count
 from ..common.thd import TENSOR_MAP_QWORDS, emit_checkpoint_seq_descs, emit_seq_descs
 from .gdn2_prefill_config import CFG
 
@@ -2857,6 +2856,8 @@ def get_compiled_cache(
     state_dtype_str: str,
     gate_dtype_str: str,
     cu_dtype_str: str,
+    device: int,
+    num_sm: int,
     HQ: int,
     HK: int,
     HV: int,
@@ -2988,6 +2989,8 @@ def chunk_gdn2_sm100(
     work_item_scratch=None,
     *,
     tensormap_workspace,
+    device: int,
+    num_sm: int,
     stream,
 ) -> None:
     """Execute the Blackwell BT=16 chunked GDN-2 prefill kernel.
@@ -3079,6 +3082,8 @@ def chunk_gdn2_sm100(
         str(state_dtype_src),
         str(gate.dtype),
         str(cu_seqlens.dtype),
+        device,
+        num_sm,
         HQ,
         HK,
         HV,
@@ -3144,7 +3149,7 @@ def chunk_gdn2_sm100(
             v_ratio,
             HO,
             dynamic_scheduling,
-            num_sm=multiprocessor_count(current_device()),
+            num_sm=num_sm,
             q_cute=q_cute,
             k_cute=k_cute,
             v_cute=v_cute,

--- a/python/cudnn/linear_attention/frost/kernel/gdn2_recompute_f16.py
+++ b/python/cudnn/linear_attention/frost/kernel/gdn2_recompute_f16.py
@@ -30,7 +30,6 @@ from ..common.beta_guard import beta_guard
 from ..common.split_k import ORDER_CAPACITY, ORDER_ELEMENTS, ORDER_THREADS, decode_work_item, order_body
 from ..common.host import get_dtype
 from cudnn.frost.buffers import data_ptr
-from cudnn.frost.device import current_device, multiprocessor_count
 from ..common.thd import TENSOR_MAP_QWORDS, emit_checkpoint_seq_descs, emit_seq_descs
 from .gdn2_recompute_config import CFG
 
@@ -2372,6 +2371,8 @@ def get_compiled_cache(
     state_dtype_str: str,
     gate_dtype_str: str,
     cu_dtype_str: str,
+    device: int,
+    num_sm: int,
     HO: int,
     HK: int,
     HV: int,
@@ -2496,6 +2497,8 @@ def chunk_gdn2_recompute_sm100(
     order_in_prologue: bool = False,
     *,
     tensormap_workspace,
+    device: int,
+    num_sm: int,
     stream,
 ) -> None:
     """Execute the Blackwell BT=16 chunked GDN-2 recompute (state/checkpoint-only) kernel.
@@ -2584,6 +2587,8 @@ def chunk_gdn2_recompute_sm100(
         str(state_dtype_src),
         str(gate.dtype),
         str(cu_seqlens.dtype),
+        device,
+        num_sm,
         HO,
         HK,
         HV,
@@ -2648,7 +2653,7 @@ def chunk_gdn2_recompute_sm100(
             v_ratio,
             HO,
             dynamic_scheduling,
-            num_sm=multiprocessor_count(current_device()),
+            num_sm=num_sm,
             k_cute=k_cute,
             v_cute=v_cute,
             gate_cute=gate_cute,

--- a/python/cudnn/linear_attention/frost/kernel/gdn_bprop_f16.py
+++ b/python/cudnn/linear_attention/frost/kernel/gdn_bprop_f16.py
@@ -698,7 +698,10 @@ def gate_beta_warp(
 
                 # ---- Gate load: GMEM -> SMEM (OOB neutral: 1.0 -> log2 = 0.0) --------
                 oob_neutral = cutlass.Float32(0.0) if cutlass.const_expr(cfg.log_gate) else cutlass.Float32(1.0)
-                gate_vals = [gGate[lane_idx + col * cfg.threads_per_warp].to(cutlass.Float32) if pos_valid[col] else oob_neutral for col in range(n_cols)]
+                gate_vals = [
+                    gGate[min(lane_idx + col * cfg.threads_per_warp, batch_end - chunk_offset - 1)].to(cutlass.Float32) if pos_valid[col] else oob_neutral
+                    for col in range(n_cols)
+                ]
 
                 if cutlass.const_expr(cfg.safe_gate):
                     for col in cutlass.range_constexpr(0, n_cols, 2):

--- a/python/cudnn/linear_attention/frost/kernel/gdn_bprop_f16.py
+++ b/python/cudnn/linear_attention/frost/kernel/gdn_bprop_f16.py
@@ -120,7 +120,6 @@ from ..common.thd import emit_checkpoint_seq_descs, emit_seq_descs, TENSOR_MAP_Q
 from ..common.split_k import ORDER_CAPACITY, ORDER_ELEMENTS, ORDER_THREADS, decode_work_item, order_body
 from ..common.host import get_dtype
 from cudnn.frost.buffers import data_ptr
-from cudnn.frost.device import current_device, multiprocessor_count
 
 RCP_LN2 = 1.4426950408889634  # 1/ln(2): natural-log gates -> the kernel's log2 domain
 from cudnn.frost.tile_dsl.barrier import (
@@ -4342,6 +4341,8 @@ def get_compiled_cache(
     beta_dtype_str: str,
     dstate_in_dtype_str: str,
     dstate0_dtype_str: str,
+    device: int,
+    num_sm: int,
     HQ: int,
     HK: int,
     HV: int,
@@ -4475,6 +4476,8 @@ def chunk_gdn_bwd_sm100(
     dt_bias=None,
     use_beta_sigmoid: bool = False,
     workspace,
+    device: int,
+    num_sm: int,
     stream,
 ) -> None:
     """Execute the Blackwell chunked GDN bprop kernel (THD / varlen entry).
@@ -4563,6 +4566,8 @@ def chunk_gdn_bwd_sm100(
         str(beta.dtype),
         str(d_final_state.dtype) if d_final_state is not None else "none",
         str(d_initial_state.dtype) if d_initial_state is not None else "none",
+        device,
+        num_sm,
         HQ,
         HK,
         HV,
@@ -4606,7 +4611,7 @@ def chunk_gdn_bwd_sm100(
             safe_gate=safe_gate,
             beta_sigmoid=use_beta_sigmoid,
             dynamic_scheduling=dynamic_scheduling,
-            num_sm=multiprocessor_count(current_device()),
+            num_sm=num_sm,
             h_q=HQ,
             h_k=HK,
             h_v=HV,

--- a/python/cudnn/linear_attention/frost/kernel/gdn_prefill_f16.py
+++ b/python/cudnn/linear_attention/frost/kernel/gdn_prefill_f16.py
@@ -98,7 +98,6 @@ from ..common.thd import emit_checkpoint_seq_descs, emit_seq_descs, TENSOR_MAP_Q
 from ..common.split_k import ORDER_CAPACITY, ORDER_ELEMENTS, ORDER_THREADS, decode_work_item, order_body
 from ..common.host import get_dtype
 from cudnn.frost.buffers import data_ptr
-from cudnn.frost.device import current_device, multiprocessor_count
 
 RCP_LN2 = 1.4426950408889634  # 1/ln(2): natural-log gates -> the kernel's log2 domain
 from cudnn.frost.tile_dsl.barrier import (
@@ -2780,6 +2779,8 @@ def get_compiled_cache(
     cu_dtype_str: str,
     gate_dtype_str: str,
     beta_dtype_str: str,
+    device: int,
+    num_sm: int,
     HQ: int,
     HK: int,
     HV: int,
@@ -2899,6 +2900,8 @@ def chunk_gdn_sm100(
     work_item_scratch=None,
     *,
     workspace,
+    device: int,
+    num_sm: int,
     stream,
 ) -> None:
     """Execute the Blackwell chunked GDN prefill kernel (THD / varlen entry).
@@ -2975,13 +2978,14 @@ def chunk_gdn_sm100(
     state_dtype = get_dtype(state_dtype_src) if state_dtype_src is not None else cutlass.Float32
 
     cu_stream = cuda.CUstream(int(stream))
-
     cache = get_compiled_cache(
         str(q.dtype),
         str(state_dtype_src),
         str(cu_seqlens.dtype),
         str(gate.dtype),
         str(beta.dtype),
+        device,
+        num_sm,
         HQ,
         k.shape[1],
         HV,
@@ -3038,7 +3042,7 @@ def chunk_gdn_sm100(
             safe_gate,
             use_beta_sigmoid,
             dynamic_scheduling,
-            num_sm=multiprocessor_count(current_device()),
+            num_sm=num_sm,
             h_q=HQ,
             h_k=k.shape[1],
             h_v=HV,

--- a/python/cudnn/linear_attention/frost/kernel/gdn_recompute_f16.py
+++ b/python/cudnn/linear_attention/frost/kernel/gdn_recompute_f16.py
@@ -88,7 +88,6 @@ from ..common.thd import emit_checkpoint_seq_descs, emit_seq_descs, TENSOR_MAP_Q
 from ..common.split_k import ORDER_CAPACITY, ORDER_ELEMENTS, ORDER_THREADS, decode_work_item, order_body
 from ..common.host import get_dtype
 from cudnn.frost.buffers import data_ptr
-from cudnn.frost.device import current_device, multiprocessor_count
 
 RCP_LN2 = 1.4426950408889634  # 1/ln(2): natural-log gates -> the kernel's log2 domain
 from cudnn.frost.tile_dsl.barrier import (
@@ -2360,6 +2359,8 @@ def get_compiled_cache(
     cu_dtype_str: str,
     gate_dtype_str: str,
     beta_dtype_str: str,
+    device: int,
+    num_sm: int,
     HK: int,
     HV: int,
     HO: int,
@@ -2473,6 +2474,8 @@ def chunk_gdn_recompute_sm100(
     use_beta_sigmoid: bool = False,
     *,
     workspace,
+    device: int,
+    num_sm: int,
     stream,
 ) -> None:
     """Execute the Blackwell chunked GDN recompute kernel (state/checkpoint-only,
@@ -2553,13 +2556,14 @@ def chunk_gdn_recompute_sm100(
     state_dtype = get_dtype(state_dtype_src) if state_dtype_src is not None else cutlass.Float32
 
     cu_stream = cuda.CUstream(int(stream))
-
     cache = get_compiled_cache(
         str(k.dtype),
         str(state_dtype_src),
         str(cu_seqlens.dtype),
         str(gate.dtype),
         str(beta.dtype),
+        device,
+        num_sm,
         HK,
         HV,
         HO,
@@ -2615,7 +2619,7 @@ def chunk_gdn_recompute_sm100(
             safe_gate,
             use_beta_sigmoid,
             dynamic_scheduling,
-            num_sm=multiprocessor_count(current_device()),
+            num_sm=num_sm,
             h_k=HK,
             h_v=HV,
             n_heads_out=HO,

--- a/python/cudnn/linear_attention/frost/kernel/kda_bprop_f16.py
+++ b/python/cudnn/linear_attention/frost/kernel/kda_bprop_f16.py
@@ -12,7 +12,6 @@ from cutlass.cute.runtime import from_dlpack
 from ..common.split_k import ORDER_CAPACITY, ORDER_ELEMENTS, ORDER_THREADS, decode_work_item, order_body
 from ..common.host import get_dtype
 from cudnn.frost.buffers import data_ptr
-from cudnn.frost.device import current_device, multiprocessor_count
 from ..common.thd import TENSOR_MAP_QWORDS, emit_checkpoint_seq_descs, emit_seq_descs
 from .kda_bprop_config import CFG
 
@@ -3895,6 +3894,8 @@ def get_compiled_cache(
     gate_dtype_str: str,
     cu_dtype_str: str,
     beta_dtype_str: str,
+    device: int,
+    num_sm: int,
     HQ: int,
     HK: int,
     HV: int,
@@ -3944,6 +3945,8 @@ def chunk_kda_bwd_sm100(
     work_item_scratch=None,
     order_in_prologue: bool = False,
     tensormap_workspace,
+    device: int,
+    num_sm: int,
     stream,
 ) -> None:
     """Execute the Blackwell BT=16 chunked KDA backward kernel.
@@ -4033,6 +4036,8 @@ def chunk_kda_bwd_sm100(
         str(gate.dtype),
         str(cu_seqlens.dtype),
         str(beta.dtype),
+        device,
+        num_sm,
         HQ,
         HK,
         HV,
@@ -4065,7 +4070,7 @@ def chunk_kda_bwd_sm100(
             k_ratio=HO // HK,
             v_ratio=HO // HV,
             n_heads_out=HO,
-            max_active_clusters=multiprocessor_count(current_device()),
+            max_active_clusters=num_sm,
             dynamic_scheduling=dynamic_scheduling,
         )
 

--- a/python/cudnn/linear_attention/frost/kernel/kda_prefill_f16.py
+++ b/python/cudnn/linear_attention/frost/kernel/kda_prefill_f16.py
@@ -29,7 +29,6 @@ from cutlass.cute.runtime import from_dlpack
 from ..common.split_k import ORDER_CAPACITY, ORDER_ELEMENTS, ORDER_THREADS, decode_work_item, order_body
 from ..common.host import get_dtype
 from cudnn.frost.buffers import data_ptr
-from cudnn.frost.device import current_device, multiprocessor_count
 from ..common.thd import TENSOR_MAP_QWORDS, emit_checkpoint_seq_descs, emit_seq_descs
 from .kda_prefill_config import CFG
 
@@ -2711,6 +2710,8 @@ def get_compiled_cache(
     gate_dtype_str: str,
     cu_dtype_str: str,
     beta_dtype_str: str,
+    device: int,
+    num_sm: int,
     HQ: int,
     HK: int,
     HV: int,
@@ -2835,6 +2836,8 @@ def chunk_kda_sm100(
     work_item_scratch=None,
     *,
     tensormap_workspace,
+    device: int,
+    num_sm: int,
     stream,
 ) -> None:
     """Execute the Blackwell BT=16 chunked KDA prefill kernel.
@@ -2932,6 +2935,8 @@ def chunk_kda_sm100(
         str(gate.dtype),
         str(cu_seqlens.dtype),
         str(beta.dtype),
+        device,
+        num_sm,
         HQ,
         HK,
         HV,
@@ -2994,7 +2999,7 @@ def chunk_kda_sm100(
             v_ratio,
             HO,
             dynamic_scheduling,
-            num_sm=multiprocessor_count(current_device()),
+            num_sm=num_sm,
             q_cute=q_cute,
             k_cute=k_cute,
             v_cute=v_cute,
@@ -3043,7 +3048,7 @@ def chunk_kda_sm100(
             prologue,
             io_dtype,
             CFG.B_T,
-            multiprocessor_count(current_device()),
+            num_sm,
             order_gen,
             dynamic_scheduling,
             q_pl,

--- a/python/cudnn/linear_attention/frost/kernel/kda_recompute_f16.py
+++ b/python/cudnn/linear_attention/frost/kernel/kda_recompute_f16.py
@@ -29,7 +29,6 @@ from cutlass.cute.runtime import from_dlpack
 from ..common.split_k import ORDER_CAPACITY, ORDER_ELEMENTS, ORDER_THREADS, decode_work_item, order_body
 from ..common.host import get_dtype
 from cudnn.frost.buffers import data_ptr
-from cudnn.frost.device import current_device, multiprocessor_count
 from ..common.thd import TENSOR_MAP_QWORDS, emit_checkpoint_seq_descs, emit_seq_descs
 from .kda_recompute_config import CFG
 
@@ -2226,6 +2225,8 @@ def get_compiled_cache(
     gate_dtype_str: str,
     cu_dtype_str: str,
     beta_dtype_str: str,
+    device: int,
+    num_sm: int,
     HO: int,
     HK: int,
     HV: int,
@@ -2342,6 +2343,8 @@ def chunk_kda_recompute_sm100(
     order_in_prologue: bool = False,
     *,
     tensormap_workspace,
+    device: int,
+    num_sm: int,
     stream,
 ) -> None:
     """Execute the Blackwell BT=16 chunked KDA recompute (state/checkpoints-only)
@@ -2438,6 +2441,8 @@ def chunk_kda_recompute_sm100(
         str(gate.dtype),
         str(cu_seqlens.dtype),
         str(beta.dtype),
+        device,
+        num_sm,
         HO,
         HK,
         HV,
@@ -2498,7 +2503,7 @@ def chunk_kda_recompute_sm100(
             v_ratio,
             HO,
             dynamic_scheduling,
-            num_sm=multiprocessor_count(current_device()),
+            num_sm=num_sm,
             k_cute=k_cute,
             v_cute=v_cute,
             gate_cute=gate_cute,

--- a/test/python/linear_attention/test_frost_compiled_cache.py
+++ b/test/python/linear_attention/test_frost_compiled_cache.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Observable device contract for FROST linear-attention plans."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from cudnn.engines.base import ExecutionContext
+from cudnn.linear_attention.frost import engine as frost_engine
+
+pytestmark = pytest.mark.L0
+
+
+class _Compiled:
+    def __init__(self, device):
+        self.device = device
+        self.plan_name = "test FROST LA plan"
+        self.workspace_size = 0
+        self.calls = []
+
+    def workspace_bytes(self):
+        return 0
+
+    def bind(self, names):
+        self.names = names
+
+    def run(self, views, workspace, stream):
+        self.calls.append((views, workspace, stream))
+
+
+class _VariantPack:
+    def __init__(self, device):
+        self._device = device
+
+    @property
+    def device(self):
+        return self._device
+
+    def all_dense_layout(self):
+        return True, -1
+
+    def operands(self, indices):
+        assert indices == []
+        return ()
+
+
+def _execution_context(device, stream=17):
+    handle = SimpleNamespace(device=SimpleNamespace(ordinal=device))
+    return ExecutionContext(handle=handle, stream=stream)
+
+
+def _prepare_plan(monkeypatch, device):
+    slots = SimpleNamespace(inputs={}, outputs={})
+    monkeypatch.setattr(frost_engine, "bind_ports", lambda graph, variant_pack: {object(): slots})
+    monkeypatch.setattr(frost_engine.Workspace, "over", lambda variant_pack, size, name: "workspace")
+    compiled = _Compiled(device)
+    return frost_engine.FrostLaPlan(compiled), compiled
+
+
+def test_handle_device_authorizes_matching_plan_even_when_pack_fallback_differs(monkeypatch):
+    plan, compiled = _prepare_plan(monkeypatch, device=3)
+    pack = _VariantPack(device=9)
+
+    plan.execute(object(), pack, _execution_context(device=3))
+
+    assert compiled.calls == [((), "workspace", 17)]
+
+
+def test_handle_device_rejects_plan_compiled_for_another_device(monkeypatch):
+    plan, compiled = _prepare_plan(monkeypatch, device=3)
+    pack = _VariantPack(device=3)
+
+    with pytest.raises(ValueError, match=r"plan was built for cuda:3, but the execution context targets cuda:4"):
+        plan.execute(object(), pack, _execution_context(device=4))
+
+    assert compiled.calls == []
+
+
+def test_handleless_execution_uses_the_variant_pack_device(monkeypatch):
+    plan, compiled = _prepare_plan(monkeypatch, device=3)
+    pack = _VariantPack(device=3)
+
+    plan.execute(object(), pack, ExecutionContext(stream=23))
+
+    assert compiled.calls == [((), "workspace", 23)]

--- a/test/python/linear_attention/test_la.py
+++ b/test/python/linear_attention/test_la.py
@@ -671,6 +671,12 @@ def test_bwd_varlen(backend, variant, seq_lens):
     assert_bwd_parity(backend, make_case(variant, torch.bfloat16, seq_lens=seq_lens))
 
 
+@pytest.mark.parametrize("backend", ["frost"], indirect=True)
+def test_gdn_bwd_partial_final_chunk(backend):
+    """The final GDN chunk has four live lanes and sixty invalid lanes."""
+    assert_bwd_parity(backend, make_case("gdn", torch.bfloat16, seq_lens=[68], H=1))
+
+
 @pytest.mark.parametrize("variant", VARIANTS)
 def test_bwd_zero_length_sequence(backend, variant):
     assert_bwd_parity(backend, make_case(variant, torch.bfloat16, seq_lens=[64, 0, 128]))

--- a/test/python/linear_attention/test_la.py
+++ b/test/python/linear_attention/test_la.py
@@ -671,6 +671,7 @@ def test_bwd_varlen(backend, variant, seq_lens):
     assert_bwd_parity(backend, make_case(variant, torch.bfloat16, seq_lens=seq_lens))
 
 
+@pytest.mark.L0
 @pytest.mark.parametrize("backend", ["frost"], indirect=True)
 def test_gdn_bwd_partial_final_chunk(backend):
     """The final GDN chunk has four live lanes and sixty invalid lanes."""


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
- [ ] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions). The milestone is set; the current token cannot set organization Projects.

## Affected area

FE OSS kernels or CuTeDSL

## Summary

- Resolve the FROST linear-attention compilation target from the cuDNN handle carried by the plan-build `ExecutionContext`.
- Record that device ordinal and its SM count once on the compiled plan, then pass the same facts to every GDN, GDN2, and KDA prefill, recompute, and backward cache/JIT path.
- Reject an execute-time handle targeting another device before launch.
- Clamp ragged final-chunk GDN backward gate loads to the last valid token before the dynamic select, preventing invalid lanes from forming out-of-range GMEM addresses.

These are correctness fixes. The device-identity change does not alter kernel math, and neither change claims model-level performance.

## Why

Equivalent linear-attention shapes can run on multiple CUDA devices in one process. The compiled callable bakes device-dependent launch facts such as `num_sm`; a shape-only cache could otherwise reuse device 0's callable on another GPU. The build handle is the authoritative device, rather than ambient `torch.cuda.current_device()`, so cache identity, compilation, and execution now describe the same target.

## Related issues

None.

## API and compatibility impact

There is no public operator-signature, accepted-shape, dtype, or architecture change.

FROST linear-attention plans are now explicitly device-bound. Reusing a built plan with a handle for another GPU raises `ValueError`; multi-GPU callers build one plan per device. Calls without an explicit handle retain the existing current-device fallback. Same-device behavior is unchanged.

## Testing

- ComputeLab B200, cuDNN 9.26: generic dispatch plus focused handle/device-contract tests — **62 passed**.
- ComputeLab B200 at `a442b7b84`: all six FROST examples passed: GDN, GDN2, and KDA forward/backward; both GDN and KDA backward exercised checkpoint recompute.
- ComputeLab B200: the new explicitly L0-classified public GDN backward regression for a 68-token ragged sequence (four live lanes in the final 64-token chunk) passed at current head `bf82311bb`; the related varlen selection was **4 passed** at the kernel-identical prior head.

```bash
for example in test/python/linear_attention/frost/examples/0{1..6}_*.py; do python "$example"; done
python -m pytest -q test/python/linear_attention/test_la.py::test_gdn_bwd_partial_final_chunk
```

- Host compile/static coverage, changed-file pre-commit, and diff checks passed at `bf82311bb`.

The prior gate code can still pass an ordinary numerical test because the later select masks the invalid-lane value and nearby allocator mappings often hide the physical over-read. The address expression itself was statically out of range; the fix makes every eagerly formed load address valid. No private generated-code string is asserted.

The focused tests verify the observable plan contract: the build handle wins over ambient-device fallback, a mismatched execute handle fails before launch, and handleless building keeps the fallback behavior. They do not pin private cache tuple layouts or leaf-function signatures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA device handling for FROST plan execution, preventing launches on mismatched devices.
  * Ensured operations consistently use the hardware configuration captured during plan initialization.
  * Added support for float16 and bfloat16 gate tensors in GDN2 prefill operations.
  * Improved handling of partial sequence chunks and boundary gate reads.
* **Tests**
  * Added coverage for matching, mismatched, and handleless execution-device scenarios.
  * Added regression coverage for partial-chunk GDN backward processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

