### PR TITLE
Row/col-wise-quantize-operation-perfo-optimization

### DIFF
--- a/benchmark/gemm/frost/benchmark_moe_block_scale_matmul_swiglu_cutedsl_vs_frost.py
+++ b/benchmark/gemm/frost/benchmark_moe_block_scale_matmul_swiglu_cutedsl_vs_frost.py
@@ -61,8 +61,8 @@ def _ceil_div(a, b):
     return (a + b - 1) // b
 
 
-def _permuted(l, mode0, mode1, dtype, *, mode0_major=False):
-    shape = (l, mode1, mode0) if mode0_major else (l, mode0, mode1)
+def _permuted(num_groups, mode0, mode1, dtype, *, mode0_major=False):
+    shape = (num_groups, mode1, mode0) if mode0_major else (num_groups, mode0, mode1)
     order = (2, 1, 0) if mode0_major else (1, 2, 0)
     if dtype is torch.float4_e2m1fn_x2:
         packed = torch.randint(0, 256, (*shape[:-1], shape[-1] // 2), dtype=torch.uint8, device=_DEV)
@@ -70,9 +70,9 @@ def _permuted(l, mode0, mode1, dtype, *, mode0_major=False):
     return torch.empty(shape, dtype=torch.float32, device=_DEV).uniform_(-2, 2).permute(order).to(dtype)
 
 
-def _make_sf(l, mn, k, sf_vec_size, dtype):
+def _make_sf(num_groups, mn, k, sf_vec_size, dtype):
     sf_k = _ceil_div(k, sf_vec_size)
-    shape = (l, _ceil_div(mn, 128), _ceil_div(sf_k, 4), 32, 4, 4)
+    shape = (num_groups, _ceil_div(mn, 128), _ceil_div(sf_k, 4), 32, 4, 4)
     buf = torch.empty(shape, dtype=torch.float32, device=_DEV).uniform_(1, 3).to(torch.int8).to(torch.float32)
     return buf.permute(3, 4, 1, 5, 2, 0).to(dtype)
 
@@ -278,7 +278,7 @@ def _frost_spec_map(combo, output_mode, alignment=1):
 
     chain = analyze(_frost_graph(1024, 256, 512, 2, combo, output_mode, alignment)[0])
     m = {}
-    for t, cfg in registry_candidates(chain):
+    for _template, cfg in registry_candidates(chain):
         if cfg.pipeline != "sm100" or cfg.mma_tile_m != 128:
             continue
         m[cfg.name] = (cfg, cfg.cta_group)
@@ -446,7 +446,7 @@ def main() -> int:
     if args.sides in ("both", "cutedsl"):
         per_set = _cutedsl_bytes(E, M, N, K, args.combo, args.output_mode)
         nbuf = bu.resolve_nbuf(args.rotate_buffers, per_set)
-        print(f"  -- cuteDSL GroupedGemmGluSm100 --")
+        print("  -- cuteDSL GroupedGemmGluSm100 --")
         bu.report_pool(nbuf, per_set)
         wset = _cutedsl_set(E, M, N, K, args.combo, args.output_mode)
         pool = _cutedsl_pool(E, M, N, K, args.combo, args.output_mode, nbuf)
@@ -497,14 +497,9 @@ def main() -> int:
         from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
 
         store_modes = {"tma": ["tma"], "stg": ["stg"], "both": ["tma", "stg"]}[args.frost_store]
-        spec_map = _frost_spec_map(args.combo, args.output_mode, args.fto_alignment)
         offsets = bu.group_offsets(S, E)
-        bad = [int(o) for o in offsets.tolist() if int(o) % args.fto_alignment]
-        if bad:
-            sys.exit(
-                f"--fto-alignment {args.fto_alignment} is not true of the offsets this bench builds "
-                f"({bad[:4]}...): the promise is unchecked at runtime and would miscompute."
-            )
+        alignment = bu.fto_alignment(args.fto_alignment, offsets)
+        spec_map = _frost_spec_map(args.combo, args.output_mode, alignment)
         wset = _frost_set(S, N, K, E, args.combo, args.output_mode)
         pool = [wset] + [_frost_set(S, N, K, E, args.combo, args.output_mode) for _ in range(max(0, nbuf - 1))]
         for cname in bu.select_configs(args.configs, spec_map):
@@ -519,7 +514,7 @@ def main() -> int:
                     print(f"  > {label} ...", flush=True)
                 t0 = time.time()
                 try:
-                    g, h = _frost_graph(S, N, K, E, args.combo, args.output_mode, args.fto_alignment)
+                    g, h = _frost_graph(S, N, K, E, args.combo, args.output_mode, alignment)
                     with C.force_stg_epi(store == "stg"):
                         plan = jit_from_cudnn_graph(g, config=cfg)
                 except (NotImplementedError, ValueError) as e:

--- a/benchmark/gemm/frost/benchmark_moe_block_scale_matmul_swiglu_cutedsl_vs_frost.py
+++ b/benchmark/gemm/frost/benchmark_moe_block_scale_matmul_swiglu_cutedsl_vs_frost.py
@@ -1,0 +1,567 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Head-to-head: cuteDSL grouped-GEMM GLU vs FROST MoE grouped block-scale
+dual-matmul + SwiGLU, on the same problem, same timing methodology and output
+contract.
+
+cuteDSL runs ONE grouped GEMM of width 2N whose gate/up halves are 32-column
+interleaved (cudnn.GroupedGemmGluSm100; on an SM 10.7 part this picks the Rubin
+kernel).  FROST runs TWO parallel grouped matmuls of width N sharing the token
+operand, fused by a pointwise SwiGLU epilogue.  Same FLOPs, different
+decomposition.
+
+The block-scaled GLU backend always materializes the pre-activation C
+(valid_m x 2N) alongside D -- generate_c is dropped on that path -- so the FROST
+graph taps both grouped-matmul outputs and writes the same bytes.  The per-side
+byte accounting is printed below the header.
+
+The FROST graph mirrors the cuteDSL epilogue op for op: the per-expert alpha
+multiplies BOTH accumulators before the activation and the taps carry the
+alpha-scaled pre-activation, exactly as the Rubin kernel does (alpha -> store_c
+-> swiglu_act).  So both sides compute silu(alpha*gate) * (alpha*up) from a
+per-group alpha of the same shape, not two differently-parenthesised functions.
+
+``--output-mode fp8-rowcol`` (MXFP8 only) additionally gives both sides the
+same dual-quant output contract: one row-wise and one column-wise FP8 E4M3 D,
+each with a block-32 E8M0 scale in F8_128x4 layout.  cuteDSL calls those
+D/D_col and SFD_row/SFD_col; FROST expresses the same work as two terminal
+block_scale_quantize nodes.  ``norm_const=1`` makes the scale conventions
+identical.
+
+    python benchmark/gemm/frost/benchmark_moe_block_scale_matmul_swiglu_cutedsl_vs_frost.py \
+        --shape 12,1024,3072,7168 --combo mxfp8 --output-mode fp8-rowcol
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import sys
+import time
+
+import torch
+
+import benchmark_moe_block_scale_matmul_swiglu as fb
+import benchmark_utils as bu
+
+# combo -> (sf_vec_size, ab dtype, sf dtype, d dtype)
+_COMBOS = {
+    "nvfp4": (16, torch.float4_e2m1fn_x2, torch.float8_e4m3fn, torch.bfloat16),
+    "mxfp4": (32, torch.float4_e2m1fn_x2, torch.float8_e8m0fnu, torch.bfloat16),
+    "mxfp8": (32, torch.float8_e4m3fn, torch.float8_e8m0fnu, torch.bfloat16),
+}
+
+_DEV = "cuda"
+_OUTPUT_MODES = ("bf16", "fp8-rowcol")
+_QUANT_BLOCK = 32
+
+
+def _ceil_div(a, b):
+    return (a + b - 1) // b
+
+
+def _permuted(l, mode0, mode1, dtype, *, mode0_major=False):
+    shape = (l, mode1, mode0) if mode0_major else (l, mode0, mode1)
+    order = (2, 1, 0) if mode0_major else (1, 2, 0)
+    if dtype is torch.float4_e2m1fn_x2:
+        packed = torch.randint(0, 256, (*shape[:-1], shape[-1] // 2), dtype=torch.uint8, device=_DEV)
+        return packed.view(dtype).permute(order)
+    return torch.empty(shape, dtype=torch.float32, device=_DEV).uniform_(-2, 2).permute(order).to(dtype)
+
+
+def _make_sf(l, mn, k, sf_vec_size, dtype):
+    sf_k = _ceil_div(k, sf_vec_size)
+    shape = (l, _ceil_div(mn, 128), _ceil_div(sf_k, 4), 32, 4, 4)
+    buf = torch.empty(shape, dtype=torch.float32, device=_DEV).uniform_(1, 3).to(torch.int8).to(torch.float32)
+    return buf.permute(3, 4, 1, 5, 2, 0).to(dtype)
+
+
+def _cutedsl_set(E, M, N, K, combo, output_mode="bf16", want_amax=False):
+    sf_vec, ab_dt, sf_dt, default_d_dt = _COMBOS[combo]
+    d_dt = torch.float8_e4m3fn if output_mode == "fp8-rowcol" else default_d_dt
+    n = 2 * N
+    valid_m = E * M
+    offsets = torch.tensor([(i + 1) * M for i in range(E)], dtype=torch.int32, device=_DEV)
+    s = {
+        "a": _permuted(1, valid_m, K, ab_dt),
+        "b": _permuted(E, n, K, ab_dt),
+        "sfa": _make_sf(1, valid_m, K, sf_vec, sf_dt),
+        "sfb": _make_sf(E, n, K, sf_vec, sf_dt),
+        "offsets": offsets,
+        "alpha": torch.ones(E, dtype=torch.float32, device=_DEV),
+        "c": _permuted(1, valid_m, n, torch.bfloat16),
+        "d": _permuted(1, valid_m, N, d_dt),
+        "d_col": _permuted(1, valid_m, N, d_dt),
+        "amax": None,
+        "sfd_row": None,
+        "sfd_col": None,
+        "norm_const": None,
+    }
+    if output_mode == "fp8-rowcol":
+        # GroupedGemmGluSm100's two D tensors are both physically N-major.  The
+        # row/col names describe the reduction axis used to make their scales,
+        # not their GMEM layout.  These are precisely the two F8_128x4 layouts
+        # used by FROST's row- and M-axis block_scale_quantize outputs below.
+        s["sfd_row"] = _make_sf(1, valid_m, N, _QUANT_BLOCK, sf_dt)
+        s["sfd_col"] = _make_sf(1, N, valid_m, _QUANT_BLOCK, sf_dt)
+        s["norm_const"] = torch.ones(1, dtype=torch.float32, device=_DEV)
+    if d_dt in (torch.bfloat16, torch.float16) and want_amax:
+        s["amax"] = torch.full((E, 1), float("-inf"), dtype=torch.float32, device=_DEV)
+    return s
+
+
+def _cutedsl_bytes(E, M, N, K, combo, output_mode):
+    s = _cutedsl_set(E, M, N, K, combo, output_mode)
+    total = sum(t.untyped_storage().nbytes() for t in s.values() if torch.is_tensor(t))
+    del s
+    torch.cuda.empty_cache()
+    return total
+
+
+def _cutedsl_pool(E, M, N, K, combo, output_mode, nbuf):
+    return [_cutedsl_set(E, M, N, K, combo, output_mode) for _ in range(max(1, nbuf))]
+
+
+def _build_cutedsl(s, combo, mma_tiler, cluster, dynamic_sched, vector_f32):
+    from cudnn import GroupedGemmGluSm100
+
+    sf_vec, _ab, _sf, _d = _COMBOS[combo]
+    api = GroupedGemmGluSm100(
+        sample_a=s["a"],
+        sample_c=s["c"],
+        sample_d=s["d"],
+        sample_sfa=s["sfa"],
+        sample_padded_offsets=s["offsets"],
+        sample_alpha=s["alpha"],
+        sample_d_col=s["d_col"],
+        sample_b=s["b"],
+        sample_sfb=s["sfb"],
+        sample_sfd_row=s["sfd_row"],
+        sample_sfd_col=s["sfd_col"],
+        sample_amax=s["amax"],
+        sample_norm_const=s["norm_const"],
+        sample_prob=None,
+        acc_dtype=torch.float32,
+        mma_tiler_mn=mma_tiler,
+        cluster_shape_mn=cluster,
+        sf_vec_size=sf_vec,
+        m_aligned=256,
+        vector_f32=vector_f32,
+        act_func="swiglu",
+        use_dynamic_sched=dynamic_sched,
+    )
+    if not api.check_support():
+        raise ValueError("check_support() returned False")
+    api.compile()
+    return api
+
+
+def _cutedsl_launch(api, s, stream):
+    api.execute(
+        a_tensor=s["a"],
+        c_tensor=s["c"],
+        d_tensor=s["d"],
+        sfa_tensor=s["sfa"],
+        padded_offsets=s["offsets"],
+        alpha_tensor=s["alpha"],
+        b_tensor=s["b"],
+        sfb_tensor=s["sfb"],
+        d_col_tensor=s["d_col"],
+        sfd_row_tensor=s["sfd_row"],
+        sfd_col_tensor=s["sfd_col"],
+        amax_tensor=s["amax"],
+        norm_const_tensor=s["norm_const"],
+        current_stream=stream,
+    )
+
+
+def _frost_graph(S, N, K, E, combo, output_mode="bf16", alignment=1):
+    import cudnn
+    from types import SimpleNamespace
+
+    block_size, a_dt, sf_dt = fb._COMBOS[combo]
+    sf_k = K // block_size
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.BFLOAT16,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    tok = g.tensor(name="token", dim=[1, S, K], stride=[S * K, K, 1], data_type=a_dt)
+    w0 = g.tensor(name="weight0", dim=[E, K, N], stride=[K * N, 1, K], data_type=a_dt)
+    w1 = g.tensor(name="weight1", dim=[E, K, N], stride=[K * N, 1, K], data_type=a_dt)
+    SFA = g.tensor(
+        name="SFA",
+        dim=[1, S, sf_k],
+        stride=[S * sf_k, sf_k, 1],
+        data_type=sf_dt,
+        reordering_type=cudnn.tensor_reordering.F8_128x4,
+    )
+    SFB0 = g.tensor(
+        name="SFB0",
+        dim=[E, sf_k, N],
+        stride=[sf_k * N, 1, sf_k],
+        data_type=sf_dt,
+        reordering_type=cudnn.tensor_reordering.F8_128x4,
+    )
+    SFB1 = g.tensor(
+        name="SFB1",
+        dim=[E, sf_k, N],
+        stride=[sf_k * N, 1, sf_k],
+        data_type=sf_dt,
+        reordering_type=cudnn.tensor_reordering.F8_128x4,
+    )
+    fto = g.tensor(
+        name="first_token_offset",
+        dim=[E, 1, 1],
+        stride=[1, 1, 1],
+        data_type=cudnn.data_type.INT32,
+        alignment_value=alignment,
+    )
+    alpha = g.tensor(name="alpha", dim=[E, 1, 1], stride=[1, 1, 1], data_type=cudnn.data_type.FLOAT)
+    tok_d = g.block_scale_dequantize(input=tok, descale=SFA, block_size=[1, block_size])
+    w0_d = g.block_scale_dequantize(input=w0, descale=SFB0, block_size=[block_size, 1])
+    w1_d = g.block_scale_dequantize(input=w1, descale=SFB1, block_size=[block_size, 1])
+    c0 = g.moe_grouped_matmul(tok_d, w0_d, fto, mode=cudnn.moe_grouped_matmul_mode.NONE, compute_data_type=cudnn.data_type.FLOAT, name="moe0")
+    c1 = g.moe_grouped_matmul(tok_d, w1_d, fto, mode=cudnn.moe_grouped_matmul_mode.NONE, compute_data_type=cudnn.data_type.FLOAT, name="moe1")
+    a0 = g.mul(a=c0, b=alpha, name="alpha0")
+    a1 = g.mul(a=c1, b=alpha, name="alpha1")
+    s0 = g.swish(input=a0, name="silu0")
+    dq = g.mul(a=s0, b=a1, name="mul0")
+    outputs = []
+    if output_mode == "fp8-rowcol":
+        qrow, sfrow = g.block_scale_quantize(input=dq, block_size=_QUANT_BLOCK, axis=-1, name="qrow")
+        qrow.set_output(True).set_data_type(cudnn.data_type.FP8_E4M3)
+        sfrow_n = _ceil_div(N // _QUANT_BLOCK, 4) * 4
+        sfrow.set_dim([1, _ceil_div(S, 128) * 128, sfrow_n]).set_stride([(_ceil_div(S, 128) * 128) * sfrow_n, sfrow_n, 1])
+        sfrow.set_output(True).set_data_type(cudnn.data_type.FP8_E8M0)
+        sfrow.set_reordering_type(cudnn.tensor_reordering.F8_128x4)
+
+        qcol, sfcol = g.block_scale_quantize(
+            input=dq,
+            block_size=_QUANT_BLOCK,
+            axis=1,
+            group_offset=fto,
+            name="qcol",
+        )
+        qcol.set_output(True).set_data_type(cudnn.data_type.FP8_E4M3)
+        sfcol_m = _ceil_div(S // _QUANT_BLOCK, 4) * 4
+        sfcol_n = _ceil_div(N, 128) * 128
+        sfcol.set_dim([1, sfcol_n, sfcol_m]).set_stride([sfcol_n * sfcol_m, sfcol_m, 1])
+        sfcol.set_output(True).set_data_type(cudnn.data_type.FP8_E8M0)
+        sfcol.set_reordering_type(cudnn.tensor_reordering.F8_128x4)
+        outputs.extend([qrow, qcol])
+    else:
+        dq.set_output(True).set_data_type(cudnn.data_type.BFLOAT16)
+        outputs.append(dq)
+    for src_c, nm in ((a0, "tapC0"), (a1, "tapC1")):
+        t = g.identity(input=src_c, name=nm)
+        t.set_output(True).set_data_type(cudnn.data_type.BFLOAT16)
+        outputs.append(t)
+    if output_mode == "fp8-rowcol":
+        # Binding order is dense outputs in set_output order, then quant scales.
+        outputs.extend([sfrow, sfcol])
+    return g, SimpleNamespace(
+        first_token_offset=fto,
+        a_operands=[tok],
+        b_operands=[w0, w1],
+        sfa_operands=[SFA],
+        sfb_operands=[SFB0, SFB1],
+        outputs=outputs,
+        aux=[alpha],
+    )
+
+
+def _frost_spec_map(combo, output_mode, alignment=1):
+    from cudnn.gemm.frost.graph_analyzer import analyze
+    from cudnn.gemm.frost.kernel_registry import candidates as registry_candidates
+
+    chain = analyze(_frost_graph(1024, 256, 512, 2, combo, output_mode, alignment)[0])
+    m = {}
+    for t, cfg in registry_candidates(chain):
+        if cfg.pipeline != "sm100" or cfg.mma_tile_m != 128:
+            continue
+        m[cfg.name] = (cfg, cfg.cta_group)
+    return m
+
+
+def _frost_set(S, N, K, E, combo, output_mode):
+    base = fb._mkdata(S, N, K, E, combo)
+    alpha = torch.ones(E, 1, 1, dtype=torch.float32, device=_DEV)
+    taps = [torch.empty(1, S, N, dtype=torch.bfloat16, device=_DEV) for _ in range(2)]
+    if output_mode == "fp8-rowcol":
+        qrow = torch.empty(1, S, N, dtype=torch.float8_e4m3fn, device=_DEV)
+        qcol = torch.empty_like(qrow)
+        sfrow = torch.empty(
+            1,
+            _ceil_div(S, 128) * 128,
+            _ceil_div(N // _QUANT_BLOCK, 4) * 4,
+            dtype=torch.float8_e8m0fnu,
+            device=_DEV,
+        )
+        sfcol = torch.empty(
+            1,
+            _ceil_div(N, 128) * 128,
+            _ceil_div(S // _QUANT_BLOCK, 4) * 4,
+            dtype=torch.float8_e8m0fnu,
+            device=_DEV,
+        )
+        outputs = [qrow, qcol, *taps, sfrow, sfcol]
+    else:
+        d = torch.empty(1, S, N, dtype=torch.bfloat16, device=_DEV)
+        outputs = [d, *taps]
+    # Drop benchmark_moe_block_scale_matmul_swiglu's own D/scalar slots: this
+    # comparison supplies its own output contract and per-expert alpha.
+    return (base[:6], alpha, outputs)
+
+
+def _frost_launch(plan, h, item, offsets, stream):
+    inputs, alpha, outputs = item
+    plan(fb._vp_moe_bs_mg(h, fb._gemm_pairs(inputs), offsets, outputs, alpha), stream=stream)
+
+
+def _cutedsl_all_tiles():
+    """Every (mma_tiler, cluster) the block-scaled GLU backend accepts: N is
+    pinned to 256, use_2cta_instrs is derived from tiler M, and
+    cluster_tiler_m = cluster_m // (2 if 2cta) * tiler_m must be 128 or 256."""
+    out = []
+    for tm in (128, 256):
+        two_cta = tm == 256
+        for cm in (1, 2, 4):
+            if two_cta and cm % 2:
+                continue
+            if (cm // (2 if two_cta else 1)) * tm not in (128, 256):
+                continue
+            for cn in (1, 2, 4):
+                if cm * cn <= 16:
+                    out.append(((tm, 256), (cm, cn)))
+    return out
+
+
+def _parse_tiles(spec):
+    if spec.strip().lower() == "all":
+        return _cutedsl_all_tiles()
+    out = []
+    for item in spec.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        tile, _, clus = item.partition(":")
+        tm, _, tn = tile.partition("x")
+        mma = (int(tm), int(tn))
+        if clus:
+            cm, _, cn = clus.partition("x")
+            out.append((mma, (int(cm), int(cn))))
+        else:
+            out.append((mma, None))
+    return out
+
+
+def _fmt_cutedsl_label(mma, cluster, dyn, vecf32):
+    c = "auto" if cluster is None else f"{cluster[0]}x{cluster[1]}"
+    return f"cutedsl {mma[0]}x{mma[1]} cluster{c}{' dynsched' if dyn else ''}{' vecf32' if vecf32 else ''}"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--shape", default="12,4096,3072,7168", help="G,M,N,K — G groups x M tokens, N = SwiGLU OUTPUT width (gemm width is 2N)")
+    p.add_argument("--combo", choices=tuple(_COMBOS), default="nvfp4")
+    p.add_argument(
+        "--output-mode",
+        choices=_OUTPUT_MODES,
+        default="bf16",
+        help="shared output contract: bf16, or dual row/col block-32 FP8+E8M0 quantization (MXFP8 only)",
+    )
+    p.add_argument("--sides", choices=("both", "cutedsl", "frost"), default="both")
+    p.add_argument("--cutedsl-tiles", default="all", help="'all' (every legal tiler x cluster) or an MxN[:cmxcn] list")
+    p.add_argument("--dynamic-sched", choices=("off", "on", "both"), default="both")
+    p.add_argument("--vector-f32", choices=("off", "on", "both"), default="both", help="cuteDSL packed f32x2 epilogue math")
+    p.add_argument("--frost-store", choices=("tma", "stg", "both"), default="both", help="FROST epilogue store mode to sweep (default: both)")
+    p.add_argument(
+        "--fto-alignment",
+        type=int,
+        default=1,
+        help="first_token_offset `alignment_value`: promise every routed-group start is a "
+        "multiple of it. Lets FROST address A / SFA / D through the ORIGINAL TMA descriptors "
+        "instead of rewriting them per group, for every config whose cluster tile M (and, "
+        "block-scale, 128) divides it. 1 (default) = no promise. The bench checks its own "
+        "offsets against it; the kernel does not.",
+    )
+    bu.add_sweep_args(p, nsys=False)
+    args = p.parse_args()
+
+    if not torch.cuda.is_available():
+        print("No CUDA, skipping.")
+        return 1
+
+    parts = [int(x) for x in args.shape.split(",")]
+    if len(parts) != 4:
+        sys.exit("--shape must be G,M,N,K")
+    E, M, N, K = parts
+    if M % 256:
+        sys.exit(f"M={M} must be a multiple of 256 (cuteDSL pads each group to m_aligned=256)")
+    if args.output_mode == "fp8-rowcol" and args.combo != "mxfp8":
+        sys.exit("--output-mode fp8-rowcol requires --combo mxfp8: GroupedGemmGluSm100 rejects low-precision D for FP4 A/B")
+    if args.output_mode == "fp8-rowcol" and (N % _QUANT_BLOCK or (E * M) % _QUANT_BLOCK):
+        sys.exit(f"--output-mode fp8-rowcol requires N and S=E*M divisible by {_QUANT_BLOCK}")
+    S = E * M
+    n_gemm = 2 * N
+
+    from cuda.bindings import driver as cuda_drv
+
+    # One stream for both sides and for the timing events: cuteDSL takes a
+    # CUstream, FROST's _as_custream takes the raw handle. Leaving FROST on its
+    # stream=None default hard-wires it to the legacy default stream, which only
+    # matches torch's current stream by coincidence.
+    stream_handle = torch.cuda.current_stream().cuda_stream
+    stream = cuda_drv.CUstream(stream_handle)
+
+    flops = 2 * S * n_gemm * K
+    major, minor = torch.cuda.get_device_capability()
+    print(f"\n=== MoE grouped SwiGLU ({args.combo}, {args.output_mode})  " f"E={E} x M={M} (S={S})  N_out={N} (gemm N={n_gemm})  K={K} ===")
+    print(f"  {torch.cuda.get_device_name(0)}  sm_{major}{minor}   ~{flops / 1e9:.1f} GFLOP")
+    print(f"  [timing: {args.timing}, warmup={args.warmup}, iters={args.iters}]")
+    if args.fto_alignment > 1:
+        print(f"  [fto alignment_value: {args.fto_alignment} — FROST may take the global-descriptor path]")
+
+    elem = 0.5 if _COMBOS[args.combo][1] is torch.float4_e2m1fn_x2 else 1.0
+    read_bytes = int(S * K * elem + E * n_gemm * K * elem)
+    if args.output_mode == "fp8-rowcol":
+        d_bytes = 2 * S * N
+        sf_bytes = (_ceil_div(S, 128) * 128) * (_ceil_div(N // _QUANT_BLOCK, 4) * 4)
+        sf_bytes += (_ceil_div(N, 128) * 128) * (_ceil_div(S // _QUANT_BLOCK, 4) * 4)
+    else:
+        d_bytes = S * N * 2
+        sf_bytes = 0
+    c_bytes = S * n_gemm * 2
+    print(
+        f"  compulsory reads ~{read_bytes / 1e6:.0f} MB   "
+        f"D write ~{d_bytes / 1e6:.0f} MB" + (f"   quant-SF write ~{sf_bytes / 1e6:.1f} MB" if sf_bytes else "")
+    )
+    print(f"  both sides also write the pre-activation C ~{c_bytes / 1e6:.0f} MB " f"(cuteDSL: one {n_gemm}-wide buffer; FROST: two {N}-wide taps)")
+    print()
+
+    results = []
+
+    if args.sides in ("both", "cutedsl"):
+        per_set = _cutedsl_bytes(E, M, N, K, args.combo, args.output_mode)
+        nbuf = bu.resolve_nbuf(args.rotate_buffers, per_set)
+        print(f"  -- cuteDSL GroupedGemmGluSm100 --")
+        bu.report_pool(nbuf, per_set)
+        wset = _cutedsl_set(E, M, N, K, args.combo, args.output_mode)
+        pool = _cutedsl_pool(E, M, N, K, args.combo, args.output_mode, nbuf)
+        modes = {"off": [False], "on": [True], "both": [False, True]}
+        dyn_modes = modes[args.dynamic_sched]
+        vec_modes = modes[args.vector_f32]
+        sweep = [(mma, cluster, dyn, vecf32) for mma, cluster in _parse_tiles(args.cutedsl_tiles) for dyn in dyn_modes for vecf32 in vec_modes]
+        for mma, cluster, dyn, vecf32 in sweep:
+            label = _fmt_cutedsl_label(mma, cluster, dyn, vecf32)
+            if args.stream:
+                print(f"  > {label} ...", flush=True)
+            t0 = time.time()
+            try:
+                api = _build_cutedsl(wset, args.combo, mma, cluster, dyn, vecf32)
+            except (ValueError, NotImplementedError, RuntimeError) as e:
+                print(f"  {label:52s} UNSUPPORTED: {type(e).__name__}: {str(e)[:60]}")
+                continue
+            try:
+                _cutedsl_launch(api, wset, stream)
+                torch.cuda.synchronize()
+            except Exception as e:  # noqa: BLE001
+                print(f"  {label:52s} LAUNCH FAIL: {type(e).__name__}: {str(e)[:60]}")
+                continue
+            jit = time.time() - t0
+            ms = bu.time_ms(
+                bu.rotating(lambda s, _a=api: _cutedsl_launch(_a, s, stream), pool),
+                lambda _a=api: _cutedsl_launch(_a, wset, stream),
+                warmup=args.warmup,
+                iters=args.iters,
+                timing=args.timing,
+            )
+            tf = flops / (ms * 1e-3) / 1e12
+            results.append((label, ms, tf))
+            print(f"  {label:52s} {tf:8.2f} TFLOP/s  {ms:8.3f} ms   [jit {jit:5.1f}s]", flush=True)
+        del wset, pool
+        torch.cuda.empty_cache()
+        print()
+
+    if args.sides in ("both", "frost"):
+        print("  -- FROST dual grouped block-scale matmul + SwiGLU + matched outputs + C taps --")
+        probe = _frost_set(S, N, K, E, args.combo, args.output_mode)
+        per_set = bu.set_bytes(probe[0]) + bu.set_bytes(probe[1:2]) + bu.set_bytes(probe[2])
+        del probe
+        torch.cuda.empty_cache()
+        nbuf = bu.resolve_nbuf(args.rotate_buffers, per_set)
+        bu.report_pool(nbuf, per_set)
+        from cudnn.gemm.frost import compiler as C
+        from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
+
+        store_modes = {"tma": ["tma"], "stg": ["stg"], "both": ["tma", "stg"]}[args.frost_store]
+        spec_map = _frost_spec_map(args.combo, args.output_mode, args.fto_alignment)
+        offsets = bu.group_offsets(S, E)
+        bad = [int(o) for o in offsets.tolist() if int(o) % args.fto_alignment]
+        if bad:
+            sys.exit(
+                f"--fto-alignment {args.fto_alignment} is not true of the offsets this bench builds "
+                f"({bad[:4]}...): the promise is unchecked at runtime and would miscompute."
+            )
+        wset = _frost_set(S, N, K, E, args.combo, args.output_mode)
+        pool = [wset] + [_frost_set(S, N, K, E, args.combo, args.output_mode) for _ in range(max(0, nbuf - 1))]
+        for cname in bu.select_configs(args.configs, spec_map):
+            spec = bu.spec_for(cname, spec_map)
+            if spec is None:
+                print(f"  {cname:52s} UNKNOWN config")
+                continue
+            cfg, cta_group = spec
+            for store in store_modes:
+                label = f"frost[{store}] {cname}"
+                if args.stream:
+                    print(f"  > {label} ...", flush=True)
+                t0 = time.time()
+                try:
+                    g, h = _frost_graph(S, N, K, E, args.combo, args.output_mode, args.fto_alignment)
+                    with C.force_stg_epi(store == "stg"):
+                        plan = jit_from_cudnn_graph(g, config=cfg)
+                except (NotImplementedError, ValueError) as e:
+                    print(f"  {label:52s} UNSUPPORTED: {type(e).__name__}: {str(e)[:60]}")
+                    continue
+                try:
+                    _frost_launch(plan, h, wset, offsets, stream_handle)
+                    torch.cuda.synchronize()
+                except Exception as e:  # noqa: BLE001
+                    print(f"  {label:52s} LAUNCH FAIL: {type(e).__name__}: {str(e)[:60]}")
+                    continue
+                jit = time.time() - t0
+                ms = bu.time_ms(
+                    bu.rotating(lambda s, _p=plan, _h=h: _frost_launch(_p, _h, s, offsets, stream_handle), pool),
+                    lambda _p=plan, _h=h: _frost_launch(_p, _h, wset, offsets, stream_handle),
+                    warmup=args.warmup,
+                    iters=args.iters,
+                    timing=args.timing,
+                )
+                tf = flops / (ms * 1e-3) / 1e12
+                results.append((label, ms, tf))
+                print(f"  {label:52s} {tf:8.2f} TFLOP/s  {ms:8.3f} ms   [jit {jit:5.1f}s]", flush=True)
+        del wset, pool
+        torch.cuda.empty_cache()
+        print()
+
+    if not results:
+        print("  nothing ran.")
+        return 1
+
+    best_cute = min((r for r in results if r[0].startswith("cutedsl")), key=lambda r: r[1], default=None)
+    best_frost = min((r for r in results if r[0].startswith("frost")), key=lambda r: r[1], default=None)
+    print("  === summary ===")
+    for tag, r in (("cuteDSL", best_cute), ("FROST", best_frost)):
+        if r is None:
+            print(f"  best {tag:8s} —")
+        else:
+            print(f"  best {tag:8s} {r[2]:8.2f} TFLOP/s  {r[1]:8.3f} ms   {r[0]}")
+    if best_cute and best_frost:
+        print(f"\n  FROST / cuteDSL = {best_cute[1] / best_frost[1]:.3f}x " f"({'FROST faster' if best_frost[1] < best_cute[1] else 'cuteDSL faster'})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -301,6 +301,17 @@ def _tma_store_issue(chain, cfg, j: int, coord: str, ptr: str) -> "list[str]":
     ]
 
 
+def _tma_store_coord(chain, dim0: str, dim1: str) -> str:
+    """Coordinate tuple matching the output TMA descriptor rank.
+
+    Routed MoE outputs are one flat ``(S, N)`` surface: their logical batch is
+    fixed to one and every store used to carry a redundant third coordinate.
+    Keep ordinary GEMM descriptors rank-3, but let MoE issue the cheaper 2-D
+    TMA-store form.
+    """
+    return f"({dim0}, {dim1})" if chain.has_moe else f"({dim0}, {dim1}, tile_l)"
+
+
 def _tma_store_one(chain, cfg, epi_n: int, j: int, dt: str, major: str) -> "list[str]":
     """One TMA-stored output's store stage: stage this lane's fragment into the
     shared ring slot, then issue from it.
@@ -340,10 +351,22 @@ def _tma_store_one(chain, cfg, epi_n: int, j: int, dt: str, major: str) -> "list
             "nvvm.barrier_cta_sync(barrier_id=EPI_SYNC_BAR_ID, thread_count=num_epilogue_warps * 32)",
         ]
         for mb in range(m_rows // atom_m):
-            lines += _tma_store_issue(chain, cfg, j, f"(coord_m + {mb * atom_m}, col, tile_l)", f"{v}.data_ptr({mb * atom_m * epi_n})")
+            lines += _tma_store_issue(
+                chain,
+                cfg,
+                j,
+                _tma_store_coord(chain, f"coord_m + {mb * atom_m}", "col"),
+                f"{v}.data_ptr({mb * atom_m * epi_n})",
+            )
         if _epi_dp22(cfg):
             # the other COLUMN half, not another M block: same rows, further along N
-            lines += _tma_store_issue(chain, cfg, j, "(coord_m, col + epi_cols_per_mma_m, tile_l)", f"{v}.data_ptr({atom_m * epi_n})")
+            lines += _tma_store_issue(
+                chain,
+                cfg,
+                j,
+                _tma_store_coord(chain, "coord_m", "col + epi_cols_per_mma_m"),
+                f"{v}.data_ptr({atom_m * epi_n})",
+            )
     else:
         row_bytes = _epi_row_bytes(dt, epi_n)
         row_elems = _epi_row_elems(dt, epi_n)
@@ -357,11 +380,17 @@ def _tma_store_one(chain, cfg, epi_n: int, j: int, dt: str, major: str) -> "list
             "cute.arch.fence_view_async_shared()",
             "nvvm.barrier_cta_sync(barrier_id=EPI_SYNC_BAR_ID, thread_count=num_epilogue_warps * 32)",
         ]
-        lines += _tma_store_issue(chain, cfg, j, f"({col_c}, coord_m, tile_l)", f"{v}.data_ptr()")
+        lines += _tma_store_issue(chain, cfg, j, _tma_store_coord(chain, col_c, "coord_m"), f"{v}.data_ptr()")
         if _epi_dp22(cfg):
             # warps 2/3's column half, staged behind the first tile
             half = "(col + epi_cols_per_mma_m) // 2" if DTYPE_BITS[dt] < 8 else "col + epi_cols_per_mma_m"
-            lines += _tma_store_issue(chain, cfg, j, f"({half}, coord_m, tile_l)", f"{v}.data_ptr({m_rows * row_elems})")
+            lines += _tma_store_issue(
+                chain,
+                cfg,
+                j,
+                _tma_store_coord(chain, half, "coord_m"),
+                f"{v}.data_ptr({m_rows * row_elems})",
+            )
     lines += [
         "    if elect_one:",
         "        nvvm.cp_async_bulk_commit_group()",
@@ -389,20 +418,23 @@ def _host_tma_c_descs(chain, tma_slots: "frozenset[int]", epi_n: int) -> str:
     strides, box and swizzle, so outputs of different dtypes and different
     layouts can share one epilogue."""
     outs = _tma_out_dtypes(chain, tma_slots)
-    batch = "1" if chain.has_moe else "batch"
     lines: list[str] = []
     for j, (slot, dt) in enumerate(outs):
         width = _cd_view_bits(dt)
         if chain.output_specs[slot].major == "m":
-            dims = f"[m, n, {batch}]"
+            dims = "[m, n]" if chain.has_moe else "[m, n, batch]"
             outer = f"out_stride_n_{slot}"
-            box = f"[{_mmajor_atom_m(dt)}, {epi_n}, 1]"
+            box = f"[{_mmajor_atom_m(dt)}, {epi_n}]" if chain.has_moe else f"[{_mmajor_atom_m(dt)}, {epi_n}, 1]"
             sw = "s128b"
         else:
-            dims = f"[{'n // 2' if DTYPE_BITS[dt] < 8 else 'n'}, m, {batch}]"
+            n_dim = "n // 2" if DTYPE_BITS[dt] < 8 else "n"
+            dims = f"[{n_dim}, m]" if chain.has_moe else f"[{n_dim}, m, batch]"
             outer = f"out_stride_m_{slot}"
-            box = f"[{_epi_row_elems(dt, epi_n)}, epi_tile_mn[0], 1]"
+            box = f"[{_epi_row_elems(dt, epi_n)}, epi_tile_mn[0]]" if chain.has_moe else f"[{_epi_row_elems(dt, epi_n)}, epi_tile_mn[0], 1]"
             sw = _EPI_SWIZZLE_BY_ROW_BYTES[_epi_row_bytes(dt, epi_n)][1]
+        strides = [f"        {outer} * {width} // 128,"]
+        if not chain.has_moe:
+            strides.append(f"        out_stride_l_{slot} * {width} // 128,")
         lines += [
             f"_c{j} = _tma_c_outputs[{j}]",
             f"tma_c_desc_{j} = _tma.create_tensor_map_tiled(",
@@ -410,8 +442,7 @@ def _host_tma_c_descs(chain, tma_slots: "frozenset[int]", epi_n: int) -> str:
             f"    dtype={_cd_cutlass(dt)},",
             f"    global_dims={dims},",
             "    global_strides=[",
-            f"        {outer} * {width} // 128,",
-            f"        out_stride_l_{slot} * {width} // 128,",
+            *strides,
             "    ],",
             f"    box_dims={box},",
             f"    swizzle=_tma.TensorMapSwizzle.{sw},",

--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -57,7 +57,7 @@ from .dtypes import (
     dense_output_layout,
     tensor_alignment,
 )
-from .epilogue_codegen import EpilogueSnippets, generate, tma_out_value
+from .epilogue_codegen import EpilogueSnippets, generate, tma_out_ready_marker, tma_out_value
 from .fusion_ir import ZERO_PRESERVING_OPS, FusionChain, TensorRef
 from .recipe import (
     CONST,
@@ -411,6 +411,25 @@ def _tma_store_sequence(chain, cfg, tma_slots: "frozenset[int]", epi_n: int) -> 
     for j, (slot, dt) in enumerate(_tma_out_dtypes(chain, tma_slots)):
         lines += _tma_store_one(chain, cfg, epi_n, j, dt, chain.output_specs[slot].major)
     return "\n".join(lines) if lines else "pass"
+
+
+def _place_tma_stores(epilogue: str, chain, cfg, tma_slots: "frozenset[int]", epi_n: int) -> tuple[str, str]:
+    """Inline each multi-output TMA store at its fragment's last use.
+
+    Single-output graphs retain the aggregate trailing sequence, preserving
+    their existing instruction scheduling.
+    """
+    outputs = _tma_out_dtypes(chain, tma_slots)
+    stream = len(outputs) > 1
+    for j, (slot, dt) in enumerate(outputs):
+        marker = tma_out_ready_marker(j)
+        if epilogue.count(marker) != 1:
+            raise RuntimeError(f"epilogue missing unique TMA-output marker {marker}")
+        replacement = ""
+        if stream:
+            replacement = "\n".join(_tma_store_one(chain, cfg, epi_n, j, dt, chain.output_specs[slot].major))
+        epilogue = epilogue.replace(marker, replacement)
+    return epilogue, "pass" if stream else _tma_store_sequence(chain, cfg, tma_slots, epi_n)
 
 
 def _host_tma_c_descs(chain, tma_slots: "frozenset[int]", epi_n: int) -> str:
@@ -1963,7 +1982,7 @@ def _render_template(
         replacements.update(_tma_c_plumbing(chain, tma_slots))
     if "@@INJECT_TMA_STORE_SEQUENCE@@" in src:
         _epi = _epi_n(config, chain.output_dtype)
-        replacements["INJECT_TMA_STORE_SEQUENCE"] = _tma_store_sequence(chain, config, tma_slots, _epi)
+        replacements["INJECT_EPILOGUE"], replacements["INJECT_TMA_STORE_SEQUENCE"] = _place_tma_stores(snippets.epilogue, chain, config, tma_slots, _epi)
         replacements["INJECT_HOST_TMA_C_DESCS"] = _host_tma_c_descs(chain, tma_slots, _epi)
     # Per-GEMM STG vector bindings — on every STG-epilogue template (mainloop
     # included; single-GEMM → `pass`).
@@ -2173,7 +2192,7 @@ def _render_block_scale_template(
         replacements.update(_tma_c_plumbing(chain, tma_slots))
     if "@@INJECT_TMA_STORE_SEQUENCE@@" in src:
         _epi = _epi_n(config, chain.output_dtype)
-        replacements["INJECT_TMA_STORE_SEQUENCE"] = _tma_store_sequence(chain, config, tma_slots, _epi)
+        replacements["INJECT_EPILOGUE"], replacements["INJECT_TMA_STORE_SEQUENCE"] = _place_tma_stores(snippets.epilogue, chain, config, tma_slots, _epi)
         replacements["INJECT_HOST_TMA_C_DESCS"] = _host_tma_c_descs(chain, tma_slots, _epi)
     # MoE block-scale raw-A-tensor plumbing (per-routed-group descriptor patch).
     if "@@INJECT_MOE_KERNEL_MA_PARAMS@@" in src:

--- a/python/cudnn/gemm/frost/epilogue_codegen.py
+++ b/python/cudnn/gemm/frost/epilogue_codegen.py
@@ -110,6 +110,11 @@ def tma_out_value(j: int) -> str:
     return "vec_out" if j == 0 else f"_tma_out_{j}"
 
 
+def tma_out_ready_marker(j: int) -> str:
+    """Codegen marker immediately after TMA output ``j`` is ready."""
+    return f"# @@FROST_TMA_OUT_{j}_READY@@"
+
+
 def _aux_reads_row(aux: TensorRef) -> bool:
     return len(aux.dim) >= 2 and aux.dim[-2] != 1
 
@@ -1044,13 +1049,26 @@ def _emit_block_quant_col(
                 quant,
             )
         )
+    # The deterministic FP32->scale converter is a hardware x2 operation (the
+    # native x4 form is stochastic-only), but the four rounded scale values can
+    # still share one vector reciprocal/min pipeline.  Keeping that pipeline as
+    # TensorSSA gives the backend the same four-wide scheduling opportunity as
+    # the specialized Rubin epilogue without changing RP/SATFINITE semantics.
+    lines.extend(
+        [
+            f"    {p}_up4 = cute.make_rmem_tensor(4, cutlass.Float32)",
+            *(f"    {p}_up4[{i}] = {p}_u{i}" for i in range(4)),
+            f"    {p}_upv = {p}_up4.load()",
+            f"    {p}_iv = cute.math.min(cute.math.rcp({p}_upv, approx=True, ftz=True), " f"cutlass.full_like({p}_upv, cutlass.Float32(3.402823466e38)))",
+        ]
+    )
+    for lane_in_batch in range(0, 4, 2):
+        other = lane_in_batch + 1
         lines.extend(
             [
-                f"    {p}_i{lane_in_batch} = cute.math.min(cute.arch.rcp_approx({p}_u{lane_in_batch}), cutlass.Float32(3.402823466e38))",
-                f"    {p}_i{other} = cute.math.min(cute.arch.rcp_approx({p}_u{other}), cutlass.Float32(3.402823466e38))",
                 f"    {p}_out[{p}_vi + {lane_in_batch}], {p}_out[{p}_vi + {other}] = cute.arch.mul_packed_f32x2("
                 f"({p}_src[{p}_vi + {lane_in_batch}], {p}_src[{p}_vi + {other}]), "
-                f'({p}_i{lane_in_batch}, {p}_i{other}), rnd="rn", ftz=False)',
+                f'({p}_iv[{lane_in_batch}], {p}_iv[{other}]), rnd="rn", ftz=False)',
                 f"    if ({p}_lane % {G}) == (({p}_vi + {lane_in_batch}) % {G}):",
                 f"        {p}_scale_mine[({p}_vi + {lane_in_batch}) // {G}] = {p}_q{lane_in_batch}",
                 f"    if ({p}_lane % {G}) == (({p}_vi + {other}) % {G}):",
@@ -1147,26 +1165,15 @@ def _emit_block_quant(
     n_sub = vsize // bs
     lines: list[str] = [
         f"{p}_src = ({source_var}).to(cutlass.Float32)",
-        f"{p}_abs = cute.math.abs({p}_src)",
+        f"{p}_frg = cute.TensorSSA({p}_src.ir_value(), ({bs}, {n_sub}), cutlass.Float32)",
+        f"{p}_abs_ir = cutlass._mlir.dialects.math.absf({p}_frg.ir_value())",
+        f"{p}_abs = type({p}_frg)({p}_abs_ir, {p}_frg.shape, {p}_frg.dtype)",
         f"{p}_out = cute.make_rmem_tensor({vsize}, cutlass.Float32)",
         f"{p}_rl = cute.arch.rcp_approx({_quant_output_max(output_dtype)})",
     ]
     for k in range(n_sub):
         base = k * bs
-        reduction = [f"{p}_abs[{base + e}]" for e in range(bs)]
-        level = 0
-        while len(reduction) > 1:
-            next_level: list[str] = []
-            for pair in range(0, len(reduction), 2):
-                if pair + 1 == len(reduction):
-                    next_level.append(reduction[pair])
-                    continue
-                var = f"{p}_r{k}_{level}_{pair // 2}"
-                lines.append(f"{var} = cute.math.max({reduction[pair]}, {reduction[pair + 1]})")
-                next_level.append(var)
-            reduction = next_level
-            level += 1
-        lines.append(f"{p}_amax{k} = {reduction[0]}")
+        lines.append(f"{p}_amax{k} = {p}_abs[None, {k}].reduce(cute.ReductionOp.MAX, cutlass.Float32(0.0), 0)")
         lines.append(f"{p}_sf{k} = {p}_amax{k} * {p}_rl")
         lines.extend(_emit_scale_quantize(p, str(k), f"{p}_sf{k}", f"{p}_scale{k}", f"{p}_up{k}", quant))
         lines.append(f"{p}_inv{k} = cute.math.min(cute.arch.rcp_approx({p}_up{k}), cutlass.Float32(3.402823466e38))")
@@ -1427,10 +1434,23 @@ def generate(
     def _scale_tap_idx(qi: int) -> int:
         return _tap_of[len(specs) + len(chain.reductions) + qi]
 
-    for si, spec in enumerate(specs):
+    output_order = list(range(len(specs)))
+    if on_tma_arm and len(tma_slots) > 1:
+        # The compiler stores each output at its ready marker.  Retire outputs
+        # backed by an exclusive source first, while register-heavy quantizers
+        # stay last.  Python's stable sort preserves slot order among ties.
+        source_uses: dict[int, int] = {}
+        for output_spec in specs:
+            source_uses[output_spec.source_ref] = source_uses.get(output_spec.source_ref, 0) + 1
+        for reduction in chain.reductions:
+            source_uses[reduction.source_ref] = source_uses.get(reduction.source_ref, 0) + 1
+        output_order.sort(key=lambda oi: (specs[oi].quant_idx is not None, source_uses[specs[oi].source_ref]))
+    for si in output_order:
+        spec = specs[si]
         src = _parent_value(spec.source_ref)
         if si in tma_slots:
-            _ov = tma_out_value(sorted(tma_slots).index(si))
+            _tma_j = sorted(tma_slots).index(si)
+            _ov = tma_out_value(_tma_j)
             if spec.quant_idx is not None:
                 body_lines.extend(
                     _emit_block_quant(
@@ -1448,6 +1468,7 @@ def generate(
                 )
             else:
                 body_lines.append(f"{_ov} = {_store_cast_expr(src, spec.dtype)}")
+            body_lines.append(tma_out_ready_marker(_tma_j))
             continue
         tap_idx = _tap_of[si]
         if spec.major == "m":

--- a/python/cudnn/gemm/frost/epilogue_codegen.py
+++ b/python/cudnn/gemm/frost/epilogue_codegen.py
@@ -1166,8 +1166,7 @@ def _emit_block_quant(
     lines: list[str] = [
         f"{p}_src = ({source_var}).to(cutlass.Float32)",
         f"{p}_frg = cute.TensorSSA({p}_src.ir_value(), ({bs}, {n_sub}), cutlass.Float32)",
-        f"{p}_abs_ir = cutlass._mlir.dialects.math.absf({p}_frg.ir_value())",
-        f"{p}_abs = type({p}_frg)({p}_abs_ir, {p}_frg.shape, {p}_frg.dtype)",
+        f"{p}_abs = cute.math.absf({p}_frg)",
         f"{p}_out = cute.make_rmem_tensor({vsize}, cutlass.Float32)",
         f"{p}_rl = cute.arch.rcp_approx({_quant_output_max(output_dtype)})",
     ]

--- a/python/cudnn/gemm/frost/epilogue_codegen.py
+++ b/python/cudnn/gemm/frost/epilogue_codegen.py
@@ -904,16 +904,6 @@ def _quant_output_max(dtype: Dtype) -> str:
     raise ValueError(f"block quantize output dtype {dtype!r} is not supported by codegen")
 
 
-def _quant_output_min(dtype: Dtype) -> str:
-    if dtype == "fp8_e4m3":
-        return "cutlass.Float32(-448.0)"
-    if dtype == "fp8_e5m2":
-        return "cutlass.Float32(-57344.0)"
-    if dtype == "fp4_e2m1":
-        return "cutlass.Float32(-6.0)"
-    raise ValueError(f"block quantize output dtype {dtype!r} is not supported by codegen")
-
-
 def _scale_store_dtype(scale_dtype: Dtype) -> str:
     """The DSL type a quantized scale is STORED as — one source of truth for the
     scale tap's element type, its zero-init, and the value written. E5M3 has no
@@ -1012,64 +1002,72 @@ def _emit_block_quant_col(
         f"{p}_src = ({source_var}).to(cutlass.Float32)",
         f"{p}_out = cute.make_rmem_tensor({vsize}, cutlass.Float32)",
         f"{p}_rl = cute.arch.rcp_approx({_quant_output_max(output_dtype)})",
+        f"{p}_scale_mine = cute.make_rmem_tensor({n_groups}, {scale_dtype})",
     ]
     for k in range(n_groups):
-        lines.append(f"{p}_scale_mine_{k} = (cutlass.Float32(0.0)).to({scale_dtype})")
-    # Columns are processed in batches of 4 warp reductions issued
-    # back-to-back so their latencies overlap; only adjacent PAIRS share an
-    # instruction, so register liveness stays bounded by the batch.
-    for b0 in range(0, vsize, 4):
-        nb = min(4, vsize - b0)
-        cols = range(b0, b0 + nb)
-        for i in cols:
-            if quant.block_size == 16:
-                # 16-row blocks: each half-warp reduces its own block (the
-                # cta_tile_m=64 1-CTA layout only ever runs the low half).
-                lines.extend(
-                    [
-                        f"{p}_a{i} = cutlass.Float32(0.0)",
-                        f"if {p}_lane < 16:",
-                        f'    {p}_a{i} = cute.arch.warp_redux_sync({p}_src[{i}], "fmax", mask_and_clamp=0x0000FFFF, abs=True)',
-                        f"else:",
-                        f'    {p}_a{i} = cute.arch.warp_redux_sync({p}_src[{i}], "fmax", mask_and_clamp=0xFFFF0000, abs=True)',
-                    ]
-                )
-            else:
-                lines.append(f'{p}_a{i} = cute.arch.warp_redux_sync({p}_src[{i}], "fmax", abs=True)')
-        for i in range(b0, b0 + nb, 2):
-            j = i + 1
-            lines.append(f'{p}_s{i}, {p}_s{j} = cute.arch.mul_packed_f32x2(({p}_a{i}, {p}_a{j}), ({p}_rl, {p}_rl), rnd="rn", ftz=False)')
-            lines.extend(
-                _emit_scale_quantize_pair(
-                    p,
-                    (str(i), f"{p}_s{i}", f"{p}_q{i}", f"{p}_u{i}"),
-                    (str(j), f"{p}_s{j}", f"{p}_q{j}", f"{p}_u{j}"),
-                    quant,
-                )
-            )
+        lines.append(f"{p}_scale_mine[{k}] = (cutlass.Float32(0.0)).to({scale_dtype})")
+
+    # Keep only four columns' reduction/scale temporaries live at once.  It is
+    # important that this is one generated constexpr loop with reused names,
+    # rather than Python-codegen unrolling into q0..q31 SSA values: the latter
+    # makes the backend retain most of the 32-column scale state concurrently.
+    lines.append(f"for {p}_vi in cutlass.range_constexpr(0, {vsize}, 4):")
+    for lane_in_batch in range(4):
+        if quant.block_size == 16:
+            # 16-row blocks: each half-warp reduces its own block (the
+            # cta_tile_m=64 1-CTA layout only ever runs the low half).
             lines.extend(
                 [
-                    f"{p}_i{i} = cute.math.min(cute.arch.rcp_approx({p}_u{i}), cutlass.Float32(3.402823466e38))",
-                    f"{p}_i{j} = cute.math.min(cute.arch.rcp_approx({p}_u{j}), cutlass.Float32(3.402823466e38))",
-                    f'{p}_out[{i}], {p}_out[{j}] = cute.arch.mul_packed_f32x2(({p}_src[{i}], {p}_src[{j}]), ({p}_i{i}, {p}_i{j}), rnd="rn", ftz=False)',
-                    f"if ({p}_lane % {G}) == {i % G}:",
-                    f"    {p}_scale_mine_{i // G} = {p}_q{i}",
-                    f"if ({p}_lane % {G}) == {j % G}:",
-                    f"    {p}_scale_mine_{j // G} = {p}_q{j}",
+                    f"    {p}_a{lane_in_batch} = cutlass.Float32(0.0)",
+                    f"    if {p}_lane < 16:",
+                    f'        {p}_a{lane_in_batch} = cute.arch.warp_redux_sync({p}_src[{p}_vi + {lane_in_batch}], "fmax", '
+                    "mask_and_clamp=0x0000FFFF, abs=True)",
+                    "    else:",
+                    f'        {p}_a{lane_in_batch} = cute.arch.warp_redux_sync({p}_src[{p}_vi + {lane_in_batch}], "fmax", '
+                    "mask_and_clamp=0xFFFF0000, abs=True)",
                 ]
             )
+        else:
+            lines.append(f'    {p}_a{lane_in_batch} = cute.arch.warp_redux_sync({p}_src[{p}_vi + {lane_in_batch}], "fmax", abs=True)')
+    for lane_in_batch in range(0, 4, 2):
+        other = lane_in_batch + 1
+        lines.append(
+            f"    {p}_s{lane_in_batch}, {p}_s{other} = cute.arch.mul_packed_f32x2("
+            f'({p}_a{lane_in_batch}, {p}_a{other}), ({p}_rl, {p}_rl), rnd="rn", ftz=False)'
+        )
+        lines.extend(
+            "    " + line
+            for line in _emit_scale_quantize_pair(
+                p,
+                (f"b{lane_in_batch}", f"{p}_s{lane_in_batch}", f"{p}_q{lane_in_batch}", f"{p}_u{lane_in_batch}"),
+                (f"b{other}", f"{p}_s{other}", f"{p}_q{other}", f"{p}_u{other}"),
+                quant,
+            )
+        )
+        lines.extend(
+            [
+                f"    {p}_i{lane_in_batch} = cute.math.min(cute.arch.rcp_approx({p}_u{lane_in_batch}), cutlass.Float32(3.402823466e38))",
+                f"    {p}_i{other} = cute.math.min(cute.arch.rcp_approx({p}_u{other}), cutlass.Float32(3.402823466e38))",
+                f"    {p}_out[{p}_vi + {lane_in_batch}], {p}_out[{p}_vi + {other}] = cute.arch.mul_packed_f32x2("
+                f"({p}_src[{p}_vi + {lane_in_batch}], {p}_src[{p}_vi + {other}]), "
+                f'({p}_i{lane_in_batch}, {p}_i{other}), rnd="rn", ftz=False)',
+                f"    if ({p}_lane % {G}) == (({p}_vi + {lane_in_batch}) % {G}):",
+                f"        {p}_scale_mine[({p}_vi + {lane_in_batch}) // {G}] = {p}_q{lane_in_batch}",
+                f"    if ({p}_lane % {G}) == (({p}_vi + {other}) % {G}):",
+                f"        {p}_scale_mine[({p}_vi + {other}) // {G}] = {p}_q{other}",
+            ]
+        )
+    # The scale is rounded up and the reciprocal comes from that stored scale,
+    # so every data value is already inside the destination format's finite
+    # range.  An explicit elementwise min/max here is redundant and lowers to
+    # hundreds of FSETP/FMNMX instructions for a dual row/col quant epilogue.
     lines.extend(
         [
             f"{p}_vec = {p}_out.load().to_vector()",
             (
-                f"{p}_clamped = cute.math.min(cute.math.max({p}_vec, "
-                f"cutlass.full_like({p}_vec, {_quant_output_min(output_dtype)})), "
-                f"cutlass.full_like({p}_vec, {_quant_output_max(output_dtype)}))"
-            ),
-            (
-                f"{out_var} = ({p}_clamped).to(cutlass.Float4E2M1FN).bitcast(cutlass.Int8)"
+                f"{out_var} = ({p}_vec).to(cutlass.Float4E2M1FN).bitcast(cutlass.Int8)"
                 if output_dtype == "fp4_e2m1"
-                else f"{out_var} = ({p}_clamped).to({DTYPE_TO_CUTLASS[output_dtype]})"
+                else f"{out_var} = ({p}_vec).to({DTYPE_TO_CUTLASS[output_dtype]})"
             ),
         ]
     )
@@ -1100,7 +1098,7 @@ def _emit_block_quant_col(
             )
         # The scale byte is a SIDE STORE: the STG arm sits inside `row < M`,
         # the TMA arm has no row bound of its own.
-        _st = f"(gC_tap_{scale_tap_idx}_ptr + {p}_sidx{k}).store({p}_scale_mine_{k}, alignment=1)"
+        _st = f"(gC_tap_{scale_tap_idx}_ptr + {p}_sidx{k}).store({p}_scale_mine[{k}], alignment=1)"
         if row_pred is None:
             lines.append(_st)
         else:
@@ -1155,9 +1153,20 @@ def _emit_block_quant(
     ]
     for k in range(n_sub):
         base = k * bs
-        lines.append(f"{p}_amax{k} = {p}_abs[{base}]")
-        for e in range(1, bs):
-            lines.append(f"{p}_amax{k} = cute.math.max({p}_amax{k}, {p}_abs[{base + e}])")
+        reduction = [f"{p}_abs[{base + e}]" for e in range(bs)]
+        level = 0
+        while len(reduction) > 1:
+            next_level: list[str] = []
+            for pair in range(0, len(reduction), 2):
+                if pair + 1 == len(reduction):
+                    next_level.append(reduction[pair])
+                    continue
+                var = f"{p}_r{k}_{level}_{pair // 2}"
+                lines.append(f"{var} = cute.math.max({reduction[pair]}, {reduction[pair + 1]})")
+                next_level.append(var)
+            reduction = next_level
+            level += 1
+        lines.append(f"{p}_amax{k} = {reduction[0]}")
         lines.append(f"{p}_sf{k} = {p}_amax{k} * {p}_rl")
         lines.extend(_emit_scale_quantize(p, str(k), f"{p}_sf{k}", f"{p}_scale{k}", f"{p}_up{k}", quant))
         lines.append(f"{p}_inv{k} = cute.math.min(cute.arch.rcp_approx({p}_up{k}), cutlass.Float32(3.402823466e38))")
@@ -1166,18 +1175,16 @@ def _emit_block_quant(
                 f"{p}_out[{base + e}], {p}_out[{base + e + 1}] = cute.arch.mul_packed_f32x2("
                 f'({p}_src[{base + e}], {p}_src[{base + e + 1}]), ({p}_inv{k}, {p}_inv{k}), rnd="rn", ftz=False)'
             )
+    # See the col-quant path above: scale-up rounding already bounds the data,
+    # and the direct narrowing is the same contract used by the specialized
+    # grouped-GEMM quant epilogues.
     lines.extend(
         [
             f"{p}_vec = {p}_out.load().to_vector()",
             (
-                f"{p}_clamped = cute.math.min(cute.math.max({p}_vec, "
-                f"cutlass.full_like({p}_vec, {_quant_output_min(output_dtype)})), "
-                f"cutlass.full_like({p}_vec, {_quant_output_max(output_dtype)}))"
-            ),
-            (
-                f"{out_var} = ({p}_clamped).to(cutlass.Float4E2M1FN).bitcast(cutlass.Int8)"
+                f"{out_var} = ({p}_vec).to(cutlass.Float4E2M1FN).bitcast(cutlass.Int8)"
                 if output_dtype == "fp4_e2m1"
-                else f"{out_var} = ({p}_clamped).to({DTYPE_TO_CUTLASS[output_dtype]})"
+                else f"{out_var} = ({p}_vec).to({DTYPE_TO_CUTLASS[output_dtype]})"
             ),
         ]
     )

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd.py
@@ -1578,7 +1578,7 @@ def _kernel(
 
         # @@TMA_STORE_ONLY:BEGIN@@
         epi_stage_idx = cutlass.Int32(EPI_SMEM_STAGES - 1)
-        # The routed output is a single (1, S, N) tensor, so the batch coord is fixed.
+        # The routed output is one flat (S, N) TMA surface.
         tile_l = cutlass.Int32(0)
         epi_block_linear = bidx + bidy * gridx
         d_desc_base_list = [

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd.py
@@ -1122,7 +1122,7 @@ def _kernel(
 
         # @@TMA_STORE_ONLY:BEGIN@@
         epi_stage_idx = cutlass.Int32(EPI_SMEM_STAGES - 1)
-        # The routed output is a single (1, S, N) tensor, so the batch coord is fixed.
+        # The routed output is one flat (S, N) TMA surface.
         tile_l = cutlass.Int32(0)
         epi_block_linear = bidx + bidy * gridx
         d_desc_base_list = [

--- a/test/python/gemm/frost/test_matmul_epilogue_fusion.py
+++ b/test/python/gemm/frost/test_matmul_epilogue_fusion.py
@@ -2834,6 +2834,8 @@ def test_row_quant_amax_uses_vector_reduce() -> None:
     used by the specialized grouped-GLU epilogue."""
     src = pathlib.Path(epilogue_codegen.__file__).read_text()
     assert "cute.TensorSSA({p}_src.ir_value(), ({bs}, {n_sub}), cutlass.Float32)" in src
+    assert "{p}_abs = cute.math.absf({p}_frg)" in src
+    assert "cutlass._mlir.dialects.math.absf" not in src
     assert "{p}_abs[None, {k}].reduce(cute.ReductionOp.MAX" in src
     assert 'lines.append(f"{var} = cute.math.max(' not in src
 

--- a/test/python/gemm/frost/test_matmul_epilogue_fusion.py
+++ b/test/python/gemm/frost/test_matmul_epilogue_fusion.py
@@ -2803,12 +2803,15 @@ def test_tma_staged_values_reach_the_store_as_vectors() -> None:
 
     sites = src.count("cute.make_rmem_tensor(")
     converted = src.count(".load().to_vector()")
-    assert sites == 4, (
-        f"epilogue_codegen has {sites} make_rmem_tensor sites, expected 4. A new one either "
+    assert sites == 5, (
+        f"epilogue_codegen has {sites} make_rmem_tensor sites, expected 5. A new one either "
         f"converts with .load().to_vector() or its feature stays off the TMA arm -- decide which, "
         f"then update this test."
     )
     assert converted == 5, f"expected exactly 5 converted rmem loads, found {converted}"
+    # Col quant's `_scale_mine` is the fifth rmem tensor. It is a one-byte-per-
+    # block side-store carrier, not a dense value entering the TMA staging ring.
+    assert src.count("_scale_mine = cute.make_rmem_tensor(") == 1
     # The two block-quantize emitters were the last holdouts: their result now
     # reaches a TMA-stored dense output, so they must convert like the rest.
     assert src.count("_out = cute.make_rmem_tensor(") == 2

--- a/test/python/gemm/frost/test_matmul_epilogue_fusion.py
+++ b/test/python/gemm/frost/test_matmul_epilogue_fusion.py
@@ -2803,8 +2803,8 @@ def test_tma_staged_values_reach_the_store_as_vectors() -> None:
 
     sites = src.count("cute.make_rmem_tensor(")
     converted = src.count(".load().to_vector()")
-    assert sites == 5, (
-        f"epilogue_codegen has {sites} make_rmem_tensor sites, expected 5. A new one either "
+    assert sites == 6, (
+        f"epilogue_codegen has {sites} make_rmem_tensor sites, expected 6. A new one either "
         f"converts with .load().to_vector() or its feature stays off the TMA arm -- decide which, "
         f"then update this test."
     )
@@ -2816,6 +2816,26 @@ def test_tma_staged_values_reach_the_store_as_vectors() -> None:
     # reaches a TMA-stored dense output, so they must convert like the rest.
     assert src.count("_out = cute.make_rmem_tensor(") == 2
     assert src.count("_vec = {p}_out.load().to_vector()") == 2, "the block-quantize emitters must hand on a Vector"
+
+
+def test_col_quant_uses_four_wide_inverse_scale_pipeline() -> None:
+    """The FP8 scale conversion itself is deterministic x2 in hardware, but
+    the four scales in one col-quant batch should share a TensorSSA reciprocal
+    and clamp instead of lowering to four scalar compare/select pairs."""
+    src = pathlib.Path(epilogue_codegen.__file__).read_text()
+    assert "{p}_up4 = cute.make_rmem_tensor(4, cutlass.Float32)" in src
+    assert "{p}_iv = cute.math.min(cute.math.rcp({p}_upv" in src
+    assert "cute.arch.rcp_approx({p}_u{lane_in_batch})" not in src
+
+
+def test_row_quant_amax_uses_vector_reduce() -> None:
+    """A scalar max tree lowers every pair to FSETP/FSEL.  Keep the row-block
+    amax in TensorSSA form so MLIR lowers it to the compact vector reduction
+    used by the specialized grouped-GLU epilogue."""
+    src = pathlib.Path(epilogue_codegen.__file__).read_text()
+    assert "cute.TensorSSA({p}_src.ir_value(), ({bs}, {n_sub}), cutlass.Float32)" in src
+    assert "{p}_abs[None, {k}].reduce(cute.ReductionOp.MAX" in src
+    assert 'lines.append(f"{var} = cute.math.max(' not in src
 
 
 _PW_M, _PW_N, _PW_K = 128, 128, 128

--- a/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
@@ -256,6 +256,24 @@ def test_analyzer_detects_moe_grouped_block_scale_matmul_fwd() -> None:
 def test_analyzer_offset_dtype_int64() -> None:
     chain = analyze(_build_graph(2, 1024, 256, 512, num_groups=4, offset_dt=cudnn.data_type.INT64))
     assert chain.moe.offset_dtype == "int64"
+
+
+def test_moe_block_scale_tma_store_uses_rank2_output_descriptor() -> None:
+    """The block-scale MoE template shares the flat (S, N) TMA output surface
+    with plain MoE; neither descriptor nor store coordinates carry batch=1."""
+    from cudnn.gemm.frost.compiler import _epi_n, _host_tma_c_descs, _tma_store_sequence
+
+    chain = analyze(_build_graph(E=4, S=512, N=256, K=512, num_groups=4))
+    cfg = by_name(_CFG)
+    epi_n = _epi_n(cfg, chain.output_dtype)
+    host = _host_tma_c_descs(chain, frozenset({0}), epi_n)
+    sequence = _tma_store_sequence(chain, cfg, frozenset({0}), epi_n)
+
+    assert "global_dims=[n, m]" in host
+    assert f"box_dims=[{epi_n}, epi_tile_mn[0]]" in host
+    assert "out_stride_l_0" not in host
+    assert "(col, coord_m)" in sequence
+    assert "tile_l" not in sequence
     assert chain.has_moe and chain.has_block_scale
 
 

--- a/test/python/gemm/frost/test_moe_grouped_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_matmul_fwd.py
@@ -561,6 +561,26 @@ def test_moe_grouped_matmul_fwd_auto_config_n_major_small_n() -> None:
     torch.testing.assert_close(output[0], _ref_f32(token, weight_k, offsets, S, N, E).to(torch.bfloat16), atol=1e-1, rtol=1e-2)
 
 
+def test_moe_tma_store_uses_rank2_output_descriptor() -> None:
+    """MoE's output is one flat (S, N) surface, so its TMA store must not carry
+    the fixed-one batch dimension paid by ordinary batched GEMM. Besides being
+    redundant in the descriptor, that extra coordinate selects UTMASTG.3D
+    instead of UTMASTG.2D in SASS."""
+    from cudnn.gemm.frost.compiler import _epi_n, _host_tma_c_descs, _tma_store_sequence
+
+    chain = analyze(_build_graph(E=4, S=512, N=256, K=128))
+    cfg = by_name(_CFG)
+    epi_n = _epi_n(cfg, chain.output_dtype)
+    host = _host_tma_c_descs(chain, frozenset({0}), epi_n)
+    sequence = _tma_store_sequence(chain, cfg, frozenset({0}), epi_n)
+
+    assert "global_dims=[n, m]" in host
+    assert f"box_dims=[{epi_n}, epi_tile_mn[0]]" in host
+    assert "out_stride_l_0" not in host
+    assert "(col, coord_m)" in sequence
+    assert "tile_l" not in sequence
+
+
 @pytest.mark.parametrize("cta_group", (1, 2))
 def test_moe_m_major_output(cta_group: int) -> None:
     """A routed MoE output may be M-major. It takes STG: TMA would clip D to


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
- [x] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

Improve the epilogue row/col-wise quantize operation performance

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added benchmarking coverage for MoE grouped matrix multiplication with NVFP4, MXFP4, and MXFP8 inputs.
  * Added comparisons across output formats, tile configurations, and execution modes.

* **Performance Improvements**
  * Improved quantized output processing and multi-output scheduling.
  * Reduced overhead for multi-output MoE workloads.

* **Bug Fixes**
  * Corrected MoE output handling for flat layouts and coordinates.

* **Tests**
  * Added regression coverage for MoE output storage and quantization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->