### PR TITLE
benchmark(sdpa): drop the unused Amax_S output from the FP8 graphs

### DIFF
--- a/benchmark/attention_training/benchmark_single_sdpa.py
+++ b/benchmark/attention_training/benchmark_single_sdpa.py
@@ -693,7 +693,6 @@ else:
             scale_dK_gpu = torch.ones(1, 1, 1, 1, dtype=torch.float, device=device)
             scale_dV_gpu = torch.ones(1, 1, 1, 1, dtype=torch.float, device=device)
             scale_dP_gpu = torch.ones(1, 1, 1, 1, dtype=torch.float, device=device)
-            amax_s_gpu = torch.zeros(1, 1, 1, 1, dtype=torch.float, device=device)
             amax_o_gpu = torch.zeros(1, 1, 1, 1, dtype=torch.float, device=device)
             amax_dQ_gpu = torch.zeros(1, 1, 1, 1, dtype=torch.float, device=device)
             amax_dK_gpu = torch.zeros(1, 1, 1, 1, dtype=torch.float, device=device)
@@ -772,7 +771,11 @@ else:
             scale_s_fwd = graph_fwd.tensor_like(scale_s_gpu)
             scale_o_fwd = graph_fwd.tensor_like(scale_o_gpu)
 
-            o_fwd, stats_fwd, amax_s_fwd, amax_o_fwd = graph_fwd.sdpa_fp8(
+            # Amax_S is returned unconditionally but never requested: it only becomes a
+            # real graph output if set_output(True) is called on it, and nothing here
+            # consumes it. Leaving it virtual also keeps the graph servable by engines
+            # that do not produce Amax_S.
+            o_fwd, stats_fwd, _amax_s_unused, amax_o_fwd = graph_fwd.sdpa_fp8(
                 q=q_fwd,
                 k=k_fwd,
                 v=v_fwd,
@@ -871,7 +874,6 @@ else:
                 (stats_fwd.set_output(True).set_dim(stats.size()).set_stride(stats.stride()).set_data_type(cudnn.data_type.FLOAT) if not is_infer else None)
 
         if args.data_type == "fp8":
-            amax_s_fwd.set_output(True).set_dim(amax_s_gpu.size()).set_stride(amax_s_gpu.stride()).set_data_type(cudnn.data_type.FLOAT)
             amax_o_fwd.set_output(True).set_dim(amax_o_gpu.size()).set_stride(amax_o_gpu.stride()).set_data_type(cudnn.data_type.FLOAT)
         elif args.data_type == "mxfp8":
             amax_o_fwd.set_output(True).set_dim(amax_o_gpu.size()).set_stride(amax_o_gpu.stride()).set_data_type(cudnn.data_type.FLOAT)
@@ -1175,7 +1177,6 @@ else:
                     descale_s_fwd: descale_s_gpu,
                     scale_s_fwd: scale_s_gpu,
                     scale_o_fwd: scale_o_gpu,
-                    amax_s_fwd: amax_s_gpu,
                     amax_o_fwd: amax_o_gpu,
                 }
 
@@ -1301,7 +1302,6 @@ else:
                     descale_s_fwd: descale_s_gpu,
                     scale_s_fwd: scale_s_gpu,
                     scale_o_fwd: scale_o_gpu,
-                    amax_s_fwd: amax_s_gpu,
                     amax_o_fwd: amax_o_gpu,
                 }
                 workspace = torch.empty(graph_fwd.get_workspace_size(), device="cuda", dtype=torch.uint8)
@@ -1583,7 +1583,6 @@ else:
             scale_dK_gpu = torch.ones(1, 1, 1, 1, dtype=torch.float, device=device)
             scale_dV_gpu = torch.ones(1, 1, 1, 1, dtype=torch.float, device=device)
             scale_dP_gpu = torch.ones(1, 1, 1, 1, dtype=torch.float, device=device)
-            amax_s_gpu = torch.zeros(1, 1, 1, 1, dtype=torch.float, device=device)
             amax_o_gpu = torch.zeros(1, 1, 1, 1, dtype=torch.float, device=device)
             amax_dQ_gpu = torch.zeros(1, 1, 1, 1, dtype=torch.float, device=device)
             amax_dK_gpu = torch.zeros(1, 1, 1, 1, dtype=torch.float, device=device)
@@ -1625,7 +1624,6 @@ else:
                         descale_s_fwd: descale_s_gpu,
                         scale_s_fwd: scale_s_gpu,
                         scale_o_fwd: scale_o_gpu,
-                        amax_s_fwd: amax_s_gpu,
                         amax_o_fwd: amax_o_gpu,
                     }
                     variant_pack_bwd = {
@@ -1737,7 +1735,6 @@ else:
                         descale_s_fwd: descale_s_gpu,
                         scale_s_fwd: scale_s_gpu,
                         scale_o_fwd: scale_o_gpu,
-                        amax_s_fwd: amax_s_gpu,
                         amax_o_fwd: amax_o_gpu,
                     }
                 elif args.data_type == "mxfp8":


### PR DESCRIPTION
## What

`sdpa_fp8()` returns the `Amax_S` port unconditionally, and the benchmark called `set_output(True)` on it, making it a real graph output. **Nothing ever read `amax_s_gpu` back**, so the only effects were a stream-ordered zero-fill per execute and whatever work the backend does to produce the value.

It also made every FP8 case unrunnable on `--sdpa_backend cudnn_oss`. The FROST engines dropped `Amax_S` in #602 and `engines.mismatch()` declines any graph that declares one:

```python
if facts.amax_s_t is not None:
    return "graph requests the Amax_S output, which the FROST engines do not produce"
```

so `pin_frost_engine_or_skip(..., required=True)` found no eligible plan and the case exited `UNSUPPORTED_CONFIG` — for every head dim, on SM100, SM107 and SM120 alike.

This stops requesting it: the port is left virtual (exactly what the FP8 suites already do — `test/python/sdpa/fp8.py`, `test_sdpa_fwd_fp8_sm100.py`, `test_sdpa_fwd_fp8_sm120.py` all unpack it as `_amax_s_unused`), and the now-dead `amax_s_gpu` buffer plus its four fwd variant-pack bindings go with it. Net −8/+5, no new flags.

## Testing

`black --line-length 160 --fast` clean (26.3.1, the pinned `rev`).

Measured on SM100 (cc 10.0), `--profile_pass fwd --num_iterations 25`, B1 H8 S4096 d128 unless noted:

| Case | Backend | Before | After |
|---|---|---|---|
| FP8 | `cudnn_oss` | `UNSUPPORTED_CONFIG` | **1097 TFLOPS**, pins `sdpa_fwd_prefill_sm100_fp8` |
| FP8 | `cudnn` | 1442 TFLOPS | 1440 TFLOPS |
| FP8, `--profile_pass bwd` | `cudnn` | — | 1240 TFLOPS (covers the `run_bwd` variant packs) |
| MXFP8 | `cudnn_oss` | — | 915 TFLOPS (never declared Amax_S; guard against collateral damage) |
| BF16 | `cudnn` | — | 1289 TFLOPS (non-quantized path untouched) |

The native `cudnn` FP8 number is unchanged within run-to-run noise, so dropping the output costs nothing on the backend that was producing it.

Also verified against the d512 FP8 engine of #845 (that kernel plus this patch, B1 H128 S8192 d512): `cudnn_oss` pins the FROST engine and runs at **2122 TFLOPS**, versus `UNSUPPORTED_CONFIG` before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Streamlined FP8 attention benchmark execution by removing unnecessary output handling.
  - Reduced forward-pass setup and per-iteration data packaging overhead.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->