### PR TITLE
Optimize-epilogue-tile-size-selection

### DIFF
--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -703,7 +703,7 @@ def _epi_vec_bytes(
 def _epi_chunk_elems(chain: FusionChain, config: TileConfig, use_tma_store: bool) -> int:
     if not use_tma_store:
         return _epi_vec_bytes(chain, config) // DTYPE_BYTES[chain.output_dtype]
-    return _epi_n(config, chain.output_dtype)
+    return _epi_n_for_chain(config, chain)
 
 
 def _epi_chunk_bytes(chain: FusionChain, config: TileConfig, use_tma_store: bool) -> int:
@@ -829,7 +829,7 @@ def _render_tile_constants(
         # Template `cta_tile_mnk` = per-CTA SMEM/TMA box dims (B's N halved under
         # 2-CTA MMA), NOT the logical per-CTA tile from TileConfig.
         f"cta_tile_mnk = {cfg.cta_smem_tile_mnk(elem_bytes)}",
-        f"epi_tile_mn = {(cfg.epi_tile_m, _epi_n(cfg, out_dt))}",
+        f"epi_tile_mn = {(cfg.epi_tile_m, _epi_n_for_chain(cfg, chain))}",
         f"threads_per_cta = {cfg.threads_per_cta}",
         f"cluster_shape_mnk = {cfg.cluster_shape}",
         f"matmul_a_batch = {chain.matmul.a_batch}",
@@ -876,7 +876,7 @@ def _render_tile_constants(
         # only cares about element byte width, identical across an a/b pair).
         f"ab_tma_dtype = {DTYPE_TO_CUTLASS[mma_a_dt]}",
         f"mma_kind = {DTYPE_TO_MMA_KIND[mma_a_dt]}",
-        *_epi_swizzle_lines(cfg, out_dt),
+        *_epi_swizzle_lines(cfg, out_dt, chain),
     ]
     # Persistent kernel always: double-TMEM + L2 N-super-block swizzle.
     # (acc_stages is emitted below, once the TMEM budget is known.)
@@ -1516,7 +1516,7 @@ def _render_block_scale_tile_constants(
         acc_stages = 2  # full per-GEMM double-buffer
     else:
         acc_stages = 1
-        gran = _epi_n(cfg, chain.output_dtype)  # epilogue TMEM-load drain unit (cols)
+        gran = _epi_n_for_chain(cfg, chain)  # epilogue TMEM-load drain unit (cols)
         ov = ((2 * acc_cols_per_stage - per_gemm + gran - 1) // gran) * gran
         if ov < acc_cols_per_stage:  # else no room -> plain 1-stage
             acc_overlap_cols = ov
@@ -1529,7 +1529,7 @@ def _render_block_scale_tile_constants(
         acc_gemm_stride = 2 * acc_cols_per_stage - acc_overlap_cols
     else:
         acc_gemm_stride = acc_cols_per_stage
-    acc_overlap_subtiles = acc_overlap_cols // _epi_n(cfg, chain.output_dtype)
+    acc_overlap_subtiles = acc_overlap_cols // _epi_n_for_chain(cfg, chain)
     acc_region_cols = acc_cols_per_stage  # per-stage stride WITHIN a GEMM
 
     sf_region_base = num_gemms * acc_gemm_stride
@@ -1614,7 +1614,7 @@ def _render_block_scale_tile_constants(
         f"cgrp_tile_mnk = ({cta_m * cfg.cga_size_m}, {cta_n * cfg.cga_size_n}, {cta_k_elems})",
         f"cgrp_tile_m = {cta_m * cfg.cga_size_m}",
         f"cgrp_tile_n = {cta_n * cfg.cga_size_n}",
-        f"epi_tile_mn = {(cfg.epi_tile_m, _epi_n(cfg, out_dt))}",
+        f"epi_tile_mn = {(cfg.epi_tile_m, _epi_n_for_chain(cfg, chain))}",
         f"threads_per_cta = {cfg.threads_per_cta}",
         f"cluster_shape_mnk = {cfg.cluster_shape}",
         f"matmul_a_batch = {chain.matmul.a_batch}",
@@ -1697,7 +1697,7 @@ def _render_block_scale_tile_constants(
         f"epi_slot_widen = {_epi_slot_widen(chain, cfg)}",
         f"epi_stage_rows = {_epi_stage_rows(cfg)}",
         f"epi_chunk_elems = {_epi_chunk_elems(chain, cfg, use_tma_store_epi)}",
-        *_epi_swizzle_lines(cfg, out_dt),
+        *_epi_swizzle_lines(cfg, out_dt, chain),
         "",
         f"# block-scale MMA",
         f"mma_block_scale_kind = nvvm.MMABlockScaleKind.{bs.mma_block_scale_kind}",
@@ -1981,7 +1981,7 @@ def _render_template(
     if "@@INJECT_KERNEL_TMA_C_PARAMS@@" in src:
         replacements.update(_tma_c_plumbing(chain, tma_slots))
     if "@@INJECT_TMA_STORE_SEQUENCE@@" in src:
-        _epi = _epi_n(config, chain.output_dtype)
+        _epi = _epi_n_for_chain(config, chain)
         replacements["INJECT_EPILOGUE"], replacements["INJECT_TMA_STORE_SEQUENCE"] = _place_tma_stores(snippets.epilogue, chain, config, tma_slots, _epi)
         replacements["INJECT_HOST_TMA_C_DESCS"] = _host_tma_c_descs(chain, tma_slots, _epi)
     # Per-GEMM STG vector bindings — on every STG-epilogue template (mainloop
@@ -2191,7 +2191,7 @@ def _render_block_scale_template(
     if "@@INJECT_KERNEL_TMA_C_PARAMS@@" in src:
         replacements.update(_tma_c_plumbing(chain, tma_slots))
     if "@@INJECT_TMA_STORE_SEQUENCE@@" in src:
-        _epi = _epi_n(config, chain.output_dtype)
+        _epi = _epi_n_for_chain(config, chain)
         replacements["INJECT_EPILOGUE"], replacements["INJECT_TMA_STORE_SEQUENCE"] = _place_tma_stores(snippets.epilogue, chain, config, tma_slots, _epi)
         replacements["INJECT_HOST_TMA_C_DESCS"] = _host_tma_c_descs(chain, tma_slots, _epi)
     # MoE block-scale raw-A-tensor plumbing (per-routed-group descriptor patch).
@@ -3077,8 +3077,26 @@ def _epi_n(cfg, out_dt: str) -> int:
     return min(_EPI_ROW_BYTES_MAX * 8 // DTYPE_BITS[out_dt], cap, _pow2_floor(cols, cap=cols))
 
 
-def _epi_swizzle_lines(cfg, out_dt: str) -> list[str]:
-    epi_n = _epi_n(cfg, out_dt)
+def _epi_n_for_chain(cfg, chain: FusionChain) -> int:
+    """Chain-aware drain width.
+
+    Column block quantization pays one warp reduction per column regardless of
+    subtile width.  A 64-column drain therefore keeps the same reduction work
+    while halving subtile-loop and output-store overhead.  Other epilogues keep
+    the measured 32-column default and its lower register footprint.
+    """
+    if not any(q.axis == 1 for q in chain.quants):
+        return _epi_n(cfg, chain.output_dtype)
+    cols = _epi_tile_cols(cfg)
+    return min(
+        _EPI_ROW_BYTES_MAX * 8 // DTYPE_BITS[chain.output_dtype],
+        _EPI_N_MAX,
+        _pow2_floor(cols, cap=cols),
+    )
+
+
+def _epi_swizzle_lines(cfg, out_dt: str, chain: FusionChain | None = None) -> list[str]:
+    epi_n = _epi_n_for_chain(cfg, chain) if chain is not None else _epi_n(cfg, out_dt)
     return [
         f"epi_n = {epi_n}",
         f"epi_row_elems = {_epi_row_elems(out_dt, epi_n)}",
@@ -3091,7 +3109,7 @@ def _epi_slot_widen(
 ) -> int:
     """One shared slot spans the widest TMA-stored row. An STG output never
     touches the ring, so it must not widen it."""
-    epi_n = _epi_n(cfg, chain.output_dtype)
+    epi_n = _epi_n_for_chain(cfg, chain)
     tma = _tma_slots_for(chain, cfg)
     widths = [_epi_row_bytes(chain.output_specs[i].dtype, epi_n) for i in sorted(tma) if i < len(chain.output_specs)]
     if not widths:
@@ -3136,7 +3154,7 @@ def _smem_d_bytes(
     mma_size_m > 1 the M blocks reuse the same slots. epi_n MUST be the same value
     the kernel renders, or the reserve under-counts and the launch is rejected."""
     out_dt = chain.output_dtype
-    row_bytes = _epi_row_bytes(out_dt, _epi_n(cfg, out_dt))
+    row_bytes = _epi_row_bytes(out_dt, _epi_n_for_chain(cfg, chain))
     return _EPI_SMEM_STAGES * _epi_stage_rows(cfg) * row_bytes * _epi_slot_widen(chain, cfg) + 16
 
 
@@ -3153,7 +3171,7 @@ def _output_store_mode(
         return "stg"
     # TMA addresses its contiguous dim in 16-byte units, and truncates. The next
     # two rejections are that granule at a different extent.
-    epi_n = _epi_n(cfg, chain.output_dtype)
+    epi_n = _epi_n_for_chain(cfg, chain)
 
     # The staged SMEM row; transposed stages the 128-byte M column instead. The
     # ceiling is the widest swizzle, not the granule.

--- a/python/cudnn/gemm/frost/epilogue_codegen.py
+++ b/python/cudnn/gemm/frost/epilogue_codegen.py
@@ -1437,13 +1437,21 @@ def generate(
     if on_tma_arm and len(tma_slots) > 1:
         # The compiler stores each output at its ready marker.  Retire outputs
         # backed by an exclusive source first, while register-heavy quantizers
-        # stay last.  Python's stable sort preserves slot order among ties.
+        # stay last.  Among quantizers retire M-axis/column reduction state
+        # before the cheaper row path; on a shared 64-column drain this avoids
+        # carrying the heavier path across the row output's TMA store.
         source_uses: dict[int, int] = {}
         for output_spec in specs:
             source_uses[output_spec.source_ref] = source_uses.get(output_spec.source_ref, 0) + 1
         for reduction in chain.reductions:
             source_uses[reduction.source_ref] = source_uses.get(reduction.source_ref, 0) + 1
-        output_order.sort(key=lambda oi: (specs[oi].quant_idx is not None, source_uses[specs[oi].source_ref]))
+        output_order.sort(
+            key=lambda oi: (
+                specs[oi].quant_idx is not None,
+                0 if specs[oi].quant_idx is not None and chain.quants[specs[oi].quant_idx].axis == 1 else 1,
+                source_uses[specs[oi].source_ref],
+            )
+        )
     for si in output_order:
         spec = specs[si]
         src = _parent_value(spec.source_ref)

--- a/test/python/gemm/frost/test_matmul.py
+++ b/test/python/gemm/frost/test_matmul.py
@@ -1173,6 +1173,10 @@ def test_dense_row_col_dual_quant_f8_reorder() -> None:
     compiled = _plan(g, config=cfg)
     chain = compiled.chain
     assert len(chain.quants) == 2 and chain.quants[0].axis in (-1, 2) and chain.quants[1].axis == 1
+    from cudnn.gemm.frost.epilogue_codegen import generate
+
+    dual_epi = generate(chain, vec_bytes_epi=64, output_elem_bytes=1, tma_slots=frozenset({0, 1})).epilogue
+    assert dual_epi.index("_q1_lane") < dual_epi.index("_q0_frg"), "retire the register-heavy col quant before row quant"
 
     a, b, _ = _mkdata(M, N, K, "bf16", "bf16")
     q_row = torch.empty(1, M, N, dtype=torch.float8_e4m3fn, device="cuda")

--- a/test/python/gemm/frost/test_matmul_epilogue_fusion.py
+++ b/test/python/gemm/frost/test_matmul_epilogue_fusion.py
@@ -2387,6 +2387,46 @@ def test_epi_n_is_one_shared_column_count_not_a_per_output_one(cfg_name: str, dt
     assert _store_modes(chain, cfg) == want
 
 
+@pytest.mark.L0
+def test_col_quant_uses_a_wide_epilogue_drain() -> None:
+    """Column quant performs the same one-warp reduction per column at either
+    drain width.  Taking 64 columns at once halves the subtile/store overhead;
+    row quant keeps the lower-register 32-column default."""
+    from cudnn.gemm.frost.compiler import _epi_n, _epi_n_for_chain
+
+    M = N = K = 128
+    cfg = by_name("CONFIG_sm100_128x128x128_128x128x32_cluster1x1")
+
+    def build(axis: int):
+        g = cudnn.pygraph(
+            io_data_type=cudnn.data_type.BFLOAT16,
+            intermediate_data_type=cudnn.data_type.FLOAT,
+            compute_data_type=cudnn.data_type.FLOAT,
+        )
+        A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
+        B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
+        C = g.relu(input=g.matmul(A=A, B=B, name="mm"), name="r")
+        Q, SF = g.block_scale_quantize(input=C, block_size=32, axis=axis, name="q")
+        Q.set_output(True).set_data_type(cudnn.data_type.FP8_E4M3)
+        if axis == 1:
+            SF.set_dim([1, M // 32, N]).set_stride([M * N // 32, N, 1])
+        else:
+            SF.set_dim([1, M, N // 32]).set_stride([M * N // 32, N // 32, 1])
+        SF.set_output(True).set_data_type(cudnn.data_type.FP8_E8M0)
+        return analyze(g)
+
+    row = build(-1)
+    col = build(1)
+    assert _epi_n(cfg, col.output_dtype) == 32, "the geometry-only default stays narrow"
+    assert _epi_n_for_chain(cfg, row) == 32
+    assert _epi_n_for_chain(cfg, col) == 64
+
+    # The wider cap must not turn a non-power-of-two drain into a partial
+    # subtile: 16 is the largest capped power-of-two divisor of 48.
+    cfg_48 = by_name("CONFIG_sm100_128x48x128_128x48x32_cluster2x1_2ctamma")
+    assert _epi_n_for_chain(cfg_48, col) == 16
+
+
 @pytest.mark.parametrize(
     "majors,want",
     [


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
- [x] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

Optimize the epilogue tile size selection for the performance of col quantize operations

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved FP8 quantized output handling for column-oriented quantization.
  * Enabled wider output drains, up to 64 columns, where supported.
  * Improved output scheduling so column-quantized results are processed before row-quantized results.

* **Bug Fixes**
  * Preserved correct drain sizing for row-quantized outputs and unsupported widths.

* **Tests**
  * Added coverage validating output ordering, drain widths, and width limits for mixed quantization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->