### PR TITLE
fix(frost): drain final MoE scheduler broadcast

### DIFF
--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd.py
@@ -703,6 +703,8 @@ def _kernel(
         # leader slot. A singleton cluster has no remote DSM lifetime to drain.
         if cutlass.const_expr(cluster_size > 1):
             if cta_rank_in_cluster == 0:
+                # Each acknowledgement flips the saved pre-wrap empty phase, so
+                # pre-wrap ``bcast_empty_phase ^ 1`` is the completed parity.
                 while not nvvm.mbarrier_try_wait_parity(
                     sched_bcast_empty_mbar_ptr.subview(last_bcast_stage),
                     last_bcast_empty_done_phase,

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd.py
@@ -446,6 +446,8 @@ def _kernel(
         bcast_stage = cutlass.Int32(0)
         bcast_full_phase = cutlass.Int32(0)
         bcast_empty_phase = cutlass.Int32(1)
+        last_bcast_stage = cutlass.Int32(0)
+        last_bcast_empty_done_phase = cutlass.Int32(0)
         linear_idx = cutlass.Int32(0)
         start_linear_idx = cutlass.Int32(0)
         total_tiles = cutlass.Int32(0)
@@ -497,6 +499,12 @@ def _kernel(
             linear_idx = (sched_bcast_slot.subview(bcast_stage)).load()
             if lane == 0:
                 nvvm.mbarrier_arrive(nvvm.mapa(sched_bcast_empty_mbar_ptr.subview(bcast_stage), 0))
+            if cutlass.const_expr(cluster_size > 1):
+                # The final invalid broadcast has no next reuse of this stage to
+                # wait for its cluster-wide acknowledgements, so retain its exact
+                # stage and completion parity for the scheduler-warp drain below.
+                last_bcast_stage = bcast_stage
+                last_bcast_empty_done_phase = bcast_empty_phase ^ 1
             bcast_stage += 1
             if bcast_stage == SCHED_BCAST_STAGES:
                 bcast_stage = cutlass.Int32(0)
@@ -688,6 +696,19 @@ def _kernel(
             if sched_stage == SCHED_STAGES:
                 sched_stage = cutlass.Int32(0)
                 sched_empty_phase = sched_empty_phase ^ 1
+
+        # Every multi-CTA cluster emits one invalid scheduler record before
+        # leaving the loop. Keep the leader CTA's DSM alive until every
+        # scheduler warp has consumed that final broadcast and acknowledged the
+        # leader slot. A singleton cluster has no remote DSM lifetime to drain.
+        if cutlass.const_expr(cluster_size > 1):
+            if cta_rank_in_cluster == 0:
+                while not nvvm.mbarrier_try_wait_parity(
+                    sched_bcast_empty_mbar_ptr.subview(last_bcast_stage),
+                    last_bcast_empty_done_phase,
+                    time_limit=10_000_000,
+                ):
+                    pass
 
     if warp_idx == tma_warp_id:
         nvvm.setmaxregister(prod_reg_count, nvvm.SetMaxRegisterAction.DECREASE)

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd.py
@@ -407,6 +407,8 @@ def _kernel(
         bcast_stage = cutlass.Int32(0)
         bcast_full_phase = cutlass.Int32(0)
         bcast_empty_phase = cutlass.Int32(1)
+        last_bcast_stage = cutlass.Int32(0)
+        last_bcast_empty_done_phase = cutlass.Int32(0)
         linear_idx = cutlass.Int32(0)
         start_linear_idx = cutlass.Int32(0)
         total_tiles = cutlass.Int32(0)
@@ -450,6 +452,12 @@ def _kernel(
             linear_idx = (sched_bcast_slot.subview(bcast_stage)).load()
             if lane == 0:
                 nvvm.mbarrier_arrive(nvvm.mapa(sched_bcast_empty_mbar_ptr.subview(bcast_stage), 0))
+            if cutlass.const_expr(cluster_size > 1):
+                # The final invalid broadcast has no next reuse of this stage to
+                # wait for its cluster-wide acknowledgements, so retain its exact
+                # stage and completion parity for the scheduler-warp drain below.
+                last_bcast_stage = bcast_stage
+                last_bcast_empty_done_phase = bcast_empty_phase ^ 1
             bcast_stage += 1
             if bcast_stage == SCHED_BCAST_STAGES:
                 bcast_stage = cutlass.Int32(0)
@@ -545,6 +553,19 @@ def _kernel(
             if sched_stage == SCHED_STAGES:
                 sched_stage = cutlass.Int32(0)
                 sched_empty_phase = sched_empty_phase ^ 1
+
+        # Every multi-CTA cluster emits one invalid scheduler record before
+        # leaving the loop. Keep the leader CTA's DSM alive until every
+        # scheduler warp has consumed that final broadcast and acknowledged the
+        # leader slot. A singleton cluster has no remote DSM lifetime to drain.
+        if cutlass.const_expr(cluster_size > 1):
+            if cta_rank_in_cluster == 0:
+                while not nvvm.mbarrier_try_wait_parity(
+                    sched_bcast_empty_mbar_ptr.subview(last_bcast_stage),
+                    last_bcast_empty_done_phase,
+                    time_limit=10_000_000,
+                ):
+                    pass
 
     if warp_idx == tma_warp_id:
         nvvm.setmaxregister(prod_reg_count, nvvm.SetMaxRegisterAction.DECREASE)

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd.py
@@ -560,6 +560,8 @@ def _kernel(
         # leader slot. A singleton cluster has no remote DSM lifetime to drain.
         if cutlass.const_expr(cluster_size > 1):
             if cta_rank_in_cluster == 0:
+                # Each acknowledgement flips the saved pre-wrap empty phase, so
+                # pre-wrap ``bcast_empty_phase ^ 1`` is the completed parity.
                 while not nvvm.mbarrier_try_wait_parity(
                     sched_bcast_empty_mbar_ptr.subview(last_bcast_stage),
                     last_bcast_empty_done_phase,

--- a/test/python/gemm/frost/gemm_test_utils.py
+++ b/test/python/gemm/frost/gemm_test_utils.py
@@ -5,8 +5,6 @@
 
 from __future__ import annotations
 
-import re
-
 import cudnn
 from dataclasses import replace
 
@@ -106,37 +104,6 @@ def resolve(name):
 def kw(name):
     """resolve() packaged as jit/Plan kwargs."""
     return dict(config=by_name(name))
-
-
-def render_moe_scheduler(chain, config_name, monkeypatch, *, block_scale):
-    """Render a grouped-MoE scheduler for source-level regression checks."""
-    from cudnn.gemm.frost import compiler
-    from cudnn.gemm.frost.epilogue_codegen import generate
-
-    cfg = by_name(config_name)
-    monkeypatch.setattr(compiler, "_current_arch", lambda device=None: 100)
-    monkeypatch.setattr(compiler, "_grid_num_clusters", lambda _cfg, device=None: 1)
-    modes = compiler._store_modes(chain, cfg)
-    tma_slots = frozenset(i for i, mode in enumerate(modes) if mode == "tma")
-    snippets = generate(
-        chain,
-        vec_bytes_epi=compiler._epi_chunk_bytes(chain, cfg, bool(tma_slots)),
-        output_elem_bytes=compiler.DTYPE_BYTES[chain.output_dtype],
-        tma_slots=tma_slots,
-        packed_lanes=compiler._epi_packed_lanes(cfg),
-    )
-    render = compiler._render_block_scale_template if block_scale else compiler._render_template
-    return cfg, render(chain, snippets, cfg)
-
-
-def assert_final_moe_broadcast_drain(rendered):
-    """Require the final-broadcast snapshot and drain without pinning source order."""
-    for pattern in (
-        r"last_bcast_stage\s*=\s*bcast_stage",
-        r"last_bcast_empty_done_phase\s*=\s*bcast_empty_phase\s*\^\s*1",
-        r"sched_bcast_empty_mbar_ptr\.subview\(\s*last_bcast_stage\s*\)",
-    ):
-        assert re.search(pattern, rendered)
 
 
 # --- variant packs ----------------------------------------------------------

--- a/test/python/gemm/frost/gemm_test_utils.py
+++ b/test/python/gemm/frost/gemm_test_utils.py
@@ -108,6 +108,37 @@ def kw(name):
     return dict(config=by_name(name))
 
 
+def render_moe_scheduler(chain, config_name, monkeypatch, *, block_scale):
+    """Render a grouped-MoE scheduler for source-level regression checks."""
+    from cudnn.gemm.frost import compiler
+    from cudnn.gemm.frost.epilogue_codegen import generate
+
+    cfg = by_name(config_name)
+    monkeypatch.setattr(compiler, "_current_arch", lambda device=None: 100)
+    monkeypatch.setattr(compiler, "_grid_num_clusters", lambda _cfg, device=None: 1)
+    modes = compiler._store_modes(chain, cfg)
+    tma_slots = frozenset(i for i, mode in enumerate(modes) if mode == "tma")
+    snippets = generate(
+        chain,
+        vec_bytes_epi=compiler._epi_chunk_bytes(chain, cfg, bool(tma_slots)),
+        output_elem_bytes=compiler.DTYPE_BYTES[chain.output_dtype],
+        tma_slots=tma_slots,
+        packed_lanes=compiler._epi_packed_lanes(cfg),
+    )
+    render = compiler._render_block_scale_template if block_scale else compiler._render_template
+    return cfg, render(chain, snippets, cfg)
+
+
+def assert_final_moe_broadcast_drain(rendered):
+    """Require the final-broadcast snapshot and drain without pinning source order."""
+    for pattern in (
+        r"last_bcast_stage\s*=\s*bcast_stage",
+        r"last_bcast_empty_done_phase\s*=\s*bcast_empty_phase\s*\^\s*1",
+        r"sched_bcast_empty_mbar_ptr\.subview\(\s*last_bcast_stage\s*\)",
+    ):
+        assert re.search(pattern, rendered)
+
+
 # --- variant packs ----------------------------------------------------------
 
 

--- a/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
@@ -26,8 +26,6 @@ from gemm_test_utils import (
     reduction_ref as _reduction_ref,
     reduction_dims as _reduction_dims,
     assert_block_scale_reduction_close as _assert_block_scale_reduction_close,
-    assert_final_moe_broadcast_drain as _assert_final_moe_broadcast_drain,
-    render_moe_scheduler as _render_moe_scheduler,
 )
 
 from cudnn.gemm.frost.dtypes import DTYPE_FROM_CUDNN as _DTYPE_FROM_CUDNN
@@ -278,23 +276,6 @@ def test_moe_block_scale_tma_store_uses_rank2_output_descriptor() -> None:
     assert "(col, coord_m)" in sequence
     assert "tile_l" not in sequence
     assert chain.has_moe and chain.has_block_scale
-
-
-@pytest.mark.L0
-@pytest.mark.parametrize(
-    "cfg_name,expected_cta_group,expected_cluster_size",
-    [
-        ("CONFIG_sm100_128x128x128_128x128x32_cluster1x1_1ctamma", 1, 1),
-        ("CONFIG_sm100_128x128x128_128x128x32_cluster1x2_1ctamma", 1, 2),
-        ("CONFIG_sm100_128x128x128_128x128x32_cluster2x1_2ctamma", 2, 2),
-    ],
-)
-def test_moe_block_scale_scheduler_codegen_drains_final_cluster_broadcast(monkeypatch, cfg_name, expected_cta_group, expected_cluster_size) -> None:
-    chain = analyze(_build_graph(2, 1024, 256, 512, num_groups=4))
-    cfg, rendered = _render_moe_scheduler(chain, cfg_name, monkeypatch, block_scale=True)
-    assert cfg.cta_group == expected_cta_group
-    assert cfg.cluster_shape[0] * cfg.cluster_shape[1] * cfg.cluster_shape[2] == expected_cluster_size
-    _assert_final_moe_broadcast_drain(rendered)
 
 
 def test_analyzer_detects_moe_grouped_block_scale_matmul_fwd_reduction() -> None:

--- a/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
@@ -260,6 +260,7 @@ def test_analyzer_offset_dtype_int64() -> None:
     assert chain.moe.offset_dtype == "int64"
 
 
+@pytest.mark.L0
 def test_moe_block_scale_tma_store_uses_rank2_output_descriptor() -> None:
     """The block-scale MoE template shares the flat (S, N) TMA output surface
     with plain MoE; neither descriptor nor store coordinates carry batch=1."""
@@ -279,6 +280,7 @@ def test_moe_block_scale_tma_store_uses_rank2_output_descriptor() -> None:
     assert chain.has_moe and chain.has_block_scale
 
 
+@pytest.mark.L0
 @pytest.mark.parametrize(
     "cfg_name,expected_cta_group,expected_cluster_size",
     [

--- a/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
@@ -26,6 +26,8 @@ from gemm_test_utils import (
     reduction_ref as _reduction_ref,
     reduction_dims as _reduction_dims,
     assert_block_scale_reduction_close as _assert_block_scale_reduction_close,
+    assert_final_moe_broadcast_drain as _assert_final_moe_broadcast_drain,
+    render_moe_scheduler as _render_moe_scheduler,
 )
 
 from cudnn.gemm.frost.dtypes import DTYPE_FROM_CUDNN as _DTYPE_FROM_CUDNN
@@ -277,29 +279,6 @@ def test_moe_block_scale_tma_store_uses_rank2_output_descriptor() -> None:
     assert chain.has_moe and chain.has_block_scale
 
 
-def _render_moe_block_scale_scheduler(monkeypatch, cfg_name):
-    # Local imports keep this regression independent of the segmented-row
-    # quantization tests that also use these rendering helpers.
-    from cudnn.gemm.frost import compiler as frost_compiler
-    from cudnn.gemm.frost.compiler import _render_block_scale_template as render_block_scale_template
-    from cudnn.gemm.frost.epilogue_codegen import generate as generate_epilogue
-
-    chain = analyze(_build_graph(2, 1024, 256, 512, num_groups=4))
-    cfg = by_name(cfg_name)
-    monkeypatch.setattr(frost_compiler, "_current_arch", lambda device=None: 100)
-    monkeypatch.setattr(frost_compiler, "_grid_num_clusters", lambda _cfg, device=None: 1)
-    modes = frost_compiler._store_modes(chain, cfg)
-    tma_slots = frozenset(i for i, mode in enumerate(modes) if mode == "tma")
-    snippets = generate_epilogue(
-        chain,
-        vec_bytes_epi=frost_compiler._epi_chunk_bytes(chain, cfg, bool(tma_slots)),
-        output_elem_bytes=frost_compiler.DTYPE_BYTES[chain.output_dtype],
-        tma_slots=tma_slots,
-        packed_lanes=frost_compiler._epi_packed_lanes(cfg),
-    )
-    return cfg, render_block_scale_template(chain, snippets, cfg)
-
-
 @pytest.mark.parametrize(
     "cfg_name,expected_cta_group,expected_cluster_size",
     [
@@ -309,23 +288,11 @@ def _render_moe_block_scale_scheduler(monkeypatch, cfg_name):
     ],
 )
 def test_moe_block_scale_scheduler_codegen_drains_final_cluster_broadcast(monkeypatch, cfg_name, expected_cta_group, expected_cluster_size) -> None:
-    cfg, rendered = _render_moe_block_scale_scheduler(monkeypatch, cfg_name)
+    chain = analyze(_build_graph(2, 1024, 256, 512, num_groups=4))
+    cfg, rendered = _render_moe_scheduler(chain, cfg_name, monkeypatch, block_scale=True)
     assert cfg.cta_group == expected_cta_group
     assert cfg.cluster_shape[0] * cfg.cluster_shape[1] * cfg.cluster_shape[2] == expected_cluster_size
-    assert f"cluster_shape_mnk = {cfg.cluster_shape}" in rendered
-    acknowledge = rendered.index("nvvm.mbarrier_arrive(nvvm.mapa(sched_bcast_empty_mbar_ptr.subview(bcast_stage), 0))")
-    snapshot = rendered.index("last_bcast_stage = bcast_stage")
-    snapshot_guard = rendered.rfind("if cutlass.const_expr(cluster_size > 1):", 0, snapshot)
-    advance = rendered.index("bcast_stage += 1")
-    drain_guard = rendered.rfind("if cutlass.const_expr(cluster_size > 1):", 0, rendered.rindex("sched_bcast_empty_mbar_ptr.subview(last_bcast_stage)"))
-    leader_guard = rendered.rindex("if cta_rank_in_cluster == 0:")
-    drain = rendered.rindex("sched_bcast_empty_mbar_ptr.subview(last_bcast_stage)")
-    assert acknowledge < snapshot_guard < snapshot < advance < drain_guard < leader_guard < drain
-    assert "last_bcast_empty_done_phase = bcast_empty_phase ^ 1" in rendered
-    assert "last_bcast_empty_done_phase," in rendered[drain : drain + 240]
-    # The rendered cluster tuple makes both guards compile-time false for 1x1,
-    # so Cute emits no snapshot or drain instructions for singleton clusters.
-    assert (expected_cluster_size > 1) == (cfg.cluster_shape != (1, 1, 1))
+    _assert_final_moe_broadcast_drain(rendered)
 
 
 def test_analyzer_detects_moe_grouped_block_scale_matmul_fwd_reduction() -> None:

--- a/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
@@ -277,6 +277,57 @@ def test_moe_block_scale_tma_store_uses_rank2_output_descriptor() -> None:
     assert chain.has_moe and chain.has_block_scale
 
 
+def _render_moe_block_scale_scheduler(monkeypatch, cfg_name):
+    # Local imports keep this regression independent of the segmented-row
+    # quantization tests that also use these rendering helpers.
+    from cudnn.gemm.frost import compiler as frost_compiler
+    from cudnn.gemm.frost.compiler import _render_block_scale_template as render_block_scale_template
+    from cudnn.gemm.frost.epilogue_codegen import generate as generate_epilogue
+
+    chain = analyze(_build_graph(2, 1024, 256, 512, num_groups=4))
+    cfg = by_name(cfg_name)
+    monkeypatch.setattr(frost_compiler, "_current_arch", lambda device=None: 100)
+    monkeypatch.setattr(frost_compiler, "_grid_num_clusters", lambda _cfg, device=None: 1)
+    modes = frost_compiler._store_modes(chain, cfg)
+    tma_slots = frozenset(i for i, mode in enumerate(modes) if mode == "tma")
+    snippets = generate_epilogue(
+        chain,
+        vec_bytes_epi=frost_compiler._epi_chunk_bytes(chain, cfg, bool(tma_slots)),
+        output_elem_bytes=frost_compiler.DTYPE_BYTES[chain.output_dtype],
+        tma_slots=tma_slots,
+        packed_lanes=frost_compiler._epi_packed_lanes(cfg),
+    )
+    return cfg, render_block_scale_template(chain, snippets, cfg)
+
+
+@pytest.mark.parametrize(
+    "cfg_name,expected_cta_group,expected_cluster_size",
+    [
+        ("CONFIG_sm100_128x128x128_128x128x32_cluster1x1_1ctamma", 1, 1),
+        ("CONFIG_sm100_128x128x128_128x128x32_cluster1x2_1ctamma", 1, 2),
+        ("CONFIG_sm100_128x128x128_128x128x32_cluster2x1_2ctamma", 2, 2),
+    ],
+)
+def test_moe_block_scale_scheduler_codegen_drains_final_cluster_broadcast(monkeypatch, cfg_name, expected_cta_group, expected_cluster_size) -> None:
+    cfg, rendered = _render_moe_block_scale_scheduler(monkeypatch, cfg_name)
+    assert cfg.cta_group == expected_cta_group
+    assert cfg.cluster_shape[0] * cfg.cluster_shape[1] * cfg.cluster_shape[2] == expected_cluster_size
+    assert f"cluster_shape_mnk = {cfg.cluster_shape}" in rendered
+    acknowledge = rendered.index("nvvm.mbarrier_arrive(nvvm.mapa(sched_bcast_empty_mbar_ptr.subview(bcast_stage), 0))")
+    snapshot = rendered.index("last_bcast_stage = bcast_stage")
+    snapshot_guard = rendered.rfind("if cutlass.const_expr(cluster_size > 1):", 0, snapshot)
+    advance = rendered.index("bcast_stage += 1")
+    drain_guard = rendered.rfind("if cutlass.const_expr(cluster_size > 1):", 0, rendered.rindex("sched_bcast_empty_mbar_ptr.subview(last_bcast_stage)"))
+    leader_guard = rendered.rindex("if cta_rank_in_cluster == 0:")
+    drain = rendered.rindex("sched_bcast_empty_mbar_ptr.subview(last_bcast_stage)")
+    assert acknowledge < snapshot_guard < snapshot < advance < drain_guard < leader_guard < drain
+    assert "last_bcast_empty_done_phase = bcast_empty_phase ^ 1" in rendered
+    assert "last_bcast_empty_done_phase," in rendered[drain : drain + 240]
+    # The rendered cluster tuple makes both guards compile-time false for 1x1,
+    # so Cute emits no snapshot or drain instructions for singleton clusters.
+    assert (expected_cluster_size > 1) == (cfg.cluster_shape != (1, 1, 1))
+
+
 def test_analyzer_detects_moe_grouped_block_scale_matmul_fwd_reduction() -> None:
     chain = analyze(
         _build_graph(

--- a/test/python/gemm/frost/test_moe_grouped_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_matmul_fwd.py
@@ -13,6 +13,9 @@ import cudnn.gemm.frost  # noqa: F401  (installs hook)
 import pytest
 import torch
 
+from cudnn.gemm.frost import compiler
+from cudnn.gemm.frost.compiler import _render_template
+from cudnn.gemm.frost.epilogue_codegen import generate
 from gemm_test_utils import (
     requires_sm100,
     Plan as _plan,
@@ -44,6 +47,9 @@ def _vp_moe(compiled, token, weight, fto, output):
 
 
 _CFG = "CONFIG_sm100_128x256x128_128x256x32_cluster2x1"
+_SCHED_CFG_1CTA = "CONFIG_sm100_128x128x128_128x128x32_cluster1x1_1ctamma"
+_SCHED_CFG_1CTA_MULTI = "CONFIG_sm100_128x128x128_128x128x32_cluster1x2_1ctamma"
+_SCHED_CFG_2CTA = "CONFIG_sm100_128x128x128_128x128x32_cluster2x1_2ctamma"
 # (config name, cta_group): 2-CTA cluster2x1 (reference) + 1-CTA cluster1x1.
 _GEOMETRIES = [
     ("CONFIG_sm100_128x256x128_128x256x32_cluster2x1", 2),
@@ -200,6 +206,47 @@ def _build_graph(
         return g
     out.set_data_type(output_dt).set_output(True)
     return g
+
+
+@pytest.mark.parametrize(
+    "cfg_name,expected_cta_group,expected_cluster_size",
+    [
+        (_SCHED_CFG_1CTA, 1, 1),
+        (_SCHED_CFG_1CTA_MULTI, 1, 2),
+        (_SCHED_CFG_2CTA, 2, 2),
+    ],
+)
+def test_moe_scheduler_codegen_drains_final_cluster_broadcast(monkeypatch, cfg_name, expected_cta_group, expected_cluster_size) -> None:
+    chain = analyze(_build_graph(2, 1024, 256, 512, num_groups=4))
+    cfg = by_name(cfg_name)
+    assert cfg.cta_group == expected_cta_group
+    monkeypatch.setattr(compiler, "_current_arch", lambda device=None: 100)
+    monkeypatch.setattr(compiler, "_grid_num_clusters", lambda _cfg, device=None: 1)
+    modes = compiler._store_modes(chain, cfg)
+    tma_slots = frozenset(i for i, mode in enumerate(modes) if mode == "tma")
+    snippets = generate(
+        chain,
+        vec_bytes_epi=compiler._epi_chunk_bytes(chain, cfg, bool(tma_slots)),
+        output_elem_bytes=compiler.DTYPE_BYTES[chain.output_dtype],
+        tma_slots=tma_slots,
+        packed_lanes=compiler._epi_packed_lanes(cfg),
+    )
+    rendered = _render_template(chain, snippets, cfg)
+    assert cfg.cluster_shape[0] * cfg.cluster_shape[1] * cfg.cluster_shape[2] == expected_cluster_size
+    assert f"cluster_shape_mnk = {cfg.cluster_shape}" in rendered
+    acknowledge = rendered.index("nvvm.mbarrier_arrive(nvvm.mapa(sched_bcast_empty_mbar_ptr.subview(bcast_stage), 0))")
+    snapshot = rendered.index("last_bcast_stage = bcast_stage")
+    snapshot_guard = rendered.rfind("if cutlass.const_expr(cluster_size > 1):", 0, snapshot)
+    advance = rendered.index("bcast_stage += 1")
+    drain_guard = rendered.rfind("if cutlass.const_expr(cluster_size > 1):", 0, rendered.rindex("sched_bcast_empty_mbar_ptr.subview(last_bcast_stage)"))
+    leader_guard = rendered.rindex("if cta_rank_in_cluster == 0:")
+    drain = rendered.rindex("sched_bcast_empty_mbar_ptr.subview(last_bcast_stage)")
+    assert acknowledge < snapshot_guard < snapshot < advance < drain_guard < leader_guard < drain
+    assert "last_bcast_empty_done_phase = bcast_empty_phase ^ 1" in rendered
+    assert "last_bcast_empty_done_phase," in rendered[drain : drain + 240]
+    # The rendered cluster tuple makes both guards compile-time false for 1x1,
+    # so Cute emits no snapshot or drain instructions for singleton clusters.
+    assert (expected_cluster_size > 1) == (cfg.cluster_shape != (1, 1, 1))
 
 
 # --------------------------------------------------------------------------- #

--- a/test/python/gemm/frost/test_moe_grouped_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_matmul_fwd.py
@@ -22,8 +22,6 @@ from gemm_test_utils import (
     reduction_ref as _reduction_ref,
     reduction_dims as _reduction_dims,
     FULL_EXPERT_REDUCE_OFFSETS as _FULL_EXPERT_REDUCE_OFFSETS,
-    assert_final_moe_broadcast_drain as _assert_final_moe_broadcast_drain,
-    render_moe_scheduler as _render_moe_scheduler,
 )
 
 from cudnn.gemm.frost.graph_analyzer import analyze
@@ -46,9 +44,6 @@ def _vp_moe(compiled, token, weight, fto, output):
 
 
 _CFG = "CONFIG_sm100_128x256x128_128x256x32_cluster2x1"
-_SCHED_CFG_1CTA = "CONFIG_sm100_128x128x128_128x128x32_cluster1x1_1ctamma"
-_SCHED_CFG_1CTA_MULTI = "CONFIG_sm100_128x128x128_128x128x32_cluster1x2_1ctamma"
-_SCHED_CFG_2CTA = "CONFIG_sm100_128x128x128_128x128x32_cluster2x1_2ctamma"
 # (config name, cta_group): 2-CTA cluster2x1 (reference) + 1-CTA cluster1x1.
 _GEOMETRIES = [
     ("CONFIG_sm100_128x256x128_128x256x32_cluster2x1", 2),
@@ -205,23 +200,6 @@ def _build_graph(
         return g
     out.set_data_type(output_dt).set_output(True)
     return g
-
-
-@pytest.mark.L0
-@pytest.mark.parametrize(
-    "cfg_name,expected_cta_group,expected_cluster_size",
-    [
-        (_SCHED_CFG_1CTA, 1, 1),
-        (_SCHED_CFG_1CTA_MULTI, 1, 2),
-        (_SCHED_CFG_2CTA, 2, 2),
-    ],
-)
-def test_moe_scheduler_codegen_drains_final_cluster_broadcast(monkeypatch, cfg_name, expected_cta_group, expected_cluster_size) -> None:
-    chain = analyze(_build_graph(2, 1024, 256, 512, num_groups=4))
-    cfg, rendered = _render_moe_scheduler(chain, cfg_name, monkeypatch, block_scale=False)
-    assert cfg.cta_group == expected_cta_group
-    assert cfg.cluster_shape[0] * cfg.cluster_shape[1] * cfg.cluster_shape[2] == expected_cluster_size
-    _assert_final_moe_broadcast_drain(rendered)
 
 
 # --------------------------------------------------------------------------- #

--- a/test/python/gemm/frost/test_moe_grouped_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_matmul_fwd.py
@@ -207,6 +207,7 @@ def _build_graph(
     return g
 
 
+@pytest.mark.L0
 @pytest.mark.parametrize(
     "cfg_name,expected_cta_group,expected_cluster_size",
     [
@@ -582,6 +583,7 @@ def test_moe_grouped_matmul_fwd_auto_config_n_major_small_n() -> None:
     torch.testing.assert_close(output[0], _ref_f32(token, weight_k, offsets, S, N, E).to(torch.bfloat16), atol=1e-1, rtol=1e-2)
 
 
+@pytest.mark.L0
 def test_moe_tma_store_uses_rank2_output_descriptor() -> None:
     """MoE's output is one flat (S, N) surface, so its TMA store must not carry
     the fixed-one batch dimension paid by ordinary batched GEMM. Besides being

--- a/test/python/gemm/frost/test_moe_grouped_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_matmul_fwd.py
@@ -13,9 +13,6 @@ import cudnn.gemm.frost  # noqa: F401  (installs hook)
 import pytest
 import torch
 
-from cudnn.gemm.frost import compiler
-from cudnn.gemm.frost.compiler import _render_template
-from cudnn.gemm.frost.epilogue_codegen import generate
 from gemm_test_utils import (
     requires_sm100,
     Plan as _plan,
@@ -25,6 +22,8 @@ from gemm_test_utils import (
     reduction_ref as _reduction_ref,
     reduction_dims as _reduction_dims,
     FULL_EXPERT_REDUCE_OFFSETS as _FULL_EXPERT_REDUCE_OFFSETS,
+    assert_final_moe_broadcast_drain as _assert_final_moe_broadcast_drain,
+    render_moe_scheduler as _render_moe_scheduler,
 )
 
 from cudnn.gemm.frost.graph_analyzer import analyze
@@ -218,35 +217,10 @@ def _build_graph(
 )
 def test_moe_scheduler_codegen_drains_final_cluster_broadcast(monkeypatch, cfg_name, expected_cta_group, expected_cluster_size) -> None:
     chain = analyze(_build_graph(2, 1024, 256, 512, num_groups=4))
-    cfg = by_name(cfg_name)
+    cfg, rendered = _render_moe_scheduler(chain, cfg_name, monkeypatch, block_scale=False)
     assert cfg.cta_group == expected_cta_group
-    monkeypatch.setattr(compiler, "_current_arch", lambda device=None: 100)
-    monkeypatch.setattr(compiler, "_grid_num_clusters", lambda _cfg, device=None: 1)
-    modes = compiler._store_modes(chain, cfg)
-    tma_slots = frozenset(i for i, mode in enumerate(modes) if mode == "tma")
-    snippets = generate(
-        chain,
-        vec_bytes_epi=compiler._epi_chunk_bytes(chain, cfg, bool(tma_slots)),
-        output_elem_bytes=compiler.DTYPE_BYTES[chain.output_dtype],
-        tma_slots=tma_slots,
-        packed_lanes=compiler._epi_packed_lanes(cfg),
-    )
-    rendered = _render_template(chain, snippets, cfg)
     assert cfg.cluster_shape[0] * cfg.cluster_shape[1] * cfg.cluster_shape[2] == expected_cluster_size
-    assert f"cluster_shape_mnk = {cfg.cluster_shape}" in rendered
-    acknowledge = rendered.index("nvvm.mbarrier_arrive(nvvm.mapa(sched_bcast_empty_mbar_ptr.subview(bcast_stage), 0))")
-    snapshot = rendered.index("last_bcast_stage = bcast_stage")
-    snapshot_guard = rendered.rfind("if cutlass.const_expr(cluster_size > 1):", 0, snapshot)
-    advance = rendered.index("bcast_stage += 1")
-    drain_guard = rendered.rfind("if cutlass.const_expr(cluster_size > 1):", 0, rendered.rindex("sched_bcast_empty_mbar_ptr.subview(last_bcast_stage)"))
-    leader_guard = rendered.rindex("if cta_rank_in_cluster == 0:")
-    drain = rendered.rindex("sched_bcast_empty_mbar_ptr.subview(last_bcast_stage)")
-    assert acknowledge < snapshot_guard < snapshot < advance < drain_guard < leader_guard < drain
-    assert "last_bcast_empty_done_phase = bcast_empty_phase ^ 1" in rendered
-    assert "last_bcast_empty_done_phase," in rendered[drain : drain + 240]
-    # The rendered cluster tuple makes both guards compile-time false for 1x1,
-    # so Cute emits no snapshot or drain instructions for singleton clusters.
-    assert (expected_cluster_size > 1) == (cfg.cluster_shape != (1, 1, 1))
+    _assert_final_moe_broadcast_drain(rendered)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
- [ ] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions). The milestone is set; the current token cannot set organization Projects.

## Affected area

FE OSS kernels or CuTeDSL

## Summary

- Retain the final grouped-MoE broadcast-ring stage and its completion parity.
- Keep the leader CTA alive until every peer scheduler warp acknowledges the final invalid record.
- Compile the snapshot and drain out for singleton clusters.
- Apply the DSM-lifetime fix symmetrically to plain and block-scaled SM100 grouped-MoE templates.

This is a correctness/lifetime fix with no public API or model-performance claim.

## Why

Normal ring reuse waits for acknowledgements before a stage is reused. The final invalid scheduler record exits the loop instead, so no later reuse keeps the leader CTA and its distributed shared-memory barrier alive while peers still acknowledge it.

The fix snapshots the final stage before ring wrap. Each acknowledgement flips the saved pre-wrap empty phase, so `pre-wrap bcast_empty_phase ^ 1` is the completed parity waited on by the leader.

## Related issues

None.

## API and compatibility impact

None. This changes only internal scheduler lifetime in the existing FROST grouped-MoE kernels. Singleton clusters compile away the additional state and wait.

## Testing

- Current review head `d784e62ae`: removed the renderer helper, private schedule constants, regex/exact generated-source assertions, and the two codegen tests. Changed-file pre-commit, Python compilation, and diff checks passed.
- ComputeLab B200 at current head: one existing clustered plain-MoE E2E and one existing block-scaled NVFP4 grouped-MoE E2E reported **2 passed in 5.35 s**.
- ComputeLab B200 at the production-fix head `daf9ba5ba`: the complete L0 suites for both affected grouped-MoE families reported **229 passed, 20 skipped**. Prior functional smoke covered all six 1x1, 1x2, and 2x1 template/cluster combinations.
- An attempted observable CUDA Graph stress test queued 33 poisoned-output replays for each template, but the unfixed parent also passed both cases. It was therefore removed rather than presented as regression evidence.
- Compute Sanitizer `synccheck` reported zero errors before and after; `racecheck` produced identical, non-discriminating DSM reports in both versions. Sanitizer silence is supporting evidence rather than proof.

No deterministic black-box RED test was found for the DSM lifetime violation. The fix is supported by the broadcast-ring protocol argument and existing fixed-path functional coverage; no timing difference is expected or claimed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Mixture-of-Experts grouped matrix multiplication by ensuring coordinated processing completes before resources are released.
  * Improved completion handling across supported multi-cluster configurations while preserving efficient behavior for single-cluster scenarios.
  * Standardized routed outputs as a flat two-dimensional surface for more consistent downstream processing.

* **Tests**
  * Updated validation coverage for grouped matrix multiplication and output layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->