### PR TITLE
Add Kimi K3 SiTU dense MLP support

### DIFF
--- a/docs/framework_integration_performance.md
+++ b/docs/framework_integration_performance.md
@@ -99,6 +99,30 @@ forward+backward versus eager torch. The earlier 1-CTA result did not show this 
 tile sweep held CTA group and cluster shape fixed. Always measure the whole step rather than
 extrapolating from an isolated fused stage.
 
+Kimi K3's bounded SiTU MLP is exposed separately as
+`cudnn.gemm.situ_mlp(x, Wg, Wu, Wd, *, beta=4.0, linear_beta=25.0)` rather
+than overloading `swiglu_mlp` with an activation string. It fuses the two BF16
+input projections with
+`beta*tanh(gate/beta)*sigmoid(gate) * linear_beta*tanh(up/linear_beta)` and
+keeps the down projection as a second kernel. The current FROST backward is
+SwiGLU-specific, so SiTU uses an exact cuDNN pointwise derivative graph.
+
+On B200, same-process interleaved CUDA-graph replay measured the complete
+three-GEMM inference call against the exact PyTorch composition below. These
+fixed-width rows are operation proxies, not an assembled MoE dispatch:
+
+| Kimi K3 role | M | H | I | PyTorch / cuDNN |
+|---|---:|---:|---:|---:|
+| dense | 512 | 7,168 | 33,792 | 1.69-1.70x |
+| shared expert | 2,048 | 7,168 | 6,144 | 1.69-1.71x |
+| routed-expert proxy | 128 | 3,584 | 3,072 | 1.92x |
+
+Across two repeated runs, the corresponding cuDNN graph-replay medians were
+0.552-0.554, 0.369-0.371, and 0.02260 ms. Relative L2 error versus the official
+FP32-activation/BF16-boundary formula was below 0.00075 for all three. This is
+inference-only operator timing; it does not imply full-model or training-step
+speedup.
+
 ### 7. Mixing libraries in a hot eager loop
 Interleaving cuDNN `execute` with cuBLAS/`torch.mm`/other-library calls, op by op, is the
 *worst* eager pattern measured here — worse than either library alone — because each switch

--- a/docs/framework_integration_performance.md
+++ b/docs/framework_integration_performance.md
@@ -107,21 +107,22 @@ input projections with
 keeps the down projection as a second kernel. The current FROST backward is
 SwiGLU-specific, so SiTU uses an exact cuDNN pointwise derivative graph.
 
-On B200, same-process interleaved CUDA-graph replay measured the complete
-three-GEMM inference call against the exact PyTorch composition below. These
-fixed-width rows are operation proxies, not an assembled MoE dispatch:
+On B200, same-process interleaved CUDA-graph replay device intervals measured
+the complete three-GEMM inference call against the exact PyTorch composition.
+Graph construction and autotuning happened before replay; each value is the
+median of 9 samples with 40 iterations per sample:
 
-| Kimi K3 role | M | H | I | PyTorch / cuDNN |
-|---|---:|---:|---:|---:|
-| dense | 512 | 7,168 | 33,792 | 1.69-1.70x |
-| shared expert | 2,048 | 7,168 | 6,144 | 1.69-1.71x |
-| routed-expert proxy | 128 | 3,584 | 3,072 | 1.92x |
+| Kimi K3 role | M | H | I | cuDNN replay (ms) | PyTorch replay (ms) | PyTorch / cuDNN |
+|---|---:|---:|---:|---:|---:|---:|
+| dense | 512 | 7,168 | 33,792 | 0.5527 | 0.8871 | 1.605x |
+| shared expert | 2,048 | 7,168 | 6,144 | 0.3704 | 0.6274 | 1.694x |
+| routed-expert proxy | 128 | 3,584 | 3,072 | 0.02058 | 0.04314 | 2.096x |
 
-Across two repeated runs, the corresponding cuDNN graph-replay medians were
-0.552-0.554, 0.369-0.371, and 0.02260 ms. Relative L2 error versus the official
-FP32-activation/BF16-boundary formula was below 0.00075 for all three. This is
-inference-only operator timing; it does not imply full-model or training-step
-speedup.
+Times are rounded to the displayed precision. Relative L2 error versus the
+official FP32-activation/BF16-boundary formula was below 0.00075 for all three.
+These fixed-width rows are inference-only operation proxies, not an assembled
+MoE dispatch, and the timings cover the full operator rather than one kernel;
+they do not imply full-model, training-step, or non-B200 speedup.
 
 ### 7. Mixing libraries in a hot eager loop
 Interleaving cuDNN `execute` with cuBLAS/`torch.mm`/other-library calls, op by op, is the

--- a/python/cudnn/gemm/__init__.py
+++ b/python/cudnn/gemm/__init__.py
@@ -19,6 +19,7 @@ from typing import Any
 
 _LAZY_EXPORTS = {
     "moe_grouped_matmul": ("cudnn.gemm.ops", "moe_grouped_matmul"),
+    "situ_mlp": ("cudnn.gemm.ops", "situ_mlp"),
     "swiglu_mlp": ("cudnn.gemm.ops", "swiglu_mlp"),
 }
 

--- a/python/cudnn/gemm/ops/__init__.py
+++ b/python/cudnn/gemm/ops/__init__.py
@@ -10,10 +10,7 @@ from typing import Any
 # specific operation is first accessed. Mirrors cudnn/gemm/__init__.py.
 _LAZY_EXPORTS = {
     "moe_grouped_matmul": ("cudnn.gemm.ops.moe_grouped_matmul", "moe_grouped_matmul"),
-    # Keep both semantic entry points in one implementation module. A public
-    # same-named ``situ_mlp`` submodule would let normal Python import machinery
-    # replace this package's callable export with the module object, depending
-    # on import order.
+    # Both semantic entry points share the existing implementation module.
     "situ_mlp": ("cudnn.gemm.ops.swiglu_mlp", "situ_mlp"),
     "swiglu_mlp": ("cudnn.gemm.ops.swiglu_mlp", "swiglu_mlp"),
 }

--- a/python/cudnn/gemm/ops/__init__.py
+++ b/python/cudnn/gemm/ops/__init__.py
@@ -10,6 +10,11 @@ from typing import Any
 # specific operation is first accessed. Mirrors cudnn/gemm/__init__.py.
 _LAZY_EXPORTS = {
     "moe_grouped_matmul": ("cudnn.gemm.ops.moe_grouped_matmul", "moe_grouped_matmul"),
+    # Keep both semantic entry points in one implementation module. A public
+    # same-named ``situ_mlp`` submodule would let normal Python import machinery
+    # replace this package's callable export with the module object, depending
+    # on import order.
+    "situ_mlp": ("cudnn.gemm.ops.swiglu_mlp", "situ_mlp"),
     "swiglu_mlp": ("cudnn.gemm.ops.swiglu_mlp", "swiglu_mlp"),
 }
 
@@ -21,9 +26,15 @@ def __getattr__(name: str) -> Any:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
     import importlib
 
-    value = getattr(importlib.import_module(module_name), attr_name)
-    globals()[name] = value
-    return value
+    module = importlib.import_module(module_name)
+    # Multiple semantic entry points can share one implementation module. Import
+    # machinery writes a same-named module onto this package while loading it;
+    # install every export from this module as its callable so either
+    # order in ``from cudnn.gemm.ops import situ_mlp, swiglu_mlp`` is stable.
+    for export_name, (export_module_name, export_attr_name) in _LAZY_EXPORTS.items():
+        if export_module_name == module_name:
+            globals()[export_name] = getattr(module, export_attr_name)
+    return globals()[name]
 
 
 __all__ = list(_LAZY_EXPORTS)

--- a/python/cudnn/gemm/ops/swiglu_mlp.py
+++ b/python/cudnn/gemm/ops/swiglu_mlp.py
@@ -130,9 +130,7 @@ def _graph_scalar(g, value, name):
     # Runtime-param scalars work with the op's cuDNN 9.x floor; compile-time
     # constants need cuDNN >= 9.22. The graph owns the value, and the cache key
     # owns its identity, so execute() has no extra tensor/scalar argument.
-    scalar = g.tensor_scalar(float(value), cudnn.scalar_type.RUNTIME_PARAM)
-    scalar.set_name(name)
-    return scalar
+    return g.tensor_scalar(float(value), cudnn.scalar_type.RUNTIME_PARAM, name=name)
 
 
 def _handle(device):

--- a/python/cudnn/gemm/ops/swiglu_mlp.py
+++ b/python/cudnn/gemm/ops/swiglu_mlp.py
@@ -130,7 +130,9 @@ def _graph_scalar(g, value, name):
     # Runtime-param scalars work with the op's cuDNN 9.x floor; compile-time
     # constants need cuDNN >= 9.22. The graph owns the value, and the cache key
     # owns its identity, so execute() has no extra tensor/scalar argument.
-    return g.tensor_scalar(float(value), cudnn.scalar_type.RUNTIME_PARAM, name=name)
+    scalar = g.tensor_scalar(float(value), cudnn.scalar_type.RUNTIME_PARAM)
+    scalar.set_name(name)
+    return scalar
 
 
 def _handle(device):

--- a/python/cudnn/gemm/ops/swiglu_mlp.py
+++ b/python/cudnn/gemm/ops/swiglu_mlp.py
@@ -1,14 +1,29 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Dense bf16 SwiGLU-MLP as a cuDNN autograd op.
+"""Dense bf16 gated MLP as a cuDNN autograd op.
 
-``out = (silu(x @ Wg^T) * (x @ Wu^T)) @ Wd^T`` — the Qwen/LLaMA-style gated MLP,
-with all GEMMs and the SwiGLU running on cuDNN.
+``swiglu_mlp`` keeps the Qwen/LLaMA contract:
 
-The forward fuses the gate GEMM, the up GEMM, ``SiLU`` and the multiply into ONE
-cuDNN kernel (the FORT-native runtime-fusion engine on SM100), which beats two
-cuBLAS GEMMs plus a torch activation by ~1.05-1.20x on the Qwen3.5-27B MLP shape;
+``out = (silu(x @ Wg^T) * (x @ Wu^T)) @ Wd^T``
+
+``situ_mlp`` is the separate semantic entry point for Kimi K3's bounded variant:
+
+``gate_act = beta * tanh(gate / beta) * sigmoid(gate)``
+
+``up_act = linear_beta * tanh(up / linear_beta)``
+
+``out = (gate_act * up_act) @ Wd^T``
+
+The two entry points share private plan/autograd machinery. Its internal
+activation tag and both SiTU betas are semantic plan inputs: they are snapshotted
+by autograd and included in every activation-plan cache key, so a plan built for
+ordinary SwiGLU, or for different SiTU betas, is never reused.
+
+For ``swiglu_mlp``, the forward fuses the gate GEMM, the up GEMM, ``SiLU`` and
+the multiply into ONE cuDNN kernel (the FORT-native runtime-fusion engine on
+SM100), which beats two cuBLAS GEMMs plus a torch activation by ~1.05-1.20x on
+the Qwen3.5-27B MLP shape;
 the down projection is a separate GEMM (a three-GEMM single graph does not
 compile). That fused kernel also emits the two pre-activations ``gate = x@Wg^T``
 and ``up = x@Wu^T`` (the GEMM accumulators it already computes) as extra outputs,
@@ -18,8 +33,9 @@ saved-activation policy; an earlier revision that
 recomputed gate/up paid two extra GEMMs and ran ~1.3x slower on the backward,
 ~1.17-1.19x on the full fwd+bwd step. Saving ``{h, gate, up}`` costs ~3x[M,I] of
 activation memory, less than the ~4x[M,I] torch autograd already keeps. The
-pointwise fallback computes ``dup`` and ``dgate`` in one two-output graph, reading
-the inputs once and running ~2x faster than two single-output kernels. By default,
+SwiGLU pointwise fallback computes ``dup`` and ``dgate`` in one two-output graph,
+reading the inputs once and running ~2x faster than two single-output kernels.
+For ``swiglu_mlp`` only, by default,
 ``dh = dout @ Wd`` dgrad GEMM and the dSwiGLU are fused into one FROST (cuTeDSL)
 kernel that never materialises ``dh`` to HBM (set
 ``CUDNN_GEMM_SWIGLU_FROST_BWD=0`` for the separate nvjet GEMM + one-kernel
@@ -35,8 +51,8 @@ At the public call boundary the op snapshots GradMode and each input's
 ``requires_grad`` into a small mask. Inference and Wd-only training use an h-only
 forward graph; partial-gradient training retains only the tensors its requested
 input gradients consume and skips unrelated backward GEMMs. Full all-gradient
-training takes the same kernels as above. The mask follows ``requires_grad`` at
-forward time; it cannot infer a narrower target list passed later to
+training takes the selected activation route's complete kernel set. The mask
+follows ``requires_grad`` at forward time; it cannot infer a narrower target list passed later to
 ``torch.autograd.grad``.
 
 Weights are the ``[I, H]`` / ``[H, I]`` ``nn.Linear`` tensors; they enter the
@@ -47,6 +63,7 @@ Requires an SM100 (Blackwell) device for the fused runtime-fusion engine; on
 other architectures the graph build declines and the op raises.
 """
 
+import math
 import os
 
 import torch
@@ -72,6 +89,48 @@ _GRAD_WG = 1 << 1
 _GRAD_WU = 1 << 2
 _GRAD_WD = 1 << 3
 _GRAD_FC1 = _GRAD_X | _GRAD_WG | _GRAD_WU
+
+_ACTIVATION_SILU = "silu"
+_ACTIVATION_SITU = "situ"
+_KIMI_SITU_BETA = 4.0
+_KIMI_SITU_LINEAR_BETA = 25.0
+
+
+def _normalize_activation_config(activation, situ_beta, situ_linear_beta, *, op_name="gated_mlp"):
+    """Return the canonical gated-activation contract used by plans/autograd.
+
+    The activation tag is private; public callers select it by choosing
+    :func:`swiglu_mlp` or :func:`situ_mlp`. SiTU requires explicit canonical
+    beta values here (the public wrapper supplies its published 4/25 defaults).
+    """
+    prefix = f"cudnn.gemm.{op_name}"
+    if activation not in (_ACTIVATION_SILU, _ACTIVATION_SITU):
+        raise ValueError(f"{prefix}: internal activation must be 'silu' or 'situ'; got {activation!r}")
+    if activation == _ACTIVATION_SILU:
+        if situ_beta is not None or situ_linear_beta is not None:
+            raise ValueError(f"{prefix}: internal SiTU betas are invalid on the SiLU route")
+        return activation, None, None
+
+    def positive_finite(name, value):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(f"{prefix}: {name} must be a positive finite Python number; got {value!r}")
+        value = float(value)
+        if not math.isfinite(value) or value <= 0.0:
+            raise ValueError(f"{prefix}: {name} must be positive and finite; got {value!r}")
+        return value
+
+    return (
+        activation,
+        positive_finite("beta", situ_beta),
+        positive_finite("linear_beta", situ_linear_beta),
+    )
+
+
+def _graph_scalar(g, value, name):
+    # Runtime-param scalars work with the op's cuDNN 9.x floor; compile-time
+    # constants need cuDNN >= 9.22. The graph owns the value, and the cache key
+    # owns its identity, so execute() has no extra tensor/scalar argument.
+    return g.tensor_scalar(float(value), cudnn.scalar_type.RUNTIME_PARAM, name=name)
 
 
 def _handle(device):
@@ -151,21 +210,44 @@ def _mm(a2, b2):
     return out.squeeze(0)
 
 
-def _swiglu_act(x, Wg, Wu, *, save_preacts=True):
-    """Fused ``h = silu(x@Wg^T) * (x@Wu^T)`` in ONE cuDNN kernel, also emitting the
-    two pre-activations ``gate = x@Wg^T`` and ``up = x@Wu^T`` when
-    ``save_preacts=True``. All requested outputs come from the single fused plan;
-    their cost is plan/runtime dependent, but they drop the two recompute GEMMs
-    from a full backward. In inference or a Wd-only backward,
-    ``save_preacts=False`` selects an h-only graph and avoids those side stores.
-    ``x:[M,H]``, ``Wg,Wu:[I,H]`` are bound as strided ``.t()`` views (no transpose
-    copy). Returns ``(h, gate, up)`` ``:[M,I]``; gate/up are ``None`` for h-only."""
+def _swiglu_act(
+    x,
+    Wg,
+    Wu,
+    *,
+    save_preacts=True,
+    activation=_ACTIVATION_SILU,
+    situ_beta=None,
+    situ_linear_beta=None,
+):
+    """Fused gated activation in ONE cuDNN kernel, optionally emitting preacts.
+
+    ``activation='silu'`` computes ``silu(gate) * up``. ``activation='situ'``
+    computes Kimi's bounded gate and bounded up branch with the supplied betas.
+    ``x:[M,H]``, ``Wg,Wu:[I,H]`` are bound as strided ``.t()`` views (no copy).
+    Returns ``(h, gate, up):[M,I]``; gate/up are ``None`` for h-only.
+    """
+    activation, situ_beta, situ_linear_beta = _normalize_activation_config(activation, situ_beta, situ_linear_beta)
     h, stream = _handle(x.device)
     M, H = x.shape
     interm = Wg.shape[0]
     xv = x.unsqueeze(0)
     wg, wu = Wg.t().unsqueeze(0), Wu.t().unsqueeze(0)  # [1,H,interm] column-major views, no copy
-    key = (M, H, interm, x.dtype, xv.stride(), wg.stride(), wu.stride(), bool(save_preacts), x.device.index, stream)
+    key = (
+        M,
+        H,
+        interm,
+        x.dtype,
+        xv.stride(),
+        wg.stride(),
+        wu.stride(),
+        bool(save_preacts),
+        x.device.index,
+        stream,
+        activation,
+        situ_beta,
+        situ_linear_beta,
+    )
     e = _SWIGLU_CACHE.get(key)
     if e is None:
         g = cudnn.pygraph(handle=h, compute_data_type=_FP32)
@@ -173,15 +255,22 @@ def _swiglu_act(x, Wg, Wu, *, save_preacts=True):
         WG = g.tensor(dim=[1, H, interm], stride=list(wg.stride()), data_type=_BF16)
         WU = g.tensor(dim=[1, H, interm], stride=list(wu.stride()), data_type=_BF16)
         gate = g.matmul(name="gate", A=X, B=WG, compute_data_type=_FP32)
-        sg = g.mul(a=gate, b=g.sigmoid(input=gate))  # SiLU = gate * sigmoid(gate)
         up = g.matmul(name="up", A=X, B=WU, compute_data_type=_FP32)
-        hh = g.mul(a=sg, b=up)
-        hh.set_output(True).set_data_type(_BF16)
         # Keep h numerically independent of whether the pre-activations are exposed:
-        # the full-training graph consumes BF16-rounded gate/up, so the h-only graph
-        # must retain those intermediate dtypes even though it does not store them.
+        # Kimi explicitly casts the two Linear outputs to fp32 inside SiTU, so both
+        # activation variants first consume the same BF16-rounded Linear results.
         gate.set_data_type(_BF16)
         up.set_data_type(_BF16)
+        if activation == _ACTIVATION_SILU:
+            gate_act = g.mul(a=gate, b=g.sigmoid(input=gate))
+            up_act = up
+        else:
+            beta = _graph_scalar(g, situ_beta, "situ_beta")
+            linear_beta = _graph_scalar(g, situ_linear_beta, "situ_linear_beta")
+            gate_act = g.mul(a=g.mul(a=beta, b=g.tanh(input=g.div(a=gate, b=beta))), b=g.sigmoid(input=gate))
+            up_act = g.mul(a=linear_beta, b=g.tanh(input=g.div(a=up, b=linear_beta)))
+        hh = g.mul(a=gate_act, b=up_act)
+        hh.set_output(True).set_data_type(_BF16)
         if save_preacts:
             gate.set_output(True)  # saved for backward -> no recompute GEMM
             up.set_output(True)
@@ -210,18 +299,25 @@ def _swiglu_act(x, Wg, Wu, *, save_preacts=True):
     return hb, gb, ub
 
 
-def _dswiglu(dh, gate, up):
-    """Fused dSwiGLU in ONE cuDNN kernel: ``dup = dh*silu(gate)`` and
-    ``dgate = dh*up*silu'(gate)`` (``silu'(g) = s + silu*(1-s)``, ``s=sigmoid(g)``)
-    as the two outputs of a single multi-output pointwise graph. ``dh,gate,up:[M,I]``
-    are dense and same-shape (elementwise, no broadcast). cuDNN's tensor-ir engine
-    declines multi-output (it logs ``unsupported multi-output fusion``), but another
-    engine serves the graph as one kernel that reads the inputs once -- ~2x the two
-    single-output kernels it replaces, which re-read the inputs and recompute the
-    sigmoid. Returns ``(dgate, dup)``."""
+def _dswiglu(
+    dh,
+    gate,
+    up,
+    *,
+    activation=_ACTIVATION_SILU,
+    situ_beta=None,
+    situ_linear_beta=None,
+):
+    """Fused two-output derivative for ordinary SwiGLU or bounded SiTU.
+
+    For SiTU, both derivatives are activation-specific: the gate includes the
+    derivative of ``beta*tanh(gate/beta)*sigmoid(gate)``, while the up branch
+    includes ``1-tanh(up/linear_beta)^2``. Returns ``(dgate, dup)``.
+    """
+    activation, situ_beta, situ_linear_beta = _normalize_activation_config(activation, situ_beta, situ_linear_beta)
     h, stream = _handle(dh.device)
     M, interm = dh.shape
-    key = (M, interm, dh.dtype, dh.device.index, stream)
+    key = (M, interm, dh.dtype, dh.device.index, stream, activation, situ_beta, situ_linear_beta)
     e = _DSWIGLU_CACHE.get(key)
     if e is None:
         g = cudnn.pygraph(handle=h, compute_data_type=_FP32)
@@ -229,10 +325,28 @@ def _dswiglu(dh, gate, up):
         GATE = g.tensor(dim=[1, M, interm], stride=[M * interm, interm, 1], data_type=_BF16)
         UP = g.tensor(dim=[1, M, interm], stride=[M * interm, interm, 1], data_type=_BF16)
         s = g.sigmoid(input=GATE)
-        silu = g.mul(a=GATE, b=s)
-        dup = g.mul(a=DH, b=silu)  # dh*silu(gate)
-        silup = g.add(a=s, b=g.sub(a=silu, b=g.mul(a=silu, b=s)))  # silu' = s + silu*(1-s)
-        dgate = g.mul(a=g.mul(a=DH, b=UP), b=silup)  # dh*up*silu'
+        if activation == _ACTIVATION_SILU:
+            gate_act = g.mul(a=GATE, b=s)
+            gate_grad = g.add(a=s, b=g.sub(a=gate_act, b=g.mul(a=gate_act, b=s)))
+            up_act = UP
+            up_grad = None
+        else:
+            one = _graph_scalar(g, 1.0, "one")
+            beta = _graph_scalar(g, situ_beta, "situ_beta")
+            linear_beta = _graph_scalar(g, situ_linear_beta, "situ_linear_beta")
+            gate_tanh = g.tanh(input=g.div(a=GATE, b=beta))
+            up_tanh = g.tanh(input=g.div(a=UP, b=linear_beta))
+            gate_act = g.mul(a=g.mul(a=beta, b=gate_tanh), b=s)
+            up_act = g.mul(a=linear_beta, b=up_tanh)
+            gate_grad = g.add(
+                a=g.mul(a=g.sub(a=one, b=g.mul(a=gate_tanh, b=gate_tanh)), b=s),
+                b=g.mul(a=g.mul(a=beta, b=gate_tanh), b=g.mul(a=s, b=g.sub(a=one, b=s))),
+            )
+            up_grad = g.sub(a=one, b=g.mul(a=up_tanh, b=up_tanh))
+        dup = g.mul(a=DH, b=gate_act)
+        if up_grad is not None:
+            dup = g.mul(a=dup, b=up_grad)
+        dgate = g.mul(a=g.mul(a=DH, b=up_act), b=gate_grad)
         dup.set_output(True).set_data_type(_BF16)
         dgate.set_output(True).set_data_type(_BF16)
         g.validate()
@@ -266,7 +380,16 @@ _FROST_BWD = os.environ.get("CUDNN_GEMM_SWIGLU_FROST_BWD", "1") != "0"
 _FROST_DECLINE_ERRORS = (NotImplementedError, cudnn.cudnnGraphNotSupportedError, ImportError)
 
 
-def _frost_dswiglu(dout2, Wd, gate, up):
+def _frost_dswiglu(
+    dout2,
+    Wd,
+    gate,
+    up,
+    *,
+    activation=_ACTIVATION_SILU,
+    situ_beta=None,
+    situ_linear_beta=None,
+):
     """Fused backward dgrad + dSwiGLU in ONE FROST kernel: ``dh = dout2 @ Wd`` with
     ``dup = dh*silu(gate)`` and ``dgate = dh*silu'(gate)*up`` as the GEMM epilogue,
     so the separate dh GEMM + two dSwiGLU pointwise kernels of :func:`_dswiglu`
@@ -283,7 +406,16 @@ def _frost_dswiglu(dout2, Wd, gate, up):
     strategy win. Small M retains the 1CTAMMA/cluster1x1 strategy. Not a transpose
     problem (dense bf16 needs none; ``dg.t()`` is a free view) and not a host-
     overhead one (host is ~1% of these compute-bound GEMMs, and #612 already cut
-    it)."""
+    it). SiTU is deliberately unsupported here: this FROST graph contains
+    ``swish``/``swish_backward`` nodes, so accepting SiTU would silently compute
+    the wrong derivative. The caller must use the exact cuDNN pointwise graph.
+    """
+    activation, situ_beta, situ_linear_beta = _normalize_activation_config(activation, situ_beta, situ_linear_beta)
+    if activation != _ACTIVATION_SILU:
+        raise NotImplementedError(
+            "cudnn.gemm.swiglu_mlp: FROST backward only implements activation='silu'; "
+            f"activation={activation!r}, situ_beta={situ_beta}, situ_linear_beta={situ_linear_beta} must use the exact cuDNN fallback"
+        )
     operands = (("dout", dout2), ("Wd", Wd), ("gate", gate), ("up", up))
     if any(t.dim() != 2 for _, t in operands):
         raise NotImplementedError("cudnn.gemm.swiglu_mlp: FROST backward requires rank-2 dout/Wd/gate/up operands")
@@ -377,9 +509,9 @@ def _frost_dswiglu(dout2, Wd, gate, up):
     return dgate.squeeze(0), dup.squeeze(0)
 
 
-class _SwigluMLP(torch.autograd.Function):
+class _GatedMLP(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x, Wg, Wu, Wd, grad_mask):
+    def forward(ctx, x, Wg, Wu, Wd, grad_mask, activation, situ_beta, situ_linear_beta):
         shp = x.shape
         x2 = x.reshape(-1, shp[-1])
         need_fc1_grad = bool(grad_mask & _GRAD_FC1)
@@ -388,6 +520,9 @@ class _SwigluMLP(torch.autograd.Function):
             Wg,
             Wu,
             save_preacts=need_fc1_grad,
+            activation=activation,
+            situ_beta=situ_beta,
+            situ_linear_beta=situ_linear_beta,
         )  # fused: h-only unless an FC1-related backward needs gate/up
         out = _mm(h, Wd.t())  # transposed weight view; cuDNN reads it column-major, no copy
 
@@ -416,6 +551,9 @@ class _SwigluMLP(torch.autograd.Function):
         ctx.save_for_backward(*saved_tensors)
         ctx.saved_names = tuple(saved_names)
         ctx.grad_mask = grad_mask
+        ctx.activation = activation
+        ctx.situ_beta = situ_beta
+        ctx.situ_linear_beta = situ_linear_beta
         ctx.shp = shp
         ctx.out_features = Wd.shape[0]
         return out.reshape(*shp[:-1], Wd.shape[0])
@@ -440,13 +578,26 @@ class _SwigluMLP(torch.autograd.Function):
             gate, up = gate.contiguous(), up.contiguous()
             # P1 retains the existing dual-output dSwiGLU whenever either output
             # is needed. It still skips the whole stage for a Wd-only backward.
-            if _FROST_BWD:
-                try:
-                    dgate, dup = _frost_dswiglu(dout2, Wd, gate, up)
-                except _FROST_DECLINE_ERRORS:
+            # The current FROST epilogue is exactly SwiGLU-specific. SiTU goes
+            # directly to its exact cuDNN derivative graph; never launch swish
+            # backward and hope the beta contract is close enough.
+            if ctx.activation == _ACTIVATION_SILU:
+                if _FROST_BWD:
+                    try:
+                        dgate, dup = _frost_dswiglu(dout2, Wd, gate, up, activation=ctx.activation)
+                    except _FROST_DECLINE_ERRORS:
+                        dgate, dup = _dswiglu(_mm(dout2, Wd), gate, up)
+                else:
                     dgate, dup = _dswiglu(_mm(dout2, Wd), gate, up)
             else:
-                dgate, dup = _dswiglu(_mm(dout2, Wd), gate, up)
+                dgate, dup = _dswiglu(
+                    _mm(dout2, Wd),
+                    gate,
+                    up,
+                    activation=ctx.activation,
+                    situ_beta=ctx.situ_beta,
+                    situ_linear_beta=ctx.situ_linear_beta,
+                )
         else:
             dgate = dup = None
 
@@ -457,7 +608,44 @@ class _SwigluMLP(torch.autograd.Function):
             dx = None
         dWg = _mm(dgate.t(), saved["x2"]) if grad_mask & _GRAD_WG else None
         dWu = _mm(dup.t(), saved["x2"]) if grad_mask & _GRAD_WU else None
-        return dx, dWg, dWu, dWd, None
+        return dx, dWg, dWu, dWd, None, None, None, None
+
+
+def _gated_mlp(x, Wg, Wu, Wd, *, activation, situ_beta, situ_linear_beta, op_name):
+    activation, situ_beta, situ_linear_beta = _normalize_activation_config(
+        activation,
+        situ_beta,
+        situ_linear_beta,
+        op_name=op_name,
+    )
+    prefix = f"cudnn.gemm.{op_name}"
+    for name, t in (("x", x), ("Wg", Wg), ("Wu", Wu), ("Wd", Wd)):
+        if t.dtype != torch.bfloat16:
+            raise TypeError(f"{prefix}: {name} must be bfloat16, got {t.dtype}")
+        if t.device.type != "cuda":
+            raise ValueError(f"{prefix}: {name} must be a CUDA tensor, got device {t.device}")
+    if any(t.device != x.device for t in (Wg, Wu, Wd)):
+        raise ValueError(f"{prefix}: x, Wg, Wu, and Wd must be on the same CUDA device; " f"got x={x.device}, Wg={Wg.device}, Wu={Wu.device}, Wd={Wd.device}")
+    if x.dim() < 2 or Wg.dim() != 2 or Wu.dim() != 2 or Wd.dim() != 2:
+        raise ValueError(
+            f"{prefix}: expected x[...,H] and 2-D Wg/Wu[I,H], Wd[H,I]; " f"got x{tuple(x.shape)} Wg{tuple(Wg.shape)} Wu{tuple(Wu.shape)} Wd{tuple(Wd.shape)}"
+        )
+    H = x.shape[-1]
+    if Wg.shape != Wu.shape or Wg.shape[1] != H or Wd.shape[0] != H or Wd.shape[1] != Wg.shape[0]:
+        raise ValueError(
+            f"{prefix}: shape mismatch — x[...,{H}], Wg{tuple(Wg.shape)}, Wu{tuple(Wu.shape)}, Wd{tuple(Wd.shape)}; "
+            f"expected Wg/Wu = [I, {H}] and Wd = [{H}, I]"
+        )
+    # A custom Function's forward always runs with GradMode disabled, while
+    # ctx.needs_input_grad still mirrors the inputs' requires_grad flags even under
+    # an outer no_grad()/inference_mode(). Capture the outer state here so inference
+    # selects the h-only graph even when model parameters remain trainable.
+    grad_mask = 0
+    if torch.is_grad_enabled():
+        for bit, tensor in ((_GRAD_X, x), (_GRAD_WG, Wg), (_GRAD_WU, Wu), (_GRAD_WD, Wd)):
+            if tensor.requires_grad:
+                grad_mask |= bit
+    return _GatedMLP.apply(x, Wg, Wu, Wd, grad_mask, activation, situ_beta, situ_linear_beta)
 
 
 def swiglu_mlp(x, Wg, Wu, Wd):
@@ -475,32 +663,46 @@ def swiglu_mlp(x, Wg, Wu, Wd):
     or a shape mismatch (the kernels are bf16-only; other dtypes are not silently
     reinterpreted).
     """
-    for name, t in (("x", x), ("Wg", Wg), ("Wu", Wu), ("Wd", Wd)):
-        if t.dtype != torch.bfloat16:
-            raise TypeError(f"cudnn.gemm.swiglu_mlp: {name} must be bfloat16, got {t.dtype}")
-        if t.device.type != "cuda":
-            raise ValueError(f"cudnn.gemm.swiglu_mlp: {name} must be a CUDA tensor, got device {t.device}")
-    if any(t.device != x.device for t in (Wg, Wu, Wd)):
-        raise ValueError(
-            "cudnn.gemm.swiglu_mlp: x, Wg, Wu, and Wd must be on the same CUDA device; " f"got x={x.device}, Wg={Wg.device}, Wu={Wu.device}, Wd={Wd.device}"
-        )
-    if x.dim() < 2 or Wg.dim() != 2 or Wu.dim() != 2 or Wd.dim() != 2:
-        raise ValueError(
-            f"cudnn.gemm.swiglu_mlp: expected x[...,H] and 2-D Wg/Wu[I,H], Wd[H,I]; got x{tuple(x.shape)} Wg{tuple(Wg.shape)} Wu{tuple(Wu.shape)} Wd{tuple(Wd.shape)}"
-        )
-    H = x.shape[-1]
-    if Wg.shape != Wu.shape or Wg.shape[1] != H or Wd.shape[0] != H or Wd.shape[1] != Wg.shape[0]:
-        raise ValueError(
-            f"cudnn.gemm.swiglu_mlp: shape mismatch — x[...,{H}], Wg{tuple(Wg.shape)}, Wu{tuple(Wu.shape)}, Wd{tuple(Wd.shape)}; "
-            f"expected Wg/Wu = [I, {H}] and Wd = [{H}, I]"
-        )
-    # A custom Function's forward always runs with GradMode disabled, while
-    # ctx.needs_input_grad still mirrors the inputs' requires_grad flags even under
-    # an outer no_grad()/inference_mode(). Capture the outer state here so inference
-    # selects the h-only graph even when model parameters remain trainable.
-    grad_mask = 0
-    if torch.is_grad_enabled():
-        for bit, tensor in ((_GRAD_X, x), (_GRAD_WG, Wg), (_GRAD_WU, Wu), (_GRAD_WD, Wd)):
-            if tensor.requires_grad:
-                grad_mask |= bit
-    return _SwigluMLP.apply(x, Wg, Wu, Wd, grad_mask)
+    return _gated_mlp(
+        x,
+        Wg,
+        Wu,
+        Wd,
+        activation=_ACTIVATION_SILU,
+        situ_beta=None,
+        situ_linear_beta=None,
+        op_name="swiglu_mlp",
+    )
+
+
+def situ_mlp(x, Wg, Wu, Wd, *, beta=_KIMI_SITU_BETA, linear_beta=_KIMI_SITU_LINEAR_BETA):
+    """Dense bf16 Kimi SiTU-MLP with bounded gate and up branches on cuDNN.
+
+    ``gate_act = beta * tanh(gate / beta) * sigmoid(gate)``
+
+    ``up_act = linear_beta * tanh(up / linear_beta)``
+
+    ``out = (gate_act * up_act) @ Wd^T``
+
+    Args:
+        x: input activations ``[..., H]`` (bf16).
+        Wg, Wu: gate / up ``nn.Linear`` weights ``[I, H]`` (bf16).
+        Wd: down ``nn.Linear`` weight ``[H, I]`` (bf16).
+        beta: positive finite gate-tanh scale. Defaults to Kimi K3's 4.0.
+        linear_beta: positive finite up-branch tanh scale. Defaults to Kimi K3's 25.0.
+
+    Returns:
+        ``[..., H]`` (bf16). Differentiable w.r.t. all four inputs. The current
+        FROST backward is SwiGLU-only, so SiTU uses the exact cuDNN derivative
+        graph rather than substituting a swish derivative.
+    """
+    return _gated_mlp(
+        x,
+        Wg,
+        Wu,
+        Wd,
+        activation=_ACTIVATION_SITU,
+        situ_beta=beta,
+        situ_linear_beta=linear_beta,
+        op_name="situ_mlp",
+    )

--- a/test/python/gemm/test_swiglu_mlp.py
+++ b/test/python/gemm/test_swiglu_mlp.py
@@ -115,16 +115,13 @@ def test_swiglu_mlp_parity(M, H, inter):
     not (torch.cuda.is_available() and _cc() >= 100),
     reason="cuDNN SiTU-MLP fusion requires SM100 (Blackwell)",
 )
-def test_situ_mlp_kimi_k3_forward_and_cache_contract():
-    """Kimi's beta=4/linear-beta=25 formula is exact, and both values own plans.
+def test_situ_mlp_kimi_k3_forward_beta_contract():
+    """Kimi's defaults and alternate beta values follow the public formula.
 
     The published dense layer has H=7168/I=33792; shared experts use
     H=7168/I=6144 and routed experts H=3584/I=3072. This smaller matrix keeps L0
     practical while preserving the identical [M,H]@[H,I] semantic contract.
     """
-    import importlib
-
-    mod = importlib.import_module("cudnn.gemm.ops.swiglu_mlp")
     torch.manual_seed(10)
     M, H, inter = 128, 256, 256
     x = torch.randn(1, M, H, device="cuda", dtype=torch.bfloat16)
@@ -141,9 +138,7 @@ def test_situ_mlp_kimi_k3_forward_and_cache_contract():
 
     assert _rel_l2(official, official_ref) < _TOL, f"official SiTU rel={_rel_l2(official, official_ref):.2e}"
     assert _rel_l2(alternate, alternate_ref) < _TOL, f"alternate SiTU rel={_rel_l2(alternate, alternate_ref):.2e}"
-    assert not torch.equal(official, alternate), "different SiTU betas must not alias one cached plan"
-    configs = {key[-3:] for key in mod._SWIGLU_CACHE if key[:3] == (M, H, inter) and key[7] is False and key[8] == x.device.index}
-    assert {("situ", 4.0, 25.0), ("situ", 2.0, 8.0)} <= configs
+    assert not torch.equal(official, alternate), "different SiTU betas must retain distinct semantics"
 
 
 @pytest.mark.L0
@@ -182,7 +177,6 @@ def test_situ_mlp_kimi_k3_backward_parity_does_not_use_frost(monkeypatch):
     assert _rel_l2(out, ref) < _TOL, f"fwd rel={_rel_l2(out, ref):.2e}"
     for name, got, expected in zip(("dx", "dWg", "dWu", "dWd"), args, refs):
         assert _rel_l2(got.grad, expected.grad) < _TOL, f"{name} rel={_rel_l2(got.grad, expected.grad):.2e}"
-    assert any(key[:2] == (M, inter) and key[-3:] == ("situ", 4.0, 25.0) for key in mod._DSWIGLU_CACHE)
 
 
 @pytest.mark.L0
@@ -454,8 +448,8 @@ def test_swiglu_mlp_all_frozen_uses_h_only(monkeypatch):
     not (torch.cuda.is_available() and _cc() >= 100),
     reason="cuDNN SwiGLU-MLP fusion requires SM100 (Blackwell)",
 )
-def test_swiglu_mlp_h_only_matches_full_and_cache_switches():
-    """The output mask is part of the plan cache and must not change h rounding."""
+def test_swiglu_mlp_h_only_matches_full():
+    """Selecting saved preactivations must not change h rounding."""
     import importlib
 
     mod = importlib.import_module("cudnn.gemm.ops.swiglu_mlp")
@@ -473,8 +467,6 @@ def test_swiglu_mlp_h_only_matches_full_and_cache_switches():
     assert gate_full is not None and up_full is not None
     assert torch.equal(h_only_1, h_full)
     assert torch.equal(h_only_1, h_only_2)
-    matching = [key for key in mod._SWIGLU_CACHE if key[:3] == (M, H, inter)]
-    assert {key[7] for key in matching} == {False, True}
 
 
 @pytest.mark.L0

--- a/test/python/gemm/test_swiglu_mlp.py
+++ b/test/python/gemm/test_swiglu_mlp.py
@@ -1,19 +1,21 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Correctness tests for cudnn.gemm.ops.swiglu_mlp (dense bf16 SwiGLU-MLP).
+"""Correctness tests for dense bf16 SwiGLU and Kimi SiTU MLP contracts.
 
-The fused SwiGLU forward runs on cuDNN's runtime-fusion engine, which needs an
-SM100 (Blackwell) device; the op must match torch to bf16 noise on the output and
-all four gradients.
+The fused forwards run on cuDNN's runtime-fusion engine, which needs an SM100
+(Blackwell) device; both semantic entry points must match their exact torch
+references to bf16 noise on the output and all four gradients.
 """
+
+import inspect
 
 import pytest
 import torch
 import torch.nn.functional as F
 import torch.utils.checkpoint
 
-from cudnn.gemm.ops import swiglu_mlp
+from cudnn.gemm.ops import situ_mlp, swiglu_mlp
 
 
 def _cc():
@@ -25,11 +27,34 @@ def _rel_l2(a, b):
     return (a.float() - b.float()).norm().item() / max(b.float().norm().item(), 1e-9)
 
 
-def _ref(x, Wg, Wu, Wd):
-    return (F.silu(x @ Wg.t()) * (x @ Wu.t())) @ Wd.t()
+def _ref(x, Wg, Wu, Wd, *, activation="silu", situ_beta=4.0, situ_linear_beta=25.0):
+    gate = x @ Wg.t()
+    up = x @ Wu.t()
+    if activation == "silu":
+        h = F.silu(gate) * up
+    elif activation == "situ":
+        # Exact Kimi K3 contract: both Linear outputs are bf16, the bounded
+        # activation is evaluated in fp32, then h is cast back before down_proj.
+        gate_f, up_f = gate.float(), up.float()
+        gate_act = situ_beta * torch.tanh(gate_f / situ_beta) * torch.sigmoid(gate_f)
+        up_act = situ_linear_beta * torch.tanh(up_f / situ_linear_beta)
+        h = (gate_act * up_act).to(gate.dtype)
+    else:
+        raise AssertionError(f"unexpected reference activation {activation!r}")
+    return h @ Wd.t()
 
 
-def _dswiglu_ref(dh, gate, up):
+def _dswiglu_ref(dh, gate, up, *, activation="silu", situ_beta=4.0, situ_linear_beta=25.0):
+    if activation == "situ":
+        gate_f, up_f, dh_f = gate.float(), up.float(), dh.float()
+        sigmoid = torch.sigmoid(gate_f)
+        gate_tanh = torch.tanh(gate_f / situ_beta)
+        up_tanh = torch.tanh(up_f / situ_linear_beta)
+        gate_value = situ_beta * gate_tanh * sigmoid
+        up_value = situ_linear_beta * up_tanh
+        gate_grad = (1 - gate_tanh.square()) * sigmoid + situ_beta * gate_tanh * sigmoid * (1 - sigmoid)
+        up_grad = 1 - up_tanh.square()
+        return (dh_f * up_value * gate_grad).to(gate.dtype), (dh_f * gate_value * up_grad).to(up.dtype)
     sigmoid = torch.sigmoid(gate)
     silu = gate * sigmoid
     return dh * up * (sigmoid + silu * (1 - sigmoid)), dh * silu
@@ -38,6 +63,20 @@ def _dswiglu_ref(dh, gate, up):
 # bf16 noise across three chained GEMMs + the SwiGLU; cuDNN vs torch differ only by
 # accumulation order, so a relative-L2 at this level is the meaningful bar.
 _TOL = 2e-2
+
+
+@pytest.mark.L0
+def test_situ_mlp_has_a_distinct_semantic_entry_point():
+    """Do not overload the public SwiGLU symbol with an activation string."""
+    import cudnn.gemm as gemm
+
+    assert gemm.situ_mlp is situ_mlp
+    assert tuple(inspect.signature(swiglu_mlp).parameters) == ("x", "Wg", "Wu", "Wd")
+    situ_signature = inspect.signature(situ_mlp)
+    assert tuple(situ_signature.parameters) == ("x", "Wg", "Wu", "Wd", "beta", "linear_beta")
+    assert situ_signature.parameters["beta"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert situ_signature.parameters["linear_beta"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert (situ_signature.parameters["beta"].default, situ_signature.parameters["linear_beta"].default) == (4.0, 25.0)
 
 
 @pytest.mark.L0
@@ -69,6 +108,107 @@ def test_swiglu_mlp_parity(M, H, inter):
     assert _rel_l2(out, ref) < _TOL, f"fwd rel={_rel_l2(out, ref):.2e}"
     for name, a, b in (("dx", x.grad, xr.grad), ("dWg", Wg.grad, Wgr.grad), ("dWu", Wu.grad, Wur.grad), ("dWd", Wd.grad, Wdr.grad)):
         assert _rel_l2(a, b) < _TOL, f"{name} rel={_rel_l2(a, b):.2e}"
+
+
+@pytest.mark.L0
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() and _cc() >= 100),
+    reason="cuDNN SiTU-MLP fusion requires SM100 (Blackwell)",
+)
+def test_situ_mlp_kimi_k3_forward_and_cache_contract():
+    """Kimi's beta=4/linear-beta=25 formula is exact, and both values own plans.
+
+    The published dense layer has H=7168/I=33792; shared experts use
+    H=7168/I=6144 and routed experts H=3584/I=3072. This smaller matrix keeps L0
+    practical while preserving the identical [M,H]@[H,I] semantic contract.
+    """
+    import importlib
+
+    mod = importlib.import_module("cudnn.gemm.ops.swiglu_mlp")
+    torch.manual_seed(10)
+    M, H, inter = 128, 256, 256
+    x = torch.randn(1, M, H, device="cuda", dtype=torch.bfloat16)
+    # Exercise both tanh bounds rather than staying in SiTU's near-linear range.
+    Wg = torch.randn(inter, H, device="cuda", dtype=torch.bfloat16) * 0.5
+    Wu = torch.randn(inter, H, device="cuda", dtype=torch.bfloat16) * 2.0
+    Wd = torch.randn(H, inter, device="cuda", dtype=torch.bfloat16) * 0.02
+
+    with torch.no_grad():
+        official = situ_mlp(x, Wg, Wu, Wd)
+        alternate = situ_mlp(x, Wg, Wu, Wd, beta=2.0, linear_beta=8.0)
+    official_ref = _ref(x, Wg, Wu, Wd, activation="situ", situ_beta=4.0, situ_linear_beta=25.0)
+    alternate_ref = _ref(x, Wg, Wu, Wd, activation="situ", situ_beta=2.0, situ_linear_beta=8.0)
+
+    assert _rel_l2(official, official_ref) < _TOL, f"official SiTU rel={_rel_l2(official, official_ref):.2e}"
+    assert _rel_l2(alternate, alternate_ref) < _TOL, f"alternate SiTU rel={_rel_l2(alternate, alternate_ref):.2e}"
+    assert not torch.equal(official, alternate), "different SiTU betas must not alias one cached plan"
+    configs = {key[-3:] for key in mod._SWIGLU_CACHE if key[:3] == (M, H, inter) and key[7] is False and key[8] == x.device.index}
+    assert {("situ", 4.0, 25.0), ("situ", 2.0, 8.0)} <= configs
+
+
+@pytest.mark.L0
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() and _cc() >= 100),
+    reason="cuDNN SiTU-MLP fusion requires SM100 (Blackwell)",
+)
+def test_situ_mlp_kimi_k3_backward_parity_does_not_use_frost(monkeypatch):
+    """All four gradients use exact dSiTU; the swish-only FROST path is closed."""
+    import importlib
+
+    mod = importlib.import_module("cudnn.gemm.ops.swiglu_mlp")
+
+    def forbidden_frost(*args, **kwargs):
+        raise AssertionError("SiTU must not launch the SwiGLU-only FROST backward")
+
+    monkeypatch.setattr(mod, "_FROST_BWD", True)
+    monkeypatch.setattr(mod, "_frost_dswiglu", forbidden_frost)
+    torch.manual_seed(11)
+    M, H, inter = 128, 256, 256
+    base = (
+        torch.randn(1, M, H, device="cuda", dtype=torch.bfloat16),
+        torch.randn(inter, H, device="cuda", dtype=torch.bfloat16) * 0.25,
+        torch.randn(inter, H, device="cuda", dtype=torch.bfloat16) * 1.0,
+        torch.randn(H, inter, device="cuda", dtype=torch.bfloat16) * 0.02,
+    )
+    args = tuple(t.detach().clone().requires_grad_(True) for t in base)
+    refs = tuple(t.detach().clone().requires_grad_(True) for t in base)
+    dout = torch.randn(1, M, H, device="cuda", dtype=torch.bfloat16) * 0.1
+
+    out = situ_mlp(*args)
+    ref = _ref(*refs, activation="situ", situ_beta=4.0, situ_linear_beta=25.0)
+    out.backward(dout)
+    ref.backward(dout)
+
+    assert _rel_l2(out, ref) < _TOL, f"fwd rel={_rel_l2(out, ref):.2e}"
+    for name, got, expected in zip(("dx", "dWg", "dWu", "dWd"), args, refs):
+        assert _rel_l2(got.grad, expected.grad) < _TOL, f"{name} rel={_rel_l2(got.grad, expected.grad):.2e}"
+    assert any(key[:2] == (M, inter) and key[-3:] == ("situ", 4.0, 25.0) for key in mod._DSWIGLU_CACHE)
+
+
+@pytest.mark.L0
+def test_situ_mlp_beta_contract_rejects_invalid_values():
+    """Beta errors are semantic and fail before any device launch."""
+    shape = (2, 2)
+    tensors = tuple(torch.empty(shape, dtype=torch.bfloat16) for _ in range(4))
+    cases = (
+        ({"beta": 0.0}, ValueError, "beta must be positive and finite"),
+        ({"linear_beta": float("nan")}, ValueError, "linear_beta must be positive and finite"),
+        ({"beta": True}, TypeError, "beta must be a positive finite Python number"),
+        ({"beta": None}, TypeError, "beta must be a positive finite Python number"),
+    )
+    for kwargs, error, match in cases:
+        with pytest.raises(error, match=match):
+            situ_mlp(*tensors, **kwargs)
+
+
+@pytest.mark.L0
+def test_frost_dswiglu_declines_situ_before_build_or_launch():
+    """A direct FROST call cannot silently substitute swish for bounded SiTU."""
+    from cudnn.gemm.ops.swiglu_mlp import _frost_dswiglu
+
+    operands = (torch.empty(0),) * 4
+    with pytest.raises(NotImplementedError, match="FROST backward only implements activation='silu'"):
+        _frost_dswiglu(*operands, activation="situ", situ_beta=4.0, situ_linear_beta=25.0)
 
 
 @pytest.mark.L0

--- a/test/python/gemm/test_swiglu_mlp.py
+++ b/test/python/gemm/test_swiglu_mlp.py
@@ -146,17 +146,8 @@ def test_situ_mlp_kimi_k3_forward_beta_contract():
     not (torch.cuda.is_available() and _cc() >= 100),
     reason="cuDNN SiTU-MLP fusion requires SM100 (Blackwell)",
 )
-def test_situ_mlp_kimi_k3_backward_parity_does_not_use_frost(monkeypatch):
-    """All four gradients use exact dSiTU; the swish-only FROST path is closed."""
-    import importlib
-
-    mod = importlib.import_module("cudnn.gemm.ops.swiglu_mlp")
-
-    def forbidden_frost(*args, **kwargs):
-        raise AssertionError("SiTU must not launch the SwiGLU-only FROST backward")
-
-    monkeypatch.setattr(mod, "_FROST_BWD", True)
-    monkeypatch.setattr(mod, "_frost_dswiglu", forbidden_frost)
+def test_situ_mlp_kimi_k3_backward_parity():
+    """The public operation computes all four exact dSiTU gradients."""
     torch.manual_seed(11)
     M, H, inter = 128, 256, 256
     base = (
@@ -193,16 +184,6 @@ def test_situ_mlp_beta_contract_rejects_invalid_values():
     for kwargs, error, match in cases:
         with pytest.raises(error, match=match):
             situ_mlp(*tensors, **kwargs)
-
-
-@pytest.mark.L0
-def test_frost_dswiglu_declines_situ_before_build_or_launch():
-    """A direct FROST call cannot silently substitute swish for bounded SiTU."""
-    from cudnn.gemm.ops.swiglu_mlp import _frost_dswiglu
-
-    operands = (torch.empty(0),) * 4
-    with pytest.raises(NotImplementedError, match="FROST backward only implements activation='silu'"):
-        _frost_dswiglu(*operands, activation="situ", situ_beta=4.0, situ_linear_beta=25.0)
 
 
 @pytest.mark.L0


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
- [ ] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions).

The milestone is set to **Frontend 1.29.0**. Projects remains unset because the current GitHub token does not have project scope.

## Affected area

Python API or bindings

## Summary

### Downstream model impact (combined attribution)

On B200, an official-count Kimi-K3 BF16 fprop+bprop feature-substack integration carrying a patch-identical rebase of this SiTU implementation measured **1.3567x / 1.3238x / 1.2189x** at 8K/16K/32K, removing **26.3% / 24.5% / 18.0%** of the declared substack latency. The all-on arm also replaces KDA and all three short convolutions, while MLA remains unchanged, so this is not a marginal #807 or full-model result. The SiTU implementation is unchanged from the measured branch; the current head adds documentation, contract-focused test cleanup, and an upstream rebase. The table is historical combined attribution, not a fresh current-head model rerun.


- Add a distinct `cudnn.gemm.situ_mlp(x, Wg, Wu, Wd, *, beta=4.0, linear_beta=25.0)` entry point for the bounded SiTU MLP used by Kimi K3, while leaving the existing `swiglu_mlp(x, Wg, Wu, Wd)` API and behavior unchanged.
- Implement `beta * tanh(gate / beta) * sigmoid(gate)` and `linear_beta * tanh(up / linear_beta)` with BF16 linear boundaries and FP32 pointwise computation.
- Add exact SiTU backward, activation/beta-aware plan caches and autograd snapshots, partial-gradient handling, and a fail-closed guard that prevents the SwiGLU-only FROST backward from serving SiTU.
- Share private graph/autograd machinery between the two semantic entry points and keep lazy exports stable in either import order.

## Why

Kimi K3 uses bounded gate and up activations rather than ordinary SwiGLU. Treating the two formulas as one public operation with an activation switch would make it easier to select the wrong derivative or reuse a semantically incompatible plan. A separate semantic entry point preserves the existing SwiGLU contract and makes both SiTU beta values explicit plan inputs.

The formula follows the [official Moonshot Kimi K3 implementation](https://huggingface.co/moonshotai/Kimi-K3/blob/main/modeling_kimi_linear.py).

For inference, cuDNN fuses both BF16 input projections with the FP32 SiTU pointwise sequence and multiply into one runtime-fusion kernel, rounds the fused activation to BF16, and executes the down projection as a second kernel. The exact PyTorch composition launches the projections and pointwise sequence separately. The measured advantage therefore comes from fewer launches and less intermediate traffic under the same math and BF16 boundaries; graph construction and autotuning happen before steady-state replay.

## Related issues

None.

## API and compatibility impact

This adds one public Python API:

```python
cudnn.gemm.situ_mlp(x, Wg, Wu, Wd, *, beta=4.0, linear_beta=25.0)
```

- `x` is BF16 `[..., H]`; `Wg` and `Wu` are BF16 `[I, H]`; `Wd` is BF16 `[H, I]`. All tensors must be on the same CUDA device.
- `beta` and `linear_beta` are keyword-only positive finite Python numbers. The defaults match Kimi K3.
- Forward and backward are differentiable with respect to all four tensor inputs. SiTU backward uses the exact cuDNN derivative graph and deliberately does not use the current SwiGLU-only FROST backward.
- The fused forward currently requires SM100 and BF16. Unsupported architectures or dtypes fail instead of silently selecting different semantics.
- Each distinct beta pair owns separately autotuned plan/workspace cache entries for the process lifetime.
- Existing `cudnn.gemm.swiglu_mlp` callers are backward compatible.

## Testing

- Current review head `aafea264e`: changed-file pre-commit, Python compilation, and diff checks passed.
- NVIDIA B200 with cuDNN 9.26 at the production-identical prior head `070d3edd2`: the complete L0 file reported **31 passed, 2 skipped**; the skipped cases require more than one visible GPU.
- NVIDIA B200 at current head: the four public SiTU API/forward/backward/beta-contract tests reported **4 passed, 28 deselected**.
- Forward and all four gradients match an independent PyTorch reference. Coverage also includes alternate-beta semantics, partial gradients, checkpointing, CUDA graph capture/replay, stream and device behavior, and public input validation. The current cleanup removes assertions that monkeypatch or directly call the private FROST route.

Same-process interleaved CUDA-graph replay device intervals, inference only, 9 median samples with 40 iterations per sample:

| Kimi K3 role | Shape `(M, H, I)` | cuDNN replay | PyTorch replay | PyTorch / cuDNN | Relative L2 |
|---|---:|---:|---:|---:|---:|
| dense | `(512, 7168, 33792)` | `0.552705 ms` | `0.887115 ms` | `1.605x` | `7.44e-4` |
| shared expert | `(2048, 7168, 6144)` | `0.370443 ms` | `0.627354 ms` | `1.694x` | `6.64e-4` |
| routed-expert proxy | `(128, 3584, 3072)` | `0.020578 ms` | `0.043139 ms` | `2.096x` | `6.06e-4` |

These timings cover the complete three-GEMM SiTU inference operator, not a single kernel. They exclude first-call graph construction and autotuning. The routed row count is an operation proxy rather than assembled MoE dispatch, and the results do not claim full-model, training-step, or non-B200 speedup.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `cudnn.gemm.situ_mlp` API for Kimi K3 bounded SiTU MLPs.
  - Supports configurable activation bounds with validated parameters.
  - Provides accurate forward and backward computations alongside existing SwiGLU functionality.
  - Automatically uses supported acceleration paths while preserving correct SiTU gradients.

- **Documentation**
  - Added integration guidance, performance measurements, and accuracy results for supported data types and expert configurations.

- **Tests**
  - Added coverage for SiTU forward/backward parity, parameter validation, API behavior, and acceleration-path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->