### PR TITLE
frost(sdpa): python-native validate() — defer C++ lowering when a python engine is a candidate

### DIFF
--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -826,10 +826,37 @@ class pygraph:
         # rejects raises from validate() where callers catch it to skip. Skipped
         # only for a graph the backend has no lowering for (GDN/KDA/...), or when
         # the caller registered its own engine — the pre-existing exemption.
+        #
+        # SDPA-family graphs with a python engine candidate validate natively in
+        # python instead (issue #704): the eager C++ round-trip couples a graph
+        # a FROST engine fully serves to the installed backend's version (an
+        # attribute the backend is too old to *validate* but will never
+        # execute). Semantic validity is checked here by _sdpa_validate with
+        # classic error types; the backend's own verdict is deferred to
+        # planning, where a decline is recorded (backend_plan_entries) and
+        # surfaced by plan() only if no python engine proposes a plan either.
         if self._backend_lowerable() and self._lowered_graph is None:
-            self._lowered_graph = self._lower_to_cpp()
-            self._lowered_graph.validate()
-            self._verify_uid_ownership()
+            if self._python_native_validation():
+                from . import _sdpa_validate
+
+                for node in self._nodes:
+                    _sdpa_validate.validate_node(node)
+            else:
+                self._lowered_graph = self._lower_to_cpp()
+                self._lowered_graph.validate()
+                self._verify_uid_ownership()
+
+    def _python_native_validation(self) -> bool:
+        """Whether validate() may skip the eager C++ lowering: every node has a
+        python-native validator AND the manifest offers a python engine for this
+        graph (frost engines available and enabled). Without a candidate the
+        backend is the only possible server, so classic timing — raise its
+        rejection from validate() — must hold."""
+        from . import _sdpa_validate
+
+        if not self._nodes or any(n.node_type not in _sdpa_validate.COVERED_NODE_TYPES for n in self._nodes):
+            return False
+        return bool(self._candidate_engines())
 
     def build_operation_graph(self) -> None:
         """Validate the graph; lower to C++ when no python engines are registered.

--- a/python/cudnn/_sdpa_validate.py
+++ b/python/cudnn/_sdpa_validate.py
@@ -1,0 +1,316 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Python-native validation for the SDPA op family (issue #704).
+
+``pygraph.validate()`` classically lowers every backend-lowerable graph to C++
+and runs the backend's ``validate()`` — which couples frontend-only (FROST)
+engines to the installed backend's version: a graph a python engine fully
+serves is rejected at validate() because the *backend* is too old to know an
+attribute it will never execute. This module is the replacement for the SDPA
+family: the graph-SEMANTIC subset of the classic C++ pre-validation (shape and
+stride invariants, ill-formed attribute combinations), expressed on the python
+IR with the classic error types and messages.
+
+Deliberately absent: every backend-version gate (``get_backend_version() < X``)
+and device-arch gate (``prop_major == Y``) from the C++ surface. Those are
+support-surface answers, not graph-validity answers — at planning time each
+python engine's ``check_support()`` gives its own, and the backend gives its
+own when it is lowered (declines recorded by ``backend_plan_entries()``, and
+surfaced by ``plan()`` only if no engine proposes a plan).
+
+Error-type parity with the pybind ``throw_if`` mapping:
+``GRAPH_NOT_SUPPORTED`` -> ``cudnn.cudnnGraphNotSupportedError`` (callers catch
+it to skip a config); ``ATTRIBUTE_NOT_SET`` / ``INVALID_VALUE`` ->
+``std::invalid_argument`` -> ``ValueError``.
+
+Import-light on purpose: only the IR types. Never import ``cudnn.sdpa`` (that
+pulls torch/cutlass) or the compiled binding at module scope.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from .graph_types import NodeType
+
+_FWD_TYPES = (NodeType.SDPA, NodeType.SDPA_FP8, NodeType.SDPA_MXFP8)
+_BWD_TYPES = (NodeType.SDPA_BWD, NodeType.SDPA_FP8_BWD, NodeType.SDPA_MXFP8_BWD)
+
+# Node types this module fully validates. pygraph.validate() may defer the C++
+# lowering only for graphs whose every node is covered here.
+COVERED_NODE_TYPES = frozenset(_FWD_TYPES + _BWD_TYPES)
+
+
+def _not_supported(message: str) -> Exception:
+    import cudnn
+
+    return cudnn.cudnnGraphNotSupportedError(message)
+
+
+def _dtype_name(t: Any) -> Optional[str]:
+    dt = t.get_data_type() if t is not None else None
+    return getattr(dt, "name", None)
+
+
+def _tensor(node, port: str):
+    return node.inputs.get(port) or node.outputs.get(port)
+
+
+def _check_dim_stride(node, port: str, t: Any) -> None:
+    """Classic parity: rank-4 dim/stride assigned, unit stride on the head dim."""
+    if t is None:
+        raise ValueError(f"{node.name}: required tensor {port} is missing")
+    if len(t.get_dim() or ()) != 4:
+        raise ValueError(f"The dim for {port} is invalid")
+    if len(t.get_stride() or ()) != 4:
+        raise ValueError(f"The stride for {port} is invalid")
+    if t.get_stride()[3] != 1:
+        raise _not_supported("The stride for the last dimension corresponding to the embedding size per head should be 1 for " + port)
+
+
+def _diagonal(params: dict) -> tuple:
+    """(alignment_name, left_bound, right_bound) with the pybind's spelling
+    precedence: the use_causal_mask* flags override diagonal_alignment and pin
+    right_bound to 0; diagonal_band_left_bound overrides sliding_window_length."""
+    causal_tl = bool(params.get("use_causal_mask"))
+    causal_br = bool(params.get("use_causal_mask_bottom_right"))
+    if causal_br:
+        alignment = "BOTTOM_RIGHT"
+    elif causal_tl:
+        alignment = "TOP_LEFT"
+    else:
+        alignment = getattr(params.get("diagonal_alignment"), "name", "TOP_LEFT")
+    right = 0 if (causal_tl or causal_br) else params.get("diagonal_band_right_bound")
+    left = params.get("diagonal_band_left_bound")
+    if left is None:
+        left = params.get("sliding_window_length")
+    return alignment, left, right
+
+
+def _dropout(node) -> tuple:
+    """(probability | None, has_custom_mask) from the captured dropout tuple:
+    (float prob, seed, offset) is probability form; an all-tensor tuple
+    ((mask, scale) / (mask, scale, scale_inv)) is the custom-mask form."""
+    if not node.params.get("_dropout_n"):
+        return None, False
+    prob = node.params.get("dropout_0")
+    if isinstance(prob, float):
+        return prob, False
+    return None, "dropout_0" in node.inputs
+
+
+def _is_ragged(*tensors) -> bool:
+    return any(t is not None and t.ragged_offset is not None for t in tensors)
+
+
+def _has(node, port: str) -> bool:
+    return node.inputs.get(port) is not None
+
+
+def validate_node(node) -> None:
+    """Validate one SDPA-family node, raising with classic error semantics."""
+    if node.node_type in _FWD_TYPES:
+        _validate_forward(node)
+    elif node.node_type in _BWD_TYPES:
+        _validate_backward(node)
+    else:
+        raise AssertionError(f"{node.node_type} is not an SDPA-family node")
+
+
+def _validate_common(node, q, k, v, o, s_q, s_kv) -> None:
+    """Checks shared verbatim by the forward and backward C++ surfaces."""
+    params = node.params
+    _, h_q, _, _ = q.get_dim()
+    h_k = k.get_dim()[1]
+    h_v = v.get_dim()[1]
+
+    if (h_q % h_k != 0) or (h_q % h_v != 0):
+        raise _not_supported("For group-query attention, number of heads for key and query must be a factor of number of heads for query")
+
+    alignment, left, right = _diagonal(params)
+    causal_br = alignment == "BOTTOM_RIGHT" and right is not None
+    padding = bool(params.get("use_padding_mask"))
+    score_mod = params.get("score_mod") is not None
+    alibi = bool(params.get("use_alibi_mask"))
+
+    if alibi and right != 0:
+        raise _not_supported("When alibi mask is used, diagonal_band_right_bound needs to be set to 0.")
+
+    bias = node.inputs.get("bias")
+    if bias is not None and _dtype_name(bias) == "BOOLEAN":
+        raise _not_supported("Bias mask data type cannot be boolean")
+
+    # Padding requires a per-sequence length tensor on each side; each side
+    # independently uses exactly one representation (per-batch or cumulative).
+    has_seq_q, has_cu_q = _has(node, "seq_len_q"), _has(node, "cu_seq_len_q")
+    has_seq_kv, has_cu_kv = _has(node, "seq_len_kv"), _has(node, "cu_seq_len_kv")
+    if has_seq_q and has_cu_q:
+        raise ValueError("seq_len_q and cu_seq_len_q cannot both be set.")
+    if has_seq_kv and has_cu_kv:
+        raise ValueError("seq_len_kv and cu_seq_len_kv cannot both be set.")
+    has_any_q, has_any_kv = has_seq_q or has_cu_q, has_seq_kv or has_cu_kv
+    if padding and not (has_any_q and has_any_kv):
+        raise ValueError("Padding mask requires seq_len_q/seq_len_kv (or cu_seq_len_q/cu_seq_len_kv) to be set.")
+    if (not padding and not score_mod) and (has_any_q or has_any_kv):
+        raise ValueError("seq_len_q/seq_len_kv (or cu_seq_len_q/cu_seq_len_kv) needs to be set only if padding mask is enabled.")
+    if has_any_q != has_any_kv:
+        raise ValueError(
+            "A Q-side and a KV-side sequence length tensor must be provided together " "(each side may independently use seq_len_* or cu_seq_len_*)."
+        )
+
+    is_ragged = _is_ragged(q, k, v, o)
+    if (params.get("max_total_seq_len_q") is not None or params.get("max_total_seq_len_kv") is not None) and not is_ragged:
+        raise _not_supported("max_total_seq_len_q/kv is only supported with packed (ragged) layout")
+
+    prob, custom_mask = _dropout(node)
+    if prob is not None and custom_mask:
+        raise ValueError("Using both, custom dropout mask and internal-mask generation using dropout probability, is ill-formed.")
+    if prob == 1.0:
+        raise ValueError("Dropout probability cannot be 1 as corresponding scale wont be well formed.")
+    is_dropout = prob is not None or custom_mask
+
+    if causal_br and not padding and s_kv is not None and s_q > s_kv:
+        raise _not_supported(
+            "Bottom right causal mask does not support max_s_q > max_s_kv. Please virtually slice the Q tensor and " "pass it as max_s_q == max_s_kv"
+        )
+    if causal_br and (bias is not None or alibi or is_dropout or (is_ragged and not padding)):
+        raise _not_supported(
+            "Bottom right causal mask is only supported with is_bias=False, is_alibi=False, is_dropout=False. "
+            "Further is_ragged==True is only allowed when padding_mask=True."
+        )
+
+    if left is not None:
+        if not padding and s_kv is not None and s_q > s_kv:
+            raise _not_supported("Sliding window attention is only supported with max_s_q <= max_s_kv.")
+        if is_ragged and not padding:
+            raise _not_supported("Left and right bounds with is_ragged==True is only allowed when padding_mask=True.")
+    if right is not None and right < 0:
+        raise ValueError("Right bound needs to be larger than or equal to zero")
+
+
+def _validate_forward(node) -> None:
+    params = node.params
+    q, k, v = node.inputs.get("q"), node.inputs.get("k"), node.inputs.get("v")
+    o = node.outputs.get("O")
+    for port, t in (("Q", q), ("K", k), ("V", v), ("O", o)):
+        _check_dim_stride(node, port, t)
+
+    _, _, s_q, d_qk = q.get_dim()
+    d_v = v.get_dim()[3]
+    paged = _has(node, "paged_attention_k_table") or _has(node, "paged_attention_v_table")
+    max_seq_kv = params.get("paged_attention_max_seq_len_kv")
+    # With paged caches K/V carry container extents; the logical s_kv is the
+    # explicit maximum when given, unknowable here otherwise.
+    s_kv = k.get_dim()[2] if not paged else max_seq_kv
+
+    _validate_common(node, q, k, v, o, s_q, s_kv)
+
+    stats = node.outputs.get("Stats")
+    if stats is not None and _dtype_name(stats) not in (None, "FLOAT"):
+        raise _not_supported("The Stats output of sdpa must be an FP32 tensor.")
+
+    is_ragged = _is_ragged(q, k, v, o)
+    score_mod = params.get("score_mod") is not None
+    if is_ragged and not (bool(params.get("use_padding_mask")) or score_mod):
+        raise _not_supported("Ragged offsets are only supported with padding mask.")
+
+    alignment, left, right = _diagonal(params)
+    if score_mod and (bool(params.get("use_alibi_mask")) or right is not None or bool(params.get("use_padding_mask")) or left is not None):
+        raise _not_supported("Attention score mod enabled and hence other subgraphs are disabled.")
+
+    if node.node_type == NodeType.SDPA:
+        if (d_qk % 8 != 0) or (d_v % 8 != 0):
+            raise _not_supported("hidden_dim should be multiple of 8")
+        if s_q == 1 and _has(node, "sink_token"):
+            raise _not_supported("decode only mode, i.e. s_q == 1, not supported with sink_token")
+
+        has_any_q = _has(node, "seq_len_q") or _has(node, "cu_seq_len_q")
+        has_any_kv = _has(node, "seq_len_kv") or _has(node, "cu_seq_len_kv")
+        if paged and not (has_any_q and has_any_kv):
+            raise _not_supported(
+                "Paged caches can only be used in combination with padding mask and variable sequence lengths "
+                "for both Q and KV (each side independently via seq_len_* or cu_seq_len_*)."
+            )
+        if not paged and max_seq_kv is not None:
+            raise _not_supported("When not using paged attention, there is no need to explicitly set max kv sequence length.")
+        if max_seq_kv is not None:
+            bias = node.inputs.get("bias")
+            if bias is not None and bias.get_dim()[3] != max_seq_kv:
+                raise _not_supported("Value set through set_paged_attention_max_seq_len_kv is incompatible with the sequence length of the bias")
+            rng_dump = node.outputs.get("rng_dump")
+            if rng_dump is not None and rng_dump.get_dim()[3] != max_seq_kv:
+                raise _not_supported("Value set through set_paged_attention_max_seq_len_kv is incompatible with the sequence length of the RNG_DUMP")
+
+    if node.node_type == NodeType.SDPA_FP8:
+        if node.inputs.get("bias") is not None:
+            raise _not_supported("SDPA FP8 does not support bias")
+        if (d_qk % 16 != 0) or (d_v % 16 != 0):
+            raise _not_supported("hidden_dim should be multiple of 16")
+
+    if node.node_type == NodeType.SDPA_MXFP8:
+        _validate_mxfp8_descales(node, q, k, v, s_kv if s_kv is not None else k.get_dim()[2])
+
+
+def _validate_mxfp8_descales(node, q, k, v, s_kv: int) -> None:
+    b, h_q, _, d = q.get_dim()
+    h_k, h_v = k.get_dim()[1], v.get_dim()[1]
+    block_size = 32  # MXFP8 block size is fixed at 32
+    d_scale = (d + block_size - 1) // block_size
+    s_scale = (s_kv + block_size - 1) // block_size
+
+    for port, h, small_axis, small_min in (
+        ("descale_q", h_q, 3, d_scale),
+        ("descale_k", h_k, 3, d_scale),
+        ("descale_v", h_v, 2, s_scale),
+    ):
+        t = node.inputs.get(port)
+        if t is None:
+            raise ValueError(f"{node.name}: MXFP8 SDPA requires {port}")
+        cap = port.title().replace("_q", "_Q").replace("_k", "_K").replace("_v", "_V")
+        if _dtype_name(t) != "FP8_E8M0":
+            raise ValueError(f"MXFP8 SDPA requires {cap} to have FP8_E8M0 data type")
+        if getattr(t.get_reordering_type(), "name", None) != "F8_128x4":
+            raise ValueError(f"MXFP8 SDPA requires {cap} to have F8_128x4 reordering")
+        dim = t.get_dim()
+        if dim[0] != b or dim[1] != h:
+            base = port.split("_")[1].upper()
+            raise ValueError(f"MXFP8 SDPA: {cap} batch/head dimensions must match {base}")
+        if dim[small_axis] < small_min:
+            what = "d_scale" if small_axis == 3 else "s_scale"
+            raise ValueError(f"MXFP8 SDPA: {cap} {what} dimension too small (expected >= {small_min})")
+
+
+def _validate_backward(node) -> None:
+    q, k, v = node.inputs.get("q"), node.inputs.get("k"), node.inputs.get("v")
+    # sdpa_mxfp8_backward carries O as its f16 twin (port "o_f16")
+    o = node.inputs.get("o") or node.inputs.get("o_f16")
+    dO = node.inputs.get("dO")
+    dQ, dK, dV = node.outputs.get("dQ"), node.outputs.get("dK"), node.outputs.get("dV")
+    for port, t in (("Q", q), ("K", k), ("V", v), ("O", o), ("dO", dO), ("dQ", dQ), ("dK", dK), ("dV", dV)):
+        _check_dim_stride(node, port, t)
+
+    s_q = q.get_dim()[2]
+    s_kv = v.get_dim()[2]
+    if s_q == 1 and s_kv == 1:
+        raise _not_supported("s_q = s_kv = 1 is not supported.")
+
+    _validate_common(node, q, k, v, o, s_q, s_kv)
+
+    params = node.params
+    alignment, left, right = _diagonal(params)
+    score_mod = params.get("score_mod") is not None
+    if score_mod and (bool(params.get("use_alibi_mask")) or bool(params.get("use_padding_mask")) or right is not None or left is not None):
+        raise _not_supported("Attention score mod enabled and hence other subgraphs are disabled.")
+
+    if left is not None and left <= 0:
+        raise ValueError("Left bound (Sliding window length) should be greater than zero when set.")
+
+    if node.outputs.get("dSink_token") is not None and node.inputs.get("sink_token") is None:
+        raise ValueError("dSink_token requires sink_token to be provided")
+
+    d_qk = q.get_dim()[3]
+    d_v = v.get_dim()[3]
+    if node.node_type == NodeType.SDPA_BWD:
+        if (d_qk % 8 != 0) or (d_v % 8 != 0):
+            raise _not_supported("hidden_dim should be multiple of 8")

--- a/test/python/sdpa/frost/test_sdpa_python_validate.py
+++ b/test/python/sdpa/frost/test_sdpa_python_validate.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Python-native SDPA validation (issue #704).
+
+With a FROST engine candidate, ``pygraph.validate()`` must not lower to C++ —
+the eager backend validation is what coupled frontend-only engines to the
+installed backend's version. Semantic invalidity must still raise from
+validate(), with classic error types (``cudnnGraphNotSupportedError`` for
+GRAPH_NOT_SUPPORTED parity, ``ValueError`` for ATTRIBUTE_NOT_SET/INVALID_VALUE
+parity). Without a candidate, the classic eager-lowering timing is unchanged.
+
+Device-free: candidates are stubbed via ``manifest.engines_for``; nothing here
+builds plans or executes.
+"""
+
+import pytest
+
+import cudnn
+from cudnn.engines import manifest
+
+pytestmark = pytest.mark.L0
+
+
+@pytest.fixture
+def frost_candidate(monkeypatch):
+    """Pretend the manifest offers a python engine for every graph."""
+    monkeypatch.setattr(manifest, "engines_for", lambda graph: [object()])
+
+
+@pytest.fixture
+def no_candidates(monkeypatch):
+    monkeypatch.setattr(manifest, "engines_for", lambda graph: [])
+
+
+def _sdpa_graph(
+    b=1,
+    h_q=2,
+    h_kv=2,
+    s_q=64,
+    s_kv=64,
+    d=64,
+    **sdpa_kwargs,
+):
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.HALF,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    q = g.tensor(name="q", dim=[b, h_q, s_q, d], stride=[h_q * s_q * d, s_q * d, d, 1])
+    k = g.tensor(name="k", dim=[b, h_kv, s_kv, d], stride=[h_kv * s_kv * d, s_kv * d, d, 1])
+    v = g.tensor(name="v", dim=[b, h_kv, s_kv, d], stride=[h_kv * s_kv * d, s_kv * d, d, 1])
+    o, stats = g.sdpa(q, k, v, generate_stats=True, **sdpa_kwargs)
+    o.set_output(True)
+    if stats is not None:
+        stats.set_output(True).set_data_type(cudnn.data_type.FLOAT)
+    return g, dict(q=q, k=k, v=v, o=o, stats=stats)
+
+
+def test_valid_graph_does_not_lower(frost_candidate):
+    g, _ = _sdpa_graph(use_causal_mask=True)
+    g.validate()
+    assert g._lowered_graph is None, "validate() must not lower to C++ when a python engine is a candidate"
+
+
+def test_classic_path_still_lowers(no_candidates):
+    g, _ = _sdpa_graph(use_causal_mask=True)
+    g.validate()
+    assert g._lowered_graph is not None, "without python candidates the classic eager lowering must be unchanged"
+
+
+def test_gqa_head_divisibility(frost_candidate):
+    g, _ = _sdpa_graph(h_q=3, h_kv=2)
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="group-query attention"):
+        g.validate()
+    assert g._lowered_graph is None
+
+
+def test_bottom_right_causal_with_bias(frost_candidate):
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.HALF,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    dims = [1, 2, 64, 64]
+    strides = [2 * 64 * 64, 64 * 64, 64, 1]
+    q = g.tensor(name="q", dim=dims, stride=strides)
+    k = g.tensor(name="k", dim=dims, stride=strides)
+    v = g.tensor(name="v", dim=dims, stride=strides)
+    bias = g.tensor(name="bias", dim=[1, 1, 64, 64], stride=[64 * 64, 64 * 64, 64, 1])
+    o, _ = g.sdpa(q, k, v, bias=bias, use_causal_mask_bottom_right=True, generate_stats=False)
+    o.set_output(True)
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="Bottom right causal mask"):
+        g.validate()
+
+
+def test_padding_mask_requires_seq_lens(frost_candidate):
+    g, _ = _sdpa_graph(use_padding_mask=True)
+    with pytest.raises(ValueError, match="Padding mask requires"):
+        g.validate()
+
+
+def test_seq_lens_require_padding_mask(frost_candidate):
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.HALF,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    dims = [2, 2, 64, 64]
+    strides = [2 * 64 * 64, 64 * 64, 64, 1]
+    q = g.tensor(name="q", dim=dims, stride=strides)
+    k = g.tensor(name="k", dim=dims, stride=strides)
+    v = g.tensor(name="v", dim=dims, stride=strides)
+    seq_q = g.tensor(name="seq_q", dim=[2, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT32)
+    seq_kv = g.tensor(name="seq_kv", dim=[2, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT32)
+    o, _ = g.sdpa(q, k, v, seq_len_q=seq_q, seq_len_kv=seq_kv, generate_stats=False)
+    o.set_output(True)
+    with pytest.raises(ValueError, match="only if padding mask is enabled"):
+        g.validate()
+
+
+def test_dropout_probability_one_rejected(frost_candidate):
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.HALF,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    dims = [1, 2, 64, 64]
+    strides = [2 * 64 * 64, 64 * 64, 64, 1]
+    q = g.tensor(name="q", dim=dims, stride=strides)
+    k = g.tensor(name="k", dim=dims, stride=strides)
+    v = g.tensor(name="v", dim=dims, stride=strides)
+    seed = g.tensor(name="seed", dim=[1, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT64)
+    offset = g.tensor(name="offset", dim=[1, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT64)
+    o, _ = g.sdpa(q, k, v, dropout=(1.0, seed, offset), generate_stats=False)
+    o.set_output(True)
+    with pytest.raises(ValueError, match="Dropout probability cannot be 1"):
+        g.validate()
+
+
+def test_alibi_requires_causal(frost_candidate):
+    g, _ = _sdpa_graph(use_alibi_mask=True)
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="alibi"):
+        g.validate()
+
+
+def test_non_fp32_stats_rejected(frost_candidate):
+    g, ts = _sdpa_graph(use_causal_mask=True)
+    ts["stats"].set_data_type(cudnn.data_type.HALF)
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="Stats output of sdpa must be an FP32"):
+        g.validate()
+
+
+def test_head_dim_multiple_of_8(frost_candidate):
+    g, _ = _sdpa_graph(d=68, use_causal_mask=True)
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="multiple of 8"):
+        g.validate()
+
+
+def test_sliding_window_sq_gt_skv_rejected(frost_candidate):
+    g, _ = _sdpa_graph(s_q=128, s_kv=64, use_causal_mask=True, sliding_window_length=16)
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="Sliding window attention"):
+        g.validate()
+
+
+def test_bwd_sq1_skv1_rejected(frost_candidate):
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.HALF,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    dims = [1, 2, 1, 64]
+    strides = [2 * 64, 64, 64, 1]
+    q = g.tensor(name="q", dim=dims, stride=strides)
+    k = g.tensor(name="k", dim=dims, stride=strides)
+    v = g.tensor(name="v", dim=dims, stride=strides)
+    o = g.tensor(name="o", dim=dims, stride=strides)
+    dO = g.tensor(name="dO", dim=dims, stride=strides)
+    stats = g.tensor(name="stats", dim=[1, 2, 1, 1], stride=[2, 1, 1, 1], data_type=cudnn.data_type.FLOAT)
+    dQ, dK, dV = g.sdpa_backward(q, k, v, o, dO, stats)
+    for t in (dQ, dK, dV):
+        t.set_output(True)
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="s_q = s_kv = 1"):
+        g.validate()
+    assert g._lowered_graph is None


### PR DESCRIPTION
Fixes #704.

## Problem

`pygraph.validate()` lowers every backend-lowerable graph to C++ and runs the backend's `validate()`. SDPA is backend-lowerable, so every SDPA pygraph pays C++ construction + backend validation — including graphs a pure-python FROST engine fully serves. That couples frontend-only engines to the installed backend's version: a frost-served graph is rejected at `validate()` because the *backend* is too old to know an attribute it will never execute (e.g. fp8/mxfp8 THD `cu_seq_len` graphs on backend < 9.25, or merely declaring an `FP8_E5M3` tensor).

## Change

- **`python/cudnn/_sdpa_validate.py` (new):** python-native semantic validation for the SDPA node family (SDPA / SDPA_BWD / FP8 / MXFP8 flavors) — the version/arch-agnostic subset of the classic C++ pre-validation (rank-4 dim/stride + unit head-dim stride, GQA divisibility, alibi/causal/bottom-right/sliding-window combination rules, padding-mask ⇔ seq-len rules, dropout well-formedness, ragged/paged constraints, FP32 Stats, MXFP8 descale layout), with classic error types (`cudnnGraphNotSupportedError` for GRAPH_NOT_SUPPORTED parity; `ValueError` for ATTRIBUTE_NOT_SET / INVALID_VALUE parity) and classic messages. Backend-version gates (`get_backend_version() < X`) and device-arch gates are deliberately absent — those are support-surface answers each engine gives at planning.
- **`pygraph.validate()`:** when every node is SDPA-family *and* the manifest offers a python engine for the graph, run the python validator and skip the eager C++ lowering. The backend's verdict is deferred to planning, where a decline is already recorded (`backend_plan_entries()`) and surfaced by `plan()` only if no python engine proposes a plan either. Without a python candidate (frost disabled, or family unavailable) the classic eager-lowering timing is byte-for-byte unchanged.

## Testing

- New `test/python/sdpa/frost/test_sdpa_python_validate.py` (12 tests, device-free): no C++ lowering at `validate()` with a frost candidate, classic path still lowers without one, and semantic rejections (GQA, BR-causal+bias, padding/seq-len rules, dropout p=1, alibi w/o causal, non-FP32 Stats, head-dim multiple, sliding-window s_q>s_kv, bwd s_q=s_kv=1) raise from `validate()` with classic error types.
- `test/python/sdpa/frost/` integration + analyzer + heuristics suites: 117 passed on SM100 / 9.26.
- End-to-end smoke both ways (bf16 causal prefill, matches torch SDPA): frost off → lowered at validate, backend engine executes; frost on → not lowered at validate, `sdpa_fwd_prefill_sm100` serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)