### PR TITLE
Prefer 1-CTA FROST plans for quantizing epilogues

### DIFF
--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -3376,19 +3376,28 @@ def _check_executable(chain: FusionChain) -> None:
         raise NotImplementedError("a norm2 reduction takes a square root after the kernel, which is a device operation this engine does not own")
 
 
+_TERMINAL_QUANT_ONE_CTA_MAX_M = 1408
+
+
 def plan_config(chain: FusionChain) -> TileConfig:
+    """Choose the automatic tile strategy for one analyzed fusion chain."""
     from .kernel_registry import preferred_strategy
     from .tile_config import select_config
 
     tile_m = chain.matmul.M
     if chain.moe is not None:
         tile_m = (chain.matmul.M + chain.moe.num_groups - 1) // chain.moe.num_groups
+    declared_rows = chain.matmul.M if chain.moe is not None else chain.matmul.M * chain.matmul.batch
     force_cta_group = None
-    if chain.num_gemms == 1 and chain.has_block_scale and chain.quants:
+    if chain.num_gemms == 1 and chain.has_block_scale and chain.quants and declared_rows <= _TERMINAL_QUANT_ONE_CTA_MAX_M:
         # A terminal block-scale quantizer adds a substantial epilogue drain.
-        # Keep both M tiles independently scheduled instead of coupling them in
-        # a 2-CTA MMA pair. select_config still scores the cluster after this
-        # strategy choice; no cluster shape is pinned here.
+        # Keep both M tiles independently scheduled over the measured row
+        # envelope instead of coupling them in a 2-CTA MMA pair. For dense
+        # batches, every batch contributes M rows; for MoE, total M is the only
+        # plan-time upper bound on a runtime expert group -- the average in
+        # tile_m cannot bound device-resident offsets.
+        # select_config still scores the cluster after this strategy choice;
+        # no cluster shape is pinned here.
         force_cta_group = 1
     config = select_config(
         tile_m,

--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -3383,6 +3383,13 @@ def plan_config(chain: FusionChain) -> TileConfig:
     tile_m = chain.matmul.M
     if chain.moe is not None:
         tile_m = (chain.matmul.M + chain.moe.num_groups - 1) // chain.moe.num_groups
+    force_cta_group = None
+    if chain.num_gemms == 1 and chain.has_block_scale and chain.quants:
+        # A terminal block-scale quantizer adds a substantial epilogue drain.
+        # Keep both M tiles independently scheduled instead of coupling them in
+        # a 2-CTA MMA pair. select_config still scores the cluster after this
+        # strategy choice; no cluster shape is pinned here.
+        force_cta_group = 1
     config = select_config(
         tile_m,
         chain.matmul.N,
@@ -3391,6 +3398,7 @@ def plan_config(chain: FusionChain) -> TileConfig:
         block_scale=chain.has_block_scale,
         b_n_major=chain.matmul.b_major == "n",
         b_elem_bytes=DTYPE_BYTES[chain.matmul.b_dtype],
+        force_cta_group=force_cta_group,
     )
     # Re-target at the preferred family and MMA-inst K width; cta_group rides
     # the geometry and only moves when the family cannot serve it (sm120 is

--- a/python/cudnn/gemm/frost/tile_config.py
+++ b/python/cudnn/gemm/frost/tile_config.py
@@ -849,6 +849,7 @@ def select_config(
     b_n_major: bool = False,
     b_elem_bytes: int = 2,
     sm_count: int | None = None,
+    force_cta_group: int | None = None,
 ) -> TileConfig:
     """Pick a TileConfig from problem geometry.
 
@@ -862,12 +863,17 @@ def select_config(
     ``K`` is optional only for callers that do not have it to hand; without it the
     small-K bias is neutral and everything else is unchanged. The pick is an sm100
     geometry; a caller building for another template family passes it through
-    :func:`as_pipeline`.
+    :func:`as_pipeline`. ``force_cta_group`` overrides only the 1-CTA/2-CTA
+    strategy heuristic; tile and cluster geometry are still selected and scored
+    normally for that final strategy.
     """
     sm = sm_count if sm_count is not None else _sm_count()
     x = max(1, num_gemms)
     # Multi-GEMM shares the 256-wide N budget across the parallel GEMMs.
     cta_n_max = max(32, min(256, _floor_pow2(256 // x)))
+
+    if force_cta_group not in (None, 1, 2) or isinstance(force_cta_group, bool):
+        raise ValueError(f"force_cta_group must be None, 1, or 2; got {force_cta_group!r}")
 
     # --- tile ---------------------------------------------------------------
     rep_m = min(_floor_pow2(max(1, M)), 4096)
@@ -892,7 +898,14 @@ def select_config(
 
     # 2-CTA needs a second M-tile to be worth it. Multi-GEMM is only implemented by the
     # 1ctamma template (see compiler._check_multi_gemm), so it stays at 1.
-    cta_group = 1 if x > 1 else (2 if M > cta_m else 1)
+    if x > 1:
+        if force_cta_group == 2:
+            raise NotImplementedError("multi-GEMM is 1ctamma-only; cannot force cta_group=2")
+        cta_group = 1
+    elif force_cta_group is not None:
+        cta_group = force_cta_group
+    else:
+        cta_group = 2 if M > cta_m else 1
 
     if block_scale:
         cta_m = max(cta_m, 128)

--- a/test/python/gemm/frost/test_tile_select_analytic.py
+++ b/test/python/gemm/frost/test_tile_select_analytic.py
@@ -16,12 +16,8 @@ Selection is pure geometry, so every invariant is checkable on CPU:
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 import pytest
 from cudnn.gemm.frost.tile_config import by_name, select_config
-
-pytestmark = pytest.mark.L0
 
 MS = (1, 4, 16, 32, 64, 96, 128, 129, 256, 512, 1024, 4096)
 NS = (32, 64, 128, 256, 512, 1024, 4096, 8192, 10240)
@@ -65,43 +61,19 @@ def test_multi_gemm_budget_and_constraints():
             assert cfg.cta_group == 1, "multi-GEMM is 1ctamma-only"
 
 
+@pytest.mark.L0
 @pytest.mark.parametrize("M", [384, 768, 1408])
-def test_terminal_quant_strategy_forces_one_cta_and_rescores_cluster(M):
-    """Ultra-like terminal-quant up projections use 1-CTA; the matching down
-    geometry keeps the default 2-CTA policy.  The cluster remains a scorer result."""
-    from cudnn.gemm.frost import tile_config as tc
-
-    sm_count = 148
-    up = select_config(
-        M,
-        5120,
-        1,
-        K=2048,
-        block_scale=True,
-        sm_count=sm_count,
-        force_cta_group=1,
-    )
-    down = select_config(M, 2048, 1, K=5120, block_scale=True, sm_count=sm_count)
-    assert up.cta_group == 1
-    assert down.cta_group == 2
-
-    pool = [cluster for cluster in tc._CLUSTERS_1D + tc._CLUSTERS_2D if not tc._hang_prone(up.cta_tile_m, up.cta_tile_n, *cluster)]
-    expected = max(
-        pool,
-        key=lambda cluster: tc._cluster_score(
-            M,
-            5120,
-            up.cta_tile_m,
-            up.cta_tile_n,
-            1,
-            *cluster,
-            sm_count,
-        ),
-    )
-    assert (up.cga_size_m, up.cga_size_n) == expected
+def test_terminal_quant_strategy_can_select_one_cta(M):
+    """The strategy override selects a runnable 1-CTA config without pinning a
+    private tile or cluster identity."""
+    config = select_config(M, 5120, 1, K=2048, block_scale=True, sm_count=148, force_cta_group=1)
+    assert config.cta_group == 1
+    assert by_name(config.name) is config
 
 
+@pytest.mark.L0
 def test_force_cta_group_rejects_invalid_or_unsupported_values():
+    """Invalid overrides and a 2-CTA multi-GEMM request fail explicitly."""
     for value in (True, 0, 3):
         with pytest.raises(ValueError, match="force_cta_group"):
             select_config(384, 5120, 1, force_cta_group=value)
@@ -109,28 +81,91 @@ def test_force_cta_group_rejects_invalid_or_unsupported_values():
         select_config(384, 5120, 2, force_cta_group=2)
 
 
-@pytest.mark.parametrize("M", [384, 768, 1408])
-def test_planner_applies_one_cta_to_dense_and_grouped_terminal_quant_chain(monkeypatch, M):
+def _block_scaled_chain(*, M, N=5120, K=2048, batch=1, quantized=True, moe_groups=None):
+    """Build the semantic IR consumed by the planner, without GPU storage."""
+    from cudnn.gemm.frost.fusion_ir import (
+        BlockQuantizeSpec,
+        BlockScaleSpec,
+        FusionChain,
+        MatmulSpec,
+        MoeSpec,
+        OutputSpec,
+        gemm_source,
+    )
+
+    if moe_groups is not None and batch != 1:
+        raise ValueError("MoE analyzer IR always has batch=1")
+    matmul = MatmulSpec(
+        M=M,
+        N=N,
+        K=K,
+        batch=batch,
+        a_batch=1,
+        b_batch=batch,
+        a_dtype="fp4_e2m1",
+        b_dtype="fp4_e2m1",
+    )
+    block_scale = BlockScaleSpec(
+        a_dtype="fp4_e2m1",
+        b_dtype="fp4_e2m1",
+        block_size_a=(1, 16),
+        block_size_b=(16, 1),
+        sf_dtype_a="fp8_e4m3",
+        sf_dtype_b="fp8_e4m3",
+        sfa_reorder="F8_128x4",
+        sfb_reorder="F8_128x4",
+        dequant_compute_a="fp32",
+        dequant_compute_b="fp32",
+        dequant_out_a="fp32",
+        dequant_out_b="fp32",
+    )
+    source = gemm_source(0)
+    quants = [BlockQuantizeSpec(source_ref=source, block_size=16, scale_dtype="fp8_e4m3")] if quantized else []
+    output = OutputSpec(source_ref=source, dtype="fp4_e2m1", quant_idx=0) if quantized else OutputSpec(source_ref=source, dtype="bf16")
+    moe = None if moe_groups is None else MoeSpec(num_experts=moe_groups, num_groups=moe_groups)
+    return FusionChain(matmul=matmul, block_scale=block_scale, moe=moe, quants=quants, output_specs=[output])
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("M,expected_cta_group", [(384, 1), (1408, 1), (1409, 2), (4096, 2)])
+def test_planner_bounds_terminal_quant_one_cta_to_measured_total_rows(monkeypatch, M, expected_cta_group):
+    """The terminal-quant override stops at the measured total-row boundary."""
     from cudnn.gemm.frost import compiler, kernel_registry
 
     monkeypatch.setattr(kernel_registry, "preferred_strategy", lambda _chain, config: config)
+    config = compiler.plan_config(_block_scaled_chain(M=M))
+    assert config.cta_group == expected_cta_group
 
-    def chain(*, N, K, quants, moe_groups=None):
-        return SimpleNamespace(
-            matmul=SimpleNamespace(M=M * (moe_groups or 1), N=N, K=K, b_major="k", b_dtype="fp4_e2m1"),
-            moe=None if moe_groups is None else SimpleNamespace(num_groups=moe_groups),
-            num_gemms=1,
-            has_block_scale=True,
-            has_moe=moe_groups is not None,
-            quants=quants,
-        )
 
-    up = compiler.plan_config(chain(N=5120, K=2048, quants=[object()]))
-    down = compiler.plan_config(chain(N=2048, K=5120, quants=[]))
-    moe_quant = compiler.plan_config(chain(N=5120, K=2048, quants=[object()], moe_groups=64))
-    assert up.cta_group == 1
-    assert down.cta_group == 2
-    assert moe_quant.cta_group == 1
+@pytest.mark.L0
+def test_planner_uses_total_m_not_unobservable_moe_row_distribution(monkeypatch):
+    """A low average cannot extend the override past total M; naturally M-starved
+    grouped problems may still select 1-CTA through the ordinary heuristic."""
+    from cudnn.gemm.frost import compiler, kernel_registry
+
+    monkeypatch.setattr(kernel_registry, "preferred_strategy", lambda _chain, config: config)
+    assert compiler.plan_config(_block_scaled_chain(M=2816, moe_groups=2)).cta_group == 2
+    assert compiler.plan_config(_block_scaled_chain(M=2816, moe_groups=23)).cta_group == 1
+
+
+@pytest.mark.L0
+def test_planner_counts_every_dense_batch_row(monkeypatch):
+    """A small per-batch M does not bypass the total declared-row boundary."""
+    from cudnn.gemm.frost import compiler, kernel_registry
+
+    monkeypatch.setattr(kernel_registry, "preferred_strategy", lambda _chain, config: config)
+    assert compiler.plan_config(_block_scaled_chain(M=384, batch=3)).cta_group == 1
+    assert compiler.plan_config(_block_scaled_chain(M=384, batch=4)).cta_group == 2
+
+
+@pytest.mark.L0
+def test_non_quantizing_graph_keeps_default_cta_policy(monkeypatch):
+    """A block-scaled graph without a materialized quantizer is unaffected."""
+    from cudnn.gemm.frost import compiler, kernel_registry
+
+    monkeypatch.setattr(kernel_registry, "preferred_strategy", lambda _chain, config: config)
+    config = compiler.plan_config(_block_scaled_chain(M=384, N=2048, K=5120, quantized=False))
+    assert config.cta_group == 2
 
 
 def test_n_major_b_lifts_the_n_tile():

--- a/test/python/gemm/frost/test_tile_select_analytic.py
+++ b/test/python/gemm/frost/test_tile_select_analytic.py
@@ -16,9 +16,12 @@ Selection is pure geometry, so every invariant is checkable on CPU:
 
 from __future__ import annotations
 
-import pytest
+from types import SimpleNamespace
 
+import pytest
 from cudnn.gemm.frost.tile_config import by_name, select_config
+
+pytestmark = pytest.mark.L0
 
 MS = (1, 4, 16, 32, 64, 96, 128, 129, 256, 512, 1024, 4096)
 NS = (32, 64, 128, 256, 512, 1024, 4096, 8192, 10240)
@@ -60,6 +63,74 @@ def test_multi_gemm_budget_and_constraints():
             cfg = select_config(M, 8192, ng, K=4096)
             assert cfg.cta_tile_n <= cap
             assert cfg.cta_group == 1, "multi-GEMM is 1ctamma-only"
+
+
+@pytest.mark.parametrize("M", [384, 768, 1408])
+def test_terminal_quant_strategy_forces_one_cta_and_rescores_cluster(M):
+    """Ultra-like terminal-quant up projections use 1-CTA; the matching down
+    geometry keeps the default 2-CTA policy.  The cluster remains a scorer result."""
+    from cudnn.gemm.frost import tile_config as tc
+
+    sm_count = 148
+    up = select_config(
+        M,
+        5120,
+        1,
+        K=2048,
+        block_scale=True,
+        sm_count=sm_count,
+        force_cta_group=1,
+    )
+    down = select_config(M, 2048, 1, K=5120, block_scale=True, sm_count=sm_count)
+    assert up.cta_group == 1
+    assert down.cta_group == 2
+
+    pool = [cluster for cluster in tc._CLUSTERS_1D + tc._CLUSTERS_2D if not tc._hang_prone(up.cta_tile_m, up.cta_tile_n, *cluster)]
+    expected = max(
+        pool,
+        key=lambda cluster: tc._cluster_score(
+            M,
+            5120,
+            up.cta_tile_m,
+            up.cta_tile_n,
+            1,
+            *cluster,
+            sm_count,
+        ),
+    )
+    assert (up.cga_size_m, up.cga_size_n) == expected
+
+
+def test_force_cta_group_rejects_invalid_or_unsupported_values():
+    for value in (True, 0, 3):
+        with pytest.raises(ValueError, match="force_cta_group"):
+            select_config(384, 5120, 1, force_cta_group=value)
+    with pytest.raises(NotImplementedError, match="multi-GEMM is 1ctamma-only"):
+        select_config(384, 5120, 2, force_cta_group=2)
+
+
+@pytest.mark.parametrize("M", [384, 768, 1408])
+def test_planner_applies_one_cta_to_dense_and_grouped_terminal_quant_chain(monkeypatch, M):
+    from cudnn.gemm.frost import compiler, kernel_registry
+
+    monkeypatch.setattr(kernel_registry, "preferred_strategy", lambda _chain, config: config)
+
+    def chain(*, N, K, quants, moe_groups=None):
+        return SimpleNamespace(
+            matmul=SimpleNamespace(M=M * (moe_groups or 1), N=N, K=K, b_major="k", b_dtype="fp4_e2m1"),
+            moe=None if moe_groups is None else SimpleNamespace(num_groups=moe_groups),
+            num_gemms=1,
+            has_block_scale=True,
+            has_moe=moe_groups is not None,
+            quants=quants,
+        )
+
+    up = compiler.plan_config(chain(N=5120, K=2048, quants=[object()]))
+    down = compiler.plan_config(chain(N=2048, K=5120, quants=[]))
+    moe_quant = compiler.plan_config(chain(N=5120, K=2048, quants=[object()], moe_groups=64))
+    assert up.cta_group == 1
+    assert down.cta_group == 2
+    assert moe_quant.cta_group == 1
 
 
 def test_n_major_b_lifts_the_n_tile():


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
- [ ] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions). The milestone is set; the current token cannot set organization Projects.

## Affected area

FE OSS kernels or CuTeDSL

## Summary

- Prefer 1-CTA FROST plans for a single-root block-scaled GEMM with a terminal block-scale quantizer when its declared total rows are at most 1408.
- Use `M * batch` for dense graphs and flat total `M` for grouped-MoE graphs; do not infer a bound from runtime expert averages.
- Leave larger declared workloads, non-quantizing graphs, and cluster scoring on the existing heuristic.

At the measured B200 routed-expert row counts 384/768/1408, the complete up/quantize plus down leaf proxy improved by **1.083x / 1.050x / 1.046x**. This is a model-shaped two-graph leaf proxy, not a full MoE block or model result.

## Why

A terminal block-scale quantizer adds a long epilogue drain after the MMA. At the audited small-row regime, coupling two M tiles as a 2-CTA MMA pair is slower than scheduling them independently. The evidence does not justify overriding the existing selector at arbitrary M, so the policy is deliberately bounded to the measured regime.

The matching non-quantizing down projection remains on its ordinary heuristic. For MoE, flat total `M` is the only static upper bound on any runtime expert; average rows per expert can hide arbitrary skew and is not used for selection.

## Related issues

None.

## API and compatibility impact

No public API changes. This only narrows internal analytic plan selection for one semantic class: a single-root block-scaled graph with a terminal block-scale quantizer and declared total rows `<= 1408`. Invalid overrides still fail closed, and multi-GEMM remains restricted to its existing 1-CTA contract.

## Testing

- Analytic selector tests use real `FusionChain` IR and observable CTA policy: **11 L0 passed; 17 full-file passed**.
- ComputeLab B200 structured correctness passed before every timing point, including nonuniform values and physical scale reorder.
- Current-head boundary sweep (`34231d13a`) proved the intended route transition:

| declared rows | selected up route | two-FROST-graph CUDA replay |
|---:|---|---:|
| 384 | 1-CTA, cluster1x1 | 28.614 us |
| 1408 | 1-CTA, cluster1x1 | 41.028 us |
| 1536 | 2-CTA, cluster2x1 | 42.484 us |
| 4096 | existing 2-CTA large-tile heuristic | 84.144 us |

The performance A/B used the actual block-scaled up/terminal-quant graph followed by its block-scaled down graph. Medians came from paired, interleaved CUDA-event rounds:

| routed rows | old planner | bounded 1-CTA policy | speedup |
|---:|---:|---:|---:|
| 384 | 33.331 us | 30.766 us | 1.083x |
| 768 | 41.140 us | 39.191 us | 1.050x |
| 1408 | 49.386 us | 47.202 us | 1.046x |

A separate 2816-row, 23-active-expert ragged experiment measured 1-CTA versus matching 2-CTA for the quantizing up graph at `52.781 us` versus `83.842 us` (`1.5885x`). That is explicitly config-vs-config evidence, not an effect of this bounded override: normal grouped selection can already choose 1-CTA from the small per-group tiles. It is not a full-path or end-to-end result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved execution planning for block-scaled quantization workloads, including dense and mixture-of-experts scenarios.
  * Enhanced output handling for multi-result GEMM operations.
  * Added support for selecting optimized single-CTA execution where applicable.

* **Reliability**
  * Added validation for unsupported execution-configuration overrides.
  * Expanded coverage for boundary conditions and preserved existing behavior for non-quantizing workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->