### PR TITLE
Tune underfilled KDA forward split tables on B200

### DIFF
--- a/python/cudnn/linear_attention/frost/common/split_k.py
+++ b/python/cudnn/linear_attention/frost/common/split_k.py
@@ -179,8 +179,10 @@ def clamped_log2(log_gate: cutlass.Constexpr[bool], gate_val: cutlass.Float32) -
 
 
 @cute.jit
-def piece_choice(overhead_chunks: cutlass.Constexpr[int], num_sms: cutlass.Constexpr[int], batch_num_chunks, n_tiles, ideal_chunks):
-    """Per-tile piece choice.  Returns ``(span, num_blocks)``."""
+def piece_choice(overhead_chunks: cutlass.Constexpr[int], num_sms: cutlass.Constexpr[int], batch_num_chunks, n_tiles, ideal_chunks, piece_cap):
+    """Per-tile piece choice.  A positive runtime ``piece_cap`` clamps the
+    normal search result; zero leaves it adaptive.  Returns ``(span,
+    num_blocks)``."""
     # ---- even-spread cap: no span past ideal_chunks ----------------------------------
     p_hi = batch_num_chunks if batch_num_chunks < cutlass.Int32(MAX_BLOCKS) else cutlass.Int32(MAX_BLOCKS)
     p_hi = p_hi if p_hi > 0 else cutlass.Int32(1)
@@ -207,6 +209,8 @@ def piece_choice(overhead_chunks: cutlass.Constexpr[int], num_sms: cutlass.Const
         uncut_estimate = ((n_tiles + num_sms - cutlass.Int32(1)) // num_sms) * (batch_num_chunks + cutlass.Int32(overhead_chunks))
         if cutlass.Int32(4) * best > cutlass.Int32(3) * uncut_estimate:
             p = cutlass.Int32(1)
+    if (piece_cap > 0) and (p > piece_cap):
+        p = piece_cap
     span = cutlass.Int32(0)
     num_blocks = cutlass.Int32(0)
     if batch_num_chunks > 0:
@@ -223,6 +227,7 @@ def common_span(
     num_sms: cutlass.Constexpr[int],
     n_tiles,
     ideal_chunks,
+    piece_cap,
     batch_size,
     mCuSeqlens,
 ):
@@ -259,7 +264,7 @@ def common_span(
             b = cutlass.Int32(0)
             while b < batch_size:
                 nc = cute.ceil_div(cutlass.Int32(mCuSeqlens[b + 1]) - cutlass.Int32(mCuSeqlens[b]), b_t)
-                _, nb = piece_choice(overhead_chunks, num_sms, nc, n_tiles, ideal_chunks)
+                _, nb = piece_choice(overhead_chunks, num_sms, nc, n_tiles, ideal_chunks, piece_cap)
                 blocks = blocks + nb
                 b = b + cutlass.Int32(1)
 
@@ -287,12 +292,12 @@ def common_span(
 
 
 @cute.jit
-def span_choice(overhead_chunks: cutlass.Constexpr[int], num_sms: cutlass.Constexpr[int], batch_num_chunks, n_tiles, ideal_chunks, common):
+def span_choice(overhead_chunks: cutlass.Constexpr[int], num_sms: cutlass.Constexpr[int], batch_num_chunks, n_tiles, ideal_chunks, piece_cap, common):
     """Per-tile piece choice, overridden by the batch-wide ``common`` span
     from :func:`common_span` (0 when it does not apply) whenever the
     per-sequence choice left this tile in one piece.  Returns ``(span,
     num_blocks)``."""
-    span, num_blocks = piece_choice(overhead_chunks, num_sms, batch_num_chunks, n_tiles, ideal_chunks)
+    span, num_blocks = piece_choice(overhead_chunks, num_sms, batch_num_chunks, n_tiles, ideal_chunks, piece_cap)
     if (n_tiles < num_sms) and (num_blocks == cutlass.Int32(1)) and (common > cutlass.Int32(0)):
         span = common if common < batch_num_chunks else batch_num_chunks
         num_blocks = cute.ceil_div(batch_num_chunks, span) if span > 0 else cutlass.Int32(0)
@@ -362,6 +367,7 @@ def frost_split_k_plan(
     num_sms: cutlass.Constexpr[int],
     n_tiles: cutlass.Int32,
     ideal_chunks: cutlass.Int32,
+    piece_cap: cutlass.Int32,
     batch_size: cutlass.Int32,
     mCuSeqlens: cute.Tensor,
     mChunkVals: cute.Tensor,
@@ -379,7 +385,7 @@ def frost_split_k_plan(
     tidx, _, _ = cute.arch.thread_idx()
     if cutlass.Int32(tidx) == 0:
         mCount[0] = cutlass.Int32(0)
-        common = common_span(b_t, overhead_chunks, n_heads_out, num_sms, n_tiles, ideal_chunks, batch_size, mCuSeqlens)
+        common = common_span(b_t, overhead_chunks, n_heads_out, num_sms, n_tiles, ideal_chunks, piece_cap, batch_size, mCuSeqlens)
         mChunkVals[mChunkVals.shape[0] - cutlass.Int32(1), 0] = cutlass.Float32(common)
 
 
@@ -395,6 +401,7 @@ def frost_split_k_scan_channel(
     num_sms: cutlass.Constexpr[int],
     n_tiles: cutlass.Int32,
     ideal_chunks: cutlass.Int32,
+    piece_cap: cutlass.Int32,
     batch_size: cutlass.Int32,
     gate_scale_log2: cutlass.Float32,
     mGate: cute.Tensor,
@@ -429,7 +436,7 @@ def frost_split_k_scan_channel(
     batch_end = cutlass.Int32(mCuSeqlens[batch_idx + 1])
     batch_num_chunks = cute.ceil_div(batch_end - batch_start, b_t)
     chunk_value_base = batch_start // cutlass.Int32(b_t) + batch_idx
-    span, num_blocks = span_choice(overhead_chunks, num_sms, batch_num_chunks, n_tiles, ideal_chunks, common)
+    span, num_blocks = span_choice(overhead_chunks, num_sms, batch_num_chunks, n_tiles, ideal_chunks, piece_cap, common)
 
     for rr in cutlass.range_constexpr(scan_rows):
         row = row0 + cutlass.Int32(rr)
@@ -441,7 +448,7 @@ def frost_split_k_scan_channel(
             batch_end = cutlass.Int32(mCuSeqlens[batch_idx + 1])
             batch_num_chunks = cute.ceil_div(batch_end - batch_start, b_t)
             chunk_value_base = batch_start // cutlass.Int32(b_t) + batch_idx
-            span, num_blocks = span_choice(overhead_chunks, num_sms, batch_num_chunks, n_tiles, ideal_chunks, common)
+            span, num_blocks = span_choice(overhead_chunks, num_sms, batch_num_chunks, n_tiles, ideal_chunks, piece_cap, common)
         c = row - chunk_value_base
         if (c >= 0) and (c < batch_num_chunks) and (num_blocks > 1):
             if near_boundary(c, span if span > 0 else cutlass.Int32(1), num_blocks):
@@ -518,6 +525,7 @@ def frost_split_k_scan_scalar(
     num_sms: cutlass.Constexpr[int],
     n_tiles: cutlass.Int32,
     ideal_chunks: cutlass.Int32,
+    piece_cap: cutlass.Int32,
     batch_size: cutlass.Int32,
     mGate: cute.Tensor,
     mALog: cute.Tensor | None,
@@ -559,7 +567,7 @@ def frost_split_k_scan_scalar(
     batch_end = cutlass.Int32(mCuSeqlens[batch_idx + 1])
     batch_num_chunks = cute.ceil_div(batch_end - batch_start, b_t)
     chunk_value_base = batch_start // cutlass.Int32(b_t) + batch_idx
-    span, num_blocks = span_choice(overhead_chunks, num_sms, batch_num_chunks, n_tiles, ideal_chunks, common)
+    span, num_blocks = span_choice(overhead_chunks, num_sms, batch_num_chunks, n_tiles, ideal_chunks, piece_cap, common)
 
     for rr in cutlass.range_constexpr(scan_rows):
         row = row0 + cutlass.Int32(rr)
@@ -571,7 +579,7 @@ def frost_split_k_scan_scalar(
             batch_end = cutlass.Int32(mCuSeqlens[batch_idx + 1])
             batch_num_chunks = cute.ceil_div(batch_end - batch_start, b_t)
             chunk_value_base = batch_start // cutlass.Int32(b_t) + batch_idx
-            span, num_blocks = span_choice(overhead_chunks, num_sms, batch_num_chunks, n_tiles, ideal_chunks, common)
+            span, num_blocks = span_choice(overhead_chunks, num_sms, batch_num_chunks, n_tiles, ideal_chunks, piece_cap, common)
         c = row - chunk_value_base
         if (c >= 0) and (c < batch_num_chunks) and (num_blocks > 1):
             if near_boundary(c, span if span > 0 else cutlass.Int32(1), num_blocks):
@@ -601,6 +609,7 @@ def frost_split_k_walk(
     num_sms: cutlass.Constexpr[int],
     n_tiles: cutlass.Int32,
     ideal_chunks: cutlass.Int32,
+    piece_cap: cutlass.Int32,
     log2_thresh: cutlass.Float32,
     mCuSeqlens: cute.Tensor,
     mChunkVals: cute.Tensor,
@@ -624,7 +633,7 @@ def frost_split_k_walk(
     batch_end = cutlass.Int32(mCuSeqlens[batch_idx + 1])
     batch_num_chunks = cute.ceil_div(batch_end - batch_start, b_t)
     chunk_value_base = batch_start // cutlass.Int32(b_t) + batch_idx
-    span, num_blocks = span_choice(overhead_chunks, num_sms, batch_num_chunks, n_tiles, ideal_chunks, common)
+    span, num_blocks = span_choice(overhead_chunks, num_sms, batch_num_chunks, n_tiles, ideal_chunks, piece_cap, common)
     if num_blocks <= 1:
         # ---- nothing to scan: emit the whole sequence --------------------------------
         if tidx == 0:
@@ -860,6 +869,7 @@ def launch(
     num_sms: cutlass.Constexpr[int],
     n_tiles: cutlass.Int32,
     ideal_chunks: cutlass.Int32,
+    piece_cap: cutlass.Int32,
     batch_size: cutlass.Int32,
     log2_thresh: cutlass.Float32,
     gate_scale_log2: cutlass.Float32,
@@ -884,6 +894,7 @@ def launch(
             num_sms,
             n_tiles,
             ideal_chunks,
+            piece_cap,
             batch_size,
             mCuSeqlens,
             mChunkVals,
@@ -901,6 +912,7 @@ def launch(
                 num_sms,
                 n_tiles,
                 ideal_chunks,
+                piece_cap,
                 batch_size,
                 gate_scale_log2,
                 mGate,
@@ -925,6 +937,7 @@ def launch(
                 num_sms,
                 n_tiles,
                 ideal_chunks,
+                piece_cap,
                 batch_size,
                 mGate,
                 mALog,
@@ -944,6 +957,7 @@ def launch(
             num_sms,
             n_tiles,
             ideal_chunks,
+            piece_cap,
             log2_thresh,
             mCuSeqlens,
             mChunkVals,
@@ -971,6 +985,7 @@ class TableRecipe(NamedTuple):
     n_tiles: int
     num_sms: int
     ideal_chunks: int
+    piece_cap: int
     batch_size: int
     log2_threshold: float
     gate_scale_log2: float
@@ -984,6 +999,7 @@ def run_table(r, gate, a_log, dt_bias, cu_seqlens, chunk_scratch, item_scratch, 
     r.compiled(
         r.n_tiles,
         r.ideal_chunks,
+        r.piece_cap,
         r.batch_size,
         r.log2_threshold,
         r.gate_scale_log2,
@@ -1021,6 +1037,7 @@ def build_split_table(
     dt_bias=None,
     gate_lower_bound=None,
     scheduler_counter=None,
+    piece_cap=0,
     split=True,
     stream,
 ) -> "TableRecipe":
@@ -1042,7 +1059,10 @@ def build_split_table(
     ``(1,)`` int32; ``chunk_scratch`` is ``(>= chunk_scratch_rows(...), HO)``
     fp32, whose LAST row carries the plan rather than a chunk value.
     ``scheduler_counter`` cells are zeroed by the order phase, the count by the
-    plan.  Runs entirely on device — no host synchronization."""
+    plan.  For the currently supported single-sequence use,
+    ``piece_cap > 0`` clamps the adaptive choice after its normal search and
+    margin; zero leaves it unchanged.  Runs entirely on device — no host
+    synchronization."""
     if log2_threshold is None:
         log2_threshold = DEFAULT_LOG2_THRESHOLD
     if len(gate.shape) not in (2, 3):
@@ -1062,6 +1082,11 @@ def build_split_table(
         raise ValueError("split=False has no host-side stage: each main kernel's prologue synthesizes the no-cuts table (order_gen)")
     if ideal_chunks is None or chunk_scratch is None or item_scratch is None:
         raise ValueError("split=True requires ideal_chunks, chunk_scratch, and item_scratch")
+    piece_cap = int(piece_cap)
+    if piece_cap < 0:
+        raise ValueError(f"piece_cap must be non-negative, got {piece_cap}")
+    if piece_cap and batch_size != 1:
+        raise ValueError("piece_cap is currently supported only for a single sequence")
     if gate_channels and gate_channels % WARP_SIZE != 0:
         raise ValueError(f"per-channel gate dim must be a multiple of {WARP_SIZE}, got {gate_channels}")
     if gate_channels and gate_channels % 128 == 0 and data_ptr(gate) % 16 != 0:
@@ -1123,6 +1148,7 @@ def build_split_table(
             int(num_sms),
             cutlass.Int32(n_tiles),
             cutlass.Int32(ideal_chunks),
+            cutlass.Int32(piece_cap),
             cutlass.Int32(batch_size),
             cutlass.Float32(log2_threshold),
             cutlass.Float32(gate_scale_log2),
@@ -1143,6 +1169,7 @@ def build_split_table(
     compiled_cache[key](
         n_tiles,
         ideal_chunks,
+        piece_cap,
         batch_size,
         float(log2_threshold),
         float(gate_scale_log2),
@@ -1167,6 +1194,7 @@ def build_split_table(
         n_tiles,
         num_sms,
         int(ideal_chunks),
+        piece_cap,
         batch_size,
         float(log2_threshold),
         float(gate_scale_log2),

--- a/python/cudnn/linear_attention/frost/kda_engine.py
+++ b/python/cudnn/linear_attention/frost/kda_engine.py
@@ -15,10 +15,26 @@ import math
 from cudnn import behavior_note
 from cudnn.engines.base import BaseEngine, CompiledPlan
 
-from cudnn.frost.device import build_device, current_device, multiprocessor_count
+from cudnn.frost.device import build_device, compute_capability, current_device, multiprocessor_count
 from cudnn.frost.workspace import WorkspaceLayout, carve_plan
 from ..graph_analyzer import analyze
 from .engine import FrostLaPlan, frost_la_gate
+
+
+def choose_kda_fwd_piece_cap(
+    *, device_cc: tuple[int, int], checkpointed: bool, batch_size: int, n_heads_out: int, n_tiles: int, num_sms: int, ideal_chunks: int
+) -> int:
+    """Return the measured KDA-forward piece cap, or zero for adaptive.
+
+    The cap is deliberately limited to the B200, checkpoint-free,
+    single-sequence, underfilled H=64/H=96 regimes covered by the sweep.
+    ``ideal_chunks`` supplies a shape-derived length boundary without naming a
+    model or fixing a sequence length; the adaptive planner remains in charge
+    outside that evidence.
+    """
+    if device_cc == (10, 0) and not checkpointed and batch_size == 1 and n_heads_out in (64, 96) and n_tiles < num_sms and ideal_chunks <= 5 * num_sms:
+        return 2
+    return 0
 
 
 def build_kda(graph):
@@ -134,11 +150,22 @@ class CompiledKda:
         B = node.inputs["cu_seqlens"].dim[0] - 1
         layout = WorkspaceLayout()
         self.off_scheduler = layout.add(8)
-        self.num_sm = multiprocessor_count(current_device())
+        device = current_device()
+        self.num_sm = multiprocessor_count(device)
         self.n_tiles = B * HO
         self.n_heads_out = HO
+        self.piece_cap = 0
         if self.split:
             self.ideal = compute_ideal_chunks(total, HO, self.num_sm, self.b_t)
+            self.piece_cap = choose_kda_fwd_piece_cap(
+                device_cc=compute_capability(device),
+                checkpointed=self.checkpoint != 0 or self.has_state_checkpoints,
+                batch_size=B,
+                n_heads_out=HO,
+                n_tiles=self.n_tiles,
+                num_sms=self.num_sm,
+                ideal_chunks=self.ideal,
+            )
             self.work_item_rows = max_work_items(total, B, HO, self.ideal, self.b_t, self.num_sm)
         else:
             self.ideal = None
@@ -255,6 +282,7 @@ class CompiledKda:
                 dt_bias=dt_bias,
                 gate_lower_bound=self.gate_lower_bound if self.safe_gate else None,
                 scheduler_counter=scheduler_counter,
+                piece_cap=self.piece_cap,
                 split=self.split,
                 stream=stream,
             )

--- a/test/python/linear_attention/frost/test_kda_piece_cap_policy.py
+++ b/test/python/linear_attention/frost/test_kda_piece_cap_policy.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host-only contracts for the KDA-forward split-table piece cap."""
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+from cudnn.linear_attention.frost.kda_engine import choose_kda_fwd_piece_cap
+
+pytestmark = pytest.mark.L0
+
+_ROOT = Path(__file__).resolve().parents[4]
+_ENGINE_DIR = _ROOT / "python" / "cudnn" / "linear_attention" / "frost"
+
+
+@pytest.mark.parametrize(
+    "total_tokens,n_heads_out,want",
+    [
+        pytest.param(8192, 96, 2, id="kimi_8k"),
+        pytest.param(16384, 96, 2, id="kimi_16k"),
+        pytest.param(16384, 64, 2, id="glm_16k"),
+        pytest.param(32768, 64, 0, id="glm_32k"),
+    ],
+)
+def test_kda_fwd_piece_cap_evidence_boundary(total_tokens, n_heads_out, want):
+    from cudnn.linear_attention.frost.common.split_k import compute_ideal_chunks
+
+    num_sms = 148
+    ideal_chunks = compute_ideal_chunks(total_tokens, n_heads_out, num_sms, b_t=16)
+    assert (
+        choose_kda_fwd_piece_cap(
+            device_cc=(10, 0),
+            checkpointed=False,
+            batch_size=1,
+            n_heads_out=n_heads_out,
+            n_tiles=n_heads_out,
+            num_sms=num_sms,
+            ideal_chunks=ideal_chunks,
+        )
+        == want
+    )
+
+
+@pytest.mark.parametrize(
+    "device_cc,checkpointed,batch_size,n_heads_out,n_tiles,num_sms",
+    [
+        pytest.param((10, 3), False, 1, 64, 64, 148, id="sm103"),
+        pytest.param((10, 0), True, 1, 64, 64, 148, id="checkpointed"),
+        pytest.param((10, 0), False, 2, 64, 128, 148, id="ragged_batch"),
+        pytest.param((10, 0), False, 1, 80, 80, 148, id="unsupported_heads"),
+        pytest.param((10, 0), False, 1, 96, 96, 80, id="filled_grid"),
+    ],
+)
+def test_kda_fwd_piece_cap_rejects_unmeasured_regimes(device_cc, checkpointed, batch_size, n_heads_out, n_tiles, num_sms):
+    assert (
+        choose_kda_fwd_piece_cap(
+            device_cc=device_cc,
+            checkpointed=checkpointed,
+            batch_size=batch_size,
+            n_heads_out=n_heads_out,
+            n_tiles=n_tiles,
+            num_sms=num_sms,
+            ideal_chunks=333,
+        )
+        == 0
+    )
+
+
+def test_kda_fwd_piece_cap_ideal_boundary_is_inclusive():
+    common = dict(device_cc=(10, 0), checkpointed=False, batch_size=1, n_heads_out=64, n_tiles=64, num_sms=148)
+    assert choose_kda_fwd_piece_cap(**common, ideal_chunks=5 * common["num_sms"]) == 2
+    assert choose_kda_fwd_piece_cap(**common, ideal_chunks=5 * common["num_sms"] + 1) == 0
+
+
+def test_table_recipe_replays_runtime_piece_cap():
+    from cudnn.linear_attention.frost.common.split_k import TableRecipe, run_table
+
+    calls = []
+    recipe = TableRecipe(
+        compiled=lambda *args: calls.append(args),
+        split=True,
+        safe_gate=False,
+        n_heads_out=64,
+        n_tiles=64,
+        num_sms=148,
+        ideal_chunks=443,
+        piece_cap=2,
+        batch_size=1,
+        log2_threshold=-1.0,
+        gate_scale_log2=0.0,
+        n_scan_ctas=7,
+        n_walk_ctas=64,
+    )
+    gate = object()
+    cu_seqlens = object()
+    chunk_scratch = object()
+    item_scratch = object()
+    work_items = object()
+    work_count = object()
+    scheduler = object()
+
+    run_table(
+        recipe,
+        gate,
+        None,
+        None,
+        cu_seqlens,
+        chunk_scratch,
+        item_scratch,
+        work_items,
+        work_count,
+        scheduler,
+        0,
+    )
+
+    assert len(calls) == 1
+    assert calls[0][:4] == (64, 443, 2, 1)
+    assert calls[0][6:13] == (gate, None, None, cu_seqlens, chunk_scratch, item_scratch, work_items)
+
+
+def _build_split_table_calls(path):
+    tree = ast.parse(path.read_text())
+    calls = []
+    for class_node in (node for node in tree.body if isinstance(node, ast.ClassDef)):
+        for function_node in (node for node in class_node.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))):
+            for node in ast.walk(function_node):
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "build_split_table":
+                    calls.append((class_node.name, {keyword.arg for keyword in node.keywords}))
+    return calls
+
+
+def test_only_kda_forward_explicitly_owns_piece_cap():
+    calls = {}
+    for filename in ("kda_engine.py", "gdn_engine.py", "gdn2_engine.py"):
+        for class_name, keywords in _build_split_table_calls(_ENGINE_DIR / filename):
+            calls[(filename, class_name)] = keywords
+
+    assert set(calls) == {
+        ("kda_engine.py", "CompiledKda"),
+        ("kda_engine.py", "CompiledKdaBwd"),
+        ("gdn_engine.py", "CompiledGdn"),
+        ("gdn_engine.py", "CompiledGdnBwd"),
+        ("gdn2_engine.py", "CompiledGdn2"),
+        ("gdn2_engine.py", "CompiledGdn2Bwd"),
+    }
+    explicit = {owner for owner, keywords in calls.items() if "piece_cap" in keywords}
+    assert explicit == {("kda_engine.py", "CompiledKda")}
+
+
+def test_piece_cap_defaults_off_and_does_not_shrink_workspace_bound():
+    from cudnn.linear_attention.frost.common.split_k import build_split_table, max_work_items
+
+    assert inspect.signature(build_split_table).parameters["piece_cap"].default == 0
+    assert "piece_cap" not in inspect.signature(max_work_items).parameters
+
+
+def test_piece_cap_is_runtime_not_a_compile_cache_key():
+    tree = ast.parse((_ENGINE_DIR / "common" / "split_k.py").read_text())
+    build = next(node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "build_split_table")
+    key_assignment = next(
+        node for node in ast.walk(build) if isinstance(node, ast.Assign) and any(isinstance(target, ast.Name) and target.id == "key" for target in node.targets)
+    )
+    assert not any(isinstance(node, ast.Name) and node.id == "piece_cap" for node in ast.walk(key_assignment.value))


### PR DESCRIPTION
## Before submitting

- [ ] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [ ] I ran `pre-commit run` and committed any formatting changes. The current Style / pre-commit CI check is green, but the live PR body does not record a local invocation.
- [x] I added GitHub labels: `cat-perf-bug`, `mod-frost`, and `orig-nv-eng`.
- [x] I set the **Milestone** to `Frontend 1.29.0`.
- [ ] The PR still needs a **Project** assignment; the current token does not have Projects scope.

## Affected area

- FE OSS kernels or CuTeDSL

## Summary

- Add a runtime `piece_cap` to the FROST split-table planner. Zero preserves the existing adaptive search; a positive value clamps the result after the normal search and uncut margin.
- Select cap 2 only for checkpoint-free KDA forward on exact SM100 when `B=1`, output heads are 64 or 96, the head grid underfills the GPU, and `ideal_chunks <= 5 * num_sms`.
- Keep KDA backward and all GDN/GDN2 forward and backward routes on the existing adaptive default.
- Replay the cap through `TableRecipe` without adding it to the compilation-cache key. Workspace sizing remains conservative and unchanged.

## Why

For the measured single-sequence B200 KDA-forward geometries, the existing adaptive planner can split an underfilled head grid into more pieces than are beneficial. A narrow runtime cap improves those measured cases while leaving the adaptive planner and all unmeasured routes unchanged. Keeping the value runtime-only avoids a new compiled-kernel specialization and preserves the existing workspace bound.

## Related issues

None.

## API and compatibility impact

There is no public API change. `piece_cap` is an internal FROST split-table planning input and is replayed at runtime rather than included in the compilation-cache key.

The behavior change is limited to exact SM100, checkpoint-free KDA forward, `B=1`, 64 or 96 output heads, an underfilled head grid, and `ideal_chunks <= 5 * num_sms`. Other architectures, checkpointed forward, batches above one, other head counts, KDA backward, and every GDN/GDN2 forward or backward route retain the existing adaptive planner. Workspace sizing is unchanged.

The performance results below are direct KDA-forward measurements, not backward, an assembled layer, or a full-model speedup.

## Testing

- `python -m pytest -q -c test/python/pytest.ini --confcutdir=test/python/linear_attention/frost test/python/linear_attention/frost/test_kda_piece_cap_policy.py` — 14 passed, covering policy boundaries, runtime replay, cache identity, workspace sizing, and call-site ownership.
- ComputeLab job `4014222`, NVIDIA B200 SM100 with 148 SMs, cuDNN backend `92600`; Frontend base `606e16f9786ea7a13e0462c8a63edf0d7f72ae85`, PR source `70f1fa0916be5f902bc9d3a9e89408dd50087c08`.

The PR policy and adaptive control were compared in one process using the same source. The control differed only by returning zero from the host selector while its plan was built; selector replacement happened outside correctness, warmup, and timing. Each arm used 3 warmups, 9 balanced CUDA-event samples, and a 256 MiB cache flush before every timed call.

| Model geometry | Adaptive control median | PR median | Paired control / PR | Wins |
|---|---:|---:|---:|---:|
| Kimi-K3, H96, 8,192 tokens | 0.646112 ms | 0.630752 ms | 1.0322x | 9/9 |
| Kimi-K3, H96, 16,384 tokens | 1.165312 ms | 1.150016 ms | 1.0133x | 9/9 |
| GLM-5.3, H64, 16,384 tokens | 0.613472 ms | 0.590816 ms | 1.0417x | 9/9 |
| GLM-5.3, H64, 32,768 tokens | 1.099744 ms | 1.094656 ms | 1.0009x | 6/9 |

The 32K GLM-5.3 case is a same-table control: the policy remains off and both arms select identical 9-piece tables, so it is not a claimed speedup.

All output checks passed. Worst maximum-relative output differences across the four rows were `0.0012563`, `0.0012255`, `0.0005252`, and `0`; final states were bit-exact in every case. These measurements exclude backward, projections, causal convolution, output gate, residual, MLP, assembled layers, and full models.
