### PR TITLE
feat(gemm): optional tanh soft-clamp (tanh_clamp_scale) for grouped GEMM srelu/dsrelu

### DIFF
--- a/docs/fe-oss-apis/gemm_fusions/grouped_gemm_dsrelu.md
+++ b/docs/fe-oss-apis/gemm_fusions/grouped_gemm_dsrelu.md
@@ -55,6 +55,28 @@ $$
 \mathrm{dprob}[m, 0, 0] = \sum_n C[m, n, 0] \cdot \mathrm{relu}(G[m, n])^2
 $$
 
+#### Tanh soft clamp (`tanh_clamp_scale`)
+
+`tanh_clamp_scale=s` differentiates the soft-clamped forward epilogue
+(see [grouped_gemm_srelu](grouped_gemm_srelu.md)) instead of the plain one. Writing
+$t = \tanh(\mathrm{relu}(G)/s)$ and $b = s\,t$, both equations keep their shape with
+$\mathrm{relu}(G)$ replaced by $b$, and the row output picks up the chain-rule factor
+$1 - t^2$:
+
+$$
+D\_{row}[m, n] = \mathrm{prob}[m, 0, 0] \cdot 2 \cdot C[m, n, 0] \cdot b[m, n] \cdot \left(1 - t[m, n]^2\right)
+$$
+
+$$
+\mathrm{dprob}[m, 0, 0] = \sum_n C[m, n, 0] \cdot b[m, n]^2
+$$
+
+Both kernels must be built with the same `s`, or the saved pre-activation is differentiated
+against the wrong nonlinearity. `s` is baked in at compile time, so distinct values compile
+distinct kernels. Determinism is unaffected: the clamp changes only the per-element value that
+feeds the dprob accumulation, never the slotting or reduction order, so
+[deterministic dprob](#deterministic-dprob) stays bit-exact for the clamped path too.
+
 `D_col` stores the companion column-quantized output used by the grouped kernel family. When FP8 output is enabled, the kernel also emits `SFD_row` and `SFD_col`. When fp16/bf16 output is used, the kernel can emit per-expert `Amax`.
 
 ### Diagram

--- a/docs/fe-oss-apis/gemm_fusions/grouped_gemm_srelu.md
+++ b/docs/fe-oss-apis/gemm_fusions/grouped_gemm_srelu.md
@@ -48,6 +48,37 @@ $$
 D[m, n] = \mathrm{prob}[m, 0, 0] \cdot \mathrm{relu}(C[m, n])^2
 $$
 
+#### Tanh soft clamp (`tanh_clamp_scale`)
+
+Passing `tanh_clamp_scale=s` (a positive float; `None`, the default, keeps the equation above)
+soft-clamps the ReLU output before squaring, bounding `D` by $s^2 \cdot \mathrm{prob}$:
+
+$$
+D[m, n] = \mathrm{prob}[m, 0, 0] \cdot \left( s \cdot \tanh\!\left( \frac{\mathrm{relu}(C[m, n])}{s} \right) \right)^2
+$$
+
+`s` is baked into the compiled kernel, so distinct values compile distinct kernels -- it is meant
+to be constant for a whole training job, not a per-call argument.
+
+The epilogue is evaluated in FP32 with the approximate `tanh`. Measured on sm_103 against a
+correctly-rounded reference, over a sweep of $[0, 64]$ plus saturated inputs, its maximum
+absolute error is $7.7\times10^{-6}$ (the exact variant measures $1.0\times10^{-7}$ on the same
+sweep). Since $D = c^2$ with $c \le s$, that propagates to at most $2s^2 \cdot 7.7\times10^{-6}$
+absolutely -- about $1.6\times10^{-2}$ at $s = 32$ -- and to roughly $1.5\times10^{-5}$
+relative in the saturated tail. $t$ is capped at 1 before use, so $c \le s$ and the output bound
+$s^2 \cdot \mathrm{prob}$ hold structurally rather than by relying on the range of the
+approximate instruction.
+
+When `D` is FP8, even that small error is enough to carry a value across an output-format
+rounding boundary, so individual elements can land one ULP away from a reference computed with
+an exact `tanh` (12.5% relative for `e4m3`). Measured incidence on this kernel's test matrix is
+a few elements in $5\times10^{5}$. This does not affect the unclamped path, where the kernel and
+a reference both evaluate $\mathrm{relu}(x)^2$ and therefore quantize identically.
+
+The matching backward kernel takes the same `tanh_clamp_scale` -- see
+[grouped_gemm_dsrelu](grouped_gemm_dsrelu.md). Both must be built with the same `s`, or the saved
+pre-activation is differentiated against the wrong nonlinearity.
+
 `D_col` stores the same logical output in the column-quantized path used by the grouped kernel family. When `D` is FP8, the kernel also emits `SFD_row` and `SFD_col`. When `D` is fp16/bf16, the kernel can emit per-expert `Amax`.
 
 ### Diagram

--- a/docs/fe-oss-apis/overview.md
+++ b/docs/fe-oss-apis/overview.md
@@ -22,7 +22,8 @@ This folder documents the Python FE APIs implemented under `python/cudnn`. For d
 - [Grouped GEMM + dGLU (Unified)](gemm_fusions/grouped_gemm_dglu.md)
 - [Grouped GEMM + SwiGLU (Legacy, Contiguous-only)](gemm_fusions/grouped_gemm_swiglu.md)
 - [Grouped GEMM + dSwiGLU (Legacy, Contiguous-only)](gemm_fusions/grouped_gemm_dswiglu.md)
-- [Grouped GEMM + sReLU (Unified)](gemm_fusions/grouped_gemm_srelu.md)
+- [Grouped GEMM + sReLU (Unified)](gemm_fusions/grouped_gemm_srelu.md) — optionally tanh
+  soft-clamped via `tanh_clamp_scale`
 - [Grouped GEMM + dsReLU (Unified)](gemm_fusions/grouped_gemm_dsrelu.md)
 - [Discrete Grouped GEMM + SwiGLU](gemm_fusions/discrete_grouped_gemm_swiglu.md)
 - [Discrete Grouped GEMM + dSwiGLU](gemm_fusions/discrete_grouped_gemm_dswiglu.md)

--- a/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
@@ -27,6 +27,7 @@ from ..backend_utils import _torch_stream_context
 from ..moe_utils import MoEWeightMode
 from cuda.bindings import driver as cuda
 import logging
+import math
 import os
 from typing import Tuple, Optional
 
@@ -240,6 +241,7 @@ class GroupedGemmDsreluSm100(APIBase):
         use_dynamic_sched: bool = False,
         use_dsrelu_reuse: bool = False,
         deterministic: bool = False,
+        tanh_clamp_scale: Optional[float] = None,
     ):
         """Initialize the GroupedGemmDsreluSm100 API.
 
@@ -275,7 +277,10 @@ class GroupedGemmDsreluSm100(APIBase):
         :param discrete_col_sfd: Generate discrete col-major scale factor tensor
         :param b_major: Major dimension for B tensor, one of "k" or "n"
         :param use_dynamic_sched: Enable dynamic tile scheduling for load balancing
-        :param use_dsrelu_reuse: Reuse relu(C)^2 between d_srelu and dprob
+        :param use_dsrelu_reuse: Reuse relu(C)^2 (or, when clamped, c^2) between d_srelu and dprob
+        :param tanh_clamp_scale: Optional soft-clamp scale ``s``, must match the forward pass that
+            produced ``sample_c``. Must be finite and > 0. ``None`` (default) is bit-identical
+            to today's unclamped DSRELU.
         :param deterministic: Compute dprob and dbias run-to-run bit-exactly. dprob and dbias keep
             their shapes and dtypes; what the flag adds is the two scratch tensors above, which the
             kernel writes instead, and a reduction the caller runs after execute():
@@ -381,6 +386,12 @@ class GroupedGemmDsreluSm100(APIBase):
         self.use_dynamic_sched = use_dynamic_sched
         self.use_dsrelu_reuse = use_dsrelu_reuse
         self.deterministic = deterministic
+        if tanh_clamp_scale is not None:
+            self._value_error_if(
+                not math.isfinite(tanh_clamp_scale) or tanh_clamp_scale <= 0.0,
+                f"tanh_clamp_scale must be finite and positive, got {tanh_clamp_scale}",
+            )
+        self.tanh_clamp_scale = tanh_clamp_scale
 
         self._interpret_uint8_as_fp4x2 = True
         self._has_dbias = self.dbias_desc is not None
@@ -913,6 +924,7 @@ class GroupedGemmDsreluSm100(APIBase):
             generate_d_srelu=self._generate_d_srelu,
             use_dsrelu_reuse=self.use_dsrelu_reuse,
             deterministic=self.deterministic,
+            tanh_clamp_scale=self.tanh_clamp_scale,
         )
 
         hardware_info = cutlass.utils.HardwareInfo()
@@ -1659,6 +1671,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
     use_dynamic_sched: bool = False,
     use_dsrelu_reuse: bool = False,
     deterministic: Optional[bool] = None,
+    tanh_clamp_scale: Optional[float] = None,
     current_stream: Optional[cuda.CUstream] = None,
 ) -> TupleDict:
     """Convenience wrapper for grouped GEMM dSReLU backward operation.
@@ -1698,7 +1711,10 @@ def grouped_gemm_dsrelu_wrapper_sm100(
         m_aligned: M alignment (must be 256)
         discrete_col_sfd: Generate discrete col-major scale factor tensor
         use_dynamic_sched: Enable dynamic tile scheduling for load balancing
-        use_dsrelu_reuse: Reuse relu(C)^2 between d_srelu and dprob
+        use_dsrelu_reuse: Reuse relu(C)^2 (or, when clamped, c^2) between d_srelu and dprob
+        tanh_clamp_scale: Optional soft-clamp scale ``s``, must match the forward pass that
+            produced ``c_tensor``. Must be finite and > 0. ``None`` (default) is
+            bit-identical to today's unclamped DSRELU.
         deterministic: Make dprob and dbias bit-exact run to run; raises NotImplementedError
             for any framework other than torch. Every returned tensor keeps its usual shape and
             dtype -- the slot workspaces and the fixed-order reductions into them are internal to
@@ -2014,6 +2030,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             use_dynamic_sched,
             use_dsrelu_reuse,
             deterministic,
+            float(tanh_clamp_scale) if tanh_clamp_scale is not None else None,
         )
     else:
         cache_key = (
@@ -2047,6 +2064,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             deterministic,
             b_major,
             num_experts,
+            float(tanh_clamp_scale) if tanh_clamp_scale is not None else None,
         )
 
     # ---- Cache lookup or create + compile ----
@@ -2087,6 +2105,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
                 use_dynamic_sched=use_dynamic_sched,
                 use_dsrelu_reuse=use_dsrelu_reuse,
                 deterministic=deterministic,
+                tanh_clamp_scale=tanh_clamp_scale,
             )
         else:
             api = GroupedGemmDsreluSm100(
@@ -2122,6 +2141,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
                 use_dynamic_sched=use_dynamic_sched,
                 use_dsrelu_reuse=use_dsrelu_reuse,
                 deterministic=deterministic,
+                tanh_clamp_scale=tanh_clamp_scale,
             )
 
         if not api.check_support():

--- a/python/cudnn/gemm/cutedsl/grouped/dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
@@ -9,15 +9,21 @@ Supports:
     - Dense (contiguous 3-D B) / Discrete (per-expert pointer array B) weight layout
     - FP8/FP4 output quantization with row/column scale factors (SFD)
     - Optional routing-probability (prob) fusion
-    - DSRELU backward epilogue: dA = acc·relu(C)·2·prob; dprob = Σ_n(relu(C)²·acc)
+    - DSRELU backward epilogue: dA = acc·relu(C)·2·prob; dprob = Σ_n(relu(C)²·acc);
+      optionally soft-clamped, see ``tanh_clamp_scale``
     - NONE epilogue for testing (identity, no SReLU gate)
 
 EpilogueType.NONE:
     out[m,n] = alpha · (SFA·A ★ SFB·B)[m,n] · prob[m]
 
-EpilogueType.DSRELU (backward through scaled srelu):
+EpilogueType.DSRELU (backward through scaled srelu), unclamped (``tanh_clamp_scale=None``):
     out[m,n] = alpha · acc[m,n] · relu(C[m,n]) · 2 · prob[m]
     dprob[m] += Σ_n( relu(C[m,n])² · alpha · acc[m,n] )
+
+EpilogueType.DSRELU, soft-clamped (``tanh_clamp_scale=s``): let t = tanh(relu(C)/s), c = s·t
+(the unclamped equations above are the s -> infinity limit):
+    out[m,n] = alpha · acc[m,n] · c[m,n] · 2 · (1 - t[m,n]²) · prob[m]
+    dprob[m] += Σ_n( c[m,n]² · alpha · acc[m,n] )
 
 C is the forward SReLU input, and alpha · acc is the upstream gradient
 from the following GEMM.
@@ -95,8 +101,11 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
     """Block-scaled grouped GEMM backward kernel with MoE tile scheduling and DSRELU.
 
     Computes the backward pass through the SReLU epilogue:
-        out[m,n] = alpha * acc[m,n] * relu(C[m,n]) * 2 * prob[m]   (DSRELU)
-        dprob[m] += sum_n( relu(C[m,n])^2 * alpha * acc[m,n] )      (DSRELU)
+        out[m,n] = alpha * acc[m,n] * relu(C[m,n]) * 2 * prob[m]   (DSRELU, tanh_clamp_scale=None)
+        dprob[m] += sum_n( relu(C[m,n])^2 * alpha * acc[m,n] )      (DSRELU, tanh_clamp_scale=None)
+    or, with tanh_clamp_scale=s set (t = tanh(relu(C)/s), c = s*t):
+        out[m,n] = alpha * acc[m,n] * c[m,n] * 2 * (1 - t[m,n]^2) * prob[m]
+        dprob[m] += sum_n( c[m,n]^2 * alpha * acc[m,n] )
     or identity (NONE epilogue):
         out[m,n] = alpha * acc[m,n] * prob[m]
 
@@ -115,7 +124,11 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
     :param weight_mode: ``MoEWeightMode.DENSE`` or ``MoEWeightMode.DISCRETE``.
     :param use_dynamic_sched: Enable dynamic tile scheduling.
     :param epilogue_type: Epilogue type (``EpilogueType.NONE`` or ``EpilogueType.DSRELU``).
-    :param use_dsrelu_reuse: Reuse relu(C)^2 between d_srelu and dprob.
+    :param tanh_clamp_scale: Optional soft-clamp scale ``s``; must match the forward kernel
+        that produced the saved ``C`` -- a mismatch silently produces wrong gradients (and a
+        wrong regenerated fc2 input when ``generate_d_srelu`` is set). Trace-time constant;
+        ``None`` (default) is bit-identical to the unclamped path.
+    :param use_dsrelu_reuse: Reuse relu(C)^2 (or, when clamped, c^2) between d_srelu and dprob.
     :param deterministic: Compute ``dprob`` run-to-run bit-exactly. ``dprob`` must then carry
         one slot per N-tile so that each ``(token, tile_n)`` pair has a single writer, and the
         caller reduces over that dimension afterwards. Rationale and cost:
@@ -181,6 +194,7 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
         generate_d_srelu: bool = False,
         use_dsrelu_reuse: bool = False,
         deterministic: bool = False,
+        tanh_clamp_scale: Optional[float] = None,
     ):
         mma_tile_m = mma_tiler_mn[0]
         if self.FIX_PAD_SIZE % mma_tile_m != 0:
@@ -258,6 +272,9 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
 
         self.epilogue_use_functor = False
         self.epilogue_type = epilogue_type
+        # Trace-time constant; must match the forward kernel's scale (see class docstring)
+        # and key the compile cache (see dsrelu/api.py).
+        self.tanh_clamp_scale = float(tanh_clamp_scale) if tanh_clamp_scale is not None else None
 
         self.num_epilog_warps = len(self.epilog_warp_id)
 
@@ -2200,6 +2217,45 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
                         c_relu = cute.where(c_forward > 0, c_forward, cute.full_like(c_forward, 0))
                         tRelu = cute.make_rmem_tensor(acc_vec.shape, self.acc_dtype)
                         tRelu.store(c_relu)
+
+                        if cutlass.const_expr(self.tanh_clamp_scale is not None):
+                            # Soft-clamped dSReLU: t = tanh(relu(C)/s), c = s*t. Overwrite
+                            # tRelu in place with c -- every consumer below treats it as an
+                            # opaque value and none re-derives relu, so the dprob and d_srelu
+                            # paths stay correct unchanged. (1-t^2) is stashed in tCompute,
+                            # which is dead until the dgrad write below.
+                            #
+                            # t is capped at 1: mathematically t is in [0, 1], but it comes
+                            # from tanh.approx.f32, whose range this kernel does not assume --
+                            # a t above 1 would flip the gradient's sign, by a margin that
+                            # sits far inside the fp8 tolerance of every test here.
+                            one = cutlass.Float32(1.0)
+                            s = cutlass.Float32(self.tanh_clamp_scale)
+                            s_rcp = cutlass.Float32(1.0 / self.tanh_clamp_scale)
+                            if cutlass.const_expr(self.vectorized_f32):
+                                for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
+                                    t0 = fmin(cute.math.tanh(tRelu[i] * s_rcp, fastmath=True), one)
+                                    t1 = fmin(cute.math.tanh(tRelu[i + 1] * s_rcp, fastmath=True), one)
+                                    # (1-t)*(1+t) rather than 1-t*t: free, better conditioned
+                                    # as t -> 1 in the saturated tail.
+                                    tCompute[i], tCompute[i + 1] = cute.arch.mul_packed_f32x2(
+                                        (one - t0, one - t1),
+                                        (one + t0, one + t1),
+                                        rnd="rn",
+                                        ftz=False,
+                                    )
+                                    tRelu[i], tRelu[i + 1] = cute.arch.mul_packed_f32x2(
+                                        (t0, t1),
+                                        (s, s),
+                                        rnd="rn",
+                                        ftz=False,
+                                    )
+                            else:
+                                for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
+                                    t = fmin(cute.math.tanh(tRelu[i] * s_rcp, fastmath=True), one)
+                                    tCompute[i] = (one - t) * (one + t)
+                                    tRelu[i] = t * s
+
                         if cutlass.const_expr(self.use_dsrelu_reuse):
                             tRelu2 = self.compute_relu2(tTR_rAcc, tRelu)
                             if cutlass.const_expr(dprob is not None):
@@ -2218,23 +2274,54 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
                             if cutlass.const_expr(self.generate_d_srelu):
                                 tComputeSrelu = self.compute_srelu(tRelu, mProb)
                         probx2 = 2 * mProb
-                        if cutlass.const_expr(self.vectorized_f32):
-                            for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
-                                tCompute[i], tCompute[i + 1] = cute.arch.mul_packed_f32x2(
-                                    (tRelu[i], tRelu[i + 1]),
-                                    (acc_vec[i], acc_vec[i + 1]),
-                                    rnd="rn",
-                                    ftz=False,
-                                )
-                                tCompute[i], tCompute[i + 1] = cute.arch.mul_packed_f32x2(
-                                    (tCompute[i], tCompute[i + 1]),
-                                    (cutlass.Float32(probx2), cutlass.Float32(probx2)),
-                                    rnd="rn",
-                                    ftz=False,
-                                )
+                        if cutlass.const_expr(self.tanh_clamp_scale is not None):
+                            # dgrad = g * 2*c*(1-t^2) * w. (1-t^2) is stashed in tCompute from
+                            # the overwrite above; read both lanes into temporaries before this
+                            # store, since it aliases the same tensor it reads.
+                            if cutlass.const_expr(self.vectorized_f32):
+                                for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
+                                    one_minus_t2_0 = tCompute[i]
+                                    one_minus_t2_1 = tCompute[i + 1]
+                                    tCompute[i], tCompute[i + 1] = cute.arch.mul_packed_f32x2(
+                                        (tRelu[i], tRelu[i + 1]),
+                                        (acc_vec[i], acc_vec[i + 1]),
+                                        rnd="rn",
+                                        ftz=False,
+                                    )
+                                    tCompute[i], tCompute[i + 1] = cute.arch.mul_packed_f32x2(
+                                        (tCompute[i], tCompute[i + 1]),
+                                        (cutlass.Float32(probx2), cutlass.Float32(probx2)),
+                                        rnd="rn",
+                                        ftz=False,
+                                    )
+                                    tCompute[i], tCompute[i + 1] = cute.arch.mul_packed_f32x2(
+                                        (tCompute[i], tCompute[i + 1]),
+                                        (one_minus_t2_0, one_minus_t2_1),
+                                        rnd="rn",
+                                        ftz=False,
+                                    )
+                            else:
+                                for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
+                                    one_minus_t2 = tCompute[i]
+                                    tCompute[i] = tRelu[i] * acc_vec[i] * cutlass.Float32(probx2) * one_minus_t2
                         else:
-                            for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
-                                tCompute[i] = tRelu[i] * acc_vec[i] * cutlass.Float32(probx2)
+                            if cutlass.const_expr(self.vectorized_f32):
+                                for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
+                                    tCompute[i], tCompute[i + 1] = cute.arch.mul_packed_f32x2(
+                                        (tRelu[i], tRelu[i + 1]),
+                                        (acc_vec[i], acc_vec[i + 1]),
+                                        rnd="rn",
+                                        ftz=False,
+                                    )
+                                    tCompute[i], tCompute[i + 1] = cute.arch.mul_packed_f32x2(
+                                        (tCompute[i], tCompute[i + 1]),
+                                        (cutlass.Float32(probx2), cutlass.Float32(probx2)),
+                                        rnd="rn",
+                                        ftz=False,
+                                    )
+                            else:
+                                for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
+                                    tCompute[i] = tRelu[i] * acc_vec[i] * cutlass.Float32(probx2)
 
                         # Accumulate dprob: dprob[m] += sum_n(relu(C)^2 * upstream_grad)
                         if cutlass.const_expr(dprob is not None and not self.use_dsrelu_reuse):

--- a/python/cudnn/gemm/cutedsl/grouped/srelu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/srelu/api.py
@@ -10,6 +10,7 @@ SReLU output quantization in MoE (Mixture of Experts) workloads.
 
 from __future__ import annotations
 
+import math
 import os
 from typing import Optional, Tuple
 
@@ -102,6 +103,7 @@ class GroupedGemmSreluSm100(APIBase):
         discrete_col_sfd: bool = False,
         b_major: str = "k",
         use_dynamic_sched: bool = False,
+        tanh_clamp_scale: Optional[float] = None,
     ):
         """Initialize the GroupedGemmSreluSm100 API.
 
@@ -133,6 +135,9 @@ class GroupedGemmSreluSm100(APIBase):
         :param discrete_col_sfd: Enable discrete col-major scale factor tensor
         :param b_major: Major dimension for B tensor, one of "k" or "n"
         :param use_dynamic_sched: Enable dynamic tile scheduling for load balancing
+        :param tanh_clamp_scale: Optional soft-clamp scale ``s``. When set, computes
+            ``(s * tanh(relu(x) / s)) ** 2`` instead of plain ``relu(x) ** 2``; must be
+            finite and > 0. ``None`` (default) is bit-identical to today's SReLU.
         """
         framework = detect_framework(sample_a)
         if framework == "jax":
@@ -218,6 +223,12 @@ class GroupedGemmSreluSm100(APIBase):
         self.m_aligned = m_aligned
         self.discrete_col_sfd = discrete_col_sfd
         self.use_dynamic_sched = use_dynamic_sched
+        if tanh_clamp_scale is not None:
+            self._value_error_if(
+                not math.isfinite(tanh_clamp_scale) or tanh_clamp_scale <= 0.0,
+                f"tanh_clamp_scale must be finite and positive, got {tanh_clamp_scale}",
+            )
+        self.tanh_clamp_scale = tanh_clamp_scale
         if self.weight_mode == MoEWeightMode.DENSE:
             self.b_major = b_major
 
@@ -579,6 +590,7 @@ class GroupedGemmSreluSm100(APIBase):
             weight_mode=self.weight_mode,
             use_dynamic_sched=self.use_dynamic_sched,
             epilogue_type=EpilogueType.SRELU.value,
+            tanh_clamp_scale=self.tanh_clamp_scale,
         )
 
         hardware_info = cutlass.utils.HardwareInfo()
@@ -1186,6 +1198,7 @@ def grouped_gemm_srelu_wrapper_sm100(
     m_aligned: int = 256,
     discrete_col_sfd: bool = False,
     use_dynamic_sched: bool = False,
+    tanh_clamp_scale: Optional[float] = None,
     current_stream: Optional[cuda.CUstream] = None,
 ) -> TupleDict:
     """Convenience wrapper for grouped GEMM SReLU operation.
@@ -1222,6 +1235,9 @@ def grouped_gemm_srelu_wrapper_sm100(
         vector_f32: Use vectorized f32
         m_aligned: M alignment (must be 256)
         discrete_col_sfd: Enable discrete col-major scale factor tensor
+        tanh_clamp_scale: Optional soft-clamp scale ``s``. When set, computes
+            ``(s * tanh(relu(x) / s)) ** 2`` instead of plain ``relu(x) ** 2``; must be
+            finite and > 0. ``None`` (default) is bit-identical to today's SReLU.
         current_stream: CUDA stream
 
     Returns:
@@ -1439,6 +1455,7 @@ def grouped_gemm_srelu_wrapper_sm100(
             m_aligned,
             discrete_col_sfd,
             use_dynamic_sched,
+            float(tanh_clamp_scale) if tanh_clamp_scale is not None else None,
         )
     else:
         cache_key = (
@@ -1479,6 +1496,7 @@ def grouped_gemm_srelu_wrapper_sm100(
             use_dynamic_sched,
             b_major,
             num_experts,
+            float(tanh_clamp_scale) if tanh_clamp_scale is not None else None,
         )
 
     if cache_key in _cache_of_GroupedGemmSreluSm100Objects:
@@ -1511,6 +1529,7 @@ def grouped_gemm_srelu_wrapper_sm100(
                 m_aligned=m_aligned,
                 discrete_col_sfd=discrete_col_sfd,
                 use_dynamic_sched=use_dynamic_sched,
+                tanh_clamp_scale=tanh_clamp_scale,
             )
         else:
             grouped_gemm_srelu = GroupedGemmSreluSm100(
@@ -1539,6 +1558,7 @@ def grouped_gemm_srelu_wrapper_sm100(
                 discrete_col_sfd=discrete_col_sfd,
                 use_dynamic_sched=use_dynamic_sched,
                 b_major=b_major,
+                tanh_clamp_scale=tanh_clamp_scale,
             )
 
         assert grouped_gemm_srelu.check_support(), "Unsupported configuration"

--- a/python/cudnn/gemm/cutedsl/grouped/srelu/moe_blockscaled_grouped_gemm_srelu_quant.py
+++ b/python/cudnn/gemm/cutedsl/grouped/srelu/moe_blockscaled_grouped_gemm_srelu_quant.py
@@ -86,6 +86,9 @@ class BlockScaledMoEGroupedGemmQuantKernel:
     :param weight_mode: ``MoEWeightMode.DENSE`` or ``MoEWeightMode.DISCRETE``.
     :param use_dynamic_sched: Enable dynamic tile scheduling.
     :param epilogue_type: Epilogue activation type (``EpilogueType.NONE`` or ``EpilogueType.SRELU``).
+    :param tanh_clamp_scale: Optional soft-clamp scale ``s`` for the SRELU epilogue. When set,
+        computes ``(s * tanh(relu(x) / s)) ** 2`` in place of plain ``relu(x) ** 2``.
+        Trace-time constant; ``None`` (default) is bit-identical to the unclamped path.
     """
 
     FIX_PAD_SIZE = 256
@@ -145,6 +148,7 @@ class BlockScaledMoEGroupedGemmQuantKernel:
         weight_mode: MoEWeightMode = MoEWeightMode.DENSE,
         use_dynamic_sched: bool = False,
         epilogue_type: int = EpilogueType.NONE.value,
+        tanh_clamp_scale: Optional[float] = None,
     ):
         mma_tile_m = mma_tiler_mn[0]
         if self.FIX_PAD_SIZE % mma_tile_m != 0:
@@ -217,6 +221,8 @@ class BlockScaledMoEGroupedGemmQuantKernel:
 
         self.epilogue_use_functor = False
         self.epilogue_type = epilogue_type
+        # Trace-time constant; must key the compile cache (see srelu/api.py).
+        self.tanh_clamp_scale = float(tanh_clamp_scale) if tanh_clamp_scale is not None else None
 
         self.num_epilog_warps = len(self.epilog_warp_id)
 
@@ -1966,13 +1972,43 @@ class BlockScaledMoEGroupedGemmQuantKernel:
 
                     if cutlass.const_expr(self.epilogue_type == EpilogueType.SRELU.value):
                         acc_relu = cute.where(acc_vec > 0, acc_vec, cute.full_like(acc_vec, 0))
-                        for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
-                            tTR_rAcc[i], tTR_rAcc[i + 1] = cute.arch.mul_packed_f32x2(
-                                (acc_relu[i], acc_relu[i + 1]),
-                                (acc_relu[i], acc_relu[i + 1]),
-                                rnd="rn",
-                                ftz=False,
-                            )
+                        if cutlass.const_expr(self.tanh_clamp_scale is not None):
+                            # Soft-clamped squared ReLU: c = s * tanh(relu(x) / s); out = c**2.
+                            # Plain squared ReLU is the s -> infinity limit. t is capped at 1:
+                            # tanh.approx.f32's range is not assumed (the backward kernel needs
+                            # 1 - t**2 >= 0); the cap makes c <= s structural.
+                            one = cutlass.Float32(1.0)
+                            s = cutlass.Float32(self.tanh_clamp_scale)
+                            s_rcp = cutlass.Float32(1.0 / self.tanh_clamp_scale)
+                            if cutlass.const_expr(self.vectorized_f32):
+                                for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
+                                    t0 = fmin(cute.math.tanh(acc_relu[i] * s_rcp, fastmath=True), one)
+                                    t1 = fmin(cute.math.tanh(acc_relu[i + 1] * s_rcp, fastmath=True), one)
+                                    c0, c1 = cute.arch.mul_packed_f32x2(
+                                        (t0, t1),
+                                        (s, s),
+                                        rnd="rn",
+                                        ftz=False,
+                                    )
+                                    tTR_rAcc[i], tTR_rAcc[i + 1] = cute.arch.mul_packed_f32x2(
+                                        (c0, c1),
+                                        (c0, c1),
+                                        rnd="rn",
+                                        ftz=False,
+                                    )
+                            else:
+                                for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
+                                    t = fmin(cute.math.tanh(acc_relu[i] * s_rcp, fastmath=True), one)
+                                    c = t * s
+                                    tTR_rAcc[i] = c * c
+                        else:
+                            for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
+                                tTR_rAcc[i], tTR_rAcc[i + 1] = cute.arch.mul_packed_f32x2(
+                                    (acc_relu[i], acc_relu[i + 1]),
+                                    (acc_relu[i], acc_relu[i + 1]),
+                                    rnd="rn",
+                                    ftz=False,
+                                )
                         acc_vec = tTR_rAcc.load()
 
                     tCompute = cute.make_rmem_tensor(acc_vec.shape, self.acc_dtype)

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
@@ -14,6 +14,7 @@ import torch
 import pytest
 from test_utils import torch_fork_set_rng, assert_bitwise_runs, bitwise_bits
 from fe_api.grouped_gemm.test_grouped_gemm_dsrelu_utils import (
+    run_grouped_gemm_dsrelu_ref,
     with_grouped_gemm_dsrelu_params_fp4,
     with_grouped_gemm_dsrelu_params_fp8,
     allocate_grouped_gemm_dsrelu_tensors,
@@ -494,11 +495,15 @@ def _torch_deterministic_algorithms():
         torch.use_deterministic_algorithms(previous, warn_only=previous_warn_only)
 
 
-def _assert_dprob_deterministic(case, baseline, deterministic, relaunch, ref_inputs=None, dprob_rtol=1e-4, dprob_atol=1e-4):
+def _assert_dprob_deterministic(case, baseline, deterministic, relaunch, ref_inputs=None, dprob_rtol=1e-4, dprob_atol=1e-4, ref_kwargs=None):
     """The three properties deterministic=True has to hold, shared by dense and discrete.
 
     ``relaunch`` produces another deterministic run; it is called repeatedly, because a
     reduction-order race is timing-dependent and one repeat proves little.
+
+    ``ref_kwargs`` is forwarded to the final reference check. It exists for the clamped fp8
+    caller, whose block-scaled outputs need a wider rtol for a reason that has nothing to do
+    with determinism (see _clamp_ref_tolerances); default behaviour is unchanged.
     """
     torch.cuda.synchronize()
     inputs, cfg = case
@@ -533,7 +538,7 @@ def _assert_dprob_deterministic(case, baseline, deterministic, relaunch, ref_inp
     # 3. The deterministic path clears the same bar as the default one, not merely agrees
     # with it: the reference the non-deterministic wrapper tests run, over the whole backward
     # output set (dprob, dA row/col, d_srelu, amax, scale factors).
-    check_ref_grouped_gemm_dsrelu(inputs if ref_inputs is None else ref_inputs, deterministic, cfg, skip_ref=cfg["skip_ref"])
+    check_ref_grouped_gemm_dsrelu(inputs if ref_inputs is None else ref_inputs, deterministic, cfg, **(ref_kwargs or {}), skip_ref=cfg["skip_ref"])
 
 
 # n defaults to 512 against an mma_tiler_mn[1] of 256, so grid_n is 2 and the cross-N-tile
@@ -1883,3 +1888,524 @@ def _test_grouped_gemm_dsrelu_wrapper_zero_m_cache_behavior(
         grouped_gemm_dsrelu_api._cache_of_GroupedGemmDsreluSm100Objects.clear()
 
     return compile_count["value"], cache_entries
+
+
+# =============================================================================
+# Soft-clamped dSReLU (tanh_clamp_scale)
+# =============================================================================
+#
+# tanh_clamp_scale=s replaces relu(C) with c = s*tanh(relu(C)/s) throughout the backward:
+#     dgrad = g * 2*c*(1-t^2) * w      (was  g * 2*relu(C) * w)
+#     dprob = sum_n c^2 * g            (was  sum_n relu(C)^2 * g)
+#     d_srelu regen = c^2 * w          (was  relu(C)^2 * w)
+# Unclamped is the s -> infinity limit. See the srelu test file for why the cache key and
+# the vector_f32 axis are correctness requirements rather than coverage nice-to-haves.
+#
+# The backward has three consumers of the activation, and the third (d_srelu regen, used
+# only under FP8 activation recompute) is the one a partial implementation drops -- so
+# generate_d_srelu is exercised explicitly below rather than left to the default.
+
+GROUPED_GEMM_DSRELU_CLAMP_CONFIGS = [
+    pytest.param(torch.uint8, torch.bfloat16, torch.bfloat16, 16, torch.float8_e8m0fnu, True, False, id="fp4-vector_f32"),
+    pytest.param(torch.uint8, torch.bfloat16, torch.bfloat16, 16, torch.float8_e8m0fnu, False, False, id="fp4-scalar_f32"),
+    pytest.param(torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, True, True, id="fp8-vector_f32"),
+    pytest.param(torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True, id="fp8-scalar_f32"),
+]
+
+GROUPED_GEMM_DSRELU_CLAMP_SCALES = [
+    pytest.param(None, id="unclamped"),
+    pytest.param(16.0, id="clamp16"),
+    pytest.param(32.0, id="clamp32"),
+]
+
+
+# Block-scaled (MXFP8) outputs vs an independently quantized reference, once the kernel is
+# perturbed at all -- measured on GB300 (sm_103) at the clamp's 7.7e-6 max tanh perturbation
+# (repos/sqrelu_tanh/tools/):
+#   * the e8m0 scale factors do not flip at all, even though ~25% of the 32-element block
+#     amaxes in this harness sit exactly ON an exponent boundary;
+#   * d_row/d_col show rare one-ULP straddles -- 12 of 524288 elements (2.3e-5), max ratio
+#     exactly one e4m3 ULP (1.125), none beyond;
+#   * dprob (plain fp32, not block-scaled) shows no outliers.
+# A boundary straddle is a one-ULP event produced by an arbitrarily small cause, which no
+# blanket rtol below 12.5% can distinguish from a real error. The clamped fp8 cases therefore
+# allow one ULP of relative slack; the tight elementwise check of the epilogue math lives on
+# the bf16-output fp4 configs above.
+_FP8_E4M3_ULP_RTOL = 2.0**-3
+
+
+def _is_block_scaled_output(d_dtype, discrete_col_sfd):
+    return d_dtype is torch.float8_e4m3fn and discrete_col_sfd
+
+
+def _clamp_ref_tolerances(d_dtype, tanh_clamp_scale):
+    if d_dtype is torch.float8_e4m3fn and tanh_clamp_scale is not None:
+        return {"rtol": _FP8_E4M3_ULP_RTOL + 1e-2}
+    return {}
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@pytest.mark.parametrize("use_dsrelu_reuse", [False, True], ids=["no_reuse", "reuse"])
+@pytest.mark.parametrize("tanh_clamp_scale", GROUPED_GEMM_DSRELU_CLAMP_SCALES)
+@pytest.mark.parametrize(
+    "ab_dtype,c_dtype,d_dtype,sf_vec_size,sf_dtype,vector_f32,discrete_col_sfd",
+    GROUPED_GEMM_DSRELU_CLAMP_CONFIGS,
+)
+def test_grouped_gemm_dsrelu_wrapper_tanh_clamp_scale(
+    request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtype, vector_f32, discrete_col_sfd, tanh_clamp_scale, use_dsrelu_reuse
+):
+    """All three backward consumers agree with the torch reference, on both f32 variants.
+
+    use_dsrelu_reuse is crossed in because it routes dprob and d_srelu through a different
+    pair of helpers (compute_relu2 + compute_dprob_from_relu2 + scale_srelu_from_relu2)
+    than the default path -- the clamped value has to flow correctly through both.
+    """
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    case = _build_dsrelu_case(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtype, vector_f32, discrete_col_sfd)
+    inputs, cfg = case
+    cfg["tanh_clamp_scale"] = tanh_clamp_scale
+
+    try:
+        outputs = _run_dsrelu_case(case, tanh_clamp_scale=tanh_clamp_scale, use_dsrelu_reuse=use_dsrelu_reuse)
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+
+    torch.cuda.synchronize()
+    # The wrapper always regenerates d_srelu; assert it so a future change that makes it
+    # conditional cannot silently drop the third backward consumer from this test.
+    assert outputs.get("d_srelu_tensor") is not None, "wrapper must return the regenerated activation"
+
+    if tanh_clamp_scale is not None and _is_block_scaled_output(d_dtype, discrete_col_sfd):
+        # See the comment on _is_block_scaled_output: the code-for-code comparison of the
+        # MXFP8 outputs is not a valid oracle for a perturbed kernel. dprob is, and it is the
+        # consumer that would catch a wrong c^2, so assert it at full tightness.
+        if not cfg["skip_ref"]:
+            ref_tensors = run_grouped_gemm_dsrelu_ref(
+                a_ref=inputs["a_ref"],
+                b_ref=inputs["b_ref"],
+                c_ref=inputs["c_ref"],
+                sfa_ref=inputs["sfa_ref"],
+                sfb_ref=inputs["sfb_ref"],
+                alpha_tensor=inputs["alpha_tensor"],
+                prob_tensor=inputs["prob_tensor"],
+                aligned_group_m_list=inputs["aligned_group_m_list"],
+                valid_m=inputs["valid_m"],
+                generate_dbias=outputs.get("dbias_tensor") is not None,
+                generate_amax=outputs.get("amax_tensor") is not None,
+                generate_sfd=outputs.get("sfd_row_tensor") is not None and outputs.get("sfd_col_tensor") is not None,
+                norm_const_tensor=inputs.get("norm_const_tensor"),
+                c_dtype=cfg["c_dtype"],
+                d_dtype=cfg["d_dtype"],
+                sf_vec_size=cfg["sf_vec_size"],
+                sf_dtype=cfg["sf_dtype"],
+                tanh_clamp_scale=tanh_clamp_scale,
+            )
+            torch.testing.assert_close(outputs["dprob_tensor"].float(), ref_tensors["dprob_ref"].float(), atol=1e-1, rtol=1e-2)
+            assert torch.isfinite(outputs["d_srelu_tensor"].float()).all()
+            assert torch.isfinite(outputs["d_row_tensor"].float()).all()
+    else:
+        check_ref_grouped_gemm_dsrelu(inputs, outputs, cfg, skip_ref=cfg["skip_ref"])
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=19)
+@pytest.mark.parametrize(
+    "ab_dtype,c_dtype,d_dtype,sf_vec_size,sf_dtype,vector_f32,discrete_col_sfd",
+    # fp4 only: the fp8 entry has a block-scaled D whose codes are not a valid oracle for a
+    # perturbed kernel (see _is_block_scaled_output), and _assert_dprob_deterministic ends in a
+    # full reference check. Determinism itself is value-agnostic, so the fp4 entry covers it.
+    [c for c in GROUPED_GEMM_DSRELU_DETERMINISTIC_CONFIGS if c.id != "fp8"],
+)
+def test_grouped_gemm_dsrelu_deterministic_dprob_clamped(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtype, vector_f32, discrete_col_sfd):
+    """deterministic=True still holds when dprob sums c^2 instead of relu(C)^2.
+
+    The slot-parking reduction is value-agnostic, so this is expected to pass for free --
+    which is exactly why it is worth asserting: 'expected to work by construction' is the
+    class of claim that silently stops being true.
+    """
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    tanh_clamp_scale = 16.0
+    case = _build_dsrelu_case(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtype, vector_f32, discrete_col_sfd)
+    case[1]["tanh_clamp_scale"] = tanh_clamp_scale
+
+    try:
+        baseline = _run_dsrelu_case(case, deterministic=False, tanh_clamp_scale=tanh_clamp_scale)
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+    deterministic = _run_dsrelu_case(case, deterministic=True, tanh_clamp_scale=tanh_clamp_scale)
+    _assert_dprob_deterministic(
+        case,
+        baseline,
+        deterministic,
+        lambda: _run_dsrelu_case(case, deterministic=True, tanh_clamp_scale=tanh_clamp_scale),
+        ref_kwargs=_clamp_ref_tolerances(d_dtype, tanh_clamp_scale),
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=31)
+@pytest.mark.parametrize(
+    "ab_dtype,c_dtype,d_dtype,sf_vec_size,sf_dtype,vector_f32,discrete_col_sfd",
+    GROUPED_GEMM_DSRELU_DETERMINISTIC_CONFIGS,
+)
+def test_grouped_gemm_dsrelu_tanh_clamp_scale_none_is_bit_identical(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtype, vector_f32, discrete_col_sfd):
+    """tanh_clamp_scale=None must be BIT-identical to not passing the argument at all.
+
+    The backward counterpart of the srelu test of the same name, and the direct evidence
+    for the additive-only claim on this kernel: the clamped branch is const_expr'd out, so
+    an existing caller should get the same traced program and the same bits. Covers the
+    fp4 and fp8 configurations, which compile different kernels.
+    """
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    case = _build_dsrelu_case(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtype, vector_f32, discrete_col_sfd)
+
+    try:
+        omitted = _run_dsrelu_case(case)  # exactly the pre-change call signature
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+    explicit_none = _run_dsrelu_case(case, tanh_clamp_scale=None)
+    torch.cuda.synchronize()
+
+    # d_col is only written under the fp8 scale-factor path; elsewhere it keeps its
+    # allocation contents, which differ between two independent calls for reasons that
+    # have nothing to do with this flag (same caveat as the determinism test above).
+    compared = ["d_row_tensor", "d_srelu_tensor", "dprob_tensor"]
+    if omitted.get("sfd_col_tensor") is not None:
+        compared += ["d_col_tensor", "sfd_row_tensor", "sfd_col_tensor"]
+    if omitted.get("amax_tensor") is not None:
+        compared.append("amax_tensor")
+
+    for key in compared:
+        a, b = omitted[key], explicit_none[key]
+        if a is None and b is None:
+            continue
+        assert a is not None and b is not None, f"{key} missing from one of the two runs"
+        assert torch.equal(a, b), f"{key} differs between omitted and tanh_clamp_scale=None"
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=37)
+@pytest.mark.parametrize("vector_f32", [False, True], ids=["scalar_f32", "vector_f32"])
+def test_grouped_gemm_dsrelu_tanh_clamp_scale_saturated_dgrad_is_zero(request, vector_f32):
+    """Deep in the saturated tail the row gradient must be EXACTLY zero.
+
+    dgrad carries the factor 1 - t^2, which goes to zero as t -> 1, so for relu(C) >> s the
+    row output is 0 with no tolerance argument needed -- the one assertion in this file
+    sensitive to the sign of 1 - t^2 (a t above 1 from tanh.approx would come back small,
+    non-zero and sign-flipped, invisible to every fp8-tolerance test). The kernel caps t at
+    1; this asserts the cap holds.
+    """
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    # d_dtype bf16 (the fp4 config): 0.0 is exactly representable and there is no output
+    # quantization to blur an exact-zero check.
+    case = _build_dsrelu_case(request, torch.uint8, torch.bfloat16, torch.bfloat16, 16, torch.float8_e8m0fnu, vector_f32, False)
+    inputs, cfg = case
+
+    # Drive every element far past saturation. 512 is exact in bf16, so c_tensor and the
+    # fp32 c_ref agree exactly and relu(C)/s is ~1e3 even at the largest scale tested.
+    saturated = 512.0
+    inputs["c_tensor"].fill_(saturated)
+    inputs["c_ref"].fill_(saturated)
+
+    tanh_clamp_scale = 0.5
+    try:
+        outputs = _run_dsrelu_case(case, tanh_clamp_scale=tanh_clamp_scale)
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+    torch.cuda.synchronize()
+
+    d_row = outputs["d_row_tensor"].float()
+    assert torch.equal(d_row, torch.zeros_like(d_row)), (
+        "saturated dgrad is not exactly zero: max |d_row| = "
+        f"{d_row.abs().max().item():.6g}, min = {d_row.min().item():.6g}. "
+        "A negative value here means 1 - t^2 went negative, i.e. tanh returned t > 1."
+    )
+
+    # dprob keeps the c^2 term, which saturates to s^2 rather than to zero, so it is a live
+    # control: if the whole epilogue had simply produced zeros the assertion above would be
+    # vacuous.
+    dprob = outputs["dprob_tensor"].float()
+    assert torch.count_nonzero(dprob).item() > 0, "dprob is all zero -- the epilogue produced nothing"
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=23)
+def test_grouped_gemm_dsrelu_tanh_clamp_scale_cache_key(request, monkeypatch):
+    """Two clamp scales in one process must compile two kernels, not reuse the first.
+
+    ``s`` is folded at trace time, so a cache key missing it returns the s=16 kernel for an
+    s=32 call -- wrong numbers, no error. This is the backward-side twin of the srelu test
+    of the same name; both dense and discrete keys are covered because the wrapper picks
+    between them on the weight mode, and this config is the dense one.
+    """
+    try:
+        import cudnn  # noqa: F401
+        from cudnn.gemm.cutedsl.grouped.dsrelu import api as dsrelu_api
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    monkeypatch.setattr(dsrelu_api, "_cache_of_GroupedGemmDsreluSm100Objects", {})
+
+    compile_count = {"value": 0}
+    original_compile = dsrelu_api.GroupedGemmDsreluSm100.compile
+
+    def counted_compile(self):
+        compile_count["value"] += 1
+        return original_compile(self)
+
+    monkeypatch.setattr(dsrelu_api.GroupedGemmDsreluSm100, "compile", counted_compile)
+
+    args = (torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True)
+    case = _build_dsrelu_case(request, *args)
+    inputs, cfg = case
+
+    results = {}
+    for tanh_clamp_scale in (16.0, 32.0):
+        try:
+            results[tanh_clamp_scale] = _run_dsrelu_case(case, tanh_clamp_scale=tanh_clamp_scale)
+        except (ValueError, NotImplementedError) as e:
+            pytest.skip(f"Unsupported testcase: {e}")
+        torch.cuda.synchronize()
+
+    assert compile_count["value"] == 2, f"expected one compile per tanh_clamp_scale, got {compile_count['value']}"
+
+    # This config has an MXFP8 block-scaled D, so only dprob is a valid elementwise oracle
+    # (see _is_block_scaled_output). That is enough here: the point of this test is the cache
+    # key, and dprob moving with s is exactly what a stale kernel would fail to do.
+    if not cfg["skip_ref"]:
+        for tanh_clamp_scale, outputs in results.items():
+            ref_tensors = run_grouped_gemm_dsrelu_ref(
+                a_ref=inputs["a_ref"],
+                b_ref=inputs["b_ref"],
+                c_ref=inputs["c_ref"],
+                sfa_ref=inputs["sfa_ref"],
+                sfb_ref=inputs["sfb_ref"],
+                alpha_tensor=inputs["alpha_tensor"],
+                prob_tensor=inputs["prob_tensor"],
+                aligned_group_m_list=inputs["aligned_group_m_list"],
+                valid_m=inputs["valid_m"],
+                generate_dbias=outputs.get("dbias_tensor") is not None,
+                generate_amax=outputs.get("amax_tensor") is not None,
+                generate_sfd=outputs.get("sfd_row_tensor") is not None and outputs.get("sfd_col_tensor") is not None,
+                norm_const_tensor=inputs.get("norm_const_tensor"),
+                c_dtype=cfg["c_dtype"],
+                d_dtype=cfg["d_dtype"],
+                sf_vec_size=cfg["sf_vec_size"],
+                sf_dtype=cfg["sf_dtype"],
+                tanh_clamp_scale=tanh_clamp_scale,
+            )
+            torch.testing.assert_close(outputs["dprob_tensor"].float(), ref_tensors["dprob_ref"].float(), atol=1e-1, rtol=1e-2)
+
+    # A kernel that ignored tanh_clamp_scale would pass the count check and, if the reference
+    # shared the bug, the reference check too. Different s must move every consumer.
+    if not cfg["skip_ref"]:
+        assert not torch.equal(results[16.0]["d_row_tensor"], results[32.0]["d_row_tensor"])
+        assert not torch.equal(results[16.0]["dprob_tensor"], results[32.0]["dprob_tensor"])
+        assert not torch.equal(results[16.0]["d_srelu_tensor"], results[32.0]["d_srelu_tensor"])
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=29)
+@pytest.mark.parametrize("c_dtype", [torch.bfloat16, torch.float32], ids=["c_bf16", "c_fp32"])
+def test_grouped_gemm_dsrelu_tanh_clamp_scale_regen_matches_forward(request, c_dtype):
+    """The backward's d_srelu regen must reproduce the forward kernel's own output.
+
+    Under FP8 activation recompute the fc2 input is regenerated by the backward rather than
+    saved, so forward output and backward regen have to be the same function. They are two
+    separate kernels with two separate copies of the tanh expression, and nothing else in the
+    suite compares them to each other -- each is only ever checked against the torch oracle.
+
+    Sensitivity, stated rather than assumed: the forward applies the activation to its fp32
+    accumulator while the backward applies it to the SAVED C, so the two disagree by the C
+    round-trip no matter how well the tanh forms match. That floor is not guessed here, it is
+    computed from the inputs (``floor`` below) and used as the tolerance. With c_dtype=bf16
+    the floor is ~1e-2 relative, which is coarser than a pure fastmath-tanh discrepancy
+    (~1e-3), so THAT case cannot detect a subtly different tanh form -- it catches gross
+    mismatches (a swapped s vs 1/s, a missing square, prob folded in twice). The c_fp32 case
+    is the sharp one: C then stores the accumulator exactly, the floor collapses, and the two
+    tanh expressions are compared against each other with nothing in between.
+    """
+    try:
+        import cudnn  # noqa: F401
+        from cudnn import grouped_gemm_srelu_wrapper_sm100
+        from cuda.bindings import driver as cuda
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    tanh_clamp_scale = 16.0
+    # bf16 D so the comparison is not floored by fp8 output quantization instead.
+    args = (torch.uint8, c_dtype, torch.bfloat16, 16, torch.float8_e8m0fnu, True, False)
+    case = _build_dsrelu_case(request, *args)
+    inputs, cfg = case
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    # 1. Forward over this case's A/B/SF/prob: gives both the stored C and the activation
+    #    the forward actually produced from its fp32 accumulator.
+    try:
+        fwd = grouped_gemm_srelu_wrapper_sm100(
+            a_tensor=inputs["a_tensor"],
+            b_tensor=inputs["b_tensor"],
+            sfa_tensor=inputs["sfa_tensor"],
+            sfb_tensor=inputs["sfb_tensor"],
+            padded_offsets=inputs["padded_offsets_tensor"],
+            alpha_tensor=inputs["alpha_tensor"],
+            norm_const_tensor=inputs.get("norm_const_tensor"),
+            prob_tensor=inputs["prob_tensor"],
+            acc_dtype=cfg["acc_dtype"],
+            c_dtype=cfg["c_dtype"],
+            d_dtype=cfg["d_dtype"],
+            cd_major=cfg["cd_major"],
+            mma_tiler_mn=cfg["mma_tiler_mn"],
+            cluster_shape_mn=cfg["cluster_shape_mn"],
+            sf_vec_size=cfg["sf_vec_size"],
+            vector_f32=cfg["vector_f32"],
+            m_aligned=cfg["m_aligned"],
+            discrete_col_sfd=cfg["discrete_col_sfd"],
+            tanh_clamp_scale=tanh_clamp_scale,
+            current_stream=stream,
+        )
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+    torch.cuda.synchronize()
+
+    # 2. Backward fed the forward's own C, regenerating the activation. The forward returns
+    #    only the valid_m rows while the backward's C carries the padded tensor_m, so copy
+    #    into the case's existing buffer rather than substituting a differently shaped one.
+    valid_m = inputs["valid_m"]
+    bwd_inputs = dict(inputs)
+    bwd_inputs["c_tensor"] = inputs["c_tensor"].clone()
+    bwd_inputs["c_tensor"][:valid_m].copy_(fwd["c_tensor"])
+    try:
+        bwd = _run_dsrelu_case((bwd_inputs, cfg), tanh_clamp_scale=tanh_clamp_scale)
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+    torch.cuda.synchronize()
+
+    d_fwd = fwd["d_tensor"].float()[:valid_m]
+    d_regen = bwd["d_srelu_tensor"].float()[:valid_m]
+    assert d_fwd.shape == d_regen.shape, f"{d_fwd.shape} vs {d_regen.shape}"
+
+    # 3. The C round-trip floor, computed from this run's own C rather than assumed.
+    c_saved = fwd["c_tensor"].float()[:valid_m]
+    prob = inputs["prob_tensor"].float().expand(-1, cfg["n"], -1)[:valid_m]
+
+    def _act(x):
+        t = torch.tanh(torch.relu(x) / tanh_clamp_scale)
+        return (tanh_clamp_scale * t) ** 2 * prob
+
+    # The forward applied the activation to its fp32 accumulator; the backward applied it to
+    # c_saved, which is that accumulator rounded to c_dtype. The unknown is the rounding, and
+    # it is bounded by one ulp -- so propagate one ulp of C through the activation and take
+    # that as the floor. For c_dtype=fp32 the ulp is 2^-24 and the floor collapses, which is
+    # what makes that parametrization the sharp one.
+    c_ulp_rel = 2.0**-8 if c_dtype is torch.bfloat16 else 2.0**-24
+    c_ulp = c_saved.abs() * c_ulp_rel
+    floor = torch.maximum((_act(c_saved + c_ulp) - _act(c_saved)).abs(), (_act(c_saved - c_ulp) - _act(c_saved)).abs()).max().item()
+
+    # Both sides are stored in d_dtype (bf16 here) and the two kernels multiply prob in a
+    # different order, so allow a couple of ulps of the output on top.
+    d_ulp = d_fwd.abs().max().item() * 2.0**-8
+    atol = floor + 2 * d_ulp
+    gap = (d_fwd - d_regen).abs().max().item()
+    assert gap <= atol, f"forward output and backward d_srelu regen disagree by {gap:.4g}, above the computed floor {atol:.4g}"
+
+
+@pytest.mark.L0
+def test_grouped_gemm_dsrelu_tanh_clamp_scale_validation(request):
+    """tanh_clamp_scale must be finite and positive; the API rejects the rest at construction."""
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    args = (torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True)
+    case = _build_dsrelu_case(request, *args)
+
+    for bad in (0.0, -1.0, float("nan"), float("inf")):
+        with pytest.raises(ValueError, match="tanh_clamp_scale"):
+            _run_dsrelu_case(case, tanh_clamp_scale=bad)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=101)
+@pytest.mark.parametrize("tanh_clamp_scale", [None, 16.0, 32.0], ids=["unclamped", "clamp16", "clamp32"])
+def test_clamped_srelu_backward_is_the_forward_derivative(tanh_clamp_scale):
+    """The backward formulas really are the derivative of the forward one -- checked by autograd.
+
+    Closes a loop nothing else in this suite closes. Every other test compares a KERNEL against
+    a torch REFERENCE, but the forward reference (test_grouped_gemm_srelu_utils) and the backward
+    reference (test_grouped_gemm_dsrelu_utils) are two halves of the same hand-derived math:
+
+        forward   y      = (s*tanh(relu(x)/s))^2 * w
+        backward  dy/dx  = g * 2c(1-t^2) * w
+                  dy/dw  = sum_n c^2 * g
+
+    If that derivative were wrong, the kernels and the references would be wrong TOGETHER and
+    every kernel-vs-reference test would still pass. So differentiate the forward expression
+    with autograd and compare against the closed forms the backward reference and the kernel
+    both use. Pure torch, fp64, no GPU kernel involved -- this validates the math, and the rest
+    of the file validates that the kernels implement it.
+
+    The unclamped case is kept as a control: it must reduce to d/dx relu(x)^2 = 2*relu(x).
+    """
+    dev = "cuda" if torch.cuda.is_available() else "cpu"
+    m, n = 64, 48
+    # fp64 so the comparison is limited by the formulas, not by rounding. Scaled to straddle
+    # the clamp: relu(x)/s spans roughly [0, 4] at s=16, so both the near-linear and the
+    # saturated regimes are exercised in one tensor.
+    x = (torch.randn(m, n, dtype=torch.float64, device=dev) * 40.0).requires_grad_(True)
+    w = torch.randn(m, 1, dtype=torch.float64, device=dev).requires_grad_(True)
+    g = torch.randn(m, n, dtype=torch.float64, device=dev)
+
+    def forward(xx, ww):
+        """Exactly what run_grouped_gemm_srelu_ref computes, clamped or not."""
+        if tanh_clamp_scale is None:
+            return torch.relu(xx) ** 2 * ww
+        t = torch.tanh(torch.relu(xx) / tanh_clamp_scale)
+        return (tanh_clamp_scale * t) ** 2 * ww
+
+    (forward(x, w) * g).sum().backward()
+
+    with torch.no_grad():
+        if tanh_clamp_scale is None:
+            # The s -> infinity limit: dgrad reduces to 2*relu(x), dprob to sum relu(x)^2 * g.
+            closed_dx = 2 * torch.relu(x) * g * w
+            closed_dw = (torch.relu(x) ** 2 * g).sum(dim=-1, keepdim=True)
+        else:
+            t = torch.tanh(torch.relu(x) / tanh_clamp_scale)
+            c = tanh_clamp_scale * t
+            closed_dx = 2 * c * (1 - t**2) * g * w
+            closed_dw = ((c**2) * g).sum(dim=-1, keepdim=True)
+
+    torch.testing.assert_close(x.grad, closed_dx, rtol=1e-10, atol=1e-10)
+    torch.testing.assert_close(w.grad, closed_dw, rtol=1e-10, atol=1e-10)
+
+    # Non-vacuous on both sides of the clamp: without saturated elements this would only be
+    # testing the near-linear regime, where clamped and unclamped agree anyway.
+    if tanh_clamp_scale is not None:
+        ratio = torch.relu(x) / tanh_clamp_scale
+        assert (ratio > 3.0).any(), "no saturated element -- the clamped branch is untested"
+        assert (ratio < 0.5).any() and (ratio > 0).any(), "no near-linear element"

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu_utils.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu_utils.py
@@ -354,15 +354,20 @@ def run_grouped_gemm_dsrelu_ref(
     d_dtype: torch.dtype = torch.float32,
     sf_vec_size: int = 16,
     sf_dtype: torch.dtype = torch.float8_e8m0fnu,
+    tanh_clamp_scale: Optional[float] = None,
 ) -> Dict[str, torch.Tensor]:
     """Run reference implementation for grouped GEMM dSReLU backward.
 
     Based on the reference in contiguous_blockscaled_grouped_gemm_dsrelu_quant_fusion.py
 
-    The dSReLU backward pass computes:
+    The dSReLU backward pass computes, with tanh_clamp_scale=None (plain, unclamped):
     1. GEMM: ref = alpha * (SFA * A) @ (SFB * B)^T per group
     2. dprob = sum over N of (relu(C)^2 * ref)
     3. D = 2 * relu(C) * ref * prob
+
+    or, with tanh_clamp_scale=s set (t = tanh(relu(C)/s), c = s*t):
+    2. dprob = sum over N of (c^2 * ref)
+    3. D = 2 * c * (1 - t^2) * ref * prob
 
     :param a_ref: A tensor (tensor_m, k, 1) in float32
     :param b_ref: B tensor (n, k, l) in float32
@@ -380,6 +385,8 @@ def run_grouped_gemm_dsrelu_ref(
     :param d_dtype: Output D tensor dtype
     :param sf_vec_size: Scale factor vector size
     :param sf_dtype: Scale factor dtype
+    :param tanh_clamp_scale: Optional soft-clamp scale ``s``, must match the forward pass that
+        produced ``c_ref``. ``None`` (default) is the plain unclamped reference.
     :return: Dictionary of reference tensors
     """
     n, k, l = b_ref.shape
@@ -400,20 +407,33 @@ def run_grouped_gemm_dsrelu_ref(
         start = end
     ref = ref.permute((1, 2, 0))  # shape [M, N, 1]
 
-    # Step 2: Apply dsquared-ReLU backward elementwise
+    # Step 2: Apply d(optionally soft-clamped)squared-ReLU backward elementwise
     c_full = c_ref.clone()
     c_relu = torch.relu(c_full)
-    ref_dprob = c_relu**2 * ref
+    if tanh_clamp_scale is not None:
+        t = torch.tanh(c_relu / tanh_clamp_scale)
+        c = tanh_clamp_scale * t
+        one_minus_t2 = (1 - t) * (1 + t)
+    else:
+        c = c_relu
+        one_minus_t2 = None
+    ref_dprob = c**2 * ref
+    # Chunked sum models the kernel's per-32-column reduction order -- keep this shape even
+    # though the values above may now be the clamped c instead of relu(C).
     chunk_sums = [torch.sum(chunk, dim=1, keepdim=True) for chunk in torch.split(ref_dprob, 32, dim=1)]
     ref_dprob = torch.sum(torch.cat(chunk_sums, dim=1), dim=1, keepdim=True)
     ref_tensors["dprob_ref"] = ref_dprob
 
-    # Step 3: Compute dSReLU formula
+    # Step 3: Compute d(optionally soft-clamped)SReLU formula
     prob = prob_tensor.expand(-1, n, -1)
-    ref_d = 2 * c_relu * ref * prob
+    if tanh_clamp_scale is not None:
+        ref_d = 2 * c * one_minus_t2 * ref * prob
+    else:
+        ref_d = 2 * c * ref * prob
 
     ref_tensors["d_ref"] = ref_d.clone()
-    ref_d_srelu = (c_relu**2 * prob).to(d_dtype).to(torch.float32)
+    # Output-dtype rounding already modelled by the .to(d_dtype).to(torch.float32) round-trip.
+    ref_d_srelu = (c**2 * prob).to(d_dtype).to(torch.float32)
     ref_tensors["d_srelu_ref"] = ref_d_srelu.clone()
 
     if generate_dbias:
@@ -490,6 +510,7 @@ def check_ref_grouped_gemm_dsrelu(
         d_dtype=cfg["d_dtype"],
         sf_vec_size=cfg["sf_vec_size"],
         sf_dtype=cfg["sf_dtype"],
+        tanh_clamp_scale=cfg.get("tanh_clamp_scale"),
     )
 
     torch.testing.assert_close(outputs["dprob_tensor"].float(), ref_tensors["dprob_ref"].float(), atol=atol, rtol=rtol)

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_srelu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_srelu.py
@@ -20,6 +20,7 @@ from fe_api.grouped_gemm.test_grouped_gemm_srelu_utils import (
     allocate_grouped_gemm_input_tensors,
     allocate_grouped_gemm_output_tensors,
     check_ref_grouped_gemm_srelu,
+    run_grouped_gemm_srelu_ref,
 )
 from fe_api.grouped_gemm.test_discrete_grouped_gemm_swiglu_utils import (
     allocate_discrete_input_tensors,
@@ -845,3 +846,365 @@ def _test_grouped_gemm_srelu_wrapper_dynamic_shape_cache_behavior(
         grouped_gemm_srelu_api._cache_of_GroupedGemmSreluSm100Objects.clear()
 
     return compile_count["value"], cache_entries
+
+
+# =============================================================================
+# Soft-clamped SReLU (tanh_clamp_scale)
+# =============================================================================
+#
+# tanh_clamp_scale=s replaces the epilogue's relu(x)**2 with (s*tanh(relu(x)/s))**2, bounding the
+# output by s**2 instead of letting it grow unbounded. Unclamped is the s -> infinity limit,
+# which is why it is one kernel with a const_expr gate rather than two kernel families.
+#
+# Two properties drive the coverage below and are not obvious from the parameter names:
+#
+# 1. ``s`` is a TRACE-TIME constant -- 1/s is folded into the kernel at compile time. A cache
+#    key that omits it is therefore a correctness bug, not a missed optimization: the second
+#    tanh_clamp_scale in a process would silently reuse the first one's kernel. Hence
+#    test_grouped_gemm_srelu_tanh_clamp_scale_cache_key, and hence two live scales in the matrix.
+# 2. The clamped branch is the only place in this epilogue with BOTH a packed and a scalar
+#    variant -- the unclamped branch is packed-only regardless of vector_f32. So vector_f32
+#    False/True is the only coverage the new scalar fallback gets, and both must be in the
+#    matrix.
+
+GROUPED_GEMM_SRELU_CLAMP_CONFIGS = [
+    pytest.param(torch.uint8, torch.bfloat16, torch.bfloat16, 16, torch.float8_e8m0fnu, True, False, id="fp4-vector_f32"),
+    pytest.param(torch.uint8, torch.bfloat16, torch.bfloat16, 16, torch.float8_e8m0fnu, False, False, id="fp4-scalar_f32"),
+    pytest.param(torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, True, True, id="fp8-vector_f32"),
+    pytest.param(torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True, id="fp8-scalar_f32"),
+]
+
+# 16 and 32 are the two production candidates still under evaluation; both have to work.
+# None is kept in the matrix so the clamped and unclamped paths are exercised through
+# identical test code, which is what makes a regression in the shared plumbing visible.
+GROUPED_GEMM_SRELU_CLAMP_SCALES = [
+    pytest.param(None, id="unclamped"),
+    pytest.param(16.0, id="clamp16"),
+    pytest.param(32.0, id="clamp32"),
+]
+
+# fp8_e4m3 keeps 3 mantissa bits, so adjacent representable values are up to 2**-3 apart.
+_FP8_E4M3_ULP_RTOL = 2.0**-3
+
+
+def _assert_close_allowing_quant_boundary(actual, ref, *, rtol, atol, ulp_rtol, max_outlier_frac):
+    """assert_close, except that elements sitting on an output-quantization boundary may
+    differ by up to one representable step of the output dtype.
+
+    This is NOT a loosened tolerance in disguise. With an fp8 output the representable values
+    are ~12.5% apart, so an element whose pre-quantization value lands within the fastmath-tanh
+    error of a rounding boundary quantizes to the neighbouring code point in the kernel and to
+    this one in the fp32 reference -- a full ulp of difference produced by an arbitrarily small
+    cause, which no rtol between 1e-2 and 1.3e-1 can distinguish from a real 12% error.
+    Measured on GB300 (sm_103) for this matrix: 4-7 of 524288 elements (1.3e-5) at
+    tanh_clamp_scale 16/32, zero unclamped. So instead of widening rtol, bound both the SIZE
+    of each exception (one ulp) and the COUNT of them -- a systematic error fails the count,
+    a boundary straddle does not.
+    """
+    a = actual.float()
+    r = ref.float()
+    close = torch.isclose(a, r, rtol=rtol, atol=atol)
+    if bool(close.all()):
+        return
+    outliers = ~close
+    frac = outliers.float().mean().item()
+    assert frac <= max_outlier_frac, f"{outliers.sum().item()} / {outliers.numel()} elements ({frac:.3g}) outside tolerance, above {max_outlier_frac:.3g}"
+    gap = (a - r).abs()[outliers]
+    allowed = (r.abs()[outliers] * ulp_rtol).clamp_min(atol)
+    assert bool((gap <= allowed).all()), f"an out-of-tolerance element differs by more than one output ulp: max gap {gap.max().item():.4g}"
+
+
+def _build_srelu_case(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtype, vector_f32, discrete_col_sfd):
+    cfg = grouped_gemm_srelu_init(
+        request=request,
+        ab_dtype=ab_dtype,
+        c_dtype=c_dtype,
+        d_dtype=d_dtype,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=sf_vec_size,
+        sf_dtype=sf_dtype,
+        vector_f32=vector_f32,
+        discrete_col_sfd=discrete_col_sfd,
+    )
+    inputs = allocate_grouped_gemm_input_tensors(
+        n=cfg["n"],
+        k=cfg["k"],
+        l=cfg["l"],
+        group_m_list=cfg["group_m_list"],
+        ab_dtype=cfg["ab_dtype"],
+        sf_dtype=cfg["sf_dtype"],
+        sf_vec_size=cfg["sf_vec_size"],
+        m_aligned=cfg["m_aligned"],
+    )
+    return inputs, cfg
+
+
+def _run_srelu_case(case, **wrapper_kwargs):
+    """Run the forward wrapper over an already-built case, so repeats share identical inputs."""
+    from cudnn import grouped_gemm_srelu_wrapper_sm100
+    from cuda.bindings import driver as cuda
+
+    inputs, cfg = case
+    wrapper_kwargs.setdefault("current_stream", cuda.CUstream(torch.cuda.current_stream().cuda_stream))
+    return grouped_gemm_srelu_wrapper_sm100(
+        a_tensor=inputs["a_tensor"],
+        b_tensor=inputs["b_tensor"],
+        sfa_tensor=inputs["sfa_tensor"],
+        sfb_tensor=inputs["sfb_tensor"],
+        padded_offsets=inputs["padded_offsets_tensor"],
+        alpha_tensor=inputs["alpha_tensor"],
+        norm_const_tensor=inputs.get("norm_const_tensor"),
+        prob_tensor=inputs.get("prob_tensor"),
+        acc_dtype=cfg["acc_dtype"],
+        c_dtype=cfg["c_dtype"],
+        d_dtype=cfg["d_dtype"],
+        cd_major=cfg["cd_major"],
+        mma_tiler_mn=cfg["mma_tiler_mn"],
+        cluster_shape_mn=cfg["cluster_shape_mn"],
+        sf_vec_size=cfg["sf_vec_size"],
+        vector_f32=cfg["vector_f32"],
+        m_aligned=cfg["m_aligned"],
+        discrete_col_sfd=cfg["discrete_col_sfd"],
+        **wrapper_kwargs,
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@pytest.mark.parametrize("tanh_clamp_scale", GROUPED_GEMM_SRELU_CLAMP_SCALES)
+@pytest.mark.parametrize(
+    "ab_dtype,c_dtype,d_dtype,sf_vec_size,sf_dtype,vector_f32,discrete_col_sfd",
+    GROUPED_GEMM_SRELU_CLAMP_CONFIGS,
+)
+def test_grouped_gemm_srelu_wrapper_tanh_clamp_scale(
+    request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtype, vector_f32, discrete_col_sfd, tanh_clamp_scale
+):
+    """The fused clamped epilogue agrees with the torch reference across both f32 variants."""
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    case = _build_srelu_case(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtype, vector_f32, discrete_col_sfd)
+    inputs, cfg = case
+    # check_ref_grouped_gemm_srelu reads this to pick the clamped branch of the reference.
+    cfg["tanh_clamp_scale"] = tanh_clamp_scale
+
+    try:
+        outputs = _run_srelu_case(case, tanh_clamp_scale=tanh_clamp_scale)
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+
+    if d_dtype is torch.float8_e4m3fn and tanh_clamp_scale is not None:
+        # The whole output set at one-ulp rtol, so nothing goes unchecked...
+        check_ref_grouped_gemm_srelu(inputs, outputs, cfg, rtol=_FP8_E4M3_ULP_RTOL + 1e-2, skip_ref=cfg["skip_ref"])
+        # ...and D, the tensor the epilogue actually produces, still checked sharply.
+        if not cfg["skip_ref"]:
+            ref_tensors = run_grouped_gemm_srelu_ref(
+                a_ref=inputs["a_ref"],
+                b_ref=inputs["b_ref"],
+                sfa_ref=inputs["sfa_ref"],
+                sfb_ref=inputs["sfb_ref"],
+                alpha_tensor=inputs["alpha_tensor"],
+                prob_tensor=inputs["prob_tensor"],
+                aligned_group_m_list=inputs["aligned_group_m_list"],
+                valid_m=inputs["valid_m"],
+                generate_amax=outputs.get("amax_tensor") is not None,
+                generate_sfd=outputs.get("sfd_row_tensor") is not None and outputs.get("sfd_col_tensor") is not None,
+                norm_const_tensor=inputs.get("norm_const_tensor"),
+                c_dtype=cfg["c_dtype"],
+                d_dtype=cfg["d_dtype"],
+                sf_vec_size=cfg["sf_vec_size"],
+                sf_dtype=cfg["sf_dtype"],
+                tanh_clamp_scale=tanh_clamp_scale,
+            )
+            _assert_close_allowing_quant_boundary(
+                outputs["d_tensor"],
+                ref_tensors["d_ref"],
+                rtol=1e-2,
+                atol=1e-1,
+                ulp_rtol=_FP8_E4M3_ULP_RTOL,
+                max_outlier_frac=1e-3,
+            )
+    else:
+        check_ref_grouped_gemm_srelu(inputs, outputs, cfg, skip_ref=cfg["skip_ref"])
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=11)
+@pytest.mark.parametrize("vector_f32", [False, True], ids=["scalar_f32", "vector_f32"])
+def test_grouped_gemm_srelu_tanh_clamp_scale_none_is_bit_identical(request, vector_f32):
+    """tanh_clamp_scale=None must be BIT-identical to not passing the argument at all.
+
+    The headline claim of this feature is that it is purely additive: existing callers get
+    the same kernel and the same bits as before. Every other test here checks the clamped
+    path against a reference, which by construction cannot detect a regression in the
+    unclamped one. This compares the two call forms directly, at torch.equal rather than a
+    tolerance -- the const_expr guard means both should trace to the same program, so
+    anything short of bit-equality is a real behaviour change.
+    """
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    case = _build_srelu_case(request, torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, vector_f32, True)
+
+    try:
+        omitted = _run_srelu_case(case)  # exactly the pre-change call signature
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+    explicit_none = _run_srelu_case(case, tanh_clamp_scale=None)
+    torch.cuda.synchronize()
+
+    # d_col and the scale factors are only written when the fp8 SFD path is active;
+    # otherwise the kernel leaves them at whatever their allocation happened to contain,
+    # which differs between two independent calls for reasons unrelated to this flag.
+    compared = ["c_tensor", "d_tensor"]
+    if omitted.get("sfd_row_tensor") is not None:
+        compared += ["d_col_tensor", "sfd_row_tensor", "sfd_col_tensor"]
+    if omitted.get("amax_tensor") is not None:
+        compared.append("amax_tensor")
+
+    for key in compared:
+        a, b = omitted[key], explicit_none[key]
+        assert a is not None and b is not None, f"{key} missing from one of the two runs"
+        assert torch.equal(a, b), f"{key} differs between omitted and tanh_clamp_scale=None"
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=3)
+def test_grouped_gemm_srelu_tanh_clamp_scale_cache_key(request, monkeypatch):
+    """Two clamp scales in one process must compile two kernels, not reuse the first.
+
+    ``s`` is folded into the kernel at trace time, so this is a correctness test: if
+    tanh_clamp_scale were missing from the cache key, the s=32 call would silently return the
+    s=16 kernel's numbers. Both the compile count and the per-scale reference check have to
+    hold -- the count alone would pass a kernel that compiled twice and computed the wrong
+    thing, and the reference check alone would pass if the cache key were over-specified.
+    """
+    try:
+        import cudnn  # noqa: F401
+        from cudnn.gemm.cutedsl.grouped.srelu import api as grouped_gemm_srelu_api
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    monkeypatch.setattr(grouped_gemm_srelu_api, "_cache_of_GroupedGemmSreluSm100Objects", {})
+
+    compile_count = {"value": 0}
+    original_compile = grouped_gemm_srelu_api.GroupedGemmSreluSm100.compile
+
+    def counted_compile(self):
+        compile_count["value"] += 1
+        return original_compile(self)
+
+    monkeypatch.setattr(grouped_gemm_srelu_api.GroupedGemmSreluSm100, "compile", counted_compile)
+
+    args = (torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True)
+    case = _build_srelu_case(request, *args)
+    inputs, cfg = case
+
+    results = {}
+    for tanh_clamp_scale in (16.0, 32.0):
+        try:
+            results[tanh_clamp_scale] = _run_srelu_case(case, tanh_clamp_scale=tanh_clamp_scale)
+        except (ValueError, NotImplementedError) as e:
+            pytest.skip(f"Unsupported testcase: {e}")
+        torch.cuda.synchronize()
+
+    assert compile_count["value"] == 2, f"expected one compile per tanh_clamp_scale, got {compile_count['value']}"
+
+    for tanh_clamp_scale, outputs in results.items():
+        cfg["tanh_clamp_scale"] = tanh_clamp_scale
+        # fp8 D: one-ulp rtol, for the quantization-boundary reason documented on
+        # _assert_close_allowing_quant_boundary. The sharp per-element check of D lives in
+        # test_grouped_gemm_srelu_wrapper_tanh_clamp_scale; here the point is the cache key.
+        check_ref_grouped_gemm_srelu(inputs, outputs, cfg, rtol=_FP8_E4M3_ULP_RTOL + 1e-2, skip_ref=cfg["skip_ref"])
+
+    # Same inputs, different s => different outputs. Without this, a kernel that ignored
+    # tanh_clamp_scale entirely (computing plain sqrelu twice) would still pass the count check,
+    # and would pass the reference check too if the reference had the same bug.
+    if not cfg["skip_ref"]:
+        assert not torch.equal(results[16.0]["d_tensor"], results[32.0]["d_tensor"])
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=5)
+@pytest.mark.parametrize("vector_f32", [False, True], ids=["scalar_f32", "vector_f32"])
+def test_grouped_gemm_srelu_tanh_clamp_scale_saturated(request, vector_f32):
+    """The saturated tail: for relu(C) >> s the output must converge to the exact bound s^2*w.
+
+    This is the regime the feature exists for -- it is what bounds the MXFP8 dynamic range --
+    and it is the one the default random inputs barely reach, so it needs its own case rather
+    than another tanh_clamp_scale against the same distribution. It is also the regime where a
+    relative tolerance is the wrong instrument: the reference value is s^2*w and the fused
+    value approaches it from below, so the check is on the absolute gap.
+    """
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    # d_dtype bf16 rather than fp8: fp8 output quantization is coarser than the effect under
+    # test and would set the tolerance floor instead of the tanh.
+    args = (torch.uint8, torch.bfloat16, torch.bfloat16, 16, torch.float8_e8m0fnu, vector_f32, False)
+    case = _build_srelu_case(request, *args)
+    inputs, cfg = case
+
+    # s small enough that essentially the whole positive tail is saturated. Chosen from the
+    # measured relu(C) distribution of these inputs, not assumed.
+    tanh_clamp_scale = 0.5
+    cfg["tanh_clamp_scale"] = tanh_clamp_scale
+
+    try:
+        outputs = _run_srelu_case(case, tanh_clamp_scale=tanh_clamp_scale)
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+    torch.cuda.synchronize()
+
+    if cfg["skip_ref"]:
+        pytest.skip("--skip-ref")
+
+    check_ref_grouped_gemm_srelu(inputs, outputs, cfg, skip_ref=False)
+
+    # And the property the reference cannot check for us, because it shares the tanh: the
+    # output is bounded, everywhere, with no reliance on the reference.
+    #
+    # The bound is |d| <= s^2*|w|, NOT d <= s^2*w. This harness draws the routing probability
+    # from torch.randint(-2, 2) (srelu_utils:357), so w is one of {-2,-1,0,1} and is negative
+    # about half the time; for w < 0 the inequality d = c^2*w <= s^2*w points the other way.
+    # The signed form passes only by accident on a non-negative-w harness.
+    valid_m = inputs["valid_m"]
+    prob = inputs["prob_tensor"].float().expand(-1, cfg["n"], -1)[:valid_m]
+    d = outputs["d_tensor"].float()[:valid_m].abs()
+    bound = (tanh_clamp_scale * tanh_clamp_scale) * prob.abs()
+    # bf16 storage of d rounds up as often as down, so the bound is only exact up to one ulp
+    # of the stored value.
+    ulp = (bound * 2.0**-8).clamp_min(torch.finfo(torch.bfloat16).tiny)
+    assert torch.all(d <= bound + ulp), f"clamped |output| exceeded s^2*|w|: max excess {(d - bound).max().item():.4g}"
+    # Non-vacuous: the saturated regime was actually reached, on rows where w != 0.
+    assert torch.any(d > 0.5 * bound), "no element reached the saturated regime -- test is vacuous"
+
+
+@pytest.mark.L0
+def test_grouped_gemm_srelu_tanh_clamp_scale_validation(request):
+    """tanh_clamp_scale must be finite and positive; the API rejects the rest at construction."""
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    args = (torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True)
+    case = _build_srelu_case(request, *args)
+
+    for bad in (0.0, -1.0, float("nan"), float("inf")):
+        with pytest.raises(ValueError, match="tanh_clamp_scale"):
+            _run_srelu_case(case, tanh_clamp_scale=bad)

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_srelu_utils.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_srelu_utils.py
@@ -459,6 +459,7 @@ def run_grouped_gemm_srelu_ref(
     d_dtype: torch.dtype = torch.float32,
     sf_vec_size: int = 16,
     sf_dtype: torch.dtype = torch.float8_e8m0fnu,
+    tanh_clamp_scale: Optional[float] = None,
 ) -> torch.Tensor:
     """Run reference implementation for grouped GEMM SReLU.
 
@@ -480,6 +481,9 @@ def run_grouped_gemm_srelu_ref(
     :param d_dtype: Output D tensor dtype
     :param sf_vec_size: Scale factor vector size
     :param sf_dtype: Scale factor dtype
+    :param tanh_clamp_scale: Optional soft-clamp scale ``s``. When set, computes
+        ``(s * tanh(relu(ref) / s)) ** 2`` in fp32 instead of plain ``relu(ref) ** 2``.
+        ``None`` (default) is the plain unclamped reference.
     :return: Reference output tensor (valid_m, n_out, 1)
     """
     n, k, l = b_ref.shape
@@ -513,8 +517,12 @@ def run_grouped_gemm_srelu_ref(
 
     ref_tensors["c_ref"] = ref.clone()
 
-    # Step 3: Apply squared-ReLU and probability gating elementwise
-    ref_after_srelu = torch.relu(ref) ** 2
+    # Step 3: Apply (optionally soft-clamped) squared-ReLU and probability gating elementwise
+    if tanh_clamp_scale is not None:
+        t_ref = torch.tanh(torch.relu(ref) / tanh_clamp_scale)
+        ref_after_srelu = (tanh_clamp_scale * t_ref) ** 2
+    else:
+        ref_after_srelu = torch.relu(ref) ** 2
     ref_after_srelu = ref_after_srelu * prob_tensor.expand(-1, n_out, -1)
     ref_tensors["d_ref"] = ref_after_srelu.clone()
 
@@ -683,6 +691,7 @@ def check_ref_grouped_gemm_srelu(
         d_dtype=cfg["d_dtype"],
         sf_vec_size=cfg["sf_vec_size"],
         sf_dtype=cfg["sf_dtype"],
+        tanh_clamp_scale=cfg.get("tanh_clamp_scale"),
     )
 
     torch.testing.assert_close(outputs["c_tensor"].float(), ref_tensors["c_ref"].float(), atol=atol, rtol=rtol)


### PR DESCRIPTION
- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] Labels: suggest `cat-enhancements`, `mod-cutedsl`, `orig-nv-eng` (no access to add).

## Affected area

CuTe DSL grouped GEMM: `srelu` (forward) and `dsrelu` (backward) SM100 kernels, their Python APIs, tests, and docs.

## Summary

Adds an optional tanh soft-clamp scale `tanh_clamp_scale` to the squared-ReLU epilogues of the SM100 block-scaled grouped GEMM kernels, forward and backward. With scale `s`, writing `t = tanh(relu(x)/s)` and `c = s·t`:

- **Forward (srelu):** `out = c² · prob` — plain srelu is the `s → ∞` limit.
- **Backward (dsrelu):** `dgrad = g · 2c(1−t²) · prob`, `dprob = Σₙ c²·g`, `d_srelu` regen `= c² · prob`, replacing the `relu(C)` / `relu(C)²` terms.

`s` is a trace-time constant folded into the compiled kernel and included in the compile-cache key (distinct `s` compile distinct kernels). `tanh_clamp_scale=None` (default) is bit-identical to today's unclamped path.

## Why

A new MoE activation (tanh soft-clamped squared ReLU) currently runs as a standalone elementwise kernel between the two grouped GEMMs — extra memory round-trips and no FP8-requant fusion. This PR makes it fusable into the grouped GEMM epilogue. The clamp bounds the activation by `s² · prob`, which also keeps the fused FP8 quantization well-behaved. Downstream TE and Megatron-Core integration follow in separate PRs; this is the first link.

## API and compatibility impact

- Purely additive: new optional keyword `tanh_clamp_scale: Optional[float] = None` on `GroupedGemmSreluSm100`, `GroupedGemmDsreluSm100`, and the `grouped_gemm_srelu_wrapper_sm100` / `grouped_gemm_dsrelu_wrapper_sm100` convenience wrappers. No existing parameter changes.
- Default (`None`) reproduces current kernels bit-for-bit; all existing tests pass unmodified.
- Validated finite and > 0 when set. These APIs remain experimental and subject to change.
- Deterministic dprob (PR #521) is unaffected: the clamp changes only the per-element value feeding the accumulation, never the slotting or reduction order.

## Testing

On GB300 (sm_103), full `test_grouped_gemm_srelu.py` + `test_grouped_gemm_dsrelu.py` suites green:

- Clamped cases: two scales × {fp8, fp4} × `vector_f32` × `use_dsrelu_reuse` × deterministic dprob.
- Additive-only: `None` vs argument-omitted compared with `torch.equal` for both kernels.
- Cache-key: distinct `s` values compile distinct kernels.
- Forward/backward consistency: `d_srelu` regen matches the forward output.
- fp64 autograd check that the closed-form backward is the forward's derivative.
- Saturation: deep-tail inputs give exactly-zero dgrad (and non-zero dprob, so the check can't pass vacuously).

## Review notes

- **Why relu before tanh:** `s·tanh(relu(x)/s) ≡ relu(s·tanh(x/s))` (ReLU commutes with any non-decreasing `g` fixing 0; derivatives agree too). ReLU-first matches the existing epilogue structure and the reference implementation.
- **`t` is capped at 1** (`fmin` after `tanh.approx.f32`): defensive — measured on sm_103 over [0, 64] plus saturated inputs, the approximation never exceeded 1. The cap makes `1−t² ≥ 0` (no gradient sign flip) and the `s²·prob` output bound structural rather than observed. One instruction per element.
- **Accuracy:** measured max abs error of the tanh path is 7.7e-6 vs an fp64 reference (worst-case spec bound 4.9e-4); end-to-end output error is dominated by output quantization, not tanh.
- **Naming:** `tanh_clamp_scale` distinguishes the tanh *soft* clamp from the existing *hard* clamp parameters (`glu_clamp_max`/`glu_clamp_min`) and aligns with the downstream Megatron config `activation_func_tanh_clamp_scale`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional tanh soft-clamping for grouped GEMM SReLU and dSReLU operations.
  - Positive scale values provide bounded activations while preserving existing behavior when unset.
  - Forward and backward operations support matching clamp scales for consistent gradients.
  - Invalid scale values are rejected, and compiled variants remain separately cached.

- **Documentation**
  - Documented soft-clamped activation formulas, deterministic behavior, precision considerations, and configuration requirements.

- **Tests**
  - Added coverage for clamping, saturation, gradients, cache separation, validation, quantization paths, and backward consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->