### PR TITLE
frost: prefix GEMM and SDPA kernel symbols with cudnn

### DIFF
--- a/python/cudnn/AGENTS.md
+++ b/python/cudnn/AGENTS.md
@@ -231,6 +231,7 @@ SDPA-specific hard rules (cited as Rule S1, S2, ...) live in
 - Use the decorated function's actual name, keep the default
   ``keep_mangled_name=True``, and do not use compiler flags or symbol rewriting
   instead.
+- Verify with ``pytest -q test/python/test_frost_kernel_name_prefix.py``.
 
 
 ## Frontend-only kernel package layout

--- a/python/cudnn/AGENTS.md
+++ b/python/cudnn/AGENTS.md
@@ -231,7 +231,7 @@ SDPA-specific hard rules (cited as Rule S1, S2, ...) live in
 - Use the decorated function's actual name, keep the default
   ``keep_mangled_name=True``, and do not use compiler flags or symbol rewriting
   instead.
-- Verify with ``pytest -q test/python/test_frost_kernel_name_prefix.py``.
+- Verify with ``(cd test/python && pytest -q test_frost_kernel_name_prefix.py)``.
 
 
 ## Frontend-only kernel package layout

--- a/python/cudnn/AGENTS.md
+++ b/python/cudnn/AGENTS.md
@@ -221,24 +221,16 @@ SDPA-specific hard rules (cited as Rule S1, S2, ...) live in
 
 **Rule 6 — every Frost-generated kernel has a cuDNN-attributable symbol.**
 
-- Immediately after every ``@cute.kernel`` definition, configure the public
-  CuTe DSL naming API:
+- Immediately after every ``@cute.kernel`` definition, including auxiliary and
+  generated-template kernels, call the public naming API:
 
   ```python
   kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
   ```
 
-  Use the decorated function's actual name in place of ``kernel``. This is
-  required for main compute kernels and every auxiliary kernel (setup,
-  descriptor initialization, reduction, conversion, split/combine, and
-  similar helpers), including kernels in generated template bodies.
-- Keep the default ``keep_mangled_name=True`` behavior. The mangled function
-  name and per-trace suffix preserve readability and uniqueness; the prefix
-  identifies the symbol as originating from cuDNN instead of CUTLASS in
-  profilers and debug traces.
-- Do not replace this with an undocumented compiler option or a post-build
-  symbol rewrite. The source-level ``set_name_prefix`` call is the supported
-  contract and must be present before the kernel is traced or compiled.
+- Use the decorated function's actual name, keep the default
+  ``keep_mangled_name=True``, and do not use compiler flags or symbol rewriting
+  instead.
 
 
 ## Frontend-only kernel package layout

--- a/python/cudnn/AGENTS.md
+++ b/python/cudnn/AGENTS.md
@@ -219,6 +219,27 @@ SDPA-specific hard rules (cited as Rule S1, S2, ...) live in
 [sdpa/AGENTS.md](sdpa/AGENTS.md) — read it before touching anything under
 `python/cudnn/sdpa/`.
 
+**Rule 6 — every Frost-generated kernel has a cuDNN-attributable symbol.**
+
+- Immediately after every ``@cute.kernel`` definition, configure the public
+  CuTe DSL naming API:
+
+  ```python
+  kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+  ```
+
+  Use the decorated function's actual name in place of ``kernel``. This is
+  required for main compute kernels and every auxiliary kernel (setup,
+  descriptor initialization, reduction, conversion, split/combine, and
+  similar helpers), including kernels in generated template bodies.
+- Keep the default ``keep_mangled_name=True`` behavior. The mangled function
+  name and per-trace suffix preserve readability and uniqueness; the prefix
+  identifies the symbol as originating from cuDNN instead of CUTLASS in
+  profilers and debug traces.
+- Do not replace this with an undocumented compiler option or a post-build
+  symbol rewrite. The source-level ``set_name_prefix`` call is the supported
+  contract and must be present before the kernel is traced or compiled.
+
 
 ## Frontend-only kernel package layout
 

--- a/python/cudnn/gemm/cutedsl/dense/amax/dense_blockscaled_gemm_persistent_amax.py
+++ b/python/cudnn/gemm/cutedsl/dense/amax/dense_blockscaled_gemm_persistent_amax.py
@@ -1341,6 +1341,8 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             #
             c_pipeline.producer_tail()
 
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     def mainloop_s2t_copy_and_partition(
         self,
         sSF: cute.Tensor,

--- a/python/cudnn/gemm/cutedsl/dense/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py
+++ b/python/cudnn/gemm/cutedsl/dense/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py
@@ -1539,6 +1539,8 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             #
             c_pipeline.producer_tail(c_pipeline_producer_state)
 
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     def mainloop_s2t_copy_and_partition(
         self,
         sSF: cute.Tensor,

--- a/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8.py
+++ b/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8.py
@@ -433,6 +433,9 @@ def gemm_proj_rope_mxfp8_kernel(
         tmem.free(tmem_ptr)
 
 
+gemm_proj_rope_mxfp8_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 @cute.jit
 def gemm_proj_rope_mxfp8_host(
     mA: cute.Tensor,

--- a/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_bf16in.py
+++ b/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_bf16in.py
@@ -433,6 +433,9 @@ def gemm_proj_rope_mxfp8_kernel(
         tmem.free(tmem_ptr)
 
 
+gemm_proj_rope_mxfp8_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 @cute.jit
 def gemm_proj_rope_mxfp8_host(
     mA: cute.Tensor,

--- a/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
+++ b/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
@@ -554,6 +554,9 @@ def gemm_proj_rope_mxfp8_kernel(
         tmem.free(tmem_ptr)
 
 
+gemm_proj_rope_mxfp8_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 @cute.jit
 def gemm_proj_rope_mxfp8_host(
     mA: cute.Tensor,

--- a/python/cudnn/gemm/cutedsl/dense/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py
+++ b/python/cudnn/gemm/cutedsl/dense/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py
@@ -1458,6 +1458,8 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             c_pipeline.producer_tail()
             d_pipeline.producer_tail()
 
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     def mainloop_s2t_copy_and_partition(
         self,
         sSF: cute.Tensor,

--- a/python/cudnn/gemm/cutedsl/dense/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py
+++ b/python/cudnn/gemm/cutedsl/dense/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py
@@ -1719,6 +1719,8 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             c_pipeline.producer_tail()
             ab12_pipeline.producer_tail()
 
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     def mainloop_s2t_copy_and_partition(
         self,
         sSF: cute.Tensor,

--- a/python/cudnn/gemm/cutedsl/dense/swiglu/dense_gemm_persistent_swiglu.py
+++ b/python/cudnn/gemm/cutedsl/dense/swiglu/dense_gemm_persistent_swiglu.py
@@ -1153,6 +1153,8 @@ class PersistentDenseGemmKernel:
             #
             c_pipeline.producer_tail()
 
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     def epilog_tmem_copy_and_partition(
         self,
         tidx: cutlass.Int32,

--- a/python/cudnn/gemm/cutedsl/discrete_grouped/dswiglu/discrete_B_blockscaled_grouped_gemm_dglu_dbias.py
+++ b/python/cudnn/gemm/cutedsl/discrete_grouped/dswiglu/discrete_B_blockscaled_grouped_gemm_dglu_dbias.py
@@ -667,6 +667,8 @@ class BlockScaledDiscreteWeightDgluDbiasGroupedGemmKernel:
                 )
                 sched_counter[0] = cutlass.Int32(0)
 
+    desc_init_kernel_device_ptrs.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     @cute.jit
     def __call__(
         self,
@@ -3395,6 +3397,8 @@ class BlockScaledDiscreteWeightDgluDbiasGroupedGemmKernel:
             # Wait C buffer tail complete
             #
             c_pipeline.producer_tail(c_pipeline_producer_state)
+
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
     def epilog_tmem_copy_and_partition(
         self,

--- a/python/cudnn/gemm/cutedsl/discrete_grouped/swiglu/discrete_B_blockscaled_grouped_gemm_glu_bias.py
+++ b/python/cudnn/gemm/cutedsl/discrete_grouped/swiglu/discrete_B_blockscaled_grouped_gemm_glu_bias.py
@@ -671,6 +671,8 @@ class BlockScaledDiscreteWeightGroupedGemmBiasKernel:
                 )
                 sched_counter[0] = cutlass.Int32(0)
 
+    desc_init_kernel_device_ptrs.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     @cute.jit
     def __call__(
         self,
@@ -2864,6 +2866,8 @@ class BlockScaledDiscreteWeightGroupedGemmBiasKernel:
             #
             c_pipeline.producer_tail()
             d_pipeline.producer_tail()
+
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
     def epilog_tmem_copy_and_partition(
         self,

--- a/python/cudnn/gemm/cutedsl/grouped/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py
@@ -698,6 +698,8 @@ class BlockScaledMoEGroupedGemmDgluDbiasKernel:
                 )
                 sched_counter[0] = cutlass.Int32(0)
 
+    helper_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     @cute.jit
     def __call__(
         self,
@@ -3568,6 +3570,8 @@ class BlockScaledMoEGroupedGemmDgluDbiasKernel:
             # Wait C buffer tail complete
             #
             c_pipeline.producer_tail(c_pipeline_producer_state)
+
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
     def epilog_tmem_copy_and_partition(
         self,

--- a/python/cudnn/gemm/cutedsl/grouped/dglu/moe_blockscaled_grouped_gemm_dglu_rubin.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dglu/moe_blockscaled_grouped_gemm_dglu_rubin.py
@@ -731,6 +731,8 @@ class BlockScaledMoEGroupedGemmDgluKernel:
                 )
                 sched_counter[0] = cutlass.Int32(0)
 
+    helper_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     @cute.jit
     def __call__(
         self,
@@ -3616,6 +3618,8 @@ class BlockScaledMoEGroupedGemmDgluKernel:
             # Wait C buffer tail complete
             #
             c_pipeline.producer_tail(c_pipeline_producer_state)
+
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
     def epilog_tmem_copy_and_partition(
         self,

--- a/python/cudnn/gemm/cutedsl/grouped/dglu/moe_grouped_gemm_dglu_dbias.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dglu/moe_grouped_gemm_dglu_dbias.py
@@ -412,6 +412,8 @@ class MoEGroupedGemmDgluDbiasBf16Kernel:
                 )
                 sched_counter[0] = cutlass.Int32(0)
 
+    helper_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     @cute.jit
     def __call__(
         self,
@@ -2039,6 +2041,8 @@ class MoEGroupedGemmDgluDbiasBf16Kernel:
             # Wait C buffer tail complete
             #
             c_pipeline.producer_tail(c_pipeline_producer_state)
+
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
     def epilog_tmem_copy_and_partition(
         self,

--- a/python/cudnn/gemm/cutedsl/grouped/dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
@@ -600,6 +600,8 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
                 )
                 sched_counter[0] = cutlass.Int32(0)
 
+    helper_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     # ------------------------------------------------------------------
     # __call__
     # ------------------------------------------------------------------
@@ -2432,6 +2434,8 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
             self.epilog_sync_barrier.arrive_and_wait()
             tmem.free(tmem_ptr)
             d_pipeline.producer_tail()
+
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
     # ------------------------------------------------------------------
     # Internal: create extension based on weight_mode

--- a/python/cudnn/gemm/cutedsl/grouped/dswiglu/grouped_gemm_dswiglu_quant.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dswiglu/grouped_gemm_dswiglu_quant.py
@@ -3180,6 +3180,8 @@ class BlockScaledContiguousGroupedGemmKernel:
             #
             c_pipeline.producer_tail(c_pipeline_producer_state)
 
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     def epilog_tmem_copy_and_partition(
         self,
         tidx: cutlass.Int32,

--- a/python/cudnn/gemm/cutedsl/grouped/glu/moe_blockscaled_grouped_gemm_glu_bias.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu/moe_blockscaled_grouped_gemm_glu_bias.py
@@ -700,6 +700,8 @@ class BlockScaledMoEGroupedGemmGluBiasKernel:
                 )
                 sched_counter[0] = cutlass.Int32(0)
 
+    helper_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     @cute.jit
     def __call__(
         self,
@@ -2935,6 +2937,8 @@ class BlockScaledMoEGroupedGemmGluBiasKernel:
             #
             c_pipeline.producer_tail()
             d_pipeline.producer_tail()
+
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
     def epilog_tmem_copy_and_partition(
         self,

--- a/python/cudnn/gemm/cutedsl/grouped/glu/moe_blockscaled_grouped_gemm_glu_rubin.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu/moe_blockscaled_grouped_gemm_glu_rubin.py
@@ -715,6 +715,8 @@ class BlockScaledMoEGroupedGemmGluKernel:
                 )
                 sched_counter[0] = cutlass.Int32(0)
 
+    helper_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     @cute.jit
     def __call__(
         self,
@@ -3041,6 +3043,8 @@ class BlockScaledMoEGroupedGemmGluKernel:
             #
             c_pipeline.producer_tail()
             d_pipeline.producer_tail()
+
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
     def epilog_tmem_copy_and_partition(
         self,

--- a/python/cudnn/gemm/cutedsl/grouped/glu/moe_grouped_gemm_glu_bias.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu/moe_grouped_gemm_glu_bias.py
@@ -468,6 +468,8 @@ class MoEGroupedGemmGluBiasBf16Kernel:
                 )
                 sched_counter[0] = cutlass.Int32(0)
 
+    helper_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     @cute.jit
     def __call__(
         self,
@@ -1809,6 +1811,8 @@ class MoEGroupedGemmGluBiasBf16Kernel:
             if cutlass.const_expr(self.generate_c):
                 c_pipeline.producer_tail()
             d_pipeline.producer_tail()
+
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
     def epilog_tmem_copy_and_partition(
         self,

--- a/python/cudnn/gemm/cutedsl/grouped/glu_hadamard/moe_blockscaled_grouped_gemm_glu_hadamard.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu_hadamard/moe_blockscaled_grouped_gemm_glu_hadamard.py
@@ -529,6 +529,8 @@ class BlockScaledMoEGroupedGemmGluHadamardKernel:
                 )
                 sched_counter[0] = cutlass.Int32(0)
 
+    helper_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     @cute.jit
     def __call__(
         self,
@@ -2571,6 +2573,8 @@ class BlockScaledMoEGroupedGemmGluHadamardKernel:
                 self.epilog_sync_barrier_group1.arrive_and_wait()
                 tmem.free(tmem_ptr)
         # END OF KERNEL
+
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
 
 class BlockScaledMoEGroupedGemmGluHadamardCompatKernel(BlockScaledMoEGroupedGemmGluHadamardKernel):

--- a/python/cudnn/gemm/cutedsl/grouped/glu_hadamard_quant/moe_blockscaled_grouped_gemm_glu_hadamard_quant.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu_hadamard_quant/moe_blockscaled_grouped_gemm_glu_hadamard_quant.py
@@ -575,6 +575,8 @@ class BlockScaledMoEGroupedGemmGluHadamardQuantKernel:
                 )
                 sched_counter[0] = cutlass.Int32(0)
 
+    helper_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     @cute.jit
     def __call__(
         self,
@@ -2711,3 +2713,5 @@ class BlockScaledMoEGroupedGemmGluHadamardQuantKernel:
             if cutlass.const_expr(self.d_quant):
                 dq_pipeline.producer_tail()
         # END OF KERNEL
+
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)

--- a/python/cudnn/gemm/cutedsl/grouped/glu_hadamard_quant/moe_blockscaled_grouped_gemm_glu_hadamard_quant_rubin.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu_hadamard_quant/moe_blockscaled_grouped_gemm_glu_hadamard_quant_rubin.py
@@ -703,6 +703,8 @@ class BlockScaledMoEGroupedGemmGluHadamardQuantKernel:
                 )
                 sched_counter[0] = cutlass.Int32(0)
 
+    helper_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     @cute.jit
     def __call__(
         self,
@@ -3138,3 +3140,5 @@ class BlockScaledMoEGroupedGemmGluHadamardQuantKernel:
             if cutlass.const_expr(self.d_quant):
                 dq_pipeline.producer_tail()
         # END OF KERNEL
+
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)

--- a/python/cudnn/gemm/cutedsl/grouped/quant/grouped_gemm_quant.py
+++ b/python/cudnn/gemm/cutedsl/grouped/quant/grouped_gemm_quant.py
@@ -543,6 +543,8 @@ class BlockScaledMoEGroupedGemmQuantKernel:
                 )
                 sched_counter[0] = cutlass.Int32(0)
 
+    helper_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     # ------------------------------------------------------------------
     # __call__
     # ------------------------------------------------------------------
@@ -2017,6 +2019,8 @@ class BlockScaledMoEGroupedGemmQuantKernel:
             self.epilog_sync_barrier.arrive_and_wait()
             tmem.free(tmem_ptr)
             d_pipeline.producer_tail()
+
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
     # ------------------------------------------------------------------
     # Internal: create extension based on weight_mode

--- a/python/cudnn/gemm/cutedsl/grouped/quant/moe_blockscaled_grouped_gemm_quant_rubin.py
+++ b/python/cudnn/gemm/cutedsl/grouped/quant/moe_blockscaled_grouped_gemm_quant_rubin.py
@@ -729,6 +729,8 @@ class BlockScaledMoEGroupedGemmQuantKernel:
                 )
                 sched_counter[0] = cutlass.Int32(0)
 
+    helper_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     @cute.jit
     def __call__(
         self,
@@ -2555,6 +2557,8 @@ class BlockScaledMoEGroupedGemmQuantKernel:
             if cutlass.const_expr(self.generate_c):
                 c_pipeline.producer_tail()
             d_pipeline.producer_tail()
+
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
     # ------------------------------------------------------------------
     # Internal: create extension based on weight_mode

--- a/python/cudnn/gemm/cutedsl/grouped/srelu/moe_blockscaled_grouped_gemm_srelu_quant.py
+++ b/python/cudnn/gemm/cutedsl/grouped/srelu/moe_blockscaled_grouped_gemm_srelu_quant.py
@@ -574,6 +574,8 @@ class BlockScaledMoEGroupedGemmQuantKernel:
                 )
                 sched_counter[0] = cutlass.Int32(0)
 
+    helper_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     # ------------------------------------------------------------------
     # __call__
     # ------------------------------------------------------------------
@@ -2080,6 +2082,8 @@ class BlockScaledMoEGroupedGemmQuantKernel:
             if cutlass.const_expr(self.generate_c):
                 c_pipeline.producer_tail()
             d_pipeline.producer_tail()
+
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
     # ------------------------------------------------------------------
     # Internal: create extension based on weight_mode

--- a/python/cudnn/gemm/cutedsl/grouped/swiglu/grouped_gemm_swiglu_quant.py
+++ b/python/cudnn/gemm/cutedsl/grouped/swiglu/grouped_gemm_swiglu_quant.py
@@ -2616,6 +2616,8 @@ class BlockScaledContiguousGroupedGemmKernel:
             c_pipeline.producer_tail()
             d_pipeline.producer_tail()
 
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     def epilog_tmem_copy_and_partition(
         self,
         tidx: cutlass.Int32,

--- a/python/cudnn/gemm/cutedsl/grouped/unfused/moe_grouped_gemm.py
+++ b/python/cudnn/gemm/cutedsl/grouped/unfused/moe_grouped_gemm.py
@@ -417,6 +417,8 @@ class MoEGroupedGemmBf16Kernel:
                 )
                 sched_counter[0] = cutlass.Int32(0)
 
+    helper_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     # ------------------------------------------------------------------
     # __call__
     # ------------------------------------------------------------------
@@ -1340,6 +1342,8 @@ class MoEGroupedGemmBf16Kernel:
             if cutlass.const_expr(self.generate_c):
                 c_pipeline.producer_tail()
             d_pipeline.producer_tail()
+
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
     # ------------------------------------------------------------------
     # Internal: create extension based on weight_mode

--- a/python/cudnn/gemm/cutedsl/grouped/wgrad/moe_blockscaled_grouped_gemm_wgrad.py
+++ b/python/cudnn/gemm/cutedsl/grouped/wgrad/moe_blockscaled_grouped_gemm_wgrad.py
@@ -733,6 +733,8 @@ class BlockScaledMoEGroupedGemmWgradKernel:
         expert_idx = cute.arch.block_idx()[0]
         ctor.construct_and_write(expert_idx)
 
+    helper_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     # ------------------------------------------------------------------
     # kernel (GPU device kernel)
     # ------------------------------------------------------------------
@@ -1593,3 +1595,5 @@ class BlockScaledMoEGroupedGemmWgradKernel:
             tmem.relinquish_alloc_permit()
             epilog_sync_barrier.arrive_and_wait()
             tmem.free(acc_tmem_ptr)
+
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)

--- a/python/cudnn/gemm/cutedsl/grouped/wgrad/moe_grouped_gemm_wgrad.py
+++ b/python/cudnn/gemm/cutedsl/grouped/wgrad/moe_grouped_gemm_wgrad.py
@@ -592,6 +592,8 @@ class MoEGroupedGemmWgradBF16Kernel:
         expert_idx = cute.arch.block_idx()[0]
         ctor.construct_and_write(expert_idx)
 
+    helper_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     # ------------------------------------------------------------------
     # kernel (GPU device kernel)
     # ------------------------------------------------------------------
@@ -1152,3 +1154,5 @@ class MoEGroupedGemmWgradBF16Kernel:
             tmem.relinquish_alloc_permit()
             epilog_sync_barrier.arrive_and_wait()
             tmem.free(acc_tmem_ptr)
+
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)

--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -2017,7 +2017,7 @@ def _render_template(
     # Tag the kernel fn name with template + geometry so nsys gives each
     # (template, config) a distinct GPU kernel symbol.
     tag = re.sub(r"[^A-Za-z0-9_]", "_", f"{_template_stem(tmpl.file)}_{config.geometry_name}{_store_mode_tag(store_modes)}")
-    src = re.sub(r"\b_kernel(?=\(|\.set_name_prefix\b)", f"cudnn_frost_{tag}", src)
+    src = re.sub(r"\b_kernel(?=\(|\.set_name_prefix\b)", f"frost_{tag}", src)
 
     return src
 
@@ -2215,7 +2215,7 @@ def _render_block_scale_template(
     src = _replace_marker_lines(src, replacements, template_kind="block-scale template")
 
     tag = re.sub(r"[^A-Za-z0-9_]", "_", f"{_template_stem(tmpl.file)}_{config.geometry_name}{_store_mode_tag(store_modes)}")
-    src = re.sub(r"\b_kernel(?=\(|\.set_name_prefix\b)", f"cudnn_frost_{tag}", src)
+    src = re.sub(r"\b_kernel(?=\(|\.set_name_prefix\b)", f"frost_{tag}", src)
     return src
 
 

--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -2017,7 +2017,7 @@ def _render_template(
     # Tag the kernel fn name with template + geometry so nsys gives each
     # (template, config) a distinct GPU kernel symbol.
     tag = re.sub(r"[^A-Za-z0-9_]", "_", f"{_template_stem(tmpl.file)}_{config.geometry_name}{_store_mode_tag(store_modes)}")
-    src = re.sub(r"\b_kernel\(", f"cudnn_frost_{tag}(", src)
+    src = re.sub(r"\b_kernel(?=\(|\.set_name_prefix\b)", f"cudnn_frost_{tag}", src)
 
     return src
 
@@ -2215,7 +2215,7 @@ def _render_block_scale_template(
     src = _replace_marker_lines(src, replacements, template_kind="block-scale template")
 
     tag = re.sub(r"[^A-Za-z0-9_]", "_", f"{_template_stem(tmpl.file)}_{config.geometry_name}{_store_mode_tag(store_modes)}")
-    src = re.sub(r"\b_kernel\(", f"cudnn_frost_{tag}(", src)
+    src = re.sub(r"\b_kernel(?=\(|\.set_name_prefix\b)", f"cudnn_frost_{tag}", src)
     return src
 
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul.py
@@ -1422,6 +1422,9 @@ def _kernel(
         nvvm.setmaxregister(prod_reg_count, nvvm.SetMaxRegisterAction.DECREASE)
 
 
+_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 @cute.jit
 def _host(
     problem_size: tuple,

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul.py
@@ -1151,6 +1151,9 @@ def _kernel(
         nvvm.setmaxregister(prod_reg_count, nvvm.SetMaxRegisterAction.DECREASE)
 
 
+_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 @cute.jit
 def _host(
     problem_size: tuple,

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop.py
@@ -1447,6 +1447,9 @@ def _kernel(
         nvvm.setmaxregister(prod_reg_count, nvvm.SetMaxRegisterAction.DECREASE)
 
 
+_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 @cute.jit
 def _host(
     problem_size: tuple,

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd.py
@@ -1785,6 +1785,9 @@ def _kernel(
         nvvm.setmaxregister(prod_reg_count, nvvm.SetMaxRegisterAction.DECREASE)
 
 
+_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 @cute.jit
 def _host(
     problem_size: tuple,

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd.py
@@ -1312,6 +1312,9 @@ def _kernel(
         nvvm.setmaxregister(prod_reg_count, nvvm.SetMaxRegisterAction.DECREASE)
 
 
+_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 @cute.jit
 def _host(
     problem_size: tuple,

--- a/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul.py
@@ -1543,6 +1543,9 @@ def _kernel(
         # @@TMA_STORE_ONLY:END@@
 
 
+_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 @cute.jit
 def _host(
     problem_size: tuple,

--- a/python/cudnn/gemm/frost/kernel_templates/sm120_matmul.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm120_matmul.py
@@ -767,6 +767,9 @@ def _kernel(
         nvvm.setmaxregister(PROD_REG_COUNT, nvvm.SetMaxRegisterAction.DECREASE)
 
 
+_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 @cute.jit
 def _host(
     problem_size: tuple,

--- a/python/cudnn/sdpa/bwd/kernels/bprop_chain_f16_sm120.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_chain_f16_sm120.py
@@ -267,6 +267,8 @@ class SM120DetDqGemmKernel:
                         alignment=4,
                     )
 
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     @cute.jit
     def __call__(
         self,
@@ -414,6 +416,9 @@ def dot_do_o_kernel(
             (dq_sem_ptr + (batch * H + head) * num_q_tiles + q_block).store(cutlass.Int32(0))
 
 
+dot_do_o_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 @cute.jit
 def dot_do_o_host(
     o: cute.Tensor,
@@ -527,6 +532,9 @@ def convert_dq_kernel(
                 )
 
 
+convert_dq_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 @cute.jit
 def convert_dq_host(
     dq_accum: cute.Tensor,
@@ -572,6 +580,9 @@ def convert_dbias_kernel(
     gidx = bidx * 256 + tidx
     if gidx < total:
         (out_ptr + gidx).store((acc_ptr + gidx).load().to(out_dtype))
+
+
+convert_dbias_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
 
 @cute.jit
@@ -803,6 +814,9 @@ def dkv_reduce_kernel(
                 )
 
 
+dkv_reduce_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 @cute.jit
 def dkv_reduce_host(
     dk_ws: cute.Tensor,
@@ -882,6 +896,9 @@ def dsink_kernel(
         )
     if tidx == 0:
         (dsink.iterator.raw_ptr() + head).store(-acc)
+
+
+dsink_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
 
 @cute.jit

--- a/python/cudnn/sdpa/bwd/kernels/bprop_d64_f16_sm80.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_d64_f16_sm80.py
@@ -550,6 +550,9 @@ def _bprop_kernel(
         Pointer((dK_view.data_ptr() + base_b + dcol), dtype=cutlass.Int32).store(fp32_to_fp16(acc_dK[off + 2], acc_dK[off + 3], dtype=io_dtype), alignment=4)
 
 
+_bprop_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 @cute.kernel
 def _unpermute_dq_kernel(
     dQ_acc: cute.Tensor,  # [B, H, SQ, d] fp32 PERMUTED-flat scratch (atomic target)
@@ -591,6 +594,9 @@ def _unpermute_dq_kernel(
         dcol = dq_wc * cutlass.Int32(32) + cutlass.Int32(nf * 8) + cutlass.Int32(2) * p_lane
         Pointer((out_view.data_ptr() + out_t + dcol), dtype=cutlass.Int32).store(fp32_to_fp16(v0, v1, dtype=io_dtype), alignment=4)
         Pointer((out_view.data_ptr() + out_b + dcol), dtype=cutlass.Int32).store(fp32_to_fp16(v2, v3, dtype=io_dtype), alignment=4)
+
+
+_unpermute_dq_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
 
 @cute.jit

--- a/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm120.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm120.py
@@ -1404,6 +1404,8 @@ class SM120FusedMultiHeadAttentionFP16Backward:
         else:
             prims.setmaxregister(24, prims.SetMaxRegisterAction.DECREASE)
 
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     @cute.jit
     def __call__(
         self,

--- a/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
@@ -1124,6 +1124,9 @@ def _bprop_kernel(
                 Pointer((dK_view.data_ptr() + base_bot), dtype=cutlass.Int32).store(_kb, alignment=4)
 
 
+_bprop_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 @cute.jit
 def _atomic_add_f32(addr_i64, val):
     """``atom.global.add.f32`` on a 32-bit GMEM float element.  ``addr_i64`` is
@@ -1200,6 +1203,9 @@ def _do_dot_kernel(
             Pointer(cutlass.make_array_view(DELTA).data_ptr() + row, dtype=cutlass.Float32).store(acc)
 
 
+_do_dot_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 # ===========================================================================
 # Attention-sink gradient: dSink_h = -Σ_{b,q} exp(sink_h - lse[b,h,q]) *
 # do_dot[b,h,q].  Standalone (dQ/dK/dV are already sink-correct from the
@@ -1245,6 +1251,9 @@ def _dsink_kernel(
             _atomic_add_f32(cutlass.make_array_view(DSINK).data_ptr() + h, -acc)
 
 
+_dsink_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 # ===========================================================================
 # dQ_acc (fp32) → dQ (io_dtype) cast kernel.
 # ===========================================================================
@@ -1263,6 +1272,9 @@ def _cast_kernel(
         dst = cutlass.make_array_view(dQ_out).data_ptr()
         v = Pointer(src + gid * cutlass.Int32(2), dtype=cutlass.Float32).load(count=2)
         Pointer(dst + gid * cutlass.Int32(2), dtype=cutlass.Int32).store(fp32_to_fp16(v[0], v[1], dtype=io_dtype), alignment=4)
+
+
+_cast_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
 
 # ===========================================================================
@@ -1296,6 +1308,9 @@ def _dkv_reduce_kernel(
         for g in cutlass.range_constexpr(ratio):
             acc = acc + Pointer(src + in_base + cutlass.Int32(g * d), dtype=io_dtype).load().to(cutlass.Float32)
         Pointer(cutlass.make_array_view(OUT).data_ptr() + e, dtype=io_dtype).store(acc.to(io_dtype))
+
+
+_dkv_reduce_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
 
 # ===========================================================================

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_f16_sm100.py
@@ -653,6 +653,9 @@ def _kernel(
             scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
 
 
+_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 # === TMA-LDG warp ===
 
 

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
@@ -609,6 +609,9 @@ def _kernel(
         scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
 
 
+_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 # === TMA-LDG warp ===
 
 

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
@@ -693,6 +693,9 @@ def _kernel(
         scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
 
 
+_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 # === TMA-LDG warp ===
 
 

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
@@ -786,6 +786,9 @@ def _kernel(
         scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
 
 
+_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 # === Warp-group functions ===
 
 

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm100.py
@@ -666,6 +666,9 @@ def _kernel(
         scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
 
 
+_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 # === TMA-LDG warp ===
 
 

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
@@ -784,6 +784,9 @@ def _kernel(
         )
 
 
+_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 # === TMA-LDG warp ===
 
 

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_mxfp8_sm100.py
@@ -808,6 +808,9 @@ def _kernel(
         scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
 
 
+_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 # === Warp-group functions ===
 
 

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm100.py
@@ -477,6 +477,9 @@ def _kernel(
         scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
 
 
+_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 @cute.jit
 def _tmaldg_warp_group(
     tma_q_desc,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm80.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm80.py
@@ -1559,6 +1559,9 @@ def _sdpa_kernel(
                 Pointer(gmem_addr, dtype=cutlass.Int32).store(vec, alignment=16)
 
 
+_sdpa_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 # ---------------------------------------------------------------------------
 # Host wrapper.
 # ---------------------------------------------------------------------------

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d512_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d512_f16_sm100.py
@@ -655,6 +655,9 @@ def _kernel(
         scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
 
 
+_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 @cute.jit
 def _sg0_softmax_kv_iter(
     apply_mask: bool,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d512_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d512_fp8_sm100.py
@@ -795,6 +795,9 @@ def _kernel(
         scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
 
 
+_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 @cute.jit
 def _sg0_softmax_kv_iter(
     apply_mask: bool,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm120.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm120.py
@@ -1538,6 +1538,8 @@ class SM120FusedMultiHeadAttentionForward:
                 head_idx,
             )
 
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     @cute.jit
     def __call__(
         self,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm80.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm80.py
@@ -1558,6 +1558,9 @@ def _sdpa_kernel(
                 Pointer(gmem_addr, dtype=cutlass.Int32).store(vec, alignment=16)
 
 
+_sdpa_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 # ---------------------------------------------------------------------------
 # Host wrapper.
 # ---------------------------------------------------------------------------

--- a/python/cudnn/sdpa/fwd/kernels/prefill_fp8_sm120.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_fp8_sm120.py
@@ -1629,6 +1629,8 @@ class SM120FusedMultiHeadAttentionForward:
         else:
             prims.setmaxregister(self.load_regs, prims.SetMaxRegisterAction.DECREASE)
 
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
     @cute.jit
     def __call__(
         self,

--- a/python/cudnn/sdpa/fwd/kernels/split_combine_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/split_combine_sm100.py
@@ -128,6 +128,9 @@ def _combine_kernel(
             lo[batch, head, q_row] = lse_val
 
 
+_combine_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 @cute.jit
 def _host(
     o_partial: cute.Tensor,

--- a/python/cudnn/sdpa/fwd/kernels/thd_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/thd_sm100.py
@@ -216,6 +216,9 @@ def build_thd_meta_kernel(
         meta[cutlass.Int32(4) * n_batch + cutlass.Int32(3)] = n_ctas
 
 
+build_thd_meta_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 @cute.kernel
 def build_thd_meta_o_kv_descs_kernel(
     o_tensor: cute.Tensor,
@@ -303,6 +306,9 @@ def build_thd_meta_o_kv_descs_kernel(
     # it leaves the region uninitialized and units decode garbage batches.
     cute.arch.barrier()
     write_thd_batch_remap(cutlass.make_array_view(meta_t), n_batch, cutlass.Int32(tidx), cutlass.Int32(nthreads))
+
+
+build_thd_meta_o_kv_descs_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
 
 @cute.kernel
@@ -419,3 +425,6 @@ def build_thd_meta_o_descs_kernel(
             live = live + ((s_b + cga_tile_m - cutlass.Int32(1)) // cga_tile_m) * n_qh
         meta_w[cutlass.Int32(4) * n_batch + cutlass.Int32(2)] = live
         meta_w[cutlass.Int32(4) * n_batch + cutlass.Int32(3)] = n_clusters
+
+
+build_thd_meta_o_descs_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)

--- a/skills/cutedsl-kernel-integration/SKILL.md
+++ b/skills/cutedsl-kernel-integration/SKILL.md
@@ -32,6 +32,22 @@ Use this skill to add or update a CuTeDSL frontend-only API in cuDNN Frontend. T
 8. For grouped/discrete/MoE/SDPA kernels, preserve the source helper and scheduler topology; shared helper modules should be internal package files, not public `cudnn` exports.
 9. When an existing SM100 kernel needs a Rubin (`sm107`) variant, follow the architecture-dispatch pattern in `references/integration-pattern.md` instead of exposing a new public API. Current examples: `grouped_gemm_quant`, `grouped_gemm_glu`, and `grouped_gemm_dglu`.
 
+## Generated Kernel Names
+
+Immediately after every `@cute.kernel` definition, including main, auxiliary,
+and generated-template kernels, add:
+
+```python
+kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+```
+
+Use the decorated function's actual name in place of `kernel` and keep the
+default `keep_mangled_name=True`. Verify the rule with:
+
+```bash
+pytest -q test/python/test_frost_kernel_name_prefix.py
+```
+
 ## Verification
 
 - Run focused formatting or tests for the files changed.

--- a/skills/cutedsl-kernel-integration/SKILL.md
+++ b/skills/cutedsl-kernel-integration/SKILL.md
@@ -32,22 +32,6 @@ Use this skill to add or update a CuTeDSL frontend-only API in cuDNN Frontend. T
 8. For grouped/discrete/MoE/SDPA kernels, preserve the source helper and scheduler topology; shared helper modules should be internal package files, not public `cudnn` exports.
 9. When an existing SM100 kernel needs a Rubin (`sm107`) variant, follow the architecture-dispatch pattern in `references/integration-pattern.md` instead of exposing a new public API. Current examples: `grouped_gemm_quant`, `grouped_gemm_glu`, and `grouped_gemm_dglu`.
 
-## Generated Kernel Names
-
-Immediately after every `@cute.kernel` definition, including main, auxiliary,
-and generated-template kernels, add:
-
-```python
-kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
-```
-
-Use the decorated function's actual name in place of `kernel` and keep the
-default `keep_mangled_name=True`. Verify the rule with:
-
-```bash
-pytest -q test/python/test_frost_kernel_name_prefix.py
-```
-
 ## Verification
 
 - Run focused formatting or tests for the files changed.

--- a/test/python/gemm/frost/test_matmul.py
+++ b/test/python/gemm/frost/test_matmul.py
@@ -3392,7 +3392,7 @@ def test_sm120_render_smoke() -> None:
                 combo = (a_major, b_major, out_major)
                 assert "@@" not in src, f"leftover injection markers {combo}"
                 ast.parse(src)
-                assert "cudnn_frost_sm120_matmul_" in src
+                assert "frost_sm120_matmul_" in src
                 assert "threads_per_cta = 384" in src
                 assert f"vec_bytes_epi = {vec}" in src
                 assert "_STG_EPI_BYTES" in src, "transposed-STG arm must be rendered"

--- a/test/python/test_frost_kernel_name_prefix.py
+++ b/test/python/test_frost_kernel_name_prefix.py
@@ -22,7 +22,7 @@ def _dotted_name(node: ast.AST) -> str:
 
 
 def _is_cute_kernel(node: ast.FunctionDef) -> bool:
-    return any(_dotted_name(decorator) == "cute.kernel" for decorator in node.decorator_list)
+    return any(_dotted_name(decorator.func if isinstance(decorator, ast.Call) else decorator) == "cute.kernel" for decorator in node.decorator_list)
 
 
 def _is_cudnn_name_prefix(statement: ast.stmt, kernel_name: str) -> bool:
@@ -39,26 +39,20 @@ def _is_cudnn_name_prefix(statement: ast.stmt, kernel_name: str) -> bool:
     return isinstance(remove_cutlass_symbol, ast.Constant) and remove_cutlass_symbol.value is True
 
 
-def _is_any_cudnn_name_prefix(statement: ast.AST) -> bool:
-    if not isinstance(statement, ast.Expr) or not isinstance(statement.value, ast.Call):
-        return False
-    function = statement.value.func
-    if not isinstance(function, ast.Attribute) or function.attr != "set_name_prefix":
-        return False
-    return _is_cudnn_name_prefix(statement, _dotted_name(function.value))
-
-
-def _missing_prefixes(statements: list[ast.stmt], scope: tuple[str, ...] = ()) -> list[str]:
+def _missing_prefixes(node: ast.AST, scope: tuple[str, ...] = ()) -> list[str]:
     missing = []
-    for index, statement in enumerate(statements):
-        if isinstance(statement, ast.FunctionDef) and _is_cute_kernel(statement):
-            next_statement = statements[index + 1] if index + 1 < len(statements) else None
-            if next_statement is None or not _is_cudnn_name_prefix(next_statement, statement.name):
-                qualified_name = ".".join((*scope, statement.name))
-                missing.append(f"{statement.lineno}:{qualified_name}")
-
-        if isinstance(statement, ast.ClassDef):
-            missing.extend(_missing_prefixes(statement.body, (*scope, statement.name)))
+    for _, value in ast.iter_fields(node):
+        children = value if isinstance(value, list) else [value] if isinstance(value, ast.AST) else []
+        if isinstance(value, list):
+            for index, statement in enumerate(value):
+                if isinstance(statement, ast.FunctionDef) and _is_cute_kernel(statement):
+                    next_statement = value[index + 1] if index + 1 < len(value) else None
+                    if next_statement is None or not _is_cudnn_name_prefix(next_statement, statement.name):
+                        missing.append(f"{statement.lineno}:{'.'.join((*scope, statement.name))}")
+        for child in children:
+            if isinstance(child, ast.AST):
+                child_scope = (*scope, child.name) if isinstance(child, (ast.ClassDef, ast.FunctionDef)) else scope
+                missing.extend(_missing_prefixes(child, child_scope))
 
     return missing
 
@@ -68,15 +62,19 @@ def test_gemm_and_sdpa_kernels_have_cudnn_name_prefix():
     missing = []
     counts = {}
     for root in _KERNEL_ROOTS:
-        kernel_count = prefix_count = 0
+        kernel_count = 0
         for path in sorted(root.rglob("*.py")):
             tree = ast.parse(path.read_text(encoding="utf-8"))
             kernel_count += sum(isinstance(node, ast.FunctionDef) and _is_cute_kernel(node) for node in ast.walk(tree))
-            prefix_count += sum(_is_any_cudnn_name_prefix(node) for node in ast.walk(tree))
-            offenders = _missing_prefixes(tree.body)
+            offenders = _missing_prefixes(tree)
             missing.extend(f"{path.relative_to(_REPO_ROOT)}:{offender}" for offender in offenders)
-        counts[root.name] = (kernel_count, prefix_count)
+        counts[root.name] = kernel_count
 
-    assert all(kernel_count for kernel_count, _ in counts.values()), f"expected Frost kernels under every scanned root, got {counts}"
-    assert all(kernel_count == prefix_count for kernel_count, prefix_count in counts.values()), f"kernel/prefix count mismatch: {counts}"
+    assert all(counts.values()), f"expected Frost kernels under every scanned root, got {counts}"
     assert not missing, "Frost @cute.kernel definitions missing the required cuDNN name prefix:\n" + "\n".join(missing)
+
+
+@pytest.mark.L0
+def test_prefix_guard_covers_called_decorator_and_nested_kernel():
+    tree = ast.parse("def outer():\n    @cute.kernel()\n    def missing():\n        pass\n")
+    assert _missing_prefixes(tree) == ["3:outer.missing"]

--- a/test/python/test_frost_kernel_name_prefix.py
+++ b/test/python/test_frost_kernel_name_prefix.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_KERNEL_ROOTS = (
+    _REPO_ROOT / "python" / "cudnn" / "gemm",
+    _REPO_ROOT / "python" / "cudnn" / "sdpa",
+)
+
+
+def _dotted_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return f"{_dotted_name(node.value)}.{node.attr}"
+    return ""
+
+
+def _is_cute_kernel(node: ast.FunctionDef) -> bool:
+    return any(_dotted_name(decorator) == "cute.kernel" for decorator in node.decorator_list)
+
+
+def _is_cudnn_name_prefix(statement: ast.stmt, kernel_name: str) -> bool:
+    if not isinstance(statement, ast.Expr) or not isinstance(statement.value, ast.Call):
+        return False
+
+    call = statement.value
+    if _dotted_name(call.func) != f"{kernel_name}.set_name_prefix":
+        return False
+    if len(call.args) != 1 or not isinstance(call.args[0], ast.Constant) or call.args[0].value != "cudnn":
+        return False
+
+    remove_cutlass_symbol = next((kw.value for kw in call.keywords if kw.arg == "remove_cutlass_symbol"), None)
+    return isinstance(remove_cutlass_symbol, ast.Constant) and remove_cutlass_symbol.value is True
+
+
+def _is_any_cudnn_name_prefix(statement: ast.AST) -> bool:
+    if not isinstance(statement, ast.Expr) or not isinstance(statement.value, ast.Call):
+        return False
+    function = statement.value.func
+    if not isinstance(function, ast.Attribute) or function.attr != "set_name_prefix":
+        return False
+    return _is_cudnn_name_prefix(statement, _dotted_name(function.value))
+
+
+def _missing_prefixes(statements: list[ast.stmt], scope: tuple[str, ...] = ()) -> list[str]:
+    missing = []
+    for index, statement in enumerate(statements):
+        if isinstance(statement, ast.FunctionDef) and _is_cute_kernel(statement):
+            next_statement = statements[index + 1] if index + 1 < len(statements) else None
+            if next_statement is None or not _is_cudnn_name_prefix(next_statement, statement.name):
+                qualified_name = ".".join((*scope, statement.name))
+                missing.append(f"{statement.lineno}:{qualified_name}")
+
+        if isinstance(statement, ast.ClassDef):
+            missing.extend(_missing_prefixes(statement.body, (*scope, statement.name)))
+
+    return missing
+
+
+@pytest.mark.L0
+def test_gemm_and_sdpa_kernels_have_cudnn_name_prefix():
+    missing = []
+    counts = {}
+    for root in _KERNEL_ROOTS:
+        kernel_count = prefix_count = 0
+        for path in sorted(root.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            kernel_count += sum(isinstance(node, ast.FunctionDef) and _is_cute_kernel(node) for node in ast.walk(tree))
+            prefix_count += sum(_is_any_cudnn_name_prefix(node) for node in ast.walk(tree))
+            offenders = _missing_prefixes(tree.body)
+            missing.extend(f"{path.relative_to(_REPO_ROOT)}:{offender}" for offender in offenders)
+        counts[root.name] = (kernel_count, prefix_count)
+
+    assert all(kernel_count for kernel_count, _ in counts.values()), f"expected Frost kernels under every scanned root, got {counts}"
+    assert all(kernel_count == prefix_count for kernel_count, prefix_count in counts.values()), f"kernel/prefix count mismatch: {counts}"
+    assert not missing, "Frost @cute.kernel definitions missing the required cuDNN name prefix:\n" + "\n".join(missing)


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches and the changes comply.
- [x] I added GitHub labels: one `cat-*`, one `area:*`, and one `orig-*`.

## Affected area

FE OSS kernels or CuTeDSL

## Summary

- Apply the public CuTe DSL `set_name_prefix("cudnn", remove_cutlass_symbol=True)` API to all 53 GEMM and 32 SDPA Frost kernels, including auxiliary kernels and generated GEMM templates.
- Preserve descriptive generated GEMM names without duplicating the cuDNN ownership prefix.
- Add an L0 AST guard for future GEMM/SDPA kernels and document the requirement in `python/cudnn/AGENTS.md`.

## Why

Frost kernels currently appear with CUTLASS-owned prefixes in profiler and debug traces. A consistent cuDNN prefix makes their ownership immediately identifiable while retaining the existing mangled function and trace-specific suffixes.

## Related issues

Fixes #820

## API and compatibility impact

No public API or kernel-computation changes. Generated GPU symbol names intentionally change from `cutlass_kernel...` to `cudnn_kernel...`. Kernel behavior and performance are unchanged.

## Testing

- `pre-commit run --files <all changed files>`: passed.
- `pytest -q test/python/test_frost_kernel_name_prefix.py`: 2 passed with cuDNN 9.26.
- `pytest -q test/python/test_frost_kernel_name_prefix.py test/python/gemm/frost/test_matmul.py::test_sm120_render_smoke`: 3 passed with cuDNN 9.26.
- SDPA graph-API smoke under nsys: 1 passed; generated symbol starts with `cudnn_kernel__kernel_...`.
- GEMM block-scale epilogue smoke under nsys: 1 passed; generated symbol starts with `cudnn_kernel_frost_sm100_matmul_...` with no duplicate cuDNN prefix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Standardized generated CUDA kernel symbols with a `cudnn` prefix across GEMM and scaled dot-product attention operations.
  * Removed CUTLASS-specific components from generated kernel names for clearer, more consistent identification.

* **Tests**
  * Added automated checks to verify naming conventions across supported kernels, including nested and decorated kernels.
  * Updated kernel-name expectations in rendering tests.
  * Updated the verification command used for the test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->