### PR TITLE
feat(frost): add segmented MoE row-scale quantization

### DIFF
--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -58,7 +58,12 @@ from .dtypes import (
     tensor_alignment,
 )
 from .epilogue_codegen import EpilogueSnippets, generate, tma_out_ready_marker, tma_out_value
-from .fusion_ir import ZERO_PRESERVING_OPS, FusionChain, TensorRef
+from .fusion_ir import (
+    ZERO_PRESERVING_OPS,
+    FusionChain,
+    TensorRef,
+    segmented_row_scale_capacity_rows,
+)
 from .recipe import (
     CONST,
     FROM_M,
@@ -3007,6 +3012,34 @@ def _sf_blob_reject(named_blobs) -> "str | None":
     return None
 
 
+def _grouped_row_quant_scale_blob_reject(
+    chain: FusionChain,
+    outputs,
+    total_rows: int,
+    runtime_n: int,
+    num_groups: int,
+) -> str | None:
+    """Reject a strided view where grouped-row quant stores raw blob offsets.
+
+    The F8_128x4 epilogue deliberately addresses the physical atom stream and
+    does not apply the runtime tensor strides. Reuse the input-SF packed-blob
+    contract so every accepted destination is one dense byte run.
+    """
+    blobs = []
+    for spec, buf in zip(chain.outputs, outputs):
+        if not spec.is_quant_scale:
+            continue
+        quant_idx = int(spec.source.rsplit("_", 1)[1])
+        quant = chain.quants[quant_idx]
+        if not quant.grouped_by_moe or quant.axis == 1:
+            continue
+        padded_n_blocks = ((runtime_n // quant.block_size + 3) // 4) * 4
+        required_rows = segmented_row_scale_capacity_rows(total_rows, num_groups)
+        required = required_rows * padded_n_blocks * DTYPE_BYTES[quant.scale_dtype]
+        blobs.append((f"grouped row quant scale output[{quant_idx}]", buf, required))
+    return _sf_blob_reject(blobs) if blobs else None
+
+
 def _check_input_alignment(chain: FusionChain) -> None:
     """Graph-time TMA input-alignment gate (the runtime dims are re-checked in
     ``CompiledFusedGemm.__call__`` — the kernel is shape-agnostic, so the call
@@ -3282,6 +3315,14 @@ def _check_block_quant_supported(
                 f"cols_per_acc_stage={cols_per_acc_stage} and to {MAX_EPI_CHUNK_ELEMS} "
                 f"elements); got block_size={q.block_size}, vsize={vsize}"
             )
+        if q.grouped_by_moe and q.axis != 1:
+            if not chain.has_moe:
+                raise NotImplementedError("grouped row block_scale_quantize requires a MoE grouped matmul graph")
+            if not chain.has_block_scale:
+                raise NotImplementedError(
+                    "grouped row block_scale_quantize currently requires a block-scaled MoE "
+                    "matmul whose scheduler supplies the per-group 128-row scale prefix"
+                )
         if q.axis == 1:
             # Col quant: a warp (block 32) or half-warp (block 16) of rows is
             # one M block; the redux needs every row guard uniform across the
@@ -3323,13 +3364,26 @@ def _check_block_quant_supported(
                 f"config={config.name}"
             )
         if q.scale_reorder == "F8_128x4":
-            expected_scale_dim = (
-                chain.matmul.batch,
-                ((chain.matmul.M + 127) // 128) * 128,
-                (((chain.matmul.N // q.block_size) + 3) // 4) * 4,
-            )
-            if q.scale_dim != expected_scale_dim:
-                raise NotImplementedError("F8_128x4 block_scale_quantize scale output currently requires " f"scale_dim={expected_scale_dim}; got {q.scale_dim}")
+            padded_n_blocks = (((chain.matmul.N // q.block_size) + 3) // 4) * 4
+            if q.grouped_by_moe and q.axis != 1:
+                required_rows = segmented_row_scale_capacity_rows(chain.matmul.M, chain.moe.num_groups)
+                if q.scale_dim is None or q.scale_dim[0] != 1 or q.scale_dim[1] < required_rows or q.scale_dim[1] % 128 or q.scale_dim[2] != padded_n_blocks:
+                    raise NotImplementedError(
+                        "grouped F8_128x4 row block_scale_quantize requires "
+                        "scale_dim=(1, segmented_rows, padded_N_blocks), with "
+                        f"segmented_rows a multiple of 128 and >= the static worst-case {required_rows}, and "
+                        f"padded_N_blocks={padded_n_blocks}; got {q.scale_dim}"
+                    )
+            else:
+                expected_scale_dim = (
+                    chain.matmul.batch,
+                    ((chain.matmul.M + 127) // 128) * 128,
+                    padded_n_blocks,
+                )
+                if q.scale_dim != expected_scale_dim:
+                    raise NotImplementedError(
+                        "F8_128x4 block_scale_quantize scale output currently requires " f"scale_dim={expected_scale_dim}; got {q.scale_dim}"
+                    )
 
 
 _FORCE_STG_EPI = False
@@ -4209,6 +4263,15 @@ class CompiledMoeBlockScaleGemm:
                     f"{_expected_output_shape(spec, self.chain, (S, N, K))}; "
                     f"got {tuple(t.shape)}"
                 )
+        scale_blob_reason = _grouped_row_quant_scale_blob_reject(
+            self.chain,
+            outputs,
+            S,
+            N,
+            int(first_token_offset.shape[0]),
+        )
+        if scale_blob_reason is not None:
+            raise ValueError(scale_blob_reason)
         _initialize_reduction_outputs(self.chain, outputs, stream)
         # num_experts = weight batch (E); num_groups = first_token_offset len
         # (BxE, may exceed E; group g uses expert g % E). From runtime tensors.
@@ -4278,8 +4341,9 @@ class CompiledMoeBlockScaleGemm:
         if sfa or sfb:
             _S, _N, _K = snk[0], snk[1], snk[2]
             _sf_k4 = ((_K // self.chain.block_scale.block_size) + 3) // 4
+            _segmented_sfa_rows = segmented_row_scale_capacity_rows(int(_S), int(fto.shape[0]))
             _r_sf = _sf_blob_reject(
-                [(f"SFA[{i}]", x, 512 * _sf_k4 * ((_S + 127) // 128)) for i, x in enumerate(sfa or [])]
+                [(f"SFA[{i}]", x, 4 * _sf_k4 * _segmented_sfa_rows) for i, x in enumerate(sfa or [])]
                 + [(f"SFB[{j}]", x, 512 * _sf_k4 * ((_N + 127) // 128) * int(b_bufs[j].shape[0])) for j, x in enumerate(sfb or [])]
             )
             if _r_sf is not None:
@@ -4346,6 +4410,15 @@ class CompiledMoeBlockScaleGemm:
                     f"multi-GEMM MoE block-scale output {spec.source!r} must have shape "
                     f"{_expected_output_shape(spec, chain, (S, N, K))}; got {tuple(ci.shape)}"
                 )
+        scale_blob_reason = _grouped_row_quant_scale_blob_reject(
+            chain,
+            outs,
+            S,
+            N,
+            int(first_token_offset.shape[0]),
+        )
+        if scale_blob_reason is not None:
+            raise ValueError(scale_blob_reason)
         _initialize_reduction_outputs(chain, outs, stream)
         num_experts = int(b_slots[0][0].shape[0])
         num_groups = int(first_token_offset.shape[0])

--- a/python/cudnn/gemm/frost/epilogue_codegen.py
+++ b/python/cudnn/gemm/frost/epilogue_codegen.py
@@ -917,6 +917,12 @@ def _scale_store_dtype(scale_dtype: Dtype) -> str:
     return "cutlass.Int8" if scale_dtype == "fp8_e5m3" else DTYPE_TO_CUTLASS[scale_dtype]
 
 
+def _f8_128x4_row_scale_index_expr(row: str, scale_col: str, n_col_quads: str, *, atom_base: str | None = None) -> str:
+    """Physical byte index for one logical row scale in an F8_128x4 blob."""
+    prefix = f"{atom_base} + " if atom_base is not None else ""
+    return f"{prefix}(({row} // 128) * {n_col_quads} + ({scale_col} // 4)) * 512 + " f"({row} % 32) * 16 + (({row} % 128) // 32) * 4 + ({scale_col} % 4)"
+
+
 def _emit_scale_quantize(p: str, sfx: str, src: str, scale_var: str, back_var: str, quant: BlockQuantizeSpec) -> list[str]:
     """Quantize one fp32 scale to ``quant.scale_dtype`` and read the STORED
     value back as fp32 — the data is divided by what was actually written, not
@@ -1194,19 +1200,34 @@ def _emit_block_quant(
             ),
         ]
     )
+    if quant.grouped_by_moe:
+        # Slot 6 is the block-scaled MoE scheduler's prefix sum of preceding
+        # groups' ceil(group_rows/128) scale atoms. Restart the row address at
+        # the group-local row and that atom base.
+        lines.extend(
+            [
+                f"{p}_local_row = row - group_begin",
+                f"{p}_ncb = ((N // {bs}) + 3) // 4",
+                f"{p}_base = start_sf_block_m * {p}_ncb * 512",
+            ]
+        )
     for k in range(n_sub):
         lines.append(f"{p}_scol{k} = col_j // {bs} + {k}")
         if quant.scale_reorder == "F8_128x4":
-            lines.extend(
-                [
-                    f"{p}_ncb{k} = ((N // {bs}) + 3) // 4",
-                    (
-                        f"{p}_sidx{k} = {batch_index_expr} * quant_scale_stride_l_{quant_idx} + "
-                        f"((row // 128) * {p}_ncb{k} + ({p}_scol{k} // 4)) * 512 + "
-                        f"(row % 32) * 16 + ((row % 128) // 32) * 4 + ({p}_scol{k} % 4)"
-                    ),
-                ]
-            )
+            if quant.grouped_by_moe:
+                sidx = _f8_128x4_row_scale_index_expr(f"{p}_local_row", f"{p}_scol{k}", f"{p}_ncb", atom_base=f"{p}_base")
+                lines.append(f"{p}_sidx{k} = {batch_index_expr} * quant_scale_stride_l_{quant_idx} + {sidx}")
+            else:
+                lines.extend(
+                    [
+                        f"{p}_ncb{k} = ((N // {bs}) + 3) // 4",
+                        (
+                            f"{p}_sidx{k} = {batch_index_expr} * quant_scale_stride_l_{quant_idx} + "
+                            f"((row // 128) * {p}_ncb{k} + ({p}_scol{k} // 4)) * 512 + "
+                            f"(row % 32) * 16 + ((row % 128) // 32) * 4 + ({p}_scol{k} % 4)"
+                        ),
+                    ]
+                )
         else:
             lines.append(
                 f"{p}_sidx{k} = {batch_index_expr} * quant_scale_stride_l_{quant_idx} + "

--- a/python/cudnn/gemm/frost/fusion_ir.py
+++ b/python/cudnn/gemm/frost/fusion_ir.py
@@ -257,6 +257,23 @@ QUANT_DATA_DTYPES = ("fp8_e4m3", "fp8_e5m2", "fp4_e2m1")
 M_MAJOR_OUT_DTYPES = ("bf16", "fp16", "fp32", "fp8_e4m3", "fp8_e5m2", "fp8_e8m0", "fp8_e5m3", "int8", "uint8", "int32")
 
 
+def segmented_row_scale_capacity_rows(total_rows: int, num_groups: int) -> int:
+    """Static rows needed by independently 128-row-padded group segments.
+
+    Runtime group sizes are device data. For ``total_rows=M`` split across at
+    most ``num_groups=G`` non-empty groups, the exact maximum number of 128-row
+    atoms is ``A + (M - A) // 128``, where ``A=min(M,G)``. This graph-time
+    envelope admits every valid partition without synchronizing the offsets.
+    """
+    if total_rows < 0:
+        raise ValueError(f"segmented row scale total_rows must be non-negative; got {total_rows}")
+    if num_groups < 1:
+        raise ValueError(f"segmented row scale num_groups must be positive; got {num_groups}")
+    active = min(total_rows, num_groups)
+    max_atoms = active + (total_rows - active) // 128
+    return 128 * max_atoms
+
+
 @dataclass(frozen=True)
 class BlockQuantizeSpec:
     """One block-scale quantize node (cuDNN ``block_scale_quantize``): each
@@ -269,10 +286,16 @@ class BlockQuantizeSpec:
     Col quant: compact `(B, M/block_size, N)`, F8_128x4 = the transposed atom
     `(B, rup(N,128), rup(M/bs,4))`.
 
-    ``grouped_by_moe`` (col + F8_128x4 only; declared via ``group_offset=fto``
-    on the quant node) = per-group segmented col-SF: each routed group is its
-    own compact table at its atom-quad base, same total footprint. Runtime
-    CONTRACT: every fto value must be a multiple of ``4 * block_size``."""
+    ``grouped_by_moe`` (F8_128x4 only; declared via ``group_offset=fto`` on the
+    quant node) makes each routed group its own scale segment. For col quant the
+    segment is the group's compact transposed table at its atom-quad base; the
+    runtime CONTRACT remains that every fto value is a multiple of
+    ``4 * block_size``. For row quant the segment starts at the prefix sum of
+    the preceding groups' 128-row atom counts. For fixed ``M`` and declared
+    group count ``G``, ``scale_dim[1]`` must cover the graph-time worst case
+    ``128 * (A + (M-A)//128)``, ``A=min(M,G)``. This admits every valid runtime
+    partition without reading device offsets on the host. Padding scale bytes
+    are not written by the quantizer and must be initialized to a valid value."""
 
     source_ref: int
     block_size: int
@@ -297,8 +320,8 @@ class BlockQuantizeSpec:
             raise ValueError(f"block quantize scale reordering {self.scale_reorder!r} is not supported; " "expected None or F8_128x4")
         if self.compute_dtype != "fp32":
             raise ValueError(f"block quantize compute_dtype {self.compute_dtype!r} is not supported; " "expected fp32")
-        if self.grouped_by_moe and (self.axis != 1 or self.scale_reorder != "F8_128x4"):
-            raise ValueError("grouped block quantize requires the M axis (col) and F8_128x4 scale reordering")
+        if self.grouped_by_moe and self.scale_reorder != "F8_128x4":
+            raise ValueError("grouped block quantize requires F8_128x4 scale reordering")
 
 
 @dataclass(frozen=True)

--- a/python/cudnn/gemm/frost/graph_analyzer.py
+++ b/python/cudnn/gemm/frost/graph_analyzer.py
@@ -32,6 +32,7 @@ from .fusion_ir import (
     ReductionSpec,
     TensorRef,
     gemm_source,
+    segmented_row_scale_capacity_rows,
 )
 
 # Dtype + op tables
@@ -648,6 +649,7 @@ def _collect_quants(
     N: int,
     err_ctx: str,
     fto_id: int | None = None,
+    num_groups: int | None = None,
 ) -> tuple[list[BlockQuantizeSpec], list["_RecordedOp"], list[Dtype], list[Any]]:
     """Fold every reachable ``block_scale_quantize`` whose data output is
     materialized into a :class:`BlockQuantizeSpec`. Returns (specs, recorded
@@ -685,12 +687,6 @@ def _collect_quants(
         if qop.group_offset is not None:
             if fto_id is None or qop.group_offset != fto_id:
                 raise ValueError(f"block_scale_quantize {qop.op_name!r} groupOffset must be the MoE " "first_token_offset tensor")
-            if axis != 1:
-                raise ValueError(
-                    f"block_scale_quantize {qop.op_name!r} with groupOffset supports only "
-                    "the M axis (axis=1, col quant); row scales are already per-group "
-                    "contiguous in the global layout"
-                )
             if scale_reorder != "F8_128x4":
                 raise ValueError(f"block_scale_quantize {qop.op_name!r} with groupOffset requires " "F8_128x4 scale reordering")
             grouped_by_moe = True
@@ -724,7 +720,33 @@ def _collect_quants(
             scale_dim = expected_scale_dim
         if len(scale_dim) != 3:
             raise ValueError(f"block_scale_quantize scale output must be rank-3; got {scale_dim}")
-        if tuple(scale_dim) != expected_scale_dim:
+        grouped_row = grouped_by_moe and axis != 1
+        if grouped_row:
+            # Runtime fto values live on device. Size for the exact worst-case
+            # partition at graph time rather than synchronizing fto or relying
+            # on an execute-time caller precondition.
+            if num_groups is None:
+                raise AssertionError("grouped row block quantize recorded without a MoE group count")
+            if qop.scale_output not in _TENSOR_DIM_OVERRIDE:
+                raise ValueError(
+                    f"block_scale_quantize {qop.op_name!r} grouped row scale output " "requires an explicit scale dim [1, segmented_rows, padded_N_blocks]"
+                )
+            padded_n_blocks = _round_up(int(N) // bs, 4)
+            required_rows = segmented_row_scale_capacity_rows(int(M), num_groups)
+            if int(batch) != 1 or int(scale_dim[0]) != 1:
+                raise ValueError(
+                    f"block_scale_quantize {qop.op_name!r} grouped row scales require " f"batch=1 and scale_dim[0]=1; got batch={batch}, scale_dim={scale_dim}"
+                )
+            if int(scale_dim[1]) < required_rows or int(scale_dim[1]) % 128:
+                raise ValueError(
+                    f"block_scale_quantize {qop.op_name!r} grouped row scale_dim[1] "
+                    f"must be a 128-row-aligned static worst-case capacity >= {required_rows}; got {scale_dim[1]}"
+                )
+            if int(scale_dim[2]) != padded_n_blocks:
+                raise ValueError(
+                    f"block_scale_quantize {qop.op_name!r} grouped row scale_dim[2] " f"must be padded N/block_size = {padded_n_blocks}; got {scale_dim[2]}"
+                )
+        elif tuple(scale_dim) != expected_scale_dim:
             raise ValueError(f"block_scale_quantize scale dim must be {expected_scale_dim}; got {scale_dim}")
         compute = qop.compute_dtype if qop.compute_dtype is not None else compute_dtype
         quants.append(
@@ -1124,6 +1146,7 @@ def _build_multi_moe_chain(
         N,
         "multi-MoE",
         fto_id=fto_id,
+        num_groups=num_groups,
     )
 
     # Dense outputs in plain recorder (set_output) order — no output position

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd.py
@@ -1608,6 +1608,7 @@ def _kernel(
                 is_valid = (_slot.subview(3)).load()
                 group_begin = (_slot.subview(4)).load()
                 group_end = (_slot.subview(5)).load()
+                start_sf_block_m = (_slot.subview(6)).load()
                 group_idx = (_slot.subview(7)).load()
             else:
                 slot = sched_storage.subview(sched_stage * SCHED_SLOT_WORDS)
@@ -1616,6 +1617,7 @@ def _kernel(
                 is_valid = (slot.subview(3)).load()
                 group_begin = (slot.subview(4)).load()
                 group_end = (slot.subview(5)).load()
+                start_sf_block_m = (slot.subview(6)).load()
                 group_idx = (slot.subview(7)).load()
             if elect_one:
                 nvvm.mbarrier_arrive(sched_empty_mbar_ptr.subview(sched_stage))

--- a/test/python/gemm/frost/gemm_test_utils.py
+++ b/test/python/gemm/frost/gemm_test_utils.py
@@ -14,6 +14,7 @@ import pytest
 import torch
 
 from cudnn.gemm.frost.compiler import force_stg_epi as _force_stg_epi, jit_from_cudnn_graph
+from cudnn.gemm.frost.fusion_ir import segmented_row_scale_capacity_rows
 from cudnn.gemm.frost.tile_config import by_name
 
 # --- GPU / arch gate -------------------------------------------------------
@@ -42,6 +43,15 @@ requires_sm100 = pytest.mark.skipif(
     _SM is None or not (100 <= _SM < 120),
     reason="needs a Blackwell-family GPU (100 <= SM < 120), have " + ("none" if _SM is None else f"sm_{_SM}"),
 )
+
+
+def with_static_segmented_capacity(live: torch.Tensor, total_rows: int, num_groups: int, scale_cols: int) -> torch.Tensor:
+    """Copy live scales into deterministic, analyzer-sized segmented storage."""
+    capacity_rows = segmented_row_scale_capacity_rows(total_rows, num_groups)
+    result = torch.ones((1, capacity_rows, scale_cols), dtype=live.dtype, device=live.device)
+    result.view(-1)[: live.numel()].copy_(live.reshape(-1))
+    return result
+
 
 # test_matmul.py sweeps every matmul family (sm100 tcgen05 + sm120 warp-MMA), so
 # its module gate is the union of their arch ranges; a config whose own family

--- a/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
@@ -310,11 +310,11 @@ def test_analyzer_detects_moe_grouped_block_scale_matmul_fwd_reduction() -> None
     assert [o.source for o in chain.outputs] == ["matmul", "reduction_0"]
 
 
-_SUPER_SEGMENTED_SCALE_DIM = (1, 67840, 168)
+_SEGMENTED_SCALE_DIM_M2816_G512_N2688 = (1, 67840, 168)
 
 
-def _super_segmented_row_quant_graph(*, axis=-1, scale_dim=_SUPER_SEGMENTED_SCALE_DIM, reorder=True):
-    """Metadata-only shape matching Super's routed 1024 -> 2688 up leaf."""
+def _segmented_row_quant_graph(*, axis=-1, scale_dim=_SEGMENTED_SCALE_DIM_M2816_G512_N2688, reorder=True):
+    """Metadata-only 512-group, 2816-row, 1024-to-2688 projection shape."""
     return _build_graph(
         512,
         2816,
@@ -334,12 +334,12 @@ def _super_segmented_row_quant_graph(*, axis=-1, scale_dim=_SUPER_SEGMENTED_SCAL
 
 @pytest.mark.parametrize("axis", [-1, 2])
 def test_analyzer_accepts_explicit_segmented_row_scale_capacity(axis) -> None:
-    chain = analyze(_super_segmented_row_quant_graph(axis=axis))
+    chain = analyze(_segmented_row_quant_graph(axis=axis))
     quant = chain.quants[0]
     assert chain.has_moe and chain.has_block_scale
     assert (quant.axis, quant.block_size, quant.scale_dtype) == (axis, 16, "fp8_e4m3")
     assert quant.scale_reorder == "F8_128x4"
-    assert quant.scale_dim == _SUPER_SEGMENTED_SCALE_DIM
+    assert quant.scale_dim == _SEGMENTED_SCALE_DIM_M2816_G512_N2688
     assert quant.grouped_by_moe
 
 
@@ -355,12 +355,12 @@ def test_analyzer_accepts_explicit_segmented_row_scale_capacity(axis) -> None:
 )
 def test_segmented_row_quant_rejects_invalid_capacity(scale_dim, message) -> None:
     with pytest.raises(ValueError, match=message):
-        analyze(_super_segmented_row_quant_graph(scale_dim=scale_dim))
+        analyze(_segmented_row_quant_graph(scale_dim=scale_dim))
 
 
 def test_segmented_row_quant_requires_f8_128x4() -> None:
     with pytest.raises(ValueError, match="requires F8_128x4"):
-        analyze(_super_segmented_row_quant_graph(reorder=False))
+        analyze(_segmented_row_quant_graph(reorder=False))
 
 
 @pytest.mark.parametrize(
@@ -385,8 +385,8 @@ def test_segmented_row_scale_static_capacity(total_rows, num_groups, expected_ro
     assert segmented_row_scale_capacity_rows(total_rows, num_groups) == expected_rows
 
 
-def test_segmented_row_quant_codegen_uses_scheduler_prefix_and_group_local_row(monkeypatch) -> None:
-    chain = analyze(_super_segmented_row_quant_graph())
+def test_segmented_row_quant_codegen_emits_group_local_scale_addressing(monkeypatch) -> None:
+    chain = analyze(_segmented_row_quant_graph())
     cfg = by_name(_SEGMENTED_ROW_CFG)
     monkeypatch.setattr(compiler, "_current_arch", lambda device=None: 100)
     monkeypatch.setattr(compiler, "_grid_num_clusters", lambda _cfg, device=None: 1)
@@ -400,12 +400,11 @@ def test_segmented_row_quant_codegen_uses_scheduler_prefix_and_group_local_row(m
         tma_slots=tma_slots,
         packed_lanes=compiler._epi_packed_lanes(cfg),
     )
-    assert "_q0_local_row = row - group_begin" in snippets.epilogue
-    assert "_q0_base = start_sf_block_m * _q0_ncb * 512" in snippets.epilogue
-    assert "(_q0_local_row // 128)" in snippets.epilogue
+    for semantic_name in ("_q0_local_row", "group_begin", "_q0_base", "start_sf_block_m", "_q0_ncb"):
+        assert semantic_name in snippets.epilogue
     rendered = _render_block_scale_template(chain, snippets, cfg)
-    assert "start_sf_block_m = (_slot.subview(6)).load()" in rendered
-    assert "start_sf_block_m = (slot.subview(6)).load()" in rendered
+    assert "start_sf_block_m" in rendered
+    assert "subview(6)" in rendered
 
 
 def test_segmented_row_scale_address_map_is_concatenated_per_group_atoms() -> None:

--- a/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
@@ -27,6 +27,7 @@ from gemm_test_utils import (
     reduction_ref as _reduction_ref,
     reduction_dims as _reduction_dims,
     assert_block_scale_reduction_close as _assert_block_scale_reduction_close,
+    with_static_segmented_capacity as _with_static_segmented_capacity,
 )
 
 from cudnn.gemm.frost.dtypes import DTYPE_FROM_CUDNN as _DTYPE_FROM_CUDNN
@@ -50,13 +51,6 @@ def _block_quant_q_atol(scale_dtype) -> float:
     # Non-pow2 E4M3 scales use the kernel's approximate reciprocal → up to one
     # smallest E4M3 output step off the torch reference.
     return 1.0 / 512.0 if scale_dtype is torch.float8_e4m3fn else 0.0
-
-
-def _with_static_segmented_capacity(live: torch.Tensor, total_rows: int, num_groups: int, scale_cols: int) -> torch.Tensor:
-    capacity_rows = segmented_row_scale_capacity_rows(total_rows, num_groups)
-    result = torch.ones((1, capacity_rows, scale_cols), dtype=live.dtype, device=live.device)
-    result.view(-1)[: live.numel()].copy_(live.reshape(-1))
-    return result
 
 
 # combo -> (block_size, data dtype, SF dtype).
@@ -424,7 +418,7 @@ def test_segmented_row_scale_address_map_is_concatenated_per_group_atoms() -> No
             for scale_col in (0, 3, 4, 83, 167):
                 base = start_block * n_col_quads * 512
                 expr = _f8_128x4_row_scale_index_expr(str(local_row), str(scale_col), str(n_col_quads), atom_base=str(base))
-                got = eval(expr, {"__builtins__": {}}, {})
+                got = eval(expr, {"__builtins__": {}}, {})  # noqa: S307 - expression is generated locally from integer inputs
                 within = ((local_row // 128) * n_col_quads + scale_col // 4) * 512 + (local_row % 32) * 16 + ((local_row % 128) // 32) * 4 + scale_col % 4
                 assert got == base + within
                 addresses.append(got)
@@ -986,6 +980,7 @@ def _run_e2e_segmented_row_quant_matches_bridge_and_down_output(config_name: str
 
 
 @requires_sm100
+@pytest.mark.L1
 @pytest.mark.parametrize(
     "config_name,cta_group,use_non_default_stream",
     [

--- a/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
@@ -12,7 +12,6 @@ import cudnn.gemm.frost  # noqa: F401  (installs hook)
 import pytest
 import torch
 
-from cudnn.gemm.frost import compiler
 from gemm_test_utils import (
     requires_sm100,
     requires_sm107,
@@ -31,8 +30,7 @@ from gemm_test_utils import (
 )
 
 from cudnn.gemm.frost.dtypes import DTYPE_FROM_CUDNN as _DTYPE_FROM_CUDNN
-from cudnn.gemm.frost.compiler import _check_block_quant_supported, _render_block_scale_template, jit_from_cudnn_graph
-from cudnn.gemm.frost.epilogue_codegen import _f8_128x4_row_scale_index_expr, generate
+from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
 from cudnn.gemm.frost.fusion_ir import segmented_row_scale_capacity_rows
 from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.tile_config import by_name
@@ -361,87 +359,6 @@ def test_segmented_row_quant_rejects_invalid_capacity(scale_dim, message) -> Non
 def test_segmented_row_quant_requires_f8_128x4() -> None:
     with pytest.raises(ValueError, match="requires F8_128x4"):
         analyze(_segmented_row_quant_graph(reorder=False))
-
-
-@pytest.mark.parametrize(
-    "total_rows,num_groups,expected_rows",
-    [
-        (0, 512, 0),
-        (1, 512, 128),
-        (127, 1, 128),
-        (128, 1, 128),
-        (129, 1, 256),
-        (255, 1, 256),
-        (256, 1, 256),
-        (257, 1, 384),
-        (258, 1, 384),
-        (128, 2, 256),
-        (2816, 4, 3200),
-        (2816, 23, 5632),
-        (2816, 512, 67840),
-    ],
-)
-def test_segmented_row_scale_static_capacity(total_rows, num_groups, expected_rows) -> None:
-    assert segmented_row_scale_capacity_rows(total_rows, num_groups) == expected_rows
-
-
-def test_segmented_row_quant_codegen_emits_group_local_scale_addressing(monkeypatch) -> None:
-    chain = analyze(_segmented_row_quant_graph())
-    cfg = by_name(_SEGMENTED_ROW_CFG)
-    monkeypatch.setattr(compiler, "_current_arch", lambda device=None: 100)
-    monkeypatch.setattr(compiler, "_grid_num_clusters", lambda _cfg, device=None: 1)
-    _check_block_quant_supported(chain, compiler._epi_vec_bytes(chain, cfg), cfg)
-    modes = compiler._store_modes(chain, cfg)
-    tma_slots = frozenset(i for i, mode in enumerate(modes) if mode == "tma")
-    snippets = generate(
-        chain,
-        vec_bytes_epi=compiler._epi_chunk_bytes(chain, cfg, bool(tma_slots)),
-        output_elem_bytes=1,
-        tma_slots=tma_slots,
-        packed_lanes=compiler._epi_packed_lanes(cfg),
-    )
-    for semantic_name in ("_q0_local_row", "group_begin", "_q0_base", "start_sf_block_m", "_q0_ncb"):
-        assert semantic_name in snippets.epilogue
-    rendered = _render_block_scale_template(chain, snippets, cfg)
-    assert "start_sf_block_m" in rendered
-    assert "subview(6)" in rendered
-
-
-def test_segmented_row_scale_address_map_is_concatenated_per_group_atoms() -> None:
-    group_rows, scale_cols = (100, 0, 140, 260), 168
-    n_col_quads = scale_cols // 4
-    start_block = 0
-    addresses = []
-    for count in group_rows:
-        for local_row in range(count):
-            for scale_col in (0, 3, 4, 83, 167):
-                base = start_block * n_col_quads * 512
-                expr = _f8_128x4_row_scale_index_expr(str(local_row), str(scale_col), str(n_col_quads), atom_base=str(base))
-                got = eval(expr, {"__builtins__": {}}, {})  # noqa: S307 - expression is generated locally from integer inputs
-                within = ((local_row // 128) * n_col_quads + scale_col // 4) * 512 + (local_row % 32) * 16 + ((local_row % 128) // 32) * 4 + scale_col % 4
-                assert got == base + within
-                addresses.append(got)
-        start_block += _ceil_div(count, 128)
-    assert start_block * 128 == sum(_ceil_div(count, 128) * 128 for count in group_rows)
-    assert len(addresses) == len(set(addresses))
-
-
-def test_plain_moe_segmented_row_quant_declines_without_prefix_scheduler() -> None:
-    S, N, K, E, G = 512, 256, 256, 4, 4
-    g = cudnn.pygraph(io_data_type=cudnn.data_type.BFLOAT16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
-    tok = g.tensor(name="token", dim=[1, S, K], stride=[S * K, K, 1], data_type=cudnn.data_type.BFLOAT16)
-    weight = g.tensor(name="weight", dim=[E, K, N], stride=[K * N, 1, K], data_type=cudnn.data_type.BFLOAT16)
-    fto = g.tensor(name="fto", dim=[G, 1, 1], stride=[1, 1, 1], data_type=cudnn.data_type.INT32)
-    out = g.moe_grouped_matmul(tok, weight, fto, mode=cudnn.moe_grouped_matmul_mode.NONE)
-    q, sf = g.block_scale_quantize(input=out, block_size=16, axis=-1, group_offset=fto, name="q")
-    q.set_data_type(cudnn.data_type.FP4_E2M1).set_output(True)
-    capacity_rows = segmented_row_scale_capacity_rows(S, G)
-    sf.set_dim([1, capacity_rows, 16]).set_stride([capacity_rows * 16, 16, 1])
-    sf.set_data_type(cudnn.data_type.FP8_E4M3).set_output(True).set_reordering_type(cudnn.tensor_reordering.F8_128x4)
-    chain = analyze(g)
-    assert chain.has_moe and not chain.has_block_scale and chain.quants[0].grouped_by_moe
-    with pytest.raises(NotImplementedError, match="requires a block-scaled MoE"):
-        _check_block_quant_supported(chain, 32, by_name(_SEGMENTED_ROW_CFG))
 
 
 # --------------------------------------------------------------------------- #

--- a/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
@@ -12,6 +12,7 @@ import cudnn.gemm.frost  # noqa: F401  (installs hook)
 import pytest
 import torch
 
+from cudnn.gemm.frost import compiler
 from gemm_test_utils import (
     requires_sm100,
     requires_sm107,
@@ -29,21 +30,33 @@ from gemm_test_utils import (
 )
 
 from cudnn.gemm.frost.dtypes import DTYPE_FROM_CUDNN as _DTYPE_FROM_CUDNN
-from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
+from cudnn.gemm.frost.compiler import _check_block_quant_supported, _render_block_scale_template, jit_from_cudnn_graph
+from cudnn.gemm.frost.epilogue_codegen import _f8_128x4_row_scale_index_expr, generate
+from cudnn.gemm.frost.fusion_ir import segmented_row_scale_capacity_rows
 from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.tile_config import by_name
+from test_matmul import _f8_row_scale_addr
 
 pytestmark = pytest.mark.L0
 
 
 _CFG = "CONFIG_sm100_128x256x128_128x256x32_cluster2x1"
 _CFG_1CTA = "CONFIG_sm100_128x256x128_128x256x32_cluster1x1"
+_SEGMENTED_ROW_CFG = "CONFIG_sm100_128x128x128_128x128x32_cluster1x2_1ctamma"
+_SEGMENTED_ROW_CFG_2CTA = "CONFIG_sm100_128x128x128_128x128x32_cluster2x1_2ctamma"
 
 
 def _block_quant_q_atol(scale_dtype) -> float:
     # Non-pow2 E4M3 scales use the kernel's approximate reciprocal → up to one
     # smallest E4M3 output step off the torch reference.
     return 1.0 / 512.0 if scale_dtype is torch.float8_e4m3fn else 0.0
+
+
+def _with_static_segmented_capacity(live: torch.Tensor, total_rows: int, num_groups: int, scale_cols: int) -> torch.Tensor:
+    capacity_rows = segmented_row_scale_capacity_rows(total_rows, num_groups)
+    result = torch.ones((1, capacity_rows, scale_cols), dtype=live.dtype, device=live.device)
+    result.view(-1)[: live.numel()].copy_(live.reshape(-1))
+    return result
 
 
 # combo -> (block_size, data dtype, SF dtype).
@@ -166,6 +179,9 @@ def _build_graph(
     quant_scale_dt=cudnn.data_type.FP8_E8M0,
     quant_scale_reorder=False,
     quant_scale_dim=None,
+    quant_block_size=32,
+    quant_axis=None,
+    quant_group_offset=False,
     weight_major="k",
 ):
     block_size, a_dt, sf_dt = _COMBOS[combo]
@@ -223,7 +239,12 @@ def _build_graph(
         R.set_dim(list(reduction_dims)).set_stride(list(stride))
         R.set_output(True).set_data_type(reduction_dt)
     if quant:
-        q, q_scale = g.block_scale_quantize(input=out, block_size=32, name="q")
+        quant_kwargs = {"input": out, "block_size": quant_block_size, "name": "q"}
+        if quant_axis is not None:
+            quant_kwargs["axis"] = quant_axis
+        if quant_group_offset:
+            quant_kwargs["group_offset"] = fto
+        q, q_scale = g.block_scale_quantize(**quant_kwargs)
         q.set_data_type(quant_out_dt).set_output(True)
         if quant_scale_dim is not None:
             q_scale.set_dim(list(quant_scale_dim)).set_stride([quant_scale_dim[1] * quant_scale_dim[2], quant_scale_dim[2], 1])
@@ -293,6 +314,141 @@ def test_analyzer_detects_moe_grouped_block_scale_matmul_fwd_reduction() -> None
     assert len(chain.reductions) == 1
     assert chain.reductions[0].mode == "add"
     assert [o.source for o in chain.outputs] == ["matmul", "reduction_0"]
+
+
+_SUPER_SEGMENTED_SCALE_DIM = (1, 67840, 168)
+
+
+def _super_segmented_row_quant_graph(*, axis=-1, scale_dim=_SUPER_SEGMENTED_SCALE_DIM, reorder=True):
+    """Metadata-only shape matching Super's routed 1024 -> 2688 up leaf."""
+    return _build_graph(
+        512,
+        2816,
+        2688,
+        1024,
+        num_groups=512,
+        quant=True,
+        quant_out_dt=cudnn.data_type.FP4_E2M1,
+        quant_scale_dt=cudnn.data_type.FP8_E4M3,
+        quant_scale_reorder=reorder,
+        quant_scale_dim=scale_dim,
+        quant_block_size=16,
+        quant_axis=axis,
+        quant_group_offset=True,
+    )
+
+
+@pytest.mark.parametrize("axis", [-1, 2])
+def test_analyzer_accepts_explicit_segmented_row_scale_capacity(axis) -> None:
+    chain = analyze(_super_segmented_row_quant_graph(axis=axis))
+    quant = chain.quants[0]
+    assert chain.has_moe and chain.has_block_scale
+    assert (quant.axis, quant.block_size, quant.scale_dtype) == (axis, 16, "fp8_e4m3")
+    assert quant.scale_reorder == "F8_128x4"
+    assert quant.scale_dim == _SUPER_SEGMENTED_SCALE_DIM
+    assert quant.grouped_by_moe
+
+
+@pytest.mark.parametrize(
+    "scale_dim,message",
+    [
+        (None, "explicit scale dim"),
+        ((2, 67840, 168), "batch=1"),
+        ((1, 67839, 168), "128-row-aligned"),
+        ((1, 65536, 168), "static worst-case capacity"),
+        ((1, 67840, 164), "padded N/block_size"),
+    ],
+)
+def test_segmented_row_quant_rejects_invalid_capacity(scale_dim, message) -> None:
+    with pytest.raises(ValueError, match=message):
+        analyze(_super_segmented_row_quant_graph(scale_dim=scale_dim))
+
+
+def test_segmented_row_quant_requires_f8_128x4() -> None:
+    with pytest.raises(ValueError, match="requires F8_128x4"):
+        analyze(_super_segmented_row_quant_graph(reorder=False))
+
+
+@pytest.mark.parametrize(
+    "total_rows,num_groups,expected_rows",
+    [
+        (0, 512, 0),
+        (1, 512, 128),
+        (127, 1, 128),
+        (128, 1, 128),
+        (129, 1, 256),
+        (255, 1, 256),
+        (256, 1, 256),
+        (257, 1, 384),
+        (258, 1, 384),
+        (128, 2, 256),
+        (2816, 4, 3200),
+        (2816, 23, 5632),
+        (2816, 512, 67840),
+    ],
+)
+def test_segmented_row_scale_static_capacity(total_rows, num_groups, expected_rows) -> None:
+    assert segmented_row_scale_capacity_rows(total_rows, num_groups) == expected_rows
+
+
+def test_segmented_row_quant_codegen_uses_scheduler_prefix_and_group_local_row(monkeypatch) -> None:
+    chain = analyze(_super_segmented_row_quant_graph())
+    cfg = by_name(_SEGMENTED_ROW_CFG)
+    monkeypatch.setattr(compiler, "_current_arch", lambda device=None: 100)
+    monkeypatch.setattr(compiler, "_grid_num_clusters", lambda _cfg, device=None: 1)
+    _check_block_quant_supported(chain, compiler._epi_vec_bytes(chain, cfg), cfg)
+    modes = compiler._store_modes(chain, cfg)
+    tma_slots = frozenset(i for i, mode in enumerate(modes) if mode == "tma")
+    snippets = generate(
+        chain,
+        vec_bytes_epi=compiler._epi_chunk_bytes(chain, cfg, bool(tma_slots)),
+        output_elem_bytes=1,
+        tma_slots=tma_slots,
+        packed_lanes=compiler._epi_packed_lanes(cfg),
+    )
+    assert "_q0_local_row = row - group_begin" in snippets.epilogue
+    assert "_q0_base = start_sf_block_m * _q0_ncb * 512" in snippets.epilogue
+    assert "(_q0_local_row // 128)" in snippets.epilogue
+    rendered = _render_block_scale_template(chain, snippets, cfg)
+    assert "start_sf_block_m = (_slot.subview(6)).load()" in rendered
+    assert "start_sf_block_m = (slot.subview(6)).load()" in rendered
+
+
+def test_segmented_row_scale_address_map_is_concatenated_per_group_atoms() -> None:
+    group_rows, scale_cols = (100, 0, 140, 260), 168
+    n_col_quads = scale_cols // 4
+    start_block = 0
+    addresses = []
+    for count in group_rows:
+        for local_row in range(count):
+            for scale_col in (0, 3, 4, 83, 167):
+                base = start_block * n_col_quads * 512
+                expr = _f8_128x4_row_scale_index_expr(str(local_row), str(scale_col), str(n_col_quads), atom_base=str(base))
+                got = eval(expr, {"__builtins__": {}}, {})
+                within = ((local_row // 128) * n_col_quads + scale_col // 4) * 512 + (local_row % 32) * 16 + ((local_row % 128) // 32) * 4 + scale_col % 4
+                assert got == base + within
+                addresses.append(got)
+        start_block += _ceil_div(count, 128)
+    assert start_block * 128 == sum(_ceil_div(count, 128) * 128 for count in group_rows)
+    assert len(addresses) == len(set(addresses))
+
+
+def test_plain_moe_segmented_row_quant_declines_without_prefix_scheduler() -> None:
+    S, N, K, E, G = 512, 256, 256, 4, 4
+    g = cudnn.pygraph(io_data_type=cudnn.data_type.BFLOAT16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    tok = g.tensor(name="token", dim=[1, S, K], stride=[S * K, K, 1], data_type=cudnn.data_type.BFLOAT16)
+    weight = g.tensor(name="weight", dim=[E, K, N], stride=[K * N, 1, K], data_type=cudnn.data_type.BFLOAT16)
+    fto = g.tensor(name="fto", dim=[G, 1, 1], stride=[1, 1, 1], data_type=cudnn.data_type.INT32)
+    out = g.moe_grouped_matmul(tok, weight, fto, mode=cudnn.moe_grouped_matmul_mode.NONE)
+    q, sf = g.block_scale_quantize(input=out, block_size=16, axis=-1, group_offset=fto, name="q")
+    q.set_data_type(cudnn.data_type.FP4_E2M1).set_output(True)
+    capacity_rows = segmented_row_scale_capacity_rows(S, G)
+    sf.set_dim([1, capacity_rows, 16]).set_stride([capacity_rows * 16, 16, 1])
+    sf.set_data_type(cudnn.data_type.FP8_E4M3).set_output(True).set_reordering_type(cudnn.tensor_reordering.F8_128x4)
+    chain = analyze(g)
+    assert chain.has_moe and not chain.has_block_scale and chain.quants[0].grouped_by_moe
+    with pytest.raises(NotImplementedError, match="requires a block-scaled MoE"):
+        _check_block_quant_supported(chain, 32, by_name(_SEGMENTED_ROW_CFG))
 
 
 # --------------------------------------------------------------------------- #
@@ -392,7 +548,7 @@ def _run_e2e(
         b = offsets_list[gi]
         e = offsets_list[gi + 1] if gi + 1 < num_groups else S
         sfa_parts.append(_to_blocked(sfa_log[b:e]))
-    sfa_blk = torch.cat(sfa_parts).view(1, -1, 1)
+    sfa_blk = _with_static_segmented_capacity(torch.cat(sfa_parts), S, num_groups, sf_k)
     sfb_blk = torch.cat([_to_blocked(sfb_log[e]) for e in range(E)]).view(E, sf_k, N)
     offsets = torch.tensor(offsets_list, dtype=offset_torch_dt, device=dev)
     if quant:
@@ -511,9 +667,10 @@ def _run_nonpacked_e2e(combo, config_name, cta_group, mode):
         cta_group=cta_group,
     )
 
-    sfa_blk = torch.cat(
+    sfa_live = torch.cat(
         [_to_blocked(sfa_log[offsets_list[gi] : (offsets_list[gi + 1] if gi + 1 < len(offsets_list) else S)]) for gi in range(len(offsets_list))]
-    ).view(1, -1, 1)
+    )
+    sfa_blk = _with_static_segmented_capacity(sfa_live, S, len(offsets_list), sf_k)
     sfb_blk = torch.cat([_to_blocked(sfb_log[e]) for e in range(E)]).view(E, sf_k, N)
     offsets = torch.tensor(offsets_list, dtype=torch.int32, device=dev)
     output_store = torch.zeros(1, S, N + 16, dtype=torch.bfloat16, device=dev)
@@ -657,6 +814,194 @@ def test_e2e_block_quant_epilogue(
         quant_scale_torch_dt=scale_torch_dt,
         quant_scale_reorder=scale_reorder,
     )
+
+
+def _run_e2e_segmented_row_quant_matches_bridge_and_down_output(config_name: str, cta_group: int) -> None:
+    """Direct segmented scales equal today's bridge on every consumer-live byte."""
+    torch.manual_seed(7)
+    dev = "cuda"
+    E, S, N, K, bs = 2, 512, 256, 512, 16
+    offsets_list = [0, 100, 100, 300]
+    counts = [(offsets_list[i + 1] if i + 1 < len(offsets_list) else S) - offsets_list[i] for i in range(len(offsets_list))]
+    scale_cols = N // bs
+    live_segmented_rows = sum(_ceil_div(count, 128) * 128 for count in counts)
+    capacity_rows = segmented_row_scale_capacity_rows(S, len(offsets_list))
+    segmented_dim = (1, capacity_rows, _ceil_div(scale_cols, 4) * 4)
+    common = {
+        "E": E,
+        "S": S,
+        "N": N,
+        "K": K,
+        "num_groups": len(offsets_list),
+        "combo": "nvfp4",
+        "quant": True,
+        "quant_out_dt": cudnn.data_type.FP4_E2M1,
+        "quant_scale_dt": cudnn.data_type.FP8_E4M3,
+        "quant_scale_reorder": True,
+        "quant_block_size": bs,
+        "quant_axis": -1,
+    }
+    direct = _plan(
+        _build_graph(**common, quant_scale_dim=segmented_dim, quant_group_offset=True),
+        config=by_name(config_name),
+        cta_group=cta_group,
+    )
+    global_dim = (1, _ceil_div(S, 128) * 128, segmented_dim[2])
+    global_up = _plan(
+        _build_graph(**common, quant_scale_dim=global_dim),
+        config=by_name(config_name),
+        cta_group=cta_group,
+    )
+
+    tok_u8 = torch.randint(0, 256, (1, S, K // 2), dtype=torch.uint8, device=dev)
+    weight_u8 = torch.randint(0, 256, (E, N, K // 2), dtype=torch.uint8, device=dev)
+    token, weight = tok_u8.view(torch.float4_e2m1fn_x2), weight_u8.view(torch.float4_e2m1fn_x2)
+    sfa_log = torch.randint(1, 4, (S, K // bs), device=dev).to(torch.float8_e4m3fn)
+    sfb_log = torch.randint(1, 4, (E, N, K // bs), device=dev).to(torch.float8_e4m3fn)
+    sfa_live = torch.cat([_to_blocked(sfa_log[begin : begin + count]) for begin, count in zip(offsets_list, counts) if count]).reshape(-1)
+    sfa = torch.full((1, capacity_rows, K // bs), 0x33, dtype=torch.uint8, device=dev).view(torch.float8_e4m3fn)
+    sfa.view(-1)[: sfa_live.numel()].copy_(sfa_live)
+    sfb = torch.cat([_to_blocked(sfb_log[e]) for e in range(E)]).view(E, K // bs, N)
+    offsets = torch.tensor(offsets_list, dtype=torch.int32, device=dev)
+    q_direct = torch.full((1, S, N // 2), 0xA5, dtype=torch.uint8, device=dev)
+    q_global = torch.full((1, S, N // 2), 0x5A, dtype=torch.uint8, device=dev)
+    sf_direct = torch.full(segmented_dim, 0x55, dtype=torch.uint8, device=dev).view(torch.float8_e4m3fn)
+    sf_global = torch.full(global_dim, 0x2A, dtype=torch.uint8, device=dev).view(torch.float8_e4m3fn)
+    bad_sf_store = torch.empty((1, capacity_rows, segmented_dim[2] + 16), dtype=torch.uint8, device=dev)
+    bad_sf = bad_sf_store[:, :, : segmented_dim[2]].view(torch.float8_e4m3fn)
+    assert not bad_sf.is_contiguous()
+    with pytest.raises(ValueError, match="packed blob"):
+        direct(_vp_bs(direct, token, weight, [q_direct, bad_sf], sfa, sfb, fto=offsets))
+    with pytest.raises(ValueError, match=r"SFA\[0\].*kernel reads"):
+        direct(_vp_bs(direct, token, weight, [q_direct, sf_direct], sfa_live.view(1, -1, 1), sfb, fto=offsets))
+
+    # A compiled plan admits runtime N from the weight/output shapes. The
+    # grouped-row scale blob remains graph-shaped, so a larger runtime N must
+    # be rejected before the epilogue can address past its last scale column.
+    runtime_n = N * 2
+    runtime_weight = torch.randint(0, 256, (E, runtime_n, K // 2), dtype=torch.uint8, device=dev).view(torch.float4_e2m1fn_x2)
+    runtime_sfb_log = torch.randint(1, 4, (E, runtime_n, K // bs), device=dev).to(torch.float8_e4m3fn)
+    runtime_sfb = torch.cat([_to_blocked(runtime_sfb_log[e]) for e in range(E)]).view(E, K // bs, runtime_n)
+    runtime_q = torch.full((1, S, runtime_n // 2), 0xC3, dtype=torch.uint8, device=dev)
+    sf_before = sf_direct.view(torch.uint8).clone()
+    with pytest.raises(ValueError, match=r"grouped row quant scale output\[0\].*kernel reads"):
+        direct(_vp_bs(direct, token, runtime_weight, [runtime_q, sf_direct], sfa, runtime_sfb, fto=offsets))
+    assert torch.all(runtime_q == 0xC3)
+    assert torch.equal(sf_direct.view(torch.uint8), sf_before)
+    global_up(_vp_bs(global_up, token, weight, [q_global, sf_global], sfa, sfb, fto=offsets))
+    direct(_vp_bs(direct, token, weight, [q_direct, sf_direct], sfa, sfb, fto=offsets))
+    torch.cuda.synchronize()
+
+    global_logical = sf_global.view(-1)[_f8_row_scale_addr(S, N, bs)]
+    bridged = torch.zeros_like(sf_direct)
+    valid_mask = torch.zeros(segmented_dim, dtype=torch.uint8, device=dev)
+    source_row = destination_byte = 0
+    for count in counts:
+        segment_bytes = _ceil_div(count, 128) * 128 * segmented_dim[2]
+        if count:
+            bridged.view(-1)[destination_byte : destination_byte + segment_bytes].copy_(_to_blocked(global_logical[source_row : source_row + count]))
+            live = torch.ones((count, scale_cols), dtype=torch.uint8, device=dev)
+            valid_mask.view(-1)[destination_byte : destination_byte + segment_bytes].copy_(_to_blocked(live))
+        source_row += count
+        destination_byte += segment_bytes
+    assert source_row == S
+    assert destination_byte == live_segmented_rows * segmented_dim[2]
+    valid = valid_mask.bool()
+    torch.testing.assert_close(q_direct, q_global, atol=0, rtol=0)
+    torch.testing.assert_close(sf_direct.view(torch.uint8)[valid], bridged.view(torch.uint8)[valid], atol=0, rtol=0)
+    assert torch.all(sf_direct.view(torch.uint8)[~valid] == 0x55)
+    assert torch.all(bridged.view(torch.uint8)[~valid] == 0)
+
+    recovered, cursor = [], 0
+    for count in counts:
+        segment_bytes = _ceil_div(count, 128) * 128 * segmented_dim[2]
+        if count:
+            recovered.append(sf_direct.view(-1)[cursor : cursor + segment_bytes][_f8_row_scale_addr(count, N, bs)])
+        cursor += segment_bytes
+    torch.testing.assert_close(torch.cat(recovered), global_logical, atol=0, rtol=0)
+
+    # Both handoffs feed the same down plan. Poisoned padding differs, so exact
+    # output equality proves no semantic output dependence on padded rows.
+    H = 128
+    down = _plan(_build_graph(E, S, H, N, len(offsets_list), combo="nvfp4"), config=by_name(config_name), cta_group=cta_group)
+    down_weight = torch.randint(0, 256, (E, H, N // 2), dtype=torch.uint8, device=dev).view(torch.float4_e2m1fn_x2)
+    down_sfb_log = torch.randint(1, 4, (E, H, N // bs), device=dev).to(torch.float8_e4m3fn)
+    down_sfb = torch.cat([_to_blocked(down_sfb_log[e]) for e in range(E)]).view(E, N // bs, H)
+    out_direct = torch.full((1, S, H), float("nan"), dtype=torch.bfloat16, device=dev)
+    out_bridged = torch.full((1, S, H), float("nan"), dtype=torch.bfloat16, device=dev)
+    down(_vp_bs(down, q_global.view(torch.float4_e2m1fn_x2), down_weight, out_bridged, bridged, down_sfb, fto=offsets))
+    down(_vp_bs(down, q_direct.view(torch.float4_e2m1fn_x2), down_weight, out_direct, sf_direct, down_sfb, fto=offsets))
+    torch.cuda.synchronize()
+    assert torch.isfinite(out_direct).all() and torch.isfinite(out_bridged).all()
+    torch.testing.assert_close(out_direct.view(torch.uint16), out_bridged.view(torch.uint16), atol=0, rtol=0)
+
+    # Reuse the exact same up/down plans and buffers with a second group
+    # partition. This exercises the runtime S/G envelope independently of the
+    # graph's original offsets and catches stale scheduler-prefix state.
+    balanced_offsets_list = [0, 128, 256, 384]
+    balanced_counts = [128, 128, 128, 128]
+    balanced_sfa_live = torch.cat([_to_blocked(sfa_log[begin : begin + count]) for begin, count in zip(balanced_offsets_list, balanced_counts)]).reshape(-1)
+    sfa.view(torch.uint8).fill_(0x44)
+    sfa.view(-1)[: balanced_sfa_live.numel()].copy_(balanced_sfa_live)
+    offsets.copy_(torch.tensor(balanced_offsets_list, dtype=torch.int32, device=dev))
+    q_direct.fill_(0xA5)
+    q_global.fill_(0x5A)
+    sf_direct.view(torch.uint8).fill_(0x55)
+    sf_global.view(torch.uint8).fill_(0x2A)
+    out_direct.fill_(float("nan"))
+    out_bridged.fill_(float("nan"))
+
+    global_up(_vp_bs(global_up, token, weight, [q_global, sf_global], sfa, sfb, fto=offsets))
+    direct(_vp_bs(direct, token, weight, [q_direct, sf_direct], sfa, sfb, fto=offsets))
+    torch.cuda.synchronize()
+    torch.testing.assert_close(q_direct, q_global, atol=0, rtol=0)
+
+    balanced_global_logical = sf_global.view(-1)[_f8_row_scale_addr(S, N, bs)]
+    balanced_bridged = torch.zeros_like(sf_direct)
+    balanced_valid_mask = torch.zeros(segmented_dim, dtype=torch.uint8, device=dev)
+    source_row = destination_byte = 0
+    for count in balanced_counts:
+        segment_bytes = _ceil_div(count, 128) * 128 * segmented_dim[2]
+        balanced_bridged.view(-1)[destination_byte : destination_byte + segment_bytes].copy_(
+            _to_blocked(balanced_global_logical[source_row : source_row + count])
+        )
+        balanced_live = torch.ones((count, scale_cols), dtype=torch.uint8, device=dev)
+        balanced_valid_mask.view(-1)[destination_byte : destination_byte + segment_bytes].copy_(_to_blocked(balanced_live))
+        source_row += count
+        destination_byte += segment_bytes
+    balanced_valid = balanced_valid_mask.bool()
+    torch.testing.assert_close(
+        sf_direct.view(torch.uint8)[balanced_valid],
+        balanced_bridged.view(torch.uint8)[balanced_valid],
+        atol=0,
+        rtol=0,
+    )
+    assert torch.all(sf_direct.view(torch.uint8)[~balanced_valid] == 0x55)
+
+    down(_vp_bs(down, q_global.view(torch.float4_e2m1fn_x2), down_weight, out_bridged, balanced_bridged, down_sfb, fto=offsets))
+    down(_vp_bs(down, q_direct.view(torch.float4_e2m1fn_x2), down_weight, out_direct, sf_direct, down_sfb, fto=offsets))
+    torch.cuda.synchronize()
+    assert torch.isfinite(out_direct).all() and torch.isfinite(out_bridged).all()
+    torch.testing.assert_close(out_direct.view(torch.uint16), out_bridged.view(torch.uint16), atol=0, rtol=0)
+
+
+@requires_sm100
+@pytest.mark.parametrize(
+    "config_name,cta_group,use_non_default_stream",
+    [
+        (_SEGMENTED_ROW_CFG, 1, False),
+        (_SEGMENTED_ROW_CFG_2CTA, 2, True),
+    ],
+    ids=("1cta-default-stream", "2cta-non-default-stream"),
+)
+def test_e2e_segmented_row_quant_matches_bridge_and_down_output(config_name, cta_group, use_non_default_stream) -> None:
+    if not use_non_default_stream:
+        _run_e2e_segmented_row_quant_matches_bridge_and_down_output(config_name, cta_group)
+        return
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        _run_e2e_segmented_row_quant_matches_bridge_and_down_output(config_name, cta_group)
+    stream.synchronize()
 
 
 @requires_sm100

--- a/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd_swiglu.py
+++ b/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd_swiglu.py
@@ -25,21 +25,14 @@ from gemm_test_utils import (
     unpack_fp4 as _unpack_fp4,
     rand_e8m0 as _rand_e8m0,
     block_quant_ref as _block_quant_ref,
+    with_static_segmented_capacity as _with_static_segmented_capacity,
 )
 
 from cudnn.gemm.frost.dtypes import DTYPE_FROM_CUDNN as _DTYPE_FROM_CUDNN
-from cudnn.gemm.frost.fusion_ir import segmented_row_scale_capacity_rows
 from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.tile_config import by_name
 
 pytestmark = pytest.mark.L0
-
-
-def _with_static_segmented_capacity(live: torch.Tensor, total_rows: int, num_groups: int, scale_cols: int) -> torch.Tensor:
-    capacity_rows = segmented_row_scale_capacity_rows(total_rows, num_groups)
-    result = torch.ones((1, capacity_rows, scale_cols), dtype=live.dtype, device=live.device)
-    result.view(-1)[: live.numel()].copy_(live.reshape(-1))
-    return result
 
 
 def _vp_moe_bs_mg(compiled, gemm_pairs, fto, outs, *aux):

--- a/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd_swiglu.py
+++ b/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd_swiglu.py
@@ -28,10 +28,18 @@ from gemm_test_utils import (
 )
 
 from cudnn.gemm.frost.dtypes import DTYPE_FROM_CUDNN as _DTYPE_FROM_CUDNN
+from cudnn.gemm.frost.fusion_ir import segmented_row_scale_capacity_rows
 from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.tile_config import by_name
 
 pytestmark = pytest.mark.L0
+
+
+def _with_static_segmented_capacity(live: torch.Tensor, total_rows: int, num_groups: int, scale_cols: int) -> torch.Tensor:
+    capacity_rows = segmented_row_scale_capacity_rows(total_rows, num_groups)
+    result = torch.ones((1, capacity_rows, scale_cols), dtype=live.dtype, device=live.device)
+    result.view(-1)[: live.numel()].copy_(live.reshape(-1))
+    return result
 
 
 def _vp_moe_bs_mg(compiled, gemm_pairs, fto, outs, *aux):
@@ -299,7 +307,7 @@ def test_dual_moe_grouped_block_scale_matmul_fwd_swiglu(combo, cfg_name, cta_gro
 
     # SFA padded to 128 rows PER GROUP, then concatenated; SFB per-expert.
     sfa_parts = [_to_blocked(sfa_log[offsets_list[gi] : offsets_list[gi + 1] if gi + 1 < num_groups else S]) for gi in range(num_groups)]
-    sfa_blk = torch.cat(sfa_parts).view(1, -1, 1)
+    sfa_blk = _with_static_segmented_capacity(torch.cat(sfa_parts), S, num_groups, sf_k)
     sfb0_blk = torch.cat([_to_blocked(sfb0_log[e]) for e in range(E)]).view(E, sf_k, N)
     sfb1_blk = torch.cat([_to_blocked(sfb1_log[e]) for e in range(E)]).view(E, sf_k, N)
     offsets = torch.tensor(offsets_list, dtype=torch.int32, device=dev)
@@ -369,7 +377,7 @@ def test_dual_moe_grouped_block_scale_matmul_fwd_swiglu_quant_epilogue(combo, cf
     assert compiled.chain.quants
 
     sfa_parts = [_to_blocked(sfa_log[offsets_list[gi] : offsets_list[gi + 1] if gi + 1 < num_groups else S]) for gi in range(num_groups)]
-    sfa_blk = torch.cat(sfa_parts).view(1, -1, 1)
+    sfa_blk = _with_static_segmented_capacity(torch.cat(sfa_parts), S, num_groups, sf_k)
     sfb0_blk = torch.cat([_to_blocked(sfb0_log[e]) for e in range(E)]).view(E, sf_k, N)
     sfb1_blk = torch.cat([_to_blocked(sfb1_log[e]) for e in range(E)]).view(E, sf_k, N)
     offsets = torch.tensor(offsets_list, dtype=torch.int32, device=dev)
@@ -448,7 +456,7 @@ def test_dual_moe_grouped_block_scale_matmul_fwd_swiglu_reduction_scalar() -> No
     )
 
     sfa_parts = [_to_blocked(sfa_log[offsets_list[gi] : offsets_list[gi + 1] if gi + 1 < num_groups else S]) for gi in range(num_groups)]
-    sfa_blk = torch.cat(sfa_parts).view(1, -1, 1)
+    sfa_blk = _with_static_segmented_capacity(torch.cat(sfa_parts), S, num_groups, sf_k)
     sfb0_blk = torch.cat([_to_blocked(sfb0_log[e]) for e in range(E)]).view(E, sf_k, N)
     sfb1_blk = torch.cat([_to_blocked(sfb1_log[e]) for e in range(E)]).view(E, sf_k, N)
     offsets = torch.tensor(offsets_list, dtype=torch.int32, device=dev)

--- a/test/python/gemm/frost/test_moe_grouped_matmul_fwd_epilogue_fusion.py
+++ b/test/python/gemm/frost/test_moe_grouped_matmul_fwd_epilogue_fusion.py
@@ -20,6 +20,7 @@ import inspect
 from cudnn.gemm.frost import compiler
 from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
 from cudnn.gemm.frost.epilogue_codegen import generate
+from cudnn.gemm.frost.fusion_ir import segmented_row_scale_capacity_rows
 from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.tile_config import by_name
 
@@ -415,14 +416,18 @@ def test_single_moe_col_quant_grouped_segmented(bs):
     assert mismatch < 1e-4, mismatch
 
 
-def test_single_moe_col_quant_group_offset_rejections():
-    # Row quant with group_offset: rejected (row SF is already per-group contiguous).
+def test_single_moe_quant_group_offset_rejections():
+    # Row quant is analyzable with an explicit segmented capacity, but the
+    # plain-BF16 MoE scheduler has no per-group row-atom prefix and declines it.
     g, c, fto = _graph()
     sw = g.swish(input=c, name="sw")
     q, qs = g.block_scale_quantize(input=sw, block_size=32, axis=-1, group_offset=fto, name="q")
     q.set_data_type(cudnn.data_type.FP8_E4M3).set_output(True)
-    qs.set_data_type(cudnn.data_type.FP8_E8M0).set_output(True)
-    with pytest.raises(ValueError, match="supports only the M axis"):
+    capacity_rows = segmented_row_scale_capacity_rows(_S, _G)
+    scale_cols = (_N // 32 + 3) // 4 * 4
+    qs.set_dim([1, capacity_rows, scale_cols]).set_stride([capacity_rows * scale_cols, scale_cols, 1])
+    qs.set_data_type(cudnn.data_type.FP8_E8M0).set_output(True).set_reordering_type(cudnn.tensor_reordering.F8_128x4)
+    with pytest.raises(NotImplementedError, match="requires a block-scaled MoE"):
         jit_from_cudnn_graph(g, by_name("CONFIG_sm100_128x256x128_128x256x32_cluster2x1_2ctamma"))
 
     # group_offset that is not the MoE fto: rejected.


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
- [ ] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions). The milestone is set; the current token cannot set organization Projects.

## Affected area

FE OSS kernels or CuTeDSL

## Summary

- Extend semantic `block_scale_quantize(..., group_offset=first_token_offset)` handling to F8_128x4 row scales produced by block-scaled grouped-MoE GEMM.
- Write every routed group's 128-row-padded scale segment directly from the producer epilogue using the scheduler's scale-atom prefix, eliminating the host-visible global-to-segmented repack.
- Tighten grouped scale capacity to the runtime-safe worst-case bound and validate runtime byte spans before launch.

On B200, the direct producer path reduced the measured up/scale-layout/down leaf pipeline by **1.0997x** for 23 active groups and **1.0719x** for 512 active groups. This is a routed-projection leaf comparison, not a full MoE block or model result.

## Why

A grouped NVFP4 up projection previously produced a global row-scale layout that had to be repacked into independently padded per-group segments before the grouped down projection could consume it. Producing the consumer layout directly removes that bridge and its extra memory traffic.

The accompanying input-capacity change fixes a latent out-of-bounds contract. A global `ceil(S/128)` allocation is insufficient when routed groups are fragmented because every nonempty group starts a separate 128-row atom. For total rows `S`, declared groups `G`, and `A = min(S, G)`, the safe static capacity is:

`128 * (A + (S - A) // 128)` rows.

The host cannot tighten this from actual group counts without reading `first_token_offset` back from the device. The extra capacity is at most `min(S, G) * 127` rows; for `G=128, K=2048` it is approximately 2 MiB. Large ratios only occur when `G` approaches `S` and the original buffer is very small.

## Related issues

None.

## API and compatibility impact

This extends the existing graph semantic; it adds no public function. When `group_offset` is absent, behavior is unchanged.

For grouped row-wise quantization, the graph must expose a dense scale buffer with the safe capacity above. Previously accepted undersized grouped-scale buffers now fail before launch instead of risking an out-of-bounds access. Only consumer-live bytes are specified; per-segment padding remains private and may contain any value.

The implemented execution path is the existing FROST SM100 block-scaled grouped-MoE route. No support is claimed for other architectures.

## Testing

- ComputeLab B200 at production-identical head `3194df1f5`: the three affected FROST suites reported **114 passed, 30 skipped** across L0/L1.
- Current review head `c89c34d0d`: host analyzer focus reported **8 passed**; ComputeLab B200 real-JIT route-decline plus 1-/2-CTA segmented-row E2E focus reported **3 passed**. Changed-file pre-commit, Python compilation, and diff checks passed.
- Direct packed activation bytes and every consumer-live scale byte match the previous global-scale-plus-bridge route.
- The downstream BF16 output is bit-exact with distinct poison values in padding; one compiled up/down plan and allocation are reused across concentrated and balanced partitions.
- Fail-closed tests cover undersized grouped-scale inputs and outputs, runtime-N growth beyond graph capacity, and non-dense destinations.
- At production-identical head `3194df1f5`, the broader suite covered CUDA Graph replay; current-head focused E2E covers default/non-default streams and both 1-CTA and 2-CTA configurations.
- Exact rendered-source, private compiler/config-helper, generated-expression, and cache-layout assertions have been removed. Analyzer contracts plus the end-to-end bridge-equivalence test are the regression net.

Historical B200 CUDA Graph replay measurement at source `16aeb471955cf745d9f776101fe6699e907bccbe`, using 10 paired/interleaved samples of 100 iterations per arm:

| routed layout | global scales plus bridge | direct segmented scales | speedup |
|---|---:|---:|---:|
| 23 active groups, 117-127 rows/group | 54.155 us | 49.247 us | 1.0997x |
| 512 active groups, 5-6 rows/group | 605.976 us | 565.341 us | 1.0719x |

Both arms used identical operands, down plan, and up tile configuration; only the terminal scale-layout path differed. The current follow-up changes are validation, neutral test naming, contract-focused tests, and the upstream rebase; no new performance number is claimed for them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved MoE grouped quantization support for segmented row scales and padded layouts.
  * Added support for multi-output quantized operations with improved output scheduling.
  * Expanded validation for scale capacity, dimensions, padding, and supported FP8 configurations.

* **Bug Fixes**
  * Improved output addressing and scale mapping across grouped and partitioned workloads.
  * Added readiness handling to improve reliability when producing multiple outputs.

* **Tests**
  * Expanded coverage for runtime shapes, padding, streams, partitioning, and GPU result equivalence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->