### PR TITLE
frost(sdpa): enable the LPT/LPT_L2 scheduler on the SM107 fp8 row

### DIFF
--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -634,10 +634,11 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
       (the SM107 sibling carries the same plumbing as its SM100 twin), so both
       rows advertise the split; the d192x128 file forks its own scheduler and
       has none, which is what split_d_shapes pins.
-    - sched_policies: the LPT/LPT_L2 remap is not yet ported to the SM107
-      sibling (issue #653); {NATURAL} keeps requests honest AND routes the
-      graph path around the un-ported derivation (place() hands the adapter
-      an explicit policy from this domain).
+    - sched_policies: both rows serve the full {NATURAL, LPT, LPT_L2} domain
+      (issue #653) — the SM107 sibling threads qh_per_kh/seqlen_kv through
+      every decode call site, which is what the shared LPT_L2 decode requires,
+      so its remap is in lockstep with the SM100 twin (place() hands the
+      adapter an explicit policy from this domain).
 
     Padding mask (per-batch ``seq_len_kv`` → KV-side masking) is supported: KV-only
     padding leaves every query row real, so each row's total_sum > 0 and the
@@ -687,9 +688,13 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
             # race was fixed with the mb_stats_read barrier (verified on the
             # gated 132/192/200-cluster repros, 3x each).
             skv_tail_via_padding=True,
-            # LPT/LPT_L2 remap is not yet ported to the SM107 sibling (issue
-            # #653) — its row serves NATURAL only until the port lands.
-            sched_policies=(frozenset({SCHED_NATURAL}) if rubin_row else frozenset({SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2})),
+            # LPT/LPT_L2 remap is in lockstep with the SM100 sibling (issue
+            # #653): every decode call site threads qh_per_kh/seqlen_kv, which
+            # is what the shared _common_sm100 LPT_L2 decode demands.  The L2
+            # figure the remap blocks against (CFG.L2_SIZE_MIB) is a tuning
+            # hint for the grouping, not a chip capacity, so the SM100 number
+            # carries to Rubin unchanged.
+            sched_policies=frozenset({SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2}),
             tile_ms=frozenset({128}),
             tile_ns=frozenset({128}),
             cgas=frozenset({2}),

--- a/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
+++ b/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
@@ -61,7 +61,7 @@ def test_sm107_per_tensor_fp8_advertises_only_d128():
 def test_per_tensor_fp8_rows_split_per_arch_line():
     """The per-tensor FP8 rows are split at the Rubin boundary — each row
     declares exactly what its own lowering carries, with no knob x arch
-    notches: HALF softmax and the missing split/LPT paths are row DATA."""
+    notches: the HALF softmax arm and the d192 flavor are row DATA."""
     import cudnn as _c
     from cudnn.frost.tile_dsl.constants import SCHED_LPT, SCHED_LPT_L2, SCHED_NATURAL
     from cudnn.sdpa.fwd import engines
@@ -82,15 +82,58 @@ def test_per_tensor_fp8_rows_split_per_arch_line():
     assert sm107.softmax_precisions == frozenset({_c.data_type.FLOAT, _c.data_type.HALF})
 
     # Both fp8 rows now wire the split path (the SM107 sibling carries the same
-    # make_split_helpers plumbing as its SM100 twin). The LPT remap is still
-    # un-ported on SM107 (issue #653), which the sched domain below pins.
+    # make_split_helpers plumbing as its SM100 twin) and the LPT/LPT_L2 remap
+    # (issue #653) — every SM107 decode call site threads qh_per_kh/seqlen_kv,
+    # so the sched domain is the same on both rows.
     assert sm107.split_kv_supported is True
     assert sm100.split_kv_supported is True
-    assert sm107.sched_policies == frozenset({SCHED_NATURAL})
+    assert sm107.sched_policies == frozenset({SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2})
     assert sm100.sched_policies == frozenset({SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2})
 
     # Both d128 cells carry the write_thd_meta THD leg.
     assert sm100.thd and sm107.thd and sm100.cu_seq_len and sm107.cu_seq_len
+
+
+def test_sm107_row_ranks_the_lpt_remap_for_causal():
+    """The LPT/LPT_L2 remap (issue #653) is live on the Rubin row: a causal
+    per-tensor FP8 graph at cc10.7 ranks LPT_L2 first, exactly as its SM100
+    twin does, and both remap specializations template-load. Pure — facts pin
+    the device, and nothing here compiles."""
+    import cudnn as _c
+    from cudnn.frost.tile_dsl.constants import SCHED_LPT, SCHED_LPT_L2, SCHED_NATURAL
+    from cudnn.sdpa import graph_analyzer as ga
+    from cudnn.sdpa.fwd import engines, heuristics
+
+    def facts(cc):
+        return ga.SdpaGraphFacts(
+            b=1,
+            h_q=8,
+            h_kv=8,
+            s_q=4096,
+            s_kv=4096,
+            d_qk=128,
+            d_v=128,
+            dtype=_c.data_type.FP8_E4M3,
+            dtype_o=_c.data_type.BFLOAT16,
+            is_fp8=True,
+            causal=True,
+            device_cc=cc,
+        )
+
+    caps = {s.name: s.capabilities for s in engines.ENGINE_SPECS}
+    sm100 = caps[engines.engine_name(fp8=True)]
+    sm107 = caps[engines.engine_name(arch="sm107", fp8=True)]
+
+    # One head's K+V here is 4096 * 256 * 1 B = 1 MiB, far inside the L2 budget
+    # the remap groups against, so the L2 variant leads on BOTH rows. Before
+    # the port the Rubin row had a one-element domain and took _sched_points'
+    # sole-element shortcut, which is what pinned it to NATURAL.
+    assert heuristics._sched_points(sm107, facts((10, 7))) == [SCHED_LPT_L2, SCHED_LPT, SCHED_NATURAL]
+    assert heuristics._sched_points(sm100, facts((10, 0))) == [SCHED_LPT_L2, SCHED_LPT, SCHED_NATURAL]
+
+    # Both remap specializations template-load on the Rubin sibling.
+    for policy in (SCHED_LPT, SCHED_LPT_L2):
+        assert _load(rubin=True, sched_policy=policy).CFG.SCHEDULER_POLICY == policy
 
 
 def test_softmax_half_declines_by_row_domain():


### PR DESCRIPTION
Every scheduler decode call site in the SM107 per-tensor FP8 prefill sibling threads qh_per_kh/seqlen_kv, which is what the shared _common_sm100 LPT_L2 decode requires, so the row no longer has to pin its sched domain to SCHED_NATURAL. The L2 figure the remap groups against (CFG.L2_SIZE_MIB) is a tuning hint for the grouping rather than a chip capacity, so the SM100 number carries to Rubin unchanged.

Refs #653

## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
- [x] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

<!-- What changed? Keep the scope concise. -->

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Expanded FP8 attention scheduling options on next-generation GPU hardware.
  - Added support for additional split-KV and workload-balancing strategies, helping workloads select more efficient execution paths.
  - Improved scheduling for causal attention scenarios, with better ranking of available remapping policies and support for additional execution configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->