### PR TITLE
Benchmark cudnn_oss for kimi_k3/deepseek_v4 and flash_attention (FA2) on Ampere

### DIFF
--- a/benchmark/attention_training/config_types.py
+++ b/benchmark/attention_training/config_types.py
@@ -201,6 +201,7 @@ def fa2_on_ampere():
     combos record as failed rows per the usual convention.
     """
     import torch
+
     if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 8:
         return ["flash_attention"]
     return []

--- a/benchmark/attention_training/config_types.py
+++ b/benchmark/attention_training/config_types.py
@@ -188,3 +188,19 @@ class BenchmarkResult:
     # sampled during the measurement window — the SOL denominator. None on
     # arches without a rate-table entry.
     peak_mma_tflops: Optional[float] = None
+
+
+def fa2_on_ampere():
+    """flash_attention (FA2) as an extra backend on Ampere only.
+
+    FA4's backward asserts SM90+ (flash_attn/cute/interface.py,
+    _flash_attn_bwd) while its forward supports SM80, so without FA2 the
+    SM80 dashboards have no flash-attention backward reference column. On
+    SM90+ FA4 is the reference and FA2 is not run. FA2's own limits still
+    apply per model (matching Q/KV head dims, head_dim <= 256); unsupported
+    combos record as failed rows per the usual convention.
+    """
+    import torch
+    if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 8:
+        return ["flash_attention"]
+    return []

--- a/benchmark/attention_training/configs/auto_regressive_dit.py
+++ b/benchmark/attention_training/configs/auto_regressive_dit.py
@@ -30,7 +30,7 @@ Usage:
     python -m benchmark.attention_training.runner --config auto_regressive_dit --dry-run
 """
 
-from ..config_types import ModelPreset, BenchmarkConfig
+from ..config_types import ModelPreset, BenchmarkConfig, fa2_on_ampere
 
 AR_DIT = ModelPreset(
     name="auto_regressive_dit",
@@ -49,7 +49,7 @@ CONFIG = BenchmarkConfig(
         (4096, 62208),
         (8192, 62208),
     ],
-    backends=["cudnn", "cudnn_oss", "flash_attention_4"],
+    backends=["cudnn", "cudnn_oss", "flash_attention_4"] + fa2_on_ampere(),
     data_types=["bfloat16", "fp8", "mxfp8"],
     attn_masks=["no_mask"],
     profile_pass="fwd",

--- a/benchmark/attention_training/configs/deepseek_v4.py
+++ b/benchmark/attention_training/configs/deepseek_v4.py
@@ -49,7 +49,7 @@ CONFIG = BenchmarkConfig(
         (4096, 4096),
         (2048, 2048),
     ],
-    backends=["cudnn", "flash_attention_4"],
+    backends=["cudnn", "cudnn_oss", "flash_attention_4"],
     data_types=["bfloat16", "fp8", "mxfp8"],
     attn_masks=["top_left"],
     profile_pass="both",

--- a/benchmark/attention_training/configs/deepseek_v4.py
+++ b/benchmark/attention_training/configs/deepseek_v4.py
@@ -24,7 +24,7 @@ Usage:
     python -m benchmark.attention_training.runner --config deepseek_v4 --dry-run
 """
 
-from ..config_types import ModelPreset, BenchmarkConfig
+from ..config_types import ModelPreset, BenchmarkConfig, fa2_on_ampere
 
 DSV4_FLASH = ModelPreset(
     name="dsv4_flash",
@@ -49,7 +49,7 @@ CONFIG = BenchmarkConfig(
         (4096, 4096),
         (2048, 2048),
     ],
-    backends=["cudnn", "cudnn_oss", "flash_attention_4"],
+    backends=["cudnn", "cudnn_oss", "flash_attention_4"] + fa2_on_ampere(),
     data_types=["bfloat16", "fp8", "mxfp8"],
     attn_masks=["top_left"],
     profile_pass="both",

--- a/benchmark/attention_training/configs/dsv3.py
+++ b/benchmark/attention_training/configs/dsv3.py
@@ -13,7 +13,7 @@ Usage:
     python -m benchmark.attention_training.runner --config dsv3 --dry-run
 """
 
-from ..config_types import ModelPreset, BenchmarkConfig
+from ..config_types import ModelPreset, BenchmarkConfig, fa2_on_ampere
 
 DSV3 = ModelPreset(
     name="dsv3",
@@ -33,7 +33,7 @@ CONFIG = BenchmarkConfig(
         (4096, 4096),
         (2048, 2048),
     ],
-    backends=["cudnn", "cudnn_oss", "flash_attention_4"],
+    backends=["cudnn", "cudnn_oss", "flash_attention_4"] + fa2_on_ampere(),
     data_types=["bfloat16", "fp8", "mxfp8"],
     attn_masks=["top_left", "no_mask"],  # Causal only
     profile_pass="both",  # Forward and backward

--- a/benchmark/attention_training/configs/gpt_oss.py
+++ b/benchmark/attention_training/configs/gpt_oss.py
@@ -12,7 +12,7 @@ Usage:
     python -m benchmark.attention_training.runner --config gpt_oss --dry-run
 """
 
-from ..config_types import ModelPreset, BenchmarkConfig
+from ..config_types import ModelPreset, BenchmarkConfig, fa2_on_ampere
 
 GPT_OSS = ModelPreset(
     name="gpt_oss",
@@ -31,7 +31,7 @@ CONFIG = BenchmarkConfig(
         (4096, 4096),
         (2048, 2048),
     ],
-    backends=["cudnn", "cudnn_oss", "flash_attention_4"],
+    backends=["cudnn", "cudnn_oss", "flash_attention_4"] + fa2_on_ampere(),
     data_types=["bfloat16", "fp8", "mxfp8"],
     attn_masks=["top_left"],  # Causal with sliding window
     profile_pass="both",  # Forward and backward

--- a/benchmark/attention_training/configs/kimiK26.py
+++ b/benchmark/attention_training/configs/kimiK26.py
@@ -21,7 +21,7 @@ Usage:
     python -m benchmark.attention_training.runner --config kimiK26 --dry-run
 """
 
-from ..config_types import ModelPreset, BenchmarkConfig
+from ..config_types import ModelPreset, BenchmarkConfig, fa2_on_ampere
 
 KIMI_K26 = ModelPreset(
     name="kimiK26",
@@ -41,7 +41,7 @@ CONFIG = BenchmarkConfig(
         (4096, 4096),
         (2048, 2048),
     ],
-    backends=["cudnn", "cudnn_oss", "flash_attention_4"],
+    backends=["cudnn", "cudnn_oss", "flash_attention_4"] + fa2_on_ampere(),
     data_types=["bfloat16", "fp8", "mxfp8"],
     attn_masks=["top_left", "no_mask"],
     profile_pass="both",  # Forward and backward

--- a/benchmark/attention_training/configs/kimi_k3.py
+++ b/benchmark/attention_training/configs/kimi_k3.py
@@ -19,7 +19,7 @@ Usage:
     python -m benchmark.attention_training.runner --config kimi_k3 --dry-run
 """
 
-from ..config_types import ModelPreset, BenchmarkConfig
+from ..config_types import ModelPreset, BenchmarkConfig, fa2_on_ampere
 
 KIMI_K3 = ModelPreset(
     name="kimi_k3",
@@ -39,7 +39,7 @@ CONFIG = BenchmarkConfig(
         (4096, 4096),
         (2048, 2048),
     ],
-    backends=["cudnn", "cudnn_oss", "flash_attention_4"],
+    backends=["cudnn", "cudnn_oss", "flash_attention_4"] + fa2_on_ampere(),
     data_types=["bfloat16", "fp8", "mxfp8"],
     attn_masks=["top_left", "no_mask"],
     profile_pass="both",

--- a/benchmark/attention_training/configs/kimi_k3.py
+++ b/benchmark/attention_training/configs/kimi_k3.py
@@ -39,7 +39,7 @@ CONFIG = BenchmarkConfig(
         (4096, 4096),
         (2048, 2048),
     ],
-    backends=["cudnn", "flash_attention_4"],
+    backends=["cudnn", "cudnn_oss", "flash_attention_4"],
     data_types=["bfloat16", "fp8", "mxfp8"],
     attn_masks=["top_left", "no_mask"],
     profile_pass="both",

--- a/benchmark/attention_training/configs/llama.py
+++ b/benchmark/attention_training/configs/llama.py
@@ -12,16 +12,7 @@ Usage:
     python -m benchmark.attention_training.runner --config llama --dry-run
 """
 
-import torch
-
-from ..config_types import ModelPreset, BenchmarkConfig
-
-# flash_attention (FA2) is benchmarked only on Ampere: FA4's backward asserts
-# SM90+ (flash_attn/cute/interface.py, _flash_attn_bwd) while its forward
-# supports SM80, so without FA2 the Ampere dashboard has no flash-attention
-# backward reference. On SM90+ FA4 is the reference and FA2 would only add
-# runtime. The 26.07 base container ships flash-attn 2.x natively.
-_IS_AMPERE = torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 8
+from ..config_types import ModelPreset, BenchmarkConfig, fa2_on_ampere
 
 LLAMA3_1 = ModelPreset(
     name="llama3.1",
@@ -40,8 +31,7 @@ CONFIG = BenchmarkConfig(
         (4096, 4096),
         (2048, 2048),
     ],
-    backends=["cudnn", "cudnn_oss", "flash_attention_4"]
-    + (["flash_attention"] if _IS_AMPERE else []),
+    backends=["cudnn", "cudnn_oss", "flash_attention_4"] + fa2_on_ampere(),
     data_types=["bfloat16", "fp8", "mxfp8"],
     attn_masks=["top_left", "no_mask"],  # Both causal and non-causal
     profile_pass="both",  # Forward and backward

--- a/benchmark/attention_training/configs/llama.py
+++ b/benchmark/attention_training/configs/llama.py
@@ -12,7 +12,16 @@ Usage:
     python -m benchmark.attention_training.runner --config llama --dry-run
 """
 
+import torch
+
 from ..config_types import ModelPreset, BenchmarkConfig
+
+# flash_attention (FA2) is benchmarked only on Ampere: FA4's backward asserts
+# SM90+ (flash_attn/cute/interface.py, _flash_attn_bwd) while its forward
+# supports SM80, so without FA2 the Ampere dashboard has no flash-attention
+# backward reference. On SM90+ FA4 is the reference and FA2 would only add
+# runtime. The 26.07 base container ships flash-attn 2.x natively.
+_IS_AMPERE = torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 8
 
 LLAMA3_1 = ModelPreset(
     name="llama3.1",
@@ -31,7 +40,8 @@ CONFIG = BenchmarkConfig(
         (4096, 4096),
         (2048, 2048),
     ],
-    backends=["cudnn", "cudnn_oss", "flash_attention_4"],
+    backends=["cudnn", "cudnn_oss", "flash_attention_4"]
+    + (["flash_attention"] if _IS_AMPERE else []),
     data_types=["bfloat16", "fp8", "mxfp8"],
     attn_masks=["top_left", "no_mask"],  # Both causal and non-causal
     profile_pass="both",  # Forward and backward

--- a/benchmark/attention_training/configs/ltx2.py
+++ b/benchmark/attention_training/configs/ltx2.py
@@ -31,7 +31,7 @@ Usage:
     python -m benchmark.attention_training.runner --config ltx2 --dry-run
 """
 
-from ..config_types import ModelPreset, BenchmarkConfig
+from ..config_types import ModelPreset, BenchmarkConfig, fa2_on_ampere
 
 LTX2 = ModelPreset(
     name="ltx2",
@@ -50,7 +50,7 @@ CONFIG = BenchmarkConfig(
         (30240, 30240),  # 161 frames, 960x1536
         (37632, 37632),  # 161 frames, 1024x1792
     ],
-    backends=["cudnn", "cudnn_oss", "flash_attention_4"],
+    backends=["cudnn", "cudnn_oss", "flash_attention_4"] + fa2_on_ampere(),
     data_types=["bfloat16"],  # Video DiTs are typically bf16-trained
     attn_masks=["no_mask"],  # Bidirectional diffusion DiT
     profile_pass="both",  # Forward and backward for training

--- a/benchmark/attention_training/configs/qwen35.py
+++ b/benchmark/attention_training/configs/qwen35.py
@@ -13,7 +13,7 @@ Usage:
     python -m benchmark.attention_training.runner --config qwen35 --dry-run
 """
 
-from ..config_types import ModelPreset, BenchmarkConfig
+from ..config_types import ModelPreset, BenchmarkConfig, fa2_on_ampere
 
 QWEN35 = ModelPreset(
     name="qwen35",
@@ -32,7 +32,7 @@ CONFIG = BenchmarkConfig(
         (4096, 4096),
         (2048, 2048),
     ],
-    backends=["cudnn", "cudnn_oss", "flash_attention_4"],
+    backends=["cudnn", "cudnn_oss", "flash_attention_4"] + fa2_on_ampere(),
     # Blackwell limits at head_dim=256: cuDNN bwd rejects head_dim>128 at
     # graph_bwd.validate(), and fa4's sm100 forward kernel asserts on tmem
     # exhaustion for head_dim=256 regardless of batch. Restrict to cuDNN fwd.

--- a/benchmark/attention_training/configs/wan22.py
+++ b/benchmark/attention_training/configs/wan22.py
@@ -32,7 +32,7 @@ Usage:
     python -m benchmark.attention_training.runner --config wan22 --dry-run
 """
 
-from ..config_types import ModelPreset, BenchmarkConfig
+from ..config_types import ModelPreset, BenchmarkConfig, fa2_on_ampere
 
 WAN22_A14B = ModelPreset(
     name="wan22_a14b",
@@ -51,7 +51,7 @@ CONFIG = BenchmarkConfig(
         (48360, 48360),  # 480p, 121 frames
         (75600, 75600),  # 720p, 81 frames
     ],
-    backends=["cudnn", "cudnn_oss", "flash_attention_4"],
+    backends=["cudnn", "cudnn_oss", "flash_attention_4"] + fa2_on_ampere(),
     data_types=["bfloat16"],  # Wan 2.2 is released/trained in bf16; no official FP8 checkpoint
     attn_masks=["no_mask"],  # bidirectional diffusion DiT, no causal mask
     profile_pass="both",  # forward + backward for training


### PR DESCRIPTION
Two coverage additions to the attention_training benchmark configs.

**1. cudnn_oss backend for kimi_k3 and deepseek_v4**

- kimi_k3 has the same attention geometry as dsv3 (head_dim_qk=192, head_dim_vo=128), whose config already benchmarks cudnn_oss; the backend was simply not included when kimi_k3 was added, so the dashboards show no OSS column for it.
- deepseek_v4 (head_dim=512) is the model class the SM100 d512 forward flavor (python/cudnn/sdpa/fwd/config_sm100.py) was built for, but without cudnn_oss in the config that kernel is never exercised by this benchmark.

**2. flash_attention (FA2) backend on Ampere, all configs**

FA4 backward asserts SM90+ (flash_attn/cute/interface.py, _flash_attn_bwd) while its forward supports SM80, so the Ampere dashboards had no flash-attention backward reference column at all. FA2 supports the SM80 backward and ships in the base container (2.7.4.post1 in the 26.07 image, verified on an A100), so a shared config_types.fa2_on_ampere() helper appends it to every config, only when the visible device is SM 8.x. SM90+ runs are unchanged: FA4 stays the sole flash-attention reference and no extra runtime is added.

On architectures or shapes a backend cannot serve (no matching OSS kernel; FA2 with mismatched Q/KV head dims or head_dim > 256), the unsupported (backend, pass) combos are recorded as failed rows in the CSV rather than hidden, per the existing convention in these configs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic FlashAttention-2 backend selection for supported Ampere GPUs.
  - Expanded backend coverage across attention-training benchmarks, including DeepSeek, Kimi, Llama, GPT, Qwen, Wan, and others.
  - Preserved existing cuDNN and FlashAttention-4 options while enabling compatible hardware to use the additional backend.
  - Standardized hardware-aware backend selection to improve benchmark compatibility across supported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->