### PR TITLE
Thd persistent grid

### DIFF
--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -1681,7 +1681,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             o_desc = carver.take(o_desc_slots * 16, torch.int64) if carver is not None else torch.empty(o_desc_slots * 16, dtype=torch.int64, device=dev)
         # The PLAN-TIME envelope grid — dead units exit by kernel contract.
         # PERSISTENT THD grid: cap the launch at what the device can hold
-        # resident (one cluster per CTA_MMA SMs) instead of the plan-time
+        # resident (one cluster per CGA_SIZE SMs) instead of the plan-time
         # envelope. The kernel pulls units from a device-bounded counter, so
         # the grid no longer has to cover the work list -- which is what made
         # 38-84% of clusters dead.
@@ -1689,8 +1689,15 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         if getattr(self._k_mod, "THD_PERSISTENT", False):
             # Resolved here, not above: the CLC path below never reads it, and
             # this runs per execute.
-            _cta_mma = int(getattr(self._k_mod, "CTA_MMA", 1))
-            units = min(_env, max(1, _device_sm_count(q_buf.device) // max(1, _cta_mma)))
+            #
+            # CGA_SIZE (= CGA_M * CGA_N) is the CTA count of ONE cluster, which
+            # is what the grid is laid out in: grid_x = units * CGA_M. It equals
+            # CTA_MMA on the cga2 flavors (d128/d192/d256) but NOT on d512,
+            # which pairs CGA_M=4 with CTA_MMA=2 — capping on CTA_MMA there
+            # would launch 2x the CTAs the device holds resident. CTA_MMA stays
+            # as the fallback so a module predating CGA_SIZE still caps.
+            _cluster_ctas = int(getattr(self._k_mod, "CGA_SIZE", 0) or getattr(self._k_mod, "CTA_MMA", 1))
+            units = min(_env, max(1, _device_sm_count(q_buf.device) // max(1, _cluster_ctas)))
             _dbg = int(os.environ.get("FROST_THD_CLUSTERS", "0"))  # debug override
             if _dbg > 0:
                 units = min(_env, _dbg)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
@@ -27,8 +27,9 @@ used by the f16 kernels — FP8 is element-addressed (no block-scale SF), so it
 rides the same path: packed ``[1,T,H,D]`` with DYNAMIC token extents (the
 packed totals never reach the host), the setup kernel builds the
 [kv|cu_q|cu_k] metadata + per-batch O TMA descriptors device-side, and the
-launch grid is the plan-time envelope (units past a sequence's live tiles
-decode the batch == n_batch sentinel and drain without loads or stores).
+launch grid is sized to the MACHINE and bounded by a device-read live unit
+count (issue #618; units past that total decode the batch == n_batch sentinel
+and drain without loads or stores).
 Ragged Stats ride the caller's declared layout (token-major (T, H) or
 head-major); the amax_o atomicMax is gated on live rows. Dense path
 byte-identical.
@@ -85,6 +86,7 @@ from cudnn.frost.tile_dsl.barrier import (
 from cudnn.frost.tile_dsl.scheduler import (
     Sched,
     scheduler_warp_loop,
+    scheduler_warp_loop_persistent,
     read_tile_id_arrive,
     SCHED_NATURAL,
     SCHED_LPT,
@@ -185,6 +187,10 @@ vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
 
 
 CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+# THD uses a persistent grid + device-bounded claim counter (not the CLC
+# envelope). The adapter caps the launch at min(envelope, SMs / CGA_SIZE)
+# and the setup kernel publishes the live unit total it stops at.
+THD_PERSISTENT = True
 
 
 # SM100 llama is always cga2 → LPT reverse-row count in CGA-tile units.
@@ -204,9 +210,10 @@ _resolve_seqlen_q = _sdpa_h.resolve_seqlen_q
 #   [3B+2..4B+1]=batch_remap(B)  [4B+2]=live units  [4B+3]=claim counter
 # The decode walks batch_remap on EVERY THD flavor, so the setup kernel must
 # fill it; the trailing two words are read only by the persistent schedulers.
-# The setup kernel builds it DEVICE-side from the caller's length tensors and
-# the adapter launches the plan-time envelope grid (issue #552) — no length
-# ever reaches the host.
+# The setup kernel builds it DEVICE-side from the caller's length tensors
+# (issue #552) — no length ever reaches the host — and publishes the live unit
+# total + claim counter, so the adapter launches a MACHINE-sized grid rather
+# than the plan-time envelope (issue #618).
 from cudnn.sdpa.fwd.kernels.thd_sm100 import build_thd_meta_o_kv_descs_kernel as _build_thd_meta_o_kv_descs_kernel, TENSOR_MAP_QWORDS
 
 _TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
@@ -606,7 +613,24 @@ def _kernel(
         nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
         # try_cancel.multicast::cluster::all — only CGA's (0,0,0) CTA issues.
         is_cga_first_cta = cta_id_x == cutlass.Int32(0)
-        scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
+        if cutlass.const_expr(CFG.THD_VARLEN):
+            # THD: persistent grid + device-bounded claim counter, so no unit
+            # past the live total is ever handed out (the CLC path would need
+            # the grid to BE the work list, i.e. the plan-time envelope).
+            # n_batch is a kernel argument -- do NOT re-derive it from the
+            # metadata tensor's layout.
+            scheduler_warp_loop_persistent(
+                sched,
+                CFG.SCHEDULER_STAGES,
+                is_cga_first_cta,
+                seq_kv_lens_tensor,
+                cutlass.Int32(4) * n_batch + cutlass.Int32(3),
+                cutlass.Int32(4) * n_batch + cutlass.Int32(2),
+                CGA_SIZE,
+                CFG.CGA_M,
+            )
+        else:
+            scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
 
 
 # === TMA-LDG warp ===
@@ -2160,10 +2184,14 @@ def _host(
         # DEVICE-side from the caller's length tensors (no host cumsum, no
         # H2D — issue #552), then the per-batch O descriptor array (reuse
         # tma_o_desc over the packed [1,T,QH,D_v] O as base). Main grid: the
-        # PLAN-TIME ENVELOPE (n_thd_units = B * ceil(S_q_decl/CGA_TILE_M) * QH,
-        # from the DECLARED S_q — no runtime length reaches the host); units
-        # past a sequence's live tiles decode the batch == n_batch sentinel
-        # and drain without loads or stores. grid_x = n_thd_units * CGA_M.
+        # PERSISTENT cluster count — the adapter hands down n_thd_units
+        # already capped to what the device holds resident, min(plan-time
+        # envelope, SMs / CGA_SIZE), NOT the envelope itself (issue #618). It
+        # doubles as the claim counter's seed: cluster c runs unit c off its
+        # blockIdx, then pulls from the counter, so the grid and the seed must
+        # be the same number. Dispatching past the live total stays safe — such
+        # a unit decodes the batch == n_batch sentinel and drains without loads
+        # or stores. grid_x = n_thd_units * CGA_M.
         # Per-token element stride of packed O (o_tensor.stride[1] = QH * d_v)
         # — NOT CFG.TILE_O, which is only coincidentally right at QH == 1.
         # The FP8 setup variant also clamps runtime K/V descriptors to the
@@ -2183,6 +2211,8 @@ def _host(
             cutlass.Int32(QH // HEADS_PER_TILE),
             cutlass.Int32(B),
             cutlass.Int32(o_tensor.stride[1]),
+            cutlass.Int32(CGA_TILE_M),
+            n_thd_units,
         ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
         grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
     else:

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
@@ -40,8 +40,9 @@ used by the f16 kernels — FP8 is element-addressed (no block-scale SF), so it
 rides the same path: packed ``[1,T,H,D]`` with DYNAMIC token extents (the
 packed totals never reach the host), the setup kernel builds the
 [kv|cu_q|cu_k] metadata + per-batch O TMA descriptors device-side, and the
-launch grid is the plan-time envelope (units past a sequence's live tiles
-decode the batch == n_batch sentinel and drain without loads or stores).
+launch grid is sized to the MACHINE and bounded by a device-read live unit
+count (issue #618; units past that total decode the batch == n_batch sentinel
+and drain without loads or stores).
 Ragged Stats ride the caller's declared layout (token-major (T, H) or
 head-major); the amax_o atomicMax is gated on live rows. Dense path
 byte-identical. Hunk-symmetric with prefill_d128_fp8_sm100.py.
@@ -122,6 +123,7 @@ from cudnn.frost.tile_dsl.barrier import (
 from cudnn.frost.tile_dsl.scheduler import (
     Sched,
     scheduler_warp_loop,
+    scheduler_warp_loop_persistent,
     read_tile_id_arrive,
     SCHED_NATURAL,
     SCHED_LPT,
@@ -224,6 +226,10 @@ vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
 
 
 CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+# THD uses a persistent grid + device-bounded claim counter (not the CLC
+# envelope). The adapter caps the launch at min(envelope, SMs / CGA_SIZE)
+# and the setup kernel publishes the live unit total it stops at.
+THD_PERSISTENT = True
 
 
 # SM100 llama is always cga2 → LPT reverse-row count in CGA-tile units.
@@ -243,9 +249,10 @@ _resolve_seqlen_q = _sdpa_h.resolve_seqlen_q
 #   [3B+2..4B+1]=batch_remap(B)  [4B+2]=live units  [4B+3]=claim counter
 # The decode walks batch_remap on EVERY THD flavor, so the setup kernel must
 # fill it; the trailing two words are read only by the persistent schedulers.
-# The setup kernel builds it DEVICE-side from the caller's length tensors and
-# the adapter launches the plan-time envelope grid (issue #552) — no length
-# ever reaches the host.
+# The setup kernel builds it DEVICE-side from the caller's length tensors
+# (issue #552) — no length ever reaches the host — and publishes the live unit
+# total + claim counter, so the adapter launches a MACHINE-sized grid rather
+# than the plan-time envelope (issue #618).
 from cudnn.sdpa.fwd.kernels.thd_sm100 import build_thd_meta_o_kv_descs_kernel as _build_thd_meta_o_kv_descs_kernel, TENSOR_MAP_QWORDS
 
 _TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
@@ -690,7 +697,24 @@ def _kernel(
         nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
         # try_cancel.multicast::cluster::all — only CGA's (0,0,0) CTA issues.
         is_cga_first_cta = cta_id_x == cutlass.Int32(0)
-        scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
+        if cutlass.const_expr(CFG.THD_VARLEN):
+            # THD: persistent grid + device-bounded claim counter, so no unit
+            # past the live total is ever handed out (the CLC path would need
+            # the grid to BE the work list, i.e. the plan-time envelope).
+            # n_batch is a kernel argument -- do NOT re-derive it from the
+            # metadata tensor's layout.
+            scheduler_warp_loop_persistent(
+                sched,
+                CFG.SCHEDULER_STAGES,
+                is_cga_first_cta,
+                seq_kv_lens_tensor,
+                cutlass.Int32(4) * n_batch + cutlass.Int32(3),
+                cutlass.Int32(4) * n_batch + cutlass.Int32(2),
+                CGA_SIZE,
+                CFG.CGA_M,
+            )
+        else:
+            scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
 
 
 # === TMA-LDG warp ===
@@ -2345,10 +2369,14 @@ def _host(
         # DEVICE-side from the caller's length tensors (no host cumsum, no
         # H2D — issue #552), then the per-batch O descriptor array (reuse
         # tma_o_desc over the packed [1,T,QH,D_v] O as base). Main grid: the
-        # PLAN-TIME ENVELOPE (n_thd_units = B * ceil(S_q_decl/CGA_TILE_M) * QH,
-        # from the DECLARED S_q — no runtime length reaches the host); units
-        # past a sequence's live tiles decode the batch == n_batch sentinel
-        # and drain without loads or stores. grid_x = n_thd_units * CGA_M.
+        # PERSISTENT cluster count — the adapter hands down n_thd_units
+        # already capped to what the device holds resident, min(plan-time
+        # envelope, SMs / CGA_SIZE), NOT the envelope itself (issue #618). It
+        # doubles as the claim counter's seed: cluster c runs unit c off its
+        # blockIdx, then pulls from the counter, so the grid and the seed must
+        # be the same number. Dispatching past the live total stays safe — such
+        # a unit decodes the batch == n_batch sentinel and drains without loads
+        # or stores. grid_x = n_thd_units * CGA_M.
         # Per-token element stride of packed O (o_tensor.stride[1] = QH * d_v)
         # — NOT CFG.TILE_O, which is only coincidentally right at QH == 1.
         # The FP8 setup variant also clamps runtime K/V descriptors to the
@@ -2368,6 +2396,8 @@ def _host(
             cutlass.Int32(QH // HEADS_PER_TILE),
             cutlass.Int32(B),
             cutlass.Int32(o_tensor.stride[1]),
+            cutlass.Int32(CGA_TILE_M),
+            n_thd_units,
         ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
         grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
     else:

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
@@ -58,8 +58,9 @@ FUSED_LDTM_STAT = int(PARAMS.fused_ldtm_stat)
 # plan-time-envelope design (write_thd_meta, issue #552 / PRs #606, #608) used
 # by the f16 kernels: packed [1,T,H,D] Q/K/V/O with DYNAMIC token extents, the
 # setup kernel builds the [kv|cu_q|cu_k] metadata + per-batch O TMA descriptors
-# device-side, and the launch grid is the plan-time envelope (dead units decode
-# the batch == n_batch sentinel and drain).  MXFP8-only addition: the SF
+# device-side, and the launch grid is machine-sized under a device-read live
+# unit bound (issue #618; dead units decode the batch == n_batch sentinel and
+# drain).  MXFP8-only addition: the SF
 # tensors travel PACKED per-sequence-TILE-padded (the shared MXFP8 quantizer
 # writes SF tiles at cu_sf[b] + local_tile; this kernel reads them with the
 # matching tile base from _thd_sf_tile_bases) as [1, H, Σ_b ceil(S_b/TILE),
@@ -87,6 +88,7 @@ from cudnn.frost.tile_dsl.barrier import (
 from cudnn.frost.tile_dsl.scheduler import (
     Sched,
     scheduler_warp_loop,
+    scheduler_warp_loop_persistent,
     read_tile_id_arrive,
     SCHED_NATURAL,
     SCHED_LPT,
@@ -230,6 +232,10 @@ kTmaTransactionBytes = kBufferElems * CFG.BPE * CFG.CTA_MMA
 vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
 
 CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+# THD uses a persistent grid + device-bounded claim counter (not the CLC
+# envelope). The adapter caps the launch at min(envelope, SMs / CGA_SIZE)
+# and the setup kernel publishes the live unit total it stops at.
+THD_PERSISTENT = True
 
 
 # SM100 is always cga2 → LPT reverse-row count in CGA-tile units.
@@ -783,7 +789,24 @@ def _kernel(
     else:  # warp_idx == CFG.SCHED_WARP_ID
         nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
         is_cga_first_cta = cta_id_x == cutlass.Int32(0)
-        scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
+        if cutlass.const_expr(CFG.THD_VARLEN):
+            # THD: persistent grid + device-bounded claim counter, so no unit
+            # past the live total is ever handed out (the CLC path would need
+            # the grid to BE the work list, i.e. the plan-time envelope).
+            # n_batch is a kernel argument -- do NOT re-derive it from the
+            # metadata tensor's layout.
+            scheduler_warp_loop_persistent(
+                sched,
+                CFG.SCHEDULER_STAGES,
+                is_cga_first_cta,
+                seq_kv_lens_tensor,
+                cutlass.Int32(4) * n_batch + cutlass.Int32(3),
+                cutlass.Int32(4) * n_batch + cutlass.Int32(2),
+                CGA_SIZE,
+                CFG.CGA_M,
+            )
+        else:
+            scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
 
 
 # === Warp-group functions ===
@@ -2555,10 +2578,14 @@ def _host(
         # DEVICE-side from the caller's length tensors (no host cumsum, no
         # H2D — issue #552), then the per-batch O descriptor array (reuse
         # tma_o_desc over the packed [1,T,QH,D_v] O as base). Main grid: the
-        # PLAN-TIME ENVELOPE (n_thd_units = B * ceil(S_q_decl/CGA_TILE_M) * QH,
-        # from the DECLARED S_q — no runtime length reaches the host); units
-        # past a sequence's live tiles decode the batch == n_batch sentinel
-        # and drain without loads or stores. grid_x = n_thd_units * CGA_M.
+        # PERSISTENT cluster count — the adapter hands down n_thd_units
+        # already capped to what the device holds resident, min(plan-time
+        # envelope, SMs / CGA_SIZE), NOT the envelope itself (issue #618). It
+        # doubles as the claim counter's seed: cluster c runs unit c off its
+        # blockIdx, then pulls from the counter, so the grid and the seed must
+        # be the same number. Dispatching past the live total stays safe — such
+        # a unit decodes the batch == n_batch sentinel and drains without loads
+        # or stores. grid_x = n_thd_units * CGA_M.
         # Per-token element stride of packed O (o_tensor.stride[1] = QH * d_v)
         # — NOT CFG.TILE_O, which is only coincidentally right at QH == 1.
         # The FP8-family setup variant also clamps runtime K/V descriptors to
@@ -2578,6 +2605,8 @@ def _host(
             cutlass.Int32(QH),
             cutlass.Int32(B),
             cutlass.Int32(o_tensor.stride[1]),
+            cutlass.Int32(CGA_TILE_M),
+            n_thd_units,
         ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
         grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
     else:

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm100.py
@@ -82,6 +82,7 @@ from cudnn.frost.tile_dsl.barrier import (
 from cudnn.frost.tile_dsl.scheduler import (
     Sched,
     scheduler_warp_loop,
+    scheduler_warp_loop_persistent,
     read_tile_id_arrive,
     SCHED_NATURAL,
 )
@@ -168,6 +169,10 @@ vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
 
 
 CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+# THD uses a persistent grid + device-bounded claim counter (not the CLC
+# envelope). The adapter caps the launch at min(envelope, SMs / CGA_SIZE)
+# and the setup kernel publishes the live unit total it stops at.
+THD_PERSISTENT = True
 
 
 # This flavor is cga2-only (CTA_MMA=2), so its LPT q-tile accounting in the
@@ -207,8 +212,10 @@ from cudnn.sdpa.fwd.kernels.thd_sm100 import build_thd_meta_o_descs_kernel as _b
 
 _TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
 # The setup kernel builds the THD metadata buffer DEVICE-side from the
-# caller's length tensors and the adapter launches the plan-time envelope
-# grid (issue #552) — no length ever reaches the host.
+# caller's length tensors (issue #552) — no length ever reaches the host — and
+# also publishes the live unit total + claim counter the persistent scheduler
+# reads, so the adapter launches a MACHINE-sized grid rather than the plan-time
+# envelope (issue #618).
 _dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
 _dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
 _thd_tma_offsets = _sdpa_h.thd_tma_offsets
@@ -662,7 +669,24 @@ def _kernel(
         # try_cancel.multicast::cluster::all — only (0,0,0) CTA issues; at cga1
         # cta_id_x == 0 always, so flag is 1 unconditionally.
         is_cga_first_cta = cta_id_x == cutlass.Int32(0)
-        scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
+        if cutlass.const_expr(CFG.THD_VARLEN):
+            # THD: persistent grid + device-bounded claim counter, so no unit
+            # past the live total is ever handed out (the CLC path would need
+            # the grid to BE the work list, i.e. the plan-time envelope).
+            # n_batch is a kernel argument -- do NOT re-derive it from the
+            # metadata tensor's layout.
+            scheduler_warp_loop_persistent(
+                sched,
+                CFG.SCHEDULER_STAGES,
+                is_cga_first_cta,
+                seq_kv_lens_tensor,
+                cutlass.Int32(4) * n_batch + cutlass.Int32(3),
+                cutlass.Int32(4) * n_batch + cutlass.Int32(2),
+                CGA_SIZE,
+                CFG.CGA_M,
+            )
+        else:
+            scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
 
 
 # === TMA-LDG warp ===
@@ -2255,11 +2279,15 @@ def _host(
     if cutlass.const_expr(CFG.THD_VARLEN):
         # THD: build the [kv|cu_q|cu_k] metadata + per-batch O descriptor
         # array DEVICE-side (reuse tma_o_desc over the packed [1,T,QH,D_v] O
-        # as base), then launch the PLAN-TIME ENVELOPE grid (n_thd_units =
-        # B * ceil(S_q_decl/CGA_TILE_M) * QH, from the DECLARED S_q — no
-        # runtime length reaches the host); units past a sequence's live
-        # tiles decode the batch == n_batch sentinel and drain without loads
-        # or stores. grid_x = n_thd_units * CGA_M.  Works at cga1 (CGA_M=1).
+        # as base), then launch the PERSISTENT grid: the adapter hands down
+        # n_thd_units already capped to what the device holds resident,
+        # min(plan-time envelope, SMs / CGA_SIZE), NOT the envelope itself
+        # (issue #618). It doubles as the claim counter's seed: cluster c runs
+        # unit c off its blockIdx, then pulls from the counter, so the grid and
+        # the seed must be the same number. Dispatching past the live total
+        # stays safe — such a unit decodes the batch == n_batch sentinel and
+        # drains without loads or stores. grid_x = n_thd_units * CGA_M.
+        # Works at cga1 (CGA_M=1).
         # ENVELOPE: the packed-O row stride is QH * ACTUAL d_v (o_tensor's
         # static inner extent), not QH * TILE_O — the per-batch descriptor
         # bases must step in real rows or every batch >= 1 lands OOB.
@@ -2275,7 +2303,7 @@ def _host(
             cutlass.Int32(B),
             cutlass.Int32(o_tensor.stride[1]),
             cutlass.Int32(CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA),
-            n_thd_units,  # CLC path: envelope units; the counter goes unused
+            n_thd_units,  # persistent cluster count; also seeds the claim counter
         ).launch(grid=(1, 1, 1), block=(THD_SETUP_THREADS, 1, 1), stream=stream)
         grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
     else:

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm100.py
@@ -45,6 +45,7 @@ from cudnn.frost.tile_dsl.barrier import (
 from cudnn.frost.tile_dsl.scheduler import (
     Sched,
     scheduler_warp_loop,
+    scheduler_warp_loop_persistent,
     read_tile_id_arrive,
     SCHED_NATURAL,
     SCHED_LPT,
@@ -110,6 +111,10 @@ vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
 N_O_CHUNKS = (CFG.TILE_O * CFG.BPE_O + 127) // 128
 
 CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+CTA_MMA = CFG.CTA_MMA
+# THD uses a persistent grid + device-bounded claim counter (not the CLC
+# envelope). The adapter reads both this flag and CTA_MMA to size the launch.
+THD_PERSISTENT = True
 
 _sdpa_h = make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units=True)
 _decode_initial = _sdpa_h.decode_initial
@@ -125,8 +130,12 @@ from cudnn.sdpa.fwd.kernels.thd_sm100 import build_thd_meta_o_descs_kernel as _b
 
 _TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
 # The setup kernel builds the THD metadata buffer DEVICE-side from the
-# caller's length tensors and the adapter launches the plan-time envelope
-# grid (issue #552) — no length ever reaches the host.
+# caller's length tensors (issue #552) — no length ever reaches the host — and
+# also publishes the live unit total + claim counter the persistent scheduler
+# reads, so the adapter launches a MACHINE-sized grid rather than the plan-time
+# envelope (issue #618). Metadata layout, in int32 words:
+#   [0..B-1]=seq_kv_lens  [B..2B]=cu_q(B+1)  [2B+1..3B+1]=cu_k(B+1)
+#   [3B+2..4B+1]=batch_remap(B)  [4B+2]=live units  [4B+3]=claim counter
 _dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
 _dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
 _thd_tma_offsets = _sdpa_h.thd_tma_offsets
@@ -473,7 +482,24 @@ def _kernel(
     else:
         nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
         is_cga_first_cta = cta_id_x == cutlass.Int32(0)
-        scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
+        if cutlass.const_expr(CFG.THD_VARLEN):
+            # THD: persistent grid + device-bounded claim counter, so no unit
+            # past the live total is ever handed out (the CLC path would need
+            # the grid to BE the work list, i.e. the plan-time envelope).
+            # n_batch is a kernel argument -- do NOT re-derive it from the
+            # metadata tensor's layout.
+            scheduler_warp_loop_persistent(
+                sched,
+                CFG.SCHEDULER_STAGES,
+                is_cga_first_cta,
+                seq_kv_lens_tensor,
+                cutlass.Int32(4) * n_batch + cutlass.Int32(3),
+                cutlass.Int32(4) * n_batch + cutlass.Int32(2),
+                CGA_SIZE,
+                CFG.CGA_M,
+            )
+        else:
+            scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
 
 
 @cute.jit
@@ -689,9 +715,9 @@ def _tmastg_warp_group(
         o_batch = _partial_batch(batch_idx, split_idx, n_batch)
 
         if cutlass.const_expr(CFG.THD_VARLEN):
-            # DEAD unit (batch == n_batch, envelope grid — issue #552): no O
-            # rows exist and descriptor slot n_batch is never built, so skip
-            # the store; the barrier protocol below still runs.
+            # DEAD unit (batch == n_batch, over-launched grid — issue #552):
+            # no O rows exist and descriptor slot n_batch is never built, so
+            # skip the store; the barrier protocol below still runs.
             if batch_idx < n_batch:
                 o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
                 o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), q_head_idx, q_row_coord, cutlass.Int32(0))
@@ -1764,6 +1790,17 @@ def _host(
     grid_q_supers = q_clusters * CFG.CTA_MMA
     q_supers = grid_q_supers
     if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD setup launch: build the [kv|cu_q|cu_k|remap|live|ctr] metadata
+        # buffer DEVICE-side from the caller's length tensors (no host cumsum,
+        # no H2D — issue #552), then the per-batch O descriptor array. Main
+        # grid: the PERSISTENT cluster count — the adapter hands down
+        # n_thd_units already capped to what the device holds resident,
+        # min(plan-time envelope, SMs / CTA_MMA), NOT the envelope itself
+        # (issue #618). It doubles as the claim counter's seed: cluster c runs
+        # unit c off its blockIdx, then pulls from the counter, so the grid and
+        # the seed must be the same number. Dispatching past the live total
+        # stays safe either way — such a unit decodes the batch == n_batch
+        # sentinel and drains without loads or stores.
         # ENVELOPE: the packed-O row stride is QH * ACTUAL d_v (o_tensor's
         # static inner extent), not QH * TILE_O — the per-batch descriptor
         # bases must step in real rows or every batch >= 1 lands OOB.
@@ -1779,7 +1816,7 @@ def _host(
             cutlass.Int32(B),
             cutlass.Int32(o_tensor.stride[1]),
             cutlass.Int32(CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA),
-            n_thd_units,  # CLC path: envelope units; the counter goes unused
+            n_thd_units,  # persistent cluster count; also seeds the claim counter
         ).launch(grid=(1, 1, 1), block=(THD_SETUP_THREADS, 1, 1), stream=stream)
         grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
     else:

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d512_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d512_f16_sm100.py
@@ -60,6 +60,7 @@ from cudnn.frost.tile_dsl.barrier import (
 from cudnn.frost.tile_dsl.scheduler import (
     Sched,
     scheduler_warp_loop,
+    scheduler_warp_loop_persistent,
     read_tile_id_arrive,
     SCHED_NATURAL,
     SCHED_LPT,
@@ -139,6 +140,10 @@ BMM2_V_NBLOCK_ADVANCE = CFG.TILE_N * (CFG.BMM2_N_PER_CALL // CFG.CTA_MMA) * CFG.
 N_O_CHUNKS = (CFG.TILE_O * CFG.BPE_O + 127) // 128
 
 CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+# THD uses a persistent grid + device-bounded claim counter (not the CLC
+# envelope). The adapter caps the launch at min(envelope, SMs / CGA_SIZE)
+# and the setup kernel publishes the live unit total it stops at.
+THD_PERSISTENT = True
 
 P_TMA_ITERS = (CFG.TILE_N * CFG.BPE) // CFG.Q_SWZ_BYTES
 P_D_BLOCK = CFG.TILE_N // P_TMA_ITERS
@@ -316,8 +321,10 @@ from cudnn.sdpa.fwd.kernels.thd_sm100 import build_thd_meta_o_descs_kernel as _b
 
 _TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
 # The setup kernel builds the THD metadata buffer DEVICE-side from the
-# caller's length tensors and the adapter launches the plan-time envelope
-# grid (issue #552) — no length ever reaches the host.
+# caller's length tensors (issue #552) — no length ever reaches the host — and
+# also publishes the live unit total + claim counter the persistent scheduler
+# reads, so the adapter launches a MACHINE-sized grid rather than the plan-time
+# envelope (issue #618).
 _dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
 _dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
 _thd_tma_offsets = _sdpa_h.thd_tma_offsets
@@ -651,7 +658,24 @@ def _kernel(
 
     else:
         nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
-        scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
+        if cutlass.const_expr(CFG.THD_VARLEN):
+            # THD: persistent grid + device-bounded claim counter, so no unit
+            # past the live total is ever handed out (the CLC path would need
+            # the grid to BE the work list, i.e. the plan-time envelope).
+            # n_batch is a kernel argument -- do NOT re-derive it from the
+            # metadata tensor's layout.
+            scheduler_warp_loop_persistent(
+                sched,
+                CFG.SCHEDULER_STAGES,
+                is_cga_first_cta,
+                seq_kv_lens_tensor,
+                cutlass.Int32(4) * n_batch + cutlass.Int32(3),
+                cutlass.Int32(4) * n_batch + cutlass.Int32(2),
+                CGA_SIZE,
+                CFG.CGA_M,
+            )
+        else:
+            scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
 
 
 @cute.jit
@@ -1984,7 +2008,7 @@ def _host(
             cutlass.Int32(B),
             cutlass.Int32(o_tensor.stride[1]),
             cutlass.Int32(CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA),
-            n_thd_units,  # CLC path: envelope units; the counter goes unused
+            n_thd_units,  # persistent cluster count; also seeds the claim counter
         ).launch(grid=(1, 1, 1), block=(THD_SETUP_THREADS, 1, 1), stream=stream)
         grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
     else:

--- a/python/cudnn/sdpa/fwd/kernels/thd_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/thd_sm100.py
@@ -230,6 +230,8 @@ def build_thd_meta_o_kv_descs_kernel(
     n_qh: cutlass.Int32,
     n_batch: cutlass.Int32,
     o_row_stride: cutlass.Int32,
+    cga_tile_m: cutlass.Int32,
+    n_clusters: cutlass.Int32,
 ) -> None:
     """``build_thd_meta_o_descs_kernel`` + packed-total-clamped K/V descriptors
     (the FP8/MXFP8 THD flavors).
@@ -299,6 +301,25 @@ def build_thd_meta_o_kv_descs_kernel(
     # it leaves the region uninitialized and units decode garbage batches.
     cute.arch.barrier()
     write_thd_batch_remap(cutlass.make_array_view(meta_t), n_batch, cutlass.Int32(tidx), cutlass.Int32(nthreads))
+    # Live unit total + claim counter for the persistent scheduler, exactly as
+    # build_thd_meta_o_descs_kernel writes them. The scheduler reads meta[4B+2]
+    # as its bound, so leaving these two words unwritten hands out units off
+    # uninitialized workspace (an illegal-instruction fault, not a silent
+    # wrong answer). The counter starts at n_clusters: cluster c takes unit c
+    # from its blockIdx, then pulls from the counter.
+    cute.arch.barrier()
+    # Thread 0 alone, WITHOUT elect_sync: elect.sync picks an
+    # implementation-defined lane, so conjoining it with tidx == 0 can select
+    # no thread at all and leave these words unwritten.
+    if tidx == cutlass.Int32(0):
+        meta_w = cutlass.make_array_view(meta_t)
+        cuq0 = n_batch
+        live = cutlass.Int32(0)
+        for b in cutlass.range(0, n_batch, 1, unroll=1):
+            s_b = cutlass.Int32(meta_w[cuq0 + b + cutlass.Int32(1)]) - cutlass.Int32(meta_w[cuq0 + b])
+            live = live + ((s_b + cga_tile_m - cutlass.Int32(1)) // cga_tile_m) * n_qh
+        meta_w[cutlass.Int32(4) * n_batch + cutlass.Int32(2)] = live
+        meta_w[cutlass.Int32(4) * n_batch + cutlass.Int32(3)] = n_clusters
 
 
 @cute.kernel

--- a/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
@@ -1510,27 +1510,29 @@ def test_dsl_sm100_thd_over_launched_units_are_dead(monkeypatch):
 
 
 @pytest.mark.L0
+@pytest.mark.parametrize("d", _FLAVORS, ids=_FLAVOR_IDS)
 @torch_fork_set_rng(seed=41)
-def test_dsl_sm100_thd_d256_multi_unit_per_cta(monkeypatch):
-    """d256 THD with more live units than the grid has clusters (issue #618).
+def test_dsl_sm100_thd_multi_unit_per_cta(monkeypatch, d):
+    """THD with more live units than the grid has clusters (issue #618).
 
     The persistent grid is sized to the MACHINE, so a cluster claims units
-    repeatedly off the device-bounded counter. Every other d256 THD case is
+    repeatedly off the device-bounded counter. Every other THD case here is
     small enough that each cluster is handed at most one unit, so none of them
     re-enters the K/V pipeline for a second one -- the regime where an
     unmatched consumer arrival used to desynchronise the next unit's producer
-    handshake. These lengths give 80 live units; FROST_THD_CLUSTERS pins the
-    grid to 4 clusters so the claim loop runs 20 deep regardless of the
-    device's SM count, and the unpinned pass covers the natural sizing.
+    handshake. These lengths give 48-80 live units depending on the flavor's
+    CGA tile; FROST_THD_CLUSTERS pins the grid to 4 clusters so the claim loop
+    runs deep regardless of the device's SM count, and the unpinned pass covers
+    the natural sizing.
     """
     _require_dsl()
-    lens = [1024, 768, 512, 256]  # (4+3+2+1) CGA tiles * 8 heads = 80 units
+    lens = [1024, 768, 512, 256]
 
     monkeypatch.setenv("FROST_THD_CLUSTERS", "4")
-    _run_thd_stats_case(seq_lens_q=lens, seq_lens_kv=lens, d=256, mask="causal", stats_layout="token_major")
+    _run_thd_stats_case(seq_lens_q=lens, seq_lens_kv=lens, d=d, mask="causal", stats_layout="token_major")
 
     monkeypatch.delenv("FROST_THD_CLUSTERS")
-    _run_thd_stats_case(seq_lens_q=lens, seq_lens_kv=lens, d=256, mask="causal", stats_layout="head_major")
+    _run_thd_stats_case(seq_lens_q=lens, seq_lens_kv=lens, d=d, mask="causal", stats_layout="head_major")
 
 
 @pytest.mark.L0
@@ -1641,6 +1643,47 @@ def test_dsl_sm100_thd_d192_d128_device_meta():
     assert api.check_support()
     api.compile()
     seq_lens = [200, 150]
+    lens = torch.tensor(seq_lens, dtype=torch.int32, device="cuda")
+    api.execute(q_tensor=q, k_tensor=k, v_tensor=v, o_tensor=o, seq_q_lens=lens, seq_kv_lens=lens)
+    torch.cuda.synchronize()
+    base_q = q.transpose(1, 2).reshape(b * s, h, d_qk)
+    base_k = k.transpose(1, 2).reshape(b * s, h, d_qk)
+    base_v = v.transpose(1, 2).reshape(b * s, h, d_v)
+    base_o = o.transpose(1, 2).reshape(b * s, h, d_v)
+    off = 0
+    for length in seq_lens:
+        qs = base_q[off : off + length].float()
+        ks = base_k[off : off + length].float()
+        vs = base_v[off : off + length].float()
+        scores = torch.einsum("lhd,mhd->hlm", qs, ks) * scale
+        ref = torch.einsum("hlm,mhd->lhd", torch.softmax(scores, dim=-1), vs)
+        torch.testing.assert_close(base_o[off : off + length].float(), ref, atol=5e-2, rtol=3e-2)
+        off += length
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=44)
+def test_dsl_sm100_thd_d192_d128_multi_unit_per_cta(monkeypatch):
+    """d192/d128 THD where a cluster claims more than one unit (issue #618).
+
+    The sibling device_meta case is one unit per cluster, so it never re-enters
+    the K/V pipeline. FROST_THD_CLUSTERS pins the persistent grid to 4 clusters
+    against 16 live units, making every cluster run four unit ranges."""
+    _require_dsl()
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm100
+
+    monkeypatch.setenv("FROST_THD_CLUSTERS", "4")
+    b, h, s = 2, 4, 1024
+    d_qk, d_v = 192, 128
+    dtype = torch.float16
+    scale = 1.0 / math.sqrt(d_qk)
+    q, k = (_bhsd(b, h, s, d_qk, dtype) for _ in range(2))
+    v = _bhsd(b, h, s, d_v, dtype)
+    o = torch.zeros_like(v)
+    api = SdpaFwdDslSm100(sample_q=q, sample_k=k, sample_v=v, sample_o=o, thd=True)
+    assert api.check_support()
+    api.compile()
+    seq_lens = [1024, 768]
     lens = torch.tensor(seq_lens, dtype=torch.int32, device="cuda")
     api.execute(q_tensor=q, k_tensor=k, v_tensor=v, o_tensor=o, seq_q_lens=lens, seq_kv_lens=lens)
     torch.cuda.synchronize()

--- a/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
@@ -1510,6 +1510,30 @@ def test_dsl_sm100_thd_over_launched_units_are_dead(monkeypatch):
 
 
 @pytest.mark.L0
+@torch_fork_set_rng(seed=41)
+def test_dsl_sm100_thd_d256_multi_unit_per_cta(monkeypatch):
+    """d256 THD with more live units than the grid has clusters (issue #618).
+
+    The persistent grid is sized to the MACHINE, so a cluster claims units
+    repeatedly off the device-bounded counter. Every other d256 THD case is
+    small enough that each cluster is handed at most one unit, so none of them
+    re-enters the K/V pipeline for a second one -- the regime where an
+    unmatched consumer arrival used to desynchronise the next unit's producer
+    handshake. These lengths give 80 live units; FROST_THD_CLUSTERS pins the
+    grid to 4 clusters so the claim loop runs 20 deep regardless of the
+    device's SM count, and the unpinned pass covers the natural sizing.
+    """
+    _require_dsl()
+    lens = [1024, 768, 512, 256]  # (4+3+2+1) CGA tiles * 8 heads = 80 units
+
+    monkeypatch.setenv("FROST_THD_CLUSTERS", "4")
+    _run_thd_stats_case(seq_lens_q=lens, seq_lens_kv=lens, d=256, mask="causal", stats_layout="token_major")
+
+    monkeypatch.delenv("FROST_THD_CLUSTERS")
+    _run_thd_stats_case(seq_lens_q=lens, seq_lens_kv=lens, d=256, mask="causal", stats_layout="head_major")
+
+
+@pytest.mark.L0
 @torch_fork_set_rng(seed=39)
 def test_dsl_sm100_thd_lens_never_reach_host():
     """Issue #552 (D2H removal): the length tensors are consumed ONLY on

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -936,6 +936,22 @@ def test_fp8_thd(in_key, causal):
 
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
+def test_fp8_thd_multi_unit_per_cta(monkeypatch):
+    """THD where a cluster claims more than one unit (issue #618).
+
+    The persistent grid is machine-sized, so a cluster pulls units repeatedly
+    off the device-bounded counter; every other FP8 THD case fits one unit per
+    cluster and never re-enters the K/V pipeline. FROST_THD_CLUSTERS pins the
+    grid to 4 clusters so the claim loop runs deep on any device."""
+    monkeypatch.setenv("FROST_THD_CLUSTERS", "4")
+    scale = 1.0 / math.sqrt(128)
+    lens = [1024, 768, 512, 256]
+    out, o_ref, a_o, a_o_ref, _, _ = _run_thd(lens, lens, 8, 8, "e4m3", scale=scale, causal=True)
+    _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
 def test_fp8_thd_cross_gqa():
     """THD cross-attention (unequal packed Q and K/V totals) with GQA heads."""
     scale = 1.0 / math.sqrt(128)

--- a/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
@@ -892,6 +892,24 @@ def test_mxfp8_thd(in_key, causal):
 
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
+def test_mxfp8_thd_multi_unit_per_cta(monkeypatch):
+    """THD where a cluster claims more than one unit (issue #618).
+
+    The persistent grid is machine-sized, so a cluster pulls units repeatedly
+    off the device-bounded counter; every other MXFP8 THD case fits one unit
+    per cluster and never re-enters the K/V pipeline (nor the per-sequence SF
+    tile bases for a second range). FROST_THD_CLUSTERS pins the grid to 4
+    clusters so the claim loop runs deep on any device."""
+    monkeypatch.setenv("FROST_THD_CLUSTERS", "4")
+    scale = 1.0 / math.sqrt(128)
+    lens = [1024, 768, 512, 256]
+    o_out, o_ref, amax, _ = _run_thd(lens, lens, 8, 8, "e4m3", torch.float16, scale=scale, causal=True)
+    _check(o_out, o_ref, torch.float16, "e4m3")
+    assert abs(amax.item() - o_ref.abs().max().item()) <= 0.03
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
 def test_mxfp8_thd_cross_gqa():
     """THD cross-attention (unequal packed Q and K/V totals) with GQA heads."""
     scale = 1.0 / math.sqrt(128)


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
- [x] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

<!-- What changed? Keep the scope concise. -->

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved SM100 variable-length attention execution with device-aware scheduling, helping workloads with uneven sequence lengths use available GPU capacity more efficiently.
  * Updated supported FP8, MXFP8, and FP16 attention paths for more consistent execution across varied workload sizes.

* **Bug Fixes**
  * Improved handling of workloads where multiple work units are processed per execution group.

* **Tests**
  * Added coverage for multi-unit, causal, unequal-length attention workloads, including numerical output and scaling validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->