### PR TITLE
frost(sdpa): per-tensor FP8 d512 forward kernel on SM100

### DIFF
--- a/include/cudnn_frontend/node/sdpa_support_surface.h
+++ b/include/cudnn_frontend/node/sdpa_support_surface.h
@@ -187,16 +187,29 @@ SDPA_attributes::validate_sdpa_support_surface(const detail::Context& context,
         // validate basic dimension requirements
         // d_qk=192 with d_v=128 is only supported starting from cuDNN 9.19
         bool const d192_v128_supported = (detail::get_backend_version() >= 91900);
+        // Head dims in (256, 512] on BOTH sides are served by the frontend-only
+        // FROST SM100 per-tensor FP8 prefill engine
+        // (sdpa_fwd_prefill_sm100_fp8, the d512 kernel flavor), which runs the
+        // band through its native d = 512 tile with TMA zero-padding. The floor
+        // is the engine's: below it the flavor would pad by more than 2x, and
+        // no smaller FP8 flavor reaches above 192/128. The cuDNN backend itself
+        // has no plan for the band, so a graph that does not select that engine
+        // still fails at plan creation.
+        bool const d512_supported =
+            (d_qk > 256) && (d_qk <= 512) && (d_v > 256) && (d_v <= 512) && (d_qk % 16 == 0) && (d_v % 16 == 0);
         if (prop_major >= 10) {
             RETURN_CUDNN_FRONTEND_ERROR_IF(
-                ((d_qk > 128) || (d_qk % 16 != 0)) && !(d192_v128_supported && d_qk == 192 && d_v == 128),
+                ((d_qk > 128) || (d_qk % 16 != 0)) && !(d192_v128_supported && d_qk == 192 && d_v == 128) &&
+                    !d512_supported,
                 error_code_t::GRAPH_NOT_SUPPORTED,
                 "hidden_dim d_qk should be less than or equal to 128 and hidden_dim d_qk "
-                "should be multiple of 16 unless d_qk == 192 and d_v == 128 (requires cuDNN 9.19+)");
+                "should be multiple of 16 unless d_qk == 192 and d_v == 128 (requires cuDNN 9.19+) "
+                "or both head dims are in (256, 512] and multiples of 16");
             RETURN_CUDNN_FRONTEND_ERROR_IF(
-                ((d_v > 128) || (d_v % 16 != 0)),
+                ((d_v > 128) || (d_v % 16 != 0)) && !d512_supported,
                 error_code_t::GRAPH_NOT_SUPPORTED,
-                "hidden_dim d_v should be less than or equal to 128 and hidden_dim d_v should be multiple of 16");
+                "hidden_dim d_v should be less than or equal to 128 and hidden_dim d_v should be multiple of 16 "
+                "unless both head dims are in (256, 512] and multiples of 16");
         } else {
             RETURN_CUDNN_FRONTEND_ERROR_IF(
                 (d_qk > 256) || (d_qk % 16 != 0) || (d_v > 256) || (d_v % 16 != 0),

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -84,13 +84,33 @@ _SM107_FP8_KERNEL_FILE = "prefill_d128_fp8_sm107.py"
 _SM100_FP8_KERNEL_FILES = {
     (128, 128): "prefill_d128_fp8_sm100.py",
     (192, 128): "prefill_d192_d128_fp8_sm100.py",
+    (512, 512): "prefill_d512_fp8_sm100.py",
 }
 
 
 def _sm100_fp8_shapes(pertensor: bool, device_cc: tuple[int, int]) -> frozenset[tuple[int, int]]:
+    """NATIVE (exact) FP8 kernel-flavor shapes for the device line."""
     if device_cc == (10, 7):
         return frozenset({(128, 128)})
+    # d512 is per-tensor only: there is no d512 block-scale (MXFP8) kernel.
+    if pertensor:
+        return frozenset({(128, 128), (192, 128), (512, 512)})
     return frozenset({(128, 128), (192, 128)})
+
+
+# Per-native-shape ENVELOPE FLOOR (see engines.Capabilities.d_envelope_floors,
+# which MUST agree — test_fp8_envelope_floor_matches_engine_row pins it). The
+# d512 flavor serves the (256, 512] band on both head dims: the range no
+# smaller FP8 flavor reaches, at most 2x zero-padding. A smaller graph is
+# declined rather than routed onto a kernel whose cga4x1 role-split geometry is
+# tuned for d = 512.
+_SM100_FP8_ENVELOPE_FLOORS = {(512, 512): 256}
+
+
+def _fp8_envelope_covers(d_qk: int, d_v: int, shapes) -> bool:
+    """Does some native FP8 shape cover ``(d_qk, d_v)`` as an envelope bound,
+    respecting that shape's floor?"""
+    return any(d_qk <= sq and d_v <= sv and min(d_qk, d_v) > _SM100_FP8_ENVELOPE_FLOORS.get((sq, sv), 0) for sq, sv in shapes)
 
 
 # Both flavors tile KV in TILE_N=128 columns; the KV tail is only masked when
@@ -255,8 +275,12 @@ def _flavor_tag(flavor: tuple[int, int]) -> str:
     return f"d{d_qk}" if d_qk == d_v else f"d{d_qk}_d{d_v}"
 
 
-def _pick_flavor(d_qk: int, d_v: int) -> tuple[int, int]:
-    """Smallest flavor whose envelope covers ``(d_qk, d_v)`` (f16/bf16 only).
+def _pick_flavor(d_qk: int, d_v: int, candidates: Optional[tuple[tuple[int, int], ...]] = None) -> tuple[int, int]:
+    """Smallest flavor whose envelope covers ``(d_qk, d_v)``.
+
+    ``candidates`` restricts the walk to the flavors that have a kernel for the
+    caller's quantization (the FP8 family has no d256 file, so an FP8 graph must
+    not land on it); ``None`` = the full f16/bf16 list.
 
     ENVELOPE (zero-padding) semantics: one flavor covers ``d_qk`` and ``d_v``
     with its own max extents — e.g. (192, 128) runs on the d192/d128 kernel. The
@@ -270,14 +294,12 @@ def _pick_flavor(d_qk: int, d_v: int) -> tuple[int, int]:
     including the f16 alignment rule (d % 8, the TMA 16-byte global-stride
     rule at 2 bytes/elem).
     """
-    for flavor in _SM100_FLAVORS:
+    pool = candidates if candidates is not None else _SM100_FLAVORS
+    for flavor in pool:
         fdqk, fdv = flavor
         if d_qk <= fdqk and d_v <= fdv:
             return flavor
-    raise ValueError(
-        f"Frost SM100 DSL SDPA: no flavor envelope covers (D_QK={d_qk}, D_V={d_v}); "
-        f"largest supported: {_SM100_FLAVORS[-1]} (d128/d192-d128/d256/d512 envelopes)."
-    )
+    raise ValueError(f"Frost SM100 DSL SDPA: no flavor envelope covers (D_QK={d_qk}, D_V={d_v}); available envelopes: {sorted(pool)}.")
 
 
 def _load_kernel_template(filename: str, params: Hashable, tag: str):
@@ -1017,12 +1039,16 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         # stays exact (SF plumbing not audited for zero-padding).
         fp8_shapes = _sm100_fp8_shapes(self._pertensor, self._device_cc)
         _fp8_envelope_ok = (
-            self._pertensor and not self.thd and any(int(d_qk) <= sq and int(d_v) <= sv for sq, sv in fp8_shapes) and int(d_qk) % 16 == 0 and int(d_v) % 16 == 0
+            self._pertensor and not self.thd and _fp8_envelope_covers(int(d_qk), int(d_v), fp8_shapes) and int(d_qk) % 16 == 0 and int(d_v) % 16 == 0
         )
         self._value_error_if(
             self._fp8 and (int(d_qk), int(d_v)) not in fp8_shapes and not _fp8_envelope_ok,
             f"{'FP8' if self._pertensor else 'MXFP8'} (E4M3/E5M2 inputs) requires a native shape in {sorted(fp8_shapes)}"
-            + (" — or, dense only, its envelope (head dims <= a flavor shape, multiples of 16)" if self._pertensor else " (no envelope padding)")
+            + (
+                f" — or, dense only, its envelope (head dims <= a flavor shape, multiples of 16; " f"floors {sorted(_SM100_FP8_ENVELOPE_FLOORS.items())})"
+                if self._pertensor
+                else " (no envelope padding)"
+            )
             + f"; got (D_QK={d_qk}, D_V={d_v})",
         )
         # Envelope alignment gate: the TMA descriptors are built from the
@@ -1036,7 +1062,10 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             f"(TMA 16-byte global-stride constraint at 2 bytes/elem); got "
             f"(D_QK={d_qk}, D_V={d_v})",
         )
-        self.flavor = _pick_flavor(d_qk, d_v)
+        # An FP8 graph must only land on a flavor that HAS an fp8 kernel: the
+        # quantized family has no d256 file, so the f16 flavor list would send a
+        # d256 fp8 graph to a kernel that does not exist.
+        self.flavor = _pick_flavor(d_qk, d_v, tuple(f for f in _SM100_FLAVORS if f in fp8_shapes) if self._fp8 else None)
         self._value_error_if(
             self.sched_policy is not None and self.sched_policy not in (SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2),
             f"SM100 DSL SDPA sched_policy must be NATURAL/LPT/LPT_L2 (or None to derive); got {self.sched_policy}",
@@ -1115,9 +1144,14 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         # THD leg; the d192/d128 siblings are dense-only. The engine specs
         # already route this (their d192 rows declare thd=False); the gate
         # covers direct construction.
+        # Of the quantized flavors, d128/d128 (per-tensor + block-scale) and
+        # d512/d512 (per-tensor only) carry the write_thd_meta THD leg; the
+        # d192/d128 siblings are dense-only.
+        _thd_fp8_shapes = {(128, 128), (512, 512)} if self._pertensor else {(128, 128)}
         self._not_implemented_error_if(
-            self.thd and self._fp8 and (int(d_qk), int(d_v)) != (128, 128),
-            f"THD/varlen on the FP8/MXFP8 path requires D_QK=D_V=128 (the d192/d128 " f"kernels are dense-only); got (D_QK={d_qk}, D_V={d_v})",
+            self.thd and self._fp8 and (int(d_qk), int(d_v)) not in _thd_fp8_shapes,
+            f"THD/varlen on this quantized path supports {sorted(_thd_fp8_shapes)} (the d192/d128 "
+            f"kernels are dense-only, and d512 has no block-scale kernel); got (D_QK={d_qk}, D_V={d_v})",
         )
         # Dense padded-Q trim backstops (engines.lower_dsl_prefill never sets
         # these combinations; a direct caller could).

--- a/python/cudnn/sdpa/fwd/config_sm100.py
+++ b/python/cudnn/sdpa/fwd/config_sm100.py
@@ -142,8 +142,8 @@ def _validate_params(flavor: str, k: TemplateParams) -> None:
     if k.dtype_qkv not in (DTYPE_E4M3, DTYPE_E5M2, DTYPE_BF16, DTYPE_FP16):
         raise ValueError(f"{flavor}: DTYPE_QKV must be E4M3/E5M2/BF16/FP16 (0..3); got {k.dtype_qkv}")
     fp8 = k.dtype_qkv in (DTYPE_E4M3, DTYPE_E5M2)
-    if fp8 and flavor not in ("d128", "d192"):
-        raise ValueError(f"{flavor}: FP8/MXFP8 inputs (DTYPE_QKV 0/1) are only supported on d128 and d192")
+    if fp8 and flavor not in ("d128", "d192", "d512"):
+        raise ValueError(f"{flavor}: FP8/MXFP8 inputs (DTYPE_QKV 0/1) are only supported on d128, d192 and d512")
     if k.softmax_f16 and not fp8:
         raise ValueError(f"{flavor}: softmax_f16 is per-tensor-FP8-only (f16/bf16 softmax already runs the f32 pipeline)")
     dtype_o = k.dtype_qkv if k.dtype_o < 0 else k.dtype_o
@@ -545,6 +545,7 @@ class CfgD512:
 
 def _validate_cfg_d512(cfg: CfgD512) -> None:
     """Consistency checks on the (mostly hardcoded) d512 geometry."""
+    _fp8 = cfg.DTYPE_QKV <= DTYPE_E5M2
     checks = (
         (cfg.MMA_REGS == cfg.TMALDG_REGS == cfg.TMASTG_REGS == cfg.SCHEDULER_REGS, "d512: MMA/TMALDG/TMASTG/Scheduler regs must match"),
         (cfg.MMA_REGS + cfg.CORRECTION_REGS + cfg.SOFTMAX_WARPGROUPS * cfg.SOFTMAX_REGS <= 512, "d512: register budget over 512"),
@@ -556,11 +557,33 @@ def _validate_cfg_d512(cfg: CfgD512) -> None:
         (cfg.SOFTMAX_WARPGROUPS == 1, "d512 (role-split): SOFTMAX_WARPGROUPS must be 1"),
         (cfg.CORRECTION_WARPS == 0, "d512 (role-split): CORRECTION_WARPS must be 0"),
         (cfg.READ_TILE_ARRIVERS == 25, f"d512 cga4x1: expected READ_TILE_ARRIVERS=25, got {cfg.READ_TILE_ARRIVERS}"),
-        (cfg.Q_SWZ_BYTES == 128 and cfg.K_SWZ_BYTES == 128 and cfg.V_SWZ_BYTES == 128 and cfg.O_SWZ_BYTES == 128, "d512: Q/K/V/O swizzle must all be 128B"),
-        (cfg.TILE_K_HW_BMM1 == 16 and cfg.TILE_K_HW_BMM2 == 16, "d512 f16: TILE_K_HW must be 16 (1-chunk only on SM10x — 2-chunk silently wrong)"),
-        (cfg.STAGES_KV == 2, "d512 f16 (SM100): STAGES_KV must be 2 (SMEM-cap driven)"),
-        (cfg.XFER_STAGES == 2, "d512 f16 (SM100): XFER_STAGES must be 2 (TMEM-cap driven: 2*128 S_acc + 256 Q = 512)"),
-        (cfg.DTYPE_O == cfg.DTYPE_QKV, "d512: DTYPE_O must equal DTYPE_QKV for half input"),
+        (cfg.Q_SWZ_BYTES == 128 and cfg.K_SWZ_BYTES == 128 and cfg.V_SWZ_BYTES == 128, "d512: Q/K/V swizzle must all be 128B"),
+        (cfg.O_SWZ_BYTES == 128, "d512: O swizzle must be 128B"),
+        # Both dtype families run the SM10x 1-chunk MMA step: f16 at K=16,
+        # FP8 at the K=32 QMMA (k_dim=0).  The Rubin K=64 2-chunk fast path is
+        # silently WRONG on Blackwell — see rules/mma-tma-matrix.md § 1.
+        (
+            cfg.TILE_K_HW_BMM1 == (32 if _fp8 else 16) and cfg.TILE_K_HW_BMM2 == (32 if _fp8 else 16),
+            "d512: TILE_K_HW must be 32 (fp8 K=32 QMMA) / 16 (f16, 1-chunk on SM10x — 2-chunk silently wrong)",
+        ),
+        # SMEM-cap driven: the K/V ring costs STAGES_KV * 64 KiB at f16 and
+        # STAGES_KV * 32 KiB at FP8, so FP8 buys a third stage under the same
+        # 227 KiB cap.
+        (cfg.STAGES_KV == (3 if _fp8 else 2), "d512 (SM100): STAGES_KV must be 3 (fp8) / 2 (f16) — SMEM-cap driven"),
+        # TMEM-cap driven (512 cols on Blackwell): the sg0 carve is
+        # XFER_STAGES * TILE_N (S_acc parities) + TILE_K / (4 // BPE) (Q, moved
+        # to TMEM by UTCCP).  f16: 2*128 + 256 = 512.  FP8 packs 4 elems per
+        # 4-byte column, so Q costs only 128 cols and a third parity fits:
+        # 3*128 + 128 = 512.
+        (cfg.XFER_STAGES == (3 if _fp8 else 2), "d512 (SM100): XFER_STAGES must be 3 (fp8) / 2 (f16) — TMEM-cap driven"),
+        (
+            cfg.XFER_STAGES * cfg.TILE_N + cfg.TILE_K // (4 // cfg.BPE) == 512,
+            f"d512 (SM100): sg0 TMEM carve (S_acc {cfg.XFER_STAGES * cfg.TILE_N} + Q {cfg.TILE_K // (4 // cfg.BPE)}) must be exactly 512 cols",
+        ),
+        (
+            cfg.DTYPE_O in (DTYPE_E4M3, DTYPE_E5M2, DTYPE_BF16, DTYPE_FP16) if _fp8 else cfg.DTYPE_O == cfg.DTYPE_QKV,
+            "d512: DTYPE_O must equal DTYPE_QKV for half input; fp8 allows an independent output dtype",
+        ),
     )
     for ok, msg in checks:
         if not ok:
@@ -570,18 +593,29 @@ def _validate_cfg_d512(cfg: CfgD512) -> None:
 def make_cfg_d512(params: TemplateParams) -> Tuple[CfgD512, TmaIters]:
     _validate_params("d512", params)
     b = bpe(params.dtype_qkv)
+    fp8 = params.dtype_qkv <= DTYPE_E5M2  # E4M3/E5M2 inputs → the fp8 kernel file
+    dtype_o = params.dtype_qkv if params.dtype_o < 0 else params.dtype_o
+    b_o = bpe(dtype_o)
+    # FP8 pins the Blackwell K=32 QMMA path.  NOT tile_k_hw(), which returns the
+    # Rubin K=64 answer (see mma-tma-matrix.md § 1 "latent trap in the shared
+    # helper") — k_dim=0 with TILE_K_HW=64 is the silently-wrong combination.
+    tile_k_hw_fp8 = 32 if fp8 else tile_k_hw(params.dtype_qkv)
     cfg = CfgD512(
         DTYPE_QKV=params.dtype_qkv,
-        DTYPE_O=params.dtype_qkv,
+        DTYPE_O=dtype_o,
         BPE=b,
-        BPE_O=b,
+        BPE_O=b_o,
         Q_SWZ_BYTES=q_swz_bytes(512, b),
         K_SWZ_BYTES=q_swz_bytes(512, b),
         V_SWZ_BYTES=v_swz_bytes(512, 2, b),
-        O_SWZ_BYTES=o_swz_bytes(512, b),
+        O_SWZ_BYTES=o_swz_bytes(512, b_o),
         RESCALE_THRESHOLD=rescale_threshold(params.dtype_qkv),
-        TILE_K_HW_BMM1=tile_k_hw(params.dtype_qkv),
-        TILE_K_HW_BMM2=tile_k_hw(params.dtype_qkv),
+        TILE_K_HW_BMM1=tile_k_hw_fp8,
+        TILE_K_HW_BMM2=tile_k_hw_fp8,
+        # FP8 halves the K/V ring and the TMEM-resident Q, buying a third KV
+        # stage and a third S_acc parity under the same SMEM / TMEM caps.
+        STAGES_KV=3 if fp8 else 2,
+        XFER_STAGES=3 if fp8 else 2,
         MASK_FLAGS=_mask_flags_from(params),
         WINDOW_LEFT=params.window_left or 0,
         WINDOW_RIGHT=params.window_right or 0,

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -138,6 +138,17 @@ class Capabilities:
     # quantized rows' packed THD compile key carries no head-dim entries
     # (native-tile contract), so their envelope is dense-only.
     thd_d_shapes: Optional[frozenset] = None
+    # Per-native-shape ENVELOPE FLOOR: a tuple of ``((d_qk, d_v), min_dim)``
+    # pairs (a tuple, not a dict, so the row stays hashable). A shape with a
+    # floor serves graphs whose head dims are in ``(min_dim, shape]`` rather
+    # than ``(0, shape]``, so a kernel whose geometry is tuned for a large head
+    # dim does not silently swallow a much smaller graph at a multiple-x
+    # zero-padding cost. The floor applies to BOTH head dims and only to
+    # ENVELOPE matches — an exact ``d_shapes`` hit always passes. Example: the
+    # d512 FP8 flavor floors at 256, so it serves (256, 512] on both dims
+    # (at most 2x padding) and a d256 graph is declined rather than routed
+    # onto it. ``()`` = no floors.
+    d_envelope_floors: tuple = ()
     dtypes: frozenset = frozenset({cudnn.data_type.HALF, cudnn.data_type.BFLOAT16})  # cudnn.data_type, see graph_analyzer
     is_mxfp8: bool = False  # block-scale MXFP8 engine (FP8 in + per-32-block E8M0 SF)
     is_fp8: bool = False  # per-tensor FP8 engine (FP8 in + scalar descales)
@@ -353,11 +364,14 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
         want = ".".join(str(v) for v in CUTEDSL_MIN_VERSION)
         return f"requires nvidia-cutlass-dsl >= {want}; found {version[1]}"
     shapes = sorted(capabilities.d_shapes)
-    if capabilities.d_pad_multiple:
+    if capabilities.d_pad_multiple and (facts.d_qk, facts.d_v) not in capabilities.d_shapes:
         # Envelope family: native flavor shapes are upper bounds (TMA
         # zero-padding semantics — see Capabilities.d_shapes/d_pad_multiple);
-        # the lowering picks the smallest covering flavor.
-        if not any(facts.d_qk <= sq and facts.d_v <= sv for sq, sv in capabilities.d_shapes):
+        # the lowering picks the smallest covering flavor. An EXACT native
+        # shape is served above, so only inexact graphs walk the envelope —
+        # where a per-shape floor (d_envelope_floors) may also apply.
+        floors = dict(capabilities.d_envelope_floors)
+        if not any(facts.d_qk <= sq and facts.d_v <= sv and min(facts.d_qk, facts.d_v) > floors.get((sq, sv), 0) for sq, sv in capabilities.d_shapes):
             return f"no kernel-flavor envelope covers (D_QK={facts.d_qk}, D_V={facts.d_v}); native shapes: {shapes}"
         m = capabilities.d_pad_multiple
         if m > 1 and (facts.d_qk % m != 0 or facts.d_v % m != 0):
@@ -365,7 +379,7 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
                 f"envelope zero-padding requires D_QK/D_V multiples of {m} (TMA 16-byte "
                 f"global-stride constraint); graph has D_QK={facts.d_qk}/D_V={facts.d_v}"
             )
-    elif (facts.d_qk, facts.d_v) not in capabilities.d_shapes:
+    elif not capabilities.d_pad_multiple and (facts.d_qk, facts.d_v) not in capabilities.d_shapes:
         return f"serves exact native shapes {shapes} (no envelope padding); graph has D_QK={facts.d_qk}/D_V={facts.d_v}"
     if facts.thd and capabilities.thd_d_shapes is not None and (facts.d_qk, facts.d_v) not in capabilities.thd_d_shapes:
         return (
@@ -619,9 +633,12 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
     kernel flavor (d128 or d192xd128) covering the graph. Each row declares
     exactly what its own kernels carry:
 
-    - d_shapes: the sm100 row picks between the d128 and d192xd128 flavors;
-      Rubin has only the d128 sibling, so a Rubin d192 graph is ineligible
-      at probe time instead of a late build error.
+    - d_shapes: the sm100 row picks between the d128, d192xd128 and d512
+      flavors; Rubin has only the d128 sibling, so a Rubin d192 graph is
+      ineligible at probe time instead of a late build error.  There is no
+      d256 per-tensor FP8 kernel, so the adapter's flavor walk is restricted
+      to this set (api_dsl._pick_flavor's ``candidates``) rather than the
+      f16 flavor list.
     - The ENVELOPE (d_pad_multiple=16, the TMA 16-byte global-stride rule at
       1 byte/elem): smaller head dims ride TMA zero-padding — exact in FP8,
       and the descales are scalars so no per-column plumbing is affected.
@@ -630,6 +647,8 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
     - softmax_precisions: the f16x2 exponent arm lives only in the SM107
       sibling kernel, so only that row admits HALF. FLOAT is the pipeline
       every flavor already runs.
+    - thd_d_shapes: the d128 and d512 per-tensor kernels carry the
+      write_thd_meta THD leg; the d192x128 file is dense-only.
     - split_kv_supported / split_d_shapes: both d128 kernels wire SplitHelpers
       (the SM107 sibling carries the same plumbing as its SM100 twin), so both
       rows advertise the split; the d192x128 file forks its own scheduler and
@@ -659,9 +678,15 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
             sm_lo=107 if rubin_row else _BLACKWELL[0],
             sm_hi=_BLACKWELL[1] if rubin_row else 106,
             phase="prefill",
-            d_shapes=frozenset({(128, 128)}) if rubin_row else frozenset({(128, 128), (192, 128)}),
+            d_shapes=frozenset({(128, 128)}) if rubin_row else frozenset({(128, 128), (192, 128), (512, 512)}),
             d_pad_multiple=16,
-            thd_d_shapes=frozenset({(128, 128)}),
+            # The d512 flavor serves the (256, 512] band on BOTH head dims —
+            # the range no smaller FP8 flavor reaches, at most 2x zero-padding.
+            # Below that floor it declines rather than swallowing e.g. a d256
+            # graph onto a kernel whose cga4x1 role-split geometry is tuned for
+            # d = 512. Mirrored by api_dsl._SM100_FP8_ENVELOPE_FLOORS.
+            d_envelope_floors=() if rubin_row else (((512, 512), 256),),
+            thd_d_shapes=frozenset({(128, 128)}) if rubin_row else frozenset({(128, 128), (512, 512)}),
             dtypes=frozenset({cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2}),
             out_dtypes=frozenset({cudnn.data_type.HALF, cudnn.data_type.BFLOAT16, cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2}),
             is_fp8=True,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d512_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d512_fp8_sm100.py
@@ -1,0 +1,2483 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""SM100 (Blackwell) SDPA prefill — d_qk = d_v = 512, per-tensor FP8 (E4M3/E5M2).
+
+FP8 fork of ``prefill_d512_f16_sm100.py``: same cga4x1 role-split pipeline, same
+Q u K_ring SMEM alias, same UTCCP(Q SMEM -> TMEM) + ``mma_ts`` BMM1, same THD /
+split-KV / pack-GQA legs.  Only the dtype-driven deltas differ, and every one of
+them is derived from ``CFG`` rather than spelled as a literal:
+
+  - ``STAGES_KV = 3`` — BPE=1 halves the K/V ring (32 KiB/stage), so a third
+    stage fits under the 227 KiB SM100 cap.
+  - ``XFER_STAGES = 3`` — FP8 packs 4 elements per 4-byte TMEM column, so the
+    TMEM-resident Q costs ``TILE_K / 4 = 128`` cols instead of 256, and a third
+    S_acc parity fits: ``3*128 (S_acc) + 128 (Q) = 512``, exactly at the
+    Blackwell cap.
+  - ``MMA_KIND = F8F6F4``; ``TILE_K_HW_BMM1 = TILE_K_HW_BMM2 = 32`` with idesc
+    ``k_dim=0`` (the Blackwell K=32 QMMA step).  The Rubin K=64 2-chunk fast
+    path (``k_dim=1``) is silently WRONG here — see
+    ``.claude/rules/mma-tma-matrix.md`` § 1.
+  - ``P_XFER_HALVES`` collapses to 1.  The sg0 -> sg1 P ship is split on the
+    BMM2 contraction dim at the P SMEM **swizzle-atom** boundary, which is
+    ``(TILE_N * BPE) // Q_SWZ_BYTES`` atoms per P row: 2 at f16, 1 at FP8.  At
+    FP8 the whole 128-column P row is a single 128-byte atom, so the KV-split
+    degenerates to one chunk (P shipped whole); splitting into 64-column halves
+    would straddle an atom.
+  - ``BMM2_V_NBLOCK_ADVANCE = TILE_N * V_SWZ_BYTES`` — at BPE=1 the per-CTA V
+    inner extent is ``(TILE_O / CTA_MMA) * BPE = 256`` B = 2 swizzle lines, so
+    the per-N-block slab stride carries no extra BPE factor.
+  - ``DTYPE_O`` is independent of ``DTYPE_QKV`` (E4M3 / E5M2 / BF16 / FP16).
+    The sg1 O view REINTERPRETS the FP8-typed alias backing as
+    ``OUT_STORAGE_DTYPE`` and the alias is sized in BYTES, so a BPE_O=2 output
+    cannot overflow it.
+  - Per-tensor descales are LOADED FROM DEVICE (Rule 3 — no host readback):
+    ``descale_q * descale_k`` folds into ``scale_softmax_log2`` and
+    ``descale_v * scale_o`` into ``o_scale_fused``, which the epilogue folds
+    into ``beta``.  ``Amax_O`` is produced in-kernel by atomicMax over the
+    fp32 pre-cast output and divided by ``scale_o`` on device in the adapter.
+    ``descale_s`` / ``scale_s`` are accepted and ignored (P is cast unscaled).
+
+MXFP8 (block-scale) is NOT served by this file — d512 has no MXFP8 kernel.
+"""
+
+from functools import lru_cache
+from typing import Callable, Optional, Tuple
+from dataclasses import dataclass
+from typing import NamedTuple
+
+from cutlass.experimental import primitives as nvvm
+from cutlass.experimental.primitives import print_runtime
+from cutlass.experimental.primitives import vote_sync, VoteSync
+from cutlass.experimental.cuda import tensor_map as tmap
+from cutlass._mlir.dialects import arith
+
+import cutlass
+from cutlass.experimental import primitives as prims
+import cutlass.cute as cute
+from cutlass.base_dsl.typing import Pointer
+import cuda.bindings.driver as _cuda_driver
+
+from cudnn.sdpa.fwd.config_sm100 import TemplateParams, make_cfg_d512
+
+# The per-graph params are injected as a module global by the loader
+# (api._load_kernel_module) before this body executes.  A plain import would get
+# the all-defaults config, which is FP16 — not a dtype this file serves — so the
+# standalone default pins E4M3 in / E4M3 out.  The loader always overrides it.
+PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams(dtype_qkv=0, dtype_o=0))
+CFG, _TMA = make_cfg_d512(PARAMS)
+Cfg = type(CFG)
+TMA_QK_ITERS = _TMA.QK_ITERS
+TMA_VO_ITERS = _TMA.VO_ITERS
+TMA_QK_GRANU_ELEMS = _TMA.QK_GRANU_ELEMS
+TMA_VO_GRANU_ELEMS = _TMA.VO_GRANU_ELEMS
+
+
+def _abs_max_tree(vec, n: int):
+    """``max(|vec[i]|)`` over ``n`` elements, reduced with a TERNARY tree.
+
+    Undecorated on purpose: the DSL rewrites ``for``/``while`` inside a traced
+    function into staged control flow, so the tree has to be built here, in
+    plain Python at trace time.  Same shape and rationale as
+    ``tile_dsl.pointwise.row_max_reduction`` (frost-tile-dsl.md § 9): a 3-ary
+    group builds ``max(max(a,b),c)``, the DEPENDENT pair that FMNMX3 fuses,
+    and the tree is ~log3(n) deep instead of the n-deep chain a running
+    ``acc = max(acc, |e|)`` accumulator would produce on the epilogue's
+    critical path.
+    """
+    elems = [cute.math.max(vec[i], -vec[i], ftz=True) for i in range(n)]
+    while len(elems) > 1:
+        nxt = []
+        for i in range(0, len(elems), 3):
+            grp = elems[i : i + 3]
+            acc = grp[0]
+            for g in grp[1:]:
+                acc = cute.math.max(acc, g, ftz=True)
+            nxt.append(acc)
+        elems = nxt
+    return elems[0]
+
+
+def _require(cond, msg):
+    """Geometry sanity check; raises instead of assert (asserts vanish under -O)."""
+    if not cond:
+        raise ValueError(f"prefill_sdpa_d512_fp8_sm100: {msg}")
+
+
+TMA_O_GRANU_ELEMS_HOST = CFG.O_SWZ_BYTES // CFG.BPE_O
+TMA_O_ITERS_HOST = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
+
+
+from cudnn.frost.tile_dsl.barrier import (
+    PipelineState,
+    advance,
+    wait,
+    arrive,
+    arrive_expect_tx,
+    cga_arrive,
+    cga_wait,
+    mbar_arrive_on_peer,
+    commit_mma,
+    arrive_on_leader,
+    MBarrier,
+    Producer,
+    Scope,
+)
+from cudnn.frost.tile_dsl.scheduler import (
+    Sched,
+    scheduler_warp_loop,
+    read_tile_id_arrive,
+    SCHED_NATURAL,
+    SCHED_LPT,
+    SCHED_LPT_L2,
+)
+from cudnn.frost.tile_dsl.pointwise import (
+    tmem_load_tile,
+    row_reduction_pair,
+    row_max_reduction,
+    vec_scale_pair,
+)
+from cudnn.frost.tile_dsl.regtile import RegTile, vec_concat
+from cudnn.frost.tile_dsl.mma import mma_ss, mma_ts, mma_ts_step
+from cudnn.frost.tile_dsl.tma import (
+    cp_async_bulk_shared_cluster_shared_cta,
+    tma_load_tile,
+    tma_store_tile,
+    tma_store_commit,
+    tma_store_wait,
+)
+from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, tma_slice_runtime_desc
+from cudnn.frost.tile_dsl.tmem import tmem_alloc, tmem_dealloc
+from cudnn.frost.tile_dsl.mask import (
+    apply_mask_chunk,
+    MASK_NONE,
+    MASK_PADDED,
+    MASK_CAUSAL,
+    MASK_SWA,
+)
+
+from cudnn.sdpa.fwd.kernels._common_sm100 import (
+    make_split_helpers,
+    KvLoopBounds,
+    compute_kv_loop_bounds,
+    row_max_for_exp2,
+    make_sdpa_helpers,
+)
+
+if CFG.DTYPE_QKV == 0:
+    STORAGE_DTYPE = cutlass.Float8E4M3FN
+    P_STORAGE_DTYPE = cutlass.Float8E4M3FN
+    MMA_KIND = nvvm.Tcgen05MMAKind.F8F6F4
+elif CFG.DTYPE_QKV == 1:
+    STORAGE_DTYPE = cutlass.Float8E5M2
+    P_STORAGE_DTYPE = cutlass.Float8E5M2
+    MMA_KIND = nvvm.Tcgen05MMAKind.F8F6F4
+else:
+    raise ValueError(
+        f"prefill_sdpa_d512_fp8 (SM100): DTYPE_QKV={CFG.DTYPE_QKV} not supported (expected 0=E4M3 or 1=E5M2; BF16/FP16 ship in prefill_d512_f16_sm100.py)"
+    )
+
+# DTYPE_O is independent of DTYPE_QKV: an FP8 graph may ask for a half-precision
+# O to skip a downstream dequant.  BPE_O in {1, 2}; the epilogue cast loop is
+# generic over the result dtype (the d128 fp8 kernel's hand-rolled 16:4 pack is a
+# store-shape optimization, not a correctness requirement).
+if CFG.DTYPE_O == 0:
+    OUT_STORAGE_DTYPE = cutlass.Float8E4M3FN
+elif CFG.DTYPE_O == 1:
+    OUT_STORAGE_DTYPE = cutlass.Float8E5M2
+elif CFG.DTYPE_O == 2:
+    OUT_STORAGE_DTYPE = cutlass.BFloat16
+elif CFG.DTYPE_O == 3:
+    OUT_STORAGE_DTYPE = cutlass.Float16
+else:
+    raise ValueError(f"prefill_sdpa_d512_fp8 (SM100): DTYPE_O={CFG.DTYPE_O} not supported (expected 0=E4M3 / 1=E5M2 / 2=BF16 / 3=FP16)")
+
+
+CGA_SIZE = CFG.CGA_M * CFG.CGA_N
+CTA_GROUP_KIND = nvvm.CTAGroup.CTA_2 if CFG.CTA_MMA == 2 else nvvm.CTAGroup.CTA_1
+
+qBufferElems = CFG.TILE_M * CFG.TILE_K
+kBufferElems = CFG.TILE_N * CFG.TILE_K // CFG.CTA_MMA
+vBufferElems = CFG.TILE_O * CFG.TILE_N // CFG.CTA_MMA
+oBufferElems = CFG.TILE_M * CFG.TILE_O
+pXferElems = CFG.TILE_M * CFG.TILE_N
+
+pXferBytes = pXferElems * CFG.BPE
+alphaXferBytes = CFG.TILE_M * 4
+statsXferBytes = 2 * CFG.TILE_M * 4
+
+# The sg0 -> sg1 P ship is split on the BMM2 contraction dim at the P SMEM
+# swizzle-atom boundary, so a half is one contiguously-swizzled SMEM region.
+# That makes P_XFER_HALVES identically P_TMA_ITERS = the number of 128-byte
+# swizzle atoms per P row: 2 at f16, 1 at FP8 (a 128-column FP8 P row IS one
+# atom, so the KV-split degenerates to a single whole-P chunk).
+P_XFER_HALVES = (CFG.TILE_N * CFG.BPE) // CFG.Q_SWZ_BYTES
+pHalfXferElems = pXferElems // P_XFER_HALVES
+pHalfXferBytes = pXferBytes // P_XFER_HALVES
+
+qTmaTransactionBytes = qBufferElems * CFG.BPE * CFG.CTA_MMA
+kTmaTransactionBytes = kBufferElems * CFG.BPE * CFG.CTA_MMA
+vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
+
+# Per-call BMM2 V SMEM advance between the BMM2_LOOP_N_BLOCKS calls.  At BPE=1
+# the per-CTA V inner extent is (TILE_O / CTA_MMA) * BPE = 256 B = 2 swizzle
+# lines, so the per-N-block slab stride is TILE_N * V_SWZ_BYTES with NO extra
+# BPE factor (the f16 sibling's `* BPE` form is the 4-swizzle-line case).
+BMM2_V_NBLOCK_ADVANCE = CFG.TILE_N * CFG.V_SWZ_BYTES
+
+N_O_CHUNKS = (CFG.TILE_O * CFG.BPE_O + 127) // 128
+
+CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+
+P_TMA_ITERS = (CFG.TILE_N * CFG.BPE) // CFG.Q_SWZ_BYTES
+P_D_BLOCK = CFG.TILE_N // P_TMA_ITERS
+P_BLOCK_BYTES = CFG.TILE_M * P_D_BLOCK
+SOFTMAX_CHUNK = 64
+SOFTMAX_N_CHUNKS_LOAD = CFG.TILE_N // SOFTMAX_CHUNK
+P_SMEM_SWIZZLE = cutlass.Swizzle(3, 4, 3)
+NEG_INF_F32 = cutlass.Float32(float("-inf"))
+RESCALE_THRESHOLD_F32 = cutlass.Float32(CFG.RESCALE_THRESHOLD)
+
+
+COMPUTE_LANES = CFG.SOFTMAX_WG_WARPS * 32
+SM_LANES_TOTAL = 2 * COMPUTE_LANES
+TWO_LANES_TOTAL = 2
+KV_EMPTY_ARRIVERS = CFG.CGA_N
+
+READ_TILE_ARRIVERS = CFG.READ_TILE_ARRIVERS
+
+
+_ALIAS_SMEM_KIB = (
+    max(
+        qBufferElems * CFG.BPE,
+        oBufferElems * CFG.BPE_O,
+        CFG.STAGES_KV * kBufferElems * CFG.BPE,
+        CFG.STAGES_KV * vBufferElems * CFG.BPE,
+    )
+    / 1024
+)
+_SG0_SMEM_DATA_KIB = (_ALIAS_SMEM_KIB * 1024 + CFG.XFER_STAGES * pXferBytes + CFG.XFER_STAGES * alphaXferBytes + statsXferBytes) / 1024
+_SG1_SMEM_DATA_KIB = (_ALIAS_SMEM_KIB * 1024 + CFG.XFER_STAGES * pXferBytes + CFG.XFER_STAGES * alphaXferBytes + statsXferBytes + CFG.TILE_M * 4) / 1024
+_require(_SG0_SMEM_DATA_KIB <= 223, f"sg0 SMEM data {_SG0_SMEM_DATA_KIB:.1f} KiB exceeds 223 KiB headroom under 227 KiB SM100 cap")
+_require(_SG1_SMEM_DATA_KIB <= 223, f"sg1 SMEM data {_SG1_SMEM_DATA_KIB:.1f} KiB exceeds 223 KiB headroom under 227 KiB SM100 cap")
+
+# FP8 packs 4 elements per 4-byte TMEM column, so the UTCCP'd Q costs
+# TILE_K / 4 = 128 cols (vs 256 at f16) and a third S_acc parity fits.
+_Q_TMEM_COLS = CFG.TILE_K // (4 // CFG.BPE)
+_TMEM_SG0_COLS = CFG.XFER_STAGES * CFG.TILE_N + _Q_TMEM_COLS
+_TMEM_SG1_COLS = CFG.TILE_O
+_require(_TMEM_SG0_COLS <= 512, f"sg0 (S_acc + Q) TMEM overflow: {_TMEM_SG0_COLS} > 512")
+_require(_TMEM_SG1_COLS <= 512, f"sg1 O TMEM overflow: {_TMEM_SG1_COLS} > 512")
+
+
+class Bars(NamedTuple):
+    mb_tma_q_full: object
+    mb_tma_q_empty: object
+    mb_tma_k_full: object
+    mb_tma_k_empty: object
+    mb_tma_v_full: object
+    mb_tma_v_empty: object
+    mb_q_utccp_done: object
+
+    mb_bmm1_done: object
+    mb_bmm2_done: object
+    mb_bmm2_ready: object
+    mb_s_acc_empty: object
+
+    mb_p_xfer_full: object
+    mb_p_xfer_empty: object
+    mb_alpha_xfer_full: object
+    mb_alpha_xfer_empty: object
+    mb_stats_xfer_full: object
+    mb_stats_xfer_empty: object
+
+    mb_tma_o_full: object
+    mb_tma_o_empty: object
+
+    mb_empty_mainloop: object
+    mb_tmem_dealloc: object
+
+
+def _make_d512_sm100_bars(CFG, N_O_CHUNKS: int) -> Bars:
+    def _alloc(n):
+        return cutlass.Array(cutlass.Int64, n, alignment=16, space=cutlass.AddressSpace.smem)
+
+    return Bars(
+        mb_tma_q_full=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_tma_q_empty=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.MMA_COMMIT),
+        mb_tma_k_full=MBarrier(_alloc(CFG.STAGES_KV), stages=CFG.STAGES_KV, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_tma_k_empty=MBarrier(_alloc(CFG.STAGES_KV), stages=CFG.STAGES_KV, init_count=KV_EMPTY_ARRIVERS, producer=Producer.MMA_COMMIT),
+        mb_tma_v_full=MBarrier(_alloc(CFG.STAGES_KV), stages=CFG.STAGES_KV, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_tma_v_empty=MBarrier(_alloc(CFG.STAGES_KV), stages=CFG.STAGES_KV, init_count=KV_EMPTY_ARRIVERS, producer=Producer.MMA_COMMIT),
+        mb_q_utccp_done=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.MMA_COMMIT),
+        mb_bmm1_done=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=CFG.ONE_LANE, producer=Producer.MMA_COMMIT),
+        mb_bmm2_done=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=CFG.ONE_LANE, producer=Producer.MMA_COMMIT),
+        mb_bmm2_ready=MBarrier(
+            _alloc(CFG.XFER_STAGES * CFG.N_BMM2_CHUNKS),
+            stages=CFG.XFER_STAGES * CFG.N_BMM2_CHUNKS,
+            init_count=SM_LANES_TOTAL,
+            producer=Producer.LEADER,
+            scope=Scope.LEADER,
+        ),
+        mb_s_acc_empty=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=SM_LANES_TOTAL, producer=Producer.LEADER, scope=Scope.LEADER),
+        mb_p_xfer_full=MBarrier(
+            _alloc(CFG.XFER_STAGES * P_XFER_HALVES), stages=CFG.XFER_STAGES * P_XFER_HALVES, init_count=CFG.CTA_MMA, producer=Producer.TMA_LOAD
+        ),
+        mb_p_xfer_empty=MBarrier(
+            _alloc(CFG.XFER_STAGES * P_XFER_HALVES), stages=CFG.XFER_STAGES * P_XFER_HALVES, init_count=CFG.ONE_LANE, producer=Producer.MMA_COMMIT
+        ),
+        mb_alpha_xfer_full=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_alpha_xfer_empty=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=COMPUTE_LANES, producer=Producer.THREAD),
+        mb_stats_xfer_full=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_stats_xfer_empty=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.THREAD),
+        mb_tma_o_full=MBarrier(_alloc(N_O_CHUNKS), stages=N_O_CHUNKS, init_count=COMPUTE_LANES, producer=Producer.THREAD),
+        mb_tma_o_empty=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_WARP, producer=Producer.THREAD),
+        mb_empty_mainloop=MBarrier(_alloc(1), stages=1, init_count=TWO_LANES_TOTAL, producer=Producer.LEADER, scope=Scope.LEADER),
+        mb_tmem_dealloc=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.THREAD),
+    )
+
+
+@dataclass(frozen=True)
+class KernelTmemLayout:
+    """SM100 TMEM carves (512-col cap), sg-conditional.
+
+    sg0 (FP8, XFER_STAGES=3):  S_acc parity p at [p*S_ACC_COLS, +S_ACC_COLS)
+                               for p in [0, XFER_STAGES) -> cols [0, 384);
+                               Q (UTCCP'd from sQ SMEM, consumed by mma_ts
+                               BMM1) at [384, 512).
+    sg1:                       O at [0, TILE_O) -> the full 512 fp32 cols.
+
+    The S_acc parity slot is `parity * S_ACC_COLS` — do NOT introduce per-slot
+    constexpr names; the formula scales over XFER_STAGES generically.
+    """
+
+    TOTAL_COLS: int = 512
+
+    S_ACC_COLS: int = 128
+    # Q abuts the LAST S_acc parity slot; both offsets are CFG-derived so the
+    # f16 (2 parities + 256-col Q) and FP8 (3 parities + 128-col Q) carves come
+    # out of the same expression.
+    Q_TMEM_OFF: int = CFG.XFER_STAGES * 128
+    Q_TMEM_COLS: int = _Q_TMEM_COLS
+
+    O_OFF: int = 0
+    O_COLS: int = 512
+
+
+LAYOUT = KernelTmemLayout()
+_require(
+    CFG.XFER_STAGES * LAYOUT.S_ACC_COLS == LAYOUT.Q_TMEM_OFF,
+    f"sg0: S_acc parities ({CFG.XFER_STAGES * LAYOUT.S_ACC_COLS}) must abut Q at col {LAYOUT.Q_TMEM_OFF}",
+)
+_require(LAYOUT.Q_TMEM_OFF + LAYOUT.Q_TMEM_COLS <= LAYOUT.TOTAL_COLS, f"sg0 TMEM overflow: {LAYOUT.Q_TMEM_OFF + LAYOUT.Q_TMEM_COLS} > {LAYOUT.TOTAL_COLS}")
+_require(LAYOUT.O_OFF + LAYOUT.O_COLS <= LAYOUT.TOTAL_COLS, f"sg1 TMEM overflow: {LAYOUT.O_OFF + LAYOUT.O_COLS} > {LAYOUT.TOTAL_COLS}")
+_require(LAYOUT.Q_TMEM_COLS == CFG.TILE_K // 4, f"Q TMEM cols {LAYOUT.Q_TMEM_COLS} != TILE_K/4 ({CFG.TILE_K // 4}) at FP8 (4 elems per 4-byte column)")
+
+
+_SWZ_ENUM = {128: 2, 64: 4, 32: 6}
+SMEM_LAYOUT_Q = _SWZ_ENUM[CFG.Q_SWZ_BYTES]
+SMEM_LAYOUT_K = _SWZ_ENUM[CFG.K_SWZ_BYTES]
+SMEM_LAYOUT_V = _SWZ_ENUM[CFG.V_SWZ_BYTES]
+SMEM_LAYOUT_O = _SWZ_ENUM[CFG.O_SWZ_BYTES]
+SMEM_LAYOUT_QKO = SMEM_LAYOUT_Q
+SMEM_LAYOUT_P = SMEM_LAYOUT_Q
+
+_O_SWZ_B = {128: 3, 64: 2, 32: 1}[CFG.O_SWZ_BYTES]
+_O_SMEM_SWIZZLE = cutlass.Swizzle(_O_SWZ_B, 4, 3)
+
+LEADING_BYTE_OFFSET_QK = 0
+STRIDE_BYTE_OFFSET_QK = 8 * CFG.Q_SWZ_BYTES
+
+_CORE_MATRIX_ROWS = 8
+_V_PC_COLS = CFG.TILE_O // CFG.CTA_MMA
+LEADING_BYTE_OFFSET_PV = 0 if (_V_PC_COLS // _CORE_MATRIX_ROWS) <= 8 else CFG.TILE_N * CFG.V_SWZ_BYTES
+STRIDE_BYTE_OFFSET_PV = 8 * CFG.V_SWZ_BYTES
+
+NUM_KPHASES_PV = CFG.TILE_N // CFG.TILE_K_HW_BMM2
+
+NUM_KPHASES_PV_HALF = NUM_KPHASES_PV // P_XFER_HALVES
+_require(P_TMA_ITERS == P_XFER_HALVES, f"P-xfer split assumes P_TMA_ITERS ({P_TMA_ITERS}) == P_XFER_HALVES ({P_XFER_HALVES})")
+_require(NUM_KPHASES_PV % P_XFER_HALVES == 0, f"NUM_KPHASES_PV ({NUM_KPHASES_PV}) not divisible by P_XFER_HALVES ({P_XFER_HALVES})")
+_require(
+    NUM_KPHASES_PV_HALF * CFG.TILE_K_HW_BMM2 == P_D_BLOCK,
+    f"K-split boundary ({NUM_KPHASES_PV_HALF * CFG.TILE_K_HW_BMM2}) must equal P SMEM half width P_D_BLOCK ({P_D_BLOCK})",
+)
+_require(pHalfXferElems == P_BLOCK_BYTES, f"P half ({pHalfXferElems} elems) must equal one TMA chunk P_BLOCK_BYTES ({P_BLOCK_BYTES})")
+
+
+_sdpa_h = make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units=True)
+# qtrim variant: collapses the KV loop for CGA tiles entirely past the
+# per-batch actual Q length (SEQ_Q_LENS_PRESENT; folds to plain bounds otherwise).
+_bounds_for_tile = _sdpa_h.bounds_for_tile_qtrim
+_resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+_resolve_seqlen_q = _sdpa_h.resolve_seqlen_q
+
+
+_decode_initial = _sdpa_h.decode_initial
+_decode_payload = _sdpa_h.decode_payload
+
+
+from cudnn.sdpa.fwd.kernels.thd_sm100 import build_thd_meta_o_kv_descs_kernel as _build_thd_meta_o_kv_descs_kernel, TENSOR_MAP_QWORDS, THD_SETUP_THREADS
+
+_TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
+# The setup kernel builds the THD metadata buffer DEVICE-side from the
+# caller's length tensors and the adapter launches the plan-time envelope
+# grid (issue #552) — no length ever reaches the host.
+_dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
+_dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
+_thd_tma_offsets = _sdpa_h.thd_tma_offsets
+
+# === PackGQA ===
+HEADS_PER_TILE = CFG.QH_PER_KH if CFG.PACK_GQA else 1
+TOKENS_PER_TILE = CFG.TILE_M // HEADS_PER_TILE
+
+# === KV split ===
+#
+# Mechanics live in _common_sm100.make_split_helpers, shared with the other
+# SM100 prefill flavors: each Q tile's KV loop range is cut into SPLIT_KV
+# contiguous chunks, each run as its own persistent tile, and each writing a
+# normalized partial O + its own LSE into a split-major workspace that
+# split_combine_sm100 folds with the exact log-sum-exp identity.  At
+# SPLIT_KV == 1 every closure folds away and this is the classic kernel.
+_split_h = make_split_helpers(
+    CFG,
+    bounds_for_tile=_bounds_for_tile,
+    dispatch_decode_initial=_dispatch_decode_initial,
+    dispatch_decode_payload=_dispatch_decode_payload,
+)
+SPLIT_KV = _split_h.SPLIT_KV
+MAY_BE_EMPTY = _split_h.MAY_BE_EMPTY
+_decode_initial_split = _split_h.decode_initial_split
+_decode_payload_split = _split_h.decode_payload_split
+_bounds_for_tile_split = _split_h.bounds_for_tile_split
+_nomask_range_split = _split_h.nomask_range_split
+_partial_batch = _split_h.partial_batch
+
+
+@cute.kernel
+def _kernel(
+    tma_q_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_k_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_v_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_o_desc: cutlass.GridConstant[tmap.TensorMap],
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    seqlen_q: cutlass.Int32,
+    seqlen_kv: cutlass.Int32,
+    n_q_supers: cutlass.Int32,
+    n_qh: cutlass.Int32,
+    n_batch: cutlass.Int32,
+    qh_per_kh: cutlass.Int32,
+    scale_softmax_log2: cutlass.Float32,
+    o_scale_fused: cutlass.Float32,
+    # 1-element fp32 DEVICE scales (Rule 3: no host readback anywhere).  The
+    # kernel folds descale_q*descale_k into scale_softmax_log2 and
+    # descale_v*scale_o into o_scale_fused; the scalar args carry only the
+    # bases (attn*log2(e) and 1.0).  descale_s / scale_s are accepted by the
+    # adapter and ignored — P is cast unscaled.
+    descale_q_t: cute.Tensor,
+    descale_k_t: cute.Tensor,
+    descale_v_t: cute.Tensor,
+    scale_o_t: cute.Tensor,
+    amax_o_tensor: cute.Tensor,
+    # Dense padded-Q trim: separate (B,)-int32 per-batch Q lengths (mirrors
+    # cuDNN's SEQLEN_Q pointer / FA's seqused_q). None unless
+    # CFG.SEQ_Q_LENS_PRESENT — the DSL specializes on None, so the flag-off
+    # ABI is unchanged.
+    seq_q_lens_tensor: Optional[cute.Tensor] = None,
+) -> None:
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    tidx, _, _ = cute.arch.thread_idx()
+
+    bidx = cute.arch.block_idx()[0]
+    bidy = cute.arch.block_idx()[1]
+    bidz = cute.arch.block_idx()[2]
+
+    # Each physical CTA runs ONE role (sg0 OR sg1), so the alias collapses to
+    # max(Q, K_ring, V_ring, O).  Sized in BYTES, not elements: the O view uses
+    # the OUTPUT dtype, which is WIDER than the FP8 input on the FP8 -> BF16 /
+    # FP16 path (oBufferElems * BPE_O = 128 KiB at BPE_O=2 vs 64 KiB at FP8-out).
+    # The array is allocated as STORAGE_DTYPE (1 byte at FP8), so element count
+    # == byte count.  Using raw element counts here under-allocates at BPE_O=2 —
+    # the half O store then overflows into sP_xfer and returns garbage / NaN.
+    _ALIAS_ELEMS = max(
+        qBufferElems * CFG.BPE,
+        oBufferElems * CFG.BPE_O,
+        CFG.STAGES_KV * kBufferElems * CFG.BPE,
+        CFG.STAGES_KV * vBufferElems * CFG.BPE,
+    )
+    sAliased_raw = cutlass.Array(STORAGE_DTYPE, _ALIAS_ELEMS, alignment=1024, space=cutlass.AddressSpace.smem)
+    sQ_raw = sAliased_raw
+    sK_raw = sAliased_raw
+    sV_raw = sAliased_raw
+    # sg1 epilogue O staging (after BMM2 drains V).  REINTERPRET the FP8-typed
+    # alias backing as OUT_STORAGE_DTYPE so the epilogue SMEM-store offsets and
+    # the TMA subtile stride advance in BPE_O units, not the alloc dtype's
+    # 1-byte units (frost-tile-dsl.md § 5: TMA subtile stride is in ALLOC-dtype
+    # elements).  A no-op recast for FP8 output; required for half output.
+    sO_raw = cutlass.Array(sAliased_raw.data_ptr(), shape=oBufferElems, dtype=OUT_STORAGE_DTYPE, alignment=1024)
+
+    sP_xfer_raw = cutlass.Array(P_STORAGE_DTYPE, CFG.XFER_STAGES * pXferElems, alignment=128, space=cutlass.AddressSpace.smem)
+    sAlpha_xfer_raw = cutlass.Array(cutlass.Float32, CFG.XFER_STAGES * CFG.TILE_M, alignment=128, space=cutlass.AddressSpace.smem)
+    sStats_xfer_raw = cutlass.Array(cutlass.Float32, 2 * CFG.TILE_M, alignment=128, space=cutlass.AddressSpace.smem)
+    sLSE_raw = cutlass.Array(cutlass.Float32, CFG.TILE_M, alignment=128, space=cutlass.AddressSpace.smem)
+
+    sQ = SmemTile(
+        base=sQ_raw,
+        elems_per_stage=qBufferElems,
+        stages=1,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+    )
+    sK = SmemTile(
+        base=sK_raw,
+        elems_per_stage=kBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+    )
+    sV = SmemTile(
+        base=sV_raw,
+        elems_per_stage=vBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_PV,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_PV,
+        layout=SMEM_LAYOUT_V,
+        tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
+        tma_granu_elems=TMA_VO_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+    )
+    sO = SmemTile(
+        base=sO_raw,
+        elems_per_stage=oBufferElems,
+        stages=1,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=SMEM_LAYOUT_O,
+        tma_loads_per_tile=TMA_O_ITERS_HOST,
+        tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+    )
+
+    bars = _make_d512_sm100_bars(CFG, N_O_CHUNKS)
+
+    tmem_ptr_i32 = cutlass.Array(cutlass.Int32, 1, alignment=16, space=cutlass.AddressSpace.smem)
+
+    sched = Sched(
+        **{
+            "mb_scheduler": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "mb_read_tile_id": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "tile_id_smem": cutlass.Array(cutlass.Int32, CFG.SCHEDULER_STAGES * 8, alignment=16, space=cutlass.AddressSpace.smem),
+            "bidx_init": bidx,
+            "bidy_init": bidy,
+            "bidz_init": bidz,
+        }
+    )
+
+    cta_id_x = cute.arch.block_idx_in_cluster() if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    cta_in_pair = (cta_id_x & cutlass.Int32(1)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    leader_cta_id = (cta_id_x & cutlass.Int32(~1 & 0xFFFFFFFF)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    mcast_mask = (cutlass.Int32(3) << leader_cta_id) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    sg0_mcast_mask = cutlass.Int32(0x3)
+    tma_mcast_mask = (cutlass.Int16(1) << cta_id_x.to(cutlass.Int16)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
+    is_leader = cta_in_pair == cutlass.Int32(0)
+
+    # Device-scale fold: every thread loads the four 1-element fp32 scales
+    # (same addresses -> L2 broadcast, negligible) and folds them into the
+    # softmax scale and the output scale.
+    _dsc_q = cutlass.Float32(cutlass.make_array_view(descale_q_t)[0])
+    _dsc_k = cutlass.Float32(cutlass.make_array_view(descale_k_t)[0])
+    _dsc_v = cutlass.Float32(cutlass.make_array_view(descale_v_t)[0])
+    _scl_o = cutlass.Float32(cutlass.make_array_view(scale_o_t)[0])
+    scale_softmax_log2 = scale_softmax_log2 * _dsc_q * _dsc_k
+    o_scale_fused = o_scale_fused * _dsc_v * _scl_o
+
+    sg_id = cta_id_x // cutlass.Int32(CFG.CTA_MMA)
+    is_sg0 = sg_id == cutlass.Int32(0)
+    is_sg1 = sg_id == cutlass.Int32(1)
+    cross_sg_peer = cta_id_x ^ cutlass.Int32(CFG.CTA_MMA)
+
+    is_cga_first_cta = cta_id_x == cutlass.Int32(0)
+
+    if warp_idx == 0:
+        if nvvm.elect_sync():
+            bars.mb_tma_q_full.init()
+            bars.mb_tma_q_empty.init()
+            for ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_tma_k_full[ks].init()
+                bars.mb_tma_k_empty[ks].init()
+                bars.mb_tma_v_full[ks].init()
+                bars.mb_tma_v_empty[ks].init()
+
+            for p in cutlass.range_constexpr(CFG.XFER_STAGES):
+                bars.mb_bmm1_done[p].init()
+                bars.mb_bmm2_done[p].init()
+                bars.mb_s_acc_empty[p].init()
+                for c in cutlass.range_constexpr(CFG.N_BMM2_CHUNKS):
+                    bars.mb_bmm2_ready[p * CFG.N_BMM2_CHUNKS + c].init()
+
+                p_full_init = cutlass.Int32(
+                    arith.select(
+                        is_leader.ir_value(),
+                        cutlass.Int32(CFG.CTA_MMA).ir_value(),
+                        cutlass.Int32(CFG.ONE_LANE).ir_value(),
+                    )
+                )
+                for h in cutlass.range_constexpr(P_XFER_HALVES):
+                    bars.mb_p_xfer_full[p * P_XFER_HALVES + h].init(override_count=p_full_init)
+                    bars.mb_p_xfer_empty[p * P_XFER_HALVES + h].init()
+                bars.mb_alpha_xfer_full[p].init()
+                bars.mb_alpha_xfer_empty[p].init()
+
+            bars.mb_stats_xfer_full.init()
+            bars.mb_stats_xfer_empty.init()
+
+            for c in cutlass.range_constexpr(N_O_CHUNKS):
+                bars.mb_tma_o_full[c].init()
+            bars.mb_tma_o_empty.init()
+
+            bars.mb_empty_mainloop.init()
+            bars.mb_tmem_dealloc.init()
+
+            bars.mb_q_utccp_done.init()
+
+            for s in range(CFG.SCHEDULER_STAGES):
+                nvvm.mbarrier_init(sched.mb_scheduler.subview(s), CFG.ONE_LANE)
+                nvvm.mbarrier_init(sched.mb_read_tile_id.subview(s), READ_TILE_ARRIVERS)
+
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync()
+
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        cga_arrive()
+        cga_wait()
+
+    if warp_idx >= cutlass.Int32(CFG.SOFTMAX_WG0_BASE) and warp_idx < cutlass.Int32(CFG.SOFTMAX_WG0_BASE + CFG.SOFTMAX_WG_WARPS):
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        _compute_warp_group(
+            is_sg0=is_sg0,
+            is_sg1=is_sg1,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_softmax_log2,
+            o_scale_fused=o_scale_fused,
+            amax_o_tensor=amax_o_tensor,
+            tmem_ptr_i32=tmem_ptr_i32,
+            sQ=sQ,
+            sO=sO,
+            sP_xfer_raw=sP_xfer_raw,
+            sAlpha_xfer_raw=sAlpha_xfer_raw,
+            sStats_xfer_raw=sStats_xfer_raw,
+            sLSE_raw=sLSE_raw,
+            bars=bars,
+            sched=sched,
+            lse_tensor=lse_tensor,
+            sinks_tensor=sinks_tensor,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            seq_q_lens_tensor=seq_q_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+            cta_id_x=cta_id_x,
+            cross_sg_peer=cross_sg_peer,
+            qh_per_kh=qh_per_kh,
+        )
+
+    elif warp_idx == cutlass.Int32(CFG.MMA_WARP_ID):
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        if is_leader:
+            _mma_warp_group(
+                is_sg0=is_sg0,
+                is_sg1=is_sg1,
+                seqlen_q=seqlen_q,
+                seqlen_kv=seqlen_kv,
+                sQ=sQ,
+                sK=sK,
+                sV=sV,
+                sP_xfer_raw=sP_xfer_raw,
+                tmem_ptr_i32=tmem_ptr_i32,
+                bars=bars,
+                sched=sched,
+                seq_kv_lens_tensor=seq_kv_lens_tensor,
+                seq_q_lens_tensor=seq_q_lens_tensor,
+                n_q_supers=n_q_supers,
+                n_qh=n_qh,
+                n_batch=n_batch,
+                mcast_mask=mcast_mask,
+                sg0_mcast_mask=sg0_mcast_mask,
+                cta_in_pair=cta_in_pair,
+                leader_cta_id=leader_cta_id,
+                qh_per_kh=qh_per_kh,
+            )
+        else:
+            _mma_warp_non_leader(
+                is_sg0=is_sg0,
+                is_sg1=is_sg1,
+                seqlen_q=seqlen_q,
+                seqlen_kv=seqlen_kv,
+                sQ=sQ,
+                tmem_ptr_i32=tmem_ptr_i32,
+                bars=bars,
+                sched=sched,
+                seq_kv_lens_tensor=seq_kv_lens_tensor,
+                seq_q_lens_tensor=seq_q_lens_tensor,
+                n_q_supers=n_q_supers,
+                n_qh=n_qh,
+                n_batch=n_batch,
+                mcast_mask=mcast_mask,
+                cta_in_pair=cta_in_pair,
+                leader_cta_id=leader_cta_id,
+                qh_per_kh=qh_per_kh,
+            )
+
+    elif warp_idx == cutlass.Int32(CFG.TMALDG_WARP_ID):
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        nvvm.prefetch_tensormap(tma_q_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_k_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_v_desc.get_ptr())
+        _tmaldg_warp_group(
+            is_sg0=is_sg0,
+            is_sg1=is_sg1,
+            tma_q_desc=tma_q_desc,
+            tma_k_desc=tma_k_desc,
+            tma_v_desc=tma_v_desc,
+            sQ=sQ,
+            sK=sK,
+            sV=sV,
+            bars=bars,
+            sched=sched,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            seq_q_lens_tensor=seq_q_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            qh_per_kh=qh_per_kh,
+            is_leader=is_leader,
+            cta_in_pair=cta_in_pair,
+            tma_mcast_mask=tma_mcast_mask,
+            o_desc_words=o_desc_words,
+        )
+
+    elif warp_idx == cutlass.Int32(CFG.TMASTG_WARP_ID):
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _tmastg_warp_group(
+            is_sg1=is_sg1,
+            tma_o_desc=tma_o_desc,
+            sO=sO,
+            bars=bars,
+            sched=sched,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            cta_in_pair=cta_in_pair,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
+            qh_per_kh=qh_per_kh,
+            seqlen_kv=seqlen_kv,
+        )
+
+    else:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
+
+
+@cute.jit
+def _sg0_softmax_kv_iter(
+    apply_mask: bool,
+    kv_loop,
+    sg0_xfer_state,
+    bmm1_done_state,
+    total_max,
+    total_max_safe,
+    total_sum_vec,
+    tmem_base_addr,
+    bars,
+    sP_xfer_raw,
+    sAlpha_xfer_raw,
+    q_abs,
+    eff_seqlen_kv,
+    eff_seqlen_q,
+    scale_log2,
+    tid_in_wg,
+    is_lead_warp,
+    leader_cta_id,
+    cross_sg_peer,
+):
+    cur_parity_S = sg0_xfer_state.idx
+    cur_phase_S = sg0_xfer_state.phase
+    bars.mb_bmm1_done[bmm1_done_state.idx].wait(bmm1_done_state.phase)
+    sg0_xfer_state = advance(sg0_xfer_state, CFG.XFER_STAGES)
+    bmm1_done_state = advance(bmm1_done_state, CFG.XFER_STAGES)
+
+    s_addr_base = tmem_base_addr + cur_parity_S * cutlass.Int32(LAYOUT.S_ACC_COLS)
+
+    if cutlass.const_expr(apply_mask):
+        kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+        raw_chunks = [
+            nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * SOFTMAX_CHUNK), cutlass.Float32),
+                num=SOFTMAX_CHUNK,
+            )
+            for c in range(SOFTMAX_N_CHUNKS_LOAD)
+        ]
+        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+        chunks_S = [
+            apply_mask_chunk(
+                raw_chunks[c],
+                q_abs,
+                kv_col_base + cutlass.Int32(c * SOFTMAX_CHUNK),
+                eff_seqlen_kv,
+                CFG.WINDOW_LEFT,
+                CFG.MASK_FLAGS,
+                N=SOFTMAX_CHUNK,
+                bottom_right=CFG.BOTTOM_RIGHT,
+                causal_diag=causal_diag,
+                window_right=CFG.WINDOW_RIGHT,
+                mask_value=float("-inf"),
+            )
+            for c in range(SOFTMAX_N_CHUNKS_LOAD)
+        ]
+        chunks_max = [row_max_reduction(chunks_S[c]) for c in range(SOFTMAX_N_CHUNKS_LOAD)]
+        reg_S_vec = vec_concat(chunks_S)
+        current_max_raw = chunks_max[0]
+        for m in chunks_max[1:]:
+            current_max_raw = cute.math.max(current_max_raw, m)
+        reg_S_tile = RegTile(reg_S_vec, size=CFG.TILE_N)
+    else:
+        reg_S_tile = tmem_load_tile(s_addr_base, num_elems=CFG.TILE_N)
+        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+        current_max_raw = row_max_reduction(reg_S_tile.vec)
+    current_max = current_max_raw * scale_log2  # -inf when the whole iteration is masked
+
+    bars.mb_s_acc_empty[cur_parity_S].arrive(cta_group=CFG.CTA_MMA, leader_cta_id=leader_cta_id)
+
+    # total_max starts at -inf: a live iteration always clears the threshold
+    # (real - (-inf) = +inf), a fully-masked one never does (-inf - x = -inf
+    # or NaN; ordered > is false for both), so dead iterations never move it.
+    update_cond = (current_max - total_max) > RESCALE_THRESHOLD_F32
+    total_max = cutlass.Float32(
+        arith.select(
+            update_cond.ir_value(),
+            current_max.ir_value(),
+            total_max.ir_value(),
+        )
+    )
+    # Canonical 0-substitution at point of use, on BOTH alpha operands;
+    # min(., 0) guards the dead->alive drop of the safe max (total_sum is
+    # still 0 there).  total_max_safe starts at -inf: iter-0 alpha = 0.
+    new_total_max_safe = row_max_for_exp2(total_max)
+    alpha = cute.math.exp2(
+        cute.math.min(total_max_safe - new_total_max_safe, cutlass.Float32(0.0)),
+        fastmath=True,
+    )
+    total_max_safe = new_total_max_safe
+
+    alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+    total_sum_vec = total_sum_vec * alpha_pair
+    p_slot_base = cur_parity_S * cutlass.Int32(pXferElems)
+    for chunk in cutlass.range_constexpr(P_XFER_HALVES):
+        chunk_slot = cur_parity_S * cutlass.Int32(P_XFER_HALVES) + cutlass.Int32(chunk)
+        bars.mb_p_xfer_empty[chunk_slot].wait(cur_phase_S)
+
+        reg_S_chunk = reg_S_tile[chunk * P_D_BLOCK : (chunk + 1) * P_D_BLOCK].vec
+        reg_P_fp32_chunk = cute.math.exp2(reg_S_chunk * scale_log2 - total_max_safe, fastmath=True)
+        reg_P_half_chunk = reg_P_fp32_chunk.to(P_STORAGE_DTYPE)
+        total_sum_vec = total_sum_vec + row_reduction_pair(reg_P_fp32_chunk)
+
+        smem_off = cutlass.Int32(chunk * P_BLOCK_BYTES) + tid_in_wg * cutlass.Int32(P_D_BLOCK)
+        smem_ptr = sP_xfer_raw.subview(p_slot_base + smem_off).data_ptr()
+        smem_ptr.store_swizzled(reg_P_half_chunk, alignment=64, swizzle=P_SMEM_SWIZZLE)
+
+        if cutlass.const_expr(chunk == 0):
+            alpha_slot = sAlpha_xfer_raw.subview(cur_parity_S * cutlass.Int32(CFG.TILE_M) + tid_in_wg)
+            alpha_slot.store(alpha)
+
+        nvvm.fence_proxy("async.shared", space="cta")
+        nvvm.barrier_cta_sync(barrier_id=8, thread_count=128)
+
+        ship_pred = is_lead_warp & nvvm.elect_sync()
+
+        if cutlass.const_expr(chunk == 0):
+            local_alpha_src = sAlpha_xfer_raw.subview(cur_parity_S * cutlass.Int32(CFG.TILE_M))
+            peer_alpha_dst = nvvm.mapa(local_alpha_src, cross_sg_peer, addrspace=7)
+            peer_alpha_full_mbar = nvvm.mapa(bars.mb_alpha_xfer_full[cur_parity_S].smem_ptr, cross_sg_peer, addrspace=7)
+            cp_async_bulk_shared_cluster_shared_cta(
+                peer_alpha_dst,
+                local_alpha_src,
+                peer_alpha_full_mbar,
+                alphaXferBytes,
+                pred=ship_pred,
+            )
+        local_p_src = sP_xfer_raw.subview(p_slot_base + cutlass.Int32(chunk * pHalfXferElems))
+        peer_p_dst = nvvm.mapa(local_p_src, cross_sg_peer, addrspace=7)
+        peer_p_full_mbar = nvvm.mapa(bars.mb_p_xfer_full[chunk_slot].smem_ptr, cross_sg_peer, addrspace=7)
+        cp_async_bulk_shared_cluster_shared_cta(
+            peer_p_dst,
+            local_p_src,
+            peer_p_full_mbar,
+            pHalfXferBytes,
+            pred=ship_pred,
+        )
+
+    return (sg0_xfer_state, bmm1_done_state, total_max, total_max_safe, total_sum_vec)
+
+
+@cute.jit
+def _compute_warp_group(
+    is_sg0,
+    is_sg1,
+    seqlen_q,
+    seqlen_kv,
+    scale_log2,
+    o_scale_fused,
+    amax_o_tensor,
+    tmem_ptr_i32,
+    sQ,
+    sO,
+    sP_xfer_raw,
+    sAlpha_xfer_raw,
+    sStats_xfer_raw,
+    sLSE_raw,
+    bars,
+    sched,
+    lse_tensor,
+    sinks_tensor,
+    seq_kv_lens_tensor,
+    seq_q_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+    cta_id_x,
+    cross_sg_peer,
+    qh_per_kh,
+):
+    nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WG_WARPS + 1))
+    tmem_base_addr = tmem_ptr_i32.load()
+    tmem_raw = nvvm.make_tmem_ptr(tmem_base_addr, cutlass.Int8)
+
+    tid_in_wg = cute.arch.thread_idx()[0]
+    wid_in_wg = tid_in_wg // cutlass.Int32(32)
+    is_lead_warp = wid_in_wg == cutlass.Int32(0)
+
+    q_super_idx, head_idx, batch_idx, split_idx = _decode_initial_split(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0 and SPLIT_KV == 1):
+        kv_left = cutlass.Int32(0)
+        kv_unmasked_lo = cutlass.Int32(0)
+        kv_unmasked_hi = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+        eff_seqlen_kv = seqlen_kv
+    elif cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        # Unmasked, so this split's whole slice is the unmasked band.
+        kv_left, kv_right = _nomask_range_split(seqlen_kv, split_idx)
+        kv_unmasked_lo = kv_left
+        kv_unmasked_hi = kv_right
+        eff_seqlen_kv = seqlen_kv
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
+        bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
+        kv_left = bounds_init.left
+        kv_unmasked_lo = bounds_init.unmasked_lo
+        kv_unmasked_hi = bounds_init.unmasked_hi
+        kv_right = bounds_init.right
+
+    _O_EPI_SWIZZLE = cutlass.Swizzle(3, 4, 3)
+
+    O_EPI_BLOCK_SIZE = 64 // CFG.BPE_O
+    O_TMA_ITERS = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
+    O_D_BLOCK = CFG.TILE_O // O_TMA_ITERS
+    O_TMA_GRANU_ELEMS = CFG.TILE_M * O_D_BLOCK
+    O_BLOCKS_PER_SUB = 128 // O_EPI_BLOCK_SIZE
+    O_CHUNK_ELEMS = 128 // CFG.BPE_O
+
+    bmm1_done_state = PipelineState.start(phase=0)
+    sg0_xfer_state = PipelineState.start(phase=1)
+    stats_xfer_empty_state = PipelineState.start(phase=1)
+
+    alpha_full_state = PipelineState.start(phase=0)
+    sg1_bmm2_done_state = PipelineState.start(phase=0)
+    stats_xfer_full_state = PipelineState.start(phase=0)
+    epilogue_state = PipelineState.start(phase=1)
+
+    total_max = NEG_INF_F32
+    total_max_safe = NEG_INF_F32
+    total_sum_vec = cutlass.Vector.from_elements(
+        (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+        cutlass.Float32,
+    )
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if is_sg0:
+            total_max = NEG_INF_F32
+            total_max_safe = NEG_INF_F32
+            total_sum_vec = cutlass.Vector.from_elements(
+                (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+                cutlass.Float32,
+            )
+
+            # PackGQA: q_abs is the row's TOKEN index (row // G): every mask
+            # predicate downstream is a token-space compare, and all G rows of one
+            # token share it.
+            q_abs = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
+
+            if cutlass.const_expr(MAY_BE_EMPTY) and (kv_right <= kv_left):
+                pass
+            else:
+                if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+                    for _kv in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                        sg0_xfer_state, bmm1_done_state, total_max, total_max_safe, total_sum_vec = _sg0_softmax_kv_iter(
+                            False,
+                            _kv,
+                            sg0_xfer_state,
+                            bmm1_done_state,
+                            total_max,
+                            total_max_safe,
+                            total_sum_vec,
+                            tmem_base_addr,
+                            bars,
+                            sP_xfer_raw,
+                            sAlpha_xfer_raw,
+                            q_abs,
+                            eff_seqlen_kv,
+                            eff_seqlen_q,
+                            scale_log2,
+                            tid_in_wg,
+                            is_lead_warp,
+                            leader_cta_id,
+                            cross_sg_peer,
+                        )
+                else:
+                    for _kv in cutlass.range(kv_left, kv_unmasked_lo, 1, unroll=1):
+                        sg0_xfer_state, bmm1_done_state, total_max, total_max_safe, total_sum_vec = _sg0_softmax_kv_iter(
+                            True,
+                            _kv,
+                            sg0_xfer_state,
+                            bmm1_done_state,
+                            total_max,
+                            total_max_safe,
+                            total_sum_vec,
+                            tmem_base_addr,
+                            bars,
+                            sP_xfer_raw,
+                            sAlpha_xfer_raw,
+                            q_abs,
+                            eff_seqlen_kv,
+                            eff_seqlen_q,
+                            scale_log2,
+                            tid_in_wg,
+                            is_lead_warp,
+                            leader_cta_id,
+                            cross_sg_peer,
+                        )
+                    for _kv in cutlass.range(kv_unmasked_lo, kv_unmasked_hi, 1, unroll=1):
+                        sg0_xfer_state, bmm1_done_state, total_max, total_max_safe, total_sum_vec = _sg0_softmax_kv_iter(
+                            False,
+                            _kv,
+                            sg0_xfer_state,
+                            bmm1_done_state,
+                            total_max,
+                            total_max_safe,
+                            total_sum_vec,
+                            tmem_base_addr,
+                            bars,
+                            sP_xfer_raw,
+                            sAlpha_xfer_raw,
+                            q_abs,
+                            eff_seqlen_kv,
+                            eff_seqlen_q,
+                            scale_log2,
+                            tid_in_wg,
+                            is_lead_warp,
+                            leader_cta_id,
+                            cross_sg_peer,
+                        )
+                    for _kv in cutlass.range(kv_unmasked_hi, kv_right, 1, unroll=1):
+                        sg0_xfer_state, bmm1_done_state, total_max, total_max_safe, total_sum_vec = _sg0_softmax_kv_iter(
+                            True,
+                            _kv,
+                            sg0_xfer_state,
+                            bmm1_done_state,
+                            total_max,
+                            total_max_safe,
+                            total_sum_vec,
+                            tmem_base_addr,
+                            bars,
+                            sP_xfer_raw,
+                            sAlpha_xfer_raw,
+                            q_abs,
+                            eff_seqlen_kv,
+                            eff_seqlen_q,
+                            scale_log2,
+                            tid_in_wg,
+                            is_lead_warp,
+                            leader_cta_id,
+                            cross_sg_peer,
+                        )
+
+            bars.mb_stats_xfer_empty.wait(stats_xfer_empty_state.phase)
+            stats_xfer_empty_state = advance(stats_xfer_empty_state, 1)
+
+            final_sum = total_sum_vec[0] + total_sum_vec[1]
+            stats_sum_slot = sStats_xfer_raw.subview(tid_in_wg)
+            stats_max_slot = sStats_xfer_raw.subview(cutlass.Int32(CFG.TILE_M) + tid_in_wg)
+            stats_sum_slot.store(final_sum)
+            stats_max_slot.store(total_max_safe)
+
+            nvvm.fence_proxy("async.shared", space="cta")
+            nvvm.barrier_cta_sync(barrier_id=8, thread_count=128)
+
+            ship_pred = is_lead_warp & nvvm.elect_sync()
+
+            peer_stats_dst = nvvm.mapa(sStats_xfer_raw, cross_sg_peer, addrspace=7)
+            peer_stats_full_mbar = nvvm.mapa(bars.mb_stats_xfer_full.smem_ptr, cross_sg_peer, addrspace=7)
+            cp_async_bulk_shared_cluster_shared_cta(
+                peer_stats_dst,
+                sStats_xfer_raw,
+                peer_stats_full_mbar,
+                statsXferBytes,
+                pred=ship_pred,
+            )
+        else:
+            tmem_O_base = tmem_base_addr + cutlass.Int32(LAYOUT.O_OFF)
+
+            if cutlass.const_expr(MAY_BE_EMPTY) and (kv_right <= kv_left):
+                bars.mb_empty_mainloop.arrive_on_peer(leader_cta_id, pred=is_lead_warp & nvvm.elect_sync())
+            else:
+                cur_parity_0 = alpha_full_state.idx
+                bars.mb_bmm2_ready[cur_parity_0 * cutlass.Int32(CFG.N_BMM2_CHUNKS)].arrive(cta_group=CFG.CTA_MMA, leader_cta_id=leader_cta_id)
+                bars.mb_bmm2_ready[cur_parity_0 * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(1)].arrive(
+                    cta_group=CFG.CTA_MMA, leader_cta_id=leader_cta_id
+                )
+
+                bars.mb_alpha_xfer_full[cur_parity_0].arrive(n_bytes=alphaXferBytes, pred=is_lead_warp & nvvm.elect_sync())
+                bars.mb_alpha_xfer_full[cur_parity_0].wait(alpha_full_state.phase)
+                alpha_full_state = advance(alpha_full_state, CFG.XFER_STAGES)
+
+                bars.mb_alpha_xfer_empty[cur_parity_0].arrive_on_peer(cross_sg_peer)
+
+                CORR_BLOCK_SIZE = 16
+                CORR_BLOCKS_TOTAL = CFG.TILE_O // CORR_BLOCK_SIZE
+                CORR_BLOCKS_PER_HALF = CORR_BLOCKS_TOTAL // 2
+
+                for _kv in cutlass.range(kv_left + cutlass.Int32(1), kv_right, 1, unroll=1):
+                    cur_parity = alpha_full_state.idx
+
+                    bars.mb_alpha_xfer_full[cur_parity].arrive(n_bytes=alphaXferBytes, pred=is_lead_warp & nvvm.elect_sync())
+                    bars.mb_alpha_xfer_full[cur_parity].wait(alpha_full_state.phase)
+                    alpha_full_state = advance(alpha_full_state, CFG.XFER_STAGES)
+
+                    bars.mb_bmm2_done[sg1_bmm2_done_state.idx].wait(sg1_bmm2_done_state.phase)
+                    sg1_bmm2_done_state = advance(sg1_bmm2_done_state, CFG.XFER_STAGES)
+
+                    alpha_addr = sAlpha_xfer_raw.subview(cur_parity * cutlass.Int32(CFG.TILE_M) + tid_in_wg)
+                    alpha_corr = alpha_addr.load()
+
+                    alpha_is_one = alpha_corr == cutlass.Float32(1.0)
+                    all_alpha_one = vote_sync(0xFFFFFFFF, alpha_is_one, VoteSync.ALL)
+
+                    if ~all_alpha_one:
+                        for block in cutlass.range_constexpr(CORR_BLOCKS_PER_HALF):
+                            o_off = tmem_O_base + cutlass.Int32(block * CORR_BLOCK_SIZE)
+                            o_chunk = nvvm.tcgen05_ld(
+                                "32x32b",
+                                nvvm.make_tmem_ptr(o_off, cutlass.Float32),
+                                num=CORR_BLOCK_SIZE,
+                            )
+                            o_scaled = vec_scale_pair(o_chunk, alpha_corr, CORR_BLOCK_SIZE)
+                            nvvm.tcgen05_st(
+                                "32x32b",
+                                nvvm.make_tmem_ptr(o_off, cutlass.Float32),
+                                o_scaled,
+                            )
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+
+                    bars.mb_alpha_xfer_empty[cur_parity].arrive_on_peer(cross_sg_peer)
+                    bars.mb_bmm2_ready[cur_parity * cutlass.Int32(CFG.N_BMM2_CHUNKS)].arrive(cta_group=CFG.CTA_MMA, leader_cta_id=leader_cta_id)
+
+                    if ~all_alpha_one:
+                        for block in cutlass.range_constexpr(CORR_BLOCKS_PER_HALF):
+                            block_idx = CORR_BLOCKS_PER_HALF + block
+                            o_off = tmem_O_base + cutlass.Int32(block_idx * CORR_BLOCK_SIZE)
+                            o_chunk = nvvm.tcgen05_ld(
+                                "32x32b",
+                                nvvm.make_tmem_ptr(o_off, cutlass.Float32),
+                                num=CORR_BLOCK_SIZE,
+                            )
+                            o_scaled = vec_scale_pair(o_chunk, alpha_corr, CORR_BLOCK_SIZE)
+                            nvvm.tcgen05_st(
+                                "32x32b",
+                                nvvm.make_tmem_ptr(o_off, cutlass.Float32),
+                                o_scaled,
+                            )
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+
+                    bars.mb_bmm2_ready[cur_parity * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(1)].arrive(
+                        cta_group=CFG.CTA_MMA, leader_cta_id=leader_cta_id
+                    )
+
+            bars.mb_bmm2_done[sg1_bmm2_done_state.idx].wait(sg1_bmm2_done_state.phase)
+            sg1_bmm2_done_state = advance(sg1_bmm2_done_state, CFG.XFER_STAGES)
+
+            bars.mb_tma_o_empty.wait(epilogue_state.phase)
+            epilogue_state = advance(epilogue_state, 1)
+
+            bars.mb_stats_xfer_full.arrive(n_bytes=statsXferBytes, pred=is_lead_warp & nvvm.elect_sync())
+            bars.mb_stats_xfer_full.wait(stats_xfer_full_state.phase)
+            stats_xfer_full_state = advance(stats_xfer_full_state, 1)
+
+            ell_addr = sStats_xfer_raw.subview(tid_in_wg)
+            max_addr = sStats_xfer_raw.subview(cutlass.Int32(CFG.TILE_M) + tid_in_wg)
+            final_ell = ell_addr.load()
+            final_max = max_addr.load()
+
+            bars.mb_stats_xfer_empty.arrive_on_peer(cross_sg_peer, pred=is_lead_warp & nvvm.elect_sync())
+
+            q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
+            row_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE) + (tid_in_wg % cutlass.Int32(HEADS_PER_TILE))
+            LN2 = cutlass.Float32(0.6931471805599453)
+            if cutlass.const_expr(CFG.HAS_SINK):
+                sinks_arr = cutlass.make_array_view(sinks_tensor)
+                sink_logit = sinks_arr[row_head_idx]
+                final_max_nat = final_max * LN2
+                new_max_nat = cute.math.max(final_max_nat, sink_logit)
+                scale_sink = cute.math.exp(final_max_nat - new_max_nat, fastmath=True)
+                new_sum = final_ell * scale_sink + cute.math.exp(sink_logit - new_max_nat, fastmath=True)
+                # FP8: fold the dequant scale (descale_v * scale_o) into beta so
+                # the O cast lands in the output scale.  o_scale_fused is 1.0
+                # times the two device scales (see _kernel's fold).
+                beta = (scale_sink * o_scale_fused) / new_sum
+                lse = new_max_nat + cute.math.log(new_sum, fastmath=True)
+            else:
+                final_ell_safe = cute.math.max(final_ell, cutlass.Float32(1e-30))
+                beta = o_scale_fused / final_ell_safe
+                lse = final_max * LN2 + cute.math.log(final_ell_safe, fastmath=True)
+                # Dead row (no valid KV column at all): O := 0, LSE := -inf.
+                # final_ell >= 1 for any alive row so this never fires spuriously.
+                row_dead = final_ell <= cutlass.Float32(0.0)
+                neg_inf_lse = cutlass.Float32(float("-inf"))
+                beta = cutlass.Float32(arith.select(row_dead.ir_value(), cutlass.Float32(0.0).ir_value(), beta.ir_value()))
+                lse = cutlass.Float32(arith.select(row_dead.ir_value(), neg_inf_lse.ir_value(), lse.ir_value()))
+
+            if cutlass.const_expr(CFG.SEQ_Q_LENS_PRESENT):
+                # Dense padded-Q trim (cuDNN >= 9.14): q rows >= seq_len_q[b]
+                # write O := 0 / LSE := -inf.  Applied AFTER the sink branch on
+                # purpose — a trimmed row is dead even with a sink.  Per-batch
+                # q lens come in via the dedicated seq_q_lens_tensor parameter.
+                # (q_row_global — the row's token index — is computed above,
+                # before the sink fold, which needs the row's head; beta feeds
+                # the O normalization in the store loop below.)
+                _sq_arr = cutlass.make_array_view(seq_q_lens_tensor)
+                _q_len_b = cutlass.Int32(_sq_arr[batch_idx])
+                row_trim = q_row_global >= _q_len_b
+                neg_inf_trim = cutlass.Float32(float("-inf"))
+                beta = cutlass.Float32(arith.select(row_trim.ir_value(), cutlass.Float32(0.0).ir_value(), beta.ir_value()))
+                lse = cutlass.Float32(arith.select(row_trim.ir_value(), neg_inf_trim.ir_value(), lse.ir_value()))
+
+            # amax_o = max over VALID rows of |o_scaled| (the fp32 pre-cast
+            # output).  The adapter divides by scale_o on device afterwards to
+            # give the pre-quant output amax (cuDNN's FP8 reference semantics).
+            _amax_o_ptr = Pointer(amax_o_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
+            _amax_o_local = cutlass.Float32(0.0)
+            # beta == 0 is exactly "this row's output must be zero": the no-sink
+            # dead-row select, the padded-Q trim select, and a degenerate
+            # scale_o all land here.  The sink branch keeps beta > 0 (new_sum is
+            # strictly positive), so no alive row is caught.  Needed because an
+            # empty mainloop never writes O TMEM — `garbage * 0` cannot zero a
+            # NaN, and a single NaN would poison the global amax through
+            # atomicMax.
+            _row_zero = beta == cutlass.Float32(0.0)
+            _zero_f = cutlass.Float32(0.0)
+
+            sO_base = sO[0].base
+
+            for b in cutlass.range_constexpr(CFG.TILE_O // O_EPI_BLOCK_SIZE):
+                b_intra = b & (O_BLOCKS_PER_SUB - 1)
+                b_sub = b // O_BLOCKS_PER_SUB
+                tmem_sub = ((b_sub & 1) << 1) | ((b_sub & 2) >> 1)
+                tmem_block = tmem_sub * O_BLOCKS_PER_SUB + b_intra
+
+                o_half = cutlass.Vector.from_elements(
+                    tuple(OUT_STORAGE_DTYPE(0.0) for _ in range(O_EPI_BLOCK_SIZE)),
+                    OUT_STORAGE_DTYPE,
+                )
+                if cutlass.const_expr(not MAY_BE_EMPTY) or (kv_right > kv_left):
+                    o_addr = tmem_O_base + cutlass.Int32(tmem_block * O_EPI_BLOCK_SIZE)
+                    o_fp32 = nvvm.tcgen05_ld(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                        num=O_EPI_BLOCK_SIZE,
+                    )
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                    o_scaled = o_fp32 * beta
+                    # amax over |o_scaled| via a ternary tree (see
+                    # _abs_max_tree): a running `acc = max(acc, |e|)` would
+                    # build a TILE_O-deep dependency chain through the
+                    # epilogue's critical path.  No per-element dead-row select
+                    # is needed -- a fully-masked row still has its O TMEM
+                    # written by the MMA (P is zero, so O accumulates zero), and
+                    # the only path leaving O TMEM unwritten is the empty
+                    # mainloop, which the MAY_BE_EMPTY guard above skips.  One
+                    # select on the row's scalar result covers it.
+                    _amax_o_local = cute.math.max(_amax_o_local, _abs_max_tree(o_scaled, O_EPI_BLOCK_SIZE), ftz=True)
+                    o_half = o_scaled.to(OUT_STORAGE_DTYPE)
+
+                col_offset_const = (b * O_EPI_BLOCK_SIZE) % O_D_BLOCK
+                block_idx_const = (b * O_EPI_BLOCK_SIZE) // O_D_BLOCK
+                block_offset_const = block_idx_const * O_TMA_GRANU_ELEMS
+                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(O_D_BLOCK)
+                smem_ptr = sO_base.subview(smem_offset).data_ptr()
+                smem_ptr.store_swizzled(
+                    o_half,
+                    alignment=64,
+                    swizzle=_O_EPI_SWIZZLE,
+                )
+
+                if ((b + 1) * O_EPI_BLOCK_SIZE) % O_CHUNK_ELEMS == 0:
+                    chunk = (b * O_EPI_BLOCK_SIZE) // O_CHUNK_ELEMS
+                    nvvm.fence_proxy("async.shared", space="cta")
+                    bars.mb_tma_o_full[chunk].arrive()
+
+            # Row validity — the same predicate that gates the LSE store below,
+            # hoisted so the amax reduction can share it.  THD: sequence-local
+            # rows past this sequence's own Q length are straddle/padding rows.
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                _cu = cutlass.make_array_view(seq_kv_lens_tensor)
+                _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
+                _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
+                _row_valid = q_row_global < _s_q_b
+            else:
+                _row_valid = q_row_global < seqlen_q
+
+            if cutlass.const_expr(lse_tensor is None):
+                pass  # has_lse=False: the Stats store is compiled out
+            elif cutlass.const_expr(CFG.THD_VARLEN):
+                if _row_valid:
+                    lse_arr = cutlass.make_array_view(lse_tensor)
+                    if cutlass.const_expr(len(lse_tensor.shape) == 2):
+                        # token-major packed (T, H)
+                        lse_row = lse_arr[_cu_q_b + q_row_global, :]
+                        lse_row[head_idx] = lse
+                    else:
+                        # head-major packed (1, QH, head_stride)
+                        lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
+                        lse_row[_cu_q_b + q_row_global] = lse
+            else:
+                if _row_valid:
+                    lse_arr = cutlass.make_array_view(lse_tensor)
+                    lse_batch = _partial_batch(batch_idx, split_idx, n_batch)
+                    lse_arr[lse_batch, row_head_idx, q_row_global] = lse
+
+            # Under a KV split this epilogue sees only its OWN partial, and the
+            # recombined O is a convex combination of the partials — so a max
+            # over partials OVER-reports the output amax.  split_combine_sm100
+            # computes it over the recombined O instead; this write has to stay
+            # out of the way, since atomicMax only grows.
+            if cutlass.const_expr(SPLIT_KV == 1):
+                _amax_o_local = cutlass.Float32(arith.select(_row_zero.ir_value(), _zero_f.ir_value(), _amax_o_local.ir_value()))
+                if _row_valid:
+                    nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0)).load())
+        nxt_hb = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1)).load())
+        nxt_v = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2)).load())
+        q_super_idx, head_idx, batch_idx, split_idx = _decode_payload_split(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS == 0 and SPLIT_KV > 1):
+            kv_left, kv_right = _nomask_range_split(seqlen_kv, split_idx)
+        elif cutlass.const_expr(CFG.MASK_FLAGS != 0):
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
+            bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
+            kv_left = bounds_next.left
+            kv_unmasked_lo = bounds_next.unmasked_lo
+            kv_unmasked_hi = bounds_next.unmasked_hi
+            kv_right = bounds_next.right
+
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        if is_sg0:
+            if is_lead_warp:
+                if nvvm.elect_sync():
+                    for _p in cutlass.range_constexpr(CFG.XFER_STAGES):
+                        for _c in cutlass.range_constexpr(P_XFER_HALVES):
+                            bars.mb_p_xfer_empty[sg0_xfer_state.idx * cutlass.Int32(P_XFER_HALVES) + cutlass.Int32(_c)].wait(sg0_xfer_state.phase)
+                        bars.mb_alpha_xfer_empty[sg0_xfer_state.idx].wait(sg0_xfer_state.phase)
+                        sg0_xfer_state = advance(sg0_xfer_state, CFG.XFER_STAGES)
+                    bars.mb_stats_xfer_empty.wait(stats_xfer_empty_state.phase)
+            nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        peer_cta = cta_id_x ^ cutlass.Int32(1)
+        bars.mb_tmem_dealloc.arrive_on_peer(peer_cta, pred=is_lead_warp & nvvm.elect_sync())
+
+
+@cute.jit
+def _mma_warp_group(
+    is_sg0,
+    is_sg1,
+    seqlen_q,
+    seqlen_kv,
+    sQ,
+    sK,
+    sV,
+    sP_xfer_raw,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    seq_kv_lens_tensor,
+    seq_q_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    mcast_mask,
+    sg0_mcast_mask,
+    cta_in_pair,
+    leader_cta_id,
+    qh_per_kh,
+):
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WG_WARPS + 1))
+
+    tmem_raw = nvvm.make_tmem_ptr(tmem_ptr_i32.load(), cutlass.Int8)
+
+    # k_dim selects the FP8 MMA K-step family: 0 = K=32 QMMA (Blackwell),
+    # 1 = K=64 dense 2xFP8 (Rubin).  SM100 must use K=32 for BOTH BMM1
+    # (mma_ts, Q from TMEM) and BMM2 (mma_ss, P/V from SMEM) — k_dim=1 is
+    # silently WRONG here (per-row scrambled accumulator, no crash).  Derived
+    # from CFG.TILE_K_HW_* so the two can never drift apart; see
+    # `.claude/rules/mma-tma-matrix.md` § 1.
+    _BMM1_K_DIM = 1 if CFG.TILE_K_HW_BMM1 == 64 else 0
+    _BMM2_K_DIM = 1 if CFG.TILE_K_HW_BMM2 == 64 else 0
+    idesc_qk = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_N,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        k_dim=_BMM1_K_DIM,
+    )
+    idesc_pv = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.BMM2_N_PER_CALL,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        b_major=1,
+        k_dim=_BMM2_K_DIM,
+    )
+    bmm1_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_N,
+        K=CFG.TILE_K,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=CFG.TILE_K_HW_BMM1,
+        btranspose=False,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_qk,
+        kind=MMA_KIND,
+    )
+    bmm2_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.BMM2_N_PER_CALL,
+        K=CFG.TILE_N,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=CFG.TILE_K_HW_BMM2,
+        btranspose=True,
+        k_subtile=CFG.V_SWZ_BYTES // CFG.BPE,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_pv,
+        kind=MMA_KIND,
+    )
+
+    q_super_idx, head_idx, batch_idx, split_idx = _decode_initial_split(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0 and SPLIT_KV == 1):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    elif cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left, kv_right = _nomask_range_split(seqlen_kv, split_idx)
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
+        bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    q_full_state = PipelineState.start(phase=0)
+    kv_state_K = PipelineState.start(phase=0)
+    s_acc_empty_state = PipelineState.start(phase=1)
+
+    kv_state_V = PipelineState.start(phase=0)
+    sg1_mma_state = PipelineState.start(phase=0)
+    p_full_state = PipelineState.start(phase=0)
+    bmm2_ready_state = PipelineState.start(phase=0)
+    bmm2_done_prod_state = PipelineState.start(phase=0)
+    empty_mainloop_state = PipelineState.start(phase=0)
+
+    sP_xfer = SmemTile(
+        base=sP_xfer_raw,
+        elems_per_stage=pXferElems,
+        stages=CFG.XFER_STAGES,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_P,
+    )
+
+    desc_Q = sQ[0].desc()
+    tmem_Q = tmem_raw.subview(cutlass.Int32(LAYOUT.Q_TMEM_OFF))
+    _UTCCP_BYTES_PER_CALL = 16
+    _UTCCP_TMEM_COLS_PER_CALL = _UTCCP_BYTES_PER_CALL // 4
+    _UTCCP_PER_SUBTILE = CFG.Q_SWZ_BYTES // _UTCCP_BYTES_PER_CALL
+    _UTCCP_SUBTILE_DESC_STRIDE = (CFG.TILE_M * CFG.Q_SWZ_BYTES) // _UTCCP_BYTES_PER_CALL
+    _UTCCP_N_CALLS = LAYOUT.Q_TMEM_COLS // _UTCCP_TMEM_COLS_PER_CALL
+    V_NBLOCK_ADVANCE_ELEMS = BMM2_V_NBLOCK_ADVANCE // CFG.BPE
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if is_sg0:
+            if cutlass.const_expr(MAY_BE_EMPTY) and (kv_right <= kv_left):
+                pass
+            else:
+                bars.mb_tma_q_full.wait(q_full_state.phase)
+                q_full_state = advance(q_full_state, 1)
+
+                if nvvm.elect_sync():
+                    for _qk in cutlass.range_constexpr(_UTCCP_N_CALLS):
+                        _s = _qk // _UTCCP_PER_SUBTILE
+                        _kk = _qk % _UTCCP_PER_SUBTILE
+                        _desc_off = _s * _UTCCP_SUBTILE_DESC_STRIDE + _kk
+                        nvvm.tcgen05_cp(
+                            nvvm.Tcgen05CpShape.SHAPE_128X128B,
+                            tmem_Q.subview(_qk * _UTCCP_TMEM_COLS_PER_CALL),
+                            desc_Q + _desc_off,
+                            group=CTA_GROUP_KIND,
+                        )
+                    bars.mb_q_utccp_done.arrive(cta_group=CFG.CTA_MMA, mcast_mask=mcast_mask)
+
+                for _kv in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                    cur_parity_K = s_acc_empty_state.idx
+                    bars.mb_s_acc_empty[cur_parity_K].wait(s_acc_empty_state.phase)
+                    s_acc_empty_state = advance(s_acc_empty_state, CFG.XFER_STAGES)
+
+                    bars.mb_tma_k_full[kv_state_K.idx].wait(kv_state_K.phase)
+                    desc_K = sK[kv_state_K.idx].desc()
+                    s_acc_off = cur_parity_K * cutlass.Int32(LAYOUT.S_ACC_COLS)
+                    mma_ts(bmm1_desc, tmem_Q, desc_K, tmem_raw.subview(s_acc_off), accumulate=False)
+                    elect_p = nvvm.elect_sync()
+                    bars.mb_bmm1_done[cur_parity_K].arrive(cta_group=CFG.CTA_MMA, mcast_mask=mcast_mask, pred=elect_p)
+                    bars.mb_tma_k_empty[kv_state_K.idx].arrive(cta_group=CFG.CTA_MMA, mcast_mask=mcast_mask, pred=elect_p)
+                    kv_state_K = advance(kv_state_K, CFG.STAGES_KV)
+
+                bars.mb_tma_q_empty.arrive(cta_group=CFG.CTA_MMA, mcast_mask=mcast_mask, pred=nvvm.elect_sync())
+        else:
+            if cutlass.const_expr(MAY_BE_EMPTY) and (kv_right <= kv_left):
+                bars.mb_empty_mainloop.wait(empty_mainloop_state.phase)
+                empty_mainloop_state = advance(empty_mainloop_state, 1)
+                bars.mb_bmm2_done[bmm2_done_prod_state.idx].arrive(cta_group=CFG.CTA_MMA, mcast_mask=mcast_mask, pred=nvvm.elect_sync())
+                bmm2_done_prod_state = advance(bmm2_done_prod_state, CFG.XFER_STAGES)
+            else:
+                for kv_loop in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                    cur_parity = sg1_mma_state.idx
+
+                    # Leader's own expect_tx arrive, ONE per P half (the half's
+                    # bytes are delivered by the cross-sg sg0 partner's DSMEM
+                    # bulk_copy).  P12: leader init = CTA_MMA, this contributes
+                    # 1/half and the non-leader forwarder the other.  At
+                    # top-of-iter p_full_state.idx is the (parity, half-0) slot
+                    # and idx+h is (parity, half-h) — the ring advances
+                    # P_XFER_HALVES times per iter below, so the arrive slots
+                    # can never desync from the wait slots.
+                    elect_p = nvvm.elect_sync()
+                    for _h in cutlass.range_constexpr(P_XFER_HALVES):
+                        bars.mb_p_xfer_full[p_full_state.idx + cutlass.Int32(_h)].arrive(n_bytes=pHalfXferBytes, pred=elect_p)
+
+                    bars.mb_tma_v_full[kv_state_V.idx].wait(kv_state_V.phase)
+
+                    accum_b2 = kv_loop > kv_left
+
+                    # The same bases drive every K-half: mma_ss derives the
+                    # per-k-step operand offset from the ABSOLUTE k index, so
+                    # half h's k-steps [h*HALF, (h+1)*HALF) read that half's
+                    # P/V SMEM region (the half boundary is the P SMEM
+                    # swizzle-atom boundary; asserted above).  At FP8
+                    # (P_XFER_HALVES == 1) there is a single half covering all
+                    # NUM_KPHASES_PV k-steps.
+                    desc_P = sP_xfer[cur_parity].desc()
+                    desc_V_n0 = sV[kv_state_V.idx].desc()
+                    desc_V_n1 = sV[kv_state_V.idx].shifted(V_NBLOCK_ADVANCE_ELEMS).desc()
+
+                    tmem_O_n0 = tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF))
+                    tmem_O_n1 = tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF + CFG.BMM2_N_PER_CALL))
+
+                    # Half 0 launches as soon as P half-0 lands (alpha + first
+                    # chunk are shipped first) while later halves are still in
+                    # flight.  Half 0 establishes the partial O (accumulate =
+                    # accum_b2 across kv_loops); later halves accumulate onto
+                    # it.  bmm2_ready (correction -> MMA, per N-block) is
+                    # consumed once per N-block, in half 0 only.
+                    for half in cutlass.range_constexpr(P_XFER_HALVES):
+                        k_start = half * NUM_KPHASES_PV_HALF
+                        acc = accum_b2 if half == 0 else True
+
+                        bars.mb_p_xfer_full[p_full_state.idx].wait(p_full_state.phase)
+                        p_full_state = advance(p_full_state, CFG.XFER_STAGES * P_XFER_HALVES)
+
+                        if cutlass.const_expr(half == 0):
+                            bars.mb_bmm2_ready[bmm2_ready_state.idx].wait(bmm2_ready_state.phase)
+                            bmm2_ready_state = advance(bmm2_ready_state, CFG.XFER_STAGES * CFG.N_BMM2_CHUNKS)
+                        mma_ss(bmm2_desc, desc_P, desc_V_n0, tmem_O_n0, accumulate=acc, k_start=k_start, k_count=NUM_KPHASES_PV_HALF)
+                        if cutlass.const_expr(half == 0):
+                            bars.mb_bmm2_ready[bmm2_ready_state.idx].wait(bmm2_ready_state.phase)
+                            bmm2_ready_state = advance(bmm2_ready_state, CFG.XFER_STAGES * CFG.N_BMM2_CHUNKS)
+                        mma_ss(bmm2_desc, desc_P, desc_V_n1, tmem_O_n1, accumulate=acc, k_start=k_start, k_count=NUM_KPHASES_PV_HALF)
+
+                        # This half is done -> free its P SMEM chunk on sg0.
+                        # commit_mma fires AFTER the half's MMAs drain (P13), so
+                        # sg0 may reuse the chunk while later halves read theirs.
+                        bars.mb_p_xfer_empty[cur_parity * cutlass.Int32(P_XFER_HALVES) + cutlass.Int32(half)].arrive(
+                            cta_group=CFG.CTA_MMA, mcast_mask=sg0_mcast_mask, pred=nvvm.elect_sync()
+                        )
+
+                    sg1_mma_state = advance(sg1_mma_state, CFG.XFER_STAGES)
+
+                    elect_p = nvvm.elect_sync()
+                    bars.mb_bmm2_done[bmm2_done_prod_state.idx].arrive(cta_group=CFG.CTA_MMA, mcast_mask=mcast_mask, pred=elect_p)
+                    bars.mb_tma_v_empty[kv_state_V.idx].arrive(cta_group=CFG.CTA_MMA, mcast_mask=mcast_mask, pred=elect_p)
+                    kv_state_V = advance(kv_state_V, CFG.STAGES_KV)
+                    bmm2_done_prod_state = advance(bmm2_done_prod_state, CFG.XFER_STAGES)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0)).load()
+        nxt_hb = sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1)).load()
+        nxt_v = sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2)).load()
+        q_super_idx, head_idx, batch_idx, split_idx = _decode_payload_split(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS == 0 and SPLIT_KV > 1):
+            kv_left, kv_right = _nomask_range_split(seqlen_kv, split_idx)
+        elif cutlass.const_expr(CFG.MASK_FLAGS != 0):
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
+            bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _mma_warp_non_leader(
+    is_sg0,
+    is_sg1,
+    seqlen_q,
+    seqlen_kv,
+    sQ,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    seq_kv_lens_tensor,
+    seq_q_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    mcast_mask,
+    cta_in_pair,
+    leader_cta_id,
+    qh_per_kh,
+):
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WG_WARPS + 1))
+
+    tmem_raw_nl = nvvm.make_tmem_ptr(tmem_ptr_i32.load(), cutlass.Int8)
+    tmem_Q_nl = tmem_raw_nl.subview(cutlass.Int32(LAYOUT.Q_TMEM_OFF))
+    _UTCCP_BYTES_PER_CALL = 16
+    _UTCCP_TMEM_COLS_PER_CALL = _UTCCP_BYTES_PER_CALL // 4
+    _UTCCP_PER_SUBTILE = CFG.Q_SWZ_BYTES // _UTCCP_BYTES_PER_CALL
+    _UTCCP_SUBTILE_DESC_STRIDE = (CFG.TILE_M * CFG.Q_SWZ_BYTES) // _UTCCP_BYTES_PER_CALL
+    _UTCCP_N_CALLS = LAYOUT.Q_TMEM_COLS // _UTCCP_TMEM_COLS_PER_CALL
+
+    if is_sg1:
+        q_super_idx, head_idx, batch_idx, split_idx = _decode_initial_split(
+            sched.bidx_init,
+            sched.bidy_init,
+            sched.bidz_init,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
+        )
+        is_valid_tile = cutlass.Int32(1)
+        sched_state = PipelineState.start()
+
+        if cutlass.const_expr(CFG.MASK_FLAGS == 0 and SPLIT_KV == 1):
+            kv_left = cutlass.Int32(0)
+            kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+        elif cutlass.const_expr(CFG.MASK_FLAGS == 0):
+            kv_left, kv_right = _nomask_range_split(seqlen_kv, split_idx)
+        else:
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
+            bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
+            kv_left = bounds_init.left
+            kv_right = bounds_init.right
+
+        nlmma_state = PipelineState.start(phase=0)
+
+        while is_valid_tile > cutlass.Int32(0):
+            read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+            if cutlass.const_expr(MAY_BE_EMPTY) and (kv_right <= kv_left):
+                pass
+            else:
+                for _kv in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                    for _h in cutlass.range_constexpr(P_XFER_HALVES):
+                        cur_slot = nlmma_state.idx
+                        bars.mb_p_xfer_full[cur_slot].arrive(n_bytes=pHalfXferBytes, pred=nvvm.elect_sync())
+                        bars.mb_p_xfer_full[cur_slot].wait(nlmma_state.phase)
+                        nlmma_state = advance(nlmma_state, CFG.XFER_STAGES * P_XFER_HALVES)
+                        bars.mb_p_xfer_full[cur_slot].arrive_on_peer(leader_cta_id, pred=nvvm.elect_sync())
+
+            nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+            wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+            nxt_q = sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0)).load()
+            nxt_hb = sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1)).load()
+            nxt_v = sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2)).load()
+            q_super_idx, head_idx, batch_idx, split_idx = _decode_payload_split(
+                nxt_q,
+                nxt_hb,
+                cta_in_pair,
+                n_q_supers,
+                n_qh,
+                n_batch,
+                seq_kv_lens_tensor,
+                qh_per_kh,
+                seqlen_kv,
+            )
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+            sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+            if cutlass.const_expr(CFG.MASK_FLAGS == 0 and SPLIT_KV > 1):
+                kv_left, kv_right = _nomask_range_split(seqlen_kv, split_idx)
+            elif cutlass.const_expr(CFG.MASK_FLAGS != 0):
+                eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+                eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
+                bounds_next = _bounds_for_tile_split(
+                    q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH
+                )
+                kv_left = bounds_next.left
+                kv_right = bounds_next.right
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _tmaldg_warp_group(
+    is_sg0,
+    is_sg1,
+    tma_q_desc,
+    tma_k_desc,
+    tma_v_desc,
+    sQ,
+    sK,
+    sV,
+    bars,
+    sched,
+    seqlen_q,
+    seqlen_kv,
+    seq_kv_lens_tensor,
+    seq_q_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    qh_per_kh,
+    is_leader,
+    cta_in_pair,
+    tma_mcast_mask,
+    o_desc_words,
+):
+    q_empty_state = PipelineState.start(phase=1)
+    kv_state = PipelineState.start(phase=1)
+    q_utccp_done_state = PipelineState.start(phase=0)
+    o_empty_for_v_state = PipelineState.start(phase=1)
+
+    tma_q = GmemTileTma(tma_q_desc)
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD: K/V ride the setup kernel's RUNTIME descriptors (o_desc_words
+        # slots n_batch+1 / n_batch+2), whose seq extent is clamped to the
+        # packed KV total cu_k[B].  The last sequence's tile steps past that
+        # total into the buffer's capacity tail; through the clamped
+        # descriptors those rows are TMA-OOB and land as EXACT ZEROS.  A NaN
+        # tail (which test_mhas_v2 poisons deliberately) would otherwise wipe
+        # the whole tile through BMM2's P·V — 0 · NaN == NaN — since masking
+        # zeroes P, not V.  Same closure shape as the dense GmemTileTma, so
+        # every load site below stays branch-free.
+        _k_rt_ptr = (o_desc_words.iterator.raw_ptr() + (n_batch + cutlass.Int32(1)) * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+        _v_rt_ptr = (o_desc_words.iterator.raw_ptr() + (n_batch + cutlass.Int32(2)) * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+        tma_k = lambda *coords: tma_slice_runtime_desc(_k_rt_ptr, *coords)  # noqa: E731
+        tma_v = lambda *coords: tma_slice_runtime_desc(_v_rt_ptr, *coords)  # noqa: E731
+    else:
+        tma_k = GmemTileTma(tma_k_desc)
+        tma_v = GmemTileTma(tma_v_desc)
+
+    q_super_idx, head_idx, batch_idx, split_idx = _decode_initial_split(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
+    )
+    # GQA: K/V are indexed by kv-head, not Q-head; with PackGQA the decoded
+    # head_idx is the PACKED head (Q head base = head_idx * G) and q_row_base is
+    # in TOKEN units (rows // G).
+    q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx if cutlass.const_expr(CFG.PACK_GQA) else head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE))
+    q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0 and SPLIT_KV == 1):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    elif cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left, kv_right = _nomask_range_split(seqlen_kv, split_idx)
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
+        bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    K_ROW_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_N // CFG.CTA_MMA)
+    V_COL_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_O // CFG.CTA_MMA)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if cutlass.const_expr(MAY_BE_EMPTY) and (kv_right <= kv_left):
+            # Empty KV loop (SWA window past the padded KV tail, or a dead-Q-tile
+            # collapse): no loads — but the O∪V SMEM alias gate must stay in
+            # phase.  The sg1 compute epilogue stores (trimmed) O and TMA-STG
+            # drains it — flipping mb_tma_o_empty — on EVERY tile, empty ones
+            # included, while the V-side wait below only runs on full tiles.
+            # Without this bookkeeping advance a single empty tile leaves
+            # o_empty_for_v_state one phase behind for the rest of the
+            # persistent loop, so later V loads no longer wait for the O drain
+            # sharing their SMEM slab (live-tile corruption).  Advance-only is
+            # sufficient: this tile issues no V loads, so no actual wait is
+            # needed (harmlessly tracked on sg0 CTAs, which never consume it).
+            o_empty_for_v_state = advance(o_empty_for_v_state, 1)
+        else:
+            if is_sg0:
+                bars.mb_tma_q_empty.wait(q_empty_state.phase)
+                q_empty_state = advance(q_empty_state, 1)
+                bars.mb_tma_q_full.arrive(n_bytes=qTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                tma_load_tile(
+                    sQ[0],
+                    tma_q(cutlass.Int32(0), q_head_idx, q_row_base + q_seq_off, tma_batch),
+                    bars.mb_tma_q_full.smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+
+                bars.mb_q_utccp_done.wait(q_utccp_done_state.phase)
+                q_utccp_done_state = advance(q_utccp_done_state, 1)
+
+                for kv_loop in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                    kv_row_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+                    bars.mb_tma_k_empty[kv_state.idx].wait(kv_state.phase)
+                    bars.mb_tma_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                    tma_load_tile(
+                        sK[kv_state.idx],
+                        tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
+                        bars.mb_tma_k_full[kv_state.idx].smem_ptr,
+                        cta_group=CFG.CTA_MMA,
+                        mcast_mask=tma_mcast_mask,
+                    )
+                    kv_state = advance(kv_state, CFG.STAGES_KV)
+            else:
+                bars.mb_tma_o_empty.wait(o_empty_for_v_state.phase)
+                o_empty_for_v_state = advance(o_empty_for_v_state, 1)
+
+                for kv_loop in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                    kv_row_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+                    bars.mb_tma_v_empty[kv_state.idx].wait(kv_state.phase)
+                    bars.mb_tma_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                    tma_load_tile(
+                        sV[kv_state.idx],
+                        tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
+                        bars.mb_tma_v_full[kv_state.idx].smem_ptr,
+                        cta_group=CFG.CTA_MMA,
+                        mcast_mask=tma_mcast_mask,
+                    )
+                    kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0)).load())
+        nxt_hb = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1)).load())
+        nxt_v = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2)).load())
+        q_super_idx, head_idx, batch_idx, split_idx = _decode_payload_split(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
+        )
+        q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx if cutlass.const_expr(CFG.PACK_GQA) else head_idx // qh_per_kh)
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE))
+        q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS == 0 and SPLIT_KV > 1):
+            kv_left, kv_right = _nomask_range_split(seqlen_kv, split_idx)
+        elif cutlass.const_expr(CFG.MASK_FLAGS != 0):
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
+            bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        if is_sg0:
+            for _ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_tma_k_empty[kv_state.idx].wait(kv_state.phase)
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+            bars.mb_tma_q_empty.wait(q_empty_state.phase)
+        else:
+            for _ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_tma_v_empty[kv_state.idx].wait(kv_state.phase)
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+
+@cute.jit
+def _tmastg_warp_group(
+    is_sg1,
+    tma_o_desc,
+    sO,
+    bars,
+    sched,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    cta_in_pair,
+    seq_kv_lens_tensor,
+    o_desc_words,
+    seqlen_kv,
+    qh_per_kh,
+):
+    o_full_state = PipelineState.start(phase=0)
+
+    tma_o = GmemTileTma(tma_o_desc)
+
+    q_super_idx, head_idx, batch_idx, split_idx = _decode_initial_split(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        if is_sg1:
+            read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+            for chunk in cutlass.range_constexpr(N_O_CHUNKS):
+                bars.mb_tma_o_full[chunk].wait(o_full_state.phase)
+
+            q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
+            q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+            # KV split: partials stack split-major on the workspace BATCH axis.
+            o_batch = _partial_batch(batch_idx, split_idx, n_batch)
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # DEAD unit (batch == n_batch, envelope grid — issue #552): no O
+                # rows exist and descriptor slot n_batch is never built, so skip
+                # the store; the barrier protocol below still runs.
+                if batch_idx < n_batch:
+                    o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                    o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), q_head_idx, q_row_coord, cutlass.Int32(0))
+                    tma_store_tile(sO[0], o_slice)
+            else:
+                tma_store_tile(
+                    sO[0],
+                    tma_o(cutlass.Int32(0), q_head_idx, q_row_coord, o_batch),
+                )
+            tma_store_commit()
+            tma_store_wait(0)
+
+            bars.mb_tma_o_empty.arrive()
+            nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+            o_full_state = advance(o_full_state, 1)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0)).load()
+        nxt_hb = sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1)).load()
+        nxt_v = sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2)).load()
+        q_super_idx, head_idx, batch_idx, split_idx = _decode_payload_split(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+
+@cute.jit
+def _host(
+    q_tensor: cute.Tensor,
+    k_tensor: cute.Tensor,
+    v_tensor: cute.Tensor,
+    o_tensor: cute.Tensor,
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    problem_size: Tuple[int, int, int, int, int, int],
+    scale_softmax_log2: cutlass.Float32,
+    o_scale_fused: cutlass.Float32,
+    n_thd_units: cutlass.Int32,
+    # 1-element fp32 device scales (Rule 3 — see _kernel).
+    descale_q_t: cute.Tensor,
+    descale_k_t: cute.Tensor,
+    descale_v_t: cute.Tensor,
+    scale_o_t: cute.Tensor,
+    amax_o_tensor: cute.Tensor,
+    # THD device metadata build (issue #552): the CALLER's Q/KV length
+    # tensors — (B,) per-batch lengths or (B+1,) cu prefix sums, per side via
+    # thd_lens_form (bit 0: Q is cu, bit 1: KV is cu) — consumed only by the
+    # setup kernel, which writes the [kv|cu_q|cu_k] metadata buffer
+    # (seq_kv_lens_tensor) device-side. None (folded out of the ABI) for
+    # dense graphs.  These sit DIRECTLY after amax_o because the FP8 adapter
+    # passes them positionally there (api_dsl._execute_fp8).
+    thd_q_lens_tensor: Optional[cute.Tensor] = None,
+    thd_kv_lens_tensor: Optional[cute.Tensor] = None,
+    thd_lens_form: Optional[cutlass.Int32] = None,
+    # Dense padded-Q trim: separate (B,)-int32 per-batch Q lengths; None (and
+    # absent from the compiled ABI) unless CFG.SEQ_Q_LENS_PRESENT.  LAST in the
+    # list, after the THD slots, for the positional reason above — the FP8
+    # engine row does not declare dense_seq_q_trim today, so the flag is always
+    # 0 here and the parameter folds out.
+    seq_q_lens_tensor: Optional[cute.Tensor] = None,
+    stream: _cuda_driver.CUstream = None,
+) -> None:
+    B, QH, KH, SQ, SKV, _ = problem_size
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # Packed token totals are runtime values (dynamic extents); the
+        # problem_size slots are 0 by contract.
+        SQ = q_tensor.shape[1]
+        SKV = k_tensor.shape[1]
+
+    _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE_O
+    if cutlass.const_expr(CFG.PACK_GQA and q_tensor.shape[2] != k_tensor.shape[2] * CFG.QH_PER_KH):
+        raise ValueError(f"CFG.QH_PER_KH ({CFG.QH_PER_KH}) does not match tensor head extents H_q={q_tensor.shape[2]}, H_kv={k_tensor.shape[2]}")
+    qk_box_q = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, TMA_QK_GRANU_ELEMS)
+    qk_box_k = (1, CFG.TILE_N // CFG.CTA_MMA, 1, TMA_QK_GRANU_ELEMS)
+    vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, _O_GRANU_ELEMS)
+    stride_order = (3, 2, 1, 0)
+
+    def _tma_swz(byte_w: int):
+        return tmap.TensorMapSwizzle.s128b if byte_w == 128 else tmap.TensorMapSwizzle.s64b if byte_w == 64 else tmap.TensorMapSwizzle.s32b
+
+    tma_q_desc = tmap.create_tensor_map_tiled_from_view(
+        q_tensor,
+        box_dims=qk_box_q,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.Q_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_k_desc = tmap.create_tensor_map_tiled_from_view(
+        k_tensor,
+        box_dims=qk_box_k,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.K_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_v_desc = tmap.create_tensor_map_tiled_from_view(
+        v_tensor,
+        box_dims=vo_box_v,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.V_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_o_desc = tmap.create_tensor_map_tiled_from_view(
+        o_tensor,
+        box_dims=vo_box_o,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.O_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+
+    # PackGQA: SQ*G packed rows per packed head, and QH/G packed heads.
+    rows_per_cluster = CGA_TILE_M
+    q_clusters = (SQ * HEADS_PER_TILE + rows_per_cluster - 1) // rows_per_cluster
+    grid_q_supers = q_clusters * CFG.CGA_M
+    q_supers = q_clusters * CFG.CTA_MMA
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # ENVELOPE: the packed-O row stride is QH * ACTUAL d_v (o_tensor's
+        # static inner extent), not QH * TILE_O — the per-batch descriptor
+        # bases must step in real rows or every batch >= 1 lands OOB.
+        # The FP8 setup variant additionally clamps runtime K/V descriptors to
+        # the packed KV total (o_desc_words slots n_batch+1 / n_batch+2) so a
+        # tile tail past that total zero-fills instead of reading the buffer's
+        # capacity tail — a NaN tail would poison BMM2's P·V.  It does not write
+        # the live-unit total / claim counter, which only the SM120 persistent
+        # scheduler reads; this kernel runs the plan-time envelope grid.
+        _build_thd_meta_o_kv_descs_kernel(
+            o_tensor,
+            tma_o_desc,
+            tma_k_desc,
+            tma_v_desc,
+            o_desc_words,
+            seq_kv_lens_tensor,
+            thd_q_lens_tensor,
+            thd_kv_lens_tensor,
+            thd_lens_form,
+            cutlass.Int32(QH // HEADS_PER_TILE),
+            cutlass.Int32(B),
+            cutlass.Int32(o_tensor.stride[1]),
+        ).launch(grid=(1, 1, 1), block=(THD_SETUP_THREADS, 1, 1), stream=stream)
+        grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
+    else:
+        # KV split rides the BATCH axis: z = batch + split*B.
+        grid_shape = (
+            (grid_q_supers, QH // HEADS_PER_TILE, B * SPLIT_KV)
+            if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL)
+            else (grid_q_supers * (QH // HEADS_PER_TILE) * B * SPLIT_KV, 1, 1)
+        )
+    _kernel(
+        tma_q_desc,
+        tma_k_desc,
+        tma_v_desc,
+        tma_o_desc,
+        lse_tensor,
+        sinks_tensor,
+        seq_kv_lens_tensor,
+        o_desc_words,
+        cutlass.Int32(SQ),
+        cutlass.Int32(SKV),
+        cutlass.Int32(q_supers),
+        cutlass.Int32(QH // HEADS_PER_TILE),
+        cutlass.Int32(B),
+        cutlass.Int32(QH // KH),
+        scale_softmax_log2,
+        o_scale_fused,
+        descale_q_t,
+        descale_k_t,
+        descale_v_t,
+        scale_o_t,
+        amax_o_tensor,
+        seq_q_lens_tensor,
+    ).launch(
+        grid=grid_shape,
+        block=[CFG.THREADS_PER_CTA, 1, 1],
+        cluster=(CFG.CGA_M, CFG.CGA_N, 1),
+        stream=stream,
+    )
+
+
+@lru_cache(maxsize=None)
+def compile(  # noqa: A001
+    b: int = 1,
+    qh: int = 1,
+    kh: int = 1,
+    sq: int = 256,
+    skv: int = 128,
+    d_qk: int = CFG.TILE_K,
+    d_v: int = CFG.TILE_O,
+    has_lse: bool = True,
+    lse_head_major: bool = False,
+    lse_head_stride: int = 0,
+    q_stride: Optional[tuple] = None,
+    k_stride: Optional[tuple] = None,
+    v_stride: Optional[tuple] = None,
+    o_stride: Optional[tuple] = None,
+    lse_stride: Optional[tuple[int, int, int]] = None,
+) -> Callable:
+    """ENVELOPE: ``d_qk`` / ``d_v`` are the ACTUAL head dims (defaults = full
+    TILE_K / TILE_O). TMA descriptors carry these extents while the tile box
+    stays the compile-time TILE geometry: loads past d_qk / d_v zero-fill
+    (exact zeros in the QK^T / P·V contractions), O stores past d_v clip.
+    The Q∪V∪O SMEM alias slabs keep their full compile-time extents — only
+    the GMEM descriptor extents change. d * BPE must be a 16-byte multiple
+    (TMA global-stride rule -> d % 8).
+
+    THD/varlen: ``sq``/``skv`` are IGNORED — the packed token totals are
+    runtime values (they change every step under continuous batching), so the
+    token extents compile DYNAMIC (``cute.sym_int``) and the cache key stays
+    plan-time-only; callers must not pass them. THD strides carry a ZERO batch
+    stride (the real view's batch stride is ``t_q * token_stride``, a runtime
+    value; the fake rebuilds it symbolically — batch extent 1 never steps)."""
+    if not (0 < d_qk <= CFG.TILE_K and 0 < d_v <= CFG.TILE_O):
+        raise ValueError(f"d512 envelope: need 0 < d_qk <= {CFG.TILE_K} and 0 < d_v <= {CFG.TILE_O}; got ({d_qk}, {d_v})")
+    if (d_qk * CFG.BPE) % 16 != 0 or (d_v * CFG.BPE_O) % 16 != 0:
+        raise ValueError(f"d512 envelope: d_qk*BPE and d_v*BPE must be 16-byte multiples (TMA global-stride rule); got ({d_qk}, {d_v}) at BPE={CFG.BPE}")
+    if SPLIT_KV > 1 and not has_lse:
+        raise ValueError("split_kv > 1 requires has_lse=True (the per-split LSE drives the combine)")
+    if lse_stride is not None and (CFG.THD_VARLEN or SPLIT_KV > 1):
+        raise ValueError("dense LSE strides are not valid for THD or split-KV workspaces")
+    _fake_batch = 1 if CFG.THD_VARLEN else b
+    if CFG.THD_VARLEN:
+        # Dynamic packed token totals: one symbol per ragged group (Q/O and
+        # the LSE share t_q; K/V share t_kv), so a new total re-binds the same
+        # compiled artifact instead of minting a new one (issue #552).
+        sq = cute.sym_int(divisibility=1)
+        skv = cute.sym_int(divisibility=1)
+    _o_batch = _fake_batch * SPLIT_KV
+    _lse_batch = b * SPLIT_KV
+
+    def _fake_bshd(shape, stride, dtype=STORAGE_DTYPE, bpe=CFG.BPE):
+        if stride is None:
+            return cute.runtime.make_fake_compact_tensor(dtype, shape, stride_order=(3, 2, 1, 0), assumed_align=16)
+        if stride[3] != 1:
+            raise ValueError(f"declared stride {stride}: the head dim must be innermost-contiguous (stride[3] == 1)")
+        for axis in (1, 2):  # seq/head global strides feed TMA: 16-byte rule
+            if (stride[axis] * bpe) % 16 != 0:
+                raise ValueError(f"declared stride {stride} axis {axis} must be a 16-byte multiple at BPE={bpe} (TMA global-stride rule)")
+        if CFG.THD_VARLEN:
+            # Batch stride = tokens * token_stride (`_thd_view`'s envelope),
+            # a runtime value: rebuild it from the dynamic token extent.
+            return cute.runtime.make_fake_tensor(dtype, shape, (shape[1] * stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
+        return cute.runtime.make_fake_tensor(dtype, shape, tuple(stride), assumed_align=16)
+
+    fake_q = _fake_bshd((_fake_batch, sq, qh, d_qk), q_stride)
+    fake_k = _fake_bshd((_fake_batch, skv, kh, d_qk), k_stride)
+    fake_v = _fake_bshd((_fake_batch, skv, kh, d_v), v_stride)
+    fake_o = _fake_bshd((_o_batch, sq, qh, d_v), o_stride, dtype=OUT_STORAGE_DTYPE, bpe=CFG.BPE_O)
+    if not has_lse:
+        # No Stats output: the LSE argument is None-specialized and the store
+        # is compiled out entirely — no dummy buffer exists at any level.
+        if lse_head_major or lse_head_stride:
+            raise ValueError("lse_head_major / lse_head_stride require has_lse=True")
+        fake_lse = None
+    elif CFG.THD_VARLEN:
+        # Packed ragged-Stats LSE in the caller's declared layout (align 4: the
+        # store is scalar f32 and the caller's Stats buffer only guarantees
+        # element alignment). Token-major (the default — cuDNN's TH1 ragged
+        # Stats recipe) = its natural packed rank-2 (T, H) view; head-major =
+        # the kernels' native rank-3 (1, QH, head_stride) packing with
+        # head_stride >= T (compact when 0). The epilogue store branches on
+        # the STATIC rank, so the layout is fully encoded in this fake tensor
+        # — no template parameter.
+        if lse_head_major:
+            # head_stride covering t_q is validated at execute (t_q is a
+            # runtime value); 0 = compact = the dynamic token total itself.
+            _lse_hs = lse_head_stride if lse_head_stride else sq
+            fake_lse = cute.runtime.make_fake_compact_tensor(
+                cutlass.Float32,
+                (1, qh, _lse_hs),
+                stride_order=(2, 1, 0),
+                assumed_align=4,
+            )
+        else:
+            if lse_head_stride:
+                raise ValueError("lse_head_stride is head-major-only (token-major (T, H) is compact)")
+            fake_lse = cute.runtime.make_fake_compact_tensor(
+                cutlass.Float32,
+                (sq, qh),
+                stride_order=(1, 0),
+                assumed_align=4,
+            )
+    else:
+        if lse_head_major or lse_head_stride:
+            raise ValueError("lse_head_major / lse_head_stride are THD-only")
+        fake_lse = (
+            cute.runtime.make_fake_tensor(cutlass.Float32, (_lse_batch, qh, sq), lse_stride, assumed_align=4)
+            if lse_stride is not None
+            else cute.runtime.make_fake_compact_tensor(
+                cutlass.Float32,
+                (_lse_batch, qh, sq),
+                stride_order=(2, 1, 0),
+                assumed_align=16,
+            )
+        )
+    fake_sinks = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (qh,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    _skv_len = (4 * b + 4) if CFG.THD_VARLEN else b
+    fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (_skv_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # Dense padded-Q trim: SEPARATE (B,)-int32 per-batch Q lengths parameter
+    # (cuDNN SEQLEN_Q / FA seqused_q style); None folds it out of the ABI when
+    # the flag is off.  assumed_align=4 — the caller's tensor is bound
+    # directly (no repack), so only natural int32 alignment is required.
+    fake_seq_q_lens = (
+        cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (b,),
+            stride_order=(0,),
+            assumed_align=4,
+        )
+        if CFG.SEQ_Q_LENS_PRESENT
+        else None
+    )
+    # 16 int64 per sequence + the dead-unit pad slot + the two packed-total-
+    # clamped K/V runtime descriptor slots (the FP8 THD setup variant).
+    _odesc_len = ((b + 3) * _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
+    fake_o_desc = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int64,
+        (_odesc_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # THD: the caller's Q/KV length tensors, consumed by the setup kernel's
+    # device-side metadata build. DYNAMIC extents — (B,) per-batch lengths and
+    # (B+1,) cu prefix sums bind the same artifact; the form rides the runtime
+    # thd_lens_form bitmask, so no compile key grows (Rule 4). align 4: bound
+    # directly, only natural int32 alignment is guaranteed.
+    if CFG.THD_VARLEN:
+        fake_thd_q_lens = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (cute.sym_int(divisibility=1),), stride_order=(0,), assumed_align=4)
+        fake_thd_kv_lens = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (cute.sym_int(divisibility=1),), stride_order=(0,), assumed_align=4)
+        fake_thd_lens_form = cutlass.Int32(0)
+    else:
+        fake_thd_q_lens = None
+        fake_thd_kv_lens = None
+        fake_thd_lens_form = None
+
+    # Per-tensor FP8 scales + the amax_o accumulator: 1-element fp32 DEVICE
+    # buffers (Rule 3 — the kernel reads them, nothing is read back to host).
+    def _fake_scalar_f32():
+        return cute.runtime.make_fake_compact_tensor(cutlass.Float32, (1,), stride_order=(0,), assumed_align=4)
+
+    fake_descale_q = _fake_scalar_f32()
+    fake_descale_k = _fake_scalar_f32()
+    fake_descale_v = _fake_scalar_f32()
+    fake_scale_o = _fake_scalar_f32()
+    fake_amax_o = _fake_scalar_f32()
+    return cute.compile(
+        _host,
+        fake_q,
+        fake_k,
+        fake_v,
+        fake_o,
+        fake_lse,
+        fake_sinks,
+        fake_seq_kv_lens,
+        fake_o_desc,
+        # THD: the packed totals are runtime values carried by the (dynamic)
+        # tensor extents — _host reads them from the views' shapes.
+        (b, qh, kh, 0, 0, 0) if CFG.THD_VARLEN else (b, qh, kh, sq, skv, 0),
+        cutlass.Float32(0.0),  # scale_softmax_log2 base (traced value only)
+        cutlass.Float32(0.0),  # o_scale_fused base (traced value only)
+        cutlass.Int32(0),
+        fake_descale_q,
+        fake_descale_k,
+        fake_descale_v,
+        fake_scale_o,
+        fake_amax_o,
+        fake_thd_q_lens,
+        fake_thd_kv_lens,
+        fake_thd_lens_form,
+        fake_seq_q_lens,
+        stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
+        options="--enable-tvm-ffi",
+    )

--- a/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
+++ b/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
@@ -73,9 +73,14 @@ def test_per_tensor_fp8_rows_split_per_arch_line():
     # Arch ranges tile the SM100 family at the Rubin boundary, no overlap.
     assert (sm100.sm_lo, sm100.sm_hi) == (100, 106)
     assert (sm107.sm_lo, sm107.sm_hi) == (107, 119)
-    # Kernel flavors are row DATA: Rubin has no d192 sibling.
-    assert sm100.d_shapes == frozenset({(128, 128), (192, 128)})
+    # Kernel flavors are row DATA: Rubin has no d192 or d512 sibling.
+    assert sm100.d_shapes == frozenset({(128, 128), (192, 128), (512, 512)})
     assert sm107.d_shapes == frozenset({(128, 128)})
+    # d512 carries an envelope FLOOR: it serves (256, 512] on both head dims,
+    # so a smaller graph is declined rather than routed onto the d512 kernel at
+    # a multiple-x zero-padding cost.  Rubin has no d512 flavor, hence no floor.
+    assert sm100.d_envelope_floors == (((512, 512), 256),)
+    assert sm107.d_envelope_floors == ()
 
     # The f16x2 exponent arm is Rubin-row data, not a notch.
     assert sm100.softmax_precisions == frozenset({_c.data_type.FLOAT})
@@ -284,7 +289,10 @@ def test_fp8_rows_serve_dense_envelope():
     for arch in ("sm100", "sm107"):
         row = caps[engines.engine_name(arch=arch, fp8=True)]
         assert row.d_pad_multiple == 16, arch
-        assert row.thd_d_shapes == frozenset({(128, 128)}), arch
+    # The d128 kernel carries the THD leg on both arch lines; sm100 adds the
+    # d512 flavor's THD leg.
+    assert caps[engines.engine_name(arch="sm107", fp8=True)].thd_d_shapes == frozenset({(128, 128)})
+    assert caps[engines.engine_name(arch="sm100", fp8=True)].thd_d_shapes == frozenset({(128, 128), (512, 512)})
     assert caps[engines.engine_name(mxfp8=True)].d_pad_multiple == 0
 
 
@@ -326,11 +334,29 @@ def test_fp8_envelope_mismatch_rules():
     assert "multiples of 16" in engines.mismatch(sm100, _fp8_facts(d_qk=88, d_v=88))
     assert "dense-only" in engines.mismatch(sm100, _fp8_facts(thd=True, padded=True))
     assert engines.mismatch(sm100, _fp8_facts(d_qk=128, d_v=128, thd=True, padded=True)) is None
-    # THD at the d192 native shape is dense-only (thd_d_shapes = {(128, 128)}).
+    # THD at the d192 native shape is dense-only (thd_d_shapes excludes it).
     assert "dense-only" in engines.mismatch(sm100, _fp8_facts(d_qk=192, d_v=128, thd=True, padded=True))
+    # d512 is a NATIVE shape (accepted exactly, dense and THD) and serves the
+    # (256, 512] envelope band on BOTH head dims -- at most 2x zero-padding.
+    assert engines.mismatch(sm100, _fp8_facts(d_qk=512, d_v=512)) is None
+    assert engines.mismatch(sm100, _fp8_facts(d_qk=512, d_v=512, thd=True, padded=True)) is None
+    assert engines.mismatch(sm100, _fp8_facts(d_qk=384, d_v=448)) is None
+    assert engines.mismatch(sm100, _fp8_facts(d_qk=464, d_v=368)) is None
+    assert engines.mismatch(sm100, _fp8_facts(d_qk=272, d_v=272)) is None
+    # Below the floor, or straddling it, the row declines rather than routing a
+    # much smaller graph onto the d512 kernel.
+    assert "no kernel-flavor envelope" in engines.mismatch(sm100, _fp8_facts(d_qk=256, d_v=256))
+    assert "no kernel-flavor envelope" in engines.mismatch(sm100, _fp8_facts(d_qk=512, d_v=256))
+    assert "no kernel-flavor envelope" in engines.mismatch(sm100, _fp8_facts(d_qk=384, d_v=128))
+    # THD stays native-tile: the (256, 512] envelope band is dense-only.
+    assert "dense-only" in engines.mismatch(sm100, _fp8_facts(d_qk=384, d_v=448, thd=True, padded=True))
+    # d % 16 still applies inside the band (TMA 16-byte global-stride rule).
+    assert "multiples of 16" in engines.mismatch(sm100, _fp8_facts(d_qk=392, d_v=392))
     # The Rubin row serves the same dense envelope (the ViT d=72-in-80 case)
     # but has no d192 flavor at all.
     sm107 = caps[engines.engine_name(arch="sm107", fp8=True)]
     assert engines.mismatch(sm107, _fp8_facts(device_cc=(10, 7))) is None
     assert "no kernel-flavor envelope" in engines.mismatch(sm107, _fp8_facts(device_cc=(10, 7), d_qk=192, d_v=128))
     assert "dense-only" in engines.mismatch(sm107, _fp8_facts(device_cc=(10, 7), thd=True, padded=True))
+    # There is no Rubin d512 kernel at all.
+    assert "no kernel-flavor envelope" in engines.mismatch(sm107, _fp8_facts(device_cc=(10, 7), d_qk=512, d_v=512))

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -709,7 +709,7 @@ def test_fp8_stats_less_zero_workspace(in_key):
     _check(out, o_ref, torch.float16, in_key, a_o, a_o_ref)
 
 
-def _run_thd(seq_lens_q, seq_lens_kv, H_q, H_kv, in_key, *, scale, causal=False, sink=None, stats=False, cu_lens=False, declare_totals=False):
+def _run_thd(seq_lens_q, seq_lens_kv, H_q, H_kv, in_key, *, scale, causal=False, sink=None, stats=False, cu_lens=False, declare_totals=False, d=128):
     """THD/varlen: packed [T,H,D] Q/K/V/O + per-operand ragged_offset + per-batch
     lengths (or their cu prefix-sum form).
 
@@ -721,7 +721,7 @@ def _run_thd(seq_lens_q, seq_lens_kv, H_q, H_kv, in_key, *, scale, causal=False,
     import cudnn
 
     dev = "cuda"
-    D = 128
+    D = d
     B = len(seq_lens_q)
     S_max_q, S_max_kv = max(seq_lens_q), max(seq_lens_kv)
     T_q, T_kv = sum(seq_lens_q), sum(seq_lens_kv)
@@ -1070,3 +1070,218 @@ def test_fp8_sm100_device_scales_execute_reads_no_device_memory():
     scale = 1.0 / math.sqrt(128)
     out, o_ref, a_o, a_o_ref = _run(2, 8, 8, 256, 256, "e4m3", torch.float16, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), sync_debug=True)
     _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
+
+
+# ===========================================================================
+# d512 flavor (d_qk = d_v = 512) — per-tensor FP8 only.
+#
+# Same cga4x1 role-split kernel family as the d512 f16 sibling; the FP8 fork
+# runs STAGES_KV = XFER_STAGES = 3 with a 128-column TMEM-resident Q and the
+# Blackwell K=32 QMMA step.  There is no d512 MXFP8 kernel and no Rubin d512
+# kernel, so this whole section is sm100-only.
+# ===========================================================================
+
+_skip_d512_on_rubin = pytest.mark.skipif(_SM == 107, reason="the d512 per-tensor FP8 flavor has no Rubin kernel (sm107 serves d128 only)")
+_D512 = 512
+_D512_SCALE = 1.0 / math.sqrt(_D512)
+
+
+@pytest.mark.L0
+@_skip_d512_on_rubin
+@pytest.mark.parametrize("in_key", _INS)
+@pytest.mark.parametrize("mask", list(_MASKS))
+@torch_fork_set_rng(seed=0)
+def test_fp8_d512_masks(in_key, mask):
+    """Every causal-family mask on the d512 FP8 flavor."""
+    out, o_ref, a_o, a_o_ref = _run(2, 4, 4, 256, 256, in_key, torch.float16, scale=_D512_SCALE, sdpa_kwargs=_MASKS[mask], d_qk=_D512, d_v=_D512)
+    _check(out, o_ref, torch.float16, in_key, a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@_skip_d512_on_rubin
+@pytest.mark.parametrize("out_key", ["fp16", "bf16", "e4m3", "e5m2"])
+@pytest.mark.parametrize("in_key", _INS)
+@torch_fork_set_rng(seed=0)
+def test_fp8_d512_output_dtypes(in_key, out_key):
+    """DTYPE_O is independent of DTYPE_QKV on d512 too.  The BF16/FP16 arms
+    also exercise the byte-sized Q u O SMEM alias: a BPE_O=2 output is twice
+    the FP8 input's width, and an element-sized alias would overflow into the
+    P-transfer ring."""
+    out_dt = _OUT[out_key]
+    out, o_ref, a_o, a_o_ref = _run(1, 4, 4, 256, 256, in_key, out_dt, scale=_D512_SCALE, sdpa_kwargs={}, d_qk=_D512, d_v=_D512)
+    _check(out, o_ref, out_dt, in_key, a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@_skip_d512_on_rubin
+@torch_fork_set_rng(seed=0)
+def test_fp8_d512_sink():
+    """Attention sink on d512: one extra softmax column with V = 0."""
+    sink = torch.randn(1, 8, 1, 1, device="cuda", dtype=torch.float32)
+    out, o_ref, a_o, a_o_ref = _run(1, 8, 8, 256, 256, "e4m3", torch.float16, scale=_D512_SCALE, sdpa_kwargs={}, sink=sink, d_qk=_D512, d_v=_D512)
+    _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@_skip_d512_on_rubin
+@pytest.mark.parametrize("h_q,h_kv", [(8, 2), (8, 1)], ids=["g4", "mqa"])
+@torch_fork_set_rng(seed=0)
+def test_fp8_d512_gqa(h_q, h_kv):
+    """Grouped / multi-query attention on d512."""
+    out, o_ref, a_o, a_o_ref = _run(2, h_q, h_kv, 256, 256, "e4m3", torch.float16, scale=_D512_SCALE, sdpa_kwargs={}, d_qk=_D512, d_v=_D512)
+    _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@_skip_d512_on_rubin
+@torch_fork_set_rng(seed=0)
+def test_fp8_d512_padded_kv():
+    """Per-batch KV padding (seq_len_kv) on d512: KV columns past the batch's
+    valid length are masked, so every query row keeps a well-defined
+    normalization."""
+    out, o_ref, a_o, a_o_ref = _run(2, 4, 4, 256, 256, "e4m3", torch.float16, scale=_D512_SCALE, sdpa_kwargs={}, seq_lens_kv=[200, 137], d_qk=_D512, d_v=_D512)
+    _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@_skip_d512_on_rubin
+@torch_fork_set_rng(seed=0)
+def test_fp8_d512_stats():
+    """generate_stats on d512: the dense LSE matches the natural-log reference."""
+    r = _run(1, 4, 4, 256, 256, "e4m3", torch.float16, scale=_D512_SCALE, sdpa_kwargs=dict(use_causal_mask=True), d_qk=_D512, d_v=_D512, return_lse=True)
+    _check(r.output, r.reference, torch.float16, "e4m3", r.amax, r.reference_amax)
+    diff = (r.stats.float() - r.reference_stats).abs().max().item()
+    assert diff <= 5e-2, f"max|LSE-ref| = {diff:.4f}"
+
+
+@pytest.mark.L0
+@_skip_d512_on_rubin
+@torch_fork_set_rng(seed=0)
+def test_fp8_d512_multi_tile():
+    """A shape that spans several Q tiles and several persistent waves, so the
+    scheduler ring, the S_acc parity ring (XFER_STAGES=3 at FP8) and the KV
+    ring (STAGES_KV=3) all wrap."""
+    out, o_ref, a_o, a_o_ref = _run(
+        2, 4, 4, 1024, 1024, "e4m3", torch.float16, scale=_D512_SCALE, sdpa_kwargs=dict(use_causal_mask=True), d_qk=_D512, d_v=_D512
+    )
+    _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
+
+
+# --- d512 THD / varlen -----------------------------------------------------
+
+
+@pytest.mark.L0
+@_skip_d512_on_rubin
+@pytest.mark.parametrize("in_key", _INS)
+@pytest.mark.parametrize("causal", [False, True])
+@torch_fork_set_rng(seed=0)
+def test_fp8_d512_thd(in_key, causal):
+    """THD/varlen self-attention on d512: two packed sequences of unequal,
+    tile-ragged length."""
+    out, o_ref, a_o, a_o_ref, _, _ = _run_thd([200, 150], [200, 150], 8, 8, in_key, scale=_D512_SCALE, causal=causal, d=_D512)
+    _check(out, o_ref, torch.float16, in_key, a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@_skip_d512_on_rubin
+@torch_fork_set_rng(seed=0)
+def test_fp8_d512_thd_cross_gqa():
+    """THD cross-attention on d512: unequal per-sequence Q and KV lengths with
+    unequal packed totals, under GQA."""
+    out, o_ref, a_o, a_o_ref, _, _ = _run_thd([64, 200], [256, 128], 8, 2, "e4m3", scale=_D512_SCALE, d=_D512)
+    _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@_skip_d512_on_rubin
+@torch_fork_set_rng(seed=0)
+def test_fp8_d512_thd_sink_stats():
+    """THD + sink + ragged Stats on d512 (packed token-major TH1 layout)."""
+    sink = torch.randn(1, 8, 1, 1, device="cuda", dtype=torch.float32)
+    out, o_ref, a_o, a_o_ref, lse, lse_ref = _run_thd([200, 150], [200, 150], 8, 8, "e4m3", scale=_D512_SCALE, causal=True, sink=sink, stats=True, d=_D512)
+    _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
+    diff = (lse.float() - lse_ref).abs().max().item()
+    assert diff <= 5e-2, f"max|LSE-ref| = {diff:.4f}"
+
+
+@pytest.mark.L0
+@_skip_d512_on_rubin
+@torch_fork_set_rng(seed=0)
+def test_fp8_d512_thd_zero_len_kv():
+    """THD on d512 with a zero-length KV sequence: those Q rows are dead
+    (O := 0, LSE := -inf) and must not poison amax_o."""
+    out, o_ref, a_o, a_o_ref, lse, lse_ref = _run_thd([126, 40, 60], [0, 83, 77], 8, 8, "e4m3", scale=_D512_SCALE, stats=True, d=_D512)
+    _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
+    assert torch.equal(lse[:126], torch.full_like(lse[:126], float("-inf"))), "dead rows must report LSE = -inf"
+
+
+@pytest.mark.L0
+@_skip_d512_on_rubin
+@torch_fork_set_rng(seed=0)
+def test_fp8_d512_thd_cu_seq_len():
+    """THD on d512 via the cu_seq_len prefix-sum length form."""
+    out, o_ref, a_o, a_o_ref, _, _ = _run_thd([200, 150], [180, 120], 8, 8, "e4m3", scale=_D512_SCALE, cu_lens=True, d=_D512)
+    _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@_skip_d512_on_rubin
+@pytest.mark.parametrize(
+    ("d_qk", "d_v"),
+    [(384, 448), (464, 368), (272, 272), (512, 496)],
+    ids=["d384_d448", "d464_d368", "d272", "d512_d496"],
+)
+@pytest.mark.parametrize("mask", ["none", "causal"])
+@torch_fork_set_rng(seed=0)
+def test_fp8_d512_head_dim_envelope(d_qk, d_v, mask):
+    """The d512 flavor serves the (256, 512] head-dim band, d_qk != d_v included.
+
+    ENVELOPE semantics: the TMA descriptors carry the ACTUAL extents while the
+    tile box stays the compile-time 512 geometry, so Q/K loads past d_qk and V
+    loads past d_v hardware zero-fill (exact zero terms in QK^T and P.V, so S,
+    the softmax and O are bit-identical to the unpadded problem) and O stores
+    past d_v are OOB-clipped.  d % 16 at 1 byte/elem is the TMA 16-byte
+    global-stride rule.
+    """
+    out, o_ref, a_o, a_o_ref = _run(1, 4, 4, 256, 256, "e4m3", torch.float16, scale=1.0 / math.sqrt(d_qk), sdpa_kwargs=_MASKS[mask], d_qk=d_qk, d_v=d_v)
+    _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@_skip_d512_on_rubin
+def test_fp8_d512_envelope_floor_declines_below_256():
+    """Below the d512 floor the adapter declines instead of routing a much
+    smaller graph onto a kernel tuned for d = 512 (there is no d256 FP8
+    kernel, so d256 has no home -- that is the honest answer, not a 2x-padded
+    d512 launch).  Straddling the floor is declined too."""
+    from cudnn.sdpa.fwd.api_dsl import _fp8_envelope_covers, _sm100_fp8_shapes
+
+    shapes = _sm100_fp8_shapes(pertensor=True, device_cc=(10, 0))
+    for d_qk, d_v in [(384, 448), (464, 368), (272, 272), (512, 512)]:
+        assert _fp8_envelope_covers(d_qk, d_v, shapes), (d_qk, d_v)
+    for d_qk, d_v in [(256, 256), (160, 160), (384, 128), (512, 256)]:
+        assert not _fp8_envelope_covers(d_qk, d_v, shapes), (d_qk, d_v)
+
+
+@pytest.mark.L0
+def test_fp8_envelope_floor_matches_engine_row():
+    """The adapter's floor table and the engine row's must agree: the row
+    decides eligibility, the adapter picks the flavor, and a drift between them
+    is a plan that enters the ranked list only to die in the lowering."""
+    from cudnn.sdpa.fwd import engines
+    from cudnn.sdpa.fwd.api_dsl import _SM100_FP8_ENVELOPE_FLOORS
+
+    row = {s.name: s.capabilities for s in engines.ENGINE_SPECS}[engines.engine_name(fp8=True)]
+    assert dict(row.d_envelope_floors) == _SM100_FP8_ENVELOPE_FLOORS
+
+
+@pytest.mark.L0
+@_skip_d512_on_rubin
+def test_fp8_d512_mxfp8_declines():
+    """There is no d512 block-scale kernel: an MXFP8 d512 graph must be
+    rejected up front, not fail late in the lowering."""
+    from cudnn.sdpa.fwd.api_dsl import _sm100_fp8_shapes
+
+    assert (512, 512) in _sm100_fp8_shapes(pertensor=True, device_cc=(10, 0))
+    assert (512, 512) not in _sm100_fp8_shapes(pertensor=False, device_cc=(10, 0))
+    assert (512, 512) not in _sm100_fp8_shapes(pertensor=True, device_cc=(10, 7))

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -1208,11 +1208,22 @@ def test_fp8_d512_thd_sink_stats():
 @_skip_d512_on_rubin
 @torch_fork_set_rng(seed=0)
 def test_fp8_d512_thd_zero_len_kv():
-    """THD on d512 with a zero-length KV sequence: those Q rows are dead
-    (O := 0, LSE := -inf) and must not poison amax_o."""
+    """Zero-length KV and Q sequences on d512 (the d128 sibling's shapes).
+
+    The zero-KV sequence's rows are dead: the epilogue must return O := 0 /
+    LSE := -inf rather than the unwritten O TMEM, and those rows must not
+    poison amax_o -- which, on this flavor, is what the single select on the
+    row's scalar amax result guards.
+    """
     out, o_ref, a_o, a_o_ref, lse, lse_ref = _run_thd([126, 40, 60], [0, 83, 77], 8, 8, "e4m3", scale=_D512_SCALE, stats=True, d=_D512)
     _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
+    # The whole ragged Stats buffer, live rows included -- not just the dead
+    # ones, or a wrong-but-finite LSE on the live sequences would pass.
+    torch.testing.assert_close(lse, lse_ref, atol=2e-2, rtol=2e-2, equal_nan=False)
     assert torch.equal(lse[:126], torch.full_like(lse[:126], float("-inf"))), "dead rows must report LSE = -inf"
+    # ... and a zero-length Q sequence, which contributes no tile at all.
+    out, o_ref, a_o, a_o_ref, _, _ = _run_thd([126, 0, 60], [0, 83, 77], 8, 8, "e5m2", scale=_D512_SCALE, d=_D512)
+    _check(out, o_ref, torch.float16, "e5m2", a_o, a_o_ref)
 
 
 @pytest.mark.L0


### PR DESCRIPTION
## What

Adds `prefill_d512_fp8_sm100.py` — the per-tensor FP8 (E4M3/E5M2) sibling of the d512 f16 kernel — and routes the SM100 per-tensor FP8 engine to it. Same cga4×1 role-split pipeline, Q∪K_ring SMEM alias, UTCCP(Q → TMEM) + `mma_ts` BMM1, and THD leg as the f16 flavor.

Head-dim coverage: the flavor serves **(256, 512] on both head dims** — the band no smaller FP8 flavor reaches — through the usual TMA zero-padding envelope, so `d_qk != d_v` is served too.

## Kernel deltas (all CFG-derived, no literals)

| | why |
|---|---|
| `STAGES_KV = XFER_STAGES = 3` | BPE=1 halves the K/V ring; FP8 packs 4 elements per 4-byte TMEM column, so the UTCCP'd Q costs 128 cols instead of 256 and a third S_acc parity fits: `3*128 + 128 = 512`, exactly at the Blackwell TMEM cap |
| `MMA_KIND = F8F6F4`, `TILE_K_HW = 32`, idesc `k_dim = 0` | the Blackwell K=32 QMMA step. Both `k_dim`s derive from `CFG.TILE_K_HW_*` so they cannot drift into the Rubin `k_dim=1` combination, which is **silently wrong** here (per-row scrambled accumulator, no crash) |
| `P_XFER_HALVES = (TILE_N*BPE)//Q_SWZ_BYTES` → 1 | a 128-column FP8 P row is a single swizzle atom, so the sg0→sg1 KV-split degenerates to one whole-P chunk; the BMM2 K-half unroll becomes a loop over it |
| Q∪O alias sized in **bytes**, `sO` viewed as `OUT_STORAGE_DTYPE` | an element-sized alias under-allocates at `BPE_O = 2` (FP8 in, BF16/FP16 out) and the wider O store overflows into the P-transfer ring |
| descales read from **device** | `descale_q*descale_k` → `scale_softmax_log2`, `descale_v*scale_o` → `o_scale_fused` → folded into `beta`. No host readback |
| THD via `build_thd_meta_o_kv_descs_kernel` | K/V load through packed-total-clamped runtime descriptors: the last sequence's tile steps past the packed total into the caller's capacity tail, and a NaN there would wipe the tile through BMM2's `P·V` (masking zeroes P, not V) |

`Amax_O` is an atomicMax over the fp32 pre-cast output, reduced with a **ternary tree** (`_abs_max_tree`). The obvious running `acc = max(acc, |e|)` builds a `TILE_O`-deep dependency chain on the epilogue's critical path and cost ~7% of kernel time at S=8192. A fully-masked row needs no per-element sanitizing — its O TMEM is written by the MMA with a zero P — so one select on the row's scalar result covers the dead-row case.

## Framework changes

- **`Capabilities.d_envelope_floors`** (new row data): a per-native-shape envelope floor. Without it the d512 shape would act as a plain upper bound and swallow e.g. a d256 graph at 2× zero-padding. The FP8 row floors d512 at 256; `api_dsl` mirrors the table and a test pins the two together.
- **`api_dsl._pick_flavor`** now takes a candidate set, so an FP8 graph can no longer land on the d256 flavor, which has no FP8 kernel.
- **`sdpa_support_surface.h`**: the graph-level surface rejected `d_qk > 128` for `sdpa_fp8` before any engine was consulted; it now admits the same (256, 512] band, mirroring the existing d192/d128 exception.

## Not in scope

Split-KV (needs a half-precision O and its own combine-side amax) and MXFP8 (there is no d512 block-scale kernel). Both stay pinned to `{(128, 128)}` via `split_d_shapes` / the MXFP8 row.

## Test

Blackwell (cc10.0). 34 new cases in `test_sdpa_fwd_fp8_sm100.py`: masks, all 8 in×out dtype pairs, sink, GQA/MQA, per-batch KV padding, LSE, multi-wave, the (256, 512] envelope band (`384×448`, `464×368`, `272`, `512×496`), and THD (self/cross attention, GQA, sink + ragged stats, zero-length KV, `cu_seq_len` form). Accept **and** reject coverage for the new floor in `test_sdpa_fp8_sm107.py`.

Full `sdpa/frost/` suite: **1003 passed**. The three `*_strided_stats` failures on that node pre-date this branch — they need a cuDNN backend ≥ 9.26 and the node has 9.25.1 (verified: they fail identically on the pre-change `.so`).

## Perf

Kernel-only GPU time (nsys, B=1 H=8 S=8192 d=512 dense E4M3): **530.8 µs** vs **521.4 µs** for the pre-upstream kernel this was ported from — **+1.8%**, which is the in-kernel `Amax_O` that kernel does not compute.

> **Note for reviewers:** this changes a header, so the pybind extension needs rebuilding. In-tree `pip install -e .` fails on boxes where `/usr/bin/cmake` is 3.22 (repo needs ≥ 3.23) — configure out-of-tree with a ≥3.23 cmake and copy the `.so` into `python/cudnn/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded FP8 scaled dot-product attention support on SM100+ devices for head dimensions from 256 through 512 when aligned to multiples of 16.
  * Added support for FP8 d512 configurations, including dense and variable-length inputs.
  * Added support for masks, output types, grouped-query attention, padding, statistics, and multi-tile execution with d512.

* **Bug Fixes**
  * Improved validation to reject unsupported dimensions and prevent invalid kernel selection.
  * Preserved existing MXFP8 limitations and device-specific support boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->