### PR TITLE
AGENTS.md: codify THD Stats packing rule, editable-install gotcha, PR review checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,8 +3,7 @@
 - [ ] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
 - [ ] I ran `pre-commit run` and committed any formatting changes.
 - [ ] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches (see [root AGENTS.md § Reviewing a PR](https://github.com/NVIDIA/cudnn-frontend/blob/develop/AGENTS.md#reviewing-a-pr-human-or-agent)) and my changes comply, or I explain the exception below.
-- [ ] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
-- [ ] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions).
+- [ ] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
 
 ## Affected area
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,7 @@
 
 - [ ] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
 - [ ] I ran `pre-commit run` and committed any formatting changes.
+- [ ] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches (see [root AGENTS.md § Reviewing a PR](https://github.com/NVIDIA/cudnn-frontend/blob/develop/AGENTS.md#reviewing-a-pr-human-or-agent)) and my changes comply, or I explain the exception below.
 - [ ] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
 - [ ] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions).
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,12 @@ repos:
         types_or: [python, pyi, jupyter]
         additional_dependencies: [".[jupyter]"]
         args: ["--line-length", "160"]
+-   repo: local
+    hooks:
+    -   id: spdx-license-header
+        name: SPDX license header
+        description: "Every first-party source file carries an SPDX-License-Identifier line"
+        language: pygrep
+        entry: 'SPDX-License-Identifier:'
+        args: [--negate]
+        types_or: [c++, c, cuda, python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,8 +34,8 @@ repos:
     hooks:
     -   id: spdx-license-header
         name: SPDX license header
-        description: "Every first-party source file carries an SPDX-License-Identifier line"
+        description: "Every first-party source file carries a commented SPDX-License-Identifier line with a non-empty identifier"
         language: pygrep
-        entry: 'SPDX-License-Identifier:'
+        entry: '^\s*(?:#|//|\*|/\*)\s*SPDX-License-Identifier:\s*\S+'
         args: [--negate]
         types_or: [c++, c, cuda, python]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ First invocation builds the hook environments and can take >5 minutes; later run
 - Runtime debugging: set `CUDNN_FRONTEND_LOG_INFO=1` and `CUDNN_FRONTEND_LOG_FILE=stderr` for FE logs; backend logs via `CUDNN_LOGLEVEL_DBG=3 CUDNN_LOGDEST_DBG=stderr`.
 - Public-API signatures evolve **append-only**: new parameters go at the end (with defaults), never inserted mid-signature — positional callers across C++, pybind, and Python wrappers break silently otherwise (review on PR #266).
 - Never delete an existing log or diagnostic statement in a cleanup/refactor — several were added after repeated hard-to-repro failures and are the only tripwire for a recurrence (review on PR #280). If one looks redundant, ask before removing.
-- Every new source file needs the repo's SPDX/license header (flagged in review on PR #747).
+- Every new source file needs the repo's SPDX/license header (flagged in review on PR #747) — enforced by the `spdx-license-header` pre-commit hook.
 
 ## Agent skills
 
@@ -106,10 +106,10 @@ Reusable task recipes live in `skills/` (auto-discovered by Claude Code via `.cl
 
 ## PR labels
 
-When opening a pull request, apply **at minimum one label from each group**: one `cat-*` (change type), one or more `mod-*` (affected module), and one `orig-*` (originator). See the full label list at <https://github.com/NVIDIA/cudnn-frontend/labels>.
+When opening a pull request, apply **at minimum one label from each group**: one `cat-*` (change type), one or more `area:*` / `op:*` (affected area), and one `orig-*` (originator). See the full label list at <https://github.com/NVIDIA/cudnn-frontend/labels>.
 
-Leave `closed-*` and `open-*` labels for maintainers.
+Leave `closed-*` and `open-*` labels for maintainers; Milestone/Projects sidebar fields are set by reviewers/maintainers, not authors.
 
 ## Reviewing a PR (human or agent)
 
-Each Hard Rule is numbered so it can be cited by number in review comments. Before approving or requesting changes on a diff, check it against every Hard Rules section whose directory it touches: [python/cudnn/AGENTS.md](python/cudnn/AGENTS.md) (Rules 1-6, `execute()`/import-time), [include/cudnn_frontend/AGENTS.md](include/cudnn_frontend/AGENTS.md) (header-only, warnings-as-errors), plus the conventions in [test/AGENTS.md](test/AGENTS.md) and [samples/AGENTS.md](samples/AGENTS.md). Where a rule names a detector (grep pattern, `set_sync_debug_mode` snippet, a `RED-then-green` test), prefer running or citing it over an eyeballed read. When a review surfaces a new concrete, checkable technique or trap that these guides don't already cover, land it in the relevant `AGENTS.md` in the same PR rather than leaving it in a review comment.
+Each Hard Rule is numbered so it can be cited by number in review comments. Before approving or requesting changes on a diff, check it against every Hard Rules section whose directory it touches: [python/cudnn/AGENTS.md](python/cudnn/AGENTS.md) (Rules 1-5, `execute()`/import-time), [python/cudnn/sdpa/AGENTS.md](python/cudnn/sdpa/AGENTS.md) (SDPA Rules S1+), [include/cudnn_frontend/AGENTS.md](include/cudnn_frontend/AGENTS.md) (header-only, warnings-as-errors), plus the conventions in [test/AGENTS.md](test/AGENTS.md) and [samples/AGENTS.md](samples/AGENTS.md). Where a rule names a detector (grep pattern, `set_sync_debug_mode` snippet, a `RED-then-green` test), prefer running or citing it over an eyeballed read. When a review surfaces a new concrete, checkable technique or trap that these guides don't already cover, land it in the relevant `AGENTS.md` in the same PR rather than leaving it in a review comment.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,9 @@ First invocation builds the hook environments and can take >5 minutes; later run
 - Frontend-only OSS APIs are experimental; keep the `[cutedsl]` optional-dependency boundary intact (no eager `torch`/`cutlass` imports at `cudnn` import time).
 - Version lives in three places that must stay in sync: `CMakeLists.txt` (`project(... VERSION ...)`), `include/cudnn_frontend_version.h`, `python/cudnn/__init__.py` (`__version__`).
 - Runtime debugging: set `CUDNN_FRONTEND_LOG_INFO=1` and `CUDNN_FRONTEND_LOG_FILE=stderr` for FE logs; backend logs via `CUDNN_LOGLEVEL_DBG=3 CUDNN_LOGDEST_DBG=stderr`.
+- Public-API signatures evolve **append-only**: new parameters go at the end (with defaults), never inserted mid-signature — positional callers across C++, pybind, and Python wrappers break silently otherwise (review on PR #266).
+- Never delete an existing log or diagnostic statement in a cleanup/refactor — several were added after repeated hard-to-repro failures and are the only tripwire for a recurrence (review on PR #280). If one looks redundant, ask before removing.
+- Every new source file needs the repo's SPDX/license header (flagged in review on PR #747).
 
 ## Agent skills
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,8 @@ pip install --group jax        # + jax for the CuTeDSL APIs (jax >= 0.5; XLA ent
 
 `setup.py` honors env vars: `CUDNN_PATH`, `CUDA_PATH` / `CUDAToolkit_ROOT`, `DEBUG=1` (debug build), `CMAKE_BUILD_PARALLEL_LEVEL`, `CMAKE_GENERATOR`.
 
+**Editable installs pin one checkout — a worktree or second clone is silently not under test.** `pip install -e .` installs a `sys.meta_path` finder whose `MAPPING` hard-codes the absolute path of the checkout it was installed from; meta-path finders run before `sys.path`, so `PYTHONPATH` cannot shadow it. Before trusting any measurement from a worktree or second clone, confirm the import actually resolves there: `python -c "import cudnn; print(cudnn.__file__)"`. If a deliberately destructive probe changes nothing, suspect the import path before the code.
+
 ## Test
 
 ```bash
@@ -104,3 +106,7 @@ Reusable task recipes live in `skills/` (auto-discovered by Claude Code via `.cl
 When opening a pull request, apply **at minimum one label from each group**: one `cat-*` (change type), one or more `mod-*` (affected module), and one `orig-*` (originator). See the full label list at <https://github.com/NVIDIA/cudnn-frontend/labels>.
 
 Leave `closed-*` and `open-*` labels for maintainers.
+
+## Reviewing a PR (human or agent)
+
+Each Hard Rule is numbered so it can be cited by number in review comments. Before approving or requesting changes on a diff, check it against every Hard Rules section whose directory it touches: [python/cudnn/AGENTS.md](python/cudnn/AGENTS.md) (Rules 1-6, `execute()`/import-time), [include/cudnn_frontend/AGENTS.md](include/cudnn_frontend/AGENTS.md) (header-only, warnings-as-errors), plus the conventions in [test/AGENTS.md](test/AGENTS.md) and [samples/AGENTS.md](samples/AGENTS.md). Where a rule names a detector (grep pattern, `set_sync_debug_mode` snippet, a `RED-then-green` test), prefer running or citing it over an eyeballed read. When a review surfaces a new concrete, checkable technique or trap that these guides don't already cover, land it in the relevant `AGENTS.md` in the same PR rather than leaving it in a review comment.

--- a/include/cudnn_frontend/AGENTS.md
+++ b/include/cudnn_frontend/AGENTS.md
@@ -7,7 +7,7 @@ The header-only C++ library (CMake INTERFACE target `cudnn_frontend`, C++17). Um
 - **Header-only**: no `.cpp` files, no link-time dependencies beyond cuDNN/CUDA. New third-party code must be vendored under `thirdparty/` (currently only `nlohmann/json.hpp`, excludable via `CUDNN_FRONTEND_SKIP_JSON_LIB`).
 - Builds with `-Wall -Wextra -Wpedantic -Werror` (GCC/Clang) and `/W4 /WX` (MSVC) — code must be warning-clean on both.
 - C++17 only in `include/` (the pybind11 layer under `python/` is C++20).
-- Guard anything needing a newer cuDNN with runtime `detail::get_backend_version()` checks (compare against `CUDNN_FRONTEND_VERSION`-style integers, e.g. 9.12.0 → 91200); the same headers must compile against older cuDNN 9.x.
+- Guard anything needing a newer cuDNN with runtime `detail::get_backend_version()` checks (compare against `CUDNN_FRONTEND_VERSION`-style integers, e.g. 9.12.0 → 91200); the same headers must compile against older cuDNN 9.x. **Declare unconditionally, gate in the body**: an `#if`-conditional declaration bakes the build-time cuDNN version into the artifact, so a wheel built against 9.23 silently loses the symbol on a 9.24 system — declare the API always and return not-supported at runtime instead (review on PR #246).
 - clang-format (Google-based, indent 4, 120 cols, `SortIncludes: false`) via `pre-commit run`.
 
 ## Layering

--- a/python/cudnn/AGENTS.md
+++ b/python/cudnn/AGENTS.md
@@ -38,6 +38,12 @@ Numbered so reviews can cite them; the list grows — append, never renumber.
   launches, and a second copy of the semantics that can drift). If a packed
   extent would be zero, bind a never-dereferenced dummy view over storage
   the contract already guarantees.
+- **Overlapping optional declarations are validated as a set, not one by
+  one.** When two mechanisms can declare the same thing (ragged offsets vs
+  `cu_seqlen` vs plain `seq_len` tensors), each combination is either
+  defined or explicitly rejected — an unhandled overlap is an untested code
+  path with unspecified semantics, and "both supplied" is exactly the case
+  no per-argument check catches (raised in review on PR #266).
 
 **Rule 2 — `execute()` launches exactly the kernels the plan promised:
 serve the declared layout natively, or decline — never adapt.**
@@ -168,6 +174,15 @@ not become a compile key.
   (#493) still keys `SQ`/`SKV` under `THD_VARLEN` — migrate it to dynamic
   token extents like the SM100/SM120 THD compiles rather than copying its
   pattern.
+- **Key on exactly the contract-relevant set — no more, no less.** Both
+  failure modes shipped on PR #553 and were caught in review: *under-keying*
+  (the cache keyed only `x.shape`/`w.shape` while `check_support()`
+  validated weight, RoPE, and scale descriptors — a hit can return an
+  artifact compiled for a different contract, i.e. wrong results) and
+  *over-keying* (`alpha` passed at launch, `m`/`n`/`k` on a shape-generic
+  kernel — every miss is a spurious multi-second recompile). Enumerate what
+  `check_support()` validates and what the kernel specializes on; the key
+  is that set.
 
 **Rule 5 — every torch operation on the execute path is ordered on the
 LAUNCH stream, never implicitly on torch's current stream.**
@@ -192,6 +207,13 @@ the kernel that reads it).
   context is a no-op — the race only bites direct graph-API users with an
   explicit handle stream, which is exactly why tests miss it. Order the work
   by construction rather than relying on the common case.
+- **The device is implicit state exactly like the stream.** A `torch.empty`
+  (or any allocator call) without a device context silently allocates on the
+  *current* GPU, not the input tensor's — wrap execute-path allocations in
+  the right device context as well as the stream context. And a raw pointer
+  argument is a contract: validate device-residency and dtype (a CUDA int64
+  tensor, not a host tensor) before handing its address to a kernel — both
+  flagged in review on PR #517.
 
 **Rule 6 — THD/packed Stats (LSE) must stay packed: token-major or
 head-major, never dense-padded.**

--- a/python/cudnn/AGENTS.md
+++ b/python/cudnn/AGENTS.md
@@ -193,6 +193,24 @@ the kernel that reads it).
   explicit handle stream, which is exactly why tests miss it. Order the work
   by construction rather than relying on the common case.
 
+**Rule 6 — THD/packed Stats (LSE) must stay packed: token-major or
+head-major, never dense-padded.**
+
+- Consumers read Stats through the same `cu_seqlen` packing as Q/O: TE and
+  Megatron take token-major `(T, H)` (cuDNN's TH1 recipe) natively, FA-style
+  callers take head-major `(H, head_stride)`. A dense-padded declaration
+  (per-sequence stride) mis-addresses under that packing — it must be
+  rejected at validation time, not silently accepted and mis-read.
+- Validate by stride, not by a `thd`/`packed` flag: token-major is
+  `stride_h == 1 and stride_s == H`; head-major is `stride_s == 1 and
+  stride_h >= H`; anything else raises. See `_checked_lse_view` in
+  `sdpa/fwd/api_dsl.py` (duplicated at the two THD compile-key call sites —
+  extract rather than re-copy if you touch it, per Rule 3's "suspect
+  duplicated logic first").
+- Covered by `test_fwd_probe_rejects_invalid_stats_metadata` and the
+  `stats_layout`-parametrized THD tests (`test_dsl_sm100_thd_stats` and
+  siblings) in `test/python/sdpa/frost/`.
+
 
 ## Frontend-only kernel package layout
 

--- a/python/cudnn/AGENTS.md
+++ b/python/cudnn/AGENTS.md
@@ -215,23 +215,9 @@ the kernel that reads it).
   tensor, not a host tensor) before handing its address to a kernel — both
   flagged in review on PR #517.
 
-**Rule 6 — THD/packed Stats (LSE) must stay packed: token-major or
-head-major, never dense-padded.**
-
-- Consumers read Stats through the same `cu_seqlen` packing as Q/O: TE and
-  Megatron take token-major `(T, H)` (cuDNN's TH1 recipe) natively, FA-style
-  callers take head-major `(H, head_stride)`. A dense-padded declaration
-  (per-sequence stride) mis-addresses under that packing — it must be
-  rejected at validation time, not silently accepted and mis-read.
-- Validate by stride, not by a `thd`/`packed` flag: token-major is
-  `stride_h == 1 and stride_s == H`; head-major is `stride_s == 1 and
-  stride_h >= H`; anything else raises. See `_checked_lse_view` in
-  `sdpa/fwd/api_dsl.py` (duplicated at the two THD compile-key call sites —
-  extract rather than re-copy if you touch it, per Rule 3's "suspect
-  duplicated logic first").
-- Covered by `test_fwd_probe_rejects_invalid_stats_metadata` and the
-  `stats_layout`-parametrized THD tests (`test_dsl_sm100_thd_stats` and
-  siblings) in `test/python/sdpa/frost/`.
+SDPA-specific hard rules (cited as Rule S1, S2, ...) live in
+[sdpa/AGENTS.md](sdpa/AGENTS.md) — read it before touching anything under
+`python/cudnn/sdpa/`.
 
 
 ## Frontend-only kernel package layout

--- a/python/cudnn/linear_attention/frost/kernel/gdn2_bprop_f16.py
+++ b/python/cudnn/linear_attention/frost/kernel/gdn2_bprop_f16.py
@@ -1,3 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This kernel is derived from cuDNN, NVIDIA Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import NamedTuple, Optional, Type

--- a/python/cudnn/linear_attention/frost/kernel/kda_bprop_f16.py
+++ b/python/cudnn/linear_attention/frost/kernel/kda_bprop_f16.py
@@ -1,3 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# This kernel is derived from cuDNN, NVIDIA Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import NamedTuple, Optional, Type

--- a/python/cudnn/ops/fft_causal_conv1d.py
+++ b/python/cudnn/ops/fft_causal_conv1d.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import List, Tuple
 
 import torch

--- a/python/cudnn/sdpa/AGENTS.md
+++ b/python/cudnn/sdpa/AGENTS.md
@@ -20,13 +20,15 @@ head-major, never dense-padded.**
   `stride_h` the declared head stride, which must cover the **packed token
   count `T`** — `stride_h >= H` is not the bound; at `T > stride_h` the
   per-head slices alias. `T` is a runtime total, so plan-time
-  classification can only check `stride_s == 1 and stride_h >= 1`; the
-  packed total fitting under the declared head stride is an execute-time
-  capacity check (the dense path's `_checked_lse_view` rejects via
-  `as_strided` when the backing storage is too small). See the THD
-  classification sites in `fwd/api_dsl.py` (duplicated at the two THD
-  compile-key call sites — extract rather than re-copy if you touch it,
-  per Rule 3's "suspect duplicated logic first").
+  classification can only check `stride_s == 1 and stride_h >= 1`. In the
+  THD path the packed total is a *device* value — Rule 3 bans reading it
+  back, so `stride_h >= T` is **caller contract** (stated in
+  `_thd_lse_view`'s docstring), not something the adapter verifies:
+  `as_strided` bounds-checks storage capacity, never overlap. Do not "fix"
+  this with a host-side length read; an in-kernel assert is the only
+  legal detector. See the THD classification sites in `fwd/api_dsl.py`
+  (duplicated at the two THD compile-key call sites — extract rather than
+  re-copy if you touch it, per Rule 3's "suspect duplicated logic first").
 - Covered by `test_fwd_probe_rejects_invalid_stats_metadata` and the
   `stats_layout`-parametrized THD tests (`test_dsl_sm100_thd_stats` and
   siblings) in `test/python/sdpa/frost/`.

--- a/python/cudnn/sdpa/AGENTS.md
+++ b/python/cudnn/sdpa/AGENTS.md
@@ -1,0 +1,26 @@
+# python/cudnn/sdpa — Agent Guide
+
+SDPA-specific hard rules, on top of the package-wide Rules 1-5 in
+[../AGENTS.md](../AGENTS.md). Numbered `S1, S2, ...` so reviews can cite them
+without colliding with the package-wide numbering; the list grows — append,
+never renumber.
+
+## Hard rules
+
+**Rule S1 — THD/packed Stats (LSE) must stay packed: token-major or
+head-major, never dense-padded.**
+
+- Consumers read Stats through the same `cu_seqlen` packing as Q/O: TE and
+  Megatron take token-major `(T, H)` (cuDNN's TH1 recipe) natively, FA-style
+  callers take head-major `(H, head_stride)`. A dense-padded declaration
+  (per-sequence stride) mis-addresses under that packing — it must be
+  rejected at validation time, not silently accepted and mis-read.
+- Validate by stride, not by a `thd`/`packed` flag: token-major is
+  `stride_h == 1 and stride_s == H`; head-major is `stride_s == 1 and
+  stride_h >= H`; anything else raises. See `_checked_lse_view` in
+  `fwd/api_dsl.py` (duplicated at the two THD compile-key call sites —
+  extract rather than re-copy if you touch it, per Rule 3's "suspect
+  duplicated logic first").
+- Covered by `test_fwd_probe_rejects_invalid_stats_metadata` and the
+  `stats_layout`-parametrized THD tests (`test_dsl_sm100_thd_stats` and
+  siblings) in `test/python/sdpa/frost/`.

--- a/python/cudnn/sdpa/AGENTS.md
+++ b/python/cudnn/sdpa/AGENTS.md
@@ -16,11 +16,17 @@ head-major, never dense-padded.**
   (per-sequence stride) mis-addresses under that packing — it must be
   rejected at validation time, not silently accepted and mis-read.
 - Validate by stride, not by a `thd`/`packed` flag: token-major is
-  `stride_h == 1 and stride_s == H`; head-major is `stride_s == 1 and
-  stride_h >= H`; anything else raises. See `_checked_lse_view` in
-  `fwd/api_dsl.py` (duplicated at the two THD compile-key call sites —
-  extract rather than re-copy if you touch it, per Rule 3's "suspect
-  duplicated logic first").
+  `stride_h == 1 and stride_s == H`; head-major is `stride_s == 1` with
+  `stride_h` the declared head stride, which must cover the **packed token
+  count `T`** — `stride_h >= H` is not the bound; at `T > stride_h` the
+  per-head slices alias. `T` is a runtime total, so plan-time
+  classification can only check `stride_s == 1 and stride_h >= 1`; the
+  packed total fitting under the declared head stride is an execute-time
+  capacity check (the dense path's `_checked_lse_view` rejects via
+  `as_strided` when the backing storage is too small). See the THD
+  classification sites in `fwd/api_dsl.py` (duplicated at the two THD
+  compile-key call sites — extract rather than re-copy if you touch it,
+  per Rule 3's "suspect duplicated logic first").
 - Covered by `test_fwd_probe_rejects_invalid_stats_metadata` and the
   `stats_layout`-parametrized THD tests (`test_dsl_sm100_thd_stats` and
   siblings) in `test/python/sdpa/frost/`.

--- a/samples/cpp/causal_conv1d/fft_causal_conv1d.cpp
+++ b/samples/cpp/causal_conv1d/fft_causal_conv1d.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ * SPDX-License-Identifier: MIT
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -43,6 +43,7 @@ pytest fe_api/gemm/          # OSS kernel tests
 ### Conventions for new tests
 
 - Mark with a level (`@pytest.mark.L0` ... `L4`): L0 must stay fast (default CI smoke); big parameter sweeps go to higher levels.
+- **Check for a module-level `pytestmark` before adding per-test markers.** Many files apply a level or capability marker file-wide (`pytestmark = ...` near the top); duplicating it on each test is noise, and suggesting it in review wastes a round-trip (recurred on PRs #814, #811, #797).
 - Gate on capability, don't assume it: skip via `check_support()` failures, `cudnn.backend_version()`, and `torch.cuda.get_device_capability()`.
 - Compare against a reference implementation (see existing `*_ref.py` / `*_reference.py` patterns) with dtype-appropriate tolerances.
 - **Scale the tolerance to the tensor, not to the dtype alone.** A fixed absolute bound quietly becomes wrong when magnitudes grow: GQA dK/dV sum over `h_q/h_kv` query heads, so at a group size of 4 the *relative* error stays ~0.5% while `|dv|` peaks near 9.6 and blows a bound that passed at `h_kv == h_q`. Compare against `TOL * max(|ref|.max(), 1.0)`, or the next GQA ratio someone adds will look like a correctness regression.

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_hadamard_quant.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_hadamard_quant.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for grouped GEMM GLU + Hadamard + Quant forward fusion (SM100+)."""
 
 from typing import Dict, Optional

--- a/test/python/gemm/frost/test_template_epilogue_parity.py
+++ b/test/python/gemm/frost/test_template_epilogue_parity.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """The epilogue drain is ONE logic across all 20 kernel templates.
 
 Source-level only -- no GPU, no render, no JIT. See CLAUDE.md

--- a/test/python/test_fft_causal_conv1d.py
+++ b/test/python/test_fft_causal_conv1d.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import pytest

--- a/test/python/test_sdpa_benchmark_single_sdpa.py
+++ b/test/python/test_sdpa_benchmark_single_sdpa.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import sys
 from pathlib import Path
 from typing import Optional


### PR DESCRIPTION
## Summary
- `python/cudnn/sdpa/AGENTS.md` (new): SDPA Hard Rule S1 — THD/packed Stats (LSE) must stay token-major or head-major, never dense-padded. This behavior was already implemented and tested (`_checked_lse_view`, `test_fwd_probe_rejects_invalid_stats_metadata`, the `stats_layout`-parametrized THD tests) but not written down as a Hard Rule alongside Rules 1-5.
- Root `AGENTS.md`: document that `pip install -e .` pins a `sys.meta_path` finder to the checkout it was run from, so edits made in a git worktree or second clone can silently run against the wrong code — with the one-line check to confirm (`python -c "import cudnn; print(cudnn.__file__)"`).
- Root `AGENTS.md`: add a "Reviewing a PR (human or agent)" section pointing reviewers at the numbered Hard Rules per directory, and asking that a newly-discovered concrete technique/trap get written into the relevant `AGENTS.md` in the same PR rather than left in a review comment.
- `.github/pull_request_template.md`: add a checklist item to review the relevant `AGENTS.md` Hard Rules before submitting.

- Review-mined lessons (commit 2): Rule 1 overlapping-optional-declarations, Rule 4 exact contract-relevant compile keys, Rule 5 device-context + pointer validation, include/ declare-unconditionally-gate-at-runtime, root append-only signatures / keep log statements / SPDX, test/ module-level pytestmark.
- Review feedback (commit 3): `spdx-license-header` pre-commit hook + headers for the 8 missing files; PR template drops the Milestone/Projects item and switches label groups to `cat-*` / `area:*`+`op:*` / `orig-*`.

## Why
Reviewing recent PR history against the existing Hard Rules (1-5 in `python/cudnn/AGENTS.md`) turned up one implemented-but-uncodified rule (packed Stats layout) and one recurring debugging trap (editable-install/worktree shadowing) that wasn't written down anywhere agents or humans would see it before hitting it. Making these explicit is groundwork for reviewing PRs against the Hard Rules consistently (by a human or an agent).

## Related issues
None.

## API and compatibility impact
None — documentation only.

## Testing
Docs-only change; no build/test impact. Confirmed the cited validation code (`_checked_lse_view` in `python/cudnn/sdpa/fwd/api_dsl.py`) and tests (`test_fwd_probe_rejects_invalid_stats_metadata`, `test_dsl_sm100_thd_stats` and siblings in `test/python/sdpa/frost/`) exist at HEAD.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded repository and component guidance for API compatibility, runtime support, validation, caching, device handling, data layouts, diagnostics, licensing, and testing.
  - Updated pull request checklist labels and clarified maintainer-managed milestone and project fields.
  - Added SDPA guidance on packed token capacity, stride validation, and avoiding redundant test markers.

- **Chores**
  - Strengthened automated SPDX license-header validation.
  - Added missing license headers across source, sample, and test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
