### PR TITLE
Add MiniMax Lightning Indexer static-cache decode

### DIFF
--- a/benchmark/nsa/benchmark_lightning_indexer.py
+++ b/benchmark/nsa/benchmark_lightning_indexer.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Benchmark exact MiniMax Lightning Indexer decode against its Torch reference."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import platform
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+import torch
+
+from cudnn import NSA
+
+BLOCK_SIZE = 128
+TOP_K = 16
+HEADS = 4
+HEAD_DIM = 128
+
+
+def reference(q, k, position_ids):
+    """Run the dense PyTorch score, block-max, Top-K formulation."""
+    batch, _, _, _ = q.shape
+    k_len = k.shape[1]
+    num_blocks = math.ceil(k_len / BLOCK_SIZE)
+    scores = torch.matmul(
+        q.transpose(1, 2).float(),
+        k.transpose(1, 2).float().transpose(-1, -2),
+    )
+    key_positions = torch.arange(k_len, device=q.device)
+    scores.masked_fill_(
+        key_positions[None, None, None, :] > position_ids[:, None, :, None],
+        float("-inf"),
+    )
+    if padding := num_blocks * BLOCK_SIZE - k_len:
+        scores = torch.nn.functional.pad(scores, (0, padding), value=float("-inf"))
+    block_scores = scores.view(batch, HEADS, 1, num_blocks, BLOCK_SIZE).amax(-1)
+    current = (position_ids // BLOCK_SIZE)[:, None, :, None].expand(-1, HEADS, -1, -1)
+    block_scores.scatter_(-1, current, float("inf"))
+    selected = min(TOP_K, num_blocks)
+    values, indices = torch.topk(block_scores, selected, dim=-1, sorted=False)
+    result = torch.full(
+        (batch, HEADS, 1, TOP_K),
+        -1,
+        dtype=torch.int64,
+        device=q.device,
+    )
+    result[..., :selected] = indices.masked_fill(values == float("-inf"), -1)
+    counts = (result >= 0).sum(-1, dtype=torch.int32)
+    return result, counts
+
+
+def canonical_sets(indices):
+    """Sort valid IDs while moving -1 padding to the end."""
+    sentinel = torch.iinfo(torch.int64).max
+    return torch.sort(indices.to(torch.int64).masked_fill(indices < 0, sentinel), dim=-1).values
+
+
+def measure(call, warmup, iterations):
+    """Measure one asynchronous callable with CUDA events."""
+    for _ in range(warmup):
+        call()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iterations):
+        call()
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) * 1000.0 / iterations
+
+
+def benchmark_shape(batch, k_capacity, position, warmup, iterations, rounds):
+    """Validate and interleave reference/prepared timings for one shape."""
+    generator = torch.Generator(device="cuda").manual_seed(0x4D330000 + batch * 17 + k_capacity + position)
+    q = torch.randn(
+        (batch, 1, HEADS, HEAD_DIM),
+        generator=generator,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    k = torch.randn(
+        (batch, k_capacity, 1, HEAD_DIM),
+        generator=generator,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    positions = torch.tensor([[position]], dtype=torch.int64, device="cuda").expand(batch, -1)
+    block_indices = torch.empty(
+        (batch, 1, HEADS, TOP_K),
+        dtype=torch.int32,
+        device="cuda",
+    ).transpose(1, 2)
+    block_counts = torch.empty(
+        (batch, 1, HEADS),
+        dtype=torch.int32,
+        device="cuda",
+    ).transpose(1, 2)
+    plan = NSA.LightningIndexer(q, k, positions, block_indices, block_counts)
+    plan.check_support()
+    plan.compile()
+    workspace = plan.make_workspace()
+
+    def run_prepared_api():
+        plan.execute(
+            q,
+            k,
+            positions,
+            block_indices,
+            block_counts,
+            workspace,
+        )
+
+    expected_indices, expected_counts = reference(q, k, positions)
+    run_prepared_api()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(block_counts, expected_counts, rtol=0, atol=0)
+    torch.testing.assert_close(
+        canonical_sets(block_indices),
+        canonical_sets(expected_indices),
+        rtol=0,
+        atol=0,
+    )
+
+    reference_us = []
+    prepared_api_us = []
+    for round_index in range(rounds):
+        arms = (
+            (("reference", lambda: reference(q, k, positions)), ("prepared_api", run_prepared_api))
+            if round_index % 2 == 0
+            else (("prepared_api", run_prepared_api), ("reference", lambda: reference(q, k, positions)))
+        )
+        samples = {}
+        for name, call in arms:
+            samples[name] = measure(call, warmup, iterations)
+        reference_us.append(samples["reference"])
+        prepared_api_us.append(samples["prepared_api"])
+
+    graph = torch.cuda.CUDAGraph()
+    run_prepared_api()
+    torch.cuda.synchronize()
+    with torch.cuda.graph(graph):
+        run_prepared_api()
+    graph_replay_us = [measure(graph.replay, warmup, iterations) for _ in range(rounds)]
+
+    reference_median = statistics.median(reference_us)
+    prepared_api_median = statistics.median(prepared_api_us)
+    graph_replay_median = statistics.median(graph_replay_us)
+    return {
+        "batch": batch,
+        "k_capacity": k_capacity,
+        "position": position,
+        "workspace_bytes": plan.workspace_size,
+        "reference_us": reference_us,
+        "prepared_api_us": prepared_api_us,
+        "graph_replay_us": graph_replay_us,
+        "reference_median_us": reference_median,
+        "prepared_api_median_us": prepared_api_median,
+        "graph_replay_median_us": graph_replay_median,
+        "speedup_vs_eager_dense_reference": reference_median / prepared_api_median,
+        "correct": True,
+    }
+
+
+def source_metadata():
+    """Record enough provenance to tie an artifact to an exact worktree."""
+    root = Path(__file__).resolve().parents[2]
+
+    def git(*args):
+        return subprocess.run(
+            ["git", "-C", str(root), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    return {
+        "repository": str(root),
+        "git_sha": git("rev-parse", "HEAD"),
+        "git_dirty": bool(git("status", "--porcelain")),
+        "command": [sys.executable, *sys.argv],
+        "slurm_job_id": os.environ.get("SLURM_JOB_ID"),
+        "slurm_node": os.environ.get("SLURMD_NODENAME"),
+    }
+
+
+def parse_args():
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--batch", type=int, default=1)
+    parser.add_argument(
+        "--k-capacity",
+        type=int,
+        action="append",
+        dest="capacities",
+        help="repeatable K capacity; defaults to 2048/8192/16384/32768",
+    )
+    parser.add_argument(
+        "--position",
+        type=int,
+        help="shared explicit position (default: suffix for each capacity)",
+    )
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iterations", type=int, default=100)
+    parser.add_argument("--rounds", type=int, default=5)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def main():
+    """Run requested shapes and emit machine-readable evidence."""
+    args = parse_args()
+    capacities = args.capacities or [2048, 8192, 16384, 32768]
+    if args.batch < 1:
+        raise ValueError("batch must be positive")
+    for capacity in capacities:
+        if not 1 <= capacity <= 32768:
+            raise ValueError(f"k capacity must be in [1, 32768], got {capacity}")
+        if args.position is not None and not 0 <= args.position < capacity:
+            raise ValueError(f"position must be in [0, {capacity}), got {args.position}")
+    properties = torch.cuda.get_device_properties(0)
+    rows = [
+        benchmark_shape(
+            args.batch,
+            capacity,
+            capacity - 1 if args.position is None else args.position,
+            args.warmup,
+            args.iterations,
+            args.rounds,
+        )
+        for capacity in capacities
+    ]
+    result = {
+        "environment": {
+            "platform": platform.platform(),
+            "torch": torch.__version__,
+            "cuda": torch.version.cuda,
+            "device": properties.name,
+            "compute_capability": [
+                properties.major,
+                properties.minor,
+            ],
+            "sm_count": properties.multi_processor_count,
+        },
+        "method": {
+            "warmup": args.warmup,
+            "iterations": args.iterations,
+            "rounds": args.rounds,
+            "prepared_api": (
+                "warmed execute call with native destinations/workspace; includes "
+                "Python validation and stream lifetime tracking; excludes JIT and allocation"
+            ),
+            "reference": ("eager dense PyTorch FP32 matmul + causal mask + block max + " "topk; includes intermediate allocation"),
+            "graph_replay": "native prepared API captured and replayed alone",
+        },
+        "source": source_metadata(),
+        "results": rows,
+    }
+    rendered = json.dumps(result, indent=2)
+    print(rendered)
+    if args.output is not None:
+        args.output.write_text(rendered + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/fe-oss-apis/nsa.md
+++ b/docs/fe-oss-apis/nsa.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-The Native Sparse Attention (NSA) module implements the sparse attention mechanism described in [Native Sparse Attention: Hardware-Aligned and Natively Trainable Sparse Attention](https://arxiv.org/pdf/2502.11089). NSA provides high-performance sparse attention kernels optimized for Blackwell (SM100+) GPUs. The Selection, Compression, and Top-K components are implemented with CUTLASS/CUTE. Sliding Window Attention currently utilizes cuDNN backend.
+The Native Sparse Attention (NSA) module implements the sparse attention mechanism described in [Native Sparse Attention: Hardware-Aligned and Natively Trainable Sparse Attention](https://arxiv.org/pdf/2502.11089). NSA provides high-performance sparse attention kernels with component-specific architecture support listed below. The Selection, Compression, Top-K, and Lightning Indexer components are implemented with CUTLASS/CUTE. Sliding Window Attention currently utilizes cuDNN backend.
 
 NSA combines multiple attention strategies to efficiently process long sequences:
 
@@ -72,6 +72,9 @@ NSA.sliding_window_attention_wrapper
 
 NSA.TopKReduction
 NSA.topk_reduction_wrapper
+
+NSA.LightningIndexer
+NSA.lightning_indexer
 ```
 
 ---
@@ -540,6 +543,67 @@ topk.execute(
 
 ---
 
+### 5. MiniMax Lightning Indexer Decode
+
+The experimental Lightning Indexer static-cache decode API implements the
+selection branch used by MiniMax-M3 sparse attention. It computes query-key
+scores from BF16 inputs with FP32 accumulation, max-pools every completed
+128-token key block, forces the current local block, and returns at most 16
+selected block IDs.
+
+    from cudnn import NSA
+
+    # q: [B, 1, 4, 128] BF16 (BSHD)
+    # k: [B, S_k, 1, 128] BF16 (BSHD)
+    # position_ids: [B, 1] int64 dense K-cache slot positions
+    result = NSA.lightning_indexer(q, k, position_ids)
+    block_indices = result["block_indices"]  # [B, 4, 1, 16] int32
+    block_counts = result["block_counts"]    # [B, 4, 1] int32
+
+For allocation-free replay, prepare a plan and retain separate workspaces for
+concurrent launches:
+
+    indices = torch.empty(B, 1, 4, 16, dtype=torch.int32, device="cuda").transpose(1, 2)
+    counts = torch.empty(B, 1, 4, dtype=torch.int32, device="cuda").transpose(1, 2)
+    plan = NSA.LightningIndexer(q, k, position_ids, indices, counts)
+    plan.check_support()
+    plan.compile()
+    workspace = plan.make_workspace()
+    plan.execute(q, k, position_ids, indices, counts, workspace)
+
+Contract and limitations:
+
+- Decode only: query length is exactly one, with 4 index heads and head
+  dimension 128.
+- Keys and queries are BF16; positions are int64. Inputs and the resulting FP32
+  dot-product accumulations must remain finite.
+- Position IDs are explicit zero-based dense cache-slot positions. Contiguous
+  and batch-broadcast `(0, 1)` strides are supported. Out-of-capacity positions
+  produce an empty row. This keeps a right-padded static cache correct; growing
+  dynamic caches, paged caches, holes, and left-padding remapping are not
+  supported.
+- The current block occupies one output slot. Remaining valid IDs are the exact
+  top-scoring completed blocks with lower block IDs winning exact-score ties.
+  Their slot order is not part of the API contract. IDs are left-packed and
+  unused slots are -1.
+- Context capacities from 1 through 32768 tokens are admitted. When all visible
+  blocks fit in 16 slots, a metadata-only path returns the exact selected set
+  without reading Q or K.
+- Long-context execution needs initialized, exclusive caller-owned workspace.
+  make_workspace returns a ready buffer and carries stream-ordered
+  initialization across streams with a CUDA event; each successful launch
+  restores its counters. Call initialize_workspace before first use of a
+  separately allocated buffer or after a failed launch. CUDA Graph replay is
+  supported after workspace initialization has been consumed once eagerly, or
+  when initialization and first capture use the same stream. Overlapping
+  launches must use different workspaces.
+- Explicit stream 0 and real CUDA stream handles are supported. CUDA magic
+  sentinel handles 1 and 2 are rejected; pass the resolved stream handle.
+- The kernel is functionally admitted on SM80 and newer. Its schedule and
+  published performance are tuned and measured on B200.
+
+---
+
 ## Tensor Formats
 
 ### Supported Layouts
@@ -550,6 +614,7 @@ topk.execute(
 | Compression Attention | ✅ | ✅ |
 | Sliding Window Attention | ✅ | ✅ |
 | Top-K Reduction | ✅ | ✅ |
+| Lightning Indexer Decode | ❌ | ❌ (uses `B,S,H,D`) |
 
 ### T,H,D Format (Variable-Length Batched)
 
@@ -590,6 +655,7 @@ All components require `float32` accumulator dtype for numerical stability.
 | Compression Attention | SM100 (Blackwell) | - |
 | Sliding Window Attention | SM80+ | Uses cuDNN backend |
 | Top-K Reduction | SM100 (Blackwell) | - |
+| Lightning Indexer Decode | SM80+ | Performance tuned on B200 |
 
 ---
 
@@ -601,6 +667,7 @@ For complete usage examples and tests, see:
 - `test/python/fe_api/nsa/test_NSA_compression_attention.py`
 - `test/python/fe_api/nsa/test_NSA_swa.py`
 - `test/python/fe_api/nsa/test_NSA_topk_reduction.py`
+- `test/python/fe_api/nsa/test_NSA_lightning_indexer.py`
 
 ### Example: Full NSA Pipeline
 

--- a/python/cudnn/native_sparse_attention/__init__.py
+++ b/python/cudnn/native_sparse_attention/__init__.py
@@ -8,6 +8,7 @@ from .sliding_window_attention import (
     sliding_window_attention_wrapper,
 )
 from .top_k import TopKReduction, topk_reduction_wrapper
+from .lightning_indexer import LightningIndexer, lightning_indexer
 
 
 class NSANamespace:
@@ -22,6 +23,9 @@ class NSANamespace:
 
     TopKReduction = staticmethod(TopKReduction)
     topk_reduction_wrapper = staticmethod(topk_reduction_wrapper)
+
+    LightningIndexer = staticmethod(LightningIndexer)
+    lightning_indexer = staticmethod(lightning_indexer)
 
 
 NSA = NSANamespace()

--- a/python/cudnn/native_sparse_attention/lightning_indexer/__init__.py
+++ b/python/cudnn/native_sparse_attention/lightning_indexer/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""MiniMax Lightning Indexer public API."""
+
+from .api import LightningIndexer, lightning_indexer
+
+__all__ = ["LightningIndexer", "lightning_indexer"]

--- a/python/cudnn/native_sparse_attention/lightning_indexer/api.py
+++ b/python/cudnn/native_sparse_attention/lightning_indexer/api.py
@@ -1,0 +1,570 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public API for exact MiniMax Lightning Indexer decode."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from contextlib import nullcontext
+from typing import Optional
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import torch
+
+from cudnn.api_base import APIBase, TensorDesc, TupleDict
+
+from .kernel import BLOCK_SIZE, HEAD_DIM, TOP_K, decode_host, short_host
+
+_INDEX_HEADS = 4
+_MAX_TESTED_K = 32768
+_INT32_BYTES = 4
+_CACHE_CAPACITY = 32
+_WORKSPACE_TOKEN = "_cudnn_lightning_indexer_plan_token"
+_WORKSPACE_READY_EVENT = "_cudnn_lightning_indexer_ready_event"
+_WORKSPACE_READY_STREAM = "_cudnn_lightning_indexer_ready_stream"
+_cache: OrderedDict[tuple, "LightningIndexer"] = OrderedDict()
+
+
+def _ceil_div(value: int, divisor: int) -> int:
+    """Return ceil(value / divisor) for positive integers."""
+    return (value + divisor - 1) // divisor
+
+
+def _require_alignment(tensor: torch.Tensor, alignment: int, name: str) -> None:
+    """Reject pointers that do not satisfy the raw-pointer kernel contract."""
+    if tensor.data_ptr() % alignment:
+        raise ValueError(f"{name} must be {alignment}-byte aligned, got pointer " f"0x{tensor.data_ptr():x}")
+
+
+def _tensor_key(tensor: torch.Tensor) -> tuple:
+    """Return plan-time tensor metadata without retaining its storage."""
+    return (
+        tuple(tensor.shape),
+        tuple(tensor.stride()),
+        tensor.dtype,
+        tensor.device.type,
+        tensor.device.index,
+    )
+
+
+def _as_torch_stream(stream: cuda.CUstream, device: torch.device) -> torch.cuda.Stream:
+    """Wrap a launch stream for allocator lifetime tracking."""
+    handle = int(stream)
+    if handle in (1, 2):
+        raise ValueError("CUDA magic stream handles 1 and 2 are not supported; pass 0 or " "an actual stream handle")
+    current = torch.cuda.current_stream(device)
+    if handle == current.cuda_stream:
+        return current
+    default = torch.cuda.default_stream(device)
+    if handle in (0, default.cuda_stream):
+        return default
+    return torch.cuda.ExternalStream(handle, device=device)
+
+
+def _stream_context(stream: Optional[cuda.CUstream], device: torch.device):
+    """Place allocations on a real explicit stream without wrapping sentinels."""
+    if stream is None:
+        return nullcontext()
+    handle = int(stream)
+    if handle in (1, 2):
+        raise ValueError("CUDA magic stream handles 1 and 2 are not supported; pass 0 or " "an actual stream handle")
+    torch_stream = _as_torch_stream(stream, device)
+    if torch_stream.cuda_stream == torch.cuda.current_stream(device).cuda_stream:
+        return nullcontext()
+    return torch.cuda.stream(torch_stream)
+
+
+def _resolve_stream(stream: Optional[cuda.CUstream], device: torch.device) -> cuda.CUstream:
+    """Resolve the ambient PyTorch stream on the tensor's device."""
+    if stream is not None:
+        if int(stream) in (1, 2):
+            raise ValueError("CUDA magic stream handles 1 and 2 are not supported; pass 0 " "or an actual stream handle")
+        return stream
+    return cuda.CUstream(torch.cuda.current_stream(device).cuda_stream)
+
+
+def _zero_words_async(pointer: int, count: int, stream: cuda.CUstream) -> None:
+    """Stream-order a zero fill without adding a kernel launch."""
+    result = cuda.cuMemsetD32Async(int(pointer), 0, int(count), int(stream))
+    error = result[0] if isinstance(result, tuple) else result
+    if int(error) != 0:
+        raise RuntimeError(f"cuMemsetD32Async failed: {error}")
+
+
+def _launch_on_device(compiled_kernel, device: torch.device, *args) -> None:
+    """Launch without paying a device-guard round trip on the common device."""
+    if torch.cuda.current_device() == device.index:
+        compiled_kernel(*args)
+        return
+    with torch.cuda.device(device):
+        compiled_kernel(*args)
+
+
+class LightningIndexer(APIBase):
+    """Prepared exact static-cache decode plan for the MiniMax-M3 indexer.
+
+    The supported layout is q[B, 1, 4, 128] and k[B, S_k, 1, 128] in BF16.
+    position_ids[B, 1] gives an explicit dense K-cache slot. The operation
+    returns the current 128-token block plus the 15 highest-scoring completed
+    blocks. BF16 Q/K products accumulate in FP32 before block-max reduction.
+    The FP32 dot-product accumulations must remain finite. S_k is a fixed
+    static-cache capacity for the lifetime of the plan.
+
+    Output order after the current block is deterministic but otherwise not
+    part of the contract. block_counts gives the number of left-packed valid
+    entries; unused entries are -1.
+
+    execute performs no allocation or host synchronization. Long-context plans
+    require an initialized, exclusive caller-owned workspace from
+    make_workspace. Initialization records a CUDA event so the first execution
+    may safely use a different stream. A successful launch restores its arrival
+    counters to zero. Do not share one workspace across overlapping launches.
+    """
+
+    def __init__(
+        self,
+        sample_q: torch.Tensor | TensorDesc,
+        sample_k: torch.Tensor | TensorDesc,
+        sample_position_ids: torch.Tensor | TensorDesc,
+        sample_block_indices: torch.Tensor | TensorDesc,
+        sample_block_counts: torch.Tensor | TensorDesc,
+    ):
+        super().__init__()
+        self._warn_experimental_api()
+        self.q_desc = self._make_tensor_desc(sample_q, name="sample_q")
+        self.k_desc = self._make_tensor_desc(sample_k, name="sample_k")
+        self.position_desc = self._make_tensor_desc(sample_position_ids, name="sample_position_ids")
+        self.indices_desc = self._make_tensor_desc(sample_block_indices, name="sample_block_indices")
+        self.counts_desc = self._make_tensor_desc(sample_block_counts, name="sample_block_counts")
+        self.batch_size: Optional[int] = None
+        self.k_capacity: Optional[int] = None
+        self.num_blocks: Optional[int] = None
+        self._short_context = False
+        self._workspace_numel = 0
+        self._schedule: Optional[tuple[int, ...]] = None
+        self._workspace_token = object()
+
+    @property
+    def workspace_size(self) -> int:
+        """Return required workspace size in bytes."""
+        return self._workspace_numel * _INT32_BYTES
+
+    def make_workspace(
+        self,
+        current_stream: Optional[cuda.CUstream] = None,
+    ) -> Optional[torch.Tensor]:
+        """Allocate an initialized exclusive workspace for this plan."""
+        self._ensure_support_checked()
+        if self._workspace_numel == 0:
+            return None
+        launch_stream = _resolve_stream(current_stream, self.q_desc.device)
+        with torch.cuda.device(self.q_desc.device), _stream_context(launch_stream, self.q_desc.device):
+            workspace = torch.empty(
+                self._workspace_numel,
+                dtype=torch.int32,
+                device=self.q_desc.device,
+            )
+        self.initialize_workspace(workspace, launch_stream)
+        return workspace
+
+    def initialize_workspace(
+        self,
+        workspace: torch.Tensor,
+        current_stream: Optional[cuda.CUstream] = None,
+    ) -> None:
+        """Reset arrival counters before first use or after a failed launch."""
+        self._ensure_support_checked()
+        if self._workspace_numel == 0:
+            if workspace.numel() != 0:
+                raise ValueError("short-context plans require no workspace")
+            return
+        self._validate_workspace(workspace)
+        score_words = self.batch_size * _INDEX_HEADS * self.num_blocks
+        counter_pointer = workspace.data_ptr() + score_words * _INT32_BYTES
+        launch_stream = _resolve_stream(current_stream, workspace.device)
+        torch_stream = _as_torch_stream(launch_stream, workspace.device)
+        with torch.cuda.device(workspace.device):
+            _zero_words_async(counter_pointer, self.batch_size, launch_stream)
+            ready_event = torch.cuda.Event()
+            ready_event.record(torch_stream)
+        setattr(workspace, _WORKSPACE_TOKEN, self._workspace_token)
+        setattr(workspace, _WORKSPACE_READY_EVENT, ready_event)
+        setattr(workspace, _WORKSPACE_READY_STREAM, int(launch_stream))
+        workspace.record_stream(torch_stream)
+
+    def check_support(self) -> bool:
+        """Validate the exact decode tensor and architecture contract."""
+        self._value_error_if(
+            self.q_desc.ndim != 4,
+            f"q must be rank-4 [B, 1, 4, 128], got {self.q_desc.shape}",
+        )
+        self._value_error_if(
+            self.k_desc.ndim != 4,
+            f"k must be rank-4 [B, S_k, 1, 128], got {self.k_desc.shape}",
+        )
+        b, s_q, h_q, d_q = self.q_desc.shape
+        b_k, s_k, h_k, d_k = self.k_desc.shape
+        self._value_error_if(b < 1, "batch size must be positive")
+        self._value_error_if(b > 65535, "batch size must be <= 65535")
+        self._value_error_if(
+            (s_q, h_q, d_q) != (1, _INDEX_HEADS, HEAD_DIM),
+            f"q must have shape [B, 1, 4, 128], got {self.q_desc.shape}",
+        )
+        self._value_error_if(
+            (b_k, h_k, d_k) != (b, 1, HEAD_DIM),
+            "k must have shape [B, S_k, 1, 128] with the same batch as q, " f"got {self.k_desc.shape}",
+        )
+        self._value_error_if(s_k < 1, "S_k must be positive")
+        self._value_error_if(
+            s_k > _MAX_TESTED_K,
+            f"S_k must be <= {_MAX_TESTED_K}, got {s_k}",
+        )
+        self._check_dtype(self.q_desc, torch.bfloat16, name="q")
+        self._check_dtype(self.k_desc, torch.bfloat16, name="k")
+        self._check_dtype(self.position_desc, torch.int64, name="position_ids")
+        self._check_dtype(self.indices_desc, torch.int32, name="block_indices")
+        self._check_dtype(self.counts_desc, torch.int32, name="block_counts")
+        self._check_tensor_shape(self.position_desc, (b, 1), name="position_ids")
+        self._check_tensor_shape(
+            self.indices_desc,
+            (b, _INDEX_HEADS, 1, TOP_K),
+            name="block_indices",
+        )
+        self._check_tensor_shape(
+            self.counts_desc,
+            (b, _INDEX_HEADS, 1),
+            name="block_counts",
+        )
+
+        devices = {
+            self.q_desc.device,
+            self.k_desc.device,
+            self.position_desc.device,
+            self.indices_desc.device,
+            self.counts_desc.device,
+        }
+        self._value_error_if(
+            len(devices) != 1,
+            "q, k, position_ids, block_indices, and block_counts must share a device",
+        )
+        self._value_error_if(
+            self.q_desc.device.type != "cuda",
+            f"LightningIndexer requires CUDA tensors, got {self.q_desc.device}",
+        )
+        self._runtime_error_if(not torch.cuda.is_available(), "CUDA is not available")
+        major, minor = torch.cuda.get_device_capability(self.q_desc.device)
+        self._runtime_error_if(
+            major < 8,
+            f"LightningIndexer requires SM80+, found SM{major}{minor}",
+        )
+
+        self._value_error_if(
+            (
+                self.q_desc.stride[0],
+                self.q_desc.stride[2],
+                self.q_desc.stride[3],
+            )
+            != (4 * HEAD_DIM, HEAD_DIM, 1),
+            "q must have dense head-major backing storage; " f"got strides {self.q_desc.stride}",
+        )
+        self._value_error_if(
+            (
+                self.k_desc.stride[0],
+                self.k_desc.stride[1],
+                self.k_desc.stride[3],
+            )
+            != (s_k * HEAD_DIM, HEAD_DIM, 1),
+            "k must have dense token-major storage; " f"got strides {self.k_desc.stride}",
+        )
+        self._value_error_if(
+            self.position_desc.stride not in ((0, 1), (1, 1)),
+            "position_ids must be contiguous or batch-broadcast with strides " f"(0, 1), got {self.position_desc.stride}",
+        )
+        self._value_error_if(
+            (
+                self.indices_desc.stride[0],
+                self.indices_desc.stride[1],
+                self.indices_desc.stride[3],
+            )
+            != (_INDEX_HEADS * TOP_K, TOP_K, 1),
+            "block_indices must have token-major backing storage; " f"got strides {self.indices_desc.stride}",
+        )
+        self._value_error_if(
+            (self.counts_desc.stride[0], self.counts_desc.stride[1]) != (_INDEX_HEADS, 1),
+            "block_counts must have token-major backing storage; " f"got strides {self.counts_desc.stride}",
+        )
+
+        props = torch.cuda.get_device_properties(self.q_desc.device)
+        num_blocks = _ceil_div(s_k, BLOCK_SIZE)
+        self.batch_size = b
+        self.k_capacity = s_k
+        self.num_blocks = num_blocks
+        self._short_context = num_blocks <= TOP_K
+        if not self._short_context:
+            max_candidates = (s_k - 1) // BLOCK_SIZE
+            keys_per_thread = 2 if b * max_candidates >= 1000 else 1
+            ctas_per_batch = _ceil_div(max_candidates, keys_per_thread)
+            head_split = 1
+            dim_slice = HEAD_DIM if b * ctas_per_batch * head_split <= 2 * props.multi_processor_count else 64
+            commit_groups = 2 if dim_slice == HEAD_DIM else 1
+            self._schedule = (
+                max_candidates,
+                ctas_per_batch,
+                keys_per_thread,
+                dim_slice,
+                commit_groups,
+                head_split,
+            )
+            score_words = b * _INDEX_HEADS * num_blocks
+            self._workspace_numel = score_words + b
+
+        self._is_supported = True
+        return True
+
+    def compile(self) -> None:
+        """Compile the shape- and schedule-specific launch host."""
+        self._ensure_support_checked()
+        if self._compiled_kernel is not None:
+            return
+        with torch.cuda.device(self.q_desc.device):
+            compile_stream = cuda.CUstream(0)
+            if self._short_context:
+                self._compiled_kernel = cute.compile(
+                    short_host,
+                    cutlass.Int64(0),
+                    cutlass.Int64(0),
+                    cutlass.Int64(0),
+                    compile_stream,
+                    self.batch_size,
+                    self.k_capacity,
+                    self.position_desc.stride[0],
+                )
+                return
+
+            assert self._schedule is not None
+            (
+                max_candidates,
+                ctas_per_batch,
+                keys_per_thread,
+                dim_slice,
+                commit_groups,
+                head_split,
+            ) = self._schedule
+            self._compiled_kernel = cute.compile(
+                decode_host,
+                cutlass.Int64(0),
+                cutlass.Int64(0),
+                cutlass.Int64(0),
+                cutlass.Int64(0),
+                cutlass.Int64(0),
+                cutlass.Int64(0),
+                cutlass.Int64(0),
+                compile_stream,
+                self.batch_size,
+                self.k_capacity,
+                self.position_desc.stride[0],
+                max_candidates,
+                self.num_blocks,
+                ctas_per_batch,
+                keys_per_thread,
+                dim_slice,
+                commit_groups,
+                head_split,
+            )
+
+    def _validate_runtime_tensor(
+        self,
+        tensor: torch.Tensor,
+        desc,
+        name: str,
+        alignment: int,
+    ) -> None:
+        """Validate runtime metadata against the prepared plan."""
+        signature = (
+            tuple(tensor.shape),
+            tuple(tensor.stride()),
+            tensor.dtype,
+            tensor.device,
+        )
+        expected = (desc.shape, desc.stride, desc.dtype, desc.device)
+        if signature != expected:
+            raise ValueError(f"{name} metadata differs from the compiled plan: " f"expected {expected}, got {signature}")
+        _require_alignment(tensor, alignment, name)
+
+    def _validate_workspace(self, workspace: torch.Tensor) -> None:
+        """Validate a caller-owned workspace against this plan."""
+        if (
+            workspace.dtype != torch.int32
+            or workspace.ndim != 1
+            or not workspace.is_contiguous()
+            or workspace.device != self.q_desc.device
+            or workspace.numel() < self._workspace_numel
+        ):
+            raise ValueError("workspace must be contiguous CUDA int32 on the input device " f"with at least {self._workspace_numel} elements")
+        _require_alignment(workspace, 16, "workspace")
+
+    def _consume_workspace_initialization(
+        self,
+        workspace: torch.Tensor,
+        launch_stream: cuda.CUstream,
+    ) -> None:
+        """Make first use wait for initialization without synchronizing the host."""
+        if getattr(workspace, _WORKSPACE_TOKEN, None) is not self._workspace_token:
+            raise ValueError("workspace is not initialized for this plan; call " "initialize_workspace before first use")
+        ready_event = getattr(workspace, _WORKSPACE_READY_EVENT, None)
+        if ready_event is None:
+            return
+        ready_stream = getattr(workspace, _WORKSPACE_READY_STREAM, None)
+        if ready_stream != int(launch_stream):
+            with torch.cuda.device(workspace.device):
+                error, capture_status = cuda.cuStreamIsCapturing(launch_stream)
+                if int(error) != 0:
+                    raise RuntimeError(f"cuStreamIsCapturing failed: {error}")
+                if int(capture_status) != 0:
+                    raise ValueError("consume workspace initialization once before cross-stream " "CUDA Graph capture, or initialize on the capture stream")
+                _as_torch_stream(launch_stream, workspace.device).wait_event(ready_event)
+        setattr(workspace, _WORKSPACE_READY_EVENT, None)
+        setattr(workspace, _WORKSPACE_READY_STREAM, None)
+
+    def execute(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        position_ids: torch.Tensor,
+        block_indices: torch.Tensor,
+        block_counts: torch.Tensor,
+        workspace: Optional[torch.Tensor] = None,
+        current_stream: Optional[cuda.CUstream] = None,
+    ) -> None:
+        """Launch on caller-owned destinations and workspace."""
+        self._ensure_support_checked()
+        if self._compiled_kernel is None:
+            raise ValueError("LightningIndexer kernel is not compiled")
+        self._validate_runtime_tensor(q, self.q_desc, "q", 16)
+        self._validate_runtime_tensor(k, self.k_desc, "k", 16)
+        self._validate_runtime_tensor(position_ids, self.position_desc, "position_ids", 8)
+        self._validate_runtime_tensor(block_indices, self.indices_desc, "block_indices", 16)
+        self._validate_runtime_tensor(block_counts, self.counts_desc, "block_counts", 16)
+        launch_stream = _resolve_stream(current_stream, q.device)
+        tensors = [q, k, position_ids, block_indices, block_counts]
+
+        if self._short_context:
+            if workspace is not None and workspace.numel() != 0:
+                raise ValueError("short-context plans require no workspace")
+            _launch_on_device(
+                self._compiled_kernel,
+                q.device,
+                position_ids.data_ptr(),
+                block_indices.data_ptr(),
+                block_counts.data_ptr(),
+                launch_stream,
+            )
+        else:
+            if workspace is None:
+                raise ValueError(f"workspace with at least {self.workspace_size} bytes is required")
+            self._validate_workspace(workspace)
+            self._consume_workspace_initialization(workspace, launch_stream)
+            score_words = self.batch_size * _INDEX_HEADS * self.num_blocks
+            score_pointer = workspace.data_ptr()
+            counter_pointer = score_pointer + score_words * _INT32_BYTES
+            _launch_on_device(
+                self._compiled_kernel,
+                q.device,
+                q.data_ptr(),
+                k.data_ptr(),
+                position_ids.data_ptr(),
+                block_indices.data_ptr(),
+                block_counts.data_ptr(),
+                score_pointer,
+                counter_pointer,
+                launch_stream,
+            )
+            tensors.append(workspace)
+
+        consumer = _as_torch_stream(launch_stream, q.device)
+        for tensor in tensors:
+            tensor.record_stream(consumer)
+
+
+def lightning_indexer(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    position_ids: torch.Tensor,
+    *,
+    block_indices: Optional[torch.Tensor] = None,
+    block_counts: Optional[torch.Tensor] = None,
+    workspace: Optional[torch.Tensor] = None,
+    stream: Optional[cuda.CUstream] = None,
+) -> TupleDict:
+    """Run exact MiniMax Lightning Indexer static-cache decode.
+
+    q uses BSHD layout [B, 1, 4, 128], k uses [B, S_k, 1, 128], and
+    position_ids[B, 1] is required so dense static-cache buffers stay correct.
+    K is a fixed plan capacity; growing DynamicCache tensors are not supported.
+    FP32 dot-product accumulations must remain finite. Pass destinations and
+    workspace to avoid allocation during repeated calls.
+    """
+    if (block_indices is None) != (block_counts is None):
+        raise ValueError("block_indices and block_counts must both be provided or both omitted")
+    b = q.shape[0]
+    if block_indices is None:
+        with torch.cuda.device(q.device), _stream_context(stream, q.device):
+            block_indices = torch.empty(
+                (b, 1, _INDEX_HEADS, TOP_K),
+                dtype=torch.int32,
+                device=q.device,
+            ).transpose(1, 2)
+            block_counts = torch.empty(
+                (b, 1, _INDEX_HEADS),
+                dtype=torch.int32,
+                device=q.device,
+            ).transpose(1, 2)
+
+    assert block_indices is not None
+    assert block_counts is not None
+    props = torch.cuda.get_device_properties(q.device)
+    cache_key = (
+        q.device.index,
+        props.major,
+        props.minor,
+        props.multi_processor_count,
+        _tensor_key(q),
+        _tensor_key(k),
+        _tensor_key(position_ids),
+        _tensor_key(block_indices),
+        _tensor_key(block_counts),
+    )
+    plan = _cache.get(cache_key)
+    if plan is None:
+        plan = LightningIndexer(q, k, position_ids, block_indices, block_counts)
+        plan.check_support()
+        plan.compile()
+        _cache[cache_key] = plan
+        if len(_cache) > _CACHE_CAPACITY:
+            _cache.popitem(last=False)
+    else:
+        _cache.move_to_end(cache_key)
+    if plan.workspace_size:
+        if workspace is None:
+            workspace = plan.make_workspace(stream)
+        elif getattr(workspace, _WORKSPACE_TOKEN, None) is not plan._workspace_token:
+            plan.initialize_workspace(workspace, stream)
+    plan.execute(
+        q,
+        k,
+        position_ids,
+        block_indices,
+        block_counts,
+        workspace,
+        current_stream=stream,
+    )
+    return TupleDict(
+        block_indices=block_indices,
+        block_counts=block_counts,
+    )
+
+
+__all__ = ["LightningIndexer", "lightning_indexer"]

--- a/python/cudnn/native_sparse_attention/lightning_indexer/kernel.py
+++ b/python/cudnn/native_sparse_attention/lightning_indexer/kernel.py
@@ -1,0 +1,286 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exact CuTe DSL decode kernels for the MiniMax Lightning Indexer."""
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import cpasync
+from cutlass.utils import SmemAllocator
+
+BLOCK_SIZE = 128
+TOP_K = 16
+HEAD_DIM = 128
+
+
+@cute.kernel
+def _dec(
+    mQ: cute.Tensor,  # (B, 4, 16, 8) bf16
+    mK: cute.Tensor,  # (B, S_K, 16, 8) bf16
+    mW: cute.Tensor,  # (B, 4, NB) i32 monotone score keys
+    mC: cute.Tensor,  # (B,) i32 arrival counters
+    mO: cute.Tensor,  # (B, 4, 16) i32
+    mN: cute.Tensor,  # (B, 4) i32 valid output counts
+    mP: cute.Tensor,  # (B, 1) i64 explicit query positions
+    S_K: cutlass.Constexpr,
+    NMAX: cutlass.Constexpr,  # candidate blocks below the envelope's last block
+    NB: cutlass.Constexpr,
+    NS: cutlass.Constexpr,  # CTAs per batch
+    KPT: cutlass.Constexpr,  # key blocks handled per CTA
+    HD: cutlass.Constexpr,  # dims per SMEM slice (64 or 128)
+    NGRP: cutlass.Constexpr,  # cp.async commit groups per SMEM slice
+    HS: cutlass.Constexpr,  # CTAs the four heads are split across
+):
+    NT = 128
+    HPC = 4 // HS  # heads per CTA
+    BIG = cutlass.Int32(0x7FFFFFF)
+    MINI = cutlass.Int32(-0x7FFFFFFF)
+    tidx, _, _ = cute.arch.thread_idx()
+    sp, hy, bz = cute.arch.block_idx()
+    h0 = hy * HPC
+    lane = cute.arch.lane_idx()
+    wi = cute.arch.warp_idx()
+    position = mP[bz, 0]
+    valid_position = (position >= cutlass.Int64(0)) & (position < cutlass.Int64(S_K))
+    cur_blk = cutlass.Int32(position // BLOCK_SIZE)
+
+    LD = HD + 8  # padded slice stride -> conflict-free 128-bit LDS
+    NC = HD // 8  # 8-element chunks per slice
+    NG = 128 // HD  # slices per key row
+    NCH = NC // NGRP  # chunks staged per commit group
+    alloc = SmemAllocator()
+    sK = alloc.allocate_tensor(
+        cutlass.BFloat16,
+        cute.make_layout((KPT * 128, (8, NC)), stride=(LD, (1, 8))),
+        byte_alignment=128,
+    )
+    # Q staged as BF16, not FP32: every thread re-reads the same q chunk for all
+    # four heads, so these broadcasts are the kernel's dominant L1 consumer
+    # (NCU: L1/TEX 78%).  BF16 halves the LDS instruction count for them; the
+    # extra cvt lands on the ALU, which is only ~49% issued.
+    sQ = alloc.allocate_tensor(
+        cutlass.BFloat16,
+        cute.make_layout((HPC, (8, 16)), stride=(128, (1, 8))),
+        byte_alignment=128,
+    )
+    sR = alloc.allocate_tensor(
+        cutlass.Int32,
+        cute.make_layout((4, KPT * HPC), stride=(KPT * HPC, 1)),
+        byte_alignment=16,
+    )
+    sF = alloc.allocate_tensor(cutlass.Int32, cute.make_layout(4), byte_alignment=16)
+
+    cpa = cute.make_copy_atom(cpasync.CopyG2SOp(), cutlass.BFloat16, num_bits_per_copy=128)
+    # ---- stage Q (4 heads x 128 dims) ----
+    # cp.async, not ld.global+sts: a blocking load here put a full HBM round trip
+    # in front of the first key cp.async, serialising the CTA's two cold fetches.
+    # Issued into the same commit group as the first key half, both now fly
+    # together and the CTA pays one memory latency instead of two.
+    if tidx < 16 * HPC:  # HPC heads x 16 dim-chunks of 8
+        cute.copy(
+            cpa,
+            mQ[bz, h0 + tidx // 16, tidx % 16, None],
+            sQ[tidx // 16, (None, tidx % 16)],
+        )
+
+    kbase = sp * (KPT * BLOCK_SIZE)
+    klast = cutlass.Int32(NMAX * BLOCK_SIZE - 1)
+
+    acc = cute.make_rmem_tensor(cute.make_layout(KPT * HPC), cutlass.Float32)
+    for i in cutlass.range_constexpr(KPT * HPC):
+        acc[i] = cutlass.Float32(0.0)
+    qv = cute.make_rmem_tensor(cute.make_layout(8), cutlass.Float32)
+    qsr = cute.make_rmem_tensor(cute.make_layout(8), cutlass.BFloat16)
+    kb = cute.make_rmem_tensor(cute.make_layout(8), cutlass.BFloat16)
+    kf = cute.make_rmem_tensor(cute.make_layout((KPT, 8)), cutlass.Float32)
+
+    # Small grids (B=1) leave most SMs idle, so CTA residency is worthless and
+    # the only thing that matters is the dependent-latency chain: stage the whole
+    # 128-dim key row (NG==1) and split its issue into NGRP commit groups so the
+    # dot product starts on the first arriving slice.  Large grids keep the
+    # 64-dim slice: there the halved SMEM footprint buys CTAs per SM, which is
+    # worth more than the extra round trip.
+    for g in cutlass.range_constexpr(NG):
+        for gg in cutlass.range_constexpr(NGRP):
+            for s in cutlass.range_constexpr(KPT * NCH):
+                ci = tidx + s * NT
+                gr = kbase + ci // NCH
+                gr = gr if gr < klast else klast
+                cute.copy(
+                    cpa,
+                    mK[bz, gr, g * NC + gg * NCH + ci % NCH, None],
+                    sK[ci // NCH, (None, gg * NCH + ci % NCH)],
+                )
+            cute.arch.cp_async_commit_group()
+        for gg in cutlass.range_constexpr(NGRP):
+            cute.arch.cp_async_wait_group(NGRP - 1 - gg)
+            cute.arch.barrier()
+            # head loop outside the key loop: one q chunk load + convert now
+            # feeds every key this thread owns instead of being redone per key
+            for j in cutlass.range_constexpr(gg * NCH, (gg + 1) * NCH):
+                for kk in cutlass.range_constexpr(KPT):
+                    cute.autovec_copy(sK[tidx + kk * 128, (None, j)], kb)
+                    kf[kk, None].store(kb.load().to(cutlass.Float32))
+                for h in cutlass.range_constexpr(HPC):
+                    cute.autovec_copy(sQ[h, (None, g * NC + j)], qsr)
+                    qv.store(qsr.load().to(cutlass.Float32))
+                    for kk in cutlass.range_constexpr(KPT):
+                        a = acc[kk * HPC + h]
+                        for e in cutlass.range_constexpr(8):
+                            a = a + qv[e] * kf[kk, e]
+                        acc[kk * HPC + h] = a
+        if cutlass.const_expr(NG > 1):
+            cute.arch.barrier()
+
+    # ---- monotone int key + block max reduction ----
+    kr = cute.make_rmem_tensor(cute.make_layout(KPT * HPC), cutlass.Int32)
+    kr.store(acc.load().bitcast(cutlass.Int32))
+    for i in cutlass.range_constexpr(KPT * HPC):
+        v = kr[i]
+        v = v if v >= 0 else (v ^ cutlass.Int32(0x7FFFFFFF))
+        kr[i] = cute.arch.warp_redux_sync(v, "max")
+    if lane == 0:
+        for i in cutlass.range_constexpr(KPT * HPC):
+            sR[wi, i] = kr[i]
+    cute.arch.barrier()
+    if tidx < KPT * HPC:
+        m = sR[0, tidx]
+        for w in cutlass.range_constexpr(3):
+            o = sR[w + 1, tidx]
+            m = o if o > m else m
+        nb = sp * KPT + (tidx // HPC)
+        if nb < NMAX:
+            mW[bz, h0 + (tidx % HPC), nb] = m
+    cute.arch.barrier()
+
+    # ---- recipe D: last arriving CTA merges ----
+    if tidx == 0:
+        old = cute.arch.atomic_add(mC.iterator + bz, cutlass.Int32(1), scope="gpu", sem="acq_rel")
+        sF[0] = cutlass.Int32(1) if old == NS * HS - 1 else cutlass.Int32(0)
+    cute.arch.barrier()
+
+    if sF[0] == 1:
+        # The current stream cannot begin the next invocation until this kernel
+        # exits, so reset now and overlap the atomic with the top-k merge.
+        if tidx == 0:
+            cute.arch.atomic_exch(mC.iterator + bz, cutlass.Int32(0), scope="gpu")
+        SLOTS = (NB + 31) // 32
+        vals = cute.make_rmem_tensor(cute.make_layout(SLOTS), cutlass.Int32)
+        ids = cute.make_rmem_tensor(cute.make_layout(SLOTS), cutlass.Int32)
+        for e in cutlass.range_constexpr(SLOTS):
+            nn = lane + 32 * e
+            ok = valid_position & (nn < cur_blk) & (nn < NMAX)
+            ids[e] = nn if ok else BIG
+            vals[e] = mW[bz, wi, nn if ok else 0] if ok else MINI
+        # Sort each lane's small queue once.  The global top-15 is then a
+        # 32-way merge of queue heads instead of 15 repeated local scans.
+        for ii in cutlass.range_constexpr(SLOTS):
+            for jj in cutlass.range_constexpr(SLOTS - 1 - ii):
+                av = vals[jj]
+                ai = ids[jj]
+                bv = vals[jj + 1]
+                bi = ids[jj + 1]
+                take = (bv > av) | ((bv == av) & (bi < ai))
+                vals[jj] = bv if take else av
+                ids[jj] = bi if take else ai
+                vals[jj + 1] = av if take else bv
+                ids[jj + 1] = ai if take else bi
+        if lane == 0:
+            mO[bz, wi, 0] = cur_blk if valid_position else cutlass.Int32(-1)
+            count = cur_blk + cutlass.Int32(1)
+            count = count if count < TOP_K else cutlass.Int32(TOP_K)
+            mN[bz, wi] = count if valid_position else cutlass.Int32(0)
+        for it in cutlass.range_constexpr(15):
+            lv = vals[0]
+            gv = cute.arch.warp_redux_sync(lv, "max")
+            li = ids[0] if lv == gv else BIG
+            gi = cute.arch.warp_redux_sync(li, "min")
+            if lane == 0:
+                mO[bz, wi, it + 1] = gi if gi < BIG else cutlass.Int32(-1)
+            if ids[0] == gi:
+                for e in cutlass.range_constexpr(SLOTS - 1):
+                    vals[e] = vals[e + 1]
+                    ids[e] = ids[e + 1]
+                vals[SLOTS - 1] = MINI
+                ids[SLOTS - 1] = BIG
+
+
+@cute.kernel
+def _short(
+    mP: cute.Tensor,
+    mO: cute.Tensor,
+    mN: cute.Tensor,
+    S_K: cutlass.Constexpr,
+):
+    """Emit all visible blocks when Top-K covers the complete causal prefix."""
+    tid, _, _ = cute.arch.thread_idx()
+    bz, _, _ = cute.arch.block_idx()
+    if tid < 4:
+        position = mP[bz, 0]
+        valid_position = (position >= cutlass.Int64(0)) & (position < cutlass.Int64(S_K))
+        cur_blk = cutlass.Int32(position // BLOCK_SIZE)
+        count = cur_blk + cutlass.Int32(1)
+        count = count if count < TOP_K else cutlass.Int32(TOP_K)
+        mN[bz, tid] = count if valid_position else cutlass.Int32(0)
+        mO[bz, tid, 0] = cur_blk if valid_position else cutlass.Int32(-1)
+        for slot in cutlass.range_constexpr(1, TOP_K):
+            block = cutlass.Int32(slot - 1)
+            mO[bz, tid, slot] = block if valid_position & (block < cur_blk) else cutlass.Int32(-1)
+
+
+@cute.jit
+def decode_host(
+    pq: cutlass.Int64,
+    pk: cutlass.Int64,
+    pp: cutlass.Int64,
+    po: cutlass.Int64,
+    pn: cutlass.Int64,
+    pw: cutlass.Int64,
+    pc: cutlass.Int64,
+    stream: cuda.CUstream,
+    B: cutlass.Constexpr,
+    S_K: cutlass.Constexpr,
+    P_B_STRIDE: cutlass.Constexpr,
+    NMAX: cutlass.Constexpr,
+    NB: cutlass.Constexpr,
+    NS: cutlass.Constexpr,
+    KPT: cutlass.Constexpr,
+    HD: cutlass.Constexpr,
+    NGRP: cutlass.Constexpr,
+    HS: cutlass.Constexpr,
+):
+    gQ = cute.make_tensor(
+        cute.make_ptr(cutlass.BFloat16, pq, cute.AddressSpace.gmem, assumed_align=16), cute.make_layout((B, 4, 16, 8), stride=(512, 128, 8, 1))
+    )
+    gK = cute.make_tensor(
+        cute.make_ptr(cutlass.BFloat16, pk, cute.AddressSpace.gmem, assumed_align=16), cute.make_layout((B, S_K, 16, 8), stride=(S_K * 128, 128, 8, 1))
+    )
+    gP = cute.make_tensor(
+        cute.make_ptr(cutlass.Int64, pp, cute.AddressSpace.gmem, assumed_align=8),
+        cute.make_layout((B, 1), stride=(P_B_STRIDE, 1)),
+    )
+    gO = cute.make_tensor(cute.make_ptr(cutlass.Int32, po, cute.AddressSpace.gmem, assumed_align=16), cute.make_layout((B, 4, 16), stride=(64, 16, 1)))
+    gN = cute.make_tensor(cute.make_ptr(cutlass.Int32, pn, cute.AddressSpace.gmem, assumed_align=16), cute.make_layout((B, 4), stride=(4, 1)))
+    gW = cute.make_tensor(cute.make_ptr(cutlass.Int32, pw, cute.AddressSpace.gmem, assumed_align=16), cute.make_layout((B, 4, NB), stride=(4 * NB, NB, 1)))
+    gC = cute.make_tensor(cute.make_ptr(cutlass.Int32, pc, cute.AddressSpace.gmem, assumed_align=16), cute.make_layout(B))
+    _dec(gQ, gK, gW, gC, gO, gN, gP, S_K, NMAX, NB, NS, KPT, HD, NGRP, HS).launch(grid=(NS, HS, B), block=(128, 1, 1), stream=stream)
+
+
+@cute.jit
+def short_host(
+    pp: cutlass.Int64,
+    po: cutlass.Int64,
+    pn: cutlass.Int64,
+    stream: cuda.CUstream,
+    B: cutlass.Constexpr,
+    S_K: cutlass.Constexpr,
+    P_B_STRIDE: cutlass.Constexpr,
+):
+    gP = cute.make_tensor(
+        cute.make_ptr(cutlass.Int64, pp, cute.AddressSpace.gmem, assumed_align=8),
+        cute.make_layout((B, 1), stride=(P_B_STRIDE, 1)),
+    )
+    gO = cute.make_tensor(cute.make_ptr(cutlass.Int32, po, cute.AddressSpace.gmem, assumed_align=16), cute.make_layout((B, 4, 16), stride=(64, 16, 1)))
+    gN = cute.make_tensor(cute.make_ptr(cutlass.Int32, pn, cute.AddressSpace.gmem, assumed_align=16), cute.make_layout((B, 4), stride=(4, 1)))
+    _short(gP, gO, gN, S_K).launch(grid=(B, 1, 1), block=(32, 1, 1), stream=stream)

--- a/test/python/fe_api/nsa/test_NSA_lightning_indexer.py
+++ b/test/python/fe_api/nsa/test_NSA_lightning_indexer.py
@@ -1,0 +1,486 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract tests for MiniMax Lightning Indexer exact decode."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+import torch
+
+from test_utils import torch_fork_set_rng
+
+BLOCK_SIZE = 128
+TOP_K = 16
+HEADS = 4
+HEAD_DIM = 128
+
+
+def _require_cuda():
+    try:
+        from cudnn import NSA
+    except ImportError:
+        pytest.skip("cudnn CuTe DSL optional dependencies are not installed")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    if torch.cuda.get_device_capability()[0] < 8:
+        pytest.skip("Lightning Indexer requires SM80+")
+    return NSA
+
+
+def _inputs(
+    batch: int,
+    k_capacity: int,
+    positions: list[int],
+    seed: int = 0,
+):
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    q = torch.randn(
+        (batch, 1, HEADS, HEAD_DIM),
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    k = torch.randn(
+        (batch, k_capacity, 1, HEAD_DIM),
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    position_ids = torch.tensor(positions, dtype=torch.int64, device="cuda").view(batch, 1)
+    return q, k, position_ids
+
+
+def _outputs(batch: int):
+    indices = torch.empty(
+        (batch, 1, HEADS, TOP_K),
+        dtype=torch.int32,
+        device="cuda",
+    ).transpose(1, 2)
+    counts = torch.empty(
+        (batch, 1, HEADS),
+        dtype=torch.int32,
+        device="cuda",
+    ).transpose(1, 2)
+    return indices, counts
+
+
+def _reference(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    position_ids: torch.Tensor,
+):
+    batch = q.shape[0]
+    k_len = k.shape[1]
+    num_blocks = (k_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+    scores = torch.matmul(
+        q.transpose(1, 2).float(),
+        k.transpose(1, 2).float().transpose(-1, -2),
+    )
+    key_positions = torch.arange(k_len, device=q.device)
+    scores.masked_fill_(
+        key_positions[None, None, None, :] > position_ids[:, None, :, None],
+        float("-inf"),
+    )
+    pad = num_blocks * BLOCK_SIZE - k_len
+    if pad:
+        scores = torch.nn.functional.pad(scores, (0, pad), value=float("-inf"))
+    block_scores = scores.view(batch, HEADS, 1, num_blocks, BLOCK_SIZE).amax(-1)
+    current = (position_ids // BLOCK_SIZE)[:, None, :, None].expand(-1, HEADS, -1, -1)
+    block_scores.scatter_(-1, current, float("inf"))
+
+    # Define exact-score ties toward lower block ids. Output slot order is not
+    # public, but a deterministic tie rule makes the selected set testable.
+    order = torch.argsort(block_scores, dim=-1, descending=True, stable=True)
+    selected = min(TOP_K, num_blocks)
+    chosen = order[..., :selected]
+    chosen_scores = torch.gather(block_scores, -1, chosen)
+    result = torch.full(
+        (batch, HEADS, 1, TOP_K),
+        -1,
+        dtype=torch.int32,
+        device=q.device,
+    )
+    result[..., :selected] = chosen.masked_fill(chosen_scores == float("-inf"), -1).to(torch.int32)
+    counts = (result >= 0).sum(-1, dtype=torch.int32)
+    return result, counts
+
+
+def _canonical_sets(indices: torch.Tensor) -> torch.Tensor:
+    sentinel = torch.iinfo(torch.int32).max
+    return torch.sort(indices.masked_fill(indices < 0, sentinel), dim=-1).values
+
+
+def _check(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    position_ids: torch.Tensor,
+    indices: torch.Tensor,
+    counts: torch.Tensor,
+) -> None:
+    expected_indices, expected_counts = _reference(q, k, position_ids)
+    torch.testing.assert_close(counts, expected_counts, rtol=0, atol=0)
+    torch.testing.assert_close(
+        _canonical_sets(indices),
+        _canonical_sets(expected_indices),
+        rtol=0,
+        atol=0,
+    )
+    slots = torch.arange(TOP_K, device=indices.device)
+    valid = slots < counts[..., None]
+    assert bool(torch.all(indices.masked_select(valid) >= 0))
+    assert bool(torch.all(indices.masked_select(~valid) == -1))
+
+
+@torch_fork_set_rng(seed=0)
+@pytest.mark.parametrize(
+    "k_capacity,position",
+    [
+        pytest.param(1, 0, marks=pytest.mark.L1),
+        pytest.param(127, 126, marks=pytest.mark.L1),
+        pytest.param(128, 127, marks=pytest.mark.L1),
+        pytest.param(129, 128, marks=pytest.mark.L0),
+        pytest.param(2047, 2046, marks=pytest.mark.L1),
+        pytest.param(2048, 255, marks=pytest.mark.L1),
+        pytest.param(2049, 255, marks=pytest.mark.L1),
+        pytest.param(2177, 2176, marks=pytest.mark.L1),
+        pytest.param(4097, 4096, marks=pytest.mark.L0),
+    ],
+)
+def test_lightning_indexer_decode_reference(k_capacity, position):
+    NSA = _require_cuda()
+    q, k, position_ids = _inputs(1, k_capacity, [position], seed=position)
+    result = NSA.lightning_indexer(q, k, position_ids)
+    _check(
+        q,
+        k,
+        position_ids,
+        result["block_indices"],
+        result["block_counts"],
+    )
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=11)
+def test_lightning_indexer_static_cache_batch_positions():
+    NSA = _require_cuda()
+    q, k, position_ids = _inputs(3, 4097, [255, 2048, 4096], seed=11)
+    # Make the unfilled/static-cache tail attractive. Explicit positions must
+    # still exclude it rather than inferring the current block from capacity.
+    k[0, 256:] = 32
+    k[1, 2049:] = 32
+    result = NSA.lightning_indexer(q, k, position_ids)
+    _check(
+        q,
+        k,
+        position_ids,
+        result["block_indices"],
+        result["block_counts"],
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=19)
+def test_lightning_indexer_accepts_official_transpose_views():
+    NSA = _require_cuda()
+    # MiniMax produces BHSD after norm/RoPE. Transposing to the public BSHD
+    # convention must remain a zero-copy view, including size-one odd strides.
+    q_bhsd = torch.randn(
+        (2, HEADS, 1, HEAD_DIM),
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    k_bhsd = torch.randn(
+        (2, 1, 4097, HEAD_DIM),
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    q = q_bhsd.transpose(1, 2)
+    k = k_bhsd.transpose(1, 2)
+    assert q.untyped_storage().data_ptr() == q_bhsd.untyped_storage().data_ptr()
+    assert k.untyped_storage().data_ptr() == k_bhsd.untyped_storage().data_ptr()
+    position_ids = torch.tensor([[4096]], dtype=torch.int64, device="cuda").expand(2, -1)
+    assert position_ids.stride() == (0, 1)
+    result = NSA.lightning_indexer(q, k, position_ids)
+    _check(
+        q,
+        k,
+        position_ids,
+        result["block_indices"],
+        result["block_counts"],
+    )
+
+
+@pytest.mark.L1
+def test_lightning_indexer_exact_ties_choose_low_blocks():
+    NSA = _require_cuda()
+    q = torch.ones(
+        (1, 1, HEADS, HEAD_DIM),
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    k = torch.zeros(
+        (1, 2177, 1, HEAD_DIM),
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    # Every completed block has the same exact maximum.
+    position_ids = torch.tensor([[2176]], dtype=torch.int64, device="cuda")
+    result = NSA.lightning_indexer(q, k, position_ids)
+    expected = torch.tensor(
+        [17, *range(15)],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    torch.testing.assert_close(result["block_indices"][0, 0, 0], expected, rtol=0, atol=0)
+    assert int(result["block_counts"][0, 0, 0]) == TOP_K
+
+
+@pytest.mark.L1
+def test_lightning_indexer_all_negative_block_scores():
+    NSA = _require_cuda()
+    q = torch.ones(
+        (1, 1, HEADS, HEAD_DIM),
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    k = torch.empty(
+        (1, 2177, 1, HEAD_DIM),
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    for block in range(17):
+        k[:, block * BLOCK_SIZE : (block + 1) * BLOCK_SIZE] = -(block + 1)
+    k[:, 2176:] = 64
+    position_ids = torch.tensor([[2176]], dtype=torch.int64, device="cuda")
+    result = NSA.lightning_indexer(q, k, position_ids)
+    expected = torch.tensor(
+        [17, *range(15)],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    torch.testing.assert_close(result["block_indices"][0, 0, 0], expected, rtol=0, atol=0)
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=29)
+def test_lightning_indexer_prepared_streams_and_graph():
+    NSA = _require_cuda()
+    q0, k0, p0 = _inputs(1, 4097, [4096], seed=29)
+    q1, k1, p1 = _inputs(1, 4097, [2048], seed=31)
+    out0, count0 = _outputs(1)
+    out1, count1 = _outputs(1)
+    plan = NSA.LightningIndexer(q0, k0, p0, out0, count0)
+    assert plan.check_support()
+    plan.compile()
+    # Finish input production first, then deliberately initialize workspaces on
+    # the default stream and consume them on two fresh streams without an
+    # explicit wait. The workspace's readiness event supplies that dependency.
+    torch.cuda.synchronize()
+    default = torch.cuda.current_stream()
+    producer = torch.cuda.Stream()
+    initialization_gate = torch.cuda.Event()
+    with torch.cuda.stream(producer):
+        torch.cuda._sleep(20_000_000)
+        initialization_gate.record()
+    default.wait_event(initialization_gate)
+    workspace0 = plan.make_workspace()
+    workspace1 = plan.make_workspace()
+    assert workspace0 is not None and workspace1 is not None
+
+    stream0 = torch.cuda.Stream()
+    stream1 = torch.cuda.Stream()
+    with torch.cuda.stream(stream0):
+        plan.execute(
+            q0,
+            k0,
+            p0,
+            out0,
+            count0,
+            workspace0,
+            current_stream=stream0.cuda_stream,
+        )
+    with torch.cuda.stream(stream1):
+        plan.execute(
+            q1,
+            k1,
+            p1,
+            out1,
+            count1,
+            workspace1,
+            current_stream=stream1.cuda_stream,
+        )
+    default.wait_stream(stream0)
+    default.wait_stream(stream1)
+    _check(q0, k0, p0, out0, count0)
+    _check(q1, k1, p1, out1, count1)
+
+    graph = torch.cuda.CUDAGraph()
+    plan.execute(q0, k0, p0, out0, count0, workspace0)
+    torch.cuda.synchronize()
+    with torch.cuda.graph(graph):
+        plan.execute(q0, k0, p0, out0, count0, workspace0)
+    q0.normal_()
+    k0.normal_()
+    graph.replay()
+    torch.cuda.synchronize()
+    _check(q0, k0, p0, out0, count0)
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=37)
+def test_lightning_indexer_initializes_caller_workspace():
+    NSA = _require_cuda()
+    q, k, position_ids = _inputs(2, 4097, [2048, 4096], seed=37)
+    indices, counts = _outputs(2)
+    plan = NSA.LightningIndexer(q, k, position_ids, indices, counts)
+    assert plan.check_support()
+    plan.compile()
+    workspace = torch.full(
+        (plan.workspace_size // 4,),
+        17,
+        dtype=torch.int32,
+        device="cuda",
+    )
+    plan.initialize_workspace(workspace)
+    plan.execute(q, k, position_ids, indices, counts, workspace)
+    _check(q, k, position_ids, indices, counts)
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=39)
+def test_lightning_indexer_wrapper_accepts_raw_workspace_on_stream():
+    NSA = _require_cuda()
+    q, k, position_ids = _inputs(2, 4097, [2048, 4096], seed=39)
+    indices, counts = _outputs(2)
+    sizing_plan = NSA.LightningIndexer(q, k, position_ids, indices, counts)
+    assert sizing_plan.check_support()
+    workspace = torch.empty(
+        sizing_plan.workspace_size // 4,
+        dtype=torch.int32,
+        device="cuda",
+    )
+    torch.cuda.synchronize()
+    stream = torch.cuda.Stream()
+    result = NSA.lightning_indexer(
+        q,
+        k,
+        position_ids,
+        workspace=workspace,
+        stream=stream.cuda_stream,
+    )
+    torch.cuda.current_stream().wait_stream(stream)
+    _check(
+        q,
+        k,
+        position_ids,
+        result["block_indices"],
+        result["block_counts"],
+    )
+    repeated = NSA.lightning_indexer(
+        q,
+        k,
+        position_ids,
+        workspace=workspace,
+        stream=stream.cuda_stream,
+    )
+    torch.cuda.current_stream().wait_stream(stream)
+    _check(
+        q,
+        k,
+        position_ids,
+        repeated["block_indices"],
+        repeated["block_counts"],
+    )
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize(
+    "k_capacity,position",
+    [(129, -1), (129, 129), (4097, -1), (4097, 4097)],
+)
+def test_lightning_indexer_invalid_position_returns_empty(k_capacity, position):
+    NSA = _require_cuda()
+    q, k, position_ids = _inputs(1, k_capacity, [position], seed=41)
+    result = NSA.lightning_indexer(q, k, position_ids)
+    assert int(result["block_counts"].max()) == 0
+    assert bool(torch.all(result["block_indices"] == -1))
+
+
+@pytest.mark.L0
+def test_lightning_indexer_metadata_support_validation():
+    NSA = _require_cuda()
+    q, k, position_ids = _inputs(1, 4097, [4096])
+    indices, counts = _outputs(1)
+    tensor_plan = NSA.LightningIndexer(q, k, position_ids, indices, counts)
+    metadata = (
+        tensor_plan.q_desc,
+        tensor_plan.k_desc,
+        tensor_plan.position_desc,
+        tensor_plan.indices_desc,
+        tensor_plan.counts_desc,
+    )
+    assert NSA.LightningIndexer(*metadata).check_support()
+
+    with pytest.raises(ValueError, match="q dtype mismatch"):
+        NSA.LightningIndexer(replace(tensor_plan.q_desc, dtype=torch.float16), *metadata[1:]).check_support()
+    with pytest.raises(ValueError, match="batch size must be positive"):
+        NSA.LightningIndexer(
+            replace(tensor_plan.q_desc, shape=(0, 1, HEADS, HEAD_DIM)),
+            *metadata[1:],
+        ).check_support()
+    with pytest.raises(ValueError, match="batch size must be <= 65535"):
+        NSA.LightningIndexer(
+            replace(tensor_plan.q_desc, shape=(65536, 1, HEADS, HEAD_DIM)),
+            *metadata[1:],
+        ).check_support()
+    with pytest.raises(ValueError, match="S_k must be <= 32768"):
+        bad_k = replace(
+            tensor_plan.k_desc,
+            shape=(1, 32769, 1, HEAD_DIM),
+            stride=(32769 * HEAD_DIM, HEAD_DIM, HEAD_DIM, 1),
+        )
+        NSA.LightningIndexer(metadata[0], bad_k, *metadata[2:]).check_support()
+    with pytest.raises(ValueError, match="batch-broadcast"):
+        bad_position = replace(
+            tensor_plan.position_desc,
+            stride=(2, 1),
+            stride_order=(1, 0),
+        )
+        NSA.LightningIndexer(metadata[0], metadata[1], bad_position, *metadata[3:]).check_support()
+    with pytest.raises(ValueError, match="must share a device"):
+        other_device_k = replace(tensor_plan.k_desc, device=torch.device("cuda:1"))
+        NSA.LightningIndexer(metadata[0], other_device_k, *metadata[2:]).check_support()
+    with pytest.raises(ValueError, match="requires CUDA tensors"):
+        cpu_metadata = tuple(replace(desc, device=torch.device("cpu")) for desc in metadata)
+        NSA.LightningIndexer(*cpu_metadata).check_support()
+
+
+@pytest.mark.L0
+def test_lightning_indexer_rejects_misaligned_q_at_execute():
+    NSA = _require_cuda()
+    sample_q = torch.empty(
+        (1, 1, HEADS, HEAD_DIM),
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    storage = torch.empty(
+        1 + HEADS * HEAD_DIM,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    q = storage[1:].view(1, 1, HEADS, HEAD_DIM)
+    k = torch.empty(
+        (1, 2048, 1, HEAD_DIM),
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    position_ids = torch.tensor([[2047]], dtype=torch.int64, device="cuda")
+    indices, counts = _outputs(1)
+    plan = NSA.LightningIndexer(sample_q, k, position_ids, indices, counts)
+    assert plan.check_support()
+    plan.compile()
+    with pytest.raises(ValueError, match="q must be 16-byte aligned"):
+        plan.execute(q, k, position_ids, indices, counts)


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
- [ ] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions).

## Affected area

FE OSS kernels or CuTeDSL.

## Summary

Add an experimental MiniMax-M3 Lightning Indexer primitive for bounded static-cache decode.

On ComputeLab B200, the warmed prepared API takes **19.91-28.73 us** for the measured B=1/8 shapes and is **4.25-8.54x** faster than the eager dense PyTorch formulation. At B=32, S_k=8192 it takes **28.59 us** and is **27.80x** faster. These are primitive-level steady-state decode measurements, not pure kernel-active, optimized deployment-kernel, layer, or model end-to-end comparisons.

Given already normalized and RoPE-applied BF16 `q[B, 1, 4, 128]`, BF16 `k[B, S_k, 1, 128]`, and explicit `position_ids[B, 1]`, the primitive:

- accumulates QK products in FP32;
- max-pools completed 128-token blocks and always selects the current block;
- returns fixed-width `block_indices[B, 4, 1, 16]` and `block_counts[B, 4, 1]` in int32;
- uses a metadata-only path when the visible prefix fits in 16 blocks;
- provides both `NSA.LightningIndexer` prepared-plan and `NSA.lightning_indexer` functional APIs.

The supported scope is decode only, right-padded dense static caches, and `1 <= S_k <= 32768`.

## Why

The dense PyTorch formulation materializes token scores and several intermediates for every decode query. This change implements the same block-selection semantics for the current MiniMax-M3 geometry while directly producing fixed-width metadata suitable for a sparse-attention consumer.

The prepared API keeps compilation, destination allocation, and workspace allocation outside repeated execution. Long-context plans use exclusive caller-owned workspace with stream-ordered initialization and support CUDA Graph replay.

## Related issues

Related to #804, which adds MiniMax-M3 block-128 metadata consumption to Selection Attention. The changes are independent: #804 does not currently support cached decode, and this PR does not claim an assembled indexer-to-selection-attention path.

## API and compatibility impact

This adds two experimental public entries:

```python
NSA.LightningIndexer
NSA.lightning_indexer
```

Input contract:

- `q`: BF16 BSHD `[B, 1, 4, 128]`
- `k`: BF16 BSHD `[B, S_k, 1, 128]`
- `position_ids`: int64 `[B, 1]`, contiguous or batch-broadcast with stride `(0, 1)`
- finite Q/K values whose FP32 dot-product accumulations remain finite
- dense, zero-based static-cache positions
- `1 <= S_k <= 32768`

Output contract:

- `block_indices`: int32 `[B, 4, 1, 16]`
- `block_counts`: int32 `[B, 4, 1]`
- valid IDs are left-packed and unused slots are `-1`
- exact-score ties prefer lower block IDs; output slot order is otherwise not contractual
- invalid positions produce an empty row

BHSD Q/K views can be transposed into the admitted BSHD layouts without copying. The output intentionally differs from the current dynamic-width int64 Transformers result: fixed-width int32 metadata plus counts is the sparse-consumer ABI. Squeezing the singleton query dimension gives a zero-copy THK/TH metadata view, but no current end-to-end integration with #804 is claimed.

Dynamic and paged caches, holes, left-padding remapping, prefill, chunked prefill, Q/K projection, normalization, and RoPE are out of scope. MiniMax-M3 advertises contexts longer than 32768 tokens; this PR is a bounded static-cache decode slice, not full-context model support.

The implementation is functionally admitted on SM80 and newer. Functional coverage ran on A100 SM80 and B200 SM100; performance numbers below are B200-only.

### Performance

ComputeLab B200, source `0db26f2143c7754be8753a14a8663d02ed8e019e`, job 4049129, node `umb-b200-250`, 50 warmups, 500 iterations, 9 interleaved rounds; table entries are medians:

- **Prepared API:** warmed `plan.execute`; destinations and workspace are preallocated and JIT compilation is complete. Timing includes Python validation and stream-lifetime tracking.
- **Eager PyTorch reference:** dense FP32 QK matmul, causal masking, block max, and Top-K. Timing includes PyTorch dispatch and intermediate allocation.
- **Graph replay:** the native prepared API captured and replayed alone. It is reported as absolute latency because there is no corresponding reference graph arm.

| B | `S_k` | Eager PyTorch (us) | Prepared API (us) | Reference / prepared | Native graph replay (us) |
|---:|---:|---:|---:|---:|---:|
| 1 | 2048 | 118.04 | 19.91 | 5.93x | 2.175 |
| 1 | 8192 | 118.01 | 27.42 | 4.30x | 6.147 |
| 1 | 16384 | 117.20 | 27.57 | 4.25x | 6.148 |
| 1 | 32768 | 118.28 | 27.62 | 4.28x | 6.151 |
| 8 | 8192 | 245.22 | 28.73 | 8.54x | 8.198 |
| 32 | 8192 | 794.97 | 28.59 | 27.80x | 14.350 |

The benchmark records the source SHA and dirty state, exact command, GPU/toolchain information, and ComputeLab job/node identifiers. All reported artifacts recorded `git_dirty=false`.

## Testing

```bash
pytest -q -m "L0 or L1" test/python/fe_api/nsa/test_NSA_lightning_indexer.py
```

On frozen source `0db26f2143c7754be8753a14a8663d02ed8e019e`:

- NVIDIA B200 SM100: 22 passed
- NVIDIA A100 80GB PCIe SM80: 22 passed
- B200 Compute Sanitizer memcheck on the official transpose/broadcast test: 0 errors
- B200 Compute Sanitizer racecheck on prepared streams and CUDA Graph replay: 0 hazards, 0 errors, 0 warnings

Coverage includes short- and long-context boundaries, static-cache tail exclusion, mixed batch positions, transpose and broadcast-position views, deterministic ties, negative scores, invalid positions, TensorDesc admission, alignment validation, caller-owned workspace initialization, explicit streams, independent concurrent workspaces, raw-workspace reuse, and CUDA Graph replay.

B200 benchmark commands:

```bash
python benchmark/nsa/benchmark_lightning_indexer.py \
  --batch 1 --warmup 50 --iterations 500 --rounds 9

python benchmark/nsa/benchmark_lightning_indexer.py \
  --batch 8 --k-capacity 8192 --warmup 50 --iterations 500 --rounds 9

python benchmark/nsa/benchmark_lightning_indexer.py \
  --batch 32 --k-capacity 8192 --warmup 50 --iterations 500 --rounds 9
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the MiniMax Lightning Indexer for exact sparse-attention block selection on supported CUDA hardware.
  * Added convenient functional and prepared APIs with reusable outputs, workspaces, and CUDA stream support.
  * Added support for short- and long-context decoding, static-cache batches, CUDA graphs, and supported tensor layouts.

* **Documentation**
  * Documented the Lightning Indexer API, inputs, outputs, hardware requirements, limits, workspace usage, and examples.

* **Testing**
  * Added coverage for boundary positions, ties, invalid inputs, workspace reuse, streams, graph execution, and layout compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->