### PR TITLE
frost(sdpa): rebalance the SM120 prefill setmaxnreg budgets to reduce d=256 register spills

### DIFF
--- a/python/cudnn/sdpa/fwd/config_sm120.py
+++ b/python/cudnn/sdpa/fwd/config_sm120.py
@@ -26,6 +26,17 @@ SUPPORTED_HEAD_TILES_FP8 = tuple(range(FP8_HEAD_TILE_GRANULE, SUPPORTED_HEAD_TIL
 SMEM_CAPACITY_BYTES = 101376
 
 
+def register_budgets(q_tile: int) -> tuple[int, int]:
+    max_regs_per_sm = 2048
+    max_regs_per_thread = 256
+    load_regs_per_thread = 24
+    num_compute_warps = 8 if q_tile == 128 else 4
+    num_load_warps = 4
+    free_slots = max_regs_per_sm - num_load_warps * load_regs_per_thread
+    compute_regs_per_thread = min(max_regs_per_thread, free_slots // num_compute_warps // 8 * 8)
+    return load_regs_per_thread, compute_regs_per_thread
+
+
 def smem_bytes(d_qk: int, d_v: int, q_tile: int, kv_tile: int, itemsize: int = 2, out_itemsize: Optional[int] = None) -> int:
     """SMEM the SM120 prefill kernel needs for one specialization.
 

--- a/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm120.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm120.py
@@ -71,6 +71,7 @@ from cudnn.sdpa.fwd.config_sm120 import (
     SEQ_Q_TILES as _SEQ_Q_TILES,
     SUPPORTED_HEAD_TILES as _SUPPORTED_HEAD_TILES,
     TemplateParams,
+    register_budgets,
     validate_params,
 )
 
@@ -330,6 +331,7 @@ class SM120FusedMultiHeadAttentionForward:
             self.num_warps = 8
         self.num_compute_warps = len(self.compute_warp_ids)
         self.num_load_warps = 1
+        self.load_regs, self.compute_regs = register_budgets(self.q_tile)
 
         self.bar_compute_sync = 1
         self.bar_k_consumed = 2
@@ -974,7 +976,7 @@ class SM120FusedMultiHeadAttentionForward:
         #  LOAD K/V
         # /////////////////////////////////////////////////////////////////////////////
         if warp == self.load_warp_id:
-            prims.setmaxregister(40, prims.SetMaxRegisterAction.DECREASE)
+            prims.setmaxregister(self.load_regs, prims.SetMaxRegisterAction.DECREASE)
 
             # THD collapses the packed view's batch coordinate to 0; the
             # per-sequence token base rides the seq coordinate instead. Every
@@ -1057,7 +1059,7 @@ class SM120FusedMultiHeadAttentionForward:
         #  COMPUTE
         # /////////////////////////////////////////////////////////////////////////////
         elif warp < self.load_warp_id:
-            prims.setmaxregister(232, prims.SetMaxRegisterAction.INCREASE)
+            prims.setmaxregister(self.compute_regs, prims.SetMaxRegisterAction.INCREASE)
 
             compute_warp_idx = warp
             q_warp_row0 = compute_warp_idx * self.MMA_TILER[0]
@@ -1340,7 +1342,7 @@ class SM120FusedMultiHeadAttentionForward:
         #  EMPTY
         # /////////////////////////////////////////////////////////////////////////////
         else:
-            prims.setmaxregister(40, prims.SetMaxRegisterAction.DECREASE)
+            prims.setmaxregister(self.load_regs, prims.SetMaxRegisterAction.DECREASE)
 
         return tiles_loaded
 

--- a/python/cudnn/sdpa/fwd/kernels/prefill_fp8_sm120.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_fp8_sm120.py
@@ -80,6 +80,7 @@ from cudnn.sdpa.fwd.config_sm120 import (
     SEQ_Q_TILES as _SEQ_Q_TILES,
     SUPPORTED_HEAD_TILES_FP8 as _SUPPORTED_HEAD_TILES_FP8,
     TemplateParams,
+    register_budgets,
     validate_params,
 )
 
@@ -351,6 +352,7 @@ class SM120FusedMultiHeadAttentionForward:
             self.num_warps = 8
         self.num_compute_warps = len(self.compute_warp_ids)
         self.num_load_warps = 1
+        self.load_regs, self.compute_regs = register_budgets(self.q_tile)
 
         self.bar_compute_sync = 1
         self.bar_k_consumed = 2
@@ -1193,7 +1195,7 @@ class SM120FusedMultiHeadAttentionForward:
         #  LOAD K/V
         # /////////////////////////////////////////////////////////////////////////////
         if warp == self.load_warp_id:
-            prims.setmaxregister(40, prims.SetMaxRegisterAction.DECREASE)
+            prims.setmaxregister(self.load_regs, prims.SetMaxRegisterAction.DECREASE)
 
             # THD collapses the packed view's batch coordinate to 0; the
             # per-sequence token base rides the seq coordinate instead. Every
@@ -1264,7 +1266,7 @@ class SM120FusedMultiHeadAttentionForward:
         #  COMPUTE
         # /////////////////////////////////////////////////////////////////////////////
         elif warp < self.load_warp_id:
-            prims.setmaxregister(232, prims.SetMaxRegisterAction.INCREASE)
+            prims.setmaxregister(self.compute_regs, prims.SetMaxRegisterAction.INCREASE)
 
             compute_warp_idx = warp
             q_warp_row0 = compute_warp_idx * self.MMA_TILER[0]
@@ -1625,7 +1627,7 @@ class SM120FusedMultiHeadAttentionForward:
         #  EMPTY
         # /////////////////////////////////////////////////////////////////////////////
         else:
-            prims.setmaxregister(40, prims.SetMaxRegisterAction.DECREASE)
+            prims.setmaxregister(self.load_regs, prims.SetMaxRegisterAction.DECREASE)
 
     @cute.jit
     def __call__(


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
- [x] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions).

## Affected area

FE OSS kernels or CuTeDSL

## Summary

Rebalance the SM120 prefill kernels' `setmaxnreg` budgets:
  * the load warp and the three empty padded warps: 24
  * the compute warps claim the register file's remainder: 240 per thread at `q_tile=128`, the 256 cap at `q_tile=64`

## Why

To fix the register spills issue when D=256.

Measured on RTX PRO 6000:

| shape | speedup |
|---|---|
| f16 d256 32/2 (the #834 case) | **+21.7%** |
| f16 d256 16/1 | +17.6% |
| f16 d256 32/2 s8192 | +2.4% |
| f16 d128 64/8 | +2.3% |
| f16 d64, MLA d192/128 | neutral |
| fp8 d256 32/2, tile_m=128 | +21.2% |
| fp8 d256 32/2, tile_m=64 | +7.1% |
| fp8 d128 | neutral |

## Related issues

Related to #834.

## API and compatibility impact

None.

## Testing

See the pipeline.
