### PR TITLE
Add SM100 D256 FP8 and MXFP8 SDPA kernels

### DIFF
--- a/include/cudnn_frontend/node/sdpa_support_surface.h
+++ b/include/cudnn_frontend/node/sdpa_support_surface.h
@@ -185,7 +185,8 @@ SDPA_attributes::validate_sdpa_support_surface(const detail::Context& context,
         RETURN_CUDNN_FRONTEND_ERROR_IF(is_bias, error_code_t::GRAPH_NOT_SUPPORTED, "SDPA FP8 does not support bias");
 
         // validate basic dimension requirements
-        // d_qk=192 with d_v=128 is only supported starting from cuDNN 9.19
+        // Extended native FP8 shapes are enabled only with backend versions
+        // that expose the corresponding graph surface.
         bool const d192_v128_supported = (detail::get_backend_version() >= 91900);
         // Head dims in (256, 512] on BOTH sides are served by the frontend-only
         // FROST SM100 per-tensor FP8 prefill engine
@@ -197,19 +198,22 @@ SDPA_attributes::validate_sdpa_support_surface(const detail::Context& context,
         // still fails at plan creation.
         bool const d512_supported =
             (d_qk > 256) && (d_qk <= 512) && (d_v > 256) && (d_v <= 512) && (d_qk % 16 == 0) && (d_v % 16 == 0);
+        bool const d256_v256_supported = (detail::get_backend_version() >= 92600);
         if (prop_major >= 10) {
             RETURN_CUDNN_FRONTEND_ERROR_IF(
                 ((d_qk > 128) || (d_qk % 16 != 0)) && !(d192_v128_supported && d_qk == 192 && d_v == 128) &&
-                    !d512_supported,
+                    !(d256_v256_supported && d_qk == 256 && d_v == 256) && !d512_supported,
                 error_code_t::GRAPH_NOT_SUPPORTED,
                 "hidden_dim d_qk should be less than or equal to 128 and hidden_dim d_qk "
                 "should be multiple of 16 unless d_qk == 192 and d_v == 128 (requires cuDNN 9.19+) "
-                "or both head dims are in (256, 512] and multiples of 16");
+                "or d_qk == d_v == 256 (requires cuDNN 9.26+) or both head dims are in (256, 512] and multiples of 16");
             RETURN_CUDNN_FRONTEND_ERROR_IF(
-                ((d_v > 128) || (d_v % 16 != 0)) && !d512_supported,
+                ((d_v > 128) || (d_v % 16 != 0)) && !(d256_v256_supported && d_qk == 256 && d_v == 256) &&
+                    !d512_supported,
                 error_code_t::GRAPH_NOT_SUPPORTED,
                 "hidden_dim d_v should be less than or equal to 128 and hidden_dim d_v should be multiple of 16 "
-                "unless both head dims are in (256, 512] and multiples of 16");
+                "unless d_qk == d_v == 256 (requires cuDNN 9.26+) or both head dims are in (256, 512] and multiples of "
+                "16");
         } else {
             RETURN_CUDNN_FRONTEND_ERROR_IF(
                 (d_qk > 256) || (d_qk % 16 != 0) || (d_v > 256) || (d_v % 16 != 0),

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -886,6 +886,11 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         self._lse_stride: Optional[tuple[int, int, int]] = None
         self._k_mod = None
 
+    @property
+    def _d256_quantized(self) -> bool:
+        """Whether the selected kernel uses the D256 quantized length ABI."""
+        return self._fp8 and self.flavor == (256, 256)
+
     def check_support(self) -> bool:
         self._logger.debug("Entering check_support")
 
@@ -2058,7 +2063,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             fn = km.compile(**self._thd_compile_kwargs())
             thd_lens_args = (
                 (None, pack.q_lens_dev, pack.kv_lens_dev, cutlass.Int32(pack.lens_form))
-                if self.flavor == (256, 256)
+                if self._d256_quantized
                 else (pack.q_lens_dev, pack.kv_lens_dev, cutlass.Int32(pack.lens_form))
             )
             fn(
@@ -2122,7 +2127,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         O_dst, lse_dst = O, lse
         if self.split_kv > 1:
             O_dst, lse_dst = self._split_partials(workspace, O, device, current_stream)
-        dense_q_lens_args = (seq_q_t,) if self.flavor == (256, 256) else ()
+        dense_q_lens_args = (seq_q_t,) if self._d256_quantized else ()
         self._compiled_kernel(
             Q,
             K,
@@ -2153,8 +2158,9 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 cutlass.Int32(self.split_kv),
                 stream=current_stream,
             )
-        if o_needs_copy_back:
-            O_view.copy_(O)
+        with _torch_stream_context(current_stream, device):
+            if o_needs_copy_back:
+                O_view.copy_(O)
         self._logger.debug("execute (MXFP8) completed")
 
     def _execute_fp8(
@@ -2230,7 +2236,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             fn = self._k_mod.compile(**self._thd_compile_kwargs())
             thd_lens_args = (
                 (None, pack.q_lens_dev, pack.kv_lens_dev, cutlass.Int32(pack.lens_form))
-                if self.flavor == (256, 256)
+                if self._d256_quantized
                 else (pack.q_lens_dev, pack.kv_lens_dev, cutlass.Int32(pack.lens_form))
             )
             fn(
@@ -2296,7 +2302,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         O_dst, lse_dst = O, lse
         if self.split_kv > 1:
             O_dst, lse_dst = self._split_partials(workspace, O, device, current_stream)
-        dense_q_lens_args = (seq_q_t,) if self.flavor == (256, 256) else ()
+        dense_q_lens_args = (seq_q_t,) if self._d256_quantized else ()
         self._compiled_kernel(
             Q,
             K,
@@ -2329,13 +2335,14 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 cutlass.Int32(self.split_kv),
                 stream=current_stream,
             )
-        if o_needs_copy_back:
-            O_view.copy_(O)
-        if amax_o is not None:
-            # Device divisor: the same div_ as before, minus the readback.
-            # scale_o > 0 is caller contract (backend parity); None bound a
-            # cached 1.0 above.
-            amax_o_buf.div_(so_t)
+        with _torch_stream_context(current_stream, device):
+            if o_needs_copy_back:
+                O_view.copy_(O)
+            if amax_o is not None:
+                # Device divisor: the same div_ as before, minus the readback.
+                # scale_o > 0 is caller contract (backend parity); None bound a
+                # cached 1.0 above.
+                amax_o_buf.div_(so_t)
         self._logger.debug("execute (FP8 per-tensor) completed")
 
 

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -31,7 +31,9 @@ from cudnn.frost.tile_dsl.constants import (
 from cudnn.sdpa.fwd.config_sm100 import (
     TemplateParams as Sm100TemplateParams,
     canonicalize_d192_lowering,
+    canonicalize_d256_lowering,
     derive_d192_internal_params,
+    derive_d256_internal_params,
     pack_gqa_supported,
 )
 from cudnn.sdpa.fwd.config_sm120 import (
@@ -71,7 +73,7 @@ _SM100_KERNEL_FILES = {
     (128, 128): "prefill_d128_f16_sm100.py",
 }
 # DTYPE_* codes: E4M3=0, E5M2=1, BF16=2, FP16=3. FP8 inputs (0/1) route to the
-# FP8 kernel family; the output dtype is encoded the same way.
+# FP8 kernel families; the output dtype is encoded the same way.
 _SM100_DTYPE_QKV_CODE = {
     torch.float8_e4m3fn: DTYPE_E4M3,
     torch.float8_e5m2: DTYPE_E5M2,
@@ -80,15 +82,17 @@ _SM100_DTYPE_QKV_CODE = {
 }
 _SM100_FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
 # FP8 kernels use E4M3/E5M2 inputs and BF16/FP16/FP8 outputs. Block-scale
-# Both FP8 paths have exact d128/d128 and d192/d128 kernels.
+# Per-tensor and block-scale FP8 select independently from their native maps.
 _SM100_MXFP8_KERNEL_FILES = {
     (128, 128): "prefill_d128_mxfp8_sm100.py",
     (192, 128): "prefill_d192_d128_mxfp8_sm100.py",
+    (256, 256): "prefill_d256_mxfp8_sm100.py",
 }
 _SM107_FP8_KERNEL_FILE = "prefill_d128_fp8_sm107.py"
 _SM100_FP8_KERNEL_FILES = {
     (128, 128): "prefill_d128_fp8_sm100.py",
     (192, 128): "prefill_d192_d128_fp8_sm100.py",
+    (256, 256): "prefill_d256_fp8_sm100.py",
     (512, 512): "prefill_d512_fp8_sm100.py",
 }
 
@@ -97,10 +101,8 @@ def _sm100_fp8_shapes(pertensor: bool, device_cc: tuple[int, int]) -> frozenset[
     """NATIVE (exact) FP8 kernel-flavor shapes for the device line."""
     if device_cc == (10, 7):
         return frozenset({(128, 128)})
-    # d512 is per-tensor only: there is no d512 block-scale (MXFP8) kernel.
-    if pertensor:
-        return frozenset({(128, 128), (192, 128), (512, 512)})
-    return frozenset({(128, 128), (192, 128)})
+    kernel_files = _SM100_FP8_KERNEL_FILES if pertensor else _SM100_MXFP8_KERNEL_FILES
+    return frozenset(kernel_files)
 
 
 # Per-native-shape ENVELOPE FLOOR (see engines.Capabilities.d_envelope_floors,
@@ -284,8 +286,7 @@ def _pick_flavor(d_qk: int, d_v: int, candidates: Optional[tuple[tuple[int, int]
     """Smallest flavor whose envelope covers ``(d_qk, d_v)``.
 
     ``candidates`` restricts the walk to the flavors that have a kernel for the
-    caller's quantization (the FP8 family has no d256 file, so an FP8 graph must
-    not land on it); ``None`` = the full f16/bf16 list.
+    caller's quantization; ``None`` = the full f16/bf16 list.
 
     ENVELOPE (zero-padding) semantics: one flavor covers ``d_qk`` and ``d_v``
     with its own max extents — e.g. (192, 128) runs on the d192/d128 kernel. The
@@ -293,11 +294,11 @@ def _pick_flavor(d_qk: int, d_v: int, candidates: Optional[tuple[tuple[int, int]
     the tile box stays the compile-time D, so loads past d_qk / d_v hardware
     zero-fill (adding exact zero terms to every QK^T dot product — S, softmax
     and P·V are bit-identical to the unpadded problem) and O stores past d_v
-    are OOB-clipped. Per-tensor FP8 serves the same envelope under its d128
-    tile (dense only, d % 16 at 1 byte/elem); d192 FP8 and MXFP8 use exact
-    native shapes. All of it is gated in check_support / engines.mismatch,
-    including the f16 alignment rule (d % 8, the TMA 16-byte global-stride
-    rule at 2 bytes/elem).
+    are OOB-clipped. Per-tensor FP8 serves the dense envelope of every native
+    flavor it ships (d % 16 at 1 byte/elem); MXFP8 stays exact-shape because
+    its block-scale tensors are not padded. All of it is gated in check_support
+    / engines.mismatch, including the f16 alignment rule (d % 8, the TMA
+    16-byte global-stride rule at 2 bytes/elem).
     """
     pool = candidates if candidates is not None else _SM100_FLAVORS
     for flavor in pool:
@@ -1035,7 +1036,9 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             f"SdpaFwdDslSm100 requires {_allowed_msg}; found SM{major}{minor} on {device}",
         )
 
-        # FP8 flavor shapes: SM100 serves d128/d128 and d192/d128; Rubin
+        # FP8 flavor shapes: SM100 per-tensor FP8 serves d128/d128,
+        # d192/d128, and d256/d256; MXFP8 serves the shapes in its independent
+        # native map. Rubin
         # currently serves only per-tensor FP8 d128. Per-tensor FP8 serves
         # the dense ENVELOPE of every flavor it has (TMA zero-padding, like
         # the f16 flavors — exact in FP8, and the descales are scalars, so
@@ -1070,8 +1073,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             f"(D_QK={d_qk}, D_V={d_v})",
         )
         # An FP8 graph must only land on a flavor that HAS an fp8 kernel: the
-        # quantized family has no d256 file, so the f16 flavor list would send a
-        # d256 fp8 graph to a kernel that does not exist.
+        # per-tensor and block-scale families have different native maps.
         self.flavor = _pick_flavor(d_qk, d_v, tuple(f for f in _SM100_FLAVORS if f in fp8_shapes) if self._fp8 else None)
         self._value_error_if(
             self.sched_policy is not None and self.sched_policy not in (SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2),
@@ -1085,7 +1087,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 requested is not None and requested != supported,
                 f"SM100 DSL SDPA only supports {name}={supported}",
             )
-        supported_cgas = (1, 2) if self.flavor == (192, 128) else (2,)
+        supported_cgas = (1, 2) if self.flavor == (192, 128) else (1,) if self._fp8 and self.flavor == (256, 256) else (2,)
         self._value_error_if(
             self.cga is not None and self.cga not in supported_cgas,
             f"SM100 DSL SDPA only supports cga in {supported_cgas}",
@@ -1157,7 +1159,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         )
         # Keep direct construction aligned with each quantized family's THD
         # kernels; graph routing enforces the same per-family shape domain.
-        _thd_fp8_shapes = {(128, 128), (192, 128), (512, 512)} if self._pertensor else {(128, 128), (192, 128)}
+        _thd_fp8_shapes = set(_SM100_FP8_KERNEL_FILES if self._pertensor else _SM100_MXFP8_KERNEL_FILES)
         self._not_implemented_error_if(
             self.thd and self._fp8 and (int(d_qk), int(d_v)) not in _thd_fp8_shapes,
             f"THD/varlen on this quantized path supports {sorted(_thd_fp8_shapes)}; " f"got (D_QK={d_qk}, D_V={d_v})",
@@ -1173,8 +1175,8 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             "seq_q_lens_present requires seq_kv_lens_present (padding mask)",
         )
         self._value_error_if(
-            self.seq_q_lens_present and self._fp8,
-            "seq_q_lens_present (dense padded-Q LSE trim) is not plumbed for the FP8/MXFP8 kernels",
+            self.seq_q_lens_present and self._fp8 and self.flavor != (256, 256),
+            "seq_q_lens_present (dense padded-Q LSE trim) is supported by the D256 FP8/MXFP8 flavor only",
         )
         # KV-tail correctness: the kernel zero-fills the last KV tile via TMA
         # OOB but only *masks* those columns on the padded / causal paths. A
@@ -1256,7 +1258,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             pack_gqa=self.pack_gqa,
             qh_per_kh=int(self.q_desc.shape[1]) // int(self.k_desc.shape[1]),
             split_kv=self.split_kv,
-            cta_mma=2 if self.cga is None else self.cga,
+            cta_mma=(1 if self._fp8 and self.flavor == (256, 256) else 2) if self.cga is None else self.cga,
             fused_ldtm_stat=fused_ldtm_stat,
             softmax_f16=self.softmax_precision == _cudnn_dtype.HALF,
         )
@@ -1287,6 +1289,28 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 h_q=self.h_q,
                 s_q=self.s_q_max,
                 s_kv=self.s_k_max,
+            )
+        elif self.flavor == (256, 256):
+            from cudnn.sdpa.fwd.heuristics import select_d256_auto_knobs
+
+            auto_sched, auto_cga = select_d256_auto_knobs(
+                params,
+                pertensor=self._pertensor,
+                s_q=self.s_q_max,
+                s_kv=self.s_k_max,
+            )
+            params = replace(
+                params,
+                sched_policy=auto_sched if self.sched_policy is None else params.sched_policy,
+                cta_mma=auto_cga if self.cga is None else params.cta_mma,
+            )
+            params = canonicalize_d256_lowering(params, s_q=self.s_q_max, s_kv=self.s_k_max)
+            params = derive_d256_internal_params(
+                params,
+                pertensor=self._pertensor,
+                batch_size=self.batch_size,
+                h_q=self.h_q,
+                s_q=self.s_q_max,
             )
         self._k_mod = _load_sm100_kernel_module(self.flavor, params, fp8=self._fp8, pertensor=self._pertensor, rubin=(self._device_cc == (10, 7)))
         if self.thd:
@@ -1743,7 +1767,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             #
             # CGA_SIZE (= CGA_M * CGA_N) is the CTA count of ONE cluster, which
             # is what the grid is laid out in: grid_x = units * CGA_M. It equals
-            # CTA_MMA on the cga2 flavors (d128/d192/d256) but NOT on d512,
+            # CTA_MMA on the d128/d192/d256 flavors but NOT on d512,
             # which pairs CGA_M=4 with CTA_MMA=2 — capping on CTA_MMA there
             # would launch 2x the CTAs the device holds resident. CTA_MMA stays
             # as the fallback so a module predating CGA_SIZE still caps.
@@ -2032,6 +2056,11 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             # PLAN-TIME-ONLY compile key: re-binds the artifact compile()
             # already built (packed totals + SF tile extents are dynamic).
             fn = km.compile(**self._thd_compile_kwargs())
+            thd_lens_args = (
+                (None, pack.q_lens_dev, pack.kv_lens_dev, cutlass.Int32(pack.lens_form))
+                if self.flavor == (256, 256)
+                else (pack.q_lens_dev, pack.kv_lens_dev, cutlass.Int32(pack.lens_form))
+            )
             fn(
                 pack.Q,
                 pack.K,
@@ -2048,9 +2077,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 (b, h_q, h_kv, 0, 0, 0),
                 cutlass.Float32(scale_softmax_log2),
                 cutlass.Int32(pack.units),
-                pack.q_lens_dev,
-                pack.kv_lens_dev,
-                cutlass.Int32(pack.lens_form),
+                *thd_lens_args,
                 stream=current_stream,
             )
             self._logger.debug("execute (MXFP8 THD) completed")
@@ -2078,6 +2105,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             if seq_kv_lens is not None
             else self._dummy("seq_kv", device, lambda: torch.zeros(b, dtype=torch.int32, device=device))
         )
+        seq_q_t = self._checked_seq_lens(seq_q_lens, "seq_q_lens") if self.seq_q_lens_present else None
 
         amax_o_buf = amax_o.reshape(-1)[:1] if amax_o is not None else self._dummy("amax_o", device, lambda: torch.zeros(1, dtype=torch.float32, device=device))
         # Must be enqueued on the SAME stream as the kernel launch below, else the
@@ -2094,6 +2122,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         O_dst, lse_dst = O, lse
         if self.split_kv > 1:
             O_dst, lse_dst = self._split_partials(workspace, O, device, current_stream)
+        dense_q_lens_args = (seq_q_t,) if self.flavor == (256, 256) else ()
         self._compiled_kernel(
             Q,
             K,
@@ -2110,6 +2139,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             (b, h_q, h_kv, sq, skv, 0),
             cutlass.Float32(scale_softmax_log2),
             cutlass.Int32(0),
+            *dense_q_lens_args,
             stream=current_stream,
         )
         if self.split_kv > 1:
@@ -2198,6 +2228,11 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             # PLAN-TIME-ONLY compile key: re-binds the artifact compile()
             # already built (the packed totals are dynamic extents).
             fn = self._k_mod.compile(**self._thd_compile_kwargs())
+            thd_lens_args = (
+                (None, pack.q_lens_dev, pack.kv_lens_dev, cutlass.Int32(pack.lens_form))
+                if self.flavor == (256, 256)
+                else (pack.q_lens_dev, pack.kv_lens_dev, cutlass.Int32(pack.lens_form))
+            )
             fn(
                 pack.Q,
                 pack.K,
@@ -2216,9 +2251,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 dv_t,
                 so_t,
                 amax_o_buf,
-                pack.q_lens_dev,
-                pack.kv_lens_dev,
-                cutlass.Int32(pack.lens_form),
+                *thd_lens_args,
                 stream=current_stream,
             )
             with _torch_stream_context(current_stream, device):
@@ -2245,6 +2278,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             if seq_kv_lens is not None
             else self._dummy("seq_kv", device, lambda: torch.zeros(b, dtype=torch.int32, device=device))
         )
+        seq_q_t = self._checked_seq_lens(seq_q_lens, "seq_q_lens") if self.seq_q_lens_present else None
 
         # amax_o: the kernel atomicMax'es into this buffer, so it MUST start
         # at 0. It accumulates max|o_scaled| (pre-cast, exact even for FP8 O);
@@ -2262,6 +2296,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         O_dst, lse_dst = O, lse
         if self.split_kv > 1:
             O_dst, lse_dst = self._split_partials(workspace, O, device, current_stream)
+        dense_q_lens_args = (seq_q_t,) if self.flavor == (256, 256) else ()
         self._compiled_kernel(
             Q,
             K,
@@ -2280,6 +2315,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             dv_t,
             so_t,
             amax_o_buf,
+            *dense_q_lens_args,
             stream=current_stream,
         )
         if self.split_kv > 1:

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -9,7 +9,7 @@ import logging
 import math
 import os
 from abc import abstractmethod
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, replace
 from types import SimpleNamespace
 from typing import Callable, Hashable, Iterator, Optional
@@ -147,8 +147,17 @@ _CUDA_RAW_STREAM = getattr(torch._C, "_cuda_getCurrentRawStream", None)
 
 
 @contextmanager
-def _torch_stream_context(current_stream: Optional[cuda.CUstream], device: torch.device) -> Iterator[None]:
-    """Run PyTorch work on the CUDA stream used for the kernel launch."""
+def _torch_stream_context(
+    current_stream: Optional[cuda.CUstream],
+    device: torch.device,
+    *,
+    verify_current: bool = False,
+) -> Iterator[None]:
+    """Run PyTorch work on the CUDA stream used for the kernel launch.
+
+    ``verify_current`` bypasses the private raw-handle shortcut when a caller
+    supplies the stream, making that handle authoritative for the context.
+    """
     if current_stream is None:
         yield
         return
@@ -165,7 +174,7 @@ def _torch_stream_context(current_stream: Optional[cuda.CUstream], device: torch
     # and entering a context for the current stream is a no-op. Building the two
     # Stream objects below costs ~3.4 us each and this runs several times per
     # execute; the raw handle getter is ~0.07 us.
-    if _CUDA_RAW_STREAM is not None:
+    if not verify_current and _CUDA_RAW_STREAM is not None:
         _idx = device.index if device.index is not None else torch.cuda.current_device()
         if handle == _CUDA_RAW_STREAM(_idx):
             yield
@@ -1470,6 +1479,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         # Run on the caller's stream (ExecutionContext.stream, resolved from the
         # execute-time handle); None -> the default stream. Threaded to every
         # kernel launch below (dense / fp8 / mxfp8 / THD).
+        explicit_stream = current_stream is not None
         current_stream = self._get_default_stream(current_stream)
 
         scale_val = self.scale_softmax if scale_softmax is None or scale_softmax == 0.0 else float(scale_softmax)
@@ -1507,46 +1517,50 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         if self._fp8 and self._pertensor:
             # Per-tensor FP8 (sdpa_fp8): scalar descales fold into the softmax scale
             # (descale_q·descale_k) and o_scale_fused (descale_v·scale_o).
-            self._execute_fp8(
-                q_tensor,
-                k_tensor,
-                v_tensor,
-                o_tensor,
-                lse_tensor,
-                scale_val,
-                sinks,
-                seq_kv_lens,
-                seq_q_lens,
-                descale_q,
-                descale_k,
-                descale_v,
-                scale_o,
-                amax_o,
-                current_stream,
-                workspace=workspace,
-            )
+            stream_context = _torch_stream_context(current_stream, q_tensor.device, verify_current=True) if explicit_stream else nullcontext()
+            with stream_context:
+                self._execute_fp8(
+                    q_tensor,
+                    k_tensor,
+                    v_tensor,
+                    o_tensor,
+                    lse_tensor,
+                    scale_val,
+                    sinks,
+                    seq_kv_lens,
+                    seq_q_lens,
+                    descale_q,
+                    descale_k,
+                    descale_v,
+                    scale_o,
+                    amax_o,
+                    current_stream,
+                    workspace=workspace,
+                )
             return
 
         if self._fp8:
             # MXFP8 block-scale path (E4M3/E5M2 in, half out). Per-block E8M0 scales
             # dequant in-MMA, so scale_softmax_log2 carries only attn_scale·log2(e).
-            self._execute_mxfp8(
-                q_tensor,
-                k_tensor,
-                v_tensor,
-                o_tensor,
-                lse_tensor,
-                scale_softmax_log2,
-                sinks,
-                seq_kv_lens,
-                seq_q_lens,
-                sf_q,
-                sf_k,
-                sf_v,
-                amax_o,
-                current_stream,
-                workspace=workspace,
-            )
+            stream_context = _torch_stream_context(current_stream, q_tensor.device, verify_current=True) if explicit_stream else nullcontext()
+            with stream_context:
+                self._execute_mxfp8(
+                    q_tensor,
+                    k_tensor,
+                    v_tensor,
+                    o_tensor,
+                    lse_tensor,
+                    scale_softmax_log2,
+                    sinks,
+                    seq_kv_lens,
+                    seq_q_lens,
+                    sf_q,
+                    sf_k,
+                    sf_v,
+                    amax_o,
+                    current_stream,
+                    workspace=workspace,
+                )
             return
 
         if self.thd:

--- a/python/cudnn/sdpa/fwd/config_sm100.py
+++ b/python/cudnn/sdpa/fwd/config_sm100.py
@@ -416,7 +416,10 @@ def _validate_cfg_d256(cfg: CfgD256) -> None:
             cfg.MMA_REGS + (0 if fused_corr_split_p else cfg.CORRECTION_REGS) + cfg.SOFTMAX_REGS + cfg.SOFTMAX_WG1_REGS <= 512,
             "d256: register budget over 512",
         ),
-        (cfg.MMA_REGS % 8 == 0 and cfg.CORRECTION_REGS % 8 == 0 and cfg.SOFTMAX_REGS % 8 == 0, "d256: per-role regs must be multiples of 8"),
+        (
+            cfg.MMA_REGS % 8 == 0 and cfg.CORRECTION_REGS % 8 == 0 and cfg.SOFTMAX_REGS % 8 == 0 and cfg.SOFTMAX_WG1_REGS % 8 == 0,
+            "d256: per-role regs must be multiples of 8",
+        ),
         (cfg.CGA_M == cfg.CTA_MMA, "d256 flavor pairs CGA_M with CTA_MMA"),
         (cfg.CTA_MMA == (1 if fp8 else 2), "d256 SM100: FP8 requires CTA1; BF16/FP16 requires CTA2"),
         (cfg.STAGES_KV == 2, "d256 SM100 uses two full/half-width KV stages"),
@@ -497,13 +500,13 @@ def _make_cfg_d256(params: TemplateParams, *, mxfp8: bool) -> Tuple[CfgD256, Tma
     pt_plain_top_left_causal = (
         not mxfp8 and (mask_flags & ~MASK_PADDED) == MASK_CAUSAL and not params.bottom_right and not params.window_left and not params.window_right
     )
-    split_p = fp8 and (mask_flags == MASK_NONE or pt_plain_top_left_causal)
-    pt_thd_split_p = pt_plain_top_left_causal and bool(mask_flags & MASK_PADDED)
     # The fused correction/split-P schedule is the strict top-left causal fast
     # path. Right-band widening uses the generic masked schedule; forcing the
     # widened specialization through this path makes CUTLASS DSL 4.7 lowering
     # grow pathologically without changing the supported mask semantics.
     strict_top_left_causal = (mask_flags & ~MASK_PADDED) == MASK_CAUSAL and not params.bottom_right and not params.window_right
+    split_p = fp8 and (mask_flags == MASK_NONE or pt_plain_top_left_causal)
+    pt_thd_split_p = pt_plain_top_left_causal and bool(mask_flags & MASK_PADDED)
     fused_corr_split_p = mxfp8 and strict_top_left_causal
     dtype_o = params.dtype_qkv if params.dtype_o < 0 else params.dtype_o
     b_o = bpe(dtype_o)

--- a/python/cudnn/sdpa/fwd/config_sm100.py
+++ b/python/cudnn/sdpa/fwd/config_sm100.py
@@ -90,8 +90,8 @@ class TemplateParams:
     # Compile-time LPT head/batch grouping. Keep 1 unless the selected kernel
     # and concrete graph shape opt into a divisor of B*Hq.
     lpt_head_group: int = 1
-    # Dense D192 FP8 may specialize the reverse-row LPT decoder to its exact
-    # number of query tiles. Zero keeps the existing runtime derivation.
+    # Dense FP8 kernels may specialize scheduler selection/decoding to the
+    # graph's compile-time number of query tiles. Zero keeps runtime derivation.
     lpt_q_tiles: int = 0
     # Optional L2 working-set budget for SCHED_LPT_L2. Zero keeps the flavor's
     # default budget.
@@ -145,8 +145,8 @@ def _validate_params(flavor: str, k: TemplateParams) -> None:
     if k.dtype_qkv not in (DTYPE_E4M3, DTYPE_E5M2, DTYPE_BF16, DTYPE_FP16):
         raise ValueError(f"{flavor}: DTYPE_QKV must be E4M3/E5M2/BF16/FP16 (0..3); got {k.dtype_qkv}")
     fp8 = k.dtype_qkv in (DTYPE_E4M3, DTYPE_E5M2)
-    if fp8 and flavor not in ("d128", "d192", "d512"):
-        raise ValueError(f"{flavor}: FP8/MXFP8 inputs (DTYPE_QKV 0/1) are only supported on d128, d192 and d512")
+    if fp8 and flavor not in ("d128", "d192", "d256", "d512"):
+        raise ValueError(f"{flavor}: FP8/MXFP8 inputs (DTYPE_QKV 0/1) are only supported on d128, d192, d256, and d512")
     if k.softmax_f16 and not fp8:
         raise ValueError(f"{flavor}: softmax_f16 is per-tensor-FP8-only (f16/bf16 softmax already runs the f32 pipeline)")
     dtype_o = k.dtype_qkv if k.dtype_o < 0 else k.dtype_o
@@ -180,7 +180,10 @@ def _validate_params(flavor: str, k: TemplateParams) -> None:
     # corrupt the result instead of dropping out.  Reject at the door.
     if k.split_kv != 1 and flavor not in _SPLIT_KV_FLAVORS:
         raise ValueError(f"{flavor}: split_kv is not implemented on this flavor (got {k.split_kv}); supported: {sorted(_SPLIT_KV_FLAVORS)}")
-    if k.cta_mma != 2 and flavor not in _CTA_MMA_FLAVORS:
+    # D256 selects its topology from the input family rather than exposing a
+    # free CTA-MMA knob: half inputs stay CTA2, while FP8/MXFP8 use CTA1.
+    d256_quantized_cta1 = flavor == "d256" and fp8 and k.cta_mma == 1
+    if k.cta_mma != 2 and flavor not in _CTA_MMA_FLAVORS and not d256_quantized_cta1:
         raise ValueError(f"{flavor}: cta_mma is not selectable on this flavor (got {k.cta_mma}); supported: {sorted(_CTA_MMA_FLAVORS)}")
     if flavor == "d192" and k.split_kv > 1 and k.cta_mma != 2:
         raise ValueError("d192: split_kv > 1 is validated only with cta_mma=2")
@@ -195,8 +198,9 @@ def _validate_params(flavor: str, k: TemplateParams) -> None:
             # The sink logit is folded into the softmax denominator in the
             # per-tile epilogue, so every split would add its own copy of it.
             raise ValueError(f"{flavor}: split_kv > 1 with attention sink is not supported (the sink would be counted once per split)")
-    if k.lpt_head_group not in (1, 8, 16):
-        raise ValueError(f"{flavor}: LPT_HEAD_GROUP must be 1, 8, or 16; got {k.lpt_head_group}")
+    lpt_head_groups = (1, 8, 16, 32) if flavor == "d256" else (1, 8, 16)
+    if k.lpt_head_group not in lpt_head_groups:
+        raise ValueError(f"{flavor}: LPT_HEAD_GROUP must be one of {lpt_head_groups}; got {k.lpt_head_group}")
     if k.qh_per_kh < 1:
         raise ValueError(f"{flavor}: qh_per_kh ({k.qh_per_kh}) must be >= 1")
     if k.pack_gqa:
@@ -302,7 +306,8 @@ def _tma_iters(cfg) -> TmaIters:
 
 
 # ---------------------------------------------------------------------------
-# d256 flavor — d_qk = d_v = 256, SM100 (Blackwell), cga2 (Qwen-class models)
+# d256 flavor — d_qk = d_v = 256, SM100 (Blackwell), Qwen-class models
+# Half inputs use CTA2 collective MMA; FP8/MXFP8 use an independent CTA1 tile.
 # ---------------------------------------------------------------------------
 
 
@@ -338,8 +343,12 @@ class CfgD256:
 
     SOFTMAX_WARPGROUPS: int = 1
     CORRECTION_WARPS: int = 4
+    FUSED_CORR_SPLIT_P: int = 0
 
     SOFTMAX_REGS: int = 240
+    # The DSL traces the unreachable WG1 dispatch for one-WG specializations,
+    # so its placeholder must still be a legal setmaxnreg operand.
+    SOFTMAX_WG1_REGS: int = 40
     CORRECTION_REGS: int = 96
     MMA_REGS: int = 40
     TMALDG_REGS: int = 40
@@ -367,6 +376,7 @@ class CfgD256:
     OTHER_WARPS: int = 4
 
     SOFTMAX_WG0_BASE: int = 0
+    SOFTMAX_WG1_BASE: int = 4
     CORR_WARP_BASE: int = 4
     MMA_WARP_ID: int = 8
     TMALDG_WARP_ID: int = 9
@@ -396,45 +406,182 @@ class CfgD256:
 
 def _validate_cfg_d256(cfg: CfgD256) -> None:
     """Consistency checks on the (mostly hardcoded) d256 geometry."""
+    fp8 = cfg.DTYPE_QKV in (DTYPE_E4M3, DTYPE_E5M2)
+    split_p = cfg.SOFTMAX_WARPGROUPS == 2
+    fused_corr_split_p = cfg.FUSED_CORR_SPLIT_P == 1
+    split_p_supported = fp8 and (cfg.MASK_FLAGS == MASK_NONE or ((cfg.MASK_FLAGS & ~MASK_PADDED) == MASK_CAUSAL and cfg.BOTTOM_RIGHT == 0))
     checks = (
         (cfg.MMA_REGS == cfg.TMALDG_REGS == cfg.TMASTG_REGS == cfg.SCHEDULER_REGS, "d256: MMA/TMALDG/TMASTG/SCHEDULER regs must match"),
-        (cfg.MMA_REGS + cfg.CORRECTION_REGS + cfg.SOFTMAX_WARPGROUPS * cfg.SOFTMAX_REGS <= 512, "d256: register budget over 512"),
+        (
+            cfg.MMA_REGS + (0 if fused_corr_split_p else cfg.CORRECTION_REGS) + cfg.SOFTMAX_REGS + cfg.SOFTMAX_WG1_REGS <= 512,
+            "d256: register budget over 512",
+        ),
         (cfg.MMA_REGS % 8 == 0 and cfg.CORRECTION_REGS % 8 == 0 and cfg.SOFTMAX_REGS % 8 == 0, "d256: per-role regs must be multiples of 8"),
         (cfg.CGA_M == cfg.CTA_MMA, "d256 flavor pairs CGA_M with CTA_MMA"),
-        (cfg.CTA_MMA == 2, "d256 SM100 is cga2-only (CTA_MMA must be 2)"),
-        (cfg.STAGES_KV == 2, "d256 SM100 STAGES_KV: f16/bf16 -> 2 (192 KiB SMEM budget)"),
+        (cfg.CTA_MMA == (1 if fp8 else 2), "d256 SM100: FP8 requires CTA1; BF16/FP16 requires CTA2"),
+        (cfg.STAGES_KV == 2, "d256 SM100 uses two full/half-width KV stages"),
         (cfg.Q_SWZ_BYTES in (64, 128) and cfg.K_SWZ_BYTES in (64, 128), "d256: Q/K swizzle must be 64/128B"),
         (cfg.V_SWZ_BYTES in (32, 64, 128) and cfg.O_SWZ_BYTES in (64, 128), "d256: V/O swizzle out of range"),
         (cfg.TILES_Q == 1, "d256 pipeline mandates TILES_Q == 1"),
-        (cfg.SOFTMAX_WARPGROUPS == 1, "d256 pipeline mandates SOFTMAX_WARPGROUPS == 1"),
-        (cfg.DTYPE_O == cfg.DTYPE_QKV, "d256: DTYPE_O must equal DTYPE_QKV"),
+        (not split_p or split_p_supported, "d256: unsupported split-P specialization"),
+        (cfg.SOFTMAX_WARPGROUPS == 2 if cfg.MASK_FLAGS == MASK_NONE and fp8 else True, "d256: dense FP8 must split P generation"),
+        (cfg.TOTAL_WARPS == (12 if fused_corr_split_p else 16 if split_p else 12), "d256: role layout and warp count disagree"),
+        (not fused_corr_split_p or (split_p and cfg.CORRECTION_WARPS == 0), "d256: fused split-P must replace the correction warp group"),
+        (
+            cfg.TILE_K_HW_BMM1 == (32 if fp8 else 16) and cfg.TILE_K_HW_BMM2 == (32 if fp8 else 16),
+            "d256: TILE_K_HW must be 32 for FP8 and 16 for BF16/FP16",
+        ),
+        (fp8 or cfg.DTYPE_O == cfg.DTYPE_QKV, "d256: half input requires DTYPE_O == DTYPE_QKV"),
     )
     for ok, msg in checks:
         if not ok:
             raise ValueError(msg)
 
 
-def make_cfg_d256(params: TemplateParams) -> Tuple[CfgD256, TmaIters]:
+def d256_square_br_as_tl(params: TemplateParams, *, s_q: int, s_kv: int) -> bool:
+    """Whether a D256 bottom-right mask is exactly top-left causal."""
+
+    return (
+        params.dtype_qkv in (DTYPE_E4M3, DTYPE_E5M2)
+        and not params.thd_varlen
+        and not params.seq_q_lens_present
+        and not params.seq_kv_lens_present
+        and params.window_left is None
+        and params.window_right == 0
+        and params.bottom_right
+        and s_q == s_kv
+    )
+
+
+def canonicalize_d256_lowering(params: TemplateParams, *, s_q: int, s_kv: int) -> TemplateParams:
+    """Apply strictly equivalent D256 lowering canonicalizations."""
+
+    return replace(params, bottom_right=False) if d256_square_br_as_tl(params, s_q=s_q, s_kv=s_kv) else params
+
+
+def derive_d256_internal_params(
+    params: TemplateParams,
+    *,
+    pertensor: bool,
+    batch_size: int,
+    h_q: int,
+    s_q: int,
+) -> TemplateParams:
+    """Derive D256-private codegen fields after public knobs are fixed."""
+
+    fp8 = params.dtype_qkv in (DTYPE_E4M3, DTYPE_E5M2)
+    if not fp8 or params.thd_varlen:
+        return params
+
+    pack_gqa_ratio = params.qh_per_kh if params.pack_gqa else 1
+    groups = batch_size * h_q // pack_gqa_ratio
+    lpt_head_group = 32 if pertensor and groups % 32 == 0 else 8 if not pertensor and groups % 8 == 0 else 1
+    q_tiles = (s_q + 255) // 256 if pertensor else 0
+    mask_flags = _mask_flags_from(params)
+    pt_lpt_l2 = pertensor and params.sched_policy == SCHED_LPT_L2 and mask_flags == MASK_CAUSAL and not params.bottom_right and q_tiles >= 16
+    return replace(
+        params,
+        lpt_head_group=lpt_head_group,
+        lpt_l2_size_mib=32 if pt_lpt_l2 else 0,
+    )
+
+
+def _make_cfg_d256(params: TemplateParams, *, mxfp8: bool) -> Tuple[CfgD256, TmaIters]:
     _validate_params("d256", params)
     b = bpe(params.dtype_qkv)
+    fp8 = params.dtype_qkv in (DTYPE_E4M3, DTYPE_E5M2)
+    cga = 1 if fp8 else 2
+    if params.cta_mma != cga:
+        raise ValueError(f"d256: {'FP8/MXFP8' if fp8 else 'BF16/FP16'} requires cta_mma={cga}; got {params.cta_mma}")
+    mask_flags = _mask_flags_from(params)
+    pt_plain_top_left_causal = (
+        not mxfp8 and (mask_flags & ~MASK_PADDED) == MASK_CAUSAL and not params.bottom_right and not params.window_left and not params.window_right
+    )
+    split_p = fp8 and (mask_flags == MASK_NONE or pt_plain_top_left_causal)
+    pt_thd_split_p = pt_plain_top_left_causal and bool(mask_flags & MASK_PADDED)
+    # The fused correction/split-P schedule is the strict top-left causal fast
+    # path. Right-band widening uses the generic masked schedule; forcing the
+    # widened specialization through this path makes CUTLASS DSL 4.7 lowering
+    # grow pathologically without changing the supported mask semantics.
+    strict_top_left_causal = (mask_flags & ~MASK_PADDED) == MASK_CAUSAL and not params.bottom_right and not params.window_right
+    fused_corr_split_p = mxfp8 and strict_top_left_causal
+    dtype_o = params.dtype_qkv if params.dtype_o < 0 else params.dtype_o
+    b_o = bpe(dtype_o)
+
+    # These register profiles are coupled to the kernel's role topologies;
+    # they are not independent public knobs.
+    pt_e4_causal_regs = not mxfp8 and params.dtype_qkv == DTYPE_E4M3 and mask_flags == MASK_CAUSAL and not params.bottom_right
+    pt_e5_causal_regs = not mxfp8 and params.dtype_qkv == DTYPE_E5M2 and mask_flags == MASK_CAUSAL and not params.bottom_right
+    softmax_regs, softmax_wg1_regs, correction_regs = 240, 136 if split_p else 40, 96
+    if fused_corr_split_p:
+        softmax_regs, softmax_wg1_regs, correction_regs = 248, 216, 64
+    elif mxfp8 and split_p:
+        softmax_regs, softmax_wg1_regs, correction_regs = 256, 144, 72
+    elif pt_thd_split_p:
+        softmax_wg1_regs, correction_regs = 144, 88
+    elif pt_e4_causal_regs:
+        correction_regs = 64
+        if split_p:
+            softmax_regs = 216
+            softmax_wg1_regs = 168
+    elif pt_e5_causal_regs:
+        correction_regs = 96 if split_p else 112
+    elif mxfp8 and mask_flags != MASK_NONE:
+        correction_regs = 64
+        if params.dtype_qkv == DTYPE_E5M2 or (params.dtype_qkv == DTYPE_E4M3 and mask_flags == MASK_CAUSAL):
+            softmax_regs = 248
+    elif not mxfp8 and fp8 and mask_flags != MASK_NONE:
+        correction_regs = 104
+    elif not mxfp8 and params.dtype_qkv == DTYPE_E4M3 and mask_flags == MASK_NONE:
+        correction_regs = 88
+
+    if fused_corr_split_p:
+        total_warps, softmax_wg1_base, correction_warp_base, mma_warp_id, read_tile_arrivers = 12, 4, 64, 8, 11
+    elif split_p:
+        total_warps, softmax_wg1_base, correction_warp_base, mma_warp_id, read_tile_arrivers = 16, 4, 8, 12, 15
+    else:
+        total_warps, softmax_wg1_base, correction_warp_base, mma_warp_id = 12, 64, 4, 8
+        read_tile_arrivers = 11 if fp8 else 21
+
     cfg = CfgD256(
         DTYPE_QKV=params.dtype_qkv,
-        DTYPE_O=params.dtype_qkv,
+        DTYPE_O=dtype_o,
         BPE=b,
-        BPE_O=b,
+        BPE_O=b_o,
+        # FP8 uses one M128 CTA per work unit. With a full K/V slice per CTA,
+        # two KV stages consume the same SMEM payload as CTA2's four half-slices.
+        CGA_M=params.cta_mma,
+        CTA_MMA=params.cta_mma,
         Q_SWZ_BYTES=q_swz_bytes(256, b),
         K_SWZ_BYTES=q_swz_bytes(256, b),
-        V_SWZ_BYTES=v_swz_bytes(256, 2, b),
-        O_SWZ_BYTES=o_swz_bytes(256, b),
+        V_SWZ_BYTES=v_swz_bytes(256, 1 if fp8 else 2, b),
+        O_SWZ_BYTES=o_swz_bytes(256, b_o),
         RESCALE_THRESHOLD=rescale_threshold(params.dtype_qkv),
-        TILE_K_HW_BMM1=tile_k_hw(params.dtype_qkv),
-        TILE_K_HW_BMM2=tile_k_hw(params.dtype_qkv),
-        MASK_FLAGS=_mask_flags_from(params),
+        TILE_K_HW_BMM1=32 if fp8 else tile_k_hw(params.dtype_qkv),
+        TILE_K_HW_BMM2=32 if fp8 else tile_k_hw(params.dtype_qkv),
+        STAGES_KV=2,
+        SOFTMAX_WARPGROUPS=2 if split_p or fused_corr_split_p else 1,
+        CORRECTION_WARPS=0 if fused_corr_split_p else 4,
+        FUSED_CORR_SPLIT_P=1 if fused_corr_split_p else 0,
+        SOFTMAX_REGS=softmax_regs,
+        SOFTMAX_WG1_REGS=softmax_wg1_regs,
+        CORRECTION_REGS=correction_regs,
+        TOTAL_WARPS=total_warps,
+        THREADS_PER_CTA=total_warps * 32,
+        SOFTMAX_WG1_BASE=softmax_wg1_base,
+        CORR_WARP_BASE=correction_warp_base,
+        MMA_WARP_ID=mma_warp_id,
+        TMALDG_WARP_ID=mma_warp_id + 1,
+        TMASTG_WARP_ID=mma_warp_id + 2,
+        SCHED_WARP_ID=mma_warp_id + 3,
+        READ_TILE_ARRIVERS=read_tile_arrivers,
+        MASK_FLAGS=mask_flags,
         WINDOW_LEFT=params.window_left or 0,
         WINDOW_RIGHT=params.window_right or 0,
         HAS_SINK=int(params.has_sink),
         BOTTOM_RIGHT=int(params.bottom_right),
         SCHEDULER_POLICY=params.sched_policy,
+        L2_SIZE_MIB=params.lpt_l2_size_mib or 60,
         SEQ_KV_LENS_PRESENT=1 if (params.thd_varlen or params.seq_kv_lens_present) else 0,
         SEQ_Q_LENS_PRESENT=int(params.seq_q_lens_present),
         THD_VARLEN=int(params.thd_varlen),
@@ -446,6 +593,14 @@ def make_cfg_d256(params: TemplateParams) -> Tuple[CfgD256, TmaIters]:
     if cfg.PACK_GQA and cfg.TILE_M % cfg.QH_PER_KH != 0:
         raise ValueError(f"qh_per_kh ({cfg.QH_PER_KH}) must divide TILE_M ({cfg.TILE_M}) when PACK_GQA is enabled")
     return cfg, _tma_iters(cfg)
+
+
+def make_cfg_d256(params: TemplateParams) -> Tuple[CfgD256, TmaIters]:
+    return _make_cfg_d256(params, mxfp8=False)
+
+
+def make_cfg_d256_mxfp8(params: TemplateParams) -> Tuple[CfgD256, TmaIters]:
+    return _make_cfg_d256(params, mxfp8=True)
 
 
 # ---------------------------------------------------------------------------

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -87,7 +87,7 @@ class SdpaFwdKnobs:
     sched_policy: Optional[int] = None  # tile-scheduler policy (SCHED_NATURAL, ...)
     tile_m: Optional[int] = None  # Q sequence tile width
     tile_n: Optional[int] = None  # KV sequence tile width
-    cga: Optional[int] = None  # cluster size (CTAs cooperating per tile)
+    cga: Optional[int] = None  # CTA group width used by one cooperative MMA tile
     pack_gqa: Optional[bool] = None  # Head packing for GQA/MQA
     # KV-split count: each Q tile's KV range cut into this many chunks, each
     # run by its own CTA, recombined by the split_combine pass. 1 = off.
@@ -200,10 +200,7 @@ class Capabilities:
     # grow a CU read mode (len = cu[b+1] - cu[b]) — see mismatch().
     cu_seq_len: bool = False
     # Dense padded + stats needs the per-batch seq_len_q LSE trim (padded
-    # q-rows write LSE=-inf / O=0, cuDNN >= 9.14). Plumbed for the half
-    # kernels and the SM120 fp8 kernel via SEQ_Q_LENS_PRESENT; the SM100
-    # FP8/MXFP8 kernels lack the epilogue trim, so their specs keep this
-    # False.
+    # q-rows write LSE=-inf / O=0, cuDNN >= 9.14).
     padded_stats: bool = False
     # Dense padded graphs carrying per-batch seq_len_q: the kernel's epilogue
     # trims padded q rows (O := 0, LSE := -inf). Rows whose kernel lacks the
@@ -213,6 +210,9 @@ class Capabilities:
     # row reusing an adapter for a trim-less kernel would silently inherit
     # the wrong answer otherwise).
     dense_seq_q_trim: bool = False
+    # A unified engine row may contain only some native flavors with the trim.
+    # The smallest native shape covering the graph selects this override.
+    dense_seq_q_trim_d_shapes: frozenset[tuple[int, int]] = frozenset()
     # s_q == 1 (decode-shaped) graphs; the SM80 prefill kernels are gated off.
     decode: bool = True
 
@@ -316,6 +316,12 @@ def effective_cgas(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", split
                     domain = split_domain
                     break
     return domain
+
+
+def supports_dense_seq_q_trim(capabilities: Capabilities, facts: "ga.SdpaGraphFacts") -> bool:
+    """Whether the graph-selected native flavor trims dense padded Q rows."""
+
+    return capabilities.dense_seq_q_trim or _selected_d_shape(capabilities, facts) in capabilities.dense_seq_q_trim_d_shapes
 
 
 def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Optional[SdpaFwdKnobs] = None) -> Optional[str]:
@@ -502,7 +508,7 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
             return "bottom-right alignment requires a causal upper bound (plain or right-widened)"
         if not capabilities.bottom_right:
             return "graph uses bottom-right causal, which this kernel does not support"
-    if facts.padded and facts.wants_stats and not facts.thd and not capabilities.padded_stats:
+    if facts.padded and facts.wants_stats and not facts.thd and not (capabilities.padded_stats or supports_dense_seq_q_trim(capabilities, facts)):
         return "padding mask with generate_stats is not supported yet (per-batch seq_len_q LSE trim not plumbed)"
 
     if facts.stats_t is not None and not facts.thd:
@@ -603,7 +609,7 @@ def _sm100_spec() -> EngineSpec:
 def _sm100_mxfp8_spec() -> EngineSpec:
     """Block-scale MXFP8 engine (E4M3/E5M2 + per-32-block E8M0 SF).
 
-    THD/varlen on both native shapes rides the shared packed lowering
+    THD/varlen on all three native shapes rides the shared packed lowering
     (write_thd_meta envelope design, issue #552; packed
     Q/K/V/O contract only). The SF tensors travel PACKED
     per-sequence-TILE-padded ([1, H, Σ_b ceil(S_b/128), SF_SMEM] tile sequences
@@ -619,10 +625,10 @@ def _sm100_mxfp8_spec() -> EngineSpec:
             phase="prefill",
             # Exact native shapes only (d_pad_multiple=0): the SF plumbing is
             # not audited for envelope zero-padding.
-            d_shapes=frozenset({(128, 128), (192, 128)}),
+            d_shapes=frozenset({(128, 128), (192, 128), (256, 256)}),
             d_pad_multiple=0,
-            thd_d_shapes=frozenset({(128, 128), (192, 128)}),
-            split_d_shapes=frozenset({(128, 128), (192, 128)}),
+            thd_d_shapes=frozenset({(128, 128), (192, 128), (256, 256)}),
+            split_d_shapes=frozenset({(128, 128), (192, 128), (256, 256)}),
             dtypes=frozenset({cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2}),
             out_dtypes=frozenset({cudnn.data_type.HALF, cudnn.data_type.BFLOAT16, cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2}),
             is_mxfp8=True,
@@ -636,11 +642,12 @@ def _sm100_mxfp8_spec() -> EngineSpec:
             lse_optional=True,
             thd=True,
             cu_seq_len=True,
+            dense_seq_q_trim_d_shapes=frozenset({(256, 256)}),
             sched_policies=frozenset({SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2}),
             tile_ms=frozenset({128}),
             tile_ns=frozenset({128}),
             cgas=frozenset({2}),
-            cgas_by_d_shape=(((192, 128), frozenset({1, 2})),),
+            cgas_by_d_shape=(((192, 128), frozenset({1, 2})), ((256, 256), frozenset({1}))),
             split_cgas_by_d_shape=(((192, 128), frozenset({2})),),
             # The split path also needs a half-precision O (mismatch's
             # facts x knobs gate).
@@ -662,15 +669,12 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
     "sm107" = Rubin line 107-119): the two lowerings genuinely diverge and a
     shared row could only describe their union with knob x arch notches.
     Within a row the head dim is a LOWERING concern — the adapter picks the
-    kernel flavor (d128 or d192xd128) covering the graph. Each row declares
+    kernel flavor covering the graph. Each row declares
     exactly what its own kernels carry:
 
-    - d_shapes: the sm100 row picks between the d128, d192xd128 and d512
-      flavors; Rubin has only the d128 sibling, so a Rubin d192 graph is
-      ineligible at probe time instead of a late build error.  There is no
-      d256 per-tensor FP8 kernel, so the adapter's flavor walk is restricted
-      to this set (api_dsl._pick_flavor's ``candidates``) rather than the
-      f16 flavor list.
+    - d_shapes: the sm100 row picks among d128, d192xd128, d256, and d512;
+      Rubin has only the d128 sibling, so wider Rubin graphs are ineligible at
+      probe time instead of failing during lowering.
     - The ENVELOPE (d_pad_multiple=16, the TMA 16-byte global-stride rule at
       1 byte/elem): smaller head dims ride TMA zero-padding — exact in FP8,
       and the descales are scalars so no per-column plumbing is affected.
@@ -679,11 +683,10 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
     - softmax_precisions: the f16x2 exponent arm lives only in the SM107
       sibling kernel, so only that row admits HALF. FLOAT is the pipeline
       every flavor already runs.
-    - thd_d_shapes: the SM100 d128, d192x128, and d512 kernels carry the
+    - thd_d_shapes: all SM100 native flavors carry the
       write_thd_meta THD leg; the SM107 row carries its d128 sibling.
-    - split_kv_supported / split_d_shapes: both d128 kernels wire SplitHelpers
-      (the SM107 sibling carries the same plumbing as its SM100 twin), and the
-      SM100 d192x128 per-tensor kernel carries the same split contract.
+    - split_kv_supported / split_d_shapes: both d128 kernels wire SplitHelpers;
+      SM100 d192x128 and d256 carry the same split contract.
     - sched_policies: both rows serve the full {NATURAL, LPT, LPT_L2} domain
       (issue #653) — the SM107 sibling threads qh_per_kh/seqlen_kv through
       every decode call site, which is what the shared LPT_L2 decode requires,
@@ -709,7 +712,7 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
             sm_lo=107 if rubin_row else _BLACKWELL[0],
             sm_hi=_BLACKWELL[1] if rubin_row else 106,
             phase="prefill",
-            d_shapes=frozenset({(128, 128)}) if rubin_row else frozenset({(128, 128), (192, 128), (512, 512)}),
+            d_shapes=frozenset({(128, 128)}) if rubin_row else frozenset({(128, 128), (192, 128), (256, 256), (512, 512)}),
             d_pad_multiple=16,
             # The d512 flavor serves the (256, 512] band on BOTH head dims —
             # the range no smaller FP8 flavor reaches, at most 2x zero-padding.
@@ -717,7 +720,7 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
             # graph onto a kernel whose cga4x1 role-split geometry is tuned for
             # d = 512. Mirrored by api_dsl._SM100_FP8_ENVELOPE_FLOORS.
             d_envelope_floors=() if rubin_row else (((512, 512), 256),),
-            thd_d_shapes=frozenset({(128, 128)}) if rubin_row else frozenset({(128, 128), (192, 128), (512, 512)}),
+            thd_d_shapes=frozenset({(128, 128)}) if rubin_row else frozenset({(128, 128), (192, 128), (256, 256), (512, 512)}),
             dtypes=frozenset({cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2}),
             out_dtypes=frozenset({cudnn.data_type.HALF, cudnn.data_type.BFLOAT16, cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2}),
             is_fp8=True,
@@ -731,13 +734,10 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
             lse_optional=True,
             thd=True,
             cu_seq_len=True,
-            # The fp8 kernel lacks the SEQ_Q_LENS_PRESENT epilogue trim, but its
-            # only reachable padded+stats population is KV-only padding with
-            # full-length seq_len_q (the fp8 suite; test_mhas_v2 fp8 padding
-            # comes only via paged/THD, both ineligible here), where the trim
-            # is a no-op. Dense fp8 padding with SHORT seq_len_q + stats would
-            # report untrimmed LSE — plumb the trim before relying on it.
+            # D256 carries the dense padded-Q epilogue trim; the older D128 and
+            # D192/D128 siblings remain KV-padding-only for dense graphs.
             padded_stats=True,
+            dense_seq_q_trim_d_shapes=(frozenset() if rubin_row else frozenset({(256, 256)})),
             # Multi-wave launches are served: the former single_wave_only gate
             # (wrong O past one wave) was removed after the kernel's TMEM stats
             # race was fixed with the mb_stats_read barrier (verified on the
@@ -753,7 +753,7 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
             tile_ms=frozenset({128}),
             tile_ns=frozenset({128}),
             cgas=frozenset({2}),
-            cgas_by_d_shape=(() if rubin_row else (((192, 128), frozenset({1, 2})),)),
+            cgas_by_d_shape=(() if rubin_row else (((192, 128), frozenset({1, 2})), ((256, 256), frozenset({1})))),
             split_cgas_by_d_shape=(() if rubin_row else (((192, 128), frozenset({2})),)),
             # f16x2-softmax arm: only the SM107 sibling kernel carries the
             # path (MUFU EX2.F16x2 exists below cc10.7 but no other file wires
@@ -762,7 +762,7 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
             # Split partials reduce in half precision, so mismatch()'s
             # facts x knobs gate additionally requires a bf16/fp16 O.
             split_kv_supported=True,
-            split_d_shapes=(frozenset({(128, 128)}) if rubin_row else frozenset({(128, 128), (192, 128)})),
+            split_d_shapes=(frozenset({(128, 128)}) if rubin_row else frozenset({(128, 128), (192, 128), (256, 256)})),
             pack_gqas=frozenset({False, True}),
         ),
         lower=partial(lower_dsl_prefill, api_type=_SM100),
@@ -916,7 +916,8 @@ def lower_dsl_prefill(
     # buffer a trim-less kernel can't honor is dropped here rather than
     # erroring at execute (the row declares plumbed-ness; see
     # Capabilities.dense_seq_q_trim).
-    seq_q_lens_present = facts.padded and not facts.thd and facts.seq_q_t is not None and spec.capabilities.dense_seq_q_trim
+    dense_seq_q_trim = supports_dense_seq_q_trim(spec.capabilities, facts)
+    seq_q_lens_present = facts.padded and not facts.thd and facts.seq_q_t is not None and dense_seq_q_trim
     api = _adapter(api_type)(
         sample_q=ga.tensor_desc_from_ir(facts.q_t, name="q"),
         sample_k=ga.tensor_desc_from_ir(facts.k_t, name="k"),
@@ -933,8 +934,8 @@ def lower_dsl_prefill(
         seq_kv_lens_present=facts.padded or synth_kv_padding,
         # Dense padded-Q trim (q rows >= seq_len_q[b] -> O := 0, LSE := -inf):
         # enabled whenever a dense padded graph carries per-batch Q lengths.
-        # THD carries Q lengths via cu_seqlens; the SM100 FP8/MXFP8 kernels
-        # are not plumbed (see seq_q_lens_present above).
+        # THD carries Q lengths via cu_seqlens; support is selected per native
+        # flavor above because only D256 FP8/MXFP8 currently consumes it.
         seq_q_lens_present=seq_q_lens_present,
         # cu_seq_len form (THD-only; the probe declined dense cu graphs): the
         # adapter's seq-lens execute arguments carry (B+1,) prefix sums.
@@ -1082,7 +1083,7 @@ def lower_dsl_prefill(
         # THD is exempt: ragged lengths ARE shorter than S_q by construction,
         # and the packed layout gives each sequence its own extent, so
         # nothing is written past a valid length.
-        if not spec.capabilities.dense_seq_q_trim and not facts.thd and seq_q_buf is not None:
+        if not dense_seq_q_trim and not facts.thd and seq_q_buf is not None:
             min_seq_q = int(seq_q_buf.min().item())
             if min_seq_q < int(facts.s_q):
                 raise NotImplementedError(

--- a/python/cudnn/sdpa/fwd/heuristics.py
+++ b/python/cudnn/sdpa/fwd/heuristics.py
@@ -59,6 +59,7 @@ from cudnn.sdpa.fwd.config_sm100 import (
     TemplateParams as Sm100TemplateParams,
     cga_tile_m,
     d192_square_br_as_tl,
+    d256_square_br_as_tl,
     pack_gqa_supported,
 )
 from cudnn.sdpa.fwd.config_sm120 import FP8_HEAD_TILE_GRANULE, HEAD_TILE_GRANULE, SMEM_CAPACITY_BYTES, smem_bytes
@@ -426,7 +427,40 @@ def select_d192_auto_knobs(
     return sched_policy, 1 if pt_cga1 or mx_cga1 else 2
 
 
-def _d192_params_from_facts(facts, *, split_kv: int, sched_policy: int) -> Sm100TemplateParams:
+def select_d256_auto_knobs(
+    params: Sm100TemplateParams,
+    *,
+    pertensor: bool,
+    s_q: int,
+    s_kv: int,
+) -> tuple[int, int]:
+    """Select the measured D256 scheduler and fixed FP8 CTA1 geometry."""
+
+    fp8 = params.dtype_qkv in (DTYPE_E4M3, DTYPE_E5M2)
+    if not fp8:
+        return params.sched_policy, 2
+    if params.split_kv > 1 or params.thd_varlen:
+        return SCHED_NATURAL, 1
+
+    no_mask = params.window_left is None and params.window_right is None and not params.seq_kv_lens_present
+    if no_mask:
+        return SCHED_NATURAL, 1
+
+    top_left = not params.bottom_right or d256_square_br_as_tl(params, s_q=s_q, s_kv=s_kv)
+    pt_lpt_l2 = (
+        pertensor
+        and params.window_left is None
+        and params.window_right is not None
+        and not params.seq_kv_lens_present
+        and top_left
+        and _ceil_div(s_q, 256) >= 16
+    )
+    if pt_lpt_l2:
+        return params.sched_policy, 1
+    return SCHED_LPT, 1
+
+
+def _sm100_params_from_facts(facts, *, split_kv: int, sched_policy: int) -> Sm100TemplateParams:
     dtype_codes = {
         cudnn.data_type.FP8_E4M3: DTYPE_E4M3,
         cudnn.data_type.FP8_E5M2: DTYPE_E5M2,
@@ -450,10 +484,16 @@ def _d192_params_from_facts(facts, *, split_kv: int, sched_policy: int) -> Sm100
 def _auto_sched_cga(spec: EngineSpec, facts, *, split_kv: int, sched_policy: int) -> tuple[int, Optional[int]]:
     caps = spec.capabilities
     domain = effective_cgas(caps, facts, split_kv)
-    has_d192_cga_domain = any(shape == (192, 128) for shape, _ in caps.cgas_by_d_shape)
-    if _selected_d_shape(caps, facts) != (192, 128) or not has_d192_cga_domain:
+    selected_shape = _selected_d_shape(caps, facts)
+    if selected_shape == (256, 256) and any(shape == selected_shape for shape, _ in caps.cgas_by_d_shape):
+        params = _sm100_params_from_facts(facts, split_kv=split_kv, sched_policy=sched_policy)
+        selected_sched, selected_cga = select_d256_auto_knobs(params, pertensor=facts.is_fp8, s_q=facts.s_q, s_kv=facts.s_kv)
+        if selected_cga not in domain:
+            raise ValueError(f"D256 heuristic selected cga={selected_cga} outside the declared domain {sorted(domain)}")
+        return selected_sched, selected_cga
+    if selected_shape != (192, 128) or not any(shape == (192, 128) for shape, _ in caps.cgas_by_d_shape):
         return sched_policy, _sole(domain)
-    params = _d192_params_from_facts(facts, split_kv=split_kv, sched_policy=sched_policy)
+    params = _sm100_params_from_facts(facts, split_kv=split_kv, sched_policy=sched_policy)
     selected_sched, selected_cga = select_d192_auto_knobs(params, pertensor=facts.is_fp8, s_q=facts.s_q, s_kv=facts.s_kv)
     if selected_cga not in domain:
         raise ValueError(f"D192 heuristic selected cga={selected_cga} outside the declared domain {sorted(domain)}")

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_fp8_sm100.py
@@ -8,7 +8,7 @@ two full-width KV stages. Depending on the mask specialization, one or two
 softmax warp groups generate packed FP8 probabilities for Blackwell's K=32
 FP8 QMMA path and the sdpa_fp8 output scaling/amax ABI.
 
-THD / varlen follows the shared device-built-metadata and plan-time-envelope
+THD / varlen follows the shared device-built-metadata and persistent-grid
 design used by the D128 FP8 sibling. Packed token totals stay dynamic and the
 setup kernel builds per-sequence O plus packed-total-clamped K/V descriptors.
 """
@@ -126,6 +126,7 @@ vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
 N_O_CHUNKS = (CFG.TILE_O * CFG.BPE_O + 127) // 128
 
 CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+THD_PERSISTENT = True
 
 _sdpa_h = make_sdpa_helpers(
     CFG,
@@ -267,6 +268,11 @@ def _scheduler_warp_loop_predecode(
     seq_kv_lens_tensor,
     seq_q_lens_tensor,
 ):
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        meta = cutlass.make_array_view(seq_kv_lens_tensor)
+        ctr_ptr = Pointer(seq_kv_lens_tensor.iterator.raw_ptr(), dtype=cutlass.Int32) + cutlass.Int32(4) * n_batch + cutlass.Int32(3)
+        live_off = cutlass.Int32(4) * n_batch + cutlass.Int32(2)
+
     state = PipelineState.start()
     is_valid = cutlass.Int32(1)
 
@@ -276,13 +282,41 @@ def _scheduler_warp_loop_predecode(
         if nvvm.elect_sync():
             arrive_expect_tx(sched.mb_scheduler.subview(state.idx), 16)
         if nvvm.elect_sync() and is_cga_first_cta:
-            nvvm.clusterlaunchcontrol_try_cancel(
-                sched.tile_id_smem.subview(state.idx * cutlass.Int32(SCHED_PAYLOAD_WORDS)),
-                sched.mb_scheduler.subview(state.idx),
-                multicast=1,
-            )
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                uid = cutlass.Int32(nvvm.atomicrmw(nvvm.AtomicOp.ADD, ctr_ptr, cutlass.Int32(1)))
+                live = cutlass.Int32(meta[live_off])
+                valid = cutlass.Int32(
+                    arith.select(
+                        (uid < live).ir_value(),
+                        cutlass.Int32(1).ir_value(),
+                        cutlass.Int32(0).ir_value(),
+                    )
+                )
+                tile_ptr = cute.make_ptr(
+                    cutlass.Int32,
+                    sched.tile_id_smem.subview(state.idx * cutlass.Int32(SCHED_PAYLOAD_WORDS)).data_ptr().toint(cutlass.Int32),
+                    cutlass.AddressSpace.smem,
+                    assumed_align=16,
+                )
+                mbar_ptr = cute.make_ptr(
+                    cutlass.Int64,
+                    sched.mb_scheduler.subview(state.idx).data_ptr().toint(cutlass.Int32),
+                    cutlass.AddressSpace.smem,
+                    assumed_align=8,
+                )
+                payload = (uid * cutlass.Int32(CFG.CGA_M), cutlass.Int32(0), valid, cutlass.Int32(0))
+                for cta_rank in cutlass.range_constexpr(CGA_SIZE):
+                    for word in cutlass.range_constexpr(4):
+                        cute.arch.store_async_dsmem(tile_ptr + word, payload[word], mbar_ptr, cta_rank)
+            else:
+                nvvm.clusterlaunchcontrol_try_cancel(
+                    sched.tile_id_smem.subview(state.idx * cutlass.Int32(SCHED_PAYLOAD_WORDS)),
+                    sched.mb_scheduler.subview(state.idx),
+                    multicast=1,
+                )
 
-        nvvm.fence_proxy("async.shared", space="cta")
+        if cutlass.const_expr(not CFG.THD_VARLEN):
+            nvvm.fence_proxy("async.shared", space="cta")
         nvvm.bar_warp_sync(cute.arch.FULL_MASK)
         wait(sched.mb_scheduler.subview(state.idx), state.phase)
 

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_fp8_sm100.py
@@ -1,0 +1,2888 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""SM100 per-tensor FP8 prefill SDPA for exact d_qk=d_v=256.
+
+This is an independent CTA1 pipeline: each CTA owns one M128 query tile and
+two full-width KV stages. Depending on the mask specialization, one or two
+softmax warp groups generate packed FP8 probabilities for Blackwell's K=32
+FP8 QMMA path and the sdpa_fp8 output scaling/amax ABI.
+
+THD / varlen follows the shared device-built-metadata and plan-time-envelope
+design used by the D128 FP8 sibling. Packed token totals stay dynamic and the
+setup kernel builds per-sequence O plus packed-total-clamped K/V descriptors.
+"""
+
+from functools import lru_cache
+from typing import Callable, Optional, Tuple
+
+from cutlass.base_dsl.typing import Pointer
+from cutlass.experimental import primitives as nvvm
+from cutlass.experimental.primitives import vote_sync, VoteSync  # noqa: F401
+from cutlass.experimental.cuda import tensor_map as tmap
+from cutlass._mlir.dialects import arith
+
+import cutlass
+from cutlass.experimental import primitives as prims
+import cutlass.cute as cute
+import cuda.bindings.driver as _cuda_driver  # noqa: F401
+
+from dataclasses import dataclass
+
+from cudnn.sdpa.fwd.config_sm100 import TemplateParams, make_cfg_d256
+
+# The template loader injects the graph's FP8 parameters before executing this
+# module. The default record only keeps import-time tooling well-defined; it is
+# not a supported standalone execution configuration for this FP8 kernel.
+PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
+CFG, _TMA = make_cfg_d256(PARAMS)
+Cfg = type(CFG)
+TMA_QK_ITERS = _TMA.QK_ITERS
+TMA_VO_ITERS = _TMA.VO_ITERS
+TMA_QK_GRANU_ELEMS = _TMA.QK_GRANU_ELEMS
+TMA_VO_GRANU_ELEMS = _TMA.VO_GRANU_ELEMS
+
+TMA_O_GRANU_ELEMS_HOST = CFG.O_SWZ_BYTES // CFG.BPE_O
+TMA_O_ITERS_HOST = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
+
+from cudnn.frost.tile_dsl.barrier import (
+    MBarrier,
+    PipelineState,
+    Producer,
+    advance,
+    cga_arrive,
+    cga_wait,
+    wait,
+    arrive_expect_tx,
+)
+from cudnn.frost.tile_dsl.scheduler import (
+    Sched,
+    read_tile_id_arrive,
+    SCHED_NATURAL,
+)
+from cudnn.frost.tile_dsl.pointwise import (
+    row_reduction_pair,
+    row_max_reduction,
+    vec_scale_pair,
+)
+from cudnn.frost.tile_dsl.regtile import RegTile, vec_concat
+from cudnn.frost.tile_dsl.mma import mma_ss, mma_ts_step
+from cudnn.frost.tile_dsl.tma import tma_load_tile, tma_store_commit, tma_store_wait, tma_tensormap_acquire
+from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, tma_slice_runtime_desc
+from cudnn.frost.tile_dsl.tmem import tmem_alloc, tmem_dealloc
+from cudnn.frost.tile_dsl.mask import (
+    apply_mask_chunk,
+    MASK_NONE,
+    MASK_CAUSAL,
+    MASK_PADDED,
+)
+from cudnn.block_sparse_attention.csrc.utils.kernel_utils import ex2_emulation_2
+
+if CFG.DTYPE_QKV == 0:
+    STORAGE_DTYPE = cutlass.Float8E4M3FN
+    P_STORAGE_DTYPE = cutlass.Float8E4M3FN
+    MMA_KIND = nvvm.Tcgen05MMAKind.F8F6F4
+elif CFG.DTYPE_QKV == 1:
+    STORAGE_DTYPE = cutlass.Float8E5M2
+    P_STORAGE_DTYPE = cutlass.Float8E5M2
+    MMA_KIND = nvvm.Tcgen05MMAKind.F8F6F4
+else:
+    raise ValueError(f"prefill_sdpa_d256_fp8: unsupported DTYPE_QKV={CFG.DTYPE_QKV}")
+
+if CFG.DTYPE_O == 0:
+    OUT_STORAGE_DTYPE = cutlass.Float8E4M3FN
+elif CFG.DTYPE_O == 1:
+    OUT_STORAGE_DTYPE = cutlass.Float8E5M2
+elif CFG.DTYPE_O == 2:
+    OUT_STORAGE_DTYPE = cutlass.BFloat16
+elif CFG.DTYPE_O == 3:
+    OUT_STORAGE_DTYPE = cutlass.Float16
+else:
+    raise ValueError(f"prefill_sdpa_d256_fp8: unsupported DTYPE_O={CFG.DTYPE_O}")
+
+
+from cudnn.sdpa.fwd.kernels._common_sm100 import (
+    make_split_helpers,
+    KvLoopBounds,
+    make_d256_bars,
+    row_max_for_exp2,
+    make_sdpa_helpers,
+)
+
+CGA_SIZE = CFG.CGA_M * CFG.CGA_N
+
+CTA_GROUP_KIND = nvvm.CTAGroup.CTA_2 if CFG.CTA_MMA == 2 else nvvm.CTAGroup.CTA_1
+
+qBufferElems = CFG.TILE_M * CFG.TILE_K
+kBufferElems = CFG.TILE_N * CFG.TILE_K // CFG.CTA_MMA
+vBufferElems = CFG.TILE_O * CFG.TILE_N // CFG.CTA_MMA
+oBufferElems = CFG.TILE_M * CFG.TILE_O
+qoAliasBytes = max(qBufferElems * CFG.BPE, oBufferElems * CFG.BPE_O)
+
+qTmaTransactionBytes = qBufferElems * CFG.BPE * CFG.CTA_MMA
+kTmaTransactionBytes = kBufferElems * CFG.BPE * CFG.CTA_MMA
+vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
+
+N_O_CHUNKS = (CFG.TILE_O * CFG.BPE_O + 127) // 128
+
+CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+
+_sdpa_h = make_sdpa_helpers(
+    CFG,
+    lpt_q_tiles_in_cga_units=True,
+    grouped_lpt=PARAMS.lpt_head_group > 1,
+    lpt_head_group=PARAMS.lpt_head_group,
+)
+_decode_initial = _sdpa_h.decode_initial
+_decode_payload = _sdpa_h.decode_payload
+# qtrim variant: collapses the KV loop for CGA tiles entirely past the
+# per-batch actual Q length (SEQ_Q_LENS_PRESENT; folds to plain bounds otherwise).
+_bounds_for_tile = _sdpa_h.bounds_for_tile_qtrim
+_resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+_resolve_seqlen_q = _sdpa_h.resolve_seqlen_q
+
+
+_thd_tma_offsets = _sdpa_h.thd_tma_offsets
+
+# Pack all query heads sharing one KV head into the tile's row dimension.
+HEADS_PER_TILE = CFG.QH_PER_KH if CFG.PACK_GQA else 1
+TOKENS_PER_TILE = CFG.TILE_M // HEADS_PER_TILE
+
+from cudnn.sdpa.fwd.kernels.thd_sm100 import (
+    build_thd_meta_o_kv_descs_kernel as _build_thd_meta_o_kv_descs_kernel,
+    thd_decode_unit,
+    TENSOR_MAP_QWORDS,
+)
+
+_TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
+_PLAIN_TOP_LEFT_CAUSAL = (CFG.MASK_FLAGS & ~MASK_PADDED) == MASK_CAUSAL and CFG.BOTTOM_RIGHT == 0 and CFG.WINDOW_RIGHT == 0
+_PADDED_TOP_LEFT_CAUSAL = _PLAIN_TOP_LEFT_CAUSAL and bool(CFG.MASK_FLAGS & MASK_PADDED)
+_THD_REVERSE_CAUSAL_ROWS = CFG.THD_VARLEN and _PADDED_TOP_LEFT_CAUSAL
+
+
+@cute.jit
+def _thd_decode_causal(linear_cta, seq_kv_lens_t, n_batch, n_qh, cta_in_pair):
+    meta = cutlass.make_array_view(seq_kv_lens_t)
+    unit = linear_cta // cutlass.Int32(CFG.CGA_M)
+    q_tile, batch, head = thd_decode_unit(
+        meta,
+        n_batch,
+        unit,
+        n_qh,
+        cutlass.Int32(CGA_TILE_M),
+        True,
+    )
+    cuq0 = n_batch
+    live = batch < n_batch
+    safe_batch = cute.math.min(batch, n_batch - cutlass.Int32(1))
+    seq_q = cutlass.Int32(meta[cuq0 + safe_batch + cutlass.Int32(1)]) - cutlass.Int32(meta[cuq0 + safe_batch])
+    tiles_q = (seq_q + cutlass.Int32(CGA_TILE_M - 1)) // cutlass.Int32(CGA_TILE_M)
+    rank = tiles_q - cutlass.Int32(1) - q_tile
+    group = head // cutlass.Int32(4)
+    group_head0 = group * cutlass.Int32(4)
+    group_is_full = live & (group_head0 + cutlass.Int32(3) < n_qh)
+    group_linear = (head - group_head0) * tiles_q + rank
+    grouped_head = group_head0 + (group_linear & cutlass.Int32(3))
+    grouped_rank = group_linear // cutlass.Int32(4)
+    head = cutlass.Int32(arith.select(group_is_full.ir_value(), grouped_head.ir_value(), head.ir_value()))
+    q_tile = cutlass.Int32(
+        arith.select(
+            group_is_full.ir_value(),
+            (tiles_q - cutlass.Int32(1) - grouped_rank).ir_value(),
+            q_tile.ir_value(),
+        )
+    )
+    return q_tile * cutlass.Int32(CFG.CTA_MMA) + cta_in_pair, head, batch
+
+
+@cute.jit
+def _dispatch_decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, seq_kv_lens_t, qh_per_kh=None, seqlen_kv=None):
+    if cutlass.const_expr(_THD_REVERSE_CAUSAL_ROWS):
+        return _thd_decode_causal(bidx, seq_kv_lens_t, n_batch, n_qh, cta_in_pair)
+    return _sdpa_h.dispatch_decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, seq_kv_lens_t, qh_per_kh, seqlen_kv)
+
+
+@cute.jit
+def _dispatch_decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, seq_kv_lens_t, qh_per_kh=None, seqlen_kv=None):
+    if cutlass.const_expr(_THD_REVERSE_CAUSAL_ROWS):
+        return _thd_decode_causal(t0, seq_kv_lens_t, n_batch, n_qh, cta_in_pair)
+    return _sdpa_h.dispatch_decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, seq_kv_lens_t, qh_per_kh, seqlen_kv)
+
+
+# Each split runs one contiguous slice of a Q tile's KV range and writes a
+# split-major partial O/LSE pair for split_combine_sm100.  At SPLIT_KV == 1
+# these helpers fold back to the original decode and bounds path.
+_split_h = make_split_helpers(
+    CFG,
+    bounds_for_tile=_bounds_for_tile,
+    dispatch_decode_initial=_dispatch_decode_initial,
+    dispatch_decode_payload=_dispatch_decode_payload,
+)
+SPLIT_KV = _split_h.SPLIT_KV
+MAY_BE_EMPTY = _split_h.MAY_BE_EMPTY
+_decode_initial_split = _split_h.decode_initial_split
+_decode_payload_split = _split_h.decode_payload_split
+_bounds_for_tile_split = _split_h.bounds_for_tile_split
+_nomask_range_split = _split_h.nomask_range_split
+_partial_batch = _split_h.partial_batch
+
+
+@dataclass(frozen=True)
+class KernelTmemLayout:
+    TOTAL_COLS: int = 512
+
+    S_ACC_EVEN_OFF: int = 0
+    S_ACC_ODD_OFF: int = 128
+
+    # FP8 probabilities pack four values per TMEM column and alias the tails of
+    # the two 128-column score slots.
+    P_EVEN_OFF: int = 96
+    P_ODD_OFF: int = 224
+
+    O_OFF: int = 256
+
+    STATS_EVEN_OFF: int = 0
+    STATS_ODD_OFF: int = 128
+    STATS_EPI_OFF: int = 0
+
+
+LAYOUT = KernelTmemLayout()
+# Slots 6:10 carry predecoded bounds and slot 10 carries the split index.  The
+# unsplit/no-mask specialization retains the original eight-word payload.
+SCHED_PAYLOAD_WORDS = 12 if (CFG.MASK_FLAGS != 0 or SPLIT_KV > 1) else 8
+
+
+@cute.jit
+def _scheduler_warp_loop_predecode(
+    sched,
+    mb_decoded,
+    is_cga_first_cta,
+    cta_in_pair,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    qh_per_kh,
+    seqlen_q,
+    seqlen_kv,
+    seq_kv_lens_tensor,
+    seq_q_lens_tensor,
+):
+    state = PipelineState.start()
+    is_valid = cutlass.Int32(1)
+
+    while is_valid > cutlass.Int32(0):
+        wait(sched.mb_read_tile_id.subview(state.idx), state.phase)
+
+        if nvvm.elect_sync():
+            arrive_expect_tx(sched.mb_scheduler.subview(state.idx), 16)
+        if nvvm.elect_sync() and is_cga_first_cta:
+            nvvm.clusterlaunchcontrol_try_cancel(
+                sched.tile_id_smem.subview(state.idx * cutlass.Int32(SCHED_PAYLOAD_WORDS)),
+                sched.mb_scheduler.subview(state.idx),
+                multicast=1,
+            )
+
+        nvvm.fence_proxy("async.shared", space="cta")
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+        wait(sched.mb_scheduler.subview(state.idx), state.phase)
+
+        payload_base = state.idx * cutlass.Int32(SCHED_PAYLOAD_WORDS)
+        validity = sched.tile_id_smem.subview(payload_base + cutlass.Int32(2)).load()
+        if nvvm.elect_sync():
+            nxt_q = sched.tile_id_smem.subview(payload_base + cutlass.Int32(0)).load()
+            nxt_hb = sched.tile_id_smem.subview(payload_base + cutlass.Int32(1)).load()
+            q_super_idx, head_idx, batch_idx, split_idx = _decode_payload_split(
+                nxt_q,
+                nxt_hb,
+                cta_in_pair,
+                n_q_supers,
+                n_qh,
+                n_batch,
+                seq_kv_lens_tensor,
+                qh_per_kh,
+                seqlen_kv,
+            )
+            sched.tile_id_smem.subview(payload_base + cutlass.Int32(3)).store(q_super_idx)
+            sched.tile_id_smem.subview(payload_base + cutlass.Int32(4)).store(head_idx)
+            sched.tile_id_smem.subview(payload_base + cutlass.Int32(5)).store(batch_idx)
+            if cutlass.const_expr(SPLIT_KV > 1):
+                sched.tile_id_smem.subview(payload_base + cutlass.Int32(10)).store(split_idx)
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0 or SPLIT_KV > 1):
+                eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+                eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
+                if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+                    kv_left, kv_right = _nomask_range_split(eff_seqlen_kv, split_idx)
+                    bounds = KvLoopBounds(left=kv_left, unmasked_lo=kv_left, unmasked_hi=kv_right, right=kv_right)
+                else:
+                    bounds = _bounds_for_tile_split(
+                        q_super_idx,
+                        eff_seqlen_q,
+                        eff_seqlen_kv,
+                        cta_in_pair,
+                        seq_q_lens_tensor,
+                        batch_idx,
+                        split_idx,
+                        HEADS_PER_TILE,
+                    )
+                sched.tile_id_smem.subview(payload_base + cutlass.Int32(6)).store(bounds.left)
+                sched.tile_id_smem.subview(payload_base + cutlass.Int32(7)).store(bounds.unmasked_lo)
+                sched.tile_id_smem.subview(payload_base + cutlass.Int32(8)).store(bounds.unmasked_hi)
+                sched.tile_id_smem.subview(payload_base + cutlass.Int32(9)).store(bounds.right)
+            nvvm.mbarrier_arrive(mb_decoded.subview(state.idx))
+
+        is_valid = validity & cutlass.Int32(1)
+        state = advance(state, CFG.SCHEDULER_STAGES)
+
+
+_SWZ_ENUM = {128: 2, 64: 4, 32: 6}
+SMEM_LAYOUT_Q = _SWZ_ENUM[CFG.Q_SWZ_BYTES]
+SMEM_LAYOUT_K = _SWZ_ENUM[CFG.K_SWZ_BYTES]
+SMEM_LAYOUT_V = _SWZ_ENUM[CFG.V_SWZ_BYTES]
+SMEM_LAYOUT_O = _SWZ_ENUM[CFG.O_SWZ_BYTES]
+SMEM_LAYOUT_QKO = SMEM_LAYOUT_Q
+
+_O_SWZ_B = {128: 3, 64: 2, 32: 1}[CFG.O_SWZ_BYTES]
+_O_SMEM_SWIZZLE = cutlass.Swizzle(_O_SWZ_B, 4, 3)
+
+LEADING_BYTE_OFFSET_QK = 0
+STRIDE_BYTE_OFFSET_QK = 8 * CFG.Q_SWZ_BYTES
+
+_CORE_MATRIX_ROWS = 8
+_V_PC_COLS = CFG.TILE_O // CFG.CTA_MMA
+LEADING_BYTE_OFFSET_PV = 0 if (_V_PC_COLS // _CORE_MATRIX_ROWS) <= 8 else CFG.TILE_N * CFG.V_SWZ_BYTES
+STRIDE_BYTE_OFFSET_PV = 8 * CFG.V_SWZ_BYTES
+
+NUM_KPHASES_PV = CFG.TILE_N // CFG.TILE_K_HW_BMM2
+NUM_KPHASES_PV_PER_CHUNK = NUM_KPHASES_PV // CFG.N_BMM2_CHUNKS
+
+
+def _max_abs_reduction(vec):
+    """Balanced max(abs(vec)) without materializing an abs vector."""
+    maxima = [vec[i] for i in range(int(vec.shape[0]))]
+    minima = list(maxima)
+    while len(maxima) > 1:
+        next_maxima = []
+        next_minima = []
+        for i in range(0, len(maxima), 3):
+            max_group = maxima[i : i + 3]
+            min_group = minima[i : i + 3]
+            max_acc = max_group[0]
+            min_acc = min_group[0]
+            for value in max_group[1:]:
+                max_acc = cute.math.max(max_acc, value, ftz=True)
+            for value in min_group[1:]:
+                min_acc = cute.math.min(min_acc, value, ftz=True)
+            next_maxima.append(max_acc)
+            next_minima.append(min_acc)
+        maxima = next_maxima
+        minima = next_minima
+    return cute.math.max(maxima[0], -minima[0], ftz=True)
+
+
+_E5_STYLE_SOFTMAX = CFG.DTYPE_QKV == 1 or (CFG.DTYPE_QKV == 0 and (CFG.MASK_FLAGS == MASK_NONE or _PLAIN_TOP_LEFT_CAUSAL))
+
+
+def _exp2_dense_chunk_a(vec, softmax_half):
+    values = []
+    for i in range(0, int(vec.shape[0]), 2):
+        use_e4_poly = not _E5_STYLE_SOFTMAX and i % 10 < 4 and not (softmax_half == 1 and i == 30)
+        use_e5_poly = _E5_STYLE_SOFTMAX and (
+            i % 10 < 4 or (softmax_half == 1 and (i == 24 or i == 26)) or (CFG.DTYPE_QKV == 0 and softmax_half == 0 and (i == 26 or i == 28))
+        )
+        if use_e4_poly:
+            x, y = ex2_emulation_2(vec[i], vec[i + 1])
+        elif use_e5_poly:
+            x, y = ex2_emulation_2(vec[i], vec[i + 1], poly_degree=1)
+        else:
+            x = cute.math.exp2(vec[i], fastmath=True)
+            y = cute.math.exp2(vec[i + 1], fastmath=True)
+        values.extend((x, y))
+    return cutlass.Vector.from_elements(tuple(values), cutlass.Float32)
+
+
+def _exp2_dense_chunk_b(vec, softmax_half):
+    values = []
+    for i in range(0, int(vec.shape[0]), 2):
+        e4_threshold = 20 if softmax_half == 2 else 16
+        e5_threshold = 22 if softmax_half == 3 else (20 if softmax_half == 0 else (22 if softmax_half == 2 else 24))
+        if (not _E5_STYLE_SOFTMAX and i >= e4_threshold) or (_E5_STYLE_SOFTMAX and i >= e5_threshold):
+            x, y = ex2_emulation_2(vec[i], vec[i + 1], poly_degree=1 if CFG.DTYPE_QKV == 0 else 2)
+        else:
+            x = cute.math.exp2(vec[i], fastmath=True)
+            y = cute.math.exp2(vec[i + 1], fastmath=True)
+        values.extend((x, y))
+    return cutlass.Vector.from_elements(tuple(values), cutlass.Float32)
+
+
+def _exp2_masked_tail_chunk_a(vec, softmax_half):
+    values = []
+    for i in range(0, int(vec.shape[0]), 2):
+        use_poly = i % 10 < 4 or (softmax_half == 1 and (i == 24 or i == 26)) or (softmax_half == 0 and (i == 26 or i == 28))
+        if use_poly:
+            x, y = ex2_emulation_2(vec[i], vec[i + 1], poly_degree=2)
+        else:
+            x = cute.math.exp2(vec[i], fastmath=True)
+            y = cute.math.exp2(vec[i + 1], fastmath=True)
+        values.extend((x, y))
+    return cutlass.Vector.from_elements(tuple(values), cutlass.Float32)
+
+
+def _exp2_masked_alpha(x):
+    if _E5_STYLE_SOFTMAX and _PLAIN_TOP_LEFT_CAUSAL:
+        value, _ = ex2_emulation_2(x, x, poly_degree=2)
+        return value
+    return cute.math.exp2(x, fastmath=True)
+
+
+_RARE_RESCALE_CORRECTION = _E5_STYLE_SOFTMAX
+_STAT_FULL_WARP_ARRIVALS = CFG.SOFTMAX_WARPGROUPS == 2 and _PLAIN_TOP_LEFT_CAUSAL
+_STAT_EMPTY_WARP_ARRIVALS = _STAT_FULL_WARP_ARRIVALS
+_SMEM_ALPHA_HANDOFF = _STAT_FULL_WARP_ARRIVALS and CFG.DTYPE_QKV == 0
+
+
+@cute.jit
+def _stat_arrive(bar, warp_arrivals: cutlass.Constexpr[bool]):
+    if cutlass.const_expr(warp_arrivals):
+        if nvvm.elect_sync():
+            bar.arrive()
+    else:
+        bar.arrive()
+
+
+@cute.kernel
+def _kernel(
+    tma_q_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_k_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_v_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_o_desc: cutlass.GridConstant[tmap.TensorMap],
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    seqlen_q: cutlass.Int32,
+    seqlen_kv: cutlass.Int32,
+    n_q_supers: cutlass.Int32,
+    n_qh: cutlass.Int32,
+    n_batch: cutlass.Int32,
+    qh_per_kh: cutlass.Int32,
+    scale_softmax_log2: cutlass.Float32,
+    o_scale_fused: cutlass.Float32,
+    descale_q_t: cute.Tensor,
+    descale_k_t: cute.Tensor,
+    descale_v_t: cute.Tensor,
+    scale_o_t: cute.Tensor,
+    amax_o_tensor: cute.Tensor,
+    bottom_right_diagonal: cutlass.Constexpr[bool],
+    # Dense padded-Q trim: separate (B,)-int32 per-batch Q lengths (mirrors
+    # cuDNN's SEQLEN_Q pointer / FA's seqused_q). None unless
+    # CFG.SEQ_Q_LENS_PRESENT — the DSL specializes on None, so the flag-off
+    # ABI is unchanged.
+    seq_q_lens_tensor: Optional[cute.Tensor] = None,
+) -> None:
+
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    tidx, _, _ = cute.arch.thread_idx()
+
+    bidx = cute.arch.block_idx()[0]
+    bidy = cute.arch.block_idx()[1]
+    bidz = cute.arch.block_idx()[2]
+
+    # Q and O have disjoint lifetimes. Allocate the larger byte footprint and
+    # expose typed views so promoted half output cannot overrun the FP8 Q view.
+    sQO_raw = cutlass.Array(STORAGE_DTYPE, qoAliasBytes // CFG.BPE, alignment=1024, space=cutlass.AddressSpace.smem)
+    sO_raw = cutlass.Array(sQO_raw.data_ptr(), shape=oBufferElems, dtype=OUT_STORAGE_DTYPE)
+    sK_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * kBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    sV_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * vBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+
+    sQ = SmemTile(
+        base=sQO_raw,
+        elems_per_stage=qBufferElems,
+        stages=1,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+    )
+    sK = SmemTile(
+        base=sK_raw,
+        elems_per_stage=kBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=1,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+    )
+    sV = SmemTile(
+        base=sV_raw,
+        elems_per_stage=vBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_PV,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_PV,
+        layout=SMEM_LAYOUT_V,
+        tma_loads_per_tile=1,
+        tma_granu_elems=TMA_VO_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+    )
+    sO = SmemTile(
+        base=sO_raw,
+        elems_per_stage=oBufferElems,
+        stages=1,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=SMEM_LAYOUT_O,
+        tma_loads_per_tile=TMA_O_ITERS_HOST,
+        tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+    )
+
+    bars = make_d256_bars(CFG, N_O_CHUNKS=N_O_CHUNKS)
+
+    tmem_ptr_i32 = cutlass.Array(cutlass.Int32, 1, alignment=16, space=cutlass.AddressSpace.smem)
+    # Dense-only WG0->WG1 alpha handoff (two parity slots) followed by one
+    # two-way tail denominator exchange.
+    softmax_exchange = cutlass.Array(
+        cutlass.Float32,
+        768 if CFG.SOFTMAX_WARPGROUPS == 2 else 1,
+        alignment=16,
+        space=cutlass.AddressSpace.smem,
+    )
+    mb_softmax_max = MBarrier(
+        cutlass.Array(cutlass.Int64, 2, alignment=16, space=cutlass.AddressSpace.smem),
+        stages=2,
+        init_count=CFG.SOFTMAX_LANES,
+        producer=Producer.THREAD,
+    )
+
+    sched = Sched(
+        **{
+            "mb_scheduler": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "mb_read_tile_id": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "tile_id_smem": cutlass.Array(
+                cutlass.Int32,
+                CFG.SCHEDULER_STAGES * SCHED_PAYLOAD_WORDS,
+                alignment=16,
+                space=cutlass.AddressSpace.smem,
+            ),
+            "bidx_init": bidx,
+            "bidy_init": bidy,
+            "bidz_init": bidz,
+        }
+    )
+    mb_decoded = cutlass.Array(
+        cutlass.Int64,
+        CFG.SCHEDULER_STAGES,
+        alignment=16,
+        space=cutlass.AddressSpace.smem,
+    )
+    READ_TILE_ARRIVERS_TOTAL = CFG.READ_TILE_ARRIVERS
+
+    if warp_idx == 0:
+        if nvvm.elect_sync():
+            bars.mb_q_full.init()
+            bars.mb_q_o_alias.init()
+            bars.mb_tmastg_go.init()
+            for p in cutlass.range_constexpr(2):
+                bars.mb_bmm1_done[p].init()
+                bars.mb_bmm2_done[p].init()
+                for c in cutlass.range_constexpr(CFG.N_BMM2_CHUNKS):
+                    bars.mb_bmm2_ready[p * CFG.N_BMM2_CHUNKS + c].init()
+            if cutlass.const_expr(_STAT_FULL_WARP_ARRIVALS):
+                bars.mb_stat_full.init(override_count=CFG.SOFTMAX_WG_WARPS)
+            else:
+                bars.mb_stat_full.init()
+            if cutlass.const_expr(_STAT_EMPTY_WARP_ARRIVALS):
+                bars.mb_stat_empty.init(override_count=CFG.CORRECTION_WARPS)
+            else:
+                bars.mb_stat_empty.init()
+            for chunk in cutlass.range_constexpr(N_O_CHUNKS):
+                bars.mb_o_full[chunk].init()
+            bars.mb_o_empty.init()
+            for ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_k_full[ks].init()
+                bars.mb_k_empty[ks].init()
+                bars.mb_v_full[ks].init()
+                bars.mb_v_empty[ks].init()
+            for s in range(CFG.SCHEDULER_STAGES):
+                nvvm.mbarrier_init(sched.mb_scheduler.subview(s), CFG.ONE_LANE)
+                nvvm.mbarrier_init(sched.mb_read_tile_id.subview(s), READ_TILE_ARRIVERS_TOTAL)
+                nvvm.mbarrier_init(mb_decoded.subview(s), CFG.ONE_LANE)
+            if cutlass.const_expr(CFG.SOFTMAX_WARPGROUPS == 2):
+                for p in cutlass.range_constexpr(2):
+                    mb_softmax_max[p].init()
+            bars.mb_empty_mainloop.init()
+            bars.mb_tmem_dealloc.init()
+
+            bars.mb_q_o_alias.arrive()
+
+    scale_log2_fused = scale_softmax_log2
+    if cutlass.const_expr(not CFG.THD_VARLEN):
+        scale_log2_fused = (
+            scale_softmax_log2 * cutlass.Float32(cutlass.make_array_view(descale_q_t)[0]) * cutlass.Float32(cutlass.make_array_view(descale_k_t)[0])
+        )
+    o_scale_fused = o_scale_fused * cutlass.Float32(cutlass.make_array_view(descale_v_t)[0]) * cutlass.Float32(cutlass.make_array_view(scale_o_t)[0])
+
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync()
+
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        cga_arrive()
+        cga_wait()
+
+    cta_id_x = cute.arch.block_idx_in_cluster() if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    cta_in_pair = (cta_id_x & cutlass.Int32(1)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    leader_cta_id = (cta_id_x & cutlass.Int32(~1 & 0xFFFFFFFF)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    mcast_mask = (cutlass.Int32(3) << leader_cta_id) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    tma_mcast_mask = (cutlass.Int16(1) << cta_in_pair) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
+    is_leader = cta_in_pair == cutlass.Int32(0)
+
+    if warp_idx >= CFG.SOFTMAX_WG0_BASE and warp_idx < CFG.SOFTMAX_WG0_BASE + CFG.SOFTMAX_WG_WARPS:
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        if cutlass.const_expr(CFG.THD_VARLEN):
+            scale_log2_fused = (
+                scale_softmax_log2 * cutlass.Float32(cutlass.make_array_view(descale_q_t)[0]) * cutlass.Float32(cutlass.make_array_view(descale_k_t)[0])
+            )
+        _softmax_warp_group(
+            softmax_half=0,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_log2_fused,
+            tmem_ptr_i32=tmem_ptr_i32,
+            bars=bars,
+            sched=sched,
+            mb_decoded=mb_decoded,
+            lse_tensor=lse_tensor,
+            sinks_tensor=sinks_tensor,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            seq_q_lens_tensor=seq_q_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            qh_per_kh=qh_per_kh,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+            bottom_right_diagonal=bottom_right_diagonal,
+            softmax_exchange=softmax_exchange,
+            mb_softmax_max=mb_softmax_max,
+        )
+
+    elif cutlass.const_expr(CFG.SOFTMAX_WARPGROUPS == 2) and warp_idx >= CFG.SOFTMAX_WG1_BASE and warp_idx < CFG.SOFTMAX_WG1_BASE + CFG.SOFTMAX_WG_WARPS:
+        nvvm.setmaxregister(CFG.SOFTMAX_WG1_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        if cutlass.const_expr(CFG.THD_VARLEN):
+            scale_log2_fused = (
+                scale_softmax_log2 * cutlass.Float32(cutlass.make_array_view(descale_q_t)[0]) * cutlass.Float32(cutlass.make_array_view(descale_k_t)[0])
+            )
+        _softmax_warp_group(
+            softmax_half=1,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_log2_fused,
+            tmem_ptr_i32=tmem_ptr_i32,
+            bars=bars,
+            sched=sched,
+            mb_decoded=mb_decoded,
+            lse_tensor=lse_tensor,
+            sinks_tensor=sinks_tensor,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            seq_q_lens_tensor=seq_q_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            qh_per_kh=qh_per_kh,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+            bottom_right_diagonal=bottom_right_diagonal,
+            softmax_exchange=softmax_exchange,
+            mb_softmax_max=mb_softmax_max,
+        )
+
+    elif warp_idx >= CFG.CORR_WARP_BASE and warp_idx < CFG.CORR_WARP_BASE + CFG.CORRECTION_WARPS:
+        nvvm.setmaxregister(CFG.CORRECTION_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _correction_warp_group(
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            sO=sO,
+            tmem_ptr_i32=tmem_ptr_i32,
+            tidx=tidx,
+            bars=bars,
+            sched=sched,
+            mb_decoded=mb_decoded,
+            lse_tensor=lse_tensor,
+            sinks_tensor=sinks_tensor,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            seq_q_lens_tensor=seq_q_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            qh_per_kh=qh_per_kh,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+            cta_id_x=cta_id_x,
+            bottom_right_diagonal=bottom_right_diagonal,
+            o_scale_fused=o_scale_fused,
+            amax_o_tensor=amax_o_tensor,
+            softmax_exchange=softmax_exchange,
+        )
+
+    elif warp_idx == CFG.MMA_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        if cutlass.const_expr(CFG.CTA_MMA == 2):
+            if is_leader:
+                _mma_warp_group(
+                    seqlen_q=seqlen_q,
+                    seqlen_kv=seqlen_kv,
+                    sQ=sQ,
+                    sK=sK,
+                    sV=sV,
+                    tmem_ptr_i32=tmem_ptr_i32,
+                    bars=bars,
+                    sched=sched,
+                    mb_decoded=mb_decoded,
+                    seq_kv_lens_tensor=seq_kv_lens_tensor,
+                    seq_q_lens_tensor=seq_q_lens_tensor,
+                    n_q_supers=n_q_supers,
+                    n_qh=n_qh,
+                    n_batch=n_batch,
+                    qh_per_kh=qh_per_kh,
+                    mcast_mask=mcast_mask,
+                    cta_in_pair=cta_in_pair,
+                )
+            else:
+                _mma_warp_quiet(tmem_ptr_i32, bars)
+        else:
+            _mma_warp_group(
+                seqlen_q=seqlen_q,
+                seqlen_kv=seqlen_kv,
+                sQ=sQ,
+                sK=sK,
+                sV=sV,
+                tmem_ptr_i32=tmem_ptr_i32,
+                bars=bars,
+                sched=sched,
+                mb_decoded=mb_decoded,
+                seq_kv_lens_tensor=seq_kv_lens_tensor,
+                seq_q_lens_tensor=seq_q_lens_tensor,
+                n_q_supers=n_q_supers,
+                n_qh=n_qh,
+                n_batch=n_batch,
+                qh_per_kh=qh_per_kh,
+                mcast_mask=mcast_mask,
+                cta_in_pair=cta_in_pair,
+            )
+
+    elif warp_idx == CFG.TMALDG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        nvvm.prefetch_tensormap(tma_q_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_k_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_v_desc.get_ptr())
+        _tmaldg_warp_group(
+            tma_q_desc=tma_q_desc,
+            tma_k_desc=tma_k_desc,
+            tma_v_desc=tma_v_desc,
+            sQ=sQ,
+            sK=sK,
+            sV=sV,
+            bars=bars,
+            sched=sched,
+            mb_decoded=mb_decoded,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
+            seq_q_lens_tensor=seq_q_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            qh_per_kh=qh_per_kh,
+            is_leader=is_leader,
+            cta_in_pair=cta_in_pair,
+            tma_mcast_mask=tma_mcast_mask,
+        )
+
+    elif warp_idx == CFG.TMASTG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _tmastg_warp_group(
+            tma_o_desc=tma_o_desc,
+            sO=sO,
+            bars=bars,
+            sched=sched,
+            mb_decoded=mb_decoded,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            seqlen_kv=seqlen_kv,
+            qh_per_kh=qh_per_kh,
+            cta_in_pair=cta_in_pair,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
+        )
+
+    else:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        is_cga_first_cta = cta_id_x == cutlass.Int32(0)
+        _scheduler_warp_loop_predecode(
+            sched,
+            mb_decoded,
+            is_cga_first_cta,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            qh_per_kh,
+            seqlen_q,
+            seqlen_kv,
+            seq_kv_lens_tensor,
+            seq_q_lens_tensor,
+        )
+
+
+@cute.jit
+def _tmaldg_warp_group(
+    tma_q_desc,
+    tma_k_desc,
+    tma_v_desc,
+    sQ,
+    sK,
+    sV,
+    bars,
+    sched,
+    mb_decoded,
+    seqlen_q,
+    seqlen_kv,
+    seq_kv_lens_tensor,
+    o_desc_words,
+    seq_q_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    qh_per_kh,
+    is_leader,
+    cta_in_pair,
+    tma_mcast_mask,
+):
+
+    q_o_alias_phase = cutlass.Int32(0)
+    kv_state = PipelineState.start(phase=1)
+
+    tma_q = GmemTileTma(tma_q_desc)
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        k_rt_ptr = (o_desc_words.iterator.raw_ptr() + (n_batch + cutlass.Int32(1)) * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+        v_rt_ptr = (o_desc_words.iterator.raw_ptr() + (n_batch + cutlass.Int32(2)) * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+        tma_tensormap_acquire(k_rt_ptr)
+        tma_tensormap_acquire(v_rt_ptr)
+        tma_k = lambda *coords: tma_slice_runtime_desc(k_rt_ptr, *coords)  # noqa: E731
+        tma_v = lambda *coords: tma_slice_runtime_desc(v_rt_ptr, *coords)  # noqa: E731
+    else:
+        tma_k = GmemTileTma(tma_k_desc)
+        tma_v = GmemTileTma(tma_v_desc)
+
+    q_super_idx, head_idx, batch_idx, split_idx = _decode_initial_split(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
+    )
+    q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx if cutlass.const_expr(CFG.PACK_GQA) else head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE))
+    q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0 and SPLIT_KV == 1):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    elif cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left, kv_right = _nomask_range_split(seqlen_kv, split_idx)
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
+        bounds_init = _bounds_for_tile_split(
+            q_super_idx,
+            eff_seqlen_q,
+            eff_seqlen_kv,
+            cta_in_pair,
+            seq_q_lens_tensor,
+            batch_idx,
+            split_idx,
+            HEADS_PER_TILE,
+        )
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    K_ROW_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_N // CFG.CTA_MMA)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if cutlass.const_expr(MAY_BE_EMPTY) and (kv_right <= kv_left):
+            pass
+        else:
+            # K does not alias the prior tile's O buffer. Issue the first K TMA
+            # before waiting for Q/O ownership so its latency overlaps the
+            # previous tile's output store and the alias handoff.
+            kv_row_base = kv_left * cutlass.Int32(CFG.TILE_N)
+            bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sK[kv_state.idx],
+                tma_k(cutlass.Int32(0), kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, cutlass.Int32(0), kv_head_idx, tma_batch),
+                bars.mb_k_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+                acquire=False,
+            )
+
+            bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sV[kv_state.idx],
+                tma_v(cutlass.Int32(0), kv_row_base + kv_seq_off, cutlass.Int32(0), kv_head_idx, tma_batch),
+                bars.mb_v_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+                acquire=False,
+            )
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+
+            kv_second = kv_left + cutlass.Int32(1)
+            if kv_second < kv_right:
+                kv_row_base = kv_second * cutlass.Int32(CFG.TILE_N)
+                bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sK[kv_state.idx],
+                    tma_k(cutlass.Int32(0), kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, cutlass.Int32(0), kv_head_idx, tma_batch),
+                    bars.mb_k_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                    acquire=False,
+                )
+
+                bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sV[kv_state.idx],
+                    tma_v(cutlass.Int32(0), kv_row_base + kv_seq_off, cutlass.Int32(0), kv_head_idx, tma_batch),
+                    bars.mb_v_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                    acquire=False,
+                )
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        bars.mb_q_o_alias.wait(q_o_alias_phase)
+        q_o_alias_phase = q_o_alias_phase ^ cutlass.Int32(1)
+
+        if cutlass.const_expr(MAY_BE_EMPTY) and (kv_right <= kv_left):
+            pass
+        else:
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_q_full.arrive(n_bytes=qTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_q_full.arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sQ[0],
+                tma_q(cutlass.Int32(0), q_head_idx, q_row_base + q_seq_off, tma_batch),
+                bars.mb_q_full.smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+
+            kv_main_start = cute.math.min(kv_left + cutlass.Int32(2), kv_right)
+            for kv_loop in cutlass.range(kv_main_start, kv_right, 1, unroll=1):
+                kv_row_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+
+                bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sK[kv_state.idx],
+                    tma_k(cutlass.Int32(0), kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, cutlass.Int32(0), kv_head_idx, tma_batch),
+                    bars.mb_k_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                    acquire=False,
+                )
+
+                bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sV[kv_state.idx],
+                    tma_v(cutlass.Int32(0), kv_row_base + kv_seq_off, cutlass.Int32(0), kv_head_idx, tma_batch),
+                    bars.mb_v_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                    acquire=False,
+                )
+
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        if nvvm.elect_sync():
+            bars.mb_tmastg_go.arrive()
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(mb_decoded.subview(sched_state.idx), sched_state.phase)
+        payload_base = sched_state.idx * cutlass.Int32(SCHED_PAYLOAD_WORDS)
+        nxt_v = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(2)).load())
+        q_super_idx = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(3)).load())
+        head_idx = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(4)).load())
+        batch_idx = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(5)).load())
+        q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx if cutlass.const_expr(CFG.PACK_GQA) else head_idx // qh_per_kh)
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE))
+        q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0 or SPLIT_KV > 1):
+            kv_left = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(6)).load())
+            kv_right = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(9)).load())
+
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        for _ks in cutlass.range_constexpr(CFG.STAGES_KV):
+            bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+            bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+
+@cute.jit
+def _tmastg_warp_group(
+    tma_o_desc,
+    sO,
+    bars,
+    sched,
+    mb_decoded,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    seqlen_kv,
+    qh_per_kh,
+    cta_in_pair,
+    seq_kv_lens_tensor,
+    o_desc_words,
+):
+
+    tmastg_go_phase = cutlass.Int32(0)
+    o_full_phase = cutlass.Int32(0)
+
+    tma_o = GmemTileTma(tma_o_desc)
+
+    q_super_idx, head_idx, batch_idx, split_idx = _decode_initial_split(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        bars.mb_tmastg_go.wait(tmastg_go_phase)
+        tmastg_go_phase = tmastg_go_phase ^ cutlass.Int32(1)
+
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
+        q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+        o_batch = _partial_batch(batch_idx, split_idx, n_batch)
+
+        if cutlass.const_expr(CFG.THD_VARLEN):
+            o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+        else:
+            o_slice = tma_o(cutlass.Int32(0), q_head_idx, q_row_coord, o_batch)
+            o_desc_ptr = o_slice.tma_desc.get_ptr()
+        for chunk in cutlass.range_constexpr(N_O_CHUNKS):
+            bars.mb_o_full[chunk].wait(o_full_phase)
+            smem_chunk = sO[0].base.subview(chunk * sO[0].tma_subtile_stride_elems)
+            d_coord = cutlass.Int32(chunk * TMA_O_GRANU_ELEMS_HOST)
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                if batch_idx < n_batch:
+                    nvvm.cp_async_bulk_tensor_global_shared_cta(
+                        o_desc_ptr,
+                        smem_chunk,
+                        (d_coord, q_head_idx, q_row_coord, cutlass.Int32(0)),
+                    )
+            else:
+                nvvm.cp_async_bulk_tensor_global_shared_cta(
+                    o_desc_ptr,
+                    smem_chunk,
+                    (o_slice.coord_d + d_coord, q_head_idx, q_row_coord, o_batch),
+                )
+            tma_store_commit()
+            if cutlass.const_expr(CFG.BPE_O == 2 and chunk == 1):
+                tma_store_wait(0)
+                if nvvm.elect_sync():
+                    bars.mb_q_o_alias.arrive()
+
+        tma_store_wait(0)
+        if cutlass.const_expr(CFG.BPE_O != 2):
+            if nvvm.elect_sync():
+                bars.mb_q_o_alias.arrive()
+
+        bars.mb_o_empty.arrive()
+
+        o_full_phase = o_full_phase ^ cutlass.Int32(1)
+
+        wait(mb_decoded.subview(sched_state.idx), sched_state.phase)
+        payload_base = sched_state.idx * cutlass.Int32(SCHED_PAYLOAD_WORDS)
+        nxt_v = sched.tile_id_smem.subview(payload_base + cutlass.Int32(2)).load()
+        q_super_idx = sched.tile_id_smem.subview(payload_base + cutlass.Int32(3)).load()
+        head_idx = sched.tile_id_smem.subview(payload_base + cutlass.Int32(4)).load()
+        batch_idx = sched.tile_id_smem.subview(payload_base + cutlass.Int32(5)).load()
+        if cutlass.const_expr(SPLIT_KV > 1):
+            split_idx = sched.tile_id_smem.subview(payload_base + cutlass.Int32(10)).load()
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+
+@cute.jit
+def _mma_warp_quiet(tmem_ptr_i32, bars):
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _mma_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    sQ,
+    sK,
+    sV,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    mb_decoded,
+    seq_kv_lens_tensor,
+    seq_q_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    qh_per_kh,
+    mcast_mask,
+    cta_in_pair,
+):
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    tmem_raw = nvvm.make_tmem_ptr(tmem_ptr_i32.load(), cutlass.Int8)
+
+    idesc_qk = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_N,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        k_dim=0,
+    )
+    idesc_pv = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_O,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        b_major=1,
+        k_dim=0,
+    )
+    bmm1_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_N,
+        K=CFG.TILE_K,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=CFG.TILE_K_HW_BMM1,
+        btranspose=False,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_qk,
+        kind=MMA_KIND,
+    )
+    bmm2_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_O,
+        K=CFG.TILE_N,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=CFG.TILE_K_HW_BMM2,
+        btranspose=True,
+        k_subtile=CFG.V_SWZ_BYTES // CFG.BPE,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_pv,
+        kind=MMA_KIND,
+    )
+
+    desc_Q = sQ[0].desc()
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0 and SPLIT_KV == 1):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        q_super_idx, _hd, batch_idx, split_idx = _decode_initial_split(
+            sched.bidx_init,
+            sched.bidy_init,
+            sched.bidz_init,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
+        )
+        if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+            kv_left, kv_right = _nomask_range_split(seqlen_kv, split_idx)
+        else:
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
+            bounds_init = _bounds_for_tile_split(
+                q_super_idx,
+                eff_seqlen_q,
+                eff_seqlen_kv,
+                cta_in_pair,
+                seq_q_lens_tensor,
+                batch_idx,
+                split_idx,
+                HEADS_PER_TILE,
+            )
+            kv_left = bounds_init.left
+            kv_right = bounds_init.right
+
+    q_full_phase = cutlass.Int32(0)
+    kv_state_K = PipelineState.start(phase=0)
+    kv_state_V = PipelineState.start(phase=0)
+    bmm2_ready_phase_pair = cutlass.Int32(0)
+    empty_mainloop_phase = cutlass.Int32(0)
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if cutlass.const_expr(MAY_BE_EMPTY) and (kv_right <= kv_left):
+            bars.mb_empty_mainloop.wait(empty_mainloop_phase)
+            empty_mainloop_phase = empty_mainloop_phase ^ cutlass.Int32(1)
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+        else:
+            bars.mb_q_full.wait(q_full_phase)
+            q_full_phase = q_full_phase ^ cutlass.Int32(1)
+
+            lo_parity_runtime = kv_left & cutlass.Int32(1)
+            parity_lo_is_even = lo_parity_runtime == cutlass.Int32(0)
+            tmem_S_acc_lo_addr = cutlass.Int32(
+                arith.select(
+                    parity_lo_is_even.ir_value(),
+                    cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(),
+                    cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value(),
+                )
+            )
+
+            bars.mb_k_full[kv_state_K.idx].wait(kv_state_K.phase)
+            desc_K = sK[kv_state_K.idx].desc()
+            mma_ss(
+                bmm1_desc,
+                desc_Q,
+                desc_K,
+                tmem_raw.subview(tmem_S_acc_lo_addr),
+                elect_once=(CFG.DTYPE_QKV == 1 and CFG.MASK_FLAGS == MASK_CAUSAL and CFG.BOTTOM_RIGHT == 0) or (CFG.DTYPE_QKV == 0 and _PADDED_TOP_LEFT_CAUSAL),
+            )
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm1_done[lo_parity_runtime].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bars.mb_k_empty[kv_state_K.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            kv_state_K = advance(kv_state_K, CFG.STAGES_KV)
+
+            k_per_chunk = NUM_KPHASES_PV_PER_CHUNK
+
+            for kv_loop in cutlass.range(kv_left, kv_right - cutlass.Int32(1), 1, unroll=1):
+                parity_cur_rt = kv_loop & cutlass.Int32(1)
+                parity_next_rt = (kv_loop + cutlass.Int32(1)) & cutlass.Int32(1)
+                cur_is_even = parity_cur_rt == cutlass.Int32(0)
+                next_is_even = parity_next_rt == cutlass.Int32(0)
+
+                tmem_S_acc_next_addr = cutlass.Int32(
+                    arith.select(
+                        next_is_even.ir_value(),
+                        cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(),
+                        cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value(),
+                    )
+                )
+                tmem_P_cur_addr = cutlass.Int32(
+                    arith.select(
+                        cur_is_even.ir_value(),
+                        cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(),
+                        cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value(),
+                    )
+                )
+                bmm2_ready_phase_cur = (bmm2_ready_phase_pair >> parity_cur_rt) & cutlass.Int32(1)
+
+                bars.mb_k_full[kv_state_K.idx].wait(kv_state_K.phase)
+                desc_K = sK[kv_state_K.idx].desc()
+                mma_ss(
+                    bmm1_desc,
+                    desc_Q,
+                    desc_K,
+                    tmem_raw.subview(tmem_S_acc_next_addr),
+                    elect_once=(CFG.DTYPE_QKV == 1 and CFG.MASK_FLAGS == MASK_CAUSAL and CFG.BOTTOM_RIGHT == 0)
+                    or (CFG.DTYPE_QKV == 0 and _PADDED_TOP_LEFT_CAUSAL),
+                )
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm1_done[parity_next_rt].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                bars.mb_k_empty[kv_state_K.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                kv_state_K = advance(kv_state_K, CFG.STAGES_KV)
+
+                bars.mb_v_full[kv_state_V.idx].wait(kv_state_V.phase)
+                desc_V = sV[kv_state_V.idx].desc()
+
+                scaleC = cutlass.Boolean(kv_loop != kv_left)
+                accum_b2 = scaleC
+                bmm2_issue = nvvm.elect_sync()
+                for k in cutlass.range_constexpr(NUM_KPHASES_PV):
+                    if k % k_per_chunk == 0:
+                        chunk_id = k // k_per_chunk
+                        bars.mb_bmm2_ready[parity_cur_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(chunk_id)].wait(bmm2_ready_phase_cur)
+                    mma_ts_step(
+                        bmm2_desc,
+                        tmem_raw.subview(tmem_P_cur_addr),
+                        desc_V,
+                        tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF)),
+                        k,
+                        accum_b2,
+                        issue_mma=bmm2_issue,
+                    )
+                    accum_b2 = cutlass.Boolean(True)
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm2_done[parity_cur_rt].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                bars.mb_v_empty[kv_state_V.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                bmm2_ready_phase_pair = bmm2_ready_phase_pair ^ (cutlass.Int32(1) << parity_cur_rt)
+                kv_state_V = advance(kv_state_V, CFG.STAGES_KV)
+
+            kv_last = kv_right - cutlass.Int32(1)
+            parity_last_rt = kv_last & cutlass.Int32(1)
+            last_is_even = parity_last_rt == cutlass.Int32(0)
+            tmem_P_last_addr = cutlass.Int32(
+                arith.select(
+                    last_is_even.ir_value(),
+                    cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(),
+                    cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value(),
+                )
+            )
+            bmm2_ready_phase_last = (bmm2_ready_phase_pair >> parity_last_rt) & cutlass.Int32(1)
+
+            bars.mb_v_full[kv_state_V.idx].wait(kv_state_V.phase)
+            desc_V = sV[kv_state_V.idx].desc()
+            n_kv_eff = kv_right - kv_left
+            scaleC_epi = cutlass.Boolean(n_kv_eff != cutlass.Int32(1))
+            accum_b2 = scaleC_epi
+            bmm2_issue_epi = nvvm.elect_sync()
+            for k in cutlass.range_constexpr(NUM_KPHASES_PV):
+                if k % k_per_chunk == 0:
+                    chunk_id = k // k_per_chunk
+                    bars.mb_bmm2_ready[parity_last_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(chunk_id)].wait(bmm2_ready_phase_last)
+                mma_ts_step(
+                    bmm2_desc,
+                    tmem_raw.subview(tmem_P_last_addr),
+                    desc_V,
+                    tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF)),
+                    k,
+                    accum_b2,
+                    issue_mma=bmm2_issue_epi,
+                )
+                accum_b2 = cutlass.Boolean(True)
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm2_done[parity_last_rt].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bars.mb_v_empty[kv_state_V.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bmm2_ready_phase_pair = bmm2_ready_phase_pair ^ (cutlass.Int32(1) << parity_last_rt)
+            kv_state_V = advance(kv_state_V, CFG.STAGES_KV)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(mb_decoded.subview(sched_state.idx), sched_state.phase)
+        payload_base = sched_state.idx * cutlass.Int32(SCHED_PAYLOAD_WORDS)
+        if cutlass.const_expr(CFG.MASK_FLAGS == 0 and SPLIT_KV == 1):
+            nxt_v = sched.tile_id_smem.subview(payload_base + cutlass.Int32(2)).load()
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+        else:
+            nxt_v = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(2)).load())
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+            kv_left = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(6)).load())
+            kv_right = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(9)).load())
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _softmax_warp_group(
+    softmax_half: cutlass.Constexpr[int],
+    seqlen_q,
+    seqlen_kv,
+    scale_log2: cutlass.Float32,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    mb_decoded,
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor,
+    seq_q_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    qh_per_kh,
+    leader_cta_id,
+    cta_in_pair,
+    bottom_right_diagonal: cutlass.Constexpr[bool],
+    softmax_exchange,
+    mb_softmax_max,
+):
+    nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    tmem_base = tmem_ptr_i32.load()
+
+    bmm1_done_phase_pair = cutlass.Int32(0)
+    softmax_max_phase_pair = cutlass.Int32(0)
+    stat_empty_phase = cutlass.Int32(1)
+    epilogue_state = cutlass.Int32(1)
+
+    NEG_INF = cutlass.Float32(float("-inf"))
+
+    q_super_idx, head_idx, batch_idx, split_idx = _decode_initial_split(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+
+    eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
+    bounds = _bounds_for_tile_split(
+        q_super_idx,
+        eff_seqlen_q,
+        eff_seqlen_kv,
+        cta_in_pair,
+        seq_q_lens_tensor,
+        batch_idx,
+        split_idx,
+        HEADS_PER_TILE,
+    )
+
+    softmax_wg_base = CFG.SOFTMAX_WG0_BASE if softmax_half == 0 else CFG.SOFTMAX_WG1_BASE
+    tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(softmax_wg_base * 32)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        total_max = NEG_INF
+        total_max_safe = NEG_INF
+        total_sum = cutlass.Vector.from_elements(
+            (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+            cutlass.Float32,
+        )
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
+        q_abs = q_row_coord + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
+        mask_q_abs = q_abs
+        mask_flags = CFG.MASK_FLAGS
+        if cutlass.const_expr(_PADDED_TOP_LEFT_CAUSAL):
+            mask_q_abs = cute.math.min(q_abs, eff_seqlen_kv - cutlass.Int32(1))
+            mask_flags = MASK_CAUSAL
+
+        if cutlass.const_expr(CFG.DTYPE_QKV != 1):
+            bars.mb_o_empty.wait(epilogue_state)
+        if cutlass.const_expr(softmax_half == 0):
+            bars.mb_stat_empty.wait(stat_empty_phase)
+            stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+        if cutlass.const_expr(CFG.DTYPE_QKV != 1):
+            epilogue_state = epilogue_state ^ cutlass.Int32(1)
+
+        CHUNK = 64
+        P_COLS_PER_CHUNK = CHUNK // 4
+        P_SUBCHUNK = 32
+        P_COLS_PER_SUBCHUNK = P_SUBCHUNK // 4
+        N_CHUNKS = CFG.N_BMM2_CHUNKS
+        RESCALE_THRESHOLD = cutlass.Float32(CFG.RESCALE_THRESHOLD)
+
+        if cutlass.const_expr(CFG.SOFTMAX_WARPGROUPS == 2):
+            split_hi = bounds.right if cutlass.const_expr(CFG.MASK_FLAGS == MASK_NONE) else bounds.unmasked_hi
+            for kv_loop in cutlass.range(bounds.left, split_hi, 1, unroll=1):
+                parity_rt = kv_loop & cutlass.Int32(1)
+                parity_is_even = parity_rt == cutlass.Int32(0)
+                s_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value())
+                )
+                p_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value())
+                )
+                bmm1_phase = (bmm1_done_phase_pair >> parity_rt) & cutlass.Int32(1)
+                bars.mb_bmm1_done[parity_rt].wait(bmm1_phase)
+                bmm1_done_phase_pair = bmm1_done_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+
+                s_addr_base = tmem_base + s_off_rt
+                p_addr_base = tmem_base + p_off_rt
+                stats_addr = tmem_base + s_off_rt
+
+                if cutlass.const_expr(softmax_half == 0):
+                    raw_hi = [
+                        nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(CHUNK), cutlass.Float32),
+                            num=32,
+                        ),
+                        nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(CHUNK + 32), cutlass.Float32),
+                            num=32,
+                        ),
+                    ]
+                    max_hi = row_max_reduction(RegTile(vec_concat(raw_hi), size=CHUNK).vec)
+                    raw_lo = [
+                        nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(s_addr_base, cutlass.Float32),
+                            num=32,
+                        ),
+                        nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(32), cutlass.Float32),
+                            num=32,
+                        ),
+                    ]
+                    reg_S_half = RegTile(vec_concat(raw_lo), size=CHUNK)
+                    current_max_unscaled = cute.math.max(
+                        row_max_reduction(reg_S_half.vec),
+                        max_hi,
+                        ftz=True,
+                    )
+                    current_max = current_max_unscaled * scale_log2
+                    update_cond = (current_max - total_max) > RESCALE_THRESHOLD
+                    total_max = cutlass.Float32(arith.select(update_cond.ir_value(), current_max.ir_value(), total_max.ir_value()))
+                    new_total_max_safe = total_max
+                    alpha = cute.math.exp2(
+                        cute.math.min(total_max_safe - new_total_max_safe, cutlass.Float32(0.0)),
+                        fastmath=True,
+                    )
+                    total_max_safe = new_total_max_safe
+                    exchange_base = parity_rt * cutlass.Int32(2 * CFG.TILE_M)
+                    softmax_exchange.subview(exchange_base + cutlass.Int32(CFG.TILE_M) + tid_in_wg).store(total_max_safe)
+                    mb_softmax_max[parity_rt].arrive()
+                else:
+                    reg_S_half = RegTile(
+                        nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(CHUNK), cutlass.Float32),
+                            num=CHUNK,
+                        ),
+                        size=CHUNK,
+                    )
+                if cutlass.const_expr(softmax_half == 1):
+                    softmax_max_phase = (softmax_max_phase_pair >> parity_rt) & cutlass.Int32(1)
+                    mb_softmax_max[parity_rt].wait(softmax_max_phase)
+                    softmax_max_phase_pair = softmax_max_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+                    exchange_base = parity_rt * cutlass.Int32(2 * CFG.TILE_M)
+                    new_total_max_safe = softmax_exchange.subview(exchange_base + cutlass.Int32(CFG.TILE_M) + tid_in_wg).load()
+                    alpha = cute.math.exp2(
+                        cute.math.min(total_max_safe - new_total_max_safe, cutlass.Float32(0.0)),
+                        fastmath=True,
+                    )
+                    total_max_safe = new_total_max_safe
+
+                if cutlass.const_expr(softmax_half == 0):
+                    if cutlass.const_expr(_SMEM_ALPHA_HANDOFF):
+                        alpha_idx = parity_rt * cutlass.Int32(2 * CFG.TILE_M) + tid_in_wg
+                        softmax_exchange.subview(alpha_idx).store(alpha)
+                    else:
+                        alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+                        nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                    _stat_arrive(bars.mb_stat_full, _STAT_FULL_WARP_ARRIVALS)
+
+                if cutlass.const_expr(CFG.DTYPE_QKV == 0):
+                    scale_vec = cutlass.vector.full_like(reg_S_half.vec, scale_log2)
+                    minus_max_vec = cutlass.vector.full_like(reg_S_half.vec, cutlass.Float32(0.0) - total_max_safe)
+                    reg_S_half = RegTile(
+                        nvvm.fma_packed_f32x2(reg_S_half.vec, scale_vec, minus_max_vec, rnd="rn", ftz=False),
+                        size=CHUNK,
+                    )
+                elif cutlass.const_expr(softmax_half == 0):
+                    reg_S_half = reg_S_half * scale_log2 - total_max_safe
+                else:
+                    # Device-resident FP8 descales lower to a regular register.
+                    # Keep the multiply adjacent to the subtract so PTXAS can
+                    # emit FFMA2 instead of a separate FMUL2/FADD2 pair.
+                    reg_S_half = scale_log2 * reg_S_half - total_max_safe
+                chunk_P_a = _exp2_dense_chunk_a(reg_S_half[0:P_SUBCHUNK].vec, softmax_half)
+                new_p_sum_pair = row_reduction_pair(chunk_P_a)
+                nvvm.tcgen05_st(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(
+                        p_addr_base + cutlass.Int32(softmax_half * P_COLS_PER_CHUNK),
+                        cutlass.Float32,
+                    ),
+                    chunk_P_a.to(STORAGE_DTYPE),
+                )
+                chunk_P_b = _exp2_dense_chunk_b(reg_S_half[P_SUBCHUNK:CHUNK].vec, softmax_half)
+                new_p_sum_pair = new_p_sum_pair + row_reduction_pair(chunk_P_b)
+                nvvm.tcgen05_st(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(
+                        p_addr_base + cutlass.Int32(softmax_half * P_COLS_PER_CHUNK + P_COLS_PER_SUBCHUNK),
+                        cutlass.Float32,
+                    ),
+                    chunk_P_b.to(STORAGE_DTYPE),
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(softmax_half)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+                total_sum = total_sum * alpha_pair + new_p_sum_pair
+
+                if cutlass.const_expr(softmax_half == 0):
+                    bars.mb_stat_empty.wait(stat_empty_phase)
+                    stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+
+            if cutlass.const_expr(CFG.MASK_FLAGS != MASK_NONE):
+                for kv_loop in cutlass.range(bounds.unmasked_hi, bounds.right, 1, unroll=1):
+                    parity_rt = kv_loop & cutlass.Int32(1)
+                    parity_is_even = parity_rt == cutlass.Int32(0)
+                    s_off_rt = cutlass.Int32(
+                        arith.select(
+                            parity_is_even.ir_value(),
+                            cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(),
+                            cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value(),
+                        )
+                    )
+                    p_off_rt = cutlass.Int32(
+                        arith.select(
+                            parity_is_even.ir_value(),
+                            cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(),
+                            cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value(),
+                        )
+                    )
+                    bmm1_phase = (bmm1_done_phase_pair >> parity_rt) & cutlass.Int32(1)
+                    bars.mb_bmm1_done[parity_rt].wait(bmm1_phase)
+                    bmm1_done_phase_pair = bmm1_done_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+
+                    s_addr_base = tmem_base + s_off_rt
+                    p_addr_base = tmem_base + p_off_rt
+                    stats_addr = tmem_base + s_off_rt
+                    kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+
+                    if cutlass.const_expr(bottom_right_diagonal):
+                        mask_bottom_right = 0
+                        causal_diag = None
+                    else:
+                        mask_bottom_right = CFG.BOTTOM_RIGHT
+                        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+
+                    if cutlass.const_expr(softmax_half == 0):
+                        raw_chunks = [
+                            nvvm.tcgen05_ld(
+                                "32x32b",
+                                nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32),
+                                num=CHUNK,
+                            )
+                            for c in range(N_CHUNKS)
+                        ]
+                        chunks_S = [
+                            apply_mask_chunk(
+                                raw_chunks[c],
+                                mask_q_abs - (kv_col_base + cutlass.Int32(c * CHUNK)),
+                                cutlass.Int32(0),
+                                eff_seqlen_kv - (kv_col_base + cutlass.Int32(c * CHUNK)),
+                                CFG.WINDOW_LEFT,
+                                mask_flags,
+                                N=CHUNK,
+                                bottom_right=mask_bottom_right,
+                                causal_diag=causal_diag,
+                                window_right=CFG.WINDOW_RIGHT,
+                                mask_value=float("-inf"),
+                            )
+                            for c in range(N_CHUNKS)
+                        ]
+                        reg_S_full = RegTile(vec_concat(chunks_S), size=CFG.TILE_N)
+                        current_max_unscaled = cute.math.max(
+                            row_max_reduction(reg_S_full[0:CHUNK].vec),
+                            row_max_reduction(reg_S_full[CHUNK : 2 * CHUNK].vec),
+                            ftz=True,
+                        )
+                        current_max = current_max_unscaled * scale_log2
+                        update_cond = (current_max - total_max) > RESCALE_THRESHOLD
+                        total_max = cutlass.Float32(arith.select(update_cond.ir_value(), current_max.ir_value(), total_max.ir_value()))
+                        new_total_max_safe = row_max_for_exp2(total_max)
+                        alpha = _exp2_masked_alpha(cute.math.min(total_max_safe - new_total_max_safe, cutlass.Float32(0.0)))
+                        total_max_safe = new_total_max_safe
+                        reg_S_half = reg_S_full[0:CHUNK]
+
+                        exchange_base = parity_rt * cutlass.Int32(2 * CFG.TILE_M)
+                        softmax_exchange.subview(exchange_base + cutlass.Int32(CFG.TILE_M) + tid_in_wg).store(total_max_safe)
+                        mb_softmax_max[parity_rt].arrive()
+                    else:
+                        raw_chunk = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(CHUNK), cutlass.Float32),
+                            num=CHUNK,
+                        )
+                        masked_chunk = apply_mask_chunk(
+                            raw_chunk,
+                            mask_q_abs - (kv_col_base + cutlass.Int32(CHUNK)),
+                            cutlass.Int32(0),
+                            eff_seqlen_kv - (kv_col_base + cutlass.Int32(CHUNK)),
+                            CFG.WINDOW_LEFT,
+                            mask_flags,
+                            N=CHUNK,
+                            bottom_right=mask_bottom_right,
+                            causal_diag=causal_diag,
+                            window_right=CFG.WINDOW_RIGHT,
+                            mask_value=float("-inf"),
+                        )
+                        reg_S_half = RegTile(masked_chunk, size=CHUNK)
+
+                    if cutlass.const_expr(softmax_half == 1):
+                        softmax_max_phase = (softmax_max_phase_pair >> parity_rt) & cutlass.Int32(1)
+                        mb_softmax_max[parity_rt].wait(softmax_max_phase)
+                        softmax_max_phase_pair = softmax_max_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+                        exchange_base = parity_rt * cutlass.Int32(2 * CFG.TILE_M)
+                        new_total_max_safe = softmax_exchange.subview(exchange_base + cutlass.Int32(CFG.TILE_M) + tid_in_wg).load()
+                        alpha = _exp2_masked_alpha(cute.math.min(total_max_safe - new_total_max_safe, cutlass.Float32(0.0)))
+                        total_max_safe = new_total_max_safe
+
+                    if cutlass.const_expr(softmax_half == 0):
+                        if cutlass.const_expr(_SMEM_ALPHA_HANDOFF):
+                            alpha_idx = parity_rt * cutlass.Int32(2 * CFG.TILE_M) + tid_in_wg
+                            softmax_exchange.subview(alpha_idx).store(alpha)
+                        else:
+                            alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+                            nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+                            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                        _stat_arrive(bars.mb_stat_full, _STAT_FULL_WARP_ARRIVALS)
+
+                    reg_S_half = reg_S_half * scale_log2 - total_max_safe
+                    if cutlass.const_expr(_SMEM_ALPHA_HANDOFF):
+                        chunk_P_a = _exp2_masked_tail_chunk_a(reg_S_half[0:P_SUBCHUNK].vec, softmax_half)
+                    else:
+                        chunk_P_a = cute.math.exp2(reg_S_half[0:P_SUBCHUNK].vec, fastmath=True)
+                    new_p_sum_pair = row_reduction_pair(chunk_P_a)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(
+                            p_addr_base + cutlass.Int32(softmax_half * P_COLS_PER_CHUNK),
+                            cutlass.Float32,
+                        ),
+                        chunk_P_a.to(STORAGE_DTYPE),
+                    )
+                    chunk_P_b = cute.math.exp2(reg_S_half[P_SUBCHUNK:CHUNK].vec, fastmath=True)
+                    new_p_sum_pair = new_p_sum_pair + row_reduction_pair(chunk_P_b)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(
+                            p_addr_base + cutlass.Int32(softmax_half * P_COLS_PER_CHUNK + P_COLS_PER_SUBCHUNK),
+                            cutlass.Float32,
+                        ),
+                        chunk_P_b.to(STORAGE_DTYPE),
+                    )
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                    bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(softmax_half)].arrive(
+                        leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA
+                    )
+
+                    alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+                    total_sum = total_sum * alpha_pair + new_p_sum_pair
+
+                    if cutlass.const_expr(softmax_half == 0):
+                        bars.mb_stat_empty.wait(stat_empty_phase)
+                        stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+        else:
+            # Exact top-left causal has no lower masking boundary.
+            left_edge_end = (
+                bounds.left if cutlass.const_expr(CFG.MASK_FLAGS == MASK_CAUSAL and (CFG.BOTTOM_RIGHT == 0 or bottom_right_diagonal)) else bounds.unmasked_lo
+            )
+            for kv_loop in cutlass.range(bounds.left, left_edge_end, 1, unroll=1):
+                parity_rt = kv_loop & cutlass.Int32(1)
+                parity_is_even = parity_rt == cutlass.Int32(0)
+                s_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value())
+                )
+                p_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value())
+                )
+                bmm1_phase = (bmm1_done_phase_pair >> parity_rt) & cutlass.Int32(1)
+                bars.mb_bmm1_done[parity_rt].wait(bmm1_phase)
+                bmm1_done_phase_pair = bmm1_done_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+                s_addr_base = tmem_base + s_off_rt
+                p_addr_base = tmem_base + p_off_rt
+                stats_addr = tmem_base + s_off_rt
+                kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+                raw_chunks = [
+                    nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32), num=CHUNK) for c in range(N_CHUNKS)
+                ]
+                if cutlass.const_expr(bottom_right_diagonal):
+                    mask_bottom_right = 0
+                    causal_diag = None
+                else:
+                    mask_bottom_right = CFG.BOTTOM_RIGHT
+                    causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+                chunks_S = [
+                    apply_mask_chunk(
+                        raw_chunks[c],
+                        mask_q_abs - (kv_col_base + cutlass.Int32(c * CHUNK)),
+                        cutlass.Int32(0),
+                        eff_seqlen_kv - (kv_col_base + cutlass.Int32(c * CHUNK)),
+                        CFG.WINDOW_LEFT,
+                        mask_flags,
+                        N=CHUNK,
+                        bottom_right=mask_bottom_right,
+                        causal_diag=causal_diag,
+                        window_right=CFG.WINDOW_RIGHT,
+                        mask_value=float("-inf"),
+                    )
+                    for c in range(N_CHUNKS)
+                ]
+                reg_S_vec = vec_concat(chunks_S)
+                current_max_unscaled = row_max_reduction(reg_S_vec)
+                reg_S = RegTile(reg_S_vec, size=CFG.TILE_N)
+                current_max = current_max_unscaled * scale_log2  # -inf when the whole iteration is masked
+
+                # total_max starts at -inf: a live iteration always clears the
+                # threshold (real - (-inf) = +inf), a fully-masked one never does
+                # (-inf - x = -inf or NaN; ordered > is false for both).
+                update_cond = (current_max - total_max) > RESCALE_THRESHOLD
+                total_max = cutlass.Float32(arith.select(update_cond.ir_value(), current_max.ir_value(), total_max.ir_value()))
+                # Canonical 0-substitution at point of use, on BOTH alpha operands;
+                # min(., 0) guards the dead->alive drop of the safe max (total_sum
+                # is still 0 there).  total_max_safe starts at -inf: iter-0 alpha = 0.
+                new_total_max_safe = row_max_for_exp2(total_max)
+                alpha = _exp2_masked_alpha(cute.math.min(total_max_safe - new_total_max_safe, cutlass.Float32(0.0)))
+                total_max_safe = new_total_max_safe
+                alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                _stat_arrive(bars.mb_stat_full, _STAT_FULL_WARP_ARRIVALS)
+                reg_S = reg_S * scale_log2 - total_max_safe
+
+                chunk_P_0a = cute.math.exp2(reg_S[0:P_SUBCHUNK].vec, fastmath=True)
+                hoisted_sum = row_reduction_pair(chunk_P_0a)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32), chunk_P_0a.to(STORAGE_DTYPE))
+                chunk_P_0b = cute.math.exp2(reg_S[P_SUBCHUNK:CHUNK].vec, fastmath=True)
+                hoisted_sum = hoisted_sum + row_reduction_pair(chunk_P_0b)
+                nvvm.tcgen05_st(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_SUBCHUNK), cutlass.Float32),
+                    chunk_P_0b.to(STORAGE_DTYPE),
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(0)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                deferred_sum_1 = None
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    chunk_P_1a = cute.math.exp2(reg_S[CHUNK : CHUNK + P_SUBCHUNK].vec, fastmath=True)
+                    deferred_sum_1 = row_reduction_pair(chunk_P_1a)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK), cutlass.Float32),
+                        chunk_P_1a.to(STORAGE_DTYPE),
+                    )
+                    chunk_P_1b = cute.math.exp2(reg_S[CHUNK + P_SUBCHUNK : 2 * CHUNK].vec, fastmath=True)
+                    deferred_sum_1 = deferred_sum_1 + row_reduction_pair(chunk_P_1b)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK + P_COLS_PER_SUBCHUNK), cutlass.Float32),
+                        chunk_P_1b.to(STORAGE_DTYPE),
+                    )
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                    bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(1)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                new_p_sum_pair = hoisted_sum
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    new_p_sum_pair = new_p_sum_pair + deferred_sum_1
+                alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+                total_sum = total_sum * alpha_pair + new_p_sum_pair
+                bars.mb_stat_empty.wait(stat_empty_phase)
+                stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+            for kv_loop in cutlass.range(bounds.unmasked_lo, bounds.unmasked_hi, 1, unroll=1):
+                parity_rt = kv_loop & cutlass.Int32(1)
+                parity_is_even = parity_rt == cutlass.Int32(0)
+                s_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value())
+                )
+                p_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value())
+                )
+                bmm1_phase = (bmm1_done_phase_pair >> parity_rt) & cutlass.Int32(1)
+                bars.mb_bmm1_done[parity_rt].wait(bmm1_phase)
+                bmm1_done_phase_pair = bmm1_done_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+                s_addr_base = tmem_base + s_off_rt
+                p_addr_base = tmem_base + p_off_rt
+                stats_addr = tmem_base + s_off_rt
+                if cutlass.const_expr(CFG.DTYPE_QKV == 1 or (CFG.DTYPE_QKV == 0 and CFG.MASK_FLAGS == MASK_CAUSAL and CFG.BOTTOM_RIGHT == 0)):
+                    raw_chunks = [
+                        nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_base, cutlass.Float32), num=32),
+                        nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(32), cutlass.Float32), num=32),
+                        nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(64), cutlass.Float32), num=64),
+                    ]
+                else:
+                    unmasked_chunk = 32
+                    raw_chunks = [
+                        nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * unmasked_chunk), cutlass.Float32),
+                            num=unmasked_chunk,
+                        )
+                        for c in range(CFG.TILE_N // unmasked_chunk)
+                    ]
+                reg_S_vec = vec_concat(raw_chunks)
+                current_max_unscaled = row_max_reduction(reg_S_vec)
+                reg_S = RegTile(reg_S_vec, size=CFG.TILE_N)
+                current_max = current_max_unscaled * scale_log2  # -inf when the whole iteration is masked
+
+                # total_max starts at -inf: a live iteration always clears the
+                # threshold (real - (-inf) = +inf), a fully-masked one never does
+                # (-inf - x = -inf or NaN; ordered > is false for both).
+                update_cond = (current_max - total_max) > RESCALE_THRESHOLD
+                total_max = cutlass.Float32(arith.select(update_cond.ir_value(), current_max.ir_value(), total_max.ir_value()))
+                # Every row in this interior tile is live, so the updated
+                # total_max is finite even if all preceding edge tiles were dead.
+                new_total_max_safe = total_max
+                alpha = _exp2_masked_alpha(cute.math.min(total_max_safe - new_total_max_safe, cutlass.Float32(0.0)))
+                total_max_safe = new_total_max_safe
+                alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                _stat_arrive(bars.mb_stat_full, _STAT_FULL_WARP_ARRIVALS)
+                reg_S = reg_S * scale_log2 - total_max_safe
+
+                chunk_P_0a = _exp2_dense_chunk_a(reg_S[0:P_SUBCHUNK].vec, 0)
+                if cutlass.const_expr(_E5_STYLE_SOFTMAX and CFG.MASK_FLAGS == MASK_CAUSAL and CFG.BOTTOM_RIGHT == 0):
+                    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32), chunk_P_0a.to(STORAGE_DTYPE))
+                    hoisted_sum = row_reduction_pair(chunk_P_0a)
+                else:
+                    hoisted_sum = row_reduction_pair(chunk_P_0a)
+                    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32), chunk_P_0a.to(STORAGE_DTYPE))
+                chunk_P_0b = _exp2_dense_chunk_b(reg_S[P_SUBCHUNK:CHUNK].vec, 3)
+                if cutlass.const_expr(_E5_STYLE_SOFTMAX and CFG.MASK_FLAGS == MASK_CAUSAL and CFG.BOTTOM_RIGHT == 0):
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_SUBCHUNK), cutlass.Float32),
+                        chunk_P_0b.to(STORAGE_DTYPE),
+                    )
+                    hoisted_sum = hoisted_sum + row_reduction_pair(chunk_P_0b)
+                else:
+                    hoisted_sum = hoisted_sum + row_reduction_pair(chunk_P_0b)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_SUBCHUNK), cutlass.Float32),
+                        chunk_P_0b.to(STORAGE_DTYPE),
+                    )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(0)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                deferred_sum_1 = None
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    chunk_P_1a = _exp2_dense_chunk_a(reg_S[CHUNK : CHUNK + P_SUBCHUNK].vec, 0)
+                    deferred_sum_1 = row_reduction_pair(chunk_P_1a)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK), cutlass.Float32),
+                        chunk_P_1a.to(STORAGE_DTYPE),
+                    )
+                    chunk_P_1b = _exp2_dense_chunk_b(reg_S[CHUNK + P_SUBCHUNK : 2 * CHUNK].vec, 2)
+                    deferred_sum_1 = deferred_sum_1 + row_reduction_pair(chunk_P_1b)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK + P_COLS_PER_SUBCHUNK), cutlass.Float32),
+                        chunk_P_1b.to(STORAGE_DTYPE),
+                    )
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                    bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(1)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                new_p_sum_pair = hoisted_sum
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    new_p_sum_pair = new_p_sum_pair + deferred_sum_1
+                alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+                total_sum = total_sum * alpha_pair + new_p_sum_pair
+                bars.mb_stat_empty.wait(stat_empty_phase)
+                stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+            for kv_loop in cutlass.range(bounds.unmasked_hi, bounds.right, 1, unroll=1):
+                parity_rt = kv_loop & cutlass.Int32(1)
+                parity_is_even = parity_rt == cutlass.Int32(0)
+                s_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value())
+                )
+                p_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value())
+                )
+                bmm1_phase = (bmm1_done_phase_pair >> parity_rt) & cutlass.Int32(1)
+                bars.mb_bmm1_done[parity_rt].wait(bmm1_phase)
+                bmm1_done_phase_pair = bmm1_done_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+                s_addr_base = tmem_base + s_off_rt
+                p_addr_base = tmem_base + p_off_rt
+                stats_addr = tmem_base + s_off_rt
+                kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+                raw_chunks = [
+                    nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32), num=CHUNK) for c in range(N_CHUNKS)
+                ]
+                if cutlass.const_expr(bottom_right_diagonal):
+                    mask_bottom_right = 0
+                    causal_diag = None
+                else:
+                    mask_bottom_right = CFG.BOTTOM_RIGHT
+                    causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+                chunks_S = [
+                    apply_mask_chunk(
+                        raw_chunks[c],
+                        mask_q_abs - (kv_col_base + cutlass.Int32(c * CHUNK)),
+                        cutlass.Int32(0),
+                        eff_seqlen_kv - (kv_col_base + cutlass.Int32(c * CHUNK)),
+                        CFG.WINDOW_LEFT,
+                        mask_flags,
+                        N=CHUNK,
+                        bottom_right=mask_bottom_right,
+                        causal_diag=causal_diag,
+                        window_right=CFG.WINDOW_RIGHT,
+                        mask_value=float("-inf"),
+                    )
+                    for c in range(N_CHUNKS)
+                ]
+                reg_S_vec = vec_concat(chunks_S)
+                current_max_unscaled = row_max_reduction(reg_S_vec)
+                reg_S = RegTile(reg_S_vec, size=CFG.TILE_N)
+                current_max = current_max_unscaled * scale_log2  # -inf when the whole iteration is masked
+
+                # total_max starts at -inf: a live iteration always clears the
+                # threshold (real - (-inf) = +inf), a fully-masked one never does
+                # (-inf - x = -inf or NaN; ordered > is false for both).
+                update_cond = (current_max - total_max) > RESCALE_THRESHOLD
+                total_max = cutlass.Float32(arith.select(update_cond.ir_value(), current_max.ir_value(), total_max.ir_value()))
+                # Canonical 0-substitution at point of use, on BOTH alpha operands;
+                # min(., 0) guards the dead->alive drop of the safe max (total_sum
+                # is still 0 there).  total_max_safe starts at -inf: iter-0 alpha = 0.
+                new_total_max_safe = row_max_for_exp2(total_max)
+                alpha = _exp2_masked_alpha(cute.math.min(total_max_safe - new_total_max_safe, cutlass.Float32(0.0)))
+                total_max_safe = new_total_max_safe
+                alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                _stat_arrive(bars.mb_stat_full, _STAT_FULL_WARP_ARRIVALS)
+                reg_S = reg_S * scale_log2 - total_max_safe
+
+                chunk_P_0a = cute.math.exp2(reg_S[0:P_SUBCHUNK].vec, fastmath=True)
+                hoisted_sum = row_reduction_pair(chunk_P_0a)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32), chunk_P_0a.to(STORAGE_DTYPE))
+                chunk_P_0b = cute.math.exp2(reg_S[P_SUBCHUNK:CHUNK].vec, fastmath=True)
+                hoisted_sum = hoisted_sum + row_reduction_pair(chunk_P_0b)
+                nvvm.tcgen05_st(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_SUBCHUNK), cutlass.Float32),
+                    chunk_P_0b.to(STORAGE_DTYPE),
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(0)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                deferred_sum_1 = None
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    chunk_P_1a = cute.math.exp2(reg_S[CHUNK : CHUNK + P_SUBCHUNK].vec, fastmath=True)
+                    deferred_sum_1 = row_reduction_pair(chunk_P_1a)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK), cutlass.Float32),
+                        chunk_P_1a.to(STORAGE_DTYPE),
+                    )
+                    chunk_P_1b = cute.math.exp2(reg_S[CHUNK + P_SUBCHUNK : 2 * CHUNK].vec, fastmath=True)
+                    deferred_sum_1 = deferred_sum_1 + row_reduction_pair(chunk_P_1b)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK + P_COLS_PER_SUBCHUNK), cutlass.Float32),
+                        chunk_P_1b.to(STORAGE_DTYPE),
+                    )
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                    bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(1)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                new_p_sum_pair = hoisted_sum
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    new_p_sum_pair = new_p_sum_pair + deferred_sum_1
+                alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+                total_sum = total_sum * alpha_pair + new_p_sum_pair
+                bars.mb_stat_empty.wait(stat_empty_phase)
+                stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+
+        total_sum_scalar = total_sum[0] + total_sum[1]
+        if cutlass.const_expr(CFG.SOFTMAX_WARPGROUPS == 2):
+            tail_idx = cutlass.Int32(4 * CFG.TILE_M + softmax_half * CFG.TILE_M) + tid_in_wg
+            peer_tail_idx = cutlass.Int32(4 * CFG.TILE_M + (1 - softmax_half) * CFG.TILE_M) + tid_in_wg
+            softmax_exchange.subview(tail_idx).store(total_sum_scalar)
+            nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
+            total_sum_scalar = total_sum_scalar + softmax_exchange.subview(peer_tail_idx).load()
+            nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
+
+        if cutlass.const_expr(softmax_half == 0):
+            stats_addr_epi = tmem_base + cutlass.Int32(LAYOUT.STATS_EPI_OFF)
+            stats_vec_epi = cutlass.Vector.from_elements((total_max_safe, total_sum_scalar), cutlass.Float32)
+            nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr_epi, cutlass.Float32), stats_vec_epi)
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+            _stat_arrive(bars.mb_stat_full, _STAT_FULL_WARP_ARRIVALS)
+
+        wait(mb_decoded.subview(sched_state.idx), sched_state.phase)
+        payload_base = sched_state.idx * cutlass.Int32(SCHED_PAYLOAD_WORDS)
+        nxt_v = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(2)).load())
+        q_super_idx = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(3)).load())
+        batch_idx = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(5)).load())
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0 or SPLIT_KV > 1):
+            bounds = KvLoopBounds(
+                left=cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(6)).load()),
+                unmasked_lo=cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(7)).load()),
+                unmasked_hi=cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(8)).load()),
+                right=cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(9)).load()),
+            )
+
+
+@cute.jit
+def _correction_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    sO,
+    tmem_ptr_i32,
+    tidx,
+    bars,
+    sched,
+    mb_decoded,
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor,
+    seq_q_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    qh_per_kh,
+    leader_cta_id,
+    cta_in_pair,
+    cta_id_x,
+    bottom_right_diagonal: cutlass.Constexpr[bool],
+    o_scale_fused,
+    amax_o_tensor,
+    softmax_exchange,
+):
+    nvvm.barrier_cta_sync(barrier_id=2, thread_count=32 * (CFG.CORRECTION_WARPS + 1))
+    tmem_base_corr = tmem_ptr_i32.load()
+
+    tid_raw = cute.arch.thread_idx()[0]
+    tid_in_wg = tid_raw - cutlass.Int32(CFG.CORR_WARP_BASE * 32)
+
+    bmm2_done_phase_pair = cutlass.Int32(0)
+    stat_mbar_state = cutlass.Int32(0)
+    epilogue_state = cutlass.Int32(1)
+
+    q_super_idx, head_idx, batch_idx, split_idx = _decode_initial_split(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+
+    eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
+    bounds = _bounds_for_tile_split(
+        q_super_idx,
+        eff_seqlen_q,
+        eff_seqlen_kv,
+        cta_in_pair,
+        seq_q_lens_tensor,
+        batch_idx,
+        split_idx,
+        HEADS_PER_TILE,
+    )
+
+    O_CHUNK = 16
+    N_CHUNKS_O = CFG.TILE_O // O_CHUNK
+    TMA_O_ITERS_LOCAL = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
+    D_BLOCK_SIZE = CFG.TILE_O // TMA_O_ITERS_LOCAL
+    TMA_O_GRANU_ELEMS_LOCAL = CFG.TILE_M * D_BLOCK_SIZE
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if bounds.right > bounds.left:
+            lo_parity_rt = bounds.left & cutlass.Int32(1)
+            bars.mb_bmm2_ready[lo_parity_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+            bars.mb_stat_full.wait(stat_mbar_state)
+            _stat_arrive(bars.mb_stat_empty, _STAT_EMPTY_WARP_ARRIVALS)
+            stat_mbar_state = stat_mbar_state ^ cutlass.Int32(1)
+        else:
+            bars.mb_empty_mainloop.arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+        for kv_loop in cutlass.range(bounds.left + cutlass.Int32(1), bounds.right, 1, unroll=1):
+            parity_prev_rt = (kv_loop - cutlass.Int32(1)) & cutlass.Int32(1)
+            parity_cur_rt = kv_loop & cutlass.Int32(1)
+            tmem_base_iter = tmem_base_corr
+
+            bars.mb_stat_full.wait(stat_mbar_state)
+
+            if cutlass.const_expr(_SMEM_ALPHA_HANDOFF):
+                alpha_idx = parity_cur_rt * cutlass.Int32(2 * CFG.TILE_M) + tid_in_wg
+                alpha = softmax_exchange.subview(alpha_idx).load()
+            else:
+                stats_off_cur = cutlass.Int32(
+                    arith.select(
+                        (parity_cur_rt == cutlass.Int32(0)).ir_value(),
+                        cutlass.Int32(LAYOUT.STATS_EVEN_OFF).ir_value(),
+                        cutlass.Int32(LAYOUT.STATS_ODD_OFF).ir_value(),
+                    )
+                )
+                stats_addr = tmem_base_iter + stats_off_cur
+                stats_vec = nvvm.tcgen05_ld(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(stats_addr, cutlass.Float32),
+                    num=2,
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                alpha = stats_vec[0]
+
+            alpha_is_one = alpha == cutlass.Float32(1.0)
+            all_alpha_one = vote_sync(0xFFFFFFFF, alpha_is_one, VoteSync.ALL)
+
+            _stat_arrive(bars.mb_stat_empty, _STAT_EMPTY_WARP_ARRIVALS)
+
+            bmm2_done_phase_prev = (bmm2_done_phase_pair >> parity_prev_rt) & cutlass.Int32(1)
+            # Each iteration must consume its BMM2 phase before O can be reused.
+            bars.mb_bmm2_done[parity_prev_rt].wait(bmm2_done_phase_prev)
+
+            if ~all_alpha_one:
+                for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                    o_addr = tmem_base_iter + cutlass.Int32(LAYOUT.O_OFF + chunk_idx * O_CHUNK)
+                    o_chunk = nvvm.tcgen05_ld(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                        num=O_CHUNK,
+                    )
+                    o_scaled = vec_scale_pair(o_chunk, alpha, O_CHUNK)
+                    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(o_addr, cutlass.Float32), o_scaled)
+                if cutlass.const_expr(_RARE_RESCALE_CORRECTION):
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+            if cutlass.const_expr(not _RARE_RESCALE_CORRECTION):
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+
+            bars.mb_bmm2_ready[parity_cur_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+            bmm2_done_phase_pair = bmm2_done_phase_pair ^ (cutlass.Int32(1) << parity_prev_rt)
+            stat_mbar_state = stat_mbar_state ^ cutlass.Int32(1)
+
+        tmem_base_epi = tmem_base_corr
+
+        total_max_scaled = cutlass.Float32(0.0)
+        total_sum = cutlass.Float32(0.0)
+        # UNCONDITIONAL epilogue stat handshake (mirrors d128): the softmax group
+        # publishes its epilogue stats every tile — including empty/inverted KV
+        # ranges from compute_kv_loop_bounds (SWA window past the padded KV tail).
+        # Guarding this behind right > left desyncs the mb_stat_full/mb_stat_empty
+        # phase counts and the next tile's softmax wait spins forever (the
+        # rectangular causal+SWA+padding hang). On an empty tile the published
+        # stats are the reset values (max=-inf, sum=0) and the dead-row override
+        # below emits O=0 / LSE=-inf.
+        bars.mb_stat_full.wait(stat_mbar_state)
+        stats_addr_epi = tmem_base_epi + cutlass.Int32(LAYOUT.STATS_EPI_OFF)
+        stats_vec_epi = nvvm.tcgen05_ld(
+            "32x32b",
+            nvvm.make_tmem_ptr(stats_addr_epi, cutlass.Float32),
+            num=2,
+        )
+        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+        total_max_scaled = stats_vec_epi[0]
+        total_sum = stats_vec_epi[1]
+        _stat_arrive(bars.mb_stat_empty, _STAT_EMPTY_WARP_ARRIVALS)
+        stat_mbar_state = stat_mbar_state ^ cutlass.Int32(1)
+
+        LN2 = cutlass.Float32(0.6931471805599453)
+        total_max_nat = total_max_scaled * LN2
+        lse_val = cutlass.Float32(0.0)
+        inv_sum = cutlass.Float32(0.0)
+        beta = cutlass.Float32(0.0)
+        q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
+        row_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE) + (tid_in_wg % cutlass.Int32(HEADS_PER_TILE))
+        row_dead = total_sum <= cutlass.Float32(0.0)
+        if cutlass.const_expr(CFG.HAS_SINK):
+            sinks_arr = cutlass.make_array_view(sinks_tensor)
+            sink_logit = sinks_arr[row_head_idx]
+            new_max = cute.math.max(total_max_nat, sink_logit)
+            scale = cute.math.exp(total_max_nat - new_max, fastmath=True)
+            new_sum = total_sum * scale + cute.math.exp(sink_logit - new_max, fastmath=True)
+            lse_val = new_max + cute.math.log(new_sum, fastmath=True)
+            beta = scale / new_sum
+            inv_sum = beta * o_scale_fused
+        else:
+            lse_val = total_max_nat + cute.math.log(cute.math.max(total_sum, cutlass.Float32(1e-30)), fastmath=True)
+            beta = cutlass.Float32(1.0) / cute.math.max(total_sum, cutlass.Float32(1e-30))
+            inv_sum = beta * o_scale_fused
+            # Dead row (no valid KV column, incl. empty tiles where total_sum defaults 0):
+            #   O := 0, LSE := -inf. total_sum >= 1 for any alive row so this never fires
+            #   spuriously. Skipped under sink (the sink path defines a finite LSE).
+            neg_inf_lse = cutlass.Float32(float("-inf"))
+            lse_val = cutlass.Float32(arith.select(row_dead.ir_value(), neg_inf_lse.ir_value(), lse_val.ir_value()))
+            inv_sum = cutlass.Float32(arith.select(row_dead.ir_value(), cutlass.Float32(0.0).ir_value(), inv_sum.ir_value()))
+            beta = cutlass.Float32(arith.select(row_dead.ir_value(), cutlass.Float32(0.0).ir_value(), beta.ir_value()))
+
+        if cutlass.const_expr(CFG.SEQ_Q_LENS_PRESENT):
+            # Dense padded-Q trim (cuDNN >= 9.14): q rows >= seq_len_q[b] write
+            # O := 0 / LSE := -inf.  Applied AFTER the sink branch on purpose —
+            # a trimmed row is dead even with a sink.  Per-batch q lens come in
+            # via the dedicated seq_q_lens_tensor parameter.
+            _sq_arr = cutlass.make_array_view(seq_q_lens_tensor)
+            _q_len_b = cutlass.Int32(_sq_arr[batch_idx])
+            row_trim = q_row_global >= _q_len_b
+            neg_inf_trim = cutlass.Float32(float("-inf"))
+            lse_val = cutlass.Float32(arith.select(row_trim.ir_value(), neg_inf_trim.ir_value(), lse_val.ir_value()))
+            inv_sum = cutlass.Float32(arith.select(row_trim.ir_value(), cutlass.Float32(0.0).ir_value(), inv_sum.ir_value()))
+            beta = cutlass.Float32(arith.select(row_trim.ir_value(), cutlass.Float32(0.0).ir_value(), beta.ir_value()))
+
+        if cutlass.const_expr(CFG.THD_VARLEN):
+            cu = cutlass.make_array_view(seq_kv_lens_tensor)
+            cu_q_b = cutlass.Int32(cu[n_batch + batch_idx])
+            s_q_b = cutlass.Int32(cu[n_batch + batch_idx + cutlass.Int32(1)]) - cu_q_b
+            _row_valid = q_row_global < s_q_b
+            if cutlass.const_expr(lse_tensor is not None):
+                if _row_valid:
+                    lse_arr = cutlass.make_array_view(lse_tensor)
+                    if cutlass.const_expr(len(lse_tensor.shape) == 2):
+                        lse_arr[cu_q_b + q_row_global, row_head_idx] = lse_val
+                    else:
+                        lse_arr[cutlass.Int32(0), row_head_idx, cu_q_b + q_row_global] = lse_val
+        else:
+            _row_valid = q_row_global < seqlen_q
+            if cutlass.const_expr(lse_tensor is not None):
+                if _row_valid:
+                    lse_arr = cutlass.make_array_view(lse_tensor)
+                    lse_batch = _partial_batch(batch_idx, split_idx, n_batch)
+                    lse_arr[lse_batch, row_head_idx, q_row_global] = lse_val
+
+        parity_last_rt = cutlass.Int32(0)
+        if bounds.right > bounds.left:
+            parity_last_rt = (bounds.right - cutlass.Int32(1)) & cutlass.Int32(1)
+        bmm2_done_phase_last = (bmm2_done_phase_pair >> parity_last_rt) & cutlass.Int32(1)
+        bars.mb_bmm2_done[parity_last_rt].wait(bmm2_done_phase_last)
+        bmm2_done_phase_pair = bmm2_done_phase_pair ^ (cutlass.Int32(1) << parity_last_rt)
+
+        if cutlass.const_expr(_PADDED_TOP_LEFT_CAUSAL):
+            if bounds.right <= bounds.left:
+                zero_o = cutlass.Vector.from_elements(
+                    tuple(cutlass.Float32(0.0) for _ in range(O_CHUNK)),
+                    cutlass.Float32,
+                )
+                for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                    o_addr = tmem_base_epi + cutlass.Int32(LAYOUT.O_OFF + chunk_idx * O_CHUNK)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                        zero_o,
+                    )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+
+        O_EPI_BLK = 64 // CFG.BPE_O
+        N_BLOCKS_EPI = CFG.TILE_O // O_EPI_BLK
+        CHUNKS_PER_BLK = O_EPI_BLK // O_CHUNK
+
+        sO_base = sO[0].base
+        _amax_o_ptr = Pointer(amax_o_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
+        _amax_o_local = cutlass.Float32(0.0)
+
+        for block_idx in cutlass.range_constexpr(N_BLOCKS_EPI):
+            for sub in cutlass.range_constexpr(CHUNKS_PER_BLK):
+                chunk_idx_total = block_idx * CHUNKS_PER_BLK + sub
+                o_addr = tmem_base_epi + cutlass.Int32(LAYOUT.O_OFF + chunk_idx_total * O_CHUNK)
+                o_chunk = nvvm.tcgen05_ld(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                    num=O_CHUNK,
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                o_scaled = o_chunk * inv_sum
+                # Empty BMM2 leaves O TMEM unwritten, and NaN * 0 does not
+                # sanitize it. Padded top-left clears an empty tile once above;
+                # keep per-element selects for the remaining dynamic bounds.
+                if cutlass.const_expr(
+                    not _PADDED_TOP_LEFT_CAUSAL and (CFG.SEQ_KV_LENS_PRESENT or SPLIT_KV > 1 or (CFG.BOTTOM_RIGHT and not bottom_right_diagonal))
+                ):
+                    zero = cutlass.Float32(0.0)
+                    invalid = row_dead
+                    if cutlass.const_expr(CFG.THD_VARLEN):
+                        invalid = invalid | (~_row_valid)
+                    o_scaled = cutlass.Vector.from_elements(
+                        tuple(cutlass.Float32(arith.select(invalid.ir_value(), zero.ir_value(), o_scaled[i].ir_value())) for i in range(O_CHUNK)),
+                        cutlass.Float32,
+                    )
+                _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled), ftz=True)
+                o_out = o_scaled.to(OUT_STORAGE_DTYPE)
+
+                col_offset_const = (chunk_idx_total * O_CHUNK) % D_BLOCK_SIZE
+                block_offset_const = ((chunk_idx_total * O_CHUNK) // D_BLOCK_SIZE) * TMA_O_GRANU_ELEMS_LOCAL
+                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
+                smem_ptr = sO_base.subview(smem_offset).data_ptr()
+
+                if block_idx == 0 and sub == 0:
+                    bars.mb_o_empty.wait(epilogue_state)
+                smem_ptr.store_swizzled(o_out, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+
+            fire_now = (block_idx % 2 == 1) or (CFG.TILE_O == O_EPI_BLK)
+            if cutlass.const_expr(fire_now):
+                nvvm.fence_proxy("async.shared", space="cta")
+                bars.mb_o_full[(block_idx // 2)].arrive()
+
+        if cutlass.const_expr(SPLIT_KV == 1):
+            if cutlass.const_expr(CFG.MASK_FLAGS == MASK_NONE):
+                _amax_o_valid = cutlass.Float32(
+                    arith.select(
+                        _row_valid.ir_value(),
+                        _amax_o_local.ir_value(),
+                        cutlass.Float32(0.0).ir_value(),
+                    )
+                )
+                _amax_o_warp = cute.arch.warp_redux_sync(_amax_o_valid, kind="fmax")
+                if (tid_in_wg & cutlass.Int32(31)) == cutlass.Int32(0):
+                    nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_warp.bitcast(cutlass.Int32))
+            else:
+                if _row_valid:
+                    nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
+
+        epilogue_state = epilogue_state ^ cutlass.Int32(1)
+
+        wait(mb_decoded.subview(sched_state.idx), sched_state.phase)
+        payload_base = sched_state.idx * cutlass.Int32(SCHED_PAYLOAD_WORDS)
+        nxt_v = sched.tile_id_smem.subview(payload_base + cutlass.Int32(2)).load()
+        q_super_idx = sched.tile_id_smem.subview(payload_base + cutlass.Int32(3)).load()
+        head_idx = sched.tile_id_smem.subview(payload_base + cutlass.Int32(4)).load()
+        batch_idx = sched.tile_id_smem.subview(payload_base + cutlass.Int32(5)).load()
+        if cutlass.const_expr(SPLIT_KV > 1):
+            split_idx = sched.tile_id_smem.subview(payload_base + cutlass.Int32(10)).load()
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0 or SPLIT_KV > 1):
+            bounds = KvLoopBounds(
+                left=sched.tile_id_smem.subview(payload_base + cutlass.Int32(6)).load(),
+                unmasked_lo=sched.tile_id_smem.subview(payload_base + cutlass.Int32(7)).load(),
+                unmasked_hi=sched.tile_id_smem.subview(payload_base + cutlass.Int32(8)).load(),
+                right=sched.tile_id_smem.subview(payload_base + cutlass.Int32(9)).load(),
+            )
+
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        peer_cta = cta_id_x ^ cutlass.Int32(1)
+        bars.mb_tmem_dealloc.arrive_on_peer(peer_cta)
+    bars.mb_tmem_dealloc.arrive()
+
+
+@cute.jit
+def _host(
+    q_tensor: cute.Tensor,
+    k_tensor: cute.Tensor,
+    v_tensor: cute.Tensor,
+    o_tensor: cute.Tensor,
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    problem_size: Tuple[int, int, int, int, int, int],
+    bottom_right_diagonal: cutlass.Constexpr[bool],
+    scale_softmax_log2: cutlass.Float32,
+    o_scale_fused: cutlass.Float32,
+    n_thd_units: cutlass.Int32,
+    descale_q_t: cute.Tensor,
+    descale_k_t: cute.Tensor,
+    descale_v_t: cute.Tensor,
+    scale_o_t: cute.Tensor,
+    amax_o_tensor: cute.Tensor,
+    # Dense padded-Q trim: separate (B,)-int32 lengths. None folds the
+    # parameter and all consumers out when the specialization is disabled.
+    seq_q_lens_tensor: Optional[cute.Tensor] = None,
+    thd_q_lens_tensor: Optional[cute.Tensor] = None,
+    thd_kv_lens_tensor: Optional[cute.Tensor] = None,
+    thd_lens_form: Optional[cutlass.Int32] = None,
+    stream: _cuda_driver.CUstream = None,
+) -> None:
+    B, QH, KH, SQ, SKV, _ = problem_size
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        SQ = q_tensor.shape[1]
+        SKV = k_tensor.shape[1]
+
+    _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE_O
+    k_rank5_layout = cute.make_layout(
+        (k_tensor.shape[0], k_tensor.shape[2], TMA_QK_ITERS, k_tensor.shape[1], TMA_QK_GRANU_ELEMS),
+        stride=(
+            k_tensor.stride[0],
+            k_tensor.stride[2],
+            TMA_QK_GRANU_ELEMS,
+            k_tensor.stride[1],
+            1,
+        ),
+    )
+    k_rank5_tensor = cute.make_tensor(k_tensor.iterator, k_rank5_layout)
+    v_rank5_layout = cute.make_layout(
+        (v_tensor.shape[0], v_tensor.shape[2], TMA_VO_ITERS, v_tensor.shape[1], TMA_VO_GRANU_ELEMS),
+        stride=(
+            v_tensor.stride[0],
+            v_tensor.stride[2],
+            TMA_VO_GRANU_ELEMS,
+            v_tensor.stride[1],
+            1,
+        ),
+    )
+    v_rank5_tensor = cute.make_tensor(v_tensor.iterator, v_rank5_layout)
+    if cutlass.const_expr(CFG.PACK_GQA and q_tensor.shape[2] != k_tensor.shape[2] * CFG.QH_PER_KH):
+        raise ValueError(f"CFG.QH_PER_KH ({CFG.QH_PER_KH}) does not match tensor head extents H_q={q_tensor.shape[2]}, H_kv={k_tensor.shape[2]}")
+    qk_box_q = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, TMA_QK_GRANU_ELEMS)
+    qk_box_k = (1, 1, TMA_QK_ITERS, CFG.TILE_N // CFG.CTA_MMA, TMA_QK_GRANU_ELEMS)
+    vo_box_v = (1, 1, TMA_VO_ITERS, CFG.TILE_N, TMA_VO_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, _O_GRANU_ELEMS)
+    stride_order = (3, 2, 1, 0)
+
+    def _tma_swz(byte_w: int):
+        return tmap.TensorMapSwizzle.s128b if byte_w == 128 else tmap.TensorMapSwizzle.s64b if byte_w == 64 else tmap.TensorMapSwizzle.s32b
+
+    tma_q_desc = tmap.create_tensor_map_tiled_from_view(
+        q_tensor,
+        box_dims=qk_box_q,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.Q_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_256b,
+    )
+    tma_k_desc = tmap.create_tensor_map_tiled_from_view(
+        k_rank5_tensor,
+        box_dims=qk_box_k,
+        stride_order=(4, 3, 2, 1, 0),
+        swizzle=_tma_swz(CFG.K_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_256b,
+    )
+    tma_v_desc = tmap.create_tensor_map_tiled_from_view(
+        v_rank5_tensor,
+        box_dims=vo_box_v,
+        stride_order=(4, 3, 2, 1, 0),
+        swizzle=_tma_swz(CFG.V_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_256b,
+    )
+    tma_o_desc = tmap.create_tensor_map_tiled_from_view(
+        o_tensor,
+        box_dims=vo_box_o,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.O_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+
+    rows_per_cluster = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+    q_clusters = (SQ * HEADS_PER_TILE + rows_per_cluster - 1) // rows_per_cluster
+    grid_q_supers = q_clusters * CFG.CTA_MMA
+    q_supers = grid_q_supers
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        _build_thd_meta_o_kv_descs_kernel(
+            o_tensor,
+            tma_o_desc,
+            tma_k_desc,
+            tma_v_desc,
+            o_desc_words,
+            seq_kv_lens_tensor,
+            thd_q_lens_tensor,
+            thd_kv_lens_tensor,
+            thd_lens_form,
+            cutlass.Int32(QH),
+            cutlass.Int32(B),
+            cutlass.Int32(o_tensor.stride[1]),
+            cutlass.Int32(rows_per_cluster),
+            n_thd_units,
+            1,
+            1,
+        ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
+        grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
+    else:
+        grid_shape = (
+            (grid_q_supers, QH // HEADS_PER_TILE, B * SPLIT_KV)
+            if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL)
+            else (grid_q_supers * (QH // HEADS_PER_TILE) * B * SPLIT_KV, 1, 1)
+        )
+    _kernel(
+        tma_q_desc,
+        tma_k_desc,
+        tma_v_desc,
+        tma_o_desc,
+        lse_tensor,
+        sinks_tensor,
+        seq_kv_lens_tensor,
+        o_desc_words,
+        cutlass.Int32(SQ),
+        cutlass.Int32(SKV),
+        cutlass.Int32(q_supers),
+        cutlass.Int32(QH // HEADS_PER_TILE),
+        cutlass.Int32(B),
+        cutlass.Int32(QH // KH),
+        scale_softmax_log2,
+        o_scale_fused,
+        descale_q_t,
+        descale_k_t,
+        descale_v_t,
+        scale_o_t,
+        amax_o_tensor,
+        bottom_right_diagonal,
+        seq_q_lens_tensor,
+    ).launch(
+        grid=grid_shape,
+        block=[CFG.THREADS_PER_CTA, 1, 1],
+        cluster=(CFG.CTA_MMA, 1, 1),
+        stream=stream,
+    )
+
+
+@lru_cache(maxsize=None)
+def compile(  # noqa: A001
+    b: int = 1,
+    qh: int = 1,
+    kh: int = 1,
+    sq: int = 256,
+    skv: int = 128,
+    d_qk: int = CFG.TILE_K,
+    d_v: int = CFG.TILE_O,
+    has_lse: bool = True,
+    lse_head_major: bool = False,
+    lse_head_stride: int = 0,
+    lse_stride: Optional[tuple[int, int, int]] = None,
+    q_stride: Optional[tuple] = None,
+    k_stride: Optional[tuple] = None,
+    v_stride: Optional[tuple] = None,
+    o_stride: Optional[tuple] = None,
+) -> Callable:
+    """ENVELOPE: ``d_qk`` / ``d_v`` are the ACTUAL head dims (defaults = full
+    TILE_K / TILE_O). TMA descriptors carry these extents while the tile box
+    stays the compile-time TILE geometry: loads past d_qk / d_v zero-fill
+    (exact zeros in the QK^T / P·V contractions), O stores past d_v clip.
+    d * BPE must be a 16-byte multiple (TMA global-stride rule -> d % 8)."""
+    if not (0 < d_qk <= CFG.TILE_K and 0 < d_v <= CFG.TILE_O):
+        raise ValueError(f"d256 envelope: need 0 < d_qk <= {CFG.TILE_K} and 0 < d_v <= {CFG.TILE_O}; got ({d_qk}, {d_v})")
+    if (d_qk * CFG.BPE) % 16 != 0 or (d_v * CFG.BPE_O) % 16 != 0:
+        raise ValueError(f"d256 envelope: d_qk*BPE and d_v*BPE must be 16-byte multiples (TMA global-stride rule); got ({d_qk}, {d_v}) at BPE={CFG.BPE}")
+    if CFG.THD_VARLEN and (d_qk != CFG.TILE_K or d_v != CFG.TILE_O):
+        raise ValueError("D256 FP8 THD serves native d_qk=d_v=256 only")
+    if SPLIT_KV > 1 and not has_lse:
+        raise ValueError("split_kv > 1 requires has_lse=True (the per-split LSE drives the combine)")
+    if lse_stride is not None and SPLIT_KV > 1:
+        raise ValueError("split_kv partial LSE is compact; lse_stride describes only the final combine output")
+    fake_batch = 1 if CFG.THD_VARLEN else b
+    if CFG.THD_VARLEN:
+        sq = cute.sym_int(divisibility=1)
+        skv = cute.sym_int(divisibility=1)
+    o_batch = fake_batch * SPLIT_KV
+    lse_batch = b * SPLIT_KV
+
+    def _fake_bshd(shape, stride, dtype=STORAGE_DTYPE, bpe=CFG.BPE):
+        if stride is None:
+            return cute.runtime.make_fake_compact_tensor(dtype, shape, stride_order=(3, 2, 1, 0), assumed_align=16)
+        if stride[3] != 1:
+            raise ValueError(f"declared stride {stride}: the head dim must be innermost-contiguous (stride[3] == 1)")
+        for axis in (1, 2):  # seq/head global strides feed TMA: 16-byte rule
+            if (stride[axis] * bpe) % 16 != 0:
+                raise ValueError(f"declared stride {stride} axis {axis} must be a 16-byte multiple at BPE={bpe} (TMA global-stride rule)")
+        return cute.runtime.make_fake_tensor(dtype, shape, tuple(stride), assumed_align=16)
+
+    fake_q = _fake_bshd((fake_batch, sq, qh, d_qk), q_stride)
+    fake_k = _fake_bshd((fake_batch, skv, kh, d_qk), k_stride)
+    fake_v = _fake_bshd((fake_batch, skv, kh, d_v), v_stride)
+    fake_o = _fake_bshd((o_batch, sq, qh, d_v), o_stride, dtype=OUT_STORAGE_DTYPE, bpe=CFG.BPE_O)
+    if not has_lse:
+        # No Stats output: the LSE argument is None-specialized and the store
+        # is compiled out entirely — no dummy buffer exists at any level.
+        if lse_head_major or lse_head_stride:
+            raise ValueError("lse_head_major / lse_head_stride require has_lse=True")
+        fake_lse = None
+    elif CFG.THD_VARLEN:
+        if lse_head_major:
+            lse_extent = lse_head_stride if lse_head_stride else sq
+            fake_lse = cute.runtime.make_fake_compact_tensor(
+                cutlass.Float32,
+                (1, qh, lse_extent),
+                stride_order=(2, 1, 0),
+                assumed_align=4,
+            )
+        else:
+            if lse_head_stride:
+                raise ValueError("lse_head_stride is head-major-only")
+            fake_lse = cute.runtime.make_fake_compact_tensor(
+                cutlass.Float32,
+                (sq, qh),
+                stride_order=(1, 0),
+                assumed_align=4,
+            )
+    else:
+        if lse_head_major or lse_head_stride:
+            raise ValueError("lse_head_major / lse_head_stride are unsupported for dense FP8")
+        fake_lse = (
+            cute.runtime.make_fake_tensor(cutlass.Float32, (lse_batch, qh, sq), lse_stride, assumed_align=4)
+            if lse_stride is not None
+            else cute.runtime.make_fake_compact_tensor(
+                cutlass.Float32,
+                (lse_batch, qh, sq),
+                stride_order=(2, 1, 0),
+                assumed_align=16,
+            )
+        )
+    fake_sinks = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (qh,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        ((4 * b + 4) if CFG.THD_VARLEN else b,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    fake_amax_o = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (1,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    fake_o_desc = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int64,
+        (((b + 3) * _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    fake_seq_q_lens = (
+        cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (b,),
+            stride_order=(0,),
+            assumed_align=4,
+        )
+        if CFG.SEQ_Q_LENS_PRESENT
+        else None
+    )
+
+    def _fake_scale():
+        return cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (1,),
+            stride_order=(0,),
+            assumed_align=4,
+        )
+
+    if CFG.THD_VARLEN:
+        fake_thd_q_lens = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (cute.sym_int(divisibility=1),),
+            stride_order=(0,),
+            assumed_align=4,
+        )
+        fake_thd_kv_lens = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (cute.sym_int(divisibility=1),),
+            stride_order=(0,),
+            assumed_align=4,
+        )
+        fake_thd_lens_form = cutlass.Int32(0)
+    else:
+        fake_thd_q_lens = None
+        fake_thd_kv_lens = None
+        fake_thd_lens_form = None
+
+    return cute.compile(
+        _host,
+        fake_q,
+        fake_k,
+        fake_v,
+        fake_o,
+        fake_lse,
+        fake_sinks,
+        fake_seq_kv_lens,
+        fake_o_desc,
+        (b, qh, kh, 0, 0, 0) if CFG.THD_VARLEN else (b, qh, kh, sq, skv, 0),
+        bool(CFG.MASK_FLAGS == MASK_CAUSAL and CFG.BOTTOM_RIGHT and not CFG.SEQ_KV_LENS_PRESENT and sq == skv),
+        cutlass.Float32(0.0),
+        cutlass.Float32(0.0),
+        cutlass.Int32(0),
+        _fake_scale(),
+        _fake_scale(),
+        _fake_scale(),
+        _fake_scale(),
+        fake_amax_o,
+        fake_seq_q_lens,
+        fake_thd_q_lens,
+        fake_thd_kv_lens,
+        fake_thd_lens_form,
+        stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
+        options="--enable-tvm-ffi",
+    )
+
+
+def _main():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--b", type=int, default=1)
+    parser.add_argument("--hq", type=int, default=1)
+    parser.add_argument("--hk", type=int, default=1)
+    parser.add_argument("--sq", type=int, default=256)
+    parser.add_argument("--skv", type=int, default=128)
+    parser.add_argument("--validate", action="store_true")
+    parser.add_argument("--iters", type=int, default=0)
+    args = parser.parse_args()
+
+    print(f"[d256_fp8_sm100] compile b={args.b} qh={args.hq} kh={args.hk} " f"sq={args.sq} skv={args.skv}", flush=True)
+    fn = compile(args.b, args.hq, args.hk, args.sq, args.skv)
+    print(f"[d256_fp8_sm100] compile OK: {fn}", flush=True)
+    if args.validate:
+        print("[d256_fp8_sm100] compiled - run validation via the frost SDPA test suite.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_mxfp8_sm100.py
@@ -1,0 +1,3450 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""SM100 block-scale MXFP8 prefill SDPA for exact d_qk=d_v=256.
+
+This keeps the optimized D256 FP8 pipeline and adds E8M0 scale-factor TMA,
+SMEM, and transient TMEM plumbing for Blackwell block-scaled MMA.  SM100 has a
+512-column TMEM cap, so scale factors reuse score/O regions after their prior
+owners have completed instead of occupying permanent columns above O.
+
+THD / varlen uses packed Q/K/V/O plus per-sequence-tile-padded SF buffers. A
+device setup kernel builds ragged metadata and runtime O/K/V tensor maps; the
+main launch uses a plan-time envelope and dynamic packed extents.
+"""
+
+from functools import lru_cache
+from typing import Callable, Optional, Tuple
+
+from cutlass.base_dsl.typing import Pointer
+from cutlass.experimental import primitives as nvvm
+from cutlass.experimental.primitives import vote_sync, VoteSync  # noqa: F401
+from cutlass.experimental.cuda import tensor_map as tmap
+from cutlass._mlir.dialects import arith
+
+import cutlass
+from cutlass.experimental import primitives as prims
+import cutlass.cute as cute
+import cuda.bindings.driver as _cuda_driver  # noqa: F401
+
+from dataclasses import dataclass
+
+from cudnn.sdpa.fwd.config_sm100 import TemplateParams, make_cfg_d256_mxfp8
+
+# The template loader injects the graph's MXFP8 parameters before executing
+# this module. The default record only keeps import-time tooling well-defined;
+# it is not a supported standalone execution configuration for this kernel.
+PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
+CFG, _TMA = make_cfg_d256_mxfp8(PARAMS)
+Cfg = type(CFG)
+TMA_QK_ITERS = _TMA.QK_ITERS
+TMA_VO_ITERS = _TMA.VO_ITERS
+TMA_QK_GRANU_ELEMS = _TMA.QK_GRANU_ELEMS
+TMA_VO_GRANU_ELEMS = _TMA.VO_GRANU_ELEMS
+
+TMA_O_GRANU_ELEMS_HOST = CFG.O_SWZ_BYTES // CFG.BPE_O
+TMA_O_ITERS_HOST = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
+
+from cudnn.frost.tile_dsl.barrier import (
+    PipelineState,
+    advance,
+    cga_arrive,
+    cga_wait,
+    wait,
+    arrive_expect_tx,
+)
+from cudnn.frost.tile_dsl.scheduler import (
+    Sched,
+    read_tile_id_arrive,
+    SCHED_NATURAL,
+)
+from cudnn.frost.tile_dsl.pointwise import (
+    row_reduction_pair,
+    row_max_reduction,
+    vec_scale_pair,
+)
+from cudnn.frost.tile_dsl.regtile import RegTile, vec_concat
+from cudnn.frost.tile_dsl.mma import mma_ss, mma_ts_step
+from cudnn.frost.tile_dsl.tma import tma_load_tile, tma_store_commit, tma_store_wait, tma_tensormap_acquire
+from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, tma_slice_runtime_desc
+from cudnn.frost.tile_dsl.tmem import tmem_alloc, tmem_dealloc
+from cudnn.frost.tile_dsl.mask import (
+    apply_mask_chunk,
+    MASK_NONE,
+    MASK_CAUSAL,
+    MASK_PADDED,
+)
+from cudnn.block_sparse_attention.csrc.utils.kernel_utils import ex2_emulation_2
+
+if CFG.DTYPE_QKV == 0:
+    STORAGE_DTYPE = cutlass.Float8E4M3FN
+    P_STORAGE_DTYPE = cutlass.Float8E4M3FN
+elif CFG.DTYPE_QKV == 1:
+    STORAGE_DTYPE = cutlass.Float8E5M2
+    P_STORAGE_DTYPE = cutlass.Float8E5M2
+else:
+    raise ValueError(f"prefill_sdpa_d256_mxfp8: unsupported DTYPE_QKV={CFG.DTYPE_QKV}")
+
+MMA_KIND = nvvm.MMABlockScaleKind.MXF8F6F4
+SCALE_VEC_SIZE = nvvm.Tcgen05MMAScaleVecSize.BLOCK32
+
+# SM100 MXFP8 uses the K=32 block-scaled QMMA path.  K=64 is not a valid
+# transfer from the SM107 implementation.
+_MXFP8_K_DIM = 0
+_MXFP8_TILE_K_HW = 32
+
+if CFG.DTYPE_O == 0:
+    OUT_STORAGE_DTYPE = cutlass.Float8E4M3FN
+elif CFG.DTYPE_O == 1:
+    OUT_STORAGE_DTYPE = cutlass.Float8E5M2
+elif CFG.DTYPE_O == 2:
+    OUT_STORAGE_DTYPE = cutlass.BFloat16
+elif CFG.DTYPE_O == 3:
+    OUT_STORAGE_DTYPE = cutlass.Float16
+else:
+    raise ValueError(f"prefill_sdpa_d256_mxfp8: unsupported DTYPE_O={CFG.DTYPE_O}")
+
+
+BITS_PER_SF_ELEMENT = 8
+BLOCK_SCALE_BLOCK_SIZE = 32
+SF_BLOCK_DIM_NON_K = 128
+SF_BLOCK_DIM_K = 4
+SF_SWIZZLED_BLOCK_DIM_K = 16
+SF_BYTES_PER_BLOCK = SF_BLOCK_DIM_NON_K * SF_BLOCK_DIM_K * BITS_PER_SF_ELEMENT // 8
+
+
+def _round_up(a: int, b: int) -> int:
+    return (a + b - 1) // b * b
+
+
+SF_NUM_BLOCKS_M = CFG.TILE_M // SF_BLOCK_DIM_NON_K
+SF_NUM_BLOCKS_N = CFG.TILE_N // SF_BLOCK_DIM_NON_K
+SF_NUM_BLOCKS_K = _round_up(CFG.TILE_K, 128) // BLOCK_SCALE_BLOCK_SIZE // SF_BLOCK_DIM_K
+SF_REGISTERS_PER_BLOCK = SF_SWIZZLED_BLOCK_DIM_K * BITS_PER_SF_ELEMENT // 32
+SF_TMEM_COLS_Q = SF_NUM_BLOCKS_M * SF_NUM_BLOCKS_K * SF_REGISTERS_PER_BLOCK
+SF_TMEM_COLS_K = SF_NUM_BLOCKS_N * SF_NUM_BLOCKS_K * SF_REGISTERS_PER_BLOCK
+SF_SMEM_SIZE_Q = CFG.TILE_M * _round_up(CFG.TILE_K, 128) // BLOCK_SCALE_BLOCK_SIZE
+SF_SMEM_SIZE_K = CFG.TILE_N * _round_up(CFG.TILE_K, 128) // BLOCK_SCALE_BLOCK_SIZE
+
+SF_NUM_BLOCKS_P = CFG.TILE_M // SF_BLOCK_DIM_NON_K
+SF_NUM_BLOCKS_V = _round_up(CFG.TILE_O, 128) // SF_BLOCK_DIM_NON_K
+SF_NUM_BLOCKS_K_BMM2 = CFG.TILE_N // BLOCK_SCALE_BLOCK_SIZE // SF_BLOCK_DIM_K
+SF_TMEM_COLS_P = SF_NUM_BLOCKS_P * SF_NUM_BLOCKS_K_BMM2 * SF_REGISTERS_PER_BLOCK
+SF_TMEM_COLS_V = SF_NUM_BLOCKS_V * SF_NUM_BLOCKS_K_BMM2 * SF_REGISTERS_PER_BLOCK
+SF_SMEM_SIZE_P = _round_up(CFG.TILE_M, 128) * CFG.TILE_N // BLOCK_SCALE_BLOCK_SIZE
+SF_SMEM_SIZE_V = _round_up(CFG.TILE_O, 128) * CFG.TILE_N // BLOCK_SCALE_BLOCK_SIZE
+SF_CONST_VALUE = 0x7F
+
+SF_BMM2_N_BLOCKS = _round_up(CFG.TILE_O, 128) // 128
+BMM2_LOOP_N_BLOCKS = SF_BMM2_N_BLOCKS // CFG.CTA_MMA
+BMM2_N_PER_CALL = CFG.TILE_O // BMM2_LOOP_N_BLOCKS
+BMM2_N_PER_CALL_PER_CTA = BMM2_N_PER_CALL // CFG.CTA_MMA
+BMM2_N_BLOCK_BYTE_STRIDE = CFG.TILE_N * CFG.V_SWZ_BYTES
+SF_V_COLS_PER_NBLOCK = SF_NUM_BLOCKS_K_BMM2 * SF_REGISTERS_PER_BLOCK
+
+
+from cudnn.sdpa.fwd.kernels._common_sm100 import (
+    make_split_helpers,
+    KvLoopBounds,
+    make_d256_bars,
+    row_max_for_exp2,
+    make_sdpa_helpers,
+)
+
+CGA_SIZE = CFG.CGA_M * CFG.CGA_N
+
+CTA_GROUP_KIND = nvvm.CTAGroup.CTA_2 if CFG.CTA_MMA == 2 else nvvm.CTAGroup.CTA_1
+
+qBufferElems = CFG.TILE_M * CFG.TILE_K
+kBufferElems = CFG.TILE_N * CFG.TILE_K // CFG.CTA_MMA
+vBufferElems = CFG.TILE_O * CFG.TILE_N // CFG.CTA_MMA
+oBufferElems = CFG.TILE_M * CFG.TILE_O
+qoAliasBytes = max(qBufferElems * CFG.BPE, oBufferElems * CFG.BPE_O)
+
+qTmaTransactionBytes = qBufferElems * CFG.BPE * CFG.CTA_MMA
+kTmaTransactionBytes = kBufferElems * CFG.BPE * CFG.CTA_MMA
+vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
+Q_SF_EXPECT_BYTES = SF_SMEM_SIZE_Q * CFG.CTA_MMA
+K_SF_EXPECT_BYTES = SF_SMEM_SIZE_K * CFG.CTA_MMA
+V_SF_EXPECT_BYTES = SF_SMEM_SIZE_V * CFG.CTA_MMA
+
+N_O_CHUNKS = (CFG.TILE_O * CFG.BPE_O + 127) // 128
+
+_BAR_K_EMPTY_0 = 3
+_BAR_K_EMPTY_1 = 4
+_BAR_V_EMPTY_0 = 5
+_BAR_V_EMPTY_1 = 6
+_KV_PIPELINE_LANES = 64
+
+CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+
+_sdpa_h = make_sdpa_helpers(
+    CFG,
+    lpt_q_tiles_in_cga_units=True,
+    grouped_lpt=PARAMS.lpt_head_group > 1,
+    lpt_head_group=PARAMS.lpt_head_group,
+)
+_decode_initial = _sdpa_h.decode_initial
+_decode_payload = _sdpa_h.decode_payload
+# qtrim variant: collapses the KV loop for CGA tiles entirely past the
+# per-batch actual Q length (SEQ_Q_LENS_PRESENT; folds to plain bounds otherwise).
+_bounds_for_tile = _sdpa_h.bounds_for_tile_qtrim
+_resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+_resolve_seqlen_q = _sdpa_h.resolve_seqlen_q
+
+
+_thd_tma_offsets = _sdpa_h.thd_tma_offsets
+_thd_sf_tile_bases = _sdpa_h.thd_sf_tile_bases
+
+from cudnn.sdpa.fwd.kernels.thd_sm100 import (
+    build_thd_meta_o_kv_descs_kernel as _build_thd_meta_o_kv_descs_kernel,
+    thd_decode_unit,
+    TENSOR_MAP_QWORDS,
+)
+
+_TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
+_THD_REVERSE_CAUSAL_ROWS = CFG.THD_VARLEN and CFG.MASK_FLAGS == (MASK_CAUSAL | MASK_PADDED) and CFG.BOTTOM_RIGHT == 0 and CFG.WINDOW_RIGHT == 0
+
+
+@cute.jit
+def _thd_decode_causal(linear_cta, seq_kv_lens_t, n_batch, n_qh, cta_in_pair):
+    meta = cutlass.make_array_view(seq_kv_lens_t)
+    unit = linear_cta // cutlass.Int32(CFG.CGA_M)
+    q_tile, batch, head = thd_decode_unit(
+        meta,
+        n_batch,
+        unit,
+        n_qh,
+        cutlass.Int32(CGA_TILE_M),
+        True,
+    )
+    # Keep the heavy-to-light traversal, but interleave groups of eight heads so
+    # the last wave is not dominated by one head.  A partial final group, if
+    # present, retains the original head-major order.
+    cuq0 = n_batch
+    live = batch < n_batch
+    safe_batch = cute.math.min(batch, n_batch - cutlass.Int32(1))
+    seq_q = cutlass.Int32(meta[cuq0 + safe_batch + cutlass.Int32(1)]) - cutlass.Int32(meta[cuq0 + safe_batch])
+    tiles_q = (seq_q + cutlass.Int32(CGA_TILE_M - 1)) // cutlass.Int32(CGA_TILE_M)
+    rank = tiles_q - cutlass.Int32(1) - q_tile
+    group = head // cutlass.Int32(8)
+    group_head0 = group * cutlass.Int32(8)
+    group_is_full = live & (group_head0 + cutlass.Int32(7) < n_qh)
+    group_linear = (head - group_head0) * tiles_q + rank
+    grouped_head = group_head0 + (group_linear & cutlass.Int32(7))
+    grouped_rank = group_linear // cutlass.Int32(8)
+    head = cutlass.Int32(arith.select(group_is_full.ir_value(), grouped_head.ir_value(), head.ir_value()))
+    q_tile = cutlass.Int32(
+        arith.select(
+            group_is_full.ir_value(),
+            (tiles_q - cutlass.Int32(1) - grouped_rank).ir_value(),
+            q_tile.ir_value(),
+        )
+    )
+    return q_tile * cutlass.Int32(CFG.CTA_MMA) + cta_in_pair, head, batch
+
+
+@cute.jit
+def _dispatch_decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, seq_kv_lens_t, qh_per_kh=None, seqlen_kv=None):
+    if cutlass.const_expr(_THD_REVERSE_CAUSAL_ROWS):
+        return _thd_decode_causal(bidx, seq_kv_lens_t, n_batch, n_qh, cta_in_pair)
+    return _sdpa_h.dispatch_decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, seq_kv_lens_t, qh_per_kh, seqlen_kv)
+
+
+@cute.jit
+def _dispatch_decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, seq_kv_lens_t, qh_per_kh=None, seqlen_kv=None):
+    if cutlass.const_expr(_THD_REVERSE_CAUSAL_ROWS):
+        return _thd_decode_causal(t0, seq_kv_lens_t, n_batch, n_qh, cta_in_pair)
+    return _sdpa_h.dispatch_decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, seq_kv_lens_t, qh_per_kh, seqlen_kv)
+
+
+# Each split runs one contiguous slice of a Q tile's KV range and writes a
+# split-major partial O/LSE pair for split_combine_sm100.  At SPLIT_KV == 1
+# these helpers fold back to the original decode and bounds path.
+_split_h = make_split_helpers(
+    CFG,
+    bounds_for_tile=_bounds_for_tile,
+    dispatch_decode_initial=_dispatch_decode_initial,
+    dispatch_decode_payload=_dispatch_decode_payload,
+)
+SPLIT_KV = _split_h.SPLIT_KV
+MAY_BE_EMPTY = _split_h.MAY_BE_EMPTY
+_decode_initial_split = _split_h.decode_initial_split
+_decode_payload_split = _split_h.decode_payload_split
+_bounds_for_tile_split = _split_h.bounds_for_tile_split
+_nomask_range_split = _split_h.nomask_range_split
+_partial_batch = _split_h.partial_batch
+
+
+@dataclass(frozen=True)
+class KernelTmemLayout:
+    TOTAL_COLS: int = 512
+
+    S_ACC_EVEN_OFF: int = 0
+    S_ACC_ODD_OFF: int = 128
+
+    # FP8 probabilities pack four values per TMEM column and alias the tails of
+    # the two 128-column score slots.
+    P_EVEN_OFF: int = 96
+    P_ODD_OFF: int = 224
+
+    O_OFF: int = 256
+
+    STATS_EVEN_OFF: int = 0
+    STATS_ODD_OFF: int = 128
+    STATS_EPI_OFF: int = 0
+
+    # Scale-factor scratch.  Prologue Q/K use dead O columns.  In fused split-P,
+    # steady-state Q/K use WG1's consumed high score half while P/V retain the
+    # selected low-half addresses released by WG0.
+    SF_HEAD_OFFSET: int = 64 if CFG.FUSED_CORR_SPLIT_P else 8
+    SF_AFTER_P_OFFSET: int = 32
+    SF_Q_PRO_OFF: int = 256
+    SF_K_PRO_OFF: int = 256 + SF_TMEM_COLS_Q
+
+
+LAYOUT = KernelTmemLayout()
+# Slots 6:10 carry predecoded bounds and slot 10 carries the split index.  The
+# unsplit/no-mask specialization retains the original eight-word payload.
+SCHED_PAYLOAD_WORDS = 12 if (CFG.MASK_FLAGS != 0 or SPLIT_KV > 1) else 8
+_E5_STYLE_KV_PIPELINE = CFG.DTYPE_QKV == 1 or (CFG.DTYPE_QKV == 0 and (CFG.MASK_FLAGS & ~MASK_PADDED) in (MASK_NONE, MASK_CAUSAL))
+_PADDED_TOP_LEFT_CAUSAL = CFG.MASK_FLAGS == (MASK_CAUSAL | MASK_PADDED) and CFG.BOTTOM_RIGHT == 0 and CFG.WINDOW_RIGHT == 0
+
+
+@cute.jit
+def _producer_wait_k_empty(bars, kv_state, kv_load_count):
+    if cutlass.const_expr(CFG.CTA_MMA == 1 and (_E5_STYLE_KV_PIPELINE or CFG.MASK_FLAGS == MASK_NONE)):
+        if kv_load_count >= cutlass.Int32(CFG.STAGES_KV):
+            if kv_state.idx == cutlass.Int32(0):
+                nvvm.barrier_cta_sync(_BAR_K_EMPTY_0, thread_count=_KV_PIPELINE_LANES)
+            else:
+                nvvm.barrier_cta_sync(_BAR_K_EMPTY_1, thread_count=_KV_PIPELINE_LANES)
+    else:
+        bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+
+
+@cute.jit
+def _producer_wait_v_empty(bars, kv_state, kv_load_count):
+    if cutlass.const_expr(CFG.CTA_MMA == 1 and (_E5_STYLE_KV_PIPELINE or CFG.MASK_FLAGS == MASK_NONE)):
+        if kv_load_count >= cutlass.Int32(CFG.STAGES_KV):
+            if kv_state.idx == cutlass.Int32(0):
+                nvvm.barrier_cta_sync(_BAR_V_EMPTY_0, thread_count=_KV_PIPELINE_LANES)
+            else:
+                nvvm.barrier_cta_sync(_BAR_V_EMPTY_1, thread_count=_KV_PIPELINE_LANES)
+    else:
+        bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+
+
+@cute.jit
+def _consumer_arrive_k_empty(bars, kv_state, mcast_mask):
+    if cutlass.const_expr(CFG.CTA_MMA == 1 and (_E5_STYLE_KV_PIPELINE or CFG.MASK_FLAGS == MASK_NONE)):
+        if kv_state.idx == cutlass.Int32(0):
+            nvvm.barrier_cta_arrive(_BAR_K_EMPTY_0, _KV_PIPELINE_LANES)
+        else:
+            nvvm.barrier_cta_arrive(_BAR_K_EMPTY_1, _KV_PIPELINE_LANES)
+    else:
+        bars.mb_k_empty[kv_state.idx].arrive(
+            mcast_mask=mcast_mask,
+            cta_group=CFG.CTA_MMA,
+            pred=nvvm.elect_sync(),
+        )
+
+
+@cute.jit
+def _consumer_arrive_v_empty(bars, kv_state, mcast_mask):
+    if cutlass.const_expr(CFG.CTA_MMA == 1 and (_E5_STYLE_KV_PIPELINE or CFG.MASK_FLAGS == MASK_NONE)):
+        if kv_state.idx == cutlass.Int32(0):
+            nvvm.barrier_cta_arrive(_BAR_V_EMPTY_0, _KV_PIPELINE_LANES)
+        else:
+            nvvm.barrier_cta_arrive(_BAR_V_EMPTY_1, _KV_PIPELINE_LANES)
+    else:
+        bars.mb_v_empty[kv_state.idx].arrive(
+            mcast_mask=mcast_mask,
+            cta_group=CFG.CTA_MMA,
+            pred=nvvm.elect_sync(),
+        )
+
+
+@cute.jit
+def _scheduler_warp_loop_predecode(
+    sched,
+    mb_decoded,
+    is_cga_first_cta,
+    cta_in_pair,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    seqlen_q,
+    seqlen_kv,
+    seq_kv_lens_tensor,
+    seq_q_lens_tensor,
+):
+    state = PipelineState.start()
+    is_valid = cutlass.Int32(1)
+
+    while is_valid > cutlass.Int32(0):
+        wait(sched.mb_read_tile_id.subview(state.idx), state.phase)
+
+        if nvvm.elect_sync():
+            arrive_expect_tx(sched.mb_scheduler.subview(state.idx), 16)
+        if nvvm.elect_sync() and is_cga_first_cta:
+            nvvm.clusterlaunchcontrol_try_cancel(
+                sched.tile_id_smem.subview(state.idx * cutlass.Int32(SCHED_PAYLOAD_WORDS)),
+                sched.mb_scheduler.subview(state.idx),
+                multicast=1,
+            )
+
+        nvvm.fence_proxy("async.shared", space="cta")
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+        wait(sched.mb_scheduler.subview(state.idx), state.phase)
+
+        payload_base = state.idx * cutlass.Int32(SCHED_PAYLOAD_WORDS)
+        validity = sched.tile_id_smem.subview(payload_base + cutlass.Int32(2)).load()
+        if nvvm.elect_sync():
+            nxt_q = sched.tile_id_smem.subview(payload_base + cutlass.Int32(0)).load()
+            nxt_hb = sched.tile_id_smem.subview(payload_base + cutlass.Int32(1)).load()
+            q_super_idx, head_idx, batch_idx, split_idx = _decode_payload_split(
+                nxt_q,
+                nxt_hb,
+                cta_in_pair,
+                n_q_supers,
+                n_qh,
+                n_batch,
+                seq_kv_lens_tensor,
+            )
+            sched.tile_id_smem.subview(payload_base + cutlass.Int32(3)).store(q_super_idx)
+            sched.tile_id_smem.subview(payload_base + cutlass.Int32(4)).store(head_idx)
+            sched.tile_id_smem.subview(payload_base + cutlass.Int32(5)).store(batch_idx)
+            if cutlass.const_expr(SPLIT_KV > 1):
+                sched.tile_id_smem.subview(payload_base + cutlass.Int32(10)).store(split_idx)
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0 or SPLIT_KV > 1):
+                eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+                eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
+                if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+                    kv_left, kv_right = _nomask_range_split(eff_seqlen_kv, split_idx)
+                    bounds = KvLoopBounds(left=kv_left, unmasked_lo=kv_left, unmasked_hi=kv_right, right=kv_right)
+                else:
+                    bounds = _bounds_for_tile_split(
+                        q_super_idx,
+                        eff_seqlen_q,
+                        eff_seqlen_kv,
+                        cta_in_pair,
+                        seq_q_lens_tensor,
+                        batch_idx,
+                        split_idx,
+                        CFG.QH_PER_KH,
+                    )
+                sched.tile_id_smem.subview(payload_base + cutlass.Int32(6)).store(bounds.left)
+                sched.tile_id_smem.subview(payload_base + cutlass.Int32(7)).store(bounds.unmasked_lo)
+                sched.tile_id_smem.subview(payload_base + cutlass.Int32(8)).store(bounds.unmasked_hi)
+                sched.tile_id_smem.subview(payload_base + cutlass.Int32(9)).store(bounds.right)
+            nvvm.mbarrier_arrive(mb_decoded.subview(state.idx))
+
+        is_valid = validity & cutlass.Int32(1)
+        state = advance(state, CFG.SCHEDULER_STAGES)
+
+
+_SWZ_ENUM = {128: 2, 64: 4, 32: 6}
+SMEM_LAYOUT_Q = _SWZ_ENUM[CFG.Q_SWZ_BYTES]
+SMEM_LAYOUT_K = _SWZ_ENUM[CFG.K_SWZ_BYTES]
+SMEM_LAYOUT_V = _SWZ_ENUM[CFG.V_SWZ_BYTES]
+SMEM_LAYOUT_O = _SWZ_ENUM[CFG.O_SWZ_BYTES]
+SMEM_LAYOUT_QKO = SMEM_LAYOUT_Q
+SMEM_LAYOUT_SF = 0
+SF_LEADING_BYTE_OFFSET = 16
+SF_STRIDE_BYTE_OFFSET = 128
+
+_O_SWZ_B = {128: 3, 64: 2, 32: 1}[CFG.O_SWZ_BYTES]
+_O_SMEM_SWIZZLE = cutlass.Swizzle(_O_SWZ_B, 4, 3)
+
+LEADING_BYTE_OFFSET_QK = 0
+STRIDE_BYTE_OFFSET_QK = 8 * CFG.Q_SWZ_BYTES
+
+_CORE_MATRIX_ROWS = 8
+_V_PC_COLS = CFG.TILE_O // CFG.CTA_MMA
+LEADING_BYTE_OFFSET_PV = 0 if (_V_PC_COLS // _CORE_MATRIX_ROWS) <= 8 else CFG.TILE_N * CFG.V_SWZ_BYTES
+STRIDE_BYTE_OFFSET_PV = 8 * CFG.V_SWZ_BYTES
+
+NUM_KPHASES_PV = CFG.TILE_N // _MXFP8_TILE_K_HW
+NUM_KPHASES_PV_PER_CHUNK = NUM_KPHASES_PV // CFG.N_BMM2_CHUNKS
+
+
+def _max_abs_reduction(vec):
+    """Balanced max(abs(vec)) without materializing an abs vector."""
+    maxima = [vec[i] for i in range(int(vec.shape[0]))]
+    minima = list(maxima)
+    while len(maxima) > 1:
+        next_maxima = []
+        next_minima = []
+        for i in range(0, len(maxima), 3):
+            max_group = maxima[i : i + 3]
+            min_group = minima[i : i + 3]
+            max_acc = max_group[0]
+            min_acc = min_group[0]
+            for value in max_group[1:]:
+                max_acc = cute.math.max(max_acc, value, ftz=True)
+            for value in min_group[1:]:
+                min_acc = cute.math.min(min_acc, value, ftz=True)
+            next_maxima.append(max_acc)
+            next_minima.append(min_acc)
+        maxima = next_maxima
+        minima = next_minima
+    return cute.math.max(maxima[0], -minima[0], ftz=True)
+
+
+_E5_STYLE_SOFTMAX = _E5_STYLE_KV_PIPELINE
+
+
+def _exp2_chunk0a_mixed(vec, apply_mask, dense=False, softmax_half=0):
+    values = []
+    for i in range(0, int(vec.shape[0]), 2):
+        if _E5_STYLE_SOFTMAX and apply_mask:
+            x = cute.math.exp2(vec[i], fastmath=True)
+            y = cute.math.exp2(vec[i + 1], fastmath=True)
+        elif _E5_STYLE_SOFTMAX and not dense and i == 0:
+            x = cute.math.exp2(vec[i], fastmath=True)
+            y = cute.math.exp2(vec[i + 1], fastmath=True)
+        elif _E5_STYLE_SOFTMAX and not dense:
+            x, y = ex2_emulation_2(vec[i], vec[i + 1], poly_degree=1)
+        elif _E5_STYLE_SOFTMAX and dense and (i % 10 < 4 or (softmax_half == 0 and i == 26) or (softmax_half == 1 and (i == 24 or i == 26 or i == 28))):
+            x, y = ex2_emulation_2(vec[i], vec[i + 1], poly_degree=2)
+        elif not _E5_STYLE_SOFTMAX and i % 10 < 4 and not (dense and softmax_half == 1 and i == 30):
+            x, y = ex2_emulation_2(vec[i], vec[i + 1])
+        else:
+            x = cute.math.exp2(vec[i], fastmath=True)
+            y = cute.math.exp2(vec[i + 1], fastmath=True)
+        values.extend((x, y))
+    return cutlass.Vector.from_elements(tuple(values), cutlass.Float32)
+
+
+def _exp2_chunk1b_mixed(vec, dense=False, softmax_half=0):
+    values = []
+    for i in range(0, int(vec.shape[0]), 2):
+        threshold = 16
+        if _E5_STYLE_SOFTMAX and not dense:
+            threshold = 2
+        if not _E5_STYLE_SOFTMAX and not dense:
+            threshold = 20 if softmax_half == 2 else 16
+        elif _E5_STYLE_SOFTMAX and dense:
+            threshold = 18 if softmax_half == 0 else 22
+        if i >= threshold or (_E5_STYLE_SOFTMAX and dense and softmax_half == 0 and (i == 12 or i == 14)):
+            x, y = ex2_emulation_2(vec[i], vec[i + 1], poly_degree=1)
+        else:
+            x = cute.math.exp2(vec[i], fastmath=True)
+            y = cute.math.exp2(vec[i + 1], fastmath=True)
+        values.extend((x, y))
+    return cutlass.Vector.from_elements(tuple(values), cutlass.Float32)
+
+
+@cute.kernel
+def _kernel(
+    tma_q_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_k_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_v_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_o_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_q_sf_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_k_sf_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_v_sf_desc: cutlass.GridConstant[tmap.TensorMap],
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    seqlen_q: cutlass.Int32,
+    seqlen_kv: cutlass.Int32,
+    n_q_supers: cutlass.Int32,
+    n_qh: cutlass.Int32,
+    n_batch: cutlass.Int32,
+    qh_per_kh: cutlass.Int32,
+    kv_sf_num_tiles: cutlass.Int32,
+    scale_softmax_log2: cutlass.Float32,
+    amax_o_tensor: cute.Tensor,
+    bottom_right_diagonal: cutlass.Constexpr[bool],
+    # Dense padded-Q trim: separate (B,)-int32 per-batch Q lengths (mirrors
+    # cuDNN's SEQLEN_Q pointer / FA's seqused_q). None unless
+    # CFG.SEQ_Q_LENS_PRESENT — the DSL specializes on None, so the flag-off
+    # ABI is unchanged.
+    seq_q_lens_tensor: Optional[cute.Tensor] = None,
+) -> None:
+
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    tidx, _, _ = cute.arch.thread_idx()
+
+    bidx = cute.arch.block_idx()[0]
+    bidy = cute.arch.block_idx()[1]
+    bidz = cute.arch.block_idx()[2]
+
+    # Q and O have disjoint lifetimes. Allocate the larger byte footprint and
+    # expose typed views so promoted half output cannot overrun the FP8 Q view.
+    sQO_raw = cutlass.Array(STORAGE_DTYPE, qoAliasBytes // CFG.BPE, alignment=1024, space=cutlass.AddressSpace.smem)
+    sO_raw = cutlass.Array(sQO_raw.data_ptr(), shape=oBufferElems, dtype=OUT_STORAGE_DTYPE)
+    sK_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * kBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    sV_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * vBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    sQ_SF_raw = cutlass.Array(cutlass.Int8, SF_SMEM_SIZE_Q, alignment=1024, space=cutlass.AddressSpace.smem)
+    sK_SF_raw = cutlass.Array(cutlass.Int8, CFG.STAGES_KV * SF_SMEM_SIZE_K, alignment=1024, space=cutlass.AddressSpace.smem)
+    sP_SF_raw = cutlass.Array(cutlass.Int8, SF_SMEM_SIZE_P, alignment=1024, space=cutlass.AddressSpace.smem)
+    sV_SF_raw = cutlass.Array(cutlass.Int8, CFG.STAGES_KV * SF_SMEM_SIZE_V, alignment=1024, space=cutlass.AddressSpace.smem)
+
+    sQ = SmemTile(
+        base=sQO_raw,
+        elems_per_stage=qBufferElems,
+        stages=1,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=1,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+    )
+    sK = SmemTile(
+        base=sK_raw,
+        elems_per_stage=kBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=1,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+    )
+    sV = SmemTile(
+        base=sV_raw,
+        elems_per_stage=vBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_PV,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_PV,
+        layout=SMEM_LAYOUT_V,
+        tma_loads_per_tile=1,
+        tma_granu_elems=TMA_VO_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+    )
+    sO = SmemTile(
+        base=sO_raw,
+        elems_per_stage=oBufferElems,
+        stages=1,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=SMEM_LAYOUT_O,
+        tma_loads_per_tile=TMA_O_ITERS_HOST,
+        tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+    )
+    sQ_SF = SmemTile(
+        base=sQ_SF_raw,
+        elems_per_stage=SF_SMEM_SIZE_Q,
+        stages=1,
+        leading_byte_offset=SF_LEADING_BYTE_OFFSET,
+        stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
+        layout=SMEM_LAYOUT_SF,
+    )
+    sK_SF = SmemTile(
+        base=sK_SF_raw,
+        elems_per_stage=SF_SMEM_SIZE_K,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=SF_LEADING_BYTE_OFFSET,
+        stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
+        layout=SMEM_LAYOUT_SF,
+    )
+    sP_SF = SmemTile(
+        base=sP_SF_raw,
+        elems_per_stage=SF_SMEM_SIZE_P,
+        stages=1,
+        leading_byte_offset=SF_LEADING_BYTE_OFFSET,
+        stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
+        layout=SMEM_LAYOUT_SF,
+    )
+    sV_SF = SmemTile(
+        base=sV_SF_raw,
+        elems_per_stage=SF_SMEM_SIZE_V,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=SF_LEADING_BYTE_OFFSET,
+        stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
+        layout=SMEM_LAYOUT_SF,
+    )
+
+    bars = make_d256_bars(CFG, N_O_CHUNKS=N_O_CHUNKS)
+
+    tmem_ptr_i32 = cutlass.Array(cutlass.Int32, 1, alignment=16, space=cutlass.AddressSpace.smem)
+    # Dense WG0->WG1 exchange, or two parity-indexed causal alpha slots.
+    softmax_exchange = cutlass.Array(
+        cutlass.Float32,
+        768 if CFG.SOFTMAX_WARPGROUPS == 2 else (2 * CFG.TILE_M if _E5_STYLE_SOFTMAX else 1),
+        alignment=16,
+        space=cutlass.AddressSpace.smem,
+    )
+
+    sched = Sched(
+        **{
+            "mb_scheduler": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "mb_read_tile_id": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "tile_id_smem": cutlass.Array(
+                cutlass.Int32,
+                CFG.SCHEDULER_STAGES * SCHED_PAYLOAD_WORDS,
+                alignment=16,
+                space=cutlass.AddressSpace.smem,
+            ),
+            "bidx_init": bidx,
+            "bidy_init": bidy,
+            "bidz_init": bidz,
+        }
+    )
+    mb_decoded = cutlass.Array(
+        cutlass.Int64,
+        CFG.SCHEDULER_STAGES,
+        alignment=16,
+        space=cutlass.AddressSpace.smem,
+    )
+    # P/V scale factors occupy the low score half released by WG0.  Fused
+    # split-P Q/K scale factors use a separate high-half transition from WG1.
+    mb_sf_reuse = cutlass.Array(cutlass.Int64, 2, alignment=16, space=cutlass.AddressSpace.smem)
+    mb_qk_sf_reuse = cutlass.Array(cutlass.Int64, 2, alignment=16, space=cutlass.AddressSpace.smem)
+    READ_TILE_ARRIVERS_TOTAL = CFG.READ_TILE_ARRIVERS
+
+    if warp_idx == 0:
+        if nvvm.elect_sync():
+            bars.mb_q_full.init()
+            bars.mb_q_o_alias.init()
+            bars.mb_tmastg_go.init()
+            for p in cutlass.range_constexpr(2):
+                bars.mb_bmm1_done[p].init()
+                bars.mb_bmm2_done[p].init()
+                for c in cutlass.range_constexpr(CFG.N_BMM2_CHUNKS):
+                    bars.mb_bmm2_ready[p * CFG.N_BMM2_CHUNKS + c].init()
+            bars.mb_stat_full.init()
+            bars.mb_stat_empty.init()
+            for chunk in cutlass.range_constexpr(N_O_CHUNKS):
+                bars.mb_o_full[chunk].init()
+            bars.mb_o_empty.init()
+            for ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_k_full[ks].init()
+                bars.mb_k_empty[ks].init()
+                bars.mb_v_full[ks].init()
+                bars.mb_v_empty[ks].init()
+            for s in range(CFG.SCHEDULER_STAGES):
+                nvvm.mbarrier_init(sched.mb_scheduler.subview(s), CFG.ONE_LANE)
+                nvvm.mbarrier_init(sched.mb_read_tile_id.subview(s), READ_TILE_ARRIVERS_TOTAL)
+                nvvm.mbarrier_init(mb_decoded.subview(s), CFG.ONE_LANE)
+            for p in cutlass.range_constexpr(2):
+                nvvm.mbarrier_init(
+                    mb_sf_reuse.subview(p),
+                    CFG.SOFTMAX_WG_WARPS,
+                )
+                nvvm.mbarrier_init(
+                    mb_qk_sf_reuse.subview(p),
+                    CFG.SOFTMAX_WG_WARPS,
+                )
+            bars.mb_empty_mainloop.init()
+            bars.mb_tmem_dealloc.init()
+
+            bars.mb_q_o_alias.arrive()
+
+    for sf_i in cutlass.range_constexpr((SF_SMEM_SIZE_P + CFG.THREADS_PER_CTA - 1) // CFG.THREADS_PER_CTA):
+        sf_off = tidx + cutlass.Int32(sf_i * CFG.THREADS_PER_CTA)
+        if sf_off < cutlass.Int32(SF_SMEM_SIZE_P):
+            sP_SF_raw.subview(sf_off).store(cutlass.Int8(SF_CONST_VALUE))
+
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync()
+
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        cga_arrive()
+        cga_wait()
+
+    cta_id_x = cute.arch.block_idx_in_cluster() if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    cta_in_pair = (cta_id_x & cutlass.Int32(1)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    leader_cta_id = (cta_id_x & cutlass.Int32(~1 & 0xFFFFFFFF)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    mcast_mask = (cutlass.Int32(3) << leader_cta_id) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    tma_mcast_mask = (cutlass.Int16(1) << cta_in_pair) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
+    is_leader = cta_in_pair == cutlass.Int32(0)
+
+    if warp_idx >= CFG.SOFTMAX_WG0_BASE and warp_idx < CFG.SOFTMAX_WG0_BASE + CFG.SOFTMAX_WG_WARPS:
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        _softmax_warp_group(
+            softmax_half=0,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_softmax_log2,
+            tmem_ptr_i32=tmem_ptr_i32,
+            bars=bars,
+            sched=sched,
+            mb_decoded=mb_decoded,
+            lse_tensor=lse_tensor,
+            sinks_tensor=sinks_tensor,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            seq_q_lens_tensor=seq_q_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+            bottom_right_diagonal=bottom_right_diagonal,
+            softmax_exchange=softmax_exchange,
+            mb_sf_reuse=mb_sf_reuse,
+        )
+
+    elif cutlass.const_expr(CFG.SOFTMAX_WARPGROUPS == 2) and warp_idx >= CFG.SOFTMAX_WG1_BASE and warp_idx < CFG.SOFTMAX_WG1_BASE + CFG.SOFTMAX_WG_WARPS:
+        nvvm.setmaxregister(CFG.SOFTMAX_WG1_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        if cutlass.const_expr(CFG.FUSED_CORR_SPLIT_P):
+            _correction_warp_group(
+                seqlen_q=seqlen_q,
+                seqlen_kv=seqlen_kv,
+                scale_log2=scale_softmax_log2,
+                sO=sO,
+                tmem_ptr_i32=tmem_ptr_i32,
+                tidx=tidx,
+                bars=bars,
+                sched=sched,
+                mb_decoded=mb_decoded,
+                lse_tensor=lse_tensor,
+                sinks_tensor=sinks_tensor,
+                seq_kv_lens_tensor=seq_kv_lens_tensor,
+                seq_q_lens_tensor=seq_q_lens_tensor,
+                n_q_supers=n_q_supers,
+                n_qh=n_qh,
+                n_batch=n_batch,
+                leader_cta_id=leader_cta_id,
+                cta_in_pair=cta_in_pair,
+                cta_id_x=cta_id_x,
+                bottom_right_diagonal=bottom_right_diagonal,
+                amax_o_tensor=amax_o_tensor,
+                softmax_exchange=softmax_exchange,
+                mb_sf_reuse=mb_sf_reuse,
+                mb_qk_sf_reuse=mb_qk_sf_reuse,
+            )
+        else:
+            _softmax_warp_group(
+                softmax_half=1,
+                seqlen_q=seqlen_q,
+                seqlen_kv=seqlen_kv,
+                scale_log2=scale_softmax_log2,
+                tmem_ptr_i32=tmem_ptr_i32,
+                bars=bars,
+                sched=sched,
+                mb_decoded=mb_decoded,
+                lse_tensor=lse_tensor,
+                sinks_tensor=sinks_tensor,
+                seq_kv_lens_tensor=seq_kv_lens_tensor,
+                seq_q_lens_tensor=seq_q_lens_tensor,
+                n_q_supers=n_q_supers,
+                n_qh=n_qh,
+                n_batch=n_batch,
+                leader_cta_id=leader_cta_id,
+                cta_in_pair=cta_in_pair,
+                bottom_right_diagonal=bottom_right_diagonal,
+                softmax_exchange=softmax_exchange,
+                mb_sf_reuse=mb_sf_reuse,
+            )
+
+    elif warp_idx >= CFG.CORR_WARP_BASE and warp_idx < CFG.CORR_WARP_BASE + CFG.CORRECTION_WARPS:
+        nvvm.setmaxregister(CFG.CORRECTION_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _correction_warp_group(
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_softmax_log2,
+            sO=sO,
+            tmem_ptr_i32=tmem_ptr_i32,
+            tidx=tidx,
+            bars=bars,
+            sched=sched,
+            mb_decoded=mb_decoded,
+            lse_tensor=lse_tensor,
+            sinks_tensor=sinks_tensor,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            seq_q_lens_tensor=seq_q_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+            cta_id_x=cta_id_x,
+            bottom_right_diagonal=bottom_right_diagonal,
+            amax_o_tensor=amax_o_tensor,
+            softmax_exchange=softmax_exchange,
+            mb_sf_reuse=mb_sf_reuse,
+            mb_qk_sf_reuse=mb_qk_sf_reuse,
+        )
+
+    elif warp_idx == CFG.MMA_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        if cutlass.const_expr(CFG.CTA_MMA == 2):
+            if is_leader:
+                _mma_warp_group(
+                    seqlen_q=seqlen_q,
+                    seqlen_kv=seqlen_kv,
+                    sQ=sQ,
+                    sK=sK,
+                    sV=sV,
+                    sQ_SF=sQ_SF,
+                    sK_SF=sK_SF,
+                    sP_SF=sP_SF,
+                    sV_SF=sV_SF,
+                    tmem_ptr_i32=tmem_ptr_i32,
+                    bars=bars,
+                    sched=sched,
+                    mb_decoded=mb_decoded,
+                    seq_kv_lens_tensor=seq_kv_lens_tensor,
+                    seq_q_lens_tensor=seq_q_lens_tensor,
+                    n_q_supers=n_q_supers,
+                    n_qh=n_qh,
+                    n_batch=n_batch,
+                    mcast_mask=mcast_mask,
+                    cta_in_pair=cta_in_pair,
+                    mb_sf_reuse=mb_sf_reuse,
+                    mb_qk_sf_reuse=mb_qk_sf_reuse,
+                )
+            else:
+                _mma_warp_quiet(tmem_ptr_i32, bars)
+        else:
+            _mma_warp_group(
+                seqlen_q=seqlen_q,
+                seqlen_kv=seqlen_kv,
+                sQ=sQ,
+                sK=sK,
+                sV=sV,
+                sQ_SF=sQ_SF,
+                sK_SF=sK_SF,
+                sP_SF=sP_SF,
+                sV_SF=sV_SF,
+                tmem_ptr_i32=tmem_ptr_i32,
+                bars=bars,
+                sched=sched,
+                mb_decoded=mb_decoded,
+                seq_kv_lens_tensor=seq_kv_lens_tensor,
+                seq_q_lens_tensor=seq_q_lens_tensor,
+                n_q_supers=n_q_supers,
+                n_qh=n_qh,
+                n_batch=n_batch,
+                mcast_mask=mcast_mask,
+                cta_in_pair=cta_in_pair,
+                mb_sf_reuse=mb_sf_reuse,
+                mb_qk_sf_reuse=mb_qk_sf_reuse,
+            )
+
+    elif warp_idx == CFG.TMALDG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        nvvm.prefetch_tensormap(tma_q_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_k_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_v_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_q_sf_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_k_sf_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_v_sf_desc.get_ptr())
+        _tmaldg_warp_group(
+            tma_q_desc=tma_q_desc,
+            tma_k_desc=tma_k_desc,
+            tma_v_desc=tma_v_desc,
+            tma_q_sf_desc=tma_q_sf_desc,
+            tma_k_sf_desc=tma_k_sf_desc,
+            tma_v_sf_desc=tma_v_sf_desc,
+            sQ=sQ,
+            sK=sK,
+            sV=sV,
+            sQ_SF=sQ_SF,
+            sK_SF=sK_SF,
+            sV_SF=sV_SF,
+            bars=bars,
+            sched=sched,
+            mb_decoded=mb_decoded,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
+            seq_q_lens_tensor=seq_q_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            qh_per_kh=qh_per_kh,
+            kv_sf_num_tiles=kv_sf_num_tiles,
+            is_leader=is_leader,
+            cta_in_pair=cta_in_pair,
+            tma_mcast_mask=tma_mcast_mask,
+        )
+
+    elif warp_idx == CFG.TMASTG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _tmastg_warp_group(
+            tma_o_desc=tma_o_desc,
+            sO=sO,
+            bars=bars,
+            sched=sched,
+            mb_decoded=mb_decoded,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            cta_in_pair=cta_in_pair,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
+        )
+
+    else:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        is_cga_first_cta = cta_id_x == cutlass.Int32(0)
+        _scheduler_warp_loop_predecode(
+            sched,
+            mb_decoded,
+            is_cga_first_cta,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seqlen_q,
+            seqlen_kv,
+            seq_kv_lens_tensor,
+            seq_q_lens_tensor,
+        )
+
+
+@cute.jit
+def _tmaldg_warp_group(
+    tma_q_desc,
+    tma_k_desc,
+    tma_v_desc,
+    tma_q_sf_desc,
+    tma_k_sf_desc,
+    tma_v_sf_desc,
+    sQ,
+    sK,
+    sV,
+    sQ_SF,
+    sK_SF,
+    sV_SF,
+    bars,
+    sched,
+    mb_decoded,
+    seqlen_q,
+    seqlen_kv,
+    seq_kv_lens_tensor,
+    o_desc_words,
+    seq_q_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    qh_per_kh,
+    kv_sf_num_tiles,
+    is_leader,
+    cta_in_pair,
+    tma_mcast_mask,
+):
+
+    q_o_alias_phase = cutlass.Int32(0)
+    kv_state = PipelineState.start(phase=1)
+    kv_load_count = cutlass.Int32(0)
+
+    tma_q = GmemTileTma(tma_q_desc)
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        k_rt_ptr = (o_desc_words.iterator.raw_ptr() + (n_batch + cutlass.Int32(1)) * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+        v_rt_ptr = (o_desc_words.iterator.raw_ptr() + (n_batch + cutlass.Int32(2)) * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+        tma_tensormap_acquire(k_rt_ptr)
+        tma_tensormap_acquire(v_rt_ptr)
+        tma_k = lambda *coords: tma_slice_runtime_desc(k_rt_ptr, *coords)  # noqa: E731
+        tma_v = lambda *coords: tma_slice_runtime_desc(v_rt_ptr, *coords)  # noqa: E731
+    else:
+        tma_k = GmemTileTma(tma_k_desc)
+        tma_v = GmemTileTma(tma_v_desc)
+    tma_q_sf = GmemTileTma(tma_q_sf_desc)
+    tma_k_sf = GmemTileTma(tma_k_sf_desc)
+    tma_v_sf = GmemTileTma(tma_v_sf_desc)
+
+    q_super_idx, head_idx, batch_idx, split_idx = _decode_initial_split(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+    q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+    cu_sf_q_base, cu_sf_k_base = _thd_sf_tile_bases(seq_kv_lens_tensor, batch_idx, n_batch)
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0 and SPLIT_KV == 1):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    elif cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left, kv_right = _nomask_range_split(seqlen_kv, split_idx)
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
+        bounds_init = _bounds_for_tile_split(
+            q_super_idx,
+            eff_seqlen_q,
+            eff_seqlen_kv,
+            cta_in_pair,
+            seq_q_lens_tensor,
+            batch_idx,
+            split_idx,
+            CFG.QH_PER_KH,
+        )
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    K_ROW_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_N // CFG.CTA_MMA)
+    n_kh = n_qh // qh_per_kh
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+        q_sf_tile_base = q_row_base // cutlass.Int32(CFG.TILE_M)
+
+        if cutlass.const_expr(MAY_BE_EMPTY) and (kv_right <= kv_left):
+            pass
+        else:
+            # K does not alias the prior tile's O buffer. Issue the first K TMA
+            # before waiting for Q/O ownership so its latency overlaps the
+            # previous tile's output store and the alias handoff.
+            kv_row_base = kv_left * cutlass.Int32(CFG.TILE_N)
+            _producer_wait_k_empty(bars, kv_state, kv_load_count)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sK[kv_state.idx],
+                tma_k(cutlass.Int32(0), kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, cutlass.Int32(0), kv_head_idx, tma_batch),
+                bars.mb_k_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+                acquire=False,
+            )
+            tma_load_tile(
+                sK_SF[kv_state.idx],
+                tma_k_sf(cutlass.Int32(0), cu_sf_k_base + kv_left, kv_head_idx, tma_batch, coord_0=cutlass.Int32(0)),
+                bars.mb_k_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+
+            _producer_wait_v_empty(bars, kv_state, kv_load_count)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes + V_SF_EXPECT_BYTES, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes + V_SF_EXPECT_BYTES, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sV[kv_state.idx],
+                tma_v(cutlass.Int32(0), kv_row_base + kv_seq_off, cutlass.Int32(0), kv_head_idx, tma_batch),
+                bars.mb_v_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+                acquire=False,
+            )
+            v_sf_group = (tma_batch * n_kh + kv_head_idx) * kv_sf_num_tiles + cu_sf_k_base + kv_left
+            tma_load_tile(
+                sV_SF[kv_state.idx],
+                tma_v_sf(cutlass.Int32(0), cutlass.Int32(0), cutlass.Int32(0), v_sf_group),
+                bars.mb_v_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+            if cutlass.const_expr(CFG.CTA_MMA == 1 and (_E5_STYLE_KV_PIPELINE or CFG.MASK_FLAGS == MASK_NONE)):
+                if kv_load_count < cutlass.Int32(CFG.STAGES_KV):
+                    kv_load_count = kv_load_count + cutlass.Int32(1)
+
+            kv_second = kv_left + cutlass.Int32(1)
+            if kv_second < kv_right:
+                kv_row_base = kv_second * cutlass.Int32(CFG.TILE_N)
+                _producer_wait_k_empty(bars, kv_state, kv_load_count)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sK[kv_state.idx],
+                    tma_k(cutlass.Int32(0), kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, cutlass.Int32(0), kv_head_idx, tma_batch),
+                    bars.mb_k_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                    acquire=False,
+                )
+                tma_load_tile(
+                    sK_SF[kv_state.idx],
+                    tma_k_sf(cutlass.Int32(0), cu_sf_k_base + kv_second, kv_head_idx, tma_batch, coord_0=cutlass.Int32(0)),
+                    bars.mb_k_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+
+                _producer_wait_v_empty(bars, kv_state, kv_load_count)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes + V_SF_EXPECT_BYTES, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes + V_SF_EXPECT_BYTES, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sV[kv_state.idx],
+                    tma_v(cutlass.Int32(0), kv_row_base + kv_seq_off, cutlass.Int32(0), kv_head_idx, tma_batch),
+                    bars.mb_v_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                    acquire=False,
+                )
+                v_sf_group = (tma_batch * n_kh + kv_head_idx) * kv_sf_num_tiles + cu_sf_k_base + kv_second
+                tma_load_tile(
+                    sV_SF[kv_state.idx],
+                    tma_v_sf(cutlass.Int32(0), cutlass.Int32(0), cutlass.Int32(0), v_sf_group),
+                    bars.mb_v_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+                if cutlass.const_expr(CFG.CTA_MMA == 1 and (_E5_STYLE_KV_PIPELINE or CFG.MASK_FLAGS == MASK_NONE)):
+                    if kv_load_count < cutlass.Int32(CFG.STAGES_KV):
+                        kv_load_count = kv_load_count + cutlass.Int32(1)
+
+        bars.mb_q_o_alias.wait(q_o_alias_phase)
+        q_o_alias_phase = q_o_alias_phase ^ cutlass.Int32(1)
+
+        if cutlass.const_expr(MAY_BE_EMPTY) and (kv_right <= kv_left):
+            pass
+        else:
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_q_full.arrive(n_bytes=qTmaTransactionBytes + Q_SF_EXPECT_BYTES, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_q_full.arrive(n_bytes=qTmaTransactionBytes + Q_SF_EXPECT_BYTES, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sQ[0],
+                tma_q(cutlass.Int32(0), q_row_base + q_seq_off, cutlass.Int32(0), head_idx, tma_batch),
+                bars.mb_q_full.smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+            tma_load_tile(
+                sQ_SF[0],
+                tma_q_sf(
+                    cutlass.Int32(0),
+                    cu_sf_q_base + q_sf_tile_base,
+                    head_idx,
+                    tma_batch,
+                    coord_0=cutlass.Int32(0),
+                ),
+                bars.mb_q_full.smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+
+            kv_main_start = cute.math.min(kv_left + cutlass.Int32(2), kv_right)
+            for kv_loop in cutlass.range(kv_main_start, kv_right, 1, unroll=1):
+                kv_row_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+
+                _producer_wait_k_empty(bars, kv_state, kv_load_count)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sK[kv_state.idx],
+                    tma_k(cutlass.Int32(0), kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, cutlass.Int32(0), kv_head_idx, tma_batch),
+                    bars.mb_k_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                    acquire=False,
+                )
+                tma_load_tile(
+                    sK_SF[kv_state.idx],
+                    tma_k_sf(cutlass.Int32(0), cu_sf_k_base + kv_loop, kv_head_idx, tma_batch, coord_0=cutlass.Int32(0)),
+                    bars.mb_k_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+
+                _producer_wait_v_empty(bars, kv_state, kv_load_count)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes + V_SF_EXPECT_BYTES, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes + V_SF_EXPECT_BYTES, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sV[kv_state.idx],
+                    tma_v(cutlass.Int32(0), kv_row_base + kv_seq_off, cutlass.Int32(0), kv_head_idx, tma_batch),
+                    bars.mb_v_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                    acquire=False,
+                )
+                v_sf_group = (tma_batch * n_kh + kv_head_idx) * kv_sf_num_tiles + cu_sf_k_base + kv_loop
+                tma_load_tile(
+                    sV_SF[kv_state.idx],
+                    tma_v_sf(cutlass.Int32(0), cutlass.Int32(0), cutlass.Int32(0), v_sf_group),
+                    bars.mb_v_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        if nvvm.elect_sync():
+            bars.mb_tmastg_go.arrive()
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(mb_decoded.subview(sched_state.idx), sched_state.phase)
+        payload_base = sched_state.idx * cutlass.Int32(SCHED_PAYLOAD_WORDS)
+        nxt_v = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(2)).load())
+        q_super_idx = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(3)).load())
+        head_idx = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(4)).load())
+        batch_idx = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(5)).load())
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+        q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+        cu_sf_q_base, cu_sf_k_base = _thd_sf_tile_bases(seq_kv_lens_tensor, batch_idx, n_batch)
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0 or SPLIT_KV > 1):
+            kv_left = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(6)).load())
+            kv_right = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(9)).load())
+
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        for _ks in cutlass.range_constexpr(CFG.STAGES_KV):
+            bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+            bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+
+@cute.jit
+def _tmastg_warp_group(
+    tma_o_desc,
+    sO,
+    bars,
+    sched,
+    mb_decoded,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    cta_in_pair,
+    seq_kv_lens_tensor,
+    o_desc_words,
+):
+
+    tmastg_go_phase = cutlass.Int32(0)
+    o_full_phase = cutlass.Int32(0)
+
+    tma_o = GmemTileTma(tma_o_desc)
+
+    q_super_idx, head_idx, batch_idx, split_idx = _decode_initial_split(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        bars.mb_tmastg_go.wait(tmastg_go_phase)
+        tmastg_go_phase = tmastg_go_phase ^ cutlass.Int32(1)
+
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+        o_batch = _partial_batch(batch_idx, split_idx, n_batch)
+
+        if cutlass.const_expr(CFG.THD_VARLEN):
+            o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+        else:
+            o_slice = tma_o(cutlass.Int32(0), head_idx, q_row_coord, o_batch)
+            o_desc_ptr = o_slice.tma_desc.get_ptr()
+        for chunk in cutlass.range_constexpr(N_O_CHUNKS):
+            bars.mb_o_full[chunk].wait(o_full_phase)
+            smem_chunk = sO[0].base.subview(chunk * sO[0].tma_subtile_stride_elems)
+            d_coord = cutlass.Int32(chunk * TMA_O_GRANU_ELEMS_HOST)
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                if batch_idx < n_batch:
+                    nvvm.cp_async_bulk_tensor_global_shared_cta(
+                        o_desc_ptr,
+                        smem_chunk,
+                        (d_coord, head_idx, q_row_coord, cutlass.Int32(0)),
+                    )
+            else:
+                nvvm.cp_async_bulk_tensor_global_shared_cta(
+                    o_desc_ptr,
+                    smem_chunk,
+                    (o_slice.coord_d + d_coord, head_idx, q_row_coord, o_batch),
+                )
+            tma_store_commit()
+            if cutlass.const_expr(CFG.BPE_O == 2 and chunk == 1):
+                tma_store_wait(0)
+                if nvvm.elect_sync():
+                    bars.mb_q_o_alias.arrive()
+
+        tma_store_wait(0)
+        if cutlass.const_expr(CFG.BPE_O != 2):
+            if nvvm.elect_sync():
+                bars.mb_q_o_alias.arrive()
+
+        bars.mb_o_empty.arrive()
+
+        o_full_phase = o_full_phase ^ cutlass.Int32(1)
+
+        wait(mb_decoded.subview(sched_state.idx), sched_state.phase)
+        payload_base = sched_state.idx * cutlass.Int32(SCHED_PAYLOAD_WORDS)
+        nxt_v = sched.tile_id_smem.subview(payload_base + cutlass.Int32(2)).load()
+        q_super_idx = sched.tile_id_smem.subview(payload_base + cutlass.Int32(3)).load()
+        head_idx = sched.tile_id_smem.subview(payload_base + cutlass.Int32(4)).load()
+        batch_idx = sched.tile_id_smem.subview(payload_base + cutlass.Int32(5)).load()
+        if cutlass.const_expr(SPLIT_KV > 1):
+            split_idx = sched.tile_id_smem.subview(payload_base + cutlass.Int32(10)).load()
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+
+@cute.jit
+def _mma_warp_quiet(tmem_ptr_i32, bars):
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _mma_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    sQ,
+    sK,
+    sV,
+    sQ_SF,
+    sK_SF,
+    sP_SF,
+    sV_SF,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    mb_decoded,
+    seq_kv_lens_tensor,
+    seq_q_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    mcast_mask,
+    cta_in_pair,
+    mb_sf_reuse,
+    mb_qk_sf_reuse,
+):
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    tmem_raw = nvvm.make_tmem_ptr(tmem_ptr_i32.load(), cutlass.Int8)
+
+    idesc_qk = prims.Tcgen05MxInstrDesc.build(
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_N,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        k_dim=_MXFP8_K_DIM,
+    )
+    idesc_pv = prims.Tcgen05MxInstrDesc.build(
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=BMM2_N_PER_CALL,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        b_major=1,
+        k_dim=_MXFP8_K_DIM,
+    )
+    sf_blocks_per_step = _MXFP8_TILE_K_HW // BLOCK_SCALE_BLOCK_SIZE
+    bmm1_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_N,
+        K=CFG.TILE_K,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=_MXFP8_TILE_K_HW,
+        btranspose=False,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_qk,
+        kind=MMA_KIND,
+        is_block_scale=True,
+        sf_blocks_per_step=sf_blocks_per_step,
+        scale_vec_size=SCALE_VEC_SIZE,
+    )
+    bmm2_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=BMM2_N_PER_CALL,
+        K=CFG.TILE_N,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=_MXFP8_TILE_K_HW,
+        btranspose=True,
+        k_subtile=CFG.V_SWZ_BYTES // CFG.BPE,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_pv,
+        kind=MMA_KIND,
+        is_block_scale=True,
+        sf_blocks_per_step=sf_blocks_per_step,
+        scale_vec_size=SCALE_VEC_SIZE,
+    )
+
+    desc_Q = sQ[0].desc()
+    desc_Q_SF = sQ_SF[0].desc()
+    desc_P_SF = sP_SF[0].desc()
+
+    tmem_SF_Q_pro = tmem_raw.subview(LAYOUT.SF_Q_PRO_OFF)
+    tmem_SF_K_pro = tmem_raw.subview(LAYOUT.SF_K_PRO_OFF)
+
+    def _utccp_bmm1_sf(tmem_sf_q, tmem_sf_k, smem_desc_q, smem_desc_k):
+        for sf_k in cutlass.range_constexpr(SF_NUM_BLOCKS_K):
+            nvvm.tcgen05_cp(
+                nvvm.Tcgen05CpShape.SHAPE_32X128B,
+                tmem_sf_q.subview(sf_k * SF_REGISTERS_PER_BLOCK),
+                smem_desc_q + sf_k * (SF_BYTES_PER_BLOCK // 16),
+                group=CTA_GROUP_KIND,
+                multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+            )
+        for sf_k in cutlass.range_constexpr(SF_NUM_BLOCKS_K):
+            nvvm.tcgen05_cp(
+                nvvm.Tcgen05CpShape.SHAPE_32X128B,
+                tmem_sf_k.subview(sf_k * SF_REGISTERS_PER_BLOCK),
+                smem_desc_k + sf_k * (SF_BYTES_PER_BLOCK // 16),
+                group=CTA_GROUP_KIND,
+                multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+            )
+
+    def _utccp_bmm2_sf(tmem_sf_p, tmem_sf_v, smem_desc_p, smem_desc_v):
+        nvvm.tcgen05_cp(
+            nvvm.Tcgen05CpShape.SHAPE_32X128B,
+            tmem_sf_p,
+            smem_desc_p,
+            group=CTA_GROUP_KIND,
+            multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+        )
+        for sf_n in cutlass.range_constexpr(SF_NUM_BLOCKS_V):
+            nvvm.tcgen05_cp(
+                nvvm.Tcgen05CpShape.SHAPE_32X128B,
+                tmem_sf_v.subview(sf_n * SF_V_COLS_PER_NBLOCK),
+                smem_desc_v + sf_n * (SF_BYTES_PER_BLOCK // 16),
+                group=CTA_GROUP_KIND,
+                multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+            )
+
+    def _utccp_bmm2_p_sf(tmem_sf_p, smem_desc_p):
+        nvvm.tcgen05_cp(
+            nvvm.Tcgen05CpShape.SHAPE_32X128B,
+            tmem_sf_p,
+            smem_desc_p,
+            group=CTA_GROUP_KIND,
+            multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+        )
+
+    def _utccp_bmm2_v_sf(tmem_sf_v, smem_desc_v):
+        for sf_n in cutlass.range_constexpr(SF_NUM_BLOCKS_V):
+            nvvm.tcgen05_cp(
+                nvvm.Tcgen05CpShape.SHAPE_32X128B,
+                tmem_sf_v.subview(sf_n * SF_V_COLS_PER_NBLOCK),
+                smem_desc_v + sf_n * (SF_BYTES_PER_BLOCK // 16),
+                group=CTA_GROUP_KIND,
+                multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+            )
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0 and SPLIT_KV == 1):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        q_super_idx, _hd, batch_idx, split_idx = _decode_initial_split(
+            sched.bidx_init,
+            sched.bidy_init,
+            sched.bidz_init,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+            kv_left, kv_right = _nomask_range_split(seqlen_kv, split_idx)
+        else:
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
+            bounds_init = _bounds_for_tile_split(
+                q_super_idx,
+                eff_seqlen_q,
+                eff_seqlen_kv,
+                cta_in_pair,
+                seq_q_lens_tensor,
+                batch_idx,
+                split_idx,
+                CFG.QH_PER_KH,
+            )
+            kv_left = bounds_init.left
+            kv_right = bounds_init.right
+
+    q_full_phase = cutlass.Int32(0)
+    kv_state_K = PipelineState.start(phase=0)
+    kv_state_V = PipelineState.start(phase=0)
+    bmm2_ready_phase_pair = cutlass.Int32(0)
+    sf_reuse_phase_pair = cutlass.Int32(0)
+    qk_sf_reuse_phase_pair = cutlass.Int32(0)
+    empty_mainloop_phase = cutlass.Int32(0)
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if cutlass.const_expr(MAY_BE_EMPTY) and (kv_right <= kv_left):
+            bars.mb_empty_mainloop.wait(empty_mainloop_phase)
+            empty_mainloop_phase = empty_mainloop_phase ^ cutlass.Int32(1)
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+        else:
+            bars.mb_q_full.wait(q_full_phase)
+            q_full_phase = q_full_phase ^ cutlass.Int32(1)
+
+            lo_parity_runtime = kv_left & cutlass.Int32(1)
+            tmem_S_acc_lo_addr = lo_parity_runtime << 7
+
+            bars.mb_k_full[kv_state_K.idx].wait(kv_state_K.phase)
+            desc_K = sK[kv_state_K.idx].desc()
+            desc_K_SF = sK_SF[kv_state_K.idx].desc()
+            if nvvm.elect_sync():
+                _utccp_bmm1_sf(tmem_SF_Q_pro, tmem_SF_K_pro, desc_Q_SF, desc_K_SF)
+            mma_ss(
+                bmm1_desc,
+                desc_Q,
+                desc_K,
+                tmem_raw.subview(tmem_S_acc_lo_addr),
+                tmem_sf_a=tmem_SF_Q_pro,
+                tmem_sf_b=tmem_SF_K_pro,
+                elect_once=True,
+            )
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm1_done[lo_parity_runtime].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            _consumer_arrive_k_empty(bars, kv_state_K, mcast_mask)
+            kv_state_K = advance(kv_state_K, CFG.STAGES_KV)
+
+            k_per_chunk = NUM_KPHASES_PV_PER_CHUNK
+
+            for kv_loop in cutlass.range(kv_left, kv_right - cutlass.Int32(1), 1, unroll=1):
+                parity_cur_rt = kv_loop & cutlass.Int32(1)
+                parity_next_rt = (kv_loop + cutlass.Int32(1)) & cutlass.Int32(1)
+                parity_col_off = parity_cur_rt << 7
+                tmem_S_acc_cur_addr = parity_col_off
+                tmem_S_acc_next_addr = cutlass.Int32(LAYOUT.S_ACC_ODD_OFF) - parity_col_off
+                tmem_P_cur_addr = cutlass.Int32(LAYOUT.P_EVEN_OFF) + parity_col_off
+                bmm2_ready_phase_cur = (bmm2_ready_phase_pair >> parity_cur_rt) & cutlass.Int32(1)
+                sf_reuse_phase_cur = (sf_reuse_phase_pair >> parity_cur_rt) & cutlass.Int32(1)
+                qk_sf_reuse_phase_cur = (qk_sf_reuse_phase_pair >> parity_cur_rt) & cutlass.Int32(1)
+
+                bars.mb_k_full[kv_state_K.idx].wait(kv_state_K.phase)
+                desc_K = sK[kv_state_K.idx].desc()
+                desc_K_SF = sK_SF[kv_state_K.idx].desc()
+                if cutlass.const_expr(CFG.FUSED_CORR_SPLIT_P):
+                    wait(mb_qk_sf_reuse.subview(parity_cur_rt), qk_sf_reuse_phase_cur)
+                    qk_sf_reuse_phase_pair = qk_sf_reuse_phase_pair ^ (cutlass.Int32(1) << parity_cur_rt)
+                else:
+                    wait(mb_sf_reuse.subview(parity_cur_rt), sf_reuse_phase_cur)
+                    sf_reuse_phase_pair = sf_reuse_phase_pair ^ (cutlass.Int32(1) << parity_cur_rt)
+                tmem_SF_Q = tmem_raw.subview(tmem_S_acc_cur_addr + cutlass.Int32(LAYOUT.SF_HEAD_OFFSET))
+                tmem_SF_K = tmem_raw.subview(tmem_S_acc_cur_addr + cutlass.Int32(LAYOUT.SF_HEAD_OFFSET + SF_TMEM_COLS_Q))
+                if nvvm.elect_sync():
+                    _utccp_bmm1_sf(tmem_SF_Q, tmem_SF_K, desc_Q_SF, desc_K_SF)
+                mma_ss(
+                    bmm1_desc,
+                    desc_Q,
+                    desc_K,
+                    tmem_raw.subview(tmem_S_acc_next_addr),
+                    tmem_sf_a=tmem_SF_Q,
+                    tmem_sf_b=tmem_SF_K,
+                    elect_once=True,
+                )
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm1_done[parity_next_rt].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                _consumer_arrive_k_empty(bars, kv_state_K, mcast_mask)
+                kv_state_K = advance(kv_state_K, CFG.STAGES_KV)
+
+                if cutlass.const_expr(CFG.FUSED_CORR_SPLIT_P):
+                    wait(mb_sf_reuse.subview(parity_cur_rt), sf_reuse_phase_cur)
+                    sf_reuse_phase_pair = sf_reuse_phase_pair ^ (cutlass.Int32(1) << parity_cur_rt)
+                tmem_SF_P = tmem_raw.subview(tmem_S_acc_cur_addr + cutlass.Int32(LAYOUT.SF_AFTER_P_OFFSET))
+                tmem_SF_V = tmem_raw.subview(tmem_S_acc_cur_addr + cutlass.Int32(LAYOUT.SF_AFTER_P_OFFSET + SF_TMEM_COLS_P))
+                if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+                    if nvvm.elect_sync():
+                        _utccp_bmm2_p_sf(tmem_SF_P, desc_P_SF)
+                bars.mb_v_full[kv_state_V.idx].wait(kv_state_V.phase)
+                desc_V = sV[kv_state_V.idx].desc()
+                desc_V_SF = sV_SF[kv_state_V.idx].desc()
+                if nvvm.elect_sync():
+                    if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+                        _utccp_bmm2_v_sf(tmem_SF_V, desc_V_SF)
+                    else:
+                        _utccp_bmm2_sf(tmem_SF_P, tmem_SF_V, desc_P_SF, desc_V_SF)
+
+                scaleC = cutlass.Boolean(kv_loop != kv_left)
+                if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+                    bmm2_issue = nvvm.elect_sync()
+                    for chunk_id in cutlass.range_constexpr(CFG.N_BMM2_CHUNKS):
+                        bars.mb_bmm2_ready[parity_cur_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(chunk_id)].wait(bmm2_ready_phase_cur)
+                        for n_block in cutlass.range_constexpr(BMM2_LOOP_N_BLOCKS):
+                            for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                                k = chunk_id * NUM_KPHASES_PV_PER_CHUNK + local_k
+                                accum_b2 = scaleC if k == 0 else cutlass.Boolean(True)
+                                mma_ts_step(
+                                    bmm2_desc,
+                                    tmem_raw.subview(tmem_P_cur_addr),
+                                    desc_V + n_block * (BMM2_N_BLOCK_BYTE_STRIDE // 16),
+                                    tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF + n_block * BMM2_N_PER_CALL_PER_CTA)),
+                                    k,
+                                    accum_b2,
+                                    tmem_sf_a=tmem_SF_P,
+                                    tmem_sf_b=tmem_SF_V.subview(n_block * SF_V_COLS_PER_NBLOCK),
+                                    issue_mma=bmm2_issue,
+                                )
+                elif cutlass.const_expr(_E5_STYLE_KV_PIPELINE):
+                    bmm2_issue_dense = nvvm.elect_sync()
+                    for k in cutlass.range_constexpr(NUM_KPHASES_PV):
+                        if k % k_per_chunk == 0:
+                            chunk_id = k // k_per_chunk
+                            bars.mb_bmm2_ready[parity_cur_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(chunk_id)].wait(bmm2_ready_phase_cur)
+                        for n_block in cutlass.range_constexpr(BMM2_LOOP_N_BLOCKS):
+                            accum_b2 = scaleC if k == 0 else cutlass.Boolean(True)
+                            mma_ts_step(
+                                bmm2_desc,
+                                tmem_raw.subview(tmem_P_cur_addr),
+                                desc_V + n_block * (BMM2_N_BLOCK_BYTE_STRIDE // 16),
+                                tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF + n_block * BMM2_N_PER_CALL_PER_CTA)),
+                                k,
+                                accum_b2,
+                                tmem_sf_a=tmem_SF_P,
+                                tmem_sf_b=tmem_SF_V.subview(n_block * SF_V_COLS_PER_NBLOCK),
+                                issue_mma=bmm2_issue_dense,
+                            )
+                else:
+                    for n_block in cutlass.range_constexpr(BMM2_LOOP_N_BLOCKS):
+                        accum_b2 = scaleC
+                        for k in cutlass.range_constexpr(NUM_KPHASES_PV):
+                            if n_block == 0 and k % k_per_chunk == 0:
+                                chunk_id = k // k_per_chunk
+                                bars.mb_bmm2_ready[parity_cur_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(chunk_id)].wait(bmm2_ready_phase_cur)
+                            mma_ts_step(
+                                bmm2_desc,
+                                tmem_raw.subview(tmem_P_cur_addr),
+                                desc_V + n_block * (BMM2_N_BLOCK_BYTE_STRIDE // 16),
+                                tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF + n_block * BMM2_N_PER_CALL_PER_CTA)),
+                                k,
+                                accum_b2,
+                                tmem_sf_a=tmem_SF_P,
+                                tmem_sf_b=tmem_SF_V.subview(n_block * SF_V_COLS_PER_NBLOCK),
+                            )
+                            accum_b2 = cutlass.Boolean(True)
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm2_done[parity_cur_rt].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                _consumer_arrive_v_empty(bars, kv_state_V, mcast_mask)
+                bmm2_ready_phase_pair = bmm2_ready_phase_pair ^ (cutlass.Int32(1) << parity_cur_rt)
+                kv_state_V = advance(kv_state_V, CFG.STAGES_KV)
+
+            kv_last = kv_right - cutlass.Int32(1)
+            parity_last_rt = kv_last & cutlass.Int32(1)
+            parity_last_col_off = parity_last_rt << 7
+            tmem_P_last_addr = cutlass.Int32(LAYOUT.P_EVEN_OFF) + parity_last_col_off
+            bmm2_ready_phase_last = (bmm2_ready_phase_pair >> parity_last_rt) & cutlass.Int32(1)
+            sf_reuse_phase_last = (sf_reuse_phase_pair >> parity_last_rt) & cutlass.Int32(1)
+            qk_sf_reuse_phase_last = (qk_sf_reuse_phase_pair >> parity_last_rt) & cutlass.Int32(1)
+
+            tmem_S_acc_last_addr = parity_last_col_off
+            tmem_SF_P = tmem_raw.subview(tmem_S_acc_last_addr + cutlass.Int32(LAYOUT.SF_AFTER_P_OFFSET))
+            tmem_SF_V = tmem_raw.subview(tmem_S_acc_last_addr + cutlass.Int32(LAYOUT.SF_AFTER_P_OFFSET + SF_TMEM_COLS_P))
+            if cutlass.const_expr(CFG.FUSED_CORR_SPLIT_P):
+                wait(mb_qk_sf_reuse.subview(parity_last_rt), qk_sf_reuse_phase_last)
+                qk_sf_reuse_phase_pair = qk_sf_reuse_phase_pair ^ (cutlass.Int32(1) << parity_last_rt)
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+                wait(mb_sf_reuse.subview(parity_last_rt), sf_reuse_phase_last)
+                sf_reuse_phase_pair = sf_reuse_phase_pair ^ (cutlass.Int32(1) << parity_last_rt)
+                if nvvm.elect_sync():
+                    _utccp_bmm2_p_sf(tmem_SF_P, desc_P_SF)
+            bars.mb_v_full[kv_state_V.idx].wait(kv_state_V.phase)
+            desc_V = sV[kv_state_V.idx].desc()
+            desc_V_SF = sV_SF[kv_state_V.idx].desc()
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+                if nvvm.elect_sync():
+                    _utccp_bmm2_v_sf(tmem_SF_V, desc_V_SF)
+            else:
+                wait(mb_sf_reuse.subview(parity_last_rt), sf_reuse_phase_last)
+                sf_reuse_phase_pair = sf_reuse_phase_pair ^ (cutlass.Int32(1) << parity_last_rt)
+                if nvvm.elect_sync():
+                    _utccp_bmm2_sf(tmem_SF_P, tmem_SF_V, desc_P_SF, desc_V_SF)
+            n_kv_eff = kv_right - kv_left
+            scaleC_epi = cutlass.Boolean(n_kv_eff != cutlass.Int32(1))
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+                bmm2_issue = nvvm.elect_sync()
+                for chunk_id in cutlass.range_constexpr(CFG.N_BMM2_CHUNKS):
+                    bars.mb_bmm2_ready[parity_last_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(chunk_id)].wait(bmm2_ready_phase_last)
+                    for n_block in cutlass.range_constexpr(BMM2_LOOP_N_BLOCKS):
+                        for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                            k = chunk_id * NUM_KPHASES_PV_PER_CHUNK + local_k
+                            accum_b2 = scaleC_epi if k == 0 else cutlass.Boolean(True)
+                            mma_ts_step(
+                                bmm2_desc,
+                                tmem_raw.subview(tmem_P_last_addr),
+                                desc_V + n_block * (BMM2_N_BLOCK_BYTE_STRIDE // 16),
+                                tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF + n_block * BMM2_N_PER_CALL_PER_CTA)),
+                                k,
+                                accum_b2,
+                                tmem_sf_a=tmem_SF_P,
+                                tmem_sf_b=tmem_SF_V.subview(n_block * SF_V_COLS_PER_NBLOCK),
+                                issue_mma=bmm2_issue,
+                            )
+            elif cutlass.const_expr(_E5_STYLE_KV_PIPELINE):
+                bmm2_issue_dense_epi = nvvm.elect_sync()
+                for k in cutlass.range_constexpr(NUM_KPHASES_PV):
+                    if k % k_per_chunk == 0:
+                        chunk_id = k // k_per_chunk
+                        bars.mb_bmm2_ready[parity_last_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(chunk_id)].wait(bmm2_ready_phase_last)
+                    for n_block in cutlass.range_constexpr(BMM2_LOOP_N_BLOCKS):
+                        accum_b2 = scaleC_epi if k == 0 else cutlass.Boolean(True)
+                        mma_ts_step(
+                            bmm2_desc,
+                            tmem_raw.subview(tmem_P_last_addr),
+                            desc_V + n_block * (BMM2_N_BLOCK_BYTE_STRIDE // 16),
+                            tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF + n_block * BMM2_N_PER_CALL_PER_CTA)),
+                            k,
+                            accum_b2,
+                            tmem_sf_a=tmem_SF_P,
+                            tmem_sf_b=tmem_SF_V.subview(n_block * SF_V_COLS_PER_NBLOCK),
+                            issue_mma=bmm2_issue_dense_epi,
+                        )
+            else:
+                for n_block in cutlass.range_constexpr(BMM2_LOOP_N_BLOCKS):
+                    accum_b2 = scaleC_epi
+                    for k in cutlass.range_constexpr(NUM_KPHASES_PV):
+                        if n_block == 0 and k % k_per_chunk == 0:
+                            chunk_id = k // k_per_chunk
+                            bars.mb_bmm2_ready[parity_last_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(chunk_id)].wait(bmm2_ready_phase_last)
+                        mma_ts_step(
+                            bmm2_desc,
+                            tmem_raw.subview(tmem_P_last_addr),
+                            desc_V + n_block * (BMM2_N_BLOCK_BYTE_STRIDE // 16),
+                            tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF + n_block * BMM2_N_PER_CALL_PER_CTA)),
+                            k,
+                            accum_b2,
+                            tmem_sf_a=tmem_SF_P,
+                            tmem_sf_b=tmem_SF_V.subview(n_block * SF_V_COLS_PER_NBLOCK),
+                        )
+                        accum_b2 = cutlass.Boolean(True)
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm2_done[parity_last_rt].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            _consumer_arrive_v_empty(bars, kv_state_V, mcast_mask)
+            bmm2_ready_phase_pair = bmm2_ready_phase_pair ^ (cutlass.Int32(1) << parity_last_rt)
+            kv_state_V = advance(kv_state_V, CFG.STAGES_KV)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(mb_decoded.subview(sched_state.idx), sched_state.phase)
+        payload_base = sched_state.idx * cutlass.Int32(SCHED_PAYLOAD_WORDS)
+        if cutlass.const_expr(CFG.MASK_FLAGS == 0 and SPLIT_KV == 1):
+            nxt_v = sched.tile_id_smem.subview(payload_base + cutlass.Int32(2)).load()
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+        else:
+            nxt_v = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(2)).load())
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+            kv_left = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(6)).load())
+            kv_right = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(9)).load())
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _softmax_warp_group(
+    softmax_half: cutlass.Constexpr[int],
+    seqlen_q,
+    seqlen_kv,
+    scale_log2: cutlass.Float32,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    mb_decoded,
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor,
+    seq_q_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+    bottom_right_diagonal: cutlass.Constexpr[bool],
+    softmax_exchange,
+    mb_sf_reuse,
+):
+    nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    tmem_base = tmem_ptr_i32.load()
+
+    bmm1_done_phase_pair = cutlass.Int32(0)
+    stat_empty_phase = cutlass.Int32(0 if CFG.FUSED_CORR_SPLIT_P else 1)
+    epilogue_state = cutlass.Int32(1)
+
+    NEG_INF = cutlass.Float32(float("-inf"))
+
+    q_super_idx, head_idx, batch_idx, split_idx = _decode_initial_split(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+        CFG.QH_PER_KH,
+        seqlen_kv,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+
+    eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
+    bounds = _bounds_for_tile_split(
+        q_super_idx,
+        eff_seqlen_q,
+        eff_seqlen_kv,
+        cta_in_pair,
+        seq_q_lens_tensor,
+        batch_idx,
+        split_idx,
+        CFG.QH_PER_KH,
+    )
+
+    softmax_wg_base = CFG.SOFTMAX_WG0_BASE if softmax_half == 0 else CFG.SOFTMAX_WG1_BASE
+    tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(softmax_wg_base * 32)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        total_max = NEG_INF
+        total_max_safe = NEG_INF
+        total_sum = cutlass.Vector.from_elements(
+            (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+            cutlass.Float32,
+        )
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+        q_abs = q_row_coord + tid_in_wg
+
+        if cutlass.const_expr(not CFG.FUSED_CORR_SPLIT_P):
+            bars.mb_o_empty.wait(epilogue_state)
+        if cutlass.const_expr(softmax_half == 0 and not CFG.FUSED_CORR_SPLIT_P):
+            bars.mb_stat_empty.wait(stat_empty_phase)
+            stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+        epilogue_state = epilogue_state ^ cutlass.Int32(1)
+
+        CHUNK = 64
+        P_COLS_PER_CHUNK = CHUNK // 4
+        P_SUBCHUNK = 32
+        P_COLS_PER_SUBCHUNK = P_SUBCHUNK // 4
+        N_CHUNKS = CFG.N_BMM2_CHUNKS
+        RESCALE_THRESHOLD = cutlass.Float32(CFG.RESCALE_THRESHOLD)
+
+        if cutlass.const_expr(CFG.MASK_FLAGS == MASK_NONE):
+            for kv_loop in cutlass.range(bounds.left, bounds.right, 1, unroll=1):
+                parity_rt = kv_loop & cutlass.Int32(1)
+                parity_is_even = parity_rt == cutlass.Int32(0)
+                s_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value())
+                )
+                p_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value())
+                )
+                bmm1_phase = (bmm1_done_phase_pair >> parity_rt) & cutlass.Int32(1)
+                bars.mb_bmm1_done[parity_rt].wait(bmm1_phase)
+                bmm1_done_phase_pair = bmm1_done_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+
+                s_addr_base = tmem_base + s_off_rt
+                p_addr_base = tmem_base + p_off_rt
+                stats_addr = tmem_base + s_off_rt
+
+                if cutlass.const_expr(softmax_half == 0):
+                    if cutlass.const_expr(_E5_STYLE_KV_PIPELINE):
+                        raw_hi = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(CHUNK), cutlass.Float32),
+                            num=CHUNK,
+                        )
+                        raw_lo = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(s_addr_base, cutlass.Float32),
+                            num=CHUNK,
+                        )
+                        raw_chunks = [raw_lo, raw_hi]
+                    else:
+                        raw_chunks = [
+                            nvvm.tcgen05_ld(
+                                "32x32b",
+                                nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32),
+                                num=CHUNK,
+                            )
+                            for c in range(N_CHUNKS)
+                        ]
+                    reg_S_full = RegTile(vec_concat(raw_chunks), size=CFG.TILE_N)
+                    if cutlass.const_expr(_E5_STYLE_KV_PIPELINE):
+                        max_hi = row_max_reduction(reg_S_full[CHUNK : 2 * CHUNK].vec)
+                        max_lo = row_max_reduction(reg_S_full[0:CHUNK].vec)
+                        current_max_unscaled = cute.math.max(max_lo, max_hi, ftz=True)
+                    else:
+                        current_max_unscaled = row_max_reduction(reg_S_full.vec)
+                    current_max = current_max_unscaled * scale_log2
+                    update_cond = (current_max - total_max) > RESCALE_THRESHOLD
+                    total_max = cutlass.Float32(arith.select(update_cond.ir_value(), current_max.ir_value(), total_max.ir_value()))
+                    new_total_max_safe = total_max
+                    alpha = cute.math.exp2(
+                        cute.math.min(total_max_safe - new_total_max_safe, cutlass.Float32(0.0)),
+                        fastmath=True,
+                    )
+                    total_max_safe = new_total_max_safe
+                    reg_S_half = reg_S_full[0:CHUNK]
+
+                    exchange_base = parity_rt * cutlass.Int32(2 * CFG.TILE_M)
+                    softmax_exchange.subview(exchange_base + cutlass.Int32(CFG.TILE_M) + tid_in_wg).store(total_max_safe)
+                else:
+                    reg_S_half = RegTile(
+                        nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(CHUNK), cutlass.Float32),
+                            num=CHUNK,
+                        ),
+                        size=CHUNK,
+                    )
+
+                    reg_S_half = reg_S_half * scale_log2
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                if cutlass.const_expr(CFG.SOFTMAX_WARPGROUPS == 1 or softmax_half == 0):
+                    if nvvm.elect_sync():
+                        nvvm.mbarrier_arrive(mb_sf_reuse.subview(parity_rt))
+                if cutlass.const_expr(not CFG.FUSED_CORR_SPLIT_P):
+                    nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
+                if cutlass.const_expr(softmax_half == 1):
+                    exchange_base = parity_rt * cutlass.Int32(2 * CFG.TILE_M)
+                    new_total_max_safe = softmax_exchange.subview(exchange_base + cutlass.Int32(CFG.TILE_M) + tid_in_wg).load()
+                    alpha = cute.math.exp2(
+                        cute.math.min(total_max_safe - new_total_max_safe, cutlass.Float32(0.0)),
+                        fastmath=True,
+                    )
+                    total_max_safe = new_total_max_safe
+
+                if cutlass.const_expr(softmax_half == 0):
+                    if cutlass.const_expr(CFG.FUSED_CORR_SPLIT_P):
+                        exchange_base = parity_rt * cutlass.Int32(2 * CFG.TILE_M)
+                        softmax_exchange.subview(exchange_base + tid_in_wg).store(alpha)
+                    elif cutlass.const_expr(_E5_STYLE_KV_PIPELINE):
+                        exchange_base = parity_rt * cutlass.Int32(2 * CFG.TILE_M)
+                        softmax_exchange.subview(exchange_base + tid_in_wg).store(alpha)
+                    else:
+                        alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+                        nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                    bars.mb_stat_full.arrive()
+
+                if cutlass.const_expr(softmax_half == 0):
+                    reg_S_half = reg_S_half * scale_log2 - total_max_safe
+                else:
+                    reg_S_half = reg_S_half - total_max_safe
+                chunk_P_a = _exp2_chunk0a_mixed(
+                    reg_S_half[0:P_SUBCHUNK].vec,
+                    False,
+                    dense=True,
+                    softmax_half=softmax_half,
+                )
+                new_p_sum_pair = row_reduction_pair(chunk_P_a)
+                nvvm.tcgen05_st(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(
+                        p_addr_base + cutlass.Int32(softmax_half * P_COLS_PER_CHUNK),
+                        cutlass.Float32,
+                    ),
+                    chunk_P_a.to(STORAGE_DTYPE),
+                )
+                chunk_P_b = _exp2_chunk1b_mixed(
+                    reg_S_half[P_SUBCHUNK:CHUNK].vec,
+                    dense=True,
+                    softmax_half=softmax_half,
+                )
+                new_p_sum_pair = new_p_sum_pair + row_reduction_pair(chunk_P_b)
+                nvvm.tcgen05_st(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(
+                        p_addr_base + cutlass.Int32(softmax_half * P_COLS_PER_CHUNK + P_COLS_PER_SUBCHUNK),
+                        cutlass.Float32,
+                    ),
+                    chunk_P_b.to(STORAGE_DTYPE),
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(softmax_half)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+                total_sum = total_sum * alpha_pair + new_p_sum_pair
+
+                if cutlass.const_expr(softmax_half == 0):
+                    bars.mb_stat_empty.wait(stat_empty_phase)
+                    stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+        else:
+            # Exact top-left causal has no lower masking boundary.
+            left_edge_end = (
+                bounds.left
+                if cutlass.const_expr((CFG.MASK_FLAGS & ~MASK_PADDED) == MASK_CAUSAL and (CFG.BOTTOM_RIGHT == 0 or bottom_right_diagonal))
+                else bounds.unmasked_lo
+            )
+            for kv_loop in cutlass.range(bounds.left, left_edge_end, 1, unroll=1):
+                parity_rt = kv_loop & cutlass.Int32(1)
+                parity_is_even = parity_rt == cutlass.Int32(0)
+                s_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value())
+                )
+                p_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value())
+                )
+                bmm1_phase = (bmm1_done_phase_pair >> parity_rt) & cutlass.Int32(1)
+                bars.mb_bmm1_done[parity_rt].wait(bmm1_phase)
+                bmm1_done_phase_pair = bmm1_done_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+                s_addr_base = tmem_base + s_off_rt
+                p_addr_base = tmem_base + p_off_rt
+                stats_addr = tmem_base + s_off_rt
+                kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+                raw_chunks = [
+                    nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32), num=CHUNK) for c in range(N_CHUNKS)
+                ]
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                if cutlass.const_expr(CFG.SOFTMAX_WARPGROUPS == 1 or softmax_half == 0):
+                    if nvvm.elect_sync():
+                        nvvm.mbarrier_arrive(mb_sf_reuse.subview(parity_rt))
+                if cutlass.const_expr(bottom_right_diagonal):
+                    mask_bottom_right = 0
+                    causal_diag = None
+                else:
+                    mask_bottom_right = CFG.BOTTOM_RIGHT
+                    causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+                chunks_S = [
+                    apply_mask_chunk(
+                        raw_chunks[c],
+                        q_abs - (kv_col_base + cutlass.Int32(c * CHUNK)),
+                        cutlass.Int32(0),
+                        eff_seqlen_kv - (kv_col_base + cutlass.Int32(c * CHUNK)),
+                        CFG.WINDOW_LEFT,
+                        CFG.MASK_FLAGS,
+                        N=CHUNK,
+                        bottom_right=mask_bottom_right,
+                        causal_diag=causal_diag,
+                        window_right=CFG.WINDOW_RIGHT,
+                        mask_value=float("-inf"),
+                    )
+                    for c in range(N_CHUNKS)
+                ]
+                reg_S_vec = vec_concat(chunks_S)
+                current_max_unscaled = row_max_reduction(reg_S_vec)
+                reg_S = RegTile(reg_S_vec, size=CFG.TILE_N)
+                current_max = current_max_unscaled * scale_log2  # -inf when the whole iteration is masked
+
+                # total_max starts at -inf: a live iteration always clears the
+                # threshold (real - (-inf) = +inf), a fully-masked one never does
+                # (-inf - x = -inf or NaN; ordered > is false for both).
+                update_cond = (current_max - total_max) > RESCALE_THRESHOLD
+                total_max = cutlass.Float32(arith.select(update_cond.ir_value(), current_max.ir_value(), total_max.ir_value()))
+                # Canonical 0-substitution at point of use, on BOTH alpha operands;
+                # min(., 0) guards the dead->alive drop of the safe max (total_sum
+                # is still 0 there).  total_max_safe starts at -inf: iter-0 alpha = 0.
+                new_total_max_safe = row_max_for_exp2(total_max)
+                alpha = cute.math.exp2(cute.math.min(total_max_safe - new_total_max_safe, cutlass.Float32(0.0)), fastmath=True)
+                total_max_safe = new_total_max_safe
+                if cutlass.const_expr(CFG.FUSED_CORR_SPLIT_P):
+                    exchange_base = parity_rt * cutlass.Int32(2 * CFG.TILE_M)
+                    softmax_exchange.subview(exchange_base + tid_in_wg).store(alpha)
+                    softmax_exchange.subview(exchange_base + cutlass.Int32(CFG.TILE_M) + tid_in_wg).store(total_max_safe)
+                elif cutlass.const_expr(_E5_STYLE_SOFTMAX):
+                    exchange_base = parity_rt * cutlass.Int32(CFG.TILE_M)
+                    softmax_exchange.subview(exchange_base + tid_in_wg).store(alpha)
+                else:
+                    alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+                    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_stat_full.arrive()
+                reg_S = reg_S * scale_log2 - total_max_safe
+
+                chunk_P_0a = _exp2_chunk0a_mixed(reg_S[0:P_SUBCHUNK].vec, True)
+                hoisted_sum = row_reduction_pair(chunk_P_0a)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32), chunk_P_0a.to(STORAGE_DTYPE))
+                chunk_P_0b = cute.math.exp2(reg_S[P_SUBCHUNK:CHUNK].vec, fastmath=True)
+                hoisted_sum = hoisted_sum + row_reduction_pair(chunk_P_0b)
+                nvvm.tcgen05_st(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_SUBCHUNK), cutlass.Float32),
+                    chunk_P_0b.to(STORAGE_DTYPE),
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(0)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                deferred_sum_1 = None
+                if cutlass.const_expr(N_CHUNKS == 2 and not CFG.FUSED_CORR_SPLIT_P):
+                    chunk_P_1a = cute.math.exp2(reg_S[CHUNK : CHUNK + P_SUBCHUNK].vec, fastmath=True)
+                    deferred_sum_1 = row_reduction_pair(chunk_P_1a)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK), cutlass.Float32),
+                        chunk_P_1a.to(STORAGE_DTYPE),
+                    )
+                    chunk_P_1b = _exp2_chunk1b_mixed(reg_S[CHUNK + P_SUBCHUNK : 2 * CHUNK].vec)
+                    deferred_sum_1 = deferred_sum_1 + row_reduction_pair(chunk_P_1b)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK + P_COLS_PER_SUBCHUNK), cutlass.Float32),
+                        chunk_P_1b.to(STORAGE_DTYPE),
+                    )
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                    bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(1)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                new_p_sum_pair = hoisted_sum
+                if cutlass.const_expr(N_CHUNKS == 2 and not CFG.FUSED_CORR_SPLIT_P):
+                    new_p_sum_pair = new_p_sum_pair + deferred_sum_1
+                alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+                total_sum = total_sum * alpha_pair + new_p_sum_pair
+                bars.mb_stat_empty.wait(stat_empty_phase)
+                stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+            for kv_loop in cutlass.range(bounds.unmasked_lo, bounds.unmasked_hi, 1, unroll=1):
+                parity_rt = kv_loop & cutlass.Int32(1)
+                parity_is_even = parity_rt == cutlass.Int32(0)
+                s_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value())
+                )
+                p_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value())
+                )
+                bmm1_phase = (bmm1_done_phase_pair >> parity_rt) & cutlass.Int32(1)
+                bars.mb_bmm1_done[parity_rt].wait(bmm1_phase)
+                bmm1_done_phase_pair = bmm1_done_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+                s_addr_base = tmem_base + s_off_rt
+                p_addr_base = tmem_base + p_off_rt
+                stats_addr = tmem_base + s_off_rt
+                unmasked_chunk = 32
+                raw_chunks = [
+                    nvvm.tcgen05_ld(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * unmasked_chunk), cutlass.Float32),
+                        num=unmasked_chunk,
+                    )
+                    for c in range(CFG.TILE_N // unmasked_chunk)
+                ]
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                if cutlass.const_expr(CFG.SOFTMAX_WARPGROUPS == 1 or softmax_half == 0):
+                    if nvvm.elect_sync():
+                        nvvm.mbarrier_arrive(mb_sf_reuse.subview(parity_rt))
+                reg_S_vec = vec_concat(raw_chunks)
+                max_lo = row_max_reduction(reg_S_vec[0:64])
+                max_hi = row_max_reduction(reg_S_vec[64:128])
+                current_max_unscaled = cute.math.max(max_lo, max_hi, ftz=True)
+                reg_S = RegTile(reg_S_vec, size=CFG.TILE_N)
+                current_max = current_max_unscaled * scale_log2  # -inf when the whole iteration is masked
+
+                # total_max starts at -inf: a live iteration always clears the
+                # threshold (real - (-inf) = +inf), a fully-masked one never does
+                # (-inf - x = -inf or NaN; ordered > is false for both).
+                update_cond = (current_max - total_max) > RESCALE_THRESHOLD
+                total_max = cutlass.Float32(arith.select(update_cond.ir_value(), current_max.ir_value(), total_max.ir_value()))
+                # Every row in this interior tile is live, so the updated
+                # total_max is finite even if all preceding edge tiles were dead.
+                new_total_max_safe = total_max
+                alpha = cute.math.exp2(cute.math.min(total_max_safe - new_total_max_safe, cutlass.Float32(0.0)), fastmath=True)
+                total_max_safe = new_total_max_safe
+                if cutlass.const_expr(CFG.FUSED_CORR_SPLIT_P):
+                    exchange_base = parity_rt * cutlass.Int32(2 * CFG.TILE_M)
+                    softmax_exchange.subview(exchange_base + tid_in_wg).store(alpha)
+                    softmax_exchange.subview(exchange_base + cutlass.Int32(CFG.TILE_M) + tid_in_wg).store(total_max_safe)
+                elif cutlass.const_expr(_E5_STYLE_SOFTMAX):
+                    exchange_base = parity_rt * cutlass.Int32(CFG.TILE_M)
+                    softmax_exchange.subview(exchange_base + tid_in_wg).store(alpha)
+                else:
+                    alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+                    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_stat_full.arrive()
+                reg_S = reg_S * scale_log2 - total_max_safe
+
+                chunk_P_0a = _exp2_chunk0a_mixed(reg_S[0:P_SUBCHUNK].vec, False)
+                if cutlass.const_expr(not _E5_STYLE_SOFTMAX):
+                    hoisted_sum = row_reduction_pair(chunk_P_0a)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32), chunk_P_0a.to(STORAGE_DTYPE))
+                if cutlass.const_expr(_E5_STYLE_SOFTMAX):
+                    hoisted_sum = row_reduction_pair(chunk_P_0a)
+                if cutlass.const_expr(not _E5_STYLE_SOFTMAX):
+                    chunk_P_0b = _exp2_chunk1b_mixed(reg_S[P_SUBCHUNK:CHUNK].vec)
+                else:
+                    chunk_P_0b = cute.math.exp2(reg_S[P_SUBCHUNK:CHUNK].vec, fastmath=True)
+                if cutlass.const_expr(not _E5_STYLE_SOFTMAX):
+                    hoisted_sum = hoisted_sum + row_reduction_pair(chunk_P_0b)
+                nvvm.tcgen05_st(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_SUBCHUNK), cutlass.Float32),
+                    chunk_P_0b.to(STORAGE_DTYPE),
+                )
+                if cutlass.const_expr(_E5_STYLE_SOFTMAX):
+                    hoisted_sum = hoisted_sum + row_reduction_pair(chunk_P_0b)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(0)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                deferred_sum_1 = None
+                if cutlass.const_expr(N_CHUNKS == 2 and not CFG.FUSED_CORR_SPLIT_P):
+                    chunk_P_1a = cute.math.exp2(reg_S[CHUNK : CHUNK + P_SUBCHUNK].vec, fastmath=True)
+                    deferred_sum_1 = row_reduction_pair(chunk_P_1a)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK), cutlass.Float32),
+                        chunk_P_1a.to(STORAGE_DTYPE),
+                    )
+                    chunk_P_1b = _exp2_chunk1b_mixed(
+                        reg_S[CHUNK + P_SUBCHUNK : 2 * CHUNK].vec,
+                        softmax_half=2,
+                    )
+                    deferred_sum_1 = deferred_sum_1 + row_reduction_pair(chunk_P_1b)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK + P_COLS_PER_SUBCHUNK), cutlass.Float32),
+                        chunk_P_1b.to(STORAGE_DTYPE),
+                    )
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                    bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(1)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                new_p_sum_pair = hoisted_sum
+                if cutlass.const_expr(N_CHUNKS == 2 and not CFG.FUSED_CORR_SPLIT_P):
+                    new_p_sum_pair = new_p_sum_pair + deferred_sum_1
+                alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+                total_sum = total_sum * alpha_pair + new_p_sum_pair
+                bars.mb_stat_empty.wait(stat_empty_phase)
+                stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+            for kv_loop in cutlass.range(bounds.unmasked_hi, bounds.right, 1, unroll=1):
+                tail_active = True
+                if tail_active:
+                    parity_rt = kv_loop & cutlass.Int32(1)
+                    parity_is_even = parity_rt == cutlass.Int32(0)
+                    s_off_rt = cutlass.Int32(
+                        arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value())
+                    )
+                    p_off_rt = cutlass.Int32(
+                        arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value())
+                    )
+                    bmm1_phase = (bmm1_done_phase_pair >> parity_rt) & cutlass.Int32(1)
+                    bars.mb_bmm1_done[parity_rt].wait(bmm1_phase)
+                    bmm1_done_phase_pair = bmm1_done_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+                    s_addr_base = tmem_base + s_off_rt
+                    p_addr_base = tmem_base + p_off_rt
+                    stats_addr = tmem_base + s_off_rt
+                    kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+                    raw_chunks = [
+                        nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32), num=CHUNK)
+                        for c in range(N_CHUNKS)
+                    ]
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                    if cutlass.const_expr(CFG.SOFTMAX_WARPGROUPS == 1 or softmax_half == 0):
+                        if nvvm.elect_sync():
+                            nvvm.mbarrier_arrive(mb_sf_reuse.subview(parity_rt))
+                    if cutlass.const_expr(bottom_right_diagonal):
+                        mask_bottom_right = 0
+                        causal_diag = None
+                    else:
+                        mask_bottom_right = CFG.BOTTOM_RIGHT
+                        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+                    mask_q_abs = q_abs
+                    mask_flags = CFG.MASK_FLAGS
+                    if cutlass.const_expr(_PADDED_TOP_LEFT_CAUSAL):
+                        mask_q_abs = cute.math.min(q_abs, eff_seqlen_kv - cutlass.Int32(1))
+                        mask_flags = MASK_CAUSAL
+                    chunks_S = [
+                        apply_mask_chunk(
+                            raw_chunks[c],
+                            mask_q_abs - (kv_col_base + cutlass.Int32(c * CHUNK)),
+                            cutlass.Int32(0),
+                            eff_seqlen_kv - (kv_col_base + cutlass.Int32(c * CHUNK)),
+                            CFG.WINDOW_LEFT,
+                            mask_flags,
+                            N=CHUNK,
+                            bottom_right=mask_bottom_right,
+                            causal_diag=causal_diag,
+                            window_right=CFG.WINDOW_RIGHT,
+                            mask_value=float("-inf"),
+                        )
+                        for c in range(N_CHUNKS)
+                    ]
+                    reg_S_vec = vec_concat(chunks_S)
+                    current_max_unscaled = row_max_reduction(reg_S_vec)
+                    reg_S = RegTile(reg_S_vec, size=CFG.TILE_N)
+                    current_max = current_max_unscaled * scale_log2  # -inf when the whole iteration is masked
+
+                    # total_max starts at -inf: a live iteration always clears the
+                    # threshold (real - (-inf) = +inf), a fully-masked one never does
+                    # (-inf - x = -inf or NaN; ordered > is false for both).
+                    update_cond = (current_max - total_max) > RESCALE_THRESHOLD
+                    total_max = cutlass.Float32(arith.select(update_cond.ir_value(), current_max.ir_value(), total_max.ir_value()))
+                    # Canonical 0-substitution at point of use, on BOTH alpha operands;
+                    # min(., 0) guards the dead->alive drop of the safe max (total_sum
+                    # is still 0 there).  total_max_safe starts at -inf: iter-0 alpha = 0.
+                    new_total_max_safe = row_max_for_exp2(total_max)
+                    alpha = cute.math.exp2(cute.math.min(total_max_safe - new_total_max_safe, cutlass.Float32(0.0)), fastmath=True)
+                    total_max_safe = new_total_max_safe
+                    if cutlass.const_expr(CFG.FUSED_CORR_SPLIT_P):
+                        exchange_base = parity_rt * cutlass.Int32(2 * CFG.TILE_M)
+                        softmax_exchange.subview(exchange_base + tid_in_wg).store(alpha)
+                        softmax_exchange.subview(exchange_base + cutlass.Int32(CFG.TILE_M) + tid_in_wg).store(total_max_safe)
+                    elif cutlass.const_expr(_E5_STYLE_SOFTMAX):
+                        exchange_base = parity_rt * cutlass.Int32(CFG.TILE_M)
+                        softmax_exchange.subview(exchange_base + tid_in_wg).store(alpha)
+                    else:
+                        alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+                        nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                    bars.mb_stat_full.arrive()
+                    reg_S = reg_S * scale_log2 - total_max_safe
+
+                    chunk_P_0a = _exp2_chunk0a_mixed(reg_S[0:P_SUBCHUNK].vec, True)
+                    hoisted_sum = row_reduction_pair(chunk_P_0a)
+                    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32), chunk_P_0a.to(STORAGE_DTYPE))
+                    chunk_P_0b = cute.math.exp2(reg_S[P_SUBCHUNK:CHUNK].vec, fastmath=True)
+                    hoisted_sum = hoisted_sum + row_reduction_pair(chunk_P_0b)
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_SUBCHUNK), cutlass.Float32),
+                        chunk_P_0b.to(STORAGE_DTYPE),
+                    )
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                    bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(0)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                    deferred_sum_1 = None
+                    if cutlass.const_expr(N_CHUNKS == 2 and not CFG.FUSED_CORR_SPLIT_P):
+                        chunk_P_1a = cute.math.exp2(reg_S[CHUNK : CHUNK + P_SUBCHUNK].vec, fastmath=True)
+                        deferred_sum_1 = row_reduction_pair(chunk_P_1a)
+                        nvvm.tcgen05_st(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK), cutlass.Float32),
+                            chunk_P_1a.to(STORAGE_DTYPE),
+                        )
+                        chunk_P_1b = _exp2_chunk1b_mixed(reg_S[CHUNK + P_SUBCHUNK : 2 * CHUNK].vec)
+                        deferred_sum_1 = deferred_sum_1 + row_reduction_pair(chunk_P_1b)
+                        nvvm.tcgen05_st(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK + P_COLS_PER_SUBCHUNK), cutlass.Float32),
+                            chunk_P_1b.to(STORAGE_DTYPE),
+                        )
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                        bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(1)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                    new_p_sum_pair = hoisted_sum
+                    if cutlass.const_expr(N_CHUNKS == 2 and not CFG.FUSED_CORR_SPLIT_P):
+                        new_p_sum_pair = new_p_sum_pair + deferred_sum_1
+                    alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+                    total_sum = total_sum * alpha_pair + new_p_sum_pair
+                    bars.mb_stat_empty.wait(stat_empty_phase)
+                    stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+
+        total_sum_scalar = total_sum[0] + total_sum[1]
+        if cutlass.const_expr(CFG.SOFTMAX_WARPGROUPS == 2):
+            tail_idx = cutlass.Int32(4 * CFG.TILE_M + softmax_half * CFG.TILE_M) + tid_in_wg
+            peer_tail_idx = cutlass.Int32(4 * CFG.TILE_M + (1 - softmax_half) * CFG.TILE_M) + tid_in_wg
+            softmax_exchange.subview(tail_idx).store(total_sum_scalar)
+            nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
+            total_sum_scalar = total_sum_scalar + softmax_exchange.subview(peer_tail_idx).load()
+            nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
+
+        if cutlass.const_expr(softmax_half == 0 and not CFG.FUSED_CORR_SPLIT_P):
+            stats_addr_epi = tmem_base + cutlass.Int32(LAYOUT.STATS_EPI_OFF)
+            stats_vec_epi = cutlass.Vector.from_elements((total_max_safe, total_sum_scalar), cutlass.Float32)
+            nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr_epi, cutlass.Float32), stats_vec_epi)
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+            bars.mb_stat_full.arrive()
+
+        wait(mb_decoded.subview(sched_state.idx), sched_state.phase)
+        payload_base = sched_state.idx * cutlass.Int32(SCHED_PAYLOAD_WORDS)
+        nxt_v = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(2)).load())
+        q_super_idx = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(3)).load())
+        batch_idx = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(5)).load())
+        if cutlass.const_expr(SPLIT_KV > 1):
+            split_idx = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(10)).load())
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0 or SPLIT_KV > 1):
+            bounds = KvLoopBounds(
+                left=cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(6)).load()),
+                unmasked_lo=cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(7)).load()),
+                unmasked_hi=cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(8)).load()),
+                right=cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(9)).load()),
+            )
+
+
+@cute.jit
+def _correction_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    scale_log2,
+    sO,
+    tmem_ptr_i32,
+    tidx,
+    bars,
+    sched,
+    mb_decoded,
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor,
+    seq_q_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+    cta_id_x,
+    bottom_right_diagonal: cutlass.Constexpr[bool],
+    amax_o_tensor,
+    softmax_exchange,
+    mb_sf_reuse,
+    mb_qk_sf_reuse,
+):
+    if cutlass.const_expr(CFG.FUSED_CORR_SPLIT_P):
+        nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    else:
+        nvvm.barrier_cta_sync(barrier_id=2, thread_count=32 * (CFG.CORRECTION_WARPS + 1))
+    tmem_base_corr = tmem_ptr_i32.load()
+
+    tid_raw = cute.arch.thread_idx()[0]
+    role_base = CFG.SOFTMAX_WG1_BASE if cutlass.const_expr(CFG.FUSED_CORR_SPLIT_P) else CFG.CORR_WARP_BASE
+    tid_in_wg = tid_raw - cutlass.Int32(role_base * 32)
+
+    bmm2_done_phase_pair = cutlass.Int32(0)
+    bmm1_done_phase_pair = cutlass.Int32(0)
+    stat_mbar_state = cutlass.Int32(0)
+    epilogue_state = cutlass.Int32(1)
+
+    q_super_idx, head_idx, batch_idx, split_idx = _decode_initial_split(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+        CFG.QH_PER_KH,
+        seqlen_kv,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+
+    eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
+    bounds = _bounds_for_tile_split(
+        q_super_idx,
+        eff_seqlen_q,
+        eff_seqlen_kv,
+        cta_in_pair,
+        seq_q_lens_tensor,
+        batch_idx,
+        split_idx,
+        CFG.QH_PER_KH,
+    )
+
+    O_CHUNK = 16
+    N_CHUNKS_O = CFG.TILE_O // O_CHUNK
+    TMA_O_ITERS_LOCAL = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
+    D_BLOCK_SIZE = CFG.TILE_O // TMA_O_ITERS_LOCAL
+    TMA_O_GRANU_ELEMS_LOCAL = CFG.TILE_M * D_BLOCK_SIZE
+
+    P_SUBCHUNK = 32
+    P_COLS_PER_CHUNK = 16
+    P_COLS_PER_SUBCHUNK = 8
+
+    def _fused_p1_step(
+        kv_loop,
+        masked,
+        total_max_safe,
+        total_sum_pair,
+        bmm1_phase_pair,
+        bmm2_phase_pair,
+        stat_phase,
+        q_abs,
+        eff_seqlen_kv,
+        n_chunks_o,
+        o_chunk_size,
+        p_subchunk,
+        p_cols_per_chunk,
+        p_cols_per_subchunk,
+        bars_arg,
+        mb_qk_sf_reuse_arg,
+        tmem_base_arg,
+        exchange_arg,
+        tid_in_wg_arg,
+        bounds_left,
+        leader_cta_id_arg,
+        scale_log2_arg,
+    ):
+        parity_cur_rt = kv_loop & cutlass.Int32(1)
+        parity_prev_rt = (kv_loop - cutlass.Int32(1)) & cutlass.Int32(1)
+        parity_is_even = parity_cur_rt == cutlass.Int32(0)
+        s_off_rt = cutlass.Int32(
+            arith.select(
+                parity_is_even.ir_value(),
+                cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(),
+                cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value(),
+            )
+        )
+        p_off_rt = cutlass.Int32(
+            arith.select(
+                parity_is_even.ir_value(),
+                cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(),
+                cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value(),
+            )
+        )
+        bmm1_phase = (bmm1_phase_pair >> parity_cur_rt) & cutlass.Int32(1)
+        bars_arg.mb_bmm1_done[parity_cur_rt].wait(bmm1_phase)
+        bmm1_phase_pair = bmm1_phase_pair ^ (cutlass.Int32(1) << parity_cur_rt)
+
+        s_addr_base = tmem_base_arg + s_off_rt
+        p_addr_base = tmem_base_arg + p_off_rt
+        raw_hi = nvvm.tcgen05_ld(
+            "32x32b",
+            nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(64), cutlass.Float32),
+            num=64,
+        )
+        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+        if nvvm.elect_sync():
+            nvvm.mbarrier_arrive(mb_qk_sf_reuse_arg.subview(parity_cur_rt))
+        if cutlass.const_expr(masked):
+            kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+            mask_q_abs = q_abs - (kv_col_base + cutlass.Int32(64))
+            mask_seq_kv = eff_seqlen_kv - (kv_col_base + cutlass.Int32(64))
+            mask_flags = CFG.MASK_FLAGS
+            if cutlass.const_expr(_PADDED_TOP_LEFT_CAUSAL):
+                mask_q_abs = cute.math.min(mask_q_abs, mask_seq_kv - cutlass.Int32(1))
+                mask_flags = MASK_CAUSAL
+            raw_hi = apply_mask_chunk(
+                raw_hi,
+                mask_q_abs,
+                cutlass.Int32(0),
+                mask_seq_kv,
+                CFG.WINDOW_LEFT,
+                mask_flags,
+                N=64,
+                bottom_right=0,
+                causal_diag=None,
+                window_right=CFG.WINDOW_RIGHT,
+                mask_value=float("-inf"),
+            )
+        reg_S_half = RegTile(raw_hi, size=64)
+
+        bars_arg.mb_stat_full.wait(stat_phase)
+        exchange_base = parity_cur_rt * cutlass.Int32(2 * CFG.TILE_M)
+        alpha = exchange_arg.subview(exchange_base + tid_in_wg_arg).load()
+        total_max_safe = exchange_arg.subview(exchange_base + cutlass.Int32(CFG.TILE_M) + tid_in_wg_arg).load()
+        bars_arg.mb_stat_empty.arrive()
+        stat_phase = stat_phase ^ cutlass.Int32(1)
+
+        has_previous_o = kv_loop != bounds_left
+        if has_previous_o:
+            all_alpha_one = vote_sync(0xFFFFFFFF, alpha == cutlass.Float32(1.0), VoteSync.ALL)
+            bmm2_done_phase_prev = (bmm2_phase_pair >> parity_prev_rt) & cutlass.Int32(1)
+            # Each iteration must consume its BMM2 phase before O can be reused.
+            bars_arg.mb_bmm2_done[parity_prev_rt].wait(bmm2_done_phase_prev)
+            if ~all_alpha_one:
+                for chunk_idx in cutlass.range_constexpr(n_chunks_o):
+                    o_addr = tmem_base_arg + cutlass.Int32(LAYOUT.O_OFF + chunk_idx * o_chunk_size)
+                    o_vec = nvvm.tcgen05_ld(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                        num=o_chunk_size,
+                    )
+                    nvvm.tcgen05_st(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                        vec_scale_pair(o_vec, alpha, o_chunk_size),
+                    )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+            bmm2_phase_pair = bmm2_phase_pair ^ (cutlass.Int32(1) << parity_prev_rt)
+
+        bars_arg.mb_bmm2_ready[parity_cur_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS)].arrive(
+            leader_cta_id=leader_cta_id_arg,
+            cta_group=CFG.CTA_MMA,
+        )
+
+        reg_S_half = reg_S_half * scale_log2_arg - total_max_safe
+        if cutlass.const_expr(CFG.MASK_FLAGS == MASK_NONE):
+            chunk_P_a = _exp2_chunk0a_mixed(
+                reg_S_half[0:p_subchunk].vec,
+                False,
+                dense=True,
+                softmax_half=1,
+            )
+        else:
+            chunk_P_a = cute.math.exp2(reg_S_half[0:p_subchunk].vec, fastmath=True)
+        new_p_sum_pair = row_reduction_pair(chunk_P_a)
+        nvvm.tcgen05_st(
+            "32x32b",
+            nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(p_cols_per_chunk), cutlass.Float32),
+            chunk_P_a.to(STORAGE_DTYPE),
+        )
+        chunk_P_b = _exp2_chunk1b_mixed(
+            reg_S_half[p_subchunk:64].vec,
+            dense=CFG.MASK_FLAGS == MASK_NONE,
+            softmax_half=1 if CFG.MASK_FLAGS == MASK_NONE else 2,
+        )
+        new_p_sum_pair = new_p_sum_pair + row_reduction_pair(chunk_P_b)
+        nvvm.tcgen05_st(
+            "32x32b",
+            nvvm.make_tmem_ptr(
+                p_addr_base + cutlass.Int32(p_cols_per_chunk + p_cols_per_subchunk),
+                cutlass.Float32,
+            ),
+            chunk_P_b.to(STORAGE_DTYPE),
+        )
+        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+        bars_arg.mb_bmm2_ready[parity_cur_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(1)].arrive(
+            leader_cta_id=leader_cta_id_arg,
+            cta_group=CFG.CTA_MMA,
+        )
+        alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+        total_sum_pair = total_sum_pair * alpha_pair + new_p_sum_pair
+        return total_max_safe, total_sum_pair, bmm1_phase_pair, bmm2_phase_pair, stat_phase
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        fused_total_max_safe = cutlass.Float32(float("-inf"))
+        fused_total_sum = cutlass.Vector.from_elements(
+            (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+            cutlass.Float32,
+        )
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+        q_abs = q_row_coord + tid_in_wg
+
+        if cutlass.const_expr(CFG.FUSED_CORR_SPLIT_P):
+            if bounds.right <= bounds.left:
+                bars.mb_empty_mainloop.arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+            for kv_loop in cutlass.range(bounds.unmasked_lo, bounds.unmasked_hi, 1, unroll=1):
+                fused_total_max_safe, fused_total_sum, bmm1_done_phase_pair, bmm2_done_phase_pair, stat_mbar_state = _fused_p1_step(
+                    kv_loop,
+                    False,
+                    fused_total_max_safe,
+                    fused_total_sum,
+                    bmm1_done_phase_pair,
+                    bmm2_done_phase_pair,
+                    stat_mbar_state,
+                    q_abs,
+                    eff_seqlen_kv,
+                    N_CHUNKS_O,
+                    O_CHUNK,
+                    P_SUBCHUNK,
+                    P_COLS_PER_CHUNK,
+                    P_COLS_PER_SUBCHUNK,
+                    bars,
+                    mb_qk_sf_reuse,
+                    tmem_base_corr,
+                    softmax_exchange,
+                    tid_in_wg,
+                    bounds.left,
+                    leader_cta_id,
+                    scale_log2,
+                )
+            tail_range = (bounds.unmasked_hi,)
+            for kv_loop in tail_range:
+                if bounds.unmasked_hi < bounds.right:
+                    fused_total_max_safe, fused_total_sum, bmm1_done_phase_pair, bmm2_done_phase_pair, stat_mbar_state = _fused_p1_step(
+                        kv_loop,
+                        True,
+                        fused_total_max_safe,
+                        fused_total_sum,
+                        bmm1_done_phase_pair,
+                        bmm2_done_phase_pair,
+                        stat_mbar_state,
+                        q_abs,
+                        eff_seqlen_kv,
+                        N_CHUNKS_O,
+                        O_CHUNK,
+                        P_SUBCHUNK,
+                        P_COLS_PER_CHUNK,
+                        P_COLS_PER_SUBCHUNK,
+                        bars,
+                        mb_qk_sf_reuse,
+                        tmem_base_corr,
+                        softmax_exchange,
+                        tid_in_wg,
+                        bounds.left,
+                        leader_cta_id,
+                        scale_log2,
+                    )
+
+        if cutlass.const_expr(not CFG.FUSED_CORR_SPLIT_P) and bounds.right > bounds.left:
+            lo_parity_rt = bounds.left & cutlass.Int32(1)
+            bars.mb_bmm2_ready[lo_parity_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+            bars.mb_stat_full.wait(stat_mbar_state)
+            bars.mb_stat_empty.arrive()
+            stat_mbar_state = stat_mbar_state ^ cutlass.Int32(1)
+        elif cutlass.const_expr(not CFG.FUSED_CORR_SPLIT_P):
+            bars.mb_empty_mainloop.arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+        correction_loop_start = bounds.right if cutlass.const_expr(CFG.FUSED_CORR_SPLIT_P) else bounds.left + cutlass.Int32(1)
+        for kv_loop in cutlass.range(correction_loop_start, bounds.right, 1, unroll=1):
+            parity_prev_rt = (kv_loop - cutlass.Int32(1)) & cutlass.Int32(1)
+            parity_cur_rt = kv_loop & cutlass.Int32(1)
+            tmem_base_iter = tmem_base_corr
+
+            bars.mb_stat_full.wait(stat_mbar_state)
+            if cutlass.const_expr(_E5_STYLE_SOFTMAX):
+                exchange_stride = cutlass.Int32(2 * CFG.TILE_M if CFG.MASK_FLAGS == MASK_NONE else CFG.TILE_M)
+                exchange_base = parity_cur_rt * exchange_stride
+                alpha = softmax_exchange.subview(exchange_base + tid_in_wg).load()
+            else:
+                stats_off_cur = cutlass.Int32(
+                    arith.select(
+                        (parity_cur_rt == cutlass.Int32(0)).ir_value(),
+                        cutlass.Int32(LAYOUT.STATS_EVEN_OFF).ir_value(),
+                        cutlass.Int32(LAYOUT.STATS_ODD_OFF).ir_value(),
+                    )
+                )
+                stats_addr = tmem_base_iter + stats_off_cur
+                stats_vec = nvvm.tcgen05_ld(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(stats_addr, cutlass.Float32),
+                    num=2,
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                alpha = stats_vec[0]
+
+            alpha_is_one = alpha == cutlass.Float32(1.0)
+            all_alpha_one = vote_sync(0xFFFFFFFF, alpha_is_one, VoteSync.ALL)
+
+            bars.mb_stat_empty.arrive()
+
+            bmm2_done_phase_prev = (bmm2_done_phase_pair >> parity_prev_rt) & cutlass.Int32(1)
+            # Each iteration must consume its BMM2 phase before O can be reused.
+            bars.mb_bmm2_done[parity_prev_rt].wait(bmm2_done_phase_prev)
+            if cutlass.const_expr(CFG.MASK_FLAGS != MASK_NONE):
+                if ~all_alpha_one:
+                    for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                        o_addr = tmem_base_iter + cutlass.Int32(LAYOUT.O_OFF + chunk_idx * O_CHUNK)
+                        o_chunk = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                            num=O_CHUNK,
+                        )
+                        o_scaled = vec_scale_pair(o_chunk, alpha, O_CHUNK)
+                        nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(o_addr, cutlass.Float32), o_scaled)
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+            else:
+                if ~all_alpha_one:
+                    for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                        o_addr = tmem_base_iter + cutlass.Int32(LAYOUT.O_OFF + chunk_idx * O_CHUNK)
+                        o_chunk = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                            num=O_CHUNK,
+                        )
+                        o_scaled = vec_scale_pair(o_chunk, alpha, O_CHUNK)
+                        nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(o_addr, cutlass.Float32), o_scaled)
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+            bmm2_done_phase_pair = bmm2_done_phase_pair ^ (cutlass.Int32(1) << parity_prev_rt)
+
+            bars.mb_bmm2_ready[parity_cur_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+            stat_mbar_state = stat_mbar_state ^ cutlass.Int32(1)
+
+        tmem_base_epi = tmem_base_corr
+
+        total_max_scaled = cutlass.Float32(0.0)
+        total_sum = cutlass.Float32(0.0)
+        if cutlass.const_expr(CFG.FUSED_CORR_SPLIT_P):
+            total_max_scaled = fused_total_max_safe
+            fused_sum_scalar = fused_total_sum[0] + fused_total_sum[1]
+            tail_idx = cutlass.Int32(5 * CFG.TILE_M) + tid_in_wg
+            peer_tail_idx = cutlass.Int32(4 * CFG.TILE_M) + tid_in_wg
+            softmax_exchange.subview(tail_idx).store(fused_sum_scalar)
+            nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
+            total_sum = fused_sum_scalar + softmax_exchange.subview(peer_tail_idx).load()
+            nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
+        else:
+            # The softmax producer publishes epilogue stats even for empty tiles,
+            # keeping the phase protocol aligned across persistent work items.
+            bars.mb_stat_full.wait(stat_mbar_state)
+            stats_addr_epi = tmem_base_epi + cutlass.Int32(LAYOUT.STATS_EPI_OFF)
+            stats_vec_epi = nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(stats_addr_epi, cutlass.Float32),
+                num=2,
+            )
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+            total_max_scaled = stats_vec_epi[0]
+            total_sum = stats_vec_epi[1]
+            bars.mb_stat_empty.arrive()
+            stat_mbar_state = stat_mbar_state ^ cutlass.Int32(1)
+
+        LN2 = cutlass.Float32(0.6931471805599453)
+        total_max_nat = total_max_scaled * LN2
+        lse_val = cutlass.Float32(0.0)
+        inv_sum = cutlass.Float32(0.0)
+        beta = cutlass.Float32(0.0)
+        row_dead = total_sum <= cutlass.Float32(0.0)
+        if cutlass.const_expr(CFG.HAS_SINK):
+            sinks_arr = cutlass.make_array_view(sinks_tensor)
+            sink_logit = sinks_arr[head_idx]
+            new_max = cute.math.max(total_max_nat, sink_logit)
+            scale = cute.math.exp(total_max_nat - new_max, fastmath=True)
+            new_sum = total_sum * scale + cute.math.exp(sink_logit - new_max, fastmath=True)
+            lse_val = new_max + cute.math.log(new_sum, fastmath=True)
+            beta = scale / new_sum
+            inv_sum = beta
+        else:
+            lse_val = total_max_nat + cute.math.log(cute.math.max(total_sum, cutlass.Float32(1e-30)), fastmath=True)
+            beta = cutlass.Float32(1.0) / cute.math.max(total_sum, cutlass.Float32(1e-30))
+            inv_sum = beta
+            # Dead row (no valid KV column, incl. empty tiles where total_sum defaults 0):
+            #   O := 0, LSE := -inf. total_sum >= 1 for any alive row so this never fires
+            #   spuriously. Skipped under sink (the sink path defines a finite LSE).
+            neg_inf_lse = cutlass.Float32(float("-inf"))
+            lse_val = cutlass.Float32(arith.select(row_dead.ir_value(), neg_inf_lse.ir_value(), lse_val.ir_value()))
+            inv_sum = cutlass.Float32(arith.select(row_dead.ir_value(), cutlass.Float32(0.0).ir_value(), inv_sum.ir_value()))
+            beta = cutlass.Float32(arith.select(row_dead.ir_value(), cutlass.Float32(0.0).ir_value(), beta.ir_value()))
+
+        q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + tid_in_wg
+        if cutlass.const_expr(CFG.SEQ_Q_LENS_PRESENT):
+            # Dense padded-Q trim (cuDNN >= 9.14): q rows >= seq_len_q[b] write
+            # O := 0 / LSE := -inf.  Applied AFTER the sink branch on purpose —
+            # a trimmed row is dead even with a sink.  Per-batch q lens come in
+            # via the dedicated seq_q_lens_tensor parameter.
+            _sq_arr = cutlass.make_array_view(seq_q_lens_tensor)
+            _q_len_b = cutlass.Int32(_sq_arr[batch_idx])
+            row_trim = q_row_global >= _q_len_b
+            neg_inf_trim = cutlass.Float32(float("-inf"))
+            lse_val = cutlass.Float32(arith.select(row_trim.ir_value(), neg_inf_trim.ir_value(), lse_val.ir_value()))
+            inv_sum = cutlass.Float32(arith.select(row_trim.ir_value(), cutlass.Float32(0.0).ir_value(), inv_sum.ir_value()))
+            beta = cutlass.Float32(arith.select(row_trim.ir_value(), cutlass.Float32(0.0).ir_value(), beta.ir_value()))
+
+        if cutlass.const_expr(CFG.THD_VARLEN):
+            cu = cutlass.make_array_view(seq_kv_lens_tensor)
+            cu_q_b = cutlass.Int32(cu[n_batch + batch_idx])
+            s_q_b = cutlass.Int32(cu[n_batch + batch_idx + cutlass.Int32(1)]) - cu_q_b
+            _row_valid = q_row_global < s_q_b
+            if cutlass.const_expr(lse_tensor is not None):
+                if _row_valid:
+                    lse_arr = cutlass.make_array_view(lse_tensor)
+                    if cutlass.const_expr(len(lse_tensor.shape) == 2):
+                        lse_arr[cu_q_b + q_row_global, head_idx] = lse_val
+                    else:
+                        lse_arr[cutlass.Int32(0), head_idx, cu_q_b + q_row_global] = lse_val
+        else:
+            _row_valid = q_row_global < seqlen_q
+            if cutlass.const_expr(lse_tensor is not None):
+                if _row_valid:
+                    lse_arr = cutlass.make_array_view(lse_tensor)
+                    lse_batch = _partial_batch(batch_idx, split_idx, n_batch)
+                    lse_arr[lse_batch, head_idx, q_row_global] = lse_val
+
+        parity_last_rt = cutlass.Int32(0)
+        if bounds.right > bounds.left:
+            parity_last_rt = (bounds.right - cutlass.Int32(1)) & cutlass.Int32(1)
+        bmm2_done_phase_last = (bmm2_done_phase_pair >> parity_last_rt) & cutlass.Int32(1)
+        bars.mb_bmm2_done[parity_last_rt].wait(bmm2_done_phase_last)
+        bmm2_done_phase_pair = bmm2_done_phase_pair ^ (cutlass.Int32(1) << parity_last_rt)
+
+        O_EPI_BLK = 64 // CFG.BPE_O
+        N_BLOCKS_EPI = CFG.TILE_O // O_EPI_BLK
+        CHUNKS_PER_BLK = O_EPI_BLK // O_CHUNK
+
+        sO_base = sO[0].base
+        _amax_o_ptr = Pointer(amax_o_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
+        _amax_o_local = cutlass.Float32(0.0)
+
+        for block_idx in cutlass.range_constexpr(N_BLOCKS_EPI):
+            o_chunks = None
+            if cutlass.const_expr(_E5_STYLE_SOFTMAX and CFG.MASK_FLAGS != 0):
+                o_chunks = [
+                    nvvm.tcgen05_ld(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(
+                            tmem_base_epi + cutlass.Int32(LAYOUT.O_OFF + (block_idx * CHUNKS_PER_BLK + sub) * O_CHUNK),
+                            cutlass.Float32,
+                        ),
+                        num=O_CHUNK,
+                    )
+                    for sub in range(CHUNKS_PER_BLK)
+                ]
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+            for sub in cutlass.range_constexpr(CHUNKS_PER_BLK):
+                chunk_idx_total = block_idx * CHUNKS_PER_BLK + sub
+                o_out = cutlass.Vector.from_elements(
+                    tuple(OUT_STORAGE_DTYPE(0.0) for _ in range(O_CHUNK)),
+                    OUT_STORAGE_DTYPE,
+                )
+                if cutlass.const_expr(not _PADDED_TOP_LEFT_CAUSAL) or (bounds.right > bounds.left):
+                    if cutlass.const_expr(_E5_STYLE_SOFTMAX and CFG.MASK_FLAGS != 0):
+                        o_chunk = o_chunks[sub]
+                    else:
+                        o_addr = tmem_base_epi + cutlass.Int32(LAYOUT.O_OFF + chunk_idx_total * O_CHUNK)
+                        o_chunk = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                            num=O_CHUNK,
+                        )
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                    o_scaled = o_chunk * inv_sum
+                    # Empty BMM2 leaves O TMEM unwritten, and NaN * 0 does not
+                    # sanitize it. Plain top-left/SWA and square bottom-right
+                    # always retain the diagonal, so keep this off their hot path.
+                    if cutlass.const_expr(
+                        not _PADDED_TOP_LEFT_CAUSAL and (CFG.SEQ_KV_LENS_PRESENT or SPLIT_KV > 1 or (CFG.BOTTOM_RIGHT and not bottom_right_diagonal))
+                    ):
+                        zero = cutlass.Float32(0.0)
+                        invalid = row_dead
+                        if cutlass.const_expr(CFG.THD_VARLEN):
+                            invalid = invalid | (~_row_valid)
+                        o_scaled = cutlass.Vector.from_elements(
+                            tuple(cutlass.Float32(arith.select(invalid.ir_value(), zero.ir_value(), o_scaled[i].ir_value())) for i in range(O_CHUNK)),
+                            cutlass.Float32,
+                        )
+                    _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled), ftz=True)
+                    o_out = o_scaled.to(OUT_STORAGE_DTYPE)
+
+                col_offset_const = (chunk_idx_total * O_CHUNK) % D_BLOCK_SIZE
+                block_offset_const = ((chunk_idx_total * O_CHUNK) // D_BLOCK_SIZE) * TMA_O_GRANU_ELEMS_LOCAL
+                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
+                smem_ptr = sO_base.subview(smem_offset).data_ptr()
+
+                if block_idx == 0 and sub == 0:
+                    bars.mb_o_empty.wait(epilogue_state)
+                smem_ptr.store_swizzled(o_out, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+
+            fire_now = (block_idx % 2 == 1) or (CFG.TILE_O == O_EPI_BLK)
+            if cutlass.const_expr(fire_now):
+                nvvm.fence_proxy("async.shared", space="cta")
+                bars.mb_o_full[(block_idx // 2)].arrive()
+
+        if cutlass.const_expr(SPLIT_KV == 1):
+            _amax_o_valid = cutlass.Float32(
+                arith.select(
+                    _row_valid.ir_value(),
+                    _amax_o_local.ir_value(),
+                    cutlass.Float32(0.0).ir_value(),
+                )
+            )
+            _amax_o_warp = cute.arch.warp_redux_sync(_amax_o_valid, kind="fmax")
+            if (tid_in_wg & cutlass.Int32(31)) == cutlass.Int32(0):
+                nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_warp.bitcast(cutlass.Int32))
+
+        epilogue_state = epilogue_state ^ cutlass.Int32(1)
+
+        wait(mb_decoded.subview(sched_state.idx), sched_state.phase)
+        payload_base = sched_state.idx * cutlass.Int32(SCHED_PAYLOAD_WORDS)
+        nxt_v = sched.tile_id_smem.subview(payload_base + cutlass.Int32(2)).load()
+        q_super_idx = sched.tile_id_smem.subview(payload_base + cutlass.Int32(3)).load()
+        head_idx = sched.tile_id_smem.subview(payload_base + cutlass.Int32(4)).load()
+        batch_idx = sched.tile_id_smem.subview(payload_base + cutlass.Int32(5)).load()
+        if cutlass.const_expr(SPLIT_KV > 1):
+            split_idx = sched.tile_id_smem.subview(payload_base + cutlass.Int32(10)).load()
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0 or SPLIT_KV > 1):
+            bounds = KvLoopBounds(
+                left=sched.tile_id_smem.subview(payload_base + cutlass.Int32(6)).load(),
+                unmasked_lo=sched.tile_id_smem.subview(payload_base + cutlass.Int32(7)).load(),
+                unmasked_hi=sched.tile_id_smem.subview(payload_base + cutlass.Int32(8)).load(),
+                right=sched.tile_id_smem.subview(payload_base + cutlass.Int32(9)).load(),
+            )
+
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        peer_cta = cta_id_x ^ cutlass.Int32(1)
+        bars.mb_tmem_dealloc.arrive_on_peer(peer_cta)
+    bars.mb_tmem_dealloc.arrive()
+
+
+@cute.jit
+def _host(
+    q_tensor: cute.Tensor,
+    k_tensor: cute.Tensor,
+    v_tensor: cute.Tensor,
+    o_tensor: cute.Tensor,
+    sf_q_tensor: cute.Tensor,
+    sf_k_tensor: cute.Tensor,
+    sf_v_tensor: cute.Tensor,
+    lse_tensor: Optional[cute.Tensor],
+    amax_o_tensor: cute.Tensor,
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    problem_size: Tuple[int, int, int, int, int, int],
+    scale_softmax_log2: cutlass.Float32,
+    n_thd_units: cutlass.Int32,
+    # Dense padded-Q trim: separate (B,)-int32 lengths. None folds the
+    # parameter and all consumers out when the specialization is disabled.
+    seq_q_lens_tensor: Optional[cute.Tensor] = None,
+    thd_q_lens_tensor: Optional[cute.Tensor] = None,
+    thd_kv_lens_tensor: Optional[cute.Tensor] = None,
+    thd_lens_form: Optional[cutlass.Int32] = None,
+    stream: _cuda_driver.CUstream = None,
+) -> None:
+    B, QH, KH, SQ, SKV, _ = problem_size
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        SQ = q_tensor.shape[1]
+        SKV = k_tensor.shape[1]
+
+    _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE_O
+    q_rank5_layout = cute.make_layout(
+        (q_tensor.shape[0], q_tensor.shape[2], TMA_QK_ITERS, q_tensor.shape[1], TMA_QK_GRANU_ELEMS),
+        stride=(
+            q_tensor.shape[1] * q_tensor.shape[2] * CFG.TILE_K,
+            CFG.TILE_K,
+            TMA_QK_GRANU_ELEMS,
+            q_tensor.shape[2] * CFG.TILE_K,
+            1,
+        ),
+    )
+    q_rank5_tensor = cute.make_tensor(q_tensor.iterator, q_rank5_layout)
+    k_rank5_layout = cute.make_layout(
+        (k_tensor.shape[0], k_tensor.shape[2], TMA_QK_ITERS, k_tensor.shape[1], TMA_QK_GRANU_ELEMS),
+        stride=(
+            k_tensor.shape[1] * k_tensor.shape[2] * CFG.TILE_K,
+            CFG.TILE_K,
+            TMA_QK_GRANU_ELEMS,
+            k_tensor.shape[2] * CFG.TILE_K,
+            1,
+        ),
+    )
+    k_rank5_tensor = cute.make_tensor(k_tensor.iterator, k_rank5_layout)
+    v_rank5_layout = cute.make_layout(
+        (v_tensor.shape[0], v_tensor.shape[2], TMA_VO_ITERS, v_tensor.shape[1], TMA_VO_GRANU_ELEMS),
+        stride=(
+            v_tensor.shape[1] * v_tensor.shape[2] * CFG.TILE_O,
+            CFG.TILE_O,
+            TMA_VO_GRANU_ELEMS,
+            v_tensor.shape[2] * CFG.TILE_O,
+            1,
+        ),
+    )
+    v_rank5_tensor = cute.make_tensor(v_tensor.iterator, v_rank5_layout)
+    qk_box_k = (1, 1, TMA_QK_ITERS, CFG.TILE_N // CFG.CTA_MMA, TMA_QK_GRANU_ELEMS)
+    qk_box_q = (1, 1, TMA_QK_ITERS, CFG.TILE_M, TMA_QK_GRANU_ELEMS)
+    vo_box_v = (1, 1, TMA_VO_ITERS, CFG.TILE_N, TMA_VO_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M, 1, _O_GRANU_ELEMS)
+    stride_order = (3, 2, 1, 0)
+
+    def _tma_swz(byte_w: int):
+        return tmap.TensorMapSwizzle.s128b if byte_w == 128 else tmap.TensorMapSwizzle.s64b if byte_w == 64 else tmap.TensorMapSwizzle.s32b
+
+    input_l2_promotion = tmap.TensorMapL2Promotion.l2_256b
+    tma_q_desc = tmap.create_tensor_map_tiled_from_view(
+        q_rank5_tensor,
+        box_dims=qk_box_q,
+        stride_order=(4, 3, 2, 1, 0),
+        swizzle=_tma_swz(CFG.Q_SWZ_BYTES),
+        l2_promotion=input_l2_promotion,
+    )
+    tma_k_desc = tmap.create_tensor_map_tiled_from_view(
+        k_rank5_tensor,
+        box_dims=qk_box_k,
+        stride_order=(4, 3, 2, 1, 0),
+        swizzle=_tma_swz(CFG.K_SWZ_BYTES),
+        l2_promotion=input_l2_promotion,
+    )
+    tma_v_desc = tmap.create_tensor_map_tiled_from_view(
+        v_rank5_tensor,
+        box_dims=vo_box_v,
+        stride_order=(4, 3, 2, 1, 0),
+        swizzle=_tma_swz(CFG.V_SWZ_BYTES),
+        l2_promotion=input_l2_promotion,
+    )
+    tma_o_desc = tmap.create_tensor_map_tiled_from_view(
+        o_tensor,
+        box_dims=vo_box_o,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.O_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+
+    SF_TMA_ROW_BYTES = 128
+    SF_NUM_ROWS_Q = SF_SMEM_SIZE_Q // SF_TMA_ROW_BYTES
+    SF_NUM_ROWS_K = SF_SMEM_SIZE_K // SF_TMA_ROW_BYTES
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        b_sf = 1
+        q_sf_num_tiles = sf_q_tensor.shape[2]
+        kv_sf_num_tiles = sf_k_tensor.shape[2]
+    else:
+        b_sf = B
+        q_sf_num_tiles = (SQ + CFG.TILE_M - 1) // CFG.TILE_M
+        kv_sf_num_tiles = (SKV + CFG.TILE_N - 1) // CFG.TILE_N
+
+    def _build_sf_desc(sf_tensor, num_tiles, sf_smem_size, num_rows_box, num_heads, base_offset=0):
+        sf_base = cutlass.Int64(sf_tensor.iterator.toint()) + cutlass.Int64(base_offset)
+        tile_stride_16 = sf_smem_size // 16
+        return tmap.create_tensor_map_tiled(
+            global_address=sf_base,
+            dtype=cutlass.Uint8,
+            global_dims=[
+                SF_TMA_ROW_BYTES,
+                sf_smem_size // SF_TMA_ROW_BYTES,
+                num_tiles,
+                num_heads,
+                b_sf,
+            ],
+            global_strides=[
+                SF_TMA_ROW_BYTES // 16,
+                tile_stride_16,
+                num_tiles * tile_stride_16,
+                num_heads * num_tiles * tile_stride_16,
+            ],
+            box_dims=[SF_TMA_ROW_BYTES, num_rows_box, 1, 1, 1],
+            swizzle=tmap.TensorMapSwizzle.none,
+            l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+        )
+
+    tma_q_sf_desc = _build_sf_desc(sf_q_tensor, q_sf_num_tiles, SF_SMEM_SIZE_Q, SF_NUM_ROWS_Q, QH)
+    tma_k_sf_desc = _build_sf_desc(sf_k_tensor, kv_sf_num_tiles, SF_SMEM_SIZE_K, SF_NUM_ROWS_K, KH)
+    v_sf_groups = b_sf * KH * kv_sf_num_tiles
+    v_sf_plane_bytes = v_sf_groups * SF_BYTES_PER_BLOCK
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD packs both D/128 planes for each (head, sequence tile)
+        # contiguously. Dense MXFP8 keeps each plane contiguous across all
+        # groups, so its plane stride cannot be reused here.
+        v_sf_strides = [
+            SF_TMA_ROW_BYTES // 16,
+            SF_BYTES_PER_BLOCK // 16,
+            SF_SMEM_SIZE_V // 16,
+        ]
+    else:
+        v_sf_strides = [
+            SF_TMA_ROW_BYTES // 16,
+            v_sf_plane_bytes // 16,
+            SF_BYTES_PER_BLOCK // 16,
+        ]
+    tma_v_sf_desc = tmap.create_tensor_map_tiled(
+        global_address=sf_v_tensor.iterator.toint(),
+        dtype=cutlass.Uint8,
+        global_dims=[SF_TMA_ROW_BYTES, SF_BYTES_PER_BLOCK // SF_TMA_ROW_BYTES, 2, v_sf_groups],
+        global_strides=v_sf_strides,
+        box_dims=[SF_TMA_ROW_BYTES, SF_BYTES_PER_BLOCK // SF_TMA_ROW_BYTES, 2, 1],
+        swizzle=tmap.TensorMapSwizzle.none,
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+
+    rows_per_cluster = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+    q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
+    grid_q_supers = q_clusters * CFG.CTA_MMA
+    q_supers = grid_q_supers
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        _build_thd_meta_o_kv_descs_kernel(
+            o_tensor,
+            tma_o_desc,
+            tma_k_desc,
+            tma_v_desc,
+            o_desc_words,
+            seq_kv_lens_tensor,
+            thd_q_lens_tensor,
+            thd_kv_lens_tensor,
+            thd_lens_form,
+            cutlass.Int32(QH),
+            cutlass.Int32(B),
+            cutlass.Int32(o_tensor.stride[1]),
+            cutlass.Int32(rows_per_cluster),
+            n_thd_units,
+            1,
+            1,
+        ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
+        grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
+    else:
+        grid_shape = (
+            (grid_q_supers, QH, B * SPLIT_KV) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B * SPLIT_KV, 1, 1)
+        )
+    _kernel(
+        tma_q_desc,
+        tma_k_desc,
+        tma_v_desc,
+        tma_o_desc,
+        tma_q_sf_desc,
+        tma_k_sf_desc,
+        tma_v_sf_desc,
+        lse_tensor,
+        sinks_tensor,
+        seq_kv_lens_tensor,
+        o_desc_words,
+        cutlass.Int32(SQ),
+        cutlass.Int32(SKV),
+        cutlass.Int32(q_supers),
+        cutlass.Int32(QH),
+        cutlass.Int32(B),
+        cutlass.Int32(QH // KH),
+        cutlass.Int32(kv_sf_num_tiles),
+        scale_softmax_log2,
+        amax_o_tensor,
+        False,
+        seq_q_lens_tensor,
+    ).launch(
+        grid=grid_shape,
+        block=[CFG.THREADS_PER_CTA, 1, 1],
+        cluster=(CFG.CTA_MMA, 1, 1),
+        stream=stream,
+    )
+
+
+@lru_cache(maxsize=None)
+def compile(  # noqa: A001
+    b: int = 1,
+    qh: int = 1,
+    kh: int = 1,
+    sq: int = 256,
+    skv: int = 128,
+    has_lse: bool = True,
+    lse_head_major: bool = False,
+    lse_head_stride: int = 0,
+    lse_stride: Optional[tuple[int, int, int]] = None,
+) -> Callable:
+    """Compile the exact D256 MXFP8 kernel and its per-tile SF views."""
+    if SPLIT_KV > 1 and not has_lse:
+        raise ValueError("split_kv > 1 requires has_lse=True (the per-split LSE drives the combine)")
+    if lse_stride is not None and SPLIT_KV > 1:
+        raise ValueError("split_kv partial LSE is compact; lse_stride describes only the final combine output")
+    fake_batch = 1 if CFG.THD_VARLEN else b
+    if CFG.THD_VARLEN:
+        sq = cute.sym_int(divisibility=1)
+        skv = cute.sym_int(divisibility=1)
+        q_sf_tiles = cute.sym_int(divisibility=1)
+        kv_sf_tiles = cute.sym_int(divisibility=1)
+    else:
+        q_sf_tiles = (sq + CFG.TILE_M - 1) // CFG.TILE_M
+        kv_sf_tiles = (skv + CFG.TILE_N - 1) // CFG.TILE_N
+
+    def _fake(dtype, shape):
+        return cute.runtime.make_fake_compact_tensor(dtype, shape, stride_order=tuple(range(len(shape) - 1, -1, -1)), assumed_align=16)
+
+    fake_q = _fake(STORAGE_DTYPE, (fake_batch, sq, qh, CFG.TILE_K))
+    fake_k = _fake(STORAGE_DTYPE, (fake_batch, skv, kh, CFG.TILE_K))
+    fake_v = _fake(STORAGE_DTYPE, (fake_batch, skv, kh, CFG.TILE_O))
+    fake_o = _fake(OUT_STORAGE_DTYPE, (fake_batch * SPLIT_KV, sq, qh, CFG.TILE_O))
+    fake_sf_q = _fake(cutlass.Int8, (fake_batch, qh, q_sf_tiles, SF_SMEM_SIZE_Q))
+    fake_sf_k = _fake(cutlass.Int8, (fake_batch, kh, kv_sf_tiles, SF_SMEM_SIZE_K))
+    fake_sf_v = _fake(cutlass.Int8, (fake_batch, kh, kv_sf_tiles, SF_SMEM_SIZE_V))
+    if not has_lse:
+        if lse_head_major or lse_head_stride:
+            raise ValueError("lse_head_major / lse_head_stride require has_lse=True")
+        fake_lse = None
+    elif CFG.THD_VARLEN:
+        if lse_head_major:
+            lse_extent = lse_head_stride if lse_head_stride else sq
+            fake_lse = cute.runtime.make_fake_compact_tensor(
+                cutlass.Float32,
+                (1, qh, lse_extent),
+                stride_order=(2, 1, 0),
+                assumed_align=4,
+            )
+        else:
+            if lse_head_stride:
+                raise ValueError("lse_head_stride is head-major-only")
+            fake_lse = cute.runtime.make_fake_compact_tensor(
+                cutlass.Float32,
+                (sq, qh),
+                stride_order=(1, 0),
+                assumed_align=4,
+            )
+    else:
+        if lse_head_major or lse_head_stride:
+            raise ValueError("lse_head_major / lse_head_stride are unsupported for dense MXFP8")
+        fake_lse = (
+            cute.runtime.make_fake_tensor(cutlass.Float32, (b, qh, sq), lse_stride, assumed_align=4)
+            if lse_stride is not None
+            else _fake(cutlass.Float32, (b * SPLIT_KV, qh, sq))
+        )
+    fake_sinks = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (qh,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        ((4 * b + 4) if CFG.THD_VARLEN else b,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    fake_amax_o = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (1,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    fake_o_desc = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int64,
+        (((b + 3) * _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    fake_seq_q_lens = (
+        cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (b,),
+            stride_order=(0,),
+            assumed_align=4,
+        )
+        if CFG.SEQ_Q_LENS_PRESENT
+        else None
+    )
+    if CFG.THD_VARLEN:
+        fake_thd_q_lens = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (cute.sym_int(divisibility=1),),
+            stride_order=(0,),
+            assumed_align=4,
+        )
+        fake_thd_kv_lens = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (cute.sym_int(divisibility=1),),
+            stride_order=(0,),
+            assumed_align=4,
+        )
+        fake_thd_lens_form = cutlass.Int32(0)
+    else:
+        fake_thd_q_lens = None
+        fake_thd_kv_lens = None
+        fake_thd_lens_form = None
+
+    return cute.compile(
+        _host,
+        fake_q,
+        fake_k,
+        fake_v,
+        fake_o,
+        fake_sf_q,
+        fake_sf_k,
+        fake_sf_v,
+        fake_lse,
+        fake_amax_o,
+        fake_sinks,
+        fake_seq_kv_lens,
+        fake_o_desc,
+        (b, qh, kh, 0, 0, 0) if CFG.THD_VARLEN else (b, qh, kh, sq, skv, 0),
+        cutlass.Float32(0.0),
+        cutlass.Int32(0),
+        fake_seq_q_lens,
+        fake_thd_q_lens,
+        fake_thd_kv_lens,
+        fake_thd_lens_form,
+        stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
+        options="--enable-tvm-ffi",
+    )
+
+
+def _main():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--b", type=int, default=1)
+    parser.add_argument("--hq", type=int, default=1)
+    parser.add_argument("--hk", type=int, default=1)
+    parser.add_argument("--sq", type=int, default=256)
+    parser.add_argument("--skv", type=int, default=128)
+    parser.add_argument("--validate", action="store_true")
+    parser.add_argument("--iters", type=int, default=0)
+    args = parser.parse_args()
+
+    print(f"[d256_mxfp8_sm100] compile b={args.b} qh={args.hq} kh={args.hk} " f"sq={args.sq} skv={args.skv}", flush=True)
+    fn = compile(args.b, args.hq, args.hk, args.sq, args.skv)
+    print(f"[d256_mxfp8_sm100] compile OK: {fn}", flush=True)
+    if args.validate:
+        print("[d256_mxfp8_sm100] compiled - run validation via the frost SDPA test suite.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_mxfp8_sm100.py
@@ -10,7 +10,7 @@ owners have completed instead of occupying permanent columns above O.
 
 THD / varlen uses packed Q/K/V/O plus per-sequence-tile-padded SF buffers. A
 device setup kernel builds ragged metadata and runtime O/K/V tensor maps; the
-main launch uses a plan-time envelope and dynamic packed extents.
+main launch uses a persistent grid and dynamic packed extents.
 """
 
 from functools import lru_cache
@@ -177,6 +177,7 @@ _BAR_V_EMPTY_1 = 6
 _KV_PIPELINE_LANES = 64
 
 CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+THD_PERSISTENT = True
 
 _sdpa_h = make_sdpa_helpers(
     CFG,
@@ -379,6 +380,11 @@ def _scheduler_warp_loop_predecode(
     seq_kv_lens_tensor,
     seq_q_lens_tensor,
 ):
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        meta = cutlass.make_array_view(seq_kv_lens_tensor)
+        ctr_ptr = Pointer(seq_kv_lens_tensor.iterator.raw_ptr(), dtype=cutlass.Int32) + cutlass.Int32(4) * n_batch + cutlass.Int32(3)
+        live_off = cutlass.Int32(4) * n_batch + cutlass.Int32(2)
+
     state = PipelineState.start()
     is_valid = cutlass.Int32(1)
 
@@ -388,13 +394,41 @@ def _scheduler_warp_loop_predecode(
         if nvvm.elect_sync():
             arrive_expect_tx(sched.mb_scheduler.subview(state.idx), 16)
         if nvvm.elect_sync() and is_cga_first_cta:
-            nvvm.clusterlaunchcontrol_try_cancel(
-                sched.tile_id_smem.subview(state.idx * cutlass.Int32(SCHED_PAYLOAD_WORDS)),
-                sched.mb_scheduler.subview(state.idx),
-                multicast=1,
-            )
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                uid = cutlass.Int32(nvvm.atomicrmw(nvvm.AtomicOp.ADD, ctr_ptr, cutlass.Int32(1)))
+                live = cutlass.Int32(meta[live_off])
+                valid = cutlass.Int32(
+                    arith.select(
+                        (uid < live).ir_value(),
+                        cutlass.Int32(1).ir_value(),
+                        cutlass.Int32(0).ir_value(),
+                    )
+                )
+                tile_ptr = cute.make_ptr(
+                    cutlass.Int32,
+                    sched.tile_id_smem.subview(state.idx * cutlass.Int32(SCHED_PAYLOAD_WORDS)).data_ptr().toint(cutlass.Int32),
+                    cutlass.AddressSpace.smem,
+                    assumed_align=16,
+                )
+                mbar_ptr = cute.make_ptr(
+                    cutlass.Int64,
+                    sched.mb_scheduler.subview(state.idx).data_ptr().toint(cutlass.Int32),
+                    cutlass.AddressSpace.smem,
+                    assumed_align=8,
+                )
+                payload = (uid * cutlass.Int32(CFG.CGA_M), cutlass.Int32(0), valid, cutlass.Int32(0))
+                for cta_rank in cutlass.range_constexpr(CGA_SIZE):
+                    for word in cutlass.range_constexpr(4):
+                        cute.arch.store_async_dsmem(tile_ptr + word, payload[word], mbar_ptr, cta_rank)
+            else:
+                nvvm.clusterlaunchcontrol_try_cancel(
+                    sched.tile_id_smem.subview(state.idx * cutlass.Int32(SCHED_PAYLOAD_WORDS)),
+                    sched.mb_scheduler.subview(state.idx),
+                    multicast=1,
+                )
 
-        nvvm.fence_proxy("async.shared", space="cta")
+        if cutlass.const_expr(not CFG.THD_VARLEN):
+            nvvm.fence_proxy("async.shared", space="cta")
         nvvm.bar_warp_sync(cute.arch.FULL_MASK)
         wait(sched.mb_scheduler.subview(state.idx), state.phase)
 
@@ -1638,6 +1672,8 @@ def _mma_warp_group(
                 if cutlass.const_expr(CFG.FUSED_CORR_SPLIT_P):
                     wait(mb_qk_sf_reuse.subview(parity_cur_rt), qk_sf_reuse_phase_cur)
                     qk_sf_reuse_phase_pair = qk_sf_reuse_phase_pair ^ (cutlass.Int32(1) << parity_cur_rt)
+                    wait(mb_sf_reuse.subview(parity_cur_rt), sf_reuse_phase_cur)
+                    sf_reuse_phase_pair = sf_reuse_phase_pair ^ (cutlass.Int32(1) << parity_cur_rt)
                 else:
                     wait(mb_sf_reuse.subview(parity_cur_rt), sf_reuse_phase_cur)
                     sf_reuse_phase_pair = sf_reuse_phase_pair ^ (cutlass.Int32(1) << parity_cur_rt)
@@ -1659,9 +1695,6 @@ def _mma_warp_group(
                 _consumer_arrive_k_empty(bars, kv_state_K, mcast_mask)
                 kv_state_K = advance(kv_state_K, CFG.STAGES_KV)
 
-                if cutlass.const_expr(CFG.FUSED_CORR_SPLIT_P):
-                    wait(mb_sf_reuse.subview(parity_cur_rt), sf_reuse_phase_cur)
-                    sf_reuse_phase_pair = sf_reuse_phase_pair ^ (cutlass.Int32(1) << parity_cur_rt)
                 tmem_SF_P = tmem_raw.subview(tmem_S_acc_cur_addr + cutlass.Int32(LAYOUT.SF_AFTER_P_OFFSET))
                 tmem_SF_V = tmem_raw.subview(tmem_S_acc_cur_addr + cutlass.Int32(LAYOUT.SF_AFTER_P_OFFSET + SF_TMEM_COLS_P))
                 if cutlass.const_expr(CFG.MASK_FLAGS != 0):

--- a/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
+++ b/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
@@ -56,12 +56,13 @@ def test_sm100_module_unchanged():
 def test_sm107_per_tensor_fp8_advertises_only_d128():
     assert _sm100_fp8_shapes(pertensor=True, device_cc=(10, 7)) == frozenset({(128, 128)})
     assert (192, 128) in _sm100_fp8_shapes(pertensor=True, device_cc=(10, 0))
+    assert (256, 256) in _sm100_fp8_shapes(pertensor=True, device_cc=(10, 0))
 
 
 def test_per_tensor_fp8_rows_split_per_arch_line():
     """The per-tensor FP8 rows are split at the Rubin boundary — each row
     declares exactly what its own lowering carries, with no knob x arch
-    notches: the HALF softmax arm and the d192 flavor are row DATA."""
+    notches: kernel flavors, HALF softmax, and split/LPT capabilities are row DATA."""
     import cudnn as _c
     from cudnn.frost.tile_dsl.constants import SCHED_LPT, SCHED_LPT_L2, SCHED_NATURAL
     from cudnn.sdpa.fwd import engines
@@ -73,8 +74,8 @@ def test_per_tensor_fp8_rows_split_per_arch_line():
     # Arch ranges tile the SM100 family at the Rubin boundary, no overlap.
     assert (sm100.sm_lo, sm100.sm_hi) == (100, 106)
     assert (sm107.sm_lo, sm107.sm_hi) == (107, 119)
-    # Kernel flavors are row DATA: Rubin has no d192 or d512 sibling.
-    assert sm100.d_shapes == frozenset({(128, 128), (192, 128), (512, 512)})
+    # Kernel flavors are row DATA: Rubin has no d192, d256, or d512 sibling.
+    assert sm100.d_shapes == frozenset({(128, 128), (192, 128), (256, 256), (512, 512)})
     assert sm107.d_shapes == frozenset({(128, 128)})
     # d512 carries an envelope FLOOR: it serves (256, 512] on both head dims,
     # so a smaller graph is declined rather than routed onto the d512 kernel at
@@ -333,9 +334,9 @@ def test_fp8_rows_serve_dense_envelope():
         row = caps[engines.engine_name(arch=arch, fp8=True)]
         assert row.d_pad_multiple == 16, arch
     # The d128 kernel carries the THD leg on both arch lines; sm100 adds the
-    # d192 and d512 flavors' THD legs.
+    # d192, d256, and d512 flavors' THD legs.
     assert caps[engines.engine_name(arch="sm107", fp8=True)].thd_d_shapes == frozenset({(128, 128)})
-    assert caps[engines.engine_name(arch="sm100", fp8=True)].thd_d_shapes == frozenset({(128, 128), (192, 128), (512, 512)})
+    assert caps[engines.engine_name(arch="sm100", fp8=True)].thd_d_shapes == frozenset({(128, 128), (192, 128), (256, 256), (512, 512)})
     assert caps[engines.engine_name(mxfp8=True)].d_pad_multiple == 0
 
 
@@ -373,12 +374,16 @@ def test_fp8_envelope_mismatch_rules():
     assert engines.mismatch(sm100, _fp8_facts(d_qk=96, d_v=64)) is None
     # The d192xd128 flavor serves its envelope too (kernel takes d_qk/d_v).
     assert engines.mismatch(sm100, _fp8_facts(d_qk=160, d_v=96)) is None
-    assert "no kernel-flavor envelope" in engines.mismatch(sm100, _fp8_facts(d_qk=160, d_v=160))
+    # D256xD256 extends that envelope in both dimensions.
+    assert engines.mismatch(sm100, _fp8_facts(d_qk=160, d_v=160)) is None
+    assert "no kernel-flavor envelope" in engines.mismatch(sm100, _fp8_facts(d_qk=272, d_v=256))
     assert "multiples of 16" in engines.mismatch(sm100, _fp8_facts(d_qk=88, d_v=88))
     assert "dense-only" in engines.mismatch(sm100, _fp8_facts(thd=True, padded=True))
     assert engines.mismatch(sm100, _fp8_facts(d_qk=128, d_v=128, thd=True, padded=True)) is None
-    # SM100 carries THD at both native per-tensor FP8 shapes.
+    # SM100 carries THD at each native per-tensor FP8 shape.
     assert engines.mismatch(sm100, _fp8_facts(d_qk=192, d_v=128, thd=True, padded=True)) is None
+    assert engines.mismatch(sm100, _fp8_facts(d_qk=256, d_v=256)) is None
+    assert engines.mismatch(sm100, _fp8_facts(d_qk=256, d_v=256, thd=True, padded=True)) is None
     # d512 is a NATIVE shape (accepted exactly, dense and THD) and serves the
     # (256, 512] envelope band on BOTH head dims -- at most 2x zero-padding.
     assert engines.mismatch(sm100, _fp8_facts(d_qk=512, d_v=512)) is None
@@ -386,9 +391,7 @@ def test_fp8_envelope_mismatch_rules():
     assert engines.mismatch(sm100, _fp8_facts(d_qk=384, d_v=448)) is None
     assert engines.mismatch(sm100, _fp8_facts(d_qk=464, d_v=368)) is None
     assert engines.mismatch(sm100, _fp8_facts(d_qk=272, d_v=272)) is None
-    # Below the floor, or straddling it, the row declines rather than routing a
-    # much smaller graph onto the d512 kernel.
-    assert "no kernel-flavor envelope" in engines.mismatch(sm100, _fp8_facts(d_qk=256, d_v=256))
+    # Straddling the d512 floor declines rather than routing onto that kernel.
     assert "no kernel-flavor envelope" in engines.mismatch(sm100, _fp8_facts(d_qk=512, d_v=256))
     assert "no kernel-flavor envelope" in engines.mismatch(sm100, _fp8_facts(d_qk=384, d_v=128))
     # THD stays native-tile: the (256, 512] envelope band is dense-only.

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -4,10 +4,10 @@
 """End-to-end tests for the FROST SM100 DSL per-tensor FP8 SDPA-forward engine.
 
 Drives ``graph.sdpa_fp8`` (FP8 E4M3/E5M2 Q/K/V + scalar per-tensor descales) routed to
-the d128/d128 engine (which also serves the dense d<=128 head-dim ENVELOPE via TMA
-zero-padding) or the exact d192/d128 engine, and validates O against an fp32-dequant
-reference. ``Amax_O`` is produced in-kernel (atomicMax over the pre-cast fp32 values)
-and checked.
+the unified SM100 engine, which selects the d128/d128, d192/d128, or d256/d256
+kernel flavor. The d128 flavor also serves the dense d<=128 head-dim envelope via
+TMA zero-padding. O is validated against an fp32-dequant reference, and ``Amax_O``
+is checked against pre-cast fp32 values.
 
 cuDNN's ``sdpa_fp8`` op exposes causal / bottom-right / sliding-window masks, attention
 sink, a padding mask (per-batch ``seq_len_kv`` → KV-side masking, tested here), and THD /
@@ -74,7 +74,21 @@ def _quant(x, in_key):
     return (x / dq).clamp(-fmax, fmax).to(fp8), dq
 
 
-def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=None, sinks=None, seq_lens_kv=None, return_stats=False):
+def _ref(
+    qd,
+    kd,
+    vd,
+    *,
+    scale,
+    is_causal=False,
+    bottom_right=False,
+    swa_window=None,
+    right_bound=0,
+    sinks=None,
+    seq_lens_q=None,
+    seq_lens_kv=None,
+    return_stats=False,
+):
     b, h_q, s_q, _ = qd.shape
     _, h_kv, s_kv, _ = vd.shape
     dev = qd.device
@@ -87,29 +101,36 @@ def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=N
     masked = torch.zeros(1, 1, s_q, s_kv, dtype=torch.bool, device=dev)
     if is_causal:
         lim = i + (s_kv - s_q) if bottom_right else i
-        masked = masked | (j > lim)
+        masked = masked | (j > lim + right_bound)
     if swa_window is not None:
-        masked = masked | (j < i - swa_window)
+        swa_base = i + (s_kv - s_q) if bottom_right else i
+        masked = masked | (j < swa_base - swa_window)
     if seq_lens_kv is not None:
         # Per-batch KV padding: columns j >= seq_len_kv[b] are padding -> masked.
         slk = torch.as_tensor(seq_lens_kv, device=dev, dtype=torch.long).view(b, 1, 1, 1)
         masked = masked | (j >= slk)
     scores = scores.masked_fill(masked, float("-inf"))
+
+    def finalize(o, lse=None):
+        if seq_lens_q is not None:
+            slq = torch.as_tensor(seq_lens_q, device=dev, dtype=torch.long).view(b, 1, 1, 1)
+            valid_q = i < slq
+            o = torch.where(valid_q, o, torch.zeros_like(o))
+            if lse is not None:
+                lse = torch.where(valid_q.squeeze(-1), lse, torch.full_like(lse, float("-inf")))
+        return _ReferenceWithStats(o, lse) if lse is not None else o
+
     if sinks is not None:
         col = sinks.view(1, h_q, 1, 1).float().expand(b, h_q, s_q, 1).to(dev)
         ext = torch.cat([scores, col], dim=-1)
         probs = torch.softmax(ext, dim=-1)
         o = torch.matmul(probs[..., :s_kv], v_e)
-        if return_stats:
-            return _ReferenceWithStats(o, torch.logsumexp(ext, dim=-1))
-        return o
+        return finalize(o, torch.logsumexp(ext, dim=-1) if return_stats else None)
     row_has_kv = torch.isfinite(scores).any(dim=-1, keepdim=True)
     probs = torch.softmax(scores, dim=-1)
     probs = torch.where(row_has_kv, probs, torch.zeros_like(probs))
     o = torch.matmul(probs, v_e)
-    if return_stats:
-        return _ReferenceWithStats(o, torch.logsumexp(scores, dim=-1))
-    return o
+    return finalize(o, torch.logsumexp(scores, dim=-1) if return_stats else None)
 
 
 def _run(
@@ -124,6 +145,7 @@ def _run(
     scale,
     sdpa_kwargs,
     sink=None,
+    seq_lens_q=None,
     seq_lens_kv=None,
     s_scale=1.0,
     s_descale_gain=1.0,
@@ -178,10 +200,9 @@ def _run(
         st = g.tensor_like(sink)
         kw["sink_token"] = st
         vp[st] = sink
-    if seq_lens_kv is not None:
-        # KV padding: full (unpadded) query lengths + per-batch valid KV lengths.
-        slq = torch.full((B, 1, 1, 1), S_q, dtype=torch.int32, device=dev)
-        slk = torch.tensor(seq_lens_kv, dtype=torch.int32, device=dev).reshape(B, 1, 1, 1)
+    if seq_lens_q is not None or seq_lens_kv is not None:
+        slq = torch.tensor(seq_lens_q if seq_lens_q is not None else [S_q] * B, dtype=torch.int32, device=dev).reshape(B, 1, 1, 1)
+        slk = torch.tensor(seq_lens_kv if seq_lens_kv is not None else [S_kv] * B, dtype=torch.int32, device=dev).reshape(B, 1, 1, 1)
         sq_h = g.tensor(dim=[B, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT32)
         skv_h = g.tensor(dim=[B, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT32)
         kw.update(use_padding_mask=True, seq_len_q=sq_h, seq_len_kv=skv_h)
@@ -235,9 +256,18 @@ def _run(
         ref_kw["sinks"] = sink.flatten()
     if return_lse:
         assert stats, "return_lse requires stats=True"
-        o_ref, lse_ref = _ref(Q8.float() * dq, K8.float() * dk, V8.float() * dv, scale=scale, seq_lens_kv=seq_lens_kv, return_stats=True, **ref_kw)
+        o_ref, lse_ref = _ref(
+            Q8.float() * dq,
+            K8.float() * dk,
+            V8.float() * dv,
+            scale=scale,
+            seq_lens_q=seq_lens_q,
+            seq_lens_kv=seq_lens_kv,
+            return_stats=True,
+            **ref_kw,
+        )
         return _RunWithStatsResult(Ob, o_ref, amax_o.item(), o_ref.abs().max().item(), lse.squeeze(-1), lse_ref)
-    o_ref = _ref(Q8.float() * dq, K8.float() * dk, V8.float() * dv, scale=scale, seq_lens_kv=seq_lens_kv, **ref_kw)
+    o_ref = _ref(Q8.float() * dq, K8.float() * dk, V8.float() * dv, scale=scale, seq_lens_q=seq_lens_q, seq_lens_kv=seq_lens_kv, **ref_kw)
     return _RunResult(Ob, o_ref, amax_o.item(), o_ref.abs().max().item())
 
 
@@ -248,6 +278,15 @@ def _ref_kwargs(sdpa_kwargs):
     if sdpa_kwargs.get("use_causal_mask_bottom_right"):
         out["is_causal"] = True
         out["bottom_right"] = True
+    right_bound = sdpa_kwargs.get("right_bound")
+    if right_bound is not None:
+        out["is_causal"] = True
+        out["right_bound"] = right_bound
+    diagonal_alignment = sdpa_kwargs.get("diagonal_alignment")
+    if diagonal_alignment is not None:
+        import cudnn
+
+        out["bottom_right"] = diagonal_alignment == cudnn.diagonal_alignment.BOTTOM_RIGHT
     lb = sdpa_kwargs.get("left_bound")
     if lb is not None:
         out["swa_window"] = lb - 1
@@ -482,10 +521,11 @@ def test_fp8_head_dim_envelope(dims, mask):
 
 @pytest.mark.L0
 @_skip_on_rubin
+@pytest.mark.parametrize(("d_qk", "d_v"), [(160, 96), (224, 208)], ids=["d192_envelope", "d256_envelope"])
 @torch_fork_set_rng(seed=0)
-def test_fp8_head_dim_envelope_d192_flavor():
-    """The d192xd128 flavor serves its envelope too: (160, 96) rides the
-    (192, 128) kernel with TMA zero-padding on both sides.
+def test_fp8_head_dim_envelope_large_flavors(d_qk, d_v):
+    """The D192/D128 and D256 flavors serve their dense envelopes through
+    TMA zero-padding on both head dimensions.
 
     Direct adapter API: the pygraph ``sdpa_fp8`` node validator still bounds
     the GRAPH route at d_qk <= 128 (%16) / exact (192, 128) — a pre-FE-OSS
@@ -494,7 +534,7 @@ def test_fp8_head_dim_envelope_d192_flavor():
     relaxed to describe rather than judge."""
     from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm100
 
-    B, H, S, d_qk, d_v = 2, 4, 384, 160, 96
+    B, H, S = 2, 4, 384
     dev = "cuda"
     Q8 = (torch.randn(B, H, S, d_qk, device=dev) * 0.5).to(torch.float8_e4m3fn)
     K8 = (torch.randn(B, H, S, d_qk, device=dev) * 0.5).to(torch.float8_e4m3fn)
@@ -511,7 +551,7 @@ def test_fp8_head_dim_envelope_d192_flavor():
 
     o_ref = torch.softmax(Q8.float() @ K8.float().transpose(-1, -2) * scale, dim=-1) @ V8.float()
     err = (out.float() - o_ref).abs().max().item()
-    assert err <= 5e-2 + 0.05 * o_ref.abs().max().item(), f"(160,96) envelope mismatch: max err {err}"
+    assert err <= 5e-2 + 0.05 * o_ref.abs().max().item(), f"({d_qk},{d_v}) envelope mismatch: max err {err}"
     assert not torch.isnan(out.float()).any()
 
 
@@ -535,6 +575,225 @@ def test_fp8_head_dim_envelope_padded():
         d_v=80,
     )
     _check(out, o_ref, torch.bfloat16, "e4m3", a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("out_key", ["fp16", "bf16", "e4m3", "e5m2"])
+@pytest.mark.parametrize("in_key", _INS)
+@torch_fork_set_rng(seed=0)
+def test_fp8_d256_output_dtypes(in_key, out_key):
+    scale = 1.0 / math.sqrt(256)
+    out, o_ref, a_o, a_o_ref = _run(
+        1,
+        8,
+        8,
+        512,
+        512,
+        in_key,
+        _OUT[out_key],
+        scale=scale,
+        sdpa_kwargs=dict(use_causal_mask=True),
+        d_qk=256,
+        d_v=256,
+    )
+    _check(out, o_ref, _OUT[out_key], in_key, a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("in_key", _INS)
+@pytest.mark.parametrize("mask", ["none", "causal_br", "swa"])
+@torch_fork_set_rng(seed=0)
+def test_fp8_d256_masks(in_key, mask):
+    scale = 1.0 / math.sqrt(256)
+    out, o_ref, a_o, a_o_ref = _run(
+        2,
+        8,
+        8,
+        256,
+        256,
+        in_key,
+        torch.float16,
+        scale=scale,
+        sdpa_kwargs=_MASKS[mask],
+        d_qk=256,
+        d_v=256,
+    )
+    _check(out, o_ref, torch.float16, in_key, a_o, a_o_ref)
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize("in_key", _INS)
+@torch_fork_set_rng(seed=59)
+def test_fp8_d256_strided_stats(in_key):
+    """D256 preserves the caller's non-contiguous Stats layout."""
+    _check_fp8_strided_stats(256, 256, in_key)
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize("in_key", _INS)
+@torch_fork_set_rng(seed=0)
+def test_fp8_d256_bottom_right_rectangular(in_key):
+    """D256 bottom-right causal differs from top-left when S_q != S_kv."""
+    scale = 1.0 / math.sqrt(256)
+    out, o_ref, a_o, a_o_ref = _run(
+        2,
+        8,
+        8,
+        128,
+        256,
+        in_key,
+        torch.float16,
+        scale=scale,
+        sdpa_kwargs=dict(use_causal_mask_bottom_right=True),
+        d_qk=256,
+        d_v=256,
+    )
+    _check(out, o_ref, torch.float16, in_key, a_o, a_o_ref)
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize("case", ["right", "bottom_right", "right_swa"])
+@torch_fork_set_rng(seed=0)
+def test_fp8_d256_right_band_combinations(case):
+    """Pin the FP8-specific right-band lowering, including BR anchoring and SWA."""
+    import cudnn
+
+    d = 256
+    s_q, s_kv, kwargs = {
+        "right": (256, 256, dict(right_bound=40)),
+        "bottom_right": (128, 256, dict(right_bound=40, diagonal_alignment=cudnn.diagonal_alignment.BOTTOM_RIGHT)),
+        "right_swa": (256, 256, dict(right_bound=40, left_bound=65)),
+    }[case]
+    out, o_ref, a_o, a_o_ref = _run(
+        1,
+        4,
+        4,
+        s_q,
+        s_kv,
+        "e4m3",
+        torch.float16,
+        scale=1.0 / math.sqrt(d),
+        sdpa_kwargs=kwargs,
+        d_qk=d,
+        d_v=d,
+    )
+    _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize("in_key", _INS)
+@pytest.mark.parametrize("causal", [False, True])
+@torch_fork_set_rng(seed=0)
+def test_fp8_d256_padding(in_key, causal):
+    """D256 masks a per-batch partial KV tile in dense storage."""
+    scale = 1.0 / math.sqrt(256)
+    sdpa_kwargs = dict(use_causal_mask=True) if causal else {}
+    out, o_ref, a_o, a_o_ref = _run(
+        2,
+        8,
+        8,
+        256,
+        256,
+        in_key,
+        torch.float16,
+        scale=scale,
+        sdpa_kwargs=sdpa_kwargs,
+        seq_lens_kv=[256, 192],
+        d_qk=256,
+        d_v=256,
+    )
+    _check(out, o_ref, torch.float16, in_key, a_o, a_o_ref)
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=0)
+def test_fp8_d256_dense_q_trim_stats_sink():
+    """Short dense Q rows trim O/LSE even when a sink makes softmax finite."""
+    d = 256
+    sink = torch.randn(1, 8, 1, 1, dtype=torch.float32, device="cuda")
+    result = _run(
+        2,
+        8,
+        8,
+        256,
+        256,
+        "e4m3",
+        torch.float16,
+        scale=1.0 / math.sqrt(d),
+        sdpa_kwargs={},
+        sink=sink,
+        seq_lens_q=[129, 0],
+        seq_lens_kv=[200, 256],
+        d_qk=d,
+        d_v=d,
+        return_lse=True,
+    )
+    _check(result.output, result.reference, torch.float16, "e4m3", result.amax, result.reference_amax)
+    assert (result.output[0, :, 129:] == 0).all() and (result.output[1] == 0).all()
+    assert torch.isneginf(result.stats[0, :, 129:]).all() and torch.isneginf(result.stats[1]).all()
+    torch.testing.assert_close(result.stats, result.reference_stats, atol=5e-2, rtol=3e-2)
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize("in_key", _INS)
+@torch_fork_set_rng(seed=0)
+def test_fp8_d256_gqa_sink(in_key):
+    """D256 ordinary GQA composes with a per-query-head attention sink."""
+    scale = 1.0 / math.sqrt(256)
+    sink = torch.randn(1, 8, 1, 1, dtype=torch.float32, device="cuda")
+    out, o_ref, a_o, a_o_ref = _run(
+        2,
+        8,
+        2,
+        256,
+        256,
+        in_key,
+        torch.float16,
+        scale=scale,
+        sdpa_kwargs=dict(use_causal_mask=True),
+        sink=sink,
+        d_qk=256,
+        d_v=256,
+        pack_gqa=False,
+    )
+    _check(out, o_ref, torch.float16, in_key, a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize(
+    ("in_key", "out_key", "with_sink"),
+    [
+        ("e4m3", "fp16", False),
+        ("e4m3", "e4m3", True),
+        ("e5m2", "fp16", True),
+    ],
+    ids=["e4m3-fp16-nosink", "e4m3-fp8-sink", "e5m2-fp16-sink"],
+)
+@torch_fork_set_rng(seed=0)
+def test_fp8_d256_leading_zero_length_kv(in_key: str, out_key: str, with_sink: bool):
+    """A leading zero-length KV batch must produce zero O and valid Stats."""
+    d = 256
+    sink = torch.randn(1, 8, 1, 1, dtype=torch.float32, device="cuda") if with_sink else None
+    result = _run(
+        2,
+        8,
+        8,
+        256,
+        256,
+        in_key,
+        _OUT[out_key],
+        scale=1.0 / math.sqrt(d),
+        sdpa_kwargs={},
+        sink=sink,
+        seq_lens_kv=[0, 256],
+        d_qk=d,
+        d_v=d,
+        return_lse=True,
+        poison_tmem_before_execute=True,
+    )
+    _check(result.output, result.reference, _OUT[out_key], in_key, result.amax, result.reference_amax)
+    assert (result.output[0] == 0).all()
+    torch.testing.assert_close(result.stats, result.reference_stats, atol=5e-2, rtol=3e-2)
 
 
 @pytest.mark.L0
@@ -563,12 +822,25 @@ def test_fp8_gqa(in_key):
     [(8, 4), (8, 2), (8, 1), (16, 1)],
     ids=["g2", "g4", "g8_mqa", "g16_mqa"],
 )
+@pytest.mark.parametrize("d", [128, 256], ids=["d128", "d256"])
 @torch_fork_set_rng(seed=0)
-def test_fp8_pack_gqa_ratios(h_q, h_kv):
+def test_fp8_pack_gqa_ratios(d, h_q, h_kv):
     """Packed plans across GQA ratios, causal, tile-unaligned s_q, LSE checked."""
-    scale = 1.0 / math.sqrt(128)
+    scale = 1.0 / math.sqrt(d)
     out, o_ref, a_o, a_ref, lse_v, lse_ref = _run(
-        2, h_q, h_kv, 40, 256, "e4m3", torch.float16, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), pack_gqa=True, return_lse=True
+        2,
+        h_q,
+        h_kv,
+        40,
+        256,
+        "e4m3",
+        torch.float16,
+        scale=scale,
+        sdpa_kwargs=dict(use_causal_mask=True),
+        d_qk=d,
+        d_v=d,
+        pack_gqa=True,
+        return_lse=True,
     )
     _check(out, o_ref, torch.float16, "e4m3", a_o, a_ref)
     torch.testing.assert_close(lse_v, lse_ref, atol=5e-2, rtol=3e-2)
@@ -593,10 +865,11 @@ def test_fp8_pack_gqa_tiles(s_q):
     "mask",
     ["none_padded", "causal", "causal_br", "swa", "sink_causal"],
 )
+@pytest.mark.parametrize("d", [128, 256], ids=["d128", "d256"])
 @torch_fork_set_rng(seed=0)
-def test_fp8_pack_gqa_features(mask, out_dt):
+def test_fp8_pack_gqa_features(d, mask, out_dt):
     """Packed plans x the fp8 mask/sink envelope x both output dtypes."""
-    scale = 1.0 / math.sqrt(128)
+    scale = 1.0 / math.sqrt(d)
     kw = dict()
     sink = None
     seq_lens_kv = None
@@ -612,18 +885,46 @@ def test_fp8_pack_gqa_features(mask, out_dt):
         kw = dict(use_causal_mask=True)
         sink = torch.randn(1, 8, 1, 1, dtype=torch.float32, device="cuda")
     out, o_ref, a_o, a_ref, lse_v, lse_ref = _run(
-        2, 8, 2, 40, 256, "e4m3", out_dt, scale=scale, sdpa_kwargs=kw, sink=sink, seq_lens_kv=seq_lens_kv, pack_gqa=True, return_lse=True
+        2,
+        8,
+        2,
+        40,
+        256,
+        "e4m3",
+        out_dt,
+        scale=scale,
+        sdpa_kwargs=kw,
+        sink=sink,
+        seq_lens_kv=seq_lens_kv,
+        d_qk=d,
+        d_v=d,
+        pack_gqa=True,
+        return_lse=True,
     )
     _check(out, o_ref, out_dt, "e4m3", a_o, a_ref)
     torch.testing.assert_close(lse_v, lse_ref, atol=5e-2, rtol=3e-2)
 
 
 @pytest.mark.L1
+@pytest.mark.parametrize("d", [128, 256], ids=["d128", "d256"])
 @torch_fork_set_rng(seed=0)
-def test_fp8_pack_gqa_e5m2():
+def test_fp8_pack_gqa_e5m2(d):
     """Packed e5m2 input path."""
-    scale = 1.0 / math.sqrt(128)
-    out, o_ref, a_o, a_ref = _run(2, 8, 2, 40, 256, "e5m2", torch.float16, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), pack_gqa=True)
+    scale = 1.0 / math.sqrt(d)
+    out, o_ref, a_o, a_ref = _run(
+        2,
+        8,
+        2,
+        40,
+        256,
+        "e5m2",
+        torch.float16,
+        scale=scale,
+        sdpa_kwargs=dict(use_causal_mask=True),
+        d_qk=d,
+        d_v=d,
+        pack_gqa=True,
+    )
     _check(out, o_ref, torch.float16, "e5m2", a_o, a_ref)
 
 
@@ -850,10 +1151,9 @@ def _run_thd(
         kw.update(seq_len_q=sq_h, seq_len_kv=skv_h)
     if bottom_right:
         kw["use_causal_mask_bottom_right"] = True
-    elif causal:
+    elif causal or swa_window is not None:
         kw["use_causal_mask"] = True
     if swa_window is not None:
-        kw["use_causal_mask"] = True
         kw["left_bound"] = swa_window + 1
     vp = {
         tq: q_gpu,
@@ -958,15 +1258,15 @@ def _ref_lse(qd, kd, *, scale, causal, bottom_right=False, swa_window=None, sink
     dev = qd.device
     k_e = kd.repeat_interleave(h_q // h_kv, dim=1)
     scores = torch.matmul(qd, k_e.transpose(-1, -2)) * scale
+    i = torch.arange(s_q, device=dev).view(1, 1, s_q, 1)
+    j = torch.arange(s_kv, device=dev).view(1, 1, 1, s_kv)
+    diag = s_kv - s_q if bottom_right else 0
+    masked = torch.zeros(1, 1, s_q, s_kv, dtype=torch.bool, device=dev)
     if causal:
-        i = torch.arange(s_q, device=dev).view(1, 1, s_q, 1)
-        j = torch.arange(s_kv, device=dev).view(1, 1, 1, s_kv)
-        lim = i + (s_kv - s_q) if bottom_right else i
-        scores = scores.masked_fill(j > lim, float("-inf"))
+        masked = masked | (j > i + diag)
     if swa_window is not None:
-        i = torch.arange(s_q, device=dev).view(1, 1, s_q, 1)
-        j = torch.arange(s_kv, device=dev).view(1, 1, 1, s_kv)
-        scores = scores.masked_fill(j < i - swa_window, float("-inf"))
+        masked = masked | (j < i + diag - swa_window)
+    scores = scores.masked_fill(masked, float("-inf"))
     if sinks is not None:
         col = sinks.view(1, h_q, 1, 1).float().expand(1, h_q, s_q, 1).to(dev)
         scores = torch.cat([scores, col], dim=-1)
@@ -1097,55 +1397,107 @@ def test_fp8_thd_multi_unit_per_cta(monkeypatch, d_qk, d_v):
 
 
 @pytest.mark.L0
+@pytest.mark.parametrize("in_key", _INS)
+@pytest.mark.parametrize("causal", [False, True])
 @torch_fork_set_rng(seed=0)
-def test_fp8_thd_cross_gqa():
+def test_fp8_d256_thd(in_key, causal):
+    """D256 THD/varlen uses the same packed contract as the D128 sibling."""
+    scale = 1.0 / math.sqrt(256)
+    out, o_ref, a_o, a_o_ref, _, _ = _run_thd(
+        [160, 96],
+        [160, 96],
+        8,
+        8,
+        in_key,
+        scale=scale,
+        causal=causal,
+        d=256,
+    )
+    _check(out, o_ref, torch.float16, in_key, a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("d", [128, 256])
+@pytest.mark.parametrize("in_key", _INS)
+@pytest.mark.parametrize("bottom_right", [False, True])
+@torch_fork_set_rng(seed=0)
+def test_fp8_thd_sliding_window(d, in_key, bottom_right):
+    """THD sliding window uses each sequence's local causal diagonal."""
+    q_lens = [173, 97] if bottom_right else [257, 193]
+    kv_lens = [257, 193] if bottom_right else q_lens
+    scale = 1.0 / math.sqrt(d)
+    out, o_ref, a_o, a_o_ref, lse, lse_ref = _run_thd(
+        q_lens,
+        kv_lens,
+        8,
+        2,
+        in_key,
+        scale=scale,
+        causal=not bottom_right,
+        bottom_right=bottom_right,
+        swa_window=73,
+        stats=True,
+        d=d,
+    )
+    _check(out, o_ref, torch.float16, in_key, a_o, a_o_ref)
+    torch.testing.assert_close(lse, lse_ref, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("d", [128, 256])
+@torch_fork_set_rng(seed=0)
+def test_fp8_thd_cross_gqa(d):
     """THD cross-attention (unequal packed Q and K/V totals) with GQA heads."""
-    scale = 1.0 / math.sqrt(128)
-    out, o_ref, a_o, a_o_ref, _, _ = _run_thd([64, 200], [256, 128], 8, 2, "e4m3", scale=scale)
+    scale = 1.0 / math.sqrt(d)
+    out, o_ref, a_o, a_o_ref, _, _ = _run_thd([64, 200], [256, 128], 8, 2, "e4m3", scale=scale, d=d)
     _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
 
 
 @pytest.mark.L0
+@pytest.mark.parametrize("d", [128, 256])
 @torch_fork_set_rng(seed=0)
-def test_fp8_thd_sink():
+def test_fp8_thd_sink(d):
     """THD causal + attention sink."""
-    scale = 1.0 / math.sqrt(128)
+    scale = 1.0 / math.sqrt(d)
     sink = torch.randn(1, 8, 1, 1, dtype=torch.float32, device="cuda")
-    out, o_ref, a_o, a_o_ref, _, _ = _run_thd([200, 150], [200, 150], 8, 8, "e4m3", scale=scale, causal=True, sink=sink)
+    out, o_ref, a_o, a_o_ref, _, _ = _run_thd([200, 150], [200, 150], 8, 8, "e4m3", scale=scale, causal=True, sink=sink, d=d)
     _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
 
 
 @pytest.mark.L0
+@pytest.mark.parametrize("d", [128, 256])
 @torch_fork_set_rng(seed=0)
-def test_fp8_thd_stats():
+def test_fp8_thd_stats(d):
     """THD + generate_stats: the ragged token-major TH1 LSE is written next to O."""
-    scale = 1.0 / math.sqrt(128)
-    out, o_ref, a_o, a_o_ref, lse, lse_ref = _run_thd([200, 150], [200, 150], 8, 8, "e4m3", scale=scale, causal=True, stats=True)
+    scale = 1.0 / math.sqrt(d)
+    out, o_ref, a_o, a_o_ref, lse, lse_ref = _run_thd([200, 150], [200, 150], 8, 8, "e4m3", scale=scale, causal=True, stats=True, d=d)
     _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
     torch.testing.assert_close(lse, lse_ref, atol=2e-2, rtol=2e-2)
 
 
 @pytest.mark.L0
+@pytest.mark.parametrize("d", [128, 256])
 @torch_fork_set_rng(seed=0)
-def test_fp8_thd_zero_len_kv():
+def test_fp8_thd_zero_len_kv(d):
     """Zero-length Q and KV sequences (test_mhas_v2 ragged parity, e.g.
     seq_len_q=[126, 0, 60] / seq_len_kv=[0, 83, 77]): the zero-KV sequence's
     rows are dead — the epilogue must come back O := 0 / LSE := -inf, not the
     unwritten O TMEM (garbage survives `* inv_sum(=0)` when it is NaN)."""
-    scale = 1.0 / math.sqrt(128)
-    out, o_ref, a_o, a_o_ref, lse, lse_ref = _run_thd([126, 40, 60], [0, 83, 77], 8, 8, "e4m3", scale=scale, stats=True)
+    scale = 1.0 / math.sqrt(d)
+    out, o_ref, a_o, a_o_ref, lse, lse_ref = _run_thd([126, 40, 60], [0, 83, 77], 8, 8, "e4m3", scale=scale, stats=True, d=d)
     _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
     torch.testing.assert_close(lse, lse_ref, atol=2e-2, rtol=2e-2, equal_nan=False)
-    out, o_ref, a_o, a_o_ref, _, _ = _run_thd([126, 0, 60], [0, 83, 77], 8, 8, "e5m2", scale=scale)
+    out, o_ref, a_o, a_o_ref, _, _ = _run_thd([126, 0, 60], [0, 83, 77], 8, 8, "e5m2", scale=scale, d=d)
     _check(out, o_ref, torch.float16, "e5m2", a_o, a_o_ref)
 
 
 @pytest.mark.L0
+@pytest.mark.parametrize("d", [128, 256])
 @torch_fork_set_rng(seed=0)
-def test_fp8_thd_cu_seq_len():
+def test_fp8_thd_cu_seq_len(d):
     """THD via the (B+1,) cu_seq_len prefix-sum length form."""
-    scale = 1.0 / math.sqrt(128)
-    out, o_ref, a_o, a_o_ref, _, _ = _run_thd([200, 150], [180, 120], 8, 8, "e4m3", scale=scale, cu_lens=True)
+    scale = 1.0 / math.sqrt(d)
+    out, o_ref, a_o, a_o_ref, _, _ = _run_thd([200, 150], [180, 120], 8, 8, "e4m3", scale=scale, cu_lens=True, d=d)
     _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
 
 
@@ -1422,17 +1774,14 @@ def test_fp8_d512_head_dim_envelope(d_qk, d_v, mask):
 
 @pytest.mark.L0
 @_skip_d512_on_rubin
-def test_fp8_d512_envelope_floor_declines_below_256():
-    """Below the d512 floor the adapter declines instead of routing a much
-    smaller graph onto a kernel tuned for d = 512 (there is no d256 FP8
-    kernel, so d256 has no home -- that is the honest answer, not a 2x-padded
-    d512 launch).  Straddling the floor is declined too."""
+def test_fp8_d512_envelope_floor_declines_straddling_shapes():
+    """D256 serves its own envelope; shapes straddling the D512 floor decline."""
     from cudnn.sdpa.fwd.api_dsl import _fp8_envelope_covers, _sm100_fp8_shapes
 
     shapes = _sm100_fp8_shapes(pertensor=True, device_cc=(10, 0))
-    for d_qk, d_v in [(384, 448), (464, 368), (272, 272), (512, 512)]:
+    for d_qk, d_v in [(160, 160), (256, 256), (384, 448), (464, 368), (272, 272), (512, 512)]:
         assert _fp8_envelope_covers(d_qk, d_v, shapes), (d_qk, d_v)
-    for d_qk, d_v in [(256, 256), (160, 160), (384, 128), (512, 256)]:
+    for d_qk, d_v in [(272, 256), (384, 128), (512, 256)]:
         assert not _fp8_envelope_covers(d_qk, d_v, shapes), (d_qk, d_v)
 
 

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -39,6 +39,8 @@ pytestmark = [requires_blackwell, requires_dsl]
 # under test. The d192xd128 kernel flavor exists on the sm100 engine only.
 _D128_ARCH = "sm107" if _SM == 107 else "sm100"
 _skip_on_rubin = pytest.mark.skipif(_SM == 107, reason="the d192xd128 per-tensor FP8 flavor has no Rubin kernel (sm107 serves d128 only)")
+_skip_d256_on_rubin = pytest.mark.skipif(_SM == 107, reason="the d256xd256 per-tensor FP8 flavor has no Rubin kernel (sm107 serves d128 only)")
+_D128_D256 = [pytest.param(128, id="d128"), pytest.param(256, id="d256", marks=_skip_d256_on_rubin)]
 
 _FP8 = {"e4m3": torch.float8_e4m3fn, "e5m2": torch.float8_e5m2}
 _FP8_MAX = {"e4m3": 448.0, "e5m2": 57344.0}
@@ -578,6 +580,7 @@ def test_fp8_head_dim_envelope_padded():
 
 
 @pytest.mark.L0
+@_skip_d256_on_rubin
 @pytest.mark.parametrize("out_key", ["fp16", "bf16", "e4m3", "e5m2"])
 @pytest.mark.parametrize("in_key", _INS)
 @torch_fork_set_rng(seed=0)
@@ -600,6 +603,7 @@ def test_fp8_d256_output_dtypes(in_key, out_key):
 
 
 @pytest.mark.L0
+@_skip_d256_on_rubin
 @pytest.mark.parametrize("in_key", _INS)
 @pytest.mark.parametrize("mask", ["none", "causal_br", "swa"])
 @torch_fork_set_rng(seed=0)
@@ -622,6 +626,7 @@ def test_fp8_d256_masks(in_key, mask):
 
 
 @pytest.mark.L1
+@_skip_d256_on_rubin
 @pytest.mark.parametrize("in_key", _INS)
 @torch_fork_set_rng(seed=59)
 def test_fp8_d256_strided_stats(in_key):
@@ -630,6 +635,7 @@ def test_fp8_d256_strided_stats(in_key):
 
 
 @pytest.mark.L1
+@_skip_d256_on_rubin
 @pytest.mark.parametrize("in_key", _INS)
 @torch_fork_set_rng(seed=0)
 def test_fp8_d256_bottom_right_rectangular(in_key):
@@ -652,6 +658,7 @@ def test_fp8_d256_bottom_right_rectangular(in_key):
 
 
 @pytest.mark.L1
+@_skip_d256_on_rubin
 @pytest.mark.parametrize("case", ["right", "bottom_right", "right_swa"])
 @torch_fork_set_rng(seed=0)
 def test_fp8_d256_right_band_combinations(case):
@@ -681,6 +688,7 @@ def test_fp8_d256_right_band_combinations(case):
 
 
 @pytest.mark.L1
+@_skip_d256_on_rubin
 @pytest.mark.parametrize("in_key", _INS)
 @pytest.mark.parametrize("causal", [False, True])
 @torch_fork_set_rng(seed=0)
@@ -706,6 +714,7 @@ def test_fp8_d256_padding(in_key, causal):
 
 
 @pytest.mark.L1
+@_skip_d256_on_rubin
 @torch_fork_set_rng(seed=0)
 def test_fp8_d256_dense_q_trim_stats_sink():
     """Short dense Q rows trim O/LSE even when a sink makes softmax finite."""
@@ -735,6 +744,7 @@ def test_fp8_d256_dense_q_trim_stats_sink():
 
 
 @pytest.mark.L1
+@_skip_d256_on_rubin
 @pytest.mark.parametrize("in_key", _INS)
 @torch_fork_set_rng(seed=0)
 def test_fp8_d256_gqa_sink(in_key):
@@ -760,6 +770,7 @@ def test_fp8_d256_gqa_sink(in_key):
 
 
 @pytest.mark.L0
+@_skip_d256_on_rubin
 @pytest.mark.parametrize(
     ("in_key", "out_key", "with_sink"),
     [
@@ -822,7 +833,7 @@ def test_fp8_gqa(in_key):
     [(8, 4), (8, 2), (8, 1), (16, 1)],
     ids=["g2", "g4", "g8_mqa", "g16_mqa"],
 )
-@pytest.mark.parametrize("d", [128, 256], ids=["d128", "d256"])
+@pytest.mark.parametrize("d", _D128_D256)
 @torch_fork_set_rng(seed=0)
 def test_fp8_pack_gqa_ratios(d, h_q, h_kv):
     """Packed plans across GQA ratios, causal, tile-unaligned s_q, LSE checked."""
@@ -865,7 +876,7 @@ def test_fp8_pack_gqa_tiles(s_q):
     "mask",
     ["none_padded", "causal", "causal_br", "swa", "sink_causal"],
 )
-@pytest.mark.parametrize("d", [128, 256], ids=["d128", "d256"])
+@pytest.mark.parametrize("d", _D128_D256)
 @torch_fork_set_rng(seed=0)
 def test_fp8_pack_gqa_features(d, mask, out_dt):
     """Packed plans x the fp8 mask/sink envelope x both output dtypes."""
@@ -906,7 +917,7 @@ def test_fp8_pack_gqa_features(d, mask, out_dt):
 
 
 @pytest.mark.L1
-@pytest.mark.parametrize("d", [128, 256], ids=["d128", "d256"])
+@pytest.mark.parametrize("d", _D128_D256)
 @torch_fork_set_rng(seed=0)
 def test_fp8_pack_gqa_e5m2(d):
     """Packed e5m2 input path."""
@@ -1380,7 +1391,7 @@ def test_fp8_d192_d128_thd_features():
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("d_qk,d_v", [(128, 128), (192, 128)], ids=["d128", "d192_d128"])
+@pytest.mark.parametrize("d_qk,d_v", [(128, 128), (192, 128), (256, 256)], ids=["d128", "d192_d128", "d256"])
 @torch_fork_set_rng(seed=0)
 def test_fp8_thd_multi_unit_per_cta(monkeypatch, d_qk, d_v):
     """THD where a cluster claims more than one unit (issue #618).
@@ -1397,6 +1408,7 @@ def test_fp8_thd_multi_unit_per_cta(monkeypatch, d_qk, d_v):
 
 
 @pytest.mark.L0
+@_skip_d256_on_rubin
 @pytest.mark.parametrize("in_key", _INS)
 @pytest.mark.parametrize("causal", [False, True])
 @torch_fork_set_rng(seed=0)
@@ -1417,7 +1429,7 @@ def test_fp8_d256_thd(in_key, causal):
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("d", [128, 256])
+@pytest.mark.parametrize("d", _D128_D256)
 @pytest.mark.parametrize("in_key", _INS)
 @pytest.mark.parametrize("bottom_right", [False, True])
 @torch_fork_set_rng(seed=0)
@@ -1444,7 +1456,7 @@ def test_fp8_thd_sliding_window(d, in_key, bottom_right):
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("d", [128, 256])
+@pytest.mark.parametrize("d", _D128_D256)
 @torch_fork_set_rng(seed=0)
 def test_fp8_thd_cross_gqa(d):
     """THD cross-attention (unequal packed Q and K/V totals) with GQA heads."""
@@ -1454,7 +1466,7 @@ def test_fp8_thd_cross_gqa(d):
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("d", [128, 256])
+@pytest.mark.parametrize("d", _D128_D256)
 @torch_fork_set_rng(seed=0)
 def test_fp8_thd_sink(d):
     """THD causal + attention sink."""
@@ -1465,7 +1477,7 @@ def test_fp8_thd_sink(d):
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("d", [128, 256])
+@pytest.mark.parametrize("d", _D128_D256)
 @torch_fork_set_rng(seed=0)
 def test_fp8_thd_stats(d):
     """THD + generate_stats: the ragged token-major TH1 LSE is written next to O."""
@@ -1476,7 +1488,7 @@ def test_fp8_thd_stats(d):
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("d", [128, 256])
+@pytest.mark.parametrize("d", _D128_D256)
 @torch_fork_set_rng(seed=0)
 def test_fp8_thd_zero_len_kv(d):
     """Zero-length Q and KV sequences (test_mhas_v2 ragged parity, e.g.
@@ -1492,7 +1504,7 @@ def test_fp8_thd_zero_len_kv(d):
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("d", [128, 256])
+@pytest.mark.parametrize("d", _D128_D256)
 @torch_fork_set_rng(seed=0)
 def test_fp8_thd_cu_seq_len(d):
     """THD via the (B+1,) cu_seq_len prefix-sum length form."""

--- a/test/python/sdpa/frost/test_sdpa_fwd_heuristics.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_heuristics.py
@@ -142,6 +142,107 @@ def test_sm120_d192_keeps_sm120_cga_domain(engine_name, dtype, is_fp8):
 
 
 @pytest.mark.L0
+@pytest.mark.parametrize("mxfp8", [False, True], ids=["per_tensor", "block_scale"])
+@pytest.mark.parametrize(
+    ("d_qk", "d_v", "expected_cga"),
+    [(128, 128, 2), (256, 256, 1)],
+    ids=["d128", "d256"],
+)
+def test_quantized_cga_follows_selected_native_flavor(mxfp8, d_qk, d_v, expected_cga):
+    """A unified dtype-family engine must advertise the geometry it launches."""
+
+    name = engines.engine_name(mxfp8=mxfp8, fp8=not mxfp8)
+    facts = _facts(
+        d_qk=d_qk,
+        d_v=d_v,
+        dtype=cudnn.data_type.FP8_E4M3,
+        dtype_o=cudnn.data_type.HALF,
+        is_mxfp8=mxfp8,
+        is_fp8=not mxfp8,
+    )
+    plans = recommend("A", facts, {name: 20510})
+    assert plans
+    assert {plan.knobs.cga for plan in plans} == {expected_cga}
+
+    spec = next(spec for spec in engines.ENGINE_SPECS if spec.name == name)
+    assert engines.mismatch(spec.capabilities, facts, engines.SdpaFwdKnobs(cga=expected_cga)) is None
+    wrong_cga = 1 if expected_cga == 2 else 2
+    assert "outside this engine's domain" in engines.mismatch(spec.capabilities, facts, engines.SdpaFwdKnobs(cga=wrong_cga))
+
+
+@pytest.mark.L0
+def test_per_tensor_fp8_envelope_uses_d256_cga1():
+    """A non-native dense shape inherits the geometry of its covering flavor."""
+
+    name = engines.engine_name(fp8=True)
+    facts = _facts(
+        d_qk=224,
+        d_v=224,
+        dtype=cudnn.data_type.FP8_E4M3,
+        dtype_o=cudnn.data_type.HALF,
+        is_fp8=True,
+    )
+    plans = recommend("A", facts, {name: 20510})
+    assert plans
+    assert {plan.knobs.cga for plan in plans} == {1}
+
+
+@pytest.mark.L0
+def test_d256_fp8_config_requires_cga1():
+    from cudnn.frost.tile_dsl.constants import DTYPE_E4M3, DTYPE_FP16
+    from cudnn.sdpa.fwd.config_sm100 import TemplateParams, make_cfg_d256, make_cfg_d256_mxfp8
+
+    params = TemplateParams(dtype_qkv=DTYPE_E4M3, dtype_o=DTYPE_FP16, cta_mma=1)
+    cfg_pt = make_cfg_d256(params)[0]
+    cfg_mx = make_cfg_d256_mxfp8(params)[0]
+    assert cfg_pt.CGA_M == cfg_pt.CTA_MMA == 1
+    assert cfg_mx.CGA_M == cfg_mx.CTA_MMA == 1
+    with pytest.raises(ValueError, match="FP8/MXFP8 requires cta_mma=1"):
+        make_cfg_d256(TemplateParams(dtype_qkv=DTYPE_E4M3, dtype_o=DTYPE_FP16, cta_mma=2))
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("mxfp8", [False, True], ids=["per_tensor", "block_scale"])
+@pytest.mark.parametrize("sched_policy", [0, 1, 2], ids=["natural", "lpt", "lpt_l2"])
+def test_d256_config_honors_explicit_scheduler(mxfp8, sched_policy):
+    from cudnn.frost.tile_dsl.constants import DTYPE_E4M3, DTYPE_FP16
+    from cudnn.sdpa.fwd.config_sm100 import TemplateParams, make_cfg_d256, make_cfg_d256_mxfp8
+
+    params = TemplateParams(
+        dtype_qkv=DTYPE_E4M3,
+        dtype_o=DTYPE_FP16,
+        window_right=0,
+        sched_policy=sched_policy,
+        cta_mma=1,
+    )
+    make_cfg = make_cfg_d256_mxfp8 if mxfp8 else make_cfg_d256
+    assert make_cfg(params)[0].SCHEDULER_POLICY == sched_policy
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize(
+    ("mxfp8", "expected_sched"),
+    [(False, 2), (True, 1)],
+    ids=["per_tensor_lpt_l2", "block_scale_lpt"],
+)
+def test_d256_quantized_primary_uses_measured_scheduler(mxfp8, expected_sched):
+    name = engines.engine_name(mxfp8=mxfp8, fp8=not mxfp8)
+    facts = _facts(
+        s_q=8192,
+        d_qk=256,
+        d_v=256,
+        dtype=cudnn.data_type.FP8_E4M3,
+        dtype_o=cudnn.data_type.HALF,
+        is_mxfp8=mxfp8,
+        is_fp8=not mxfp8,
+    )
+    plans = recommend("A", facts, {name: 20510})
+    assert plans[0].knobs.cga == 1
+    assert plans[0].knobs.split_kv == 1
+    assert plans[0].knobs.sched_policy == expected_sched
+
+
+@pytest.mark.L0
 def test_assemble_strips_mode_dedups_and_our_proposals_lead():
     """Placement is the SHARED layer's job (engines/heuristics._assemble):
     proposals lead the backend's entries inside each mode block by standing
@@ -222,16 +323,17 @@ def test_split_kv_plan_pinned_by_name_matches_reference():
     # The split value depends on this device's SM count — ask the chooser
     # rather than hard-coding one that only holds at one part's geometry.
     from cudnn._device import device_info
+    from cudnn.sdpa.fwd.config_sm100 import cga_tile_m
     from cudnn.sdpa.fwd.heuristics import choose_split_kv
 
     want = choose_split_kv(
-        q_tiles=-(-SQ // 256),
+        q_tiles=-(-SQ // cga_tile_m(D)),
         heads_q=H,
         batch=B,
         kv_tiles=-(-SKV // 128),
         sm_count=device_info(torch.cuda.current_device()).sm_count,
+        combine_rows=SQ * H * B,
         ctas_per_tile=2,
-        max_split=4,
     )
     if want == 1:
         pytest.skip("this part is small enough that the shape already fills it")

--- a/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
@@ -4,9 +4,10 @@
 """End-to-end tests for the FROST SM100 DSL block-scale MXFP8 SDPA-forward engine.
 
 Drives ``graph.sdpa_mxfp8`` (FP8 E4M3/E5M2 Q/K/V + per-32-block E8M0 scale factors)
-routed to the native D128/D128 or D192/D128 MXFP8 engine, and validates the output
-against an fp32-dequant reference. Inputs are quantized with the torch-only
-MXFP8 quantizer in ``test/python/sdpa/mxfp8_quant.py`` (TE-equivalent semantics
+routed to the exact D128/D128, D192/D128, or D256/D256 MXFP8 engine, and
+validates the output against an fp32-dequant reference. Inputs are quantized
+with the torch-only MXFP8 quantizer in ``test/python/sdpa/mxfp8_quant.py``
+(TE-equivalent semantics
 — the same layout cuDNN's own mxfp8 path uses), so the scale-factor tensors
 reach the engine in cuDNN's F8_128x4 reordering. TransformerEngine is NOT
 required.
@@ -89,7 +90,21 @@ def _quantize(t, b, h, s, d, fp8, *, columnwise):
     return data_d, swz_d, dq, (s_pad, d_scale_pad)
 
 
-def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=None, sinks=None, seq_lens_kv=None, return_stats=False):
+def _ref(
+    qd,
+    kd,
+    vd,
+    *,
+    scale,
+    is_causal=False,
+    bottom_right=False,
+    swa_window=None,
+    right_bound=0,
+    sinks=None,
+    seq_lens_q=None,
+    seq_lens_kv=None,
+    return_stats=False,
+):
     """fp32 reference matching the kernel's mask + sink semantics (BHSD; GQA-aware)."""
     b, h_q, s_q, _ = qd.shape
     _, h_kv, s_kv, _ = vd.shape
@@ -103,29 +118,36 @@ def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=N
     masked = torch.zeros(1, 1, s_q, s_kv, dtype=torch.bool, device=dev)
     if is_causal:
         lim = i + (s_kv - s_q) if bottom_right else i
-        masked = masked | (j > lim)
+        masked = masked | (j > lim + right_bound)
     if swa_window is not None:
-        masked = masked | (j < i - swa_window)
+        swa_base = i + (s_kv - s_q) if bottom_right else i
+        masked = masked | (j < swa_base - swa_window)
     if seq_lens_kv is not None:
         # Per-batch KV padding: columns j >= seq_len_kv[b] are padding -> masked.
         slk = torch.as_tensor(seq_lens_kv, device=dev, dtype=torch.long).view(b, 1, 1, 1)
         masked = masked | (j >= slk)
     scores = scores.masked_fill(masked, float("-inf"))
+
+    def finalize(o, lse=None):
+        if seq_lens_q is not None:
+            slq = torch.as_tensor(seq_lens_q, device=dev, dtype=torch.long).view(b, 1, 1, 1)
+            valid_q = i < slq
+            o = torch.where(valid_q, o, torch.zeros_like(o))
+            if lse is not None:
+                lse = torch.where(valid_q.squeeze(-1), lse, torch.full_like(lse, float("-inf")))
+        return _ReferenceWithStats(o, lse) if lse is not None else o
+
     if sinks is not None:
         col = sinks.view(1, h_q, 1, 1).float().expand(b, h_q, s_q, 1).to(dev)
         ext = torch.cat([scores, col], dim=-1)
         probs = torch.softmax(ext, dim=-1)
         o = torch.matmul(probs[..., :s_kv], v_e)
-        if return_stats:
-            return _ReferenceWithStats(o, torch.logsumexp(ext, dim=-1))
-        return o
+        return finalize(o, torch.logsumexp(ext, dim=-1) if return_stats else None)
     row_has_kv = torch.isfinite(scores).any(dim=-1, keepdim=True)
     probs = torch.softmax(scores, dim=-1)
     probs = torch.where(row_has_kv, probs, torch.zeros_like(probs))
     o = torch.matmul(probs, v_e)
-    if return_stats:
-        return _ReferenceWithStats(o, torch.logsumexp(scores, dim=-1))
-    return o
+    return finalize(o, torch.logsumexp(scores, dim=-1) if return_stats else None)
 
 
 def _run(
@@ -140,6 +162,7 @@ def _run(
     sdpa_kwargs,
     sink=None,
     stats=True,
+    seq_lens_q=None,
     seq_lens_kv=None,
     d_qk=128,
     d_v=128,
@@ -198,11 +221,9 @@ def _run(
         st = g.tensor_like(sink)
         kw["sink_token"] = st
         vp[st] = sink
-    if seq_lens_kv is not None:
-        # KV padding (frontend extension on sdpa_mxfp8): full (unpadded) query
-        # lengths + per-batch valid KV lengths.
-        slq = torch.full((B, 1, 1, 1), S, dtype=torch.int32, device=dev)
-        slk = torch.tensor(seq_lens_kv, dtype=torch.int32, device=dev).reshape(B, 1, 1, 1)
+    if seq_lens_q is not None or seq_lens_kv is not None:
+        slq = torch.tensor(seq_lens_q if seq_lens_q is not None else [S] * B, dtype=torch.int32, device=dev).reshape(B, 1, 1, 1)
+        slk = torch.tensor(seq_lens_kv if seq_lens_kv is not None else [S] * B, dtype=torch.int32, device=dev).reshape(B, 1, 1, 1)
         sq_h = g.tensor(dim=[B, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT32)
         skv_h = g.tensor(dim=[B, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT32)
         kw.update(use_padding_mask=True, seq_len_q=sq_h, seq_len_kv=skv_h)
@@ -250,12 +271,13 @@ def _run(
             K8.float() * dqk,
             V8.float() * dqv,
             scale=scale,
+            seq_lens_q=seq_lens_q,
             seq_lens_kv=seq_lens_kv,
             return_stats=True,
             **ref_kwargs,
         )
         return _RunWithStatsResult(Ob, o_ref, amax, lse.squeeze(-1), lse_ref)
-    o_ref = _ref(Q8.float() * dqq, K8.float() * dqk, V8.float() * dqv, scale=scale, seq_lens_kv=seq_lens_kv, **ref_kwargs)
+    o_ref = _ref(Q8.float() * dqq, K8.float() * dqk, V8.float() * dqv, scale=scale, seq_lens_q=seq_lens_q, seq_lens_kv=seq_lens_kv, **ref_kwargs)
     return _RunResult(Ob, o_ref, amax)
 
 
@@ -267,6 +289,15 @@ def _ref_from_sdpa(sdpa_kwargs):
     if sdpa_kwargs.get("use_causal_mask_bottom_right"):
         out["is_causal"] = True
         out["bottom_right"] = True
+    right_bound = sdpa_kwargs.get("diagonal_band_right_bound")
+    if right_bound is not None:
+        out["is_causal"] = True
+        out["right_bound"] = right_bound
+    diagonal_alignment = sdpa_kwargs.get("diagonal_alignment")
+    if diagonal_alignment is not None:
+        import cudnn
+
+        out["bottom_right"] = diagonal_alignment == cudnn.diagonal_alignment.BOTTOM_RIGHT
     lb = sdpa_kwargs.get("diagonal_band_left_bound")
     if lb is not None:
         out["swa_window"] = lb - 1  # cuDNN length - 1
@@ -346,6 +377,209 @@ def test_mxfp8_strided_stats():
 def test_mxfp8_strided_stats_other_flavors(d_qk, d_v, in_key):
     """The remaining block-scaled FP8 flavors preserve dense Stats strides."""
     _check_mxfp8_strided_stats(d_qk, d_v, in_key)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("in_key", _INS)
+@pytest.mark.parametrize("mask", list(_MASKS))
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_d256_masks(in_key, mask):
+    O, O_ref, amax = _run(
+        1,
+        8,
+        8,
+        256,
+        in_key,
+        torch.float16,
+        scale=1.0 / math.sqrt(256),
+        sdpa_kwargs=_MASKS[mask],
+        d_qk=256,
+        d_v=256,
+    )
+    _check(O, O_ref, torch.float16, in_key, d_qk=256)
+    assert amax.item() > 0.0
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize("out_key", ["fp16", "bf16", "e4m3", "e5m2"])
+@pytest.mark.parametrize("in_key", _INS)
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_d256_output_dtypes(in_key, out_key):
+    """D256 supports both MXFP8 encodings and every declared output dtype."""
+    d = 256
+    O, O_ref, amax = _run(
+        1,
+        8,
+        8,
+        256,
+        in_key,
+        _OUT[out_key],
+        scale=1.0 / math.sqrt(d),
+        sdpa_kwargs=dict(use_causal_mask=True),
+        d_qk=d,
+        d_v=d,
+    )
+    _check(O, O_ref, _OUT[out_key], in_key, d_qk=d)
+    assert abs(amax.item() - O_ref.abs().max().item()) <= 0.03
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize("in_key", _INS)
+@torch_fork_set_rng(seed=59)
+def test_mxfp8_d256_strided_stats(in_key):
+    """D256 preserves the caller's non-contiguous Stats layout."""
+    _check_mxfp8_strided_stats(256, 256, in_key)
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize("in_key", _INS)
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_d256_bottom_right_rectangular(in_key):
+    """D256 bottom-right causal differs from top-left when S_q != S_kv."""
+    d = 256
+    O, O_ref, _ = _run_rect(
+        2,
+        8,
+        128,
+        256,
+        in_key,
+        torch.float16,
+        scale=1.0 / math.sqrt(d),
+        sdpa_kwargs=dict(use_causal_mask_bottom_right=True),
+        d_qk=d,
+        d_v=d,
+    )
+    _check(O, O_ref, torch.float16, in_key, d_qk=d)
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_d256_right_band():
+    """Pin the MX-specific right-band lowering; shared combinations run in PT."""
+    d = 256
+    out, out_ref, _ = _run(
+        1,
+        4,
+        4,
+        256,
+        "e4m3",
+        torch.float16,
+        scale=1.0 / math.sqrt(d),
+        sdpa_kwargs=dict(diagonal_band_right_bound=40),
+        d_qk=d,
+        d_v=d,
+    )
+    _check(out, out_ref, torch.float16, "e4m3", d_qk=d)
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize("in_key", _INS)
+@pytest.mark.parametrize("causal", [False, True])
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_d256_dense_padding(in_key, causal):
+    """D256 masks a per-batch partial KV tile in dense storage."""
+    d = 256
+    sdpa_kwargs = dict(use_causal_mask=True) if causal else {}
+    O, O_ref, amax = _run(
+        2,
+        8,
+        8,
+        256,
+        in_key,
+        torch.float16,
+        scale=1.0 / math.sqrt(d),
+        sdpa_kwargs=sdpa_kwargs,
+        seq_lens_kv=[256, 192],
+        stats=False,
+        d_qk=d,
+        d_v=d,
+    )
+    _check(O, O_ref, torch.float16, in_key, d_qk=d)
+    assert abs(amax.item() - O_ref.abs().max().item()) <= 0.03
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_d256_dense_q_trim_stats_sink():
+    """Short dense Q rows trim O/LSE even when a sink makes softmax finite."""
+    d = 256
+    sink = torch.randn(1, 8, 1, 1, dtype=torch.float32, device="cuda")
+    result = _run(
+        2,
+        8,
+        8,
+        256,
+        "e4m3",
+        torch.float16,
+        scale=1.0 / math.sqrt(d),
+        sdpa_kwargs={},
+        sink=sink,
+        seq_lens_q=[129, 0],
+        seq_lens_kv=[200, 256],
+        d_qk=d,
+        d_v=d,
+        return_lse=True,
+    )
+    _check(result.output, result.reference, torch.float16, "e4m3", d_qk=d)
+    assert (result.output[0, :, 129:] == 0).all() and (result.output[1] == 0).all()
+    assert torch.isneginf(result.stats[0, :, 129:]).all() and torch.isneginf(result.stats[1]).all()
+    torch.testing.assert_close(result.stats, result.reference_stats, atol=5e-2, rtol=3e-2)
+    assert abs(result.amax.item() - result.reference.abs().max().item()) <= 0.03
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize("in_key", _INS)
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_d256_gqa_sink(in_key):
+    """D256 GQA composes with a per-query-head attention sink."""
+    d = 256
+    sink = torch.randn(1, 8, 1, 1, dtype=torch.float32, device="cuda")
+    O, O_ref, _ = _run(
+        2,
+        8,
+        2,
+        256,
+        in_key,
+        torch.float16,
+        scale=1.0 / math.sqrt(d),
+        sdpa_kwargs=dict(use_causal_mask=True),
+        sink=sink,
+        d_qk=d,
+        d_v=d,
+    )
+    _check(O, O_ref, torch.float16, in_key, d_qk=d)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize(
+    ("out_key", "with_sink"),
+    [("fp16", False), ("e4m3", True)],
+    ids=["fp16-nosink", "fp8-sink"],
+)
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_d256_leading_zero_length_kv(out_key: str, with_sink: bool):
+    """A leading zero-length KV batch must produce zero O and a finite amax."""
+    d = 256
+    sink = torch.randn(1, 8, 1, 1, dtype=torch.float32, device="cuda") if with_sink else None
+    result = _run(
+        2,
+        8,
+        8,
+        256,
+        "e4m3",
+        _OUT[out_key],
+        scale=1.0 / math.sqrt(d),
+        sdpa_kwargs={},
+        sink=sink,
+        seq_lens_kv=[0, 256],
+        stats=False,
+        d_qk=d,
+        d_v=d,
+        poison_tmem_before_execute=True,
+    )
+    _check(result.output, result.reference, _OUT[out_key], "e4m3", d_qk=d)
+    assert (result.output[0] == 0).all()
+    assert abs(result.amax.item() - result.reference.abs().max().item()) <= 0.03
 
 
 @pytest.mark.L0
@@ -621,7 +855,7 @@ def _run_rect(B, H, S_q, S_kv, in_key, out_dt, *, scale, sdpa_kwargs, d_qk=128, 
         torch.empty(max(g.get_workspace_size(), 1), device=dev, dtype=torch.uint8),
     )
     torch.cuda.synchronize()
-    o_ref = _ref(Q8.float() * dqq, K8.float() * dqk, V8.float() * dqv, scale=scale, is_causal=True, bottom_right=True)
+    o_ref = _ref(Q8.float() * dqq, K8.float() * dqk, V8.float() * dqv, scale=scale, **_ref_from_sdpa(sdpa_kwargs))
     return Ob, o_ref, amax
 
 
@@ -658,7 +892,13 @@ def _quantize_seq(t_1hsd, h, s, d, fp8, *, columnwise):
     data_d, dq_d, swz_d, data_s, dq_s, swz_s = quantize_to_mxfp8(t_1hsd, 1, h, s, d, _BLOCK, fp8, with_ref=True)
     n_tiles = _cdiv(s, 128)
     if columnwise:
-        return data_s, dq_s.reshape(1, h, s, d), swz_s.view(torch.uint8).reshape(h, n_tiles, -1)
+        # Columnwise F8_128x4 is plane-major for D > 128. THD's packed
+        # contract keeps every sequence tile contiguous, so transpose
+        # [D/128, H, tile, 512] into [H, tile, D/128, 512] before sequences
+        # are concatenated in cu_seqlens order.
+        planes = d // 128
+        sf = swz_s.view(torch.uint8).reshape(planes, h, n_tiles, 512).permute(1, 2, 0, 3).contiguous().reshape(h, n_tiles, -1)
+        return data_s, dq_s.reshape(1, h, s, d), sf
     return data_d, dq_d.reshape(1, h, s, d), swz_d.view(torch.uint8).reshape(h, n_tiles, -1)
 
 
@@ -807,7 +1047,7 @@ def _run_thd(
         kw.update(cu_seq_len_q=sq_h, cu_seq_len_kv=skv_h)
     else:
         kw.update(seq_len_q=sq_h, seq_len_kv=skv_h)
-    assert not (bottom_right and (causal or swa_window is not None))
+    assert not (bottom_right and causal)
     if bottom_right:
         kw["use_causal_mask_bottom_right"] = True
     elif causal or swa_window is not None:
@@ -922,7 +1162,7 @@ def test_mxfp8_thd(in_key, causal):
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("d_qk,d_v", [(128, 128), (192, 128)], ids=["d128", "d192_d128"])
+@pytest.mark.parametrize("d_qk,d_v", [(128, 128), (192, 128), (256, 256)], ids=["d128", "d192_d128", "d256"])
 @pytest.mark.parametrize("in_key", _INS)
 @torch_fork_set_rng(seed=0)
 def test_mxfp8_thd_multi_unit_per_cta(monkeypatch, in_key, d_qk, d_v):
@@ -942,52 +1182,121 @@ def test_mxfp8_thd_multi_unit_per_cta(monkeypatch, in_key, d_qk, d_v):
 
 
 @pytest.mark.L0
+@pytest.mark.parametrize("in_key", _INS)
+@pytest.mark.parametrize("causal", [False, True])
 @torch_fork_set_rng(seed=0)
-def test_mxfp8_thd_cross_gqa():
-    """THD cross-attention (unequal packed Q and K/V totals) with GQA heads."""
-    scale = 1.0 / math.sqrt(128)
-    o_out, o_ref, _, _ = _run_thd([64, 200], [256, 128], 8, 2, "e4m3", torch.float16, scale=scale)
-    _check(o_out, o_ref, torch.float16, "e4m3")
+def test_mxfp8_d256_thd(in_key, causal):
+    """D256 MXFP8 THD uses packed per-sequence SF tiles."""
+    scale = 1.0 / math.sqrt(256)
+    o_out, o_ref, amax, _ = _run_thd(
+        [160, 96],
+        [160, 96],
+        8,
+        8,
+        in_key,
+        torch.float16,
+        scale=scale,
+        causal=causal,
+        d_qk=256,
+        d_v=256,
+    )
+    _check(o_out, o_ref, torch.float16, in_key, d_qk=256)
+    assert abs(amax.item() - o_ref.abs().max().item()) <= 0.03
 
 
 @pytest.mark.L0
+@pytest.mark.parametrize("d", [128, 256])
+@pytest.mark.parametrize("in_key", _INS)
+@pytest.mark.parametrize("bottom_right", [False, True])
 @torch_fork_set_rng(seed=0)
-def test_mxfp8_thd_sink():
-    """THD causal + attention sink."""
-    scale = 1.0 / math.sqrt(128)
-    sink = torch.randn(1, 8, 1, 1, dtype=torch.float32, device="cuda")
-    o_out, o_ref, _, _ = _run_thd([200, 150], [200, 150], 8, 8, "e4m3", torch.float16, scale=scale, causal=True, sink=sink)
-    _check(o_out, o_ref, torch.float16, "e4m3")
-
-
-@pytest.mark.L0
-@torch_fork_set_rng(seed=0)
-def test_mxfp8_thd_stats():
-    """THD + generate_stats: the ragged token-major TH1 LSE is written next to O."""
-    scale = 1.0 / math.sqrt(128)
-    o_out, o_ref, _, lse = _run_thd([200, 150], [200, 150], 8, 8, "e4m3", torch.float16, scale=scale, causal=True, stats=True)
-    _check(o_out, o_ref, torch.float16, "e4m3")
+def test_mxfp8_thd_sliding_window(d, in_key, bottom_right):
+    """MXFP8 THD sliding window uses each sequence's local causal diagonal."""
+    q_lens = [173, 97] if bottom_right else [257, 193]
+    kv_lens = [257, 193] if bottom_right else q_lens
+    scale = 1.0 / math.sqrt(d)
+    o_out, o_ref, amax, lse = _run_thd(
+        q_lens,
+        kv_lens,
+        8,
+        2,
+        in_key,
+        torch.float16,
+        scale=scale,
+        causal=not bottom_right,
+        bottom_right=bottom_right,
+        swa_window=73,
+        stats=True,
+        d_qk=d,
+        d_v=d,
+    )
+    _check(o_out, o_ref, torch.float16, in_key, d_qk=d)
+    assert abs(amax.item() - o_ref.abs().max().item()) <= 0.03
     assert lse is not None and torch.isfinite(lse).all()
 
 
 @pytest.mark.L0
+@pytest.mark.parametrize("d", [128, 256])
 @torch_fork_set_rng(seed=0)
-def test_mxfp8_thd_zero_len_kv():
-    """Zero-length Q and KV sequences (test_mhas_v2 ragged parity): the
-    zero-KV sequence's rows are dead — the epilogue must come back O := 0,
-    not the unwritten O TMEM (garbage survives `* inv_sum(=0)` when NaN)."""
-    scale = 1.0 / math.sqrt(128)
-    o_out, o_ref, _, _ = _run_thd([126, 0, 60], [0, 83, 77], 8, 8, "e4m3", torch.float16, scale=scale)
-    _check(o_out, o_ref, torch.float16, "e4m3")
+def test_mxfp8_thd_cross_gqa(d):
+    """THD cross-attention (unequal packed Q and K/V totals) with GQA heads."""
+    scale = 1.0 / math.sqrt(d)
+    o_out, o_ref, _, _ = _run_thd([64, 200], [256, 128], 8, 2, "e4m3", torch.float16, scale=scale, d_qk=d, d_v=d)
+    _check(o_out, o_ref, torch.float16, "e4m3", d_qk=d)
 
 
 @pytest.mark.L0
+@pytest.mark.parametrize("d", [128, 256])
 @torch_fork_set_rng(seed=0)
-def test_mxfp8_thd_cu_seq_len():
+def test_mxfp8_thd_sink(d):
+    """THD causal + attention sink."""
+    scale = 1.0 / math.sqrt(d)
+    sink = torch.randn(1, 8, 1, 1, dtype=torch.float32, device="cuda")
+    o_out, o_ref, _, _ = _run_thd([200, 150], [200, 150], 8, 8, "e4m3", torch.float16, scale=scale, causal=True, sink=sink, d_qk=d, d_v=d)
+    _check(o_out, o_ref, torch.float16, "e4m3", d_qk=d)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("d", [128, 256])
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_thd_stats(d):
+    """THD + generate_stats: the ragged token-major TH1 LSE is written next to O."""
+    scale = 1.0 / math.sqrt(d)
+    o_out, o_ref, _, lse = _run_thd([200, 150], [200, 150], 8, 8, "e4m3", torch.float16, scale=scale, causal=True, stats=True, d_qk=d, d_v=d)
+    _check(o_out, o_ref, torch.float16, "e4m3", d_qk=d)
+    assert lse is not None and torch.isfinite(lse).all()
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("d", [128, 256])
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_thd_zero_len_kv(d):
+    """Zero-length Q and KV sequences (test_mhas_v2 ragged parity): the
+    zero-KV sequence's rows are dead — the epilogue must come back O := 0,
+    not the unwritten O TMEM (garbage survives `* inv_sum(=0)` when NaN)."""
+    scale = 1.0 / math.sqrt(d)
+    o_out, o_ref, _, _ = _run_thd([126, 0, 60], [0, 83, 77], 8, 8, "e4m3", torch.float16, scale=scale, d_qk=d, d_v=d)
+    _check(o_out, o_ref, torch.float16, "e4m3", d_qk=d)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("d", [128, 256])
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_thd_cu_seq_len(d):
     """THD via the (B+1,) cu_seq_len prefix-sum length form."""
-    scale = 1.0 / math.sqrt(128)
-    o_out, o_ref, _, _ = _run_thd([200, 150], [180, 120], 8, 8, "e4m3", torch.float16, scale=scale, cu_lens=True)
-    _check(o_out, o_ref, torch.float16, "e4m3")
+    scale = 1.0 / math.sqrt(d)
+    o_out, o_ref, _, _ = _run_thd(
+        [200, 150],
+        [180, 120],
+        8,
+        8,
+        "e4m3",
+        torch.float16,
+        scale=scale,
+        cu_lens=True,
+        d_qk=d,
+        d_v=d,
+    )
+    _check(o_out, o_ref, torch.float16, "e4m3", d_qk=d)
 
 
 @pytest.mark.L0

--- a/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm100.py
@@ -1110,14 +1110,27 @@ def test_api_split_writes_strided_recombined_lse():
 # --- the adapter splits the FP8 family too ----------------------------------
 
 
-def _api_fp8_case(h_q, h_kv, s_q, s_kv, *, mx, d_qk=128, d_v=128):
+def _api_fp8_case(
+    h_q,
+    h_kv,
+    s_q,
+    s_kv,
+    *,
+    mx,
+    d_qk=128,
+    d_v=128,
+    fp8_dtype=torch.float8_e4m3fn,
+    causal=False,
+    pack_gqa=False,
+    b=1,
+):
     """FP8 / MXFP8 through the adapter; returns (split, O, O_unsplit, amax)."""
     from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm100
 
     _cc = torch.cuda.get_device_capability()
     if _cc not in ((10, 0), (10, 3)) and not (_cc == (10, 7) and not mx):
         pytest.skip("MXFP8 requires cc10.0 / cc10.3; per-tensor FP8 also runs on cc10.7")
-    b, dev = 1, "cuda"
+    dev = "cuda"
 
     def build(force_one):
         torch.manual_seed(0)
@@ -1126,7 +1139,7 @@ def _api_fp8_case(h_q, h_kv, s_q, s_kv, *, mx, d_qk=128, d_v=128):
 
             def qz(shape):
                 r = torch.randn(*shape, device=dev) * 0.5
-                a, _adq, aswz, *_ = quantize_to_mxfp8(r, shape[0], shape[1], shape[2], shape[3])
+                a, _adq, aswz, *_ = quantize_to_mxfp8(r, shape[0], shape[1], shape[2], shape[3], fp8_dtype=fp8_dtype)
                 return a.reshape(*shape), aswz
 
             q, sf_q = qz((b, h_q, s_q, d_qk))
@@ -1135,7 +1148,7 @@ def _api_fp8_case(h_q, h_kv, s_q, s_kv, *, mx, d_qk=128, d_v=128):
             extra = dict(sf_q=sf_q, sf_k=sf_k, sf_v=sf_v)
             kw = {}
         else:
-            mk = lambda *sh: (torch.randn(*sh, device=dev) * 0.5).clamp(-448, 448).to(torch.float8_e4m3fn)
+            mk = lambda *sh: (torch.randn(*sh, device=dev) * 0.5).to(fp8_dtype)
             q, k, v = mk(b, h_q, s_q, d_qk), mk(b, h_kv, s_kv, d_qk), mk(b, h_kv, s_kv, d_v)
             one = lambda: torch.ones(1, dtype=torch.float32, device=dev)
             extra = dict(descale_q=one(), descale_k=one(), descale_v=one(), scale_o=one())
@@ -1144,7 +1157,17 @@ def _api_fp8_case(h_q, h_kv, s_q, s_kv, *, mx, d_qk=128, d_v=128):
         o = torch.zeros(b, h_q, s_q, d_v, device=dev, dtype=torch.float16)  # HALF out
         amax = torch.zeros(1, dtype=torch.float32, device=dev)
         split_knob = 1 if force_one else _expected_split(b, h_q, s_q, s_kv)
-        api = SdpaFwdDslSm100(sample_q=q, sample_k=k, sample_v=v, sample_o=o, dtype_o=torch.float16, split_kv=split_knob, **kw)
+        api = SdpaFwdDslSm100(
+            sample_q=q,
+            sample_k=k,
+            sample_v=v,
+            sample_o=o,
+            dtype_o=torch.float16,
+            split_kv=split_knob,
+            is_causal=causal,
+            pack_gqa=pack_gqa,
+            **kw,
+        )
         assert api.check_support()
         split = api.split_kv
         ws_bytes = api.scratch_workspace_bytes()
@@ -1161,10 +1184,49 @@ def _api_fp8_case(h_q, h_kv, s_q, s_kv, *, mx, d_qk=128, d_v=128):
 
 @pytest.mark.L0
 @pytest.mark.parametrize("mx", [False, True], ids=["fp8", "mxfp8"])
-def test_api_splits_the_fp8_family(mx):
+@pytest.mark.parametrize("d", [128, 256], ids=["d128", "d256"])
+def test_api_splits_the_fp8_family(mx, d):
     """A decode-shaped FP8 graph with a half output splits, and the split is
     numerically neutral against the same graph forced to split_kv=1."""
-    split, got, unsplit, _ = _api_fp8_case(8, 1, 512, 16384, mx=mx)
+    split, got, unsplit, _ = _api_fp8_case(8, 1, 512, 16384, mx=mx, d_qk=d, d_v=d)
+    assert split > 1
+    assert (got - unsplit).abs().max().item() <= 5e-2
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("mx", [False, True], ids=["fp8", "mxfp8"])
+def test_api_d256_fp8_family_split_causal_e5m2(mx):
+    """D256's E5M2 masked path handles empty split chunks and remains neutral."""
+    split, got, unsplit, _ = _api_fp8_case(
+        8,
+        1,
+        512,
+        4096,
+        mx=mx,
+        d_qk=256,
+        d_v=256,
+        fp8_dtype=torch.float8_e5m2,
+        causal=True,
+    )
+    assert split > 1
+    assert (got - unsplit).abs().max().item() <= 5e-2
+
+
+@pytest.mark.L0
+def test_api_d256_fp8_split_pack_gqa():
+    """D256 per-tensor split composes with full G=16 packing at B > 1."""
+    split, got, unsplit, _ = _api_fp8_case(
+        16,
+        1,
+        128,
+        4096,
+        mx=False,
+        d_qk=256,
+        d_v=256,
+        causal=True,
+        pack_gqa=True,
+        b=2,
+    )
     assert split > 1
     assert (got - unsplit).abs().max().item() <= 5e-2
 
@@ -1189,11 +1251,12 @@ def test_api_splits_mxfp8_d192():
 
 @pytest.mark.L0
 @pytest.mark.parametrize("mx", [False, True], ids=["fp8", "mxfp8"])
-def test_api_fp8_amax_describes_the_recombined_output(mx):
+@pytest.mark.parametrize("d", [128, 256], ids=["d128", "d256"])
+def test_api_fp8_amax_describes_the_recombined_output(mx, d):
     """The per-split epilogues stand down under a split; amax_o has to come
     from the combine, over the RECOMBINED O. Maxing the partials instead
     over-reports, so compare against the output the caller receives."""
-    split, got, _unsplit, amax = _api_fp8_case(8, 1, 512, 16384, mx=mx)
+    split, got, _unsplit, amax = _api_fp8_case(8, 1, 512, 16384, mx=mx, d_qk=d, d_v=d)
     assert split > 1
     true_amax = got.abs().max().item()
     assert amax >= true_amax * 0.99, f"amax {amax} under-reports |O| {true_amax}"

--- a/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm100.py
@@ -1126,6 +1126,7 @@ def _api_fp8_case(
 ):
     """FP8 / MXFP8 through the adapter; returns (split, O, O_unsplit, amax)."""
     from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm100
+    from cudnn.sdpa.fwd.config_sm100 import cga_tile_m
 
     _cc = torch.cuda.get_device_capability()
     if _cc not in ((10, 0), (10, 3)) and not (_cc == (10, 7) and not mx):
@@ -1137,26 +1138,44 @@ def _api_fp8_case(
         if mx:
             from sdpa.mxfp8_quant import quantize_to_mxfp8
 
-            def qz(shape):
+            def qz(shape, *, columnwise=False):
                 r = torch.randn(*shape, device=dev) * 0.5
-                a, _adq, aswz, *_ = quantize_to_mxfp8(r, shape[0], shape[1], shape[2], shape[3], fp8_dtype=fp8_dtype)
-                return a.reshape(*shape), aswz
+                row, row_dq, row_sf, col, col_dq, col_sf = quantize_to_mxfp8(r, shape[0], shape[1], shape[2], shape[3], fp8_dtype=fp8_dtype)
+                a, adq, aswz = (col, col_dq, col_sf) if columnwise else (row, row_dq, row_sf)
+                a = a.reshape(*shape)
+                return a, aswz, a.float() * adq.reshape(*shape)
 
-            q, sf_q = qz((b, h_q, s_q, d_qk))
-            k, sf_k = qz((b, h_kv, s_kv, d_qk))
-            v, sf_v = qz((b, h_kv, s_kv, d_v))
+            q, sf_q, q_ref = qz((b, h_q, s_q, d_qk))
+            k, sf_k, k_ref = qz((b, h_kv, s_kv, d_qk))
+            v, sf_v, v_ref = qz((b, h_kv, s_kv, d_v), columnwise=True)
             extra = dict(sf_q=sf_q, sf_k=sf_k, sf_v=sf_v)
             kw = {}
         else:
-            mk = lambda *sh: (torch.randn(*sh, device=dev) * 0.5).to(fp8_dtype)
+
+            def mk(*sh):
+                return (torch.randn(*sh, device=dev) * 0.5).to(fp8_dtype)
+
             q, k, v = mk(b, h_q, s_q, d_qk), mk(b, h_kv, s_kv, d_qk), mk(b, h_kv, s_kv, d_v)
-            one = lambda: torch.ones(1, dtype=torch.float32, device=dev)
-            extra = dict(descale_q=one(), descale_k=one(), descale_v=one(), scale_o=one())
+            q_ref, k_ref, v_ref = q.float(), k.float(), v.float()
+            one = torch.ones(1, dtype=torch.float32, device=dev)
+            extra = dict(descale_q=one, descale_k=one, descale_v=one, scale_o=one)
             kw = dict(pertensor_fp8=True)
 
         o = torch.zeros(b, h_q, s_q, d_v, device=dev, dtype=torch.float16)  # HALF out
         amax = torch.zeros(1, dtype=torch.float32, device=dev)
-        split_knob = 1 if force_one else _expected_split(b, h_q, s_q, s_kv)
+        split_cga = 1 if d_qk == 256 else 2
+        split_knob = (
+            1
+            if force_one
+            else _expected_split(
+                b,
+                h_q,
+                s_q,
+                s_kv,
+                rows_per_tile=cga_tile_m(d_qk, split_cga),
+                ctas_per_tile=split_cga,
+            )
+        )
         api = SdpaFwdDslSm100(
             sample_q=q,
             sample_k=k,
@@ -1175,10 +1194,17 @@ def _api_fp8_case(
         ws = torch.empty(ws_bytes, dtype=torch.uint8, device=dev) if ws_bytes else None
         api.execute(q_tensor=q, k_tensor=k, v_tensor=v, o_tensor=o, amax_o=amax, workspace=ws, **extra)
         torch.cuda.synchronize()
-        return split, o.float().clone(), amax.item()
+        return split, o.float().clone(), amax.item(), (q_ref, k_ref, v_ref)
 
-    _, o_one, _ = build(True)
-    split, o_split, amax = build(False)
+    _, o_one, _, _ = build(True)
+    split, o_split, amax, ref_inputs = build(False)
+    if d_qk == 256:
+        q_ref, k_ref, v_ref = (t.permute(0, 2, 1, 3) for t in ref_inputs)
+        reference = _ref_sdpa(q_ref, k_ref, v_ref, 1.0 / math.sqrt(d_qk), causal, h_kv).permute(0, 2, 1, 3)
+        atol = 8e-2 if fp8_dtype == torch.float8_e5m2 else 5e-2
+        for name, output in (("split", o_split), ("unsplit", o_one)):
+            diff = (output - reference).abs().max().item()
+            assert diff <= atol, f"D256 {name} max|O-ref|={diff:.4f} > {atol:.4f}"
     return split, o_split, o_one, amax
 
 

--- a/test/python/sdpa/frost/test_sdpa_stream_ordering.py
+++ b/test/python/sdpa/frost/test_sdpa_stream_ordering.py
@@ -25,7 +25,7 @@ import torch
 from test_utils import torch_fork_set_rng
 from frost_test_utils import requires_pre_rubin_blackwell, requires_dsl
 
-pytestmark = requires_pre_rubin_blackwell
+pytestmark = [requires_pre_rubin_blackwell, requires_dsl]
 
 # ~0.5-1 s of spin: long enough that an unordered kernel launch on the
 # default stream reliably overtakes the side-stream mutation.
@@ -103,3 +103,81 @@ def test_sdpa_fwd_dsl_side_stream_ordering(d):
 
     assert not torch.isnan(out).any(), "SDPA kernel read the poisoned Q: launch was not ordered after the " "side-stream copy (env-stream routing broken)"
     torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("mxfp8", [False, True], ids=["fp8", "mxfp8"])
+@torch_fork_set_rng(seed=0)
+def test_fp8_dense_postprocessing_follows_explicit_stream(mxfp8):
+    """Dense output copy-back and amax postprocessing use the launch stream."""
+    from cuda.bindings import driver as cuda_driver
+
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm100
+
+    b, h, s, d = 1, 4, 128, 128
+    dev = torch.device("cuda")
+
+    if mxfp8:
+        from sdpa.mxfp8_quant import quantize_to_mxfp8
+
+        def quantize(tensor, *, columnwise=False):
+            row, _, row_sf, col, _, col_sf = quantize_to_mxfp8(tensor, b, h, s, d, fp8_dtype=torch.float8_e4m3fn)
+            return (col, col_sf) if columnwise else (row, row_sf)
+
+        q, sf_q = quantize(torch.randn(b, h, s, d, device=dev) * 0.5)
+        k, sf_k = quantize(torch.randn(b, h, s, d, device=dev) * 0.5)
+        v, sf_v = quantize(torch.randn(b, h, s, d, device=dev) * 0.5, columnwise=True)
+        execute_args = dict(sf_q=sf_q, sf_k=sf_k, sf_v=sf_v)
+        api_args = {}
+    else:
+
+        def make_fp8():
+            return (torch.randn(b, h, s, d, device=dev) * 0.5).to(torch.float8_e4m3fn)
+
+        q, k, v = make_fp8(), make_fp8(), make_fp8()
+        one = torch.ones(1, dtype=torch.float32, device=dev)
+        scale_o = torch.full((1,), 2.0, dtype=torch.float32, device=dev)
+        execute_args = dict(descale_q=one, descale_k=one, descale_v=one, scale_o=scale_o)
+        api_args = dict(pertensor_fp8=True)
+
+    # Preserve D-contiguity while forcing the adapter's O scratch/copy-back path.
+    output_storage = torch.empty(b, h, s + 1, d, dtype=torch.float16, device=dev)
+    output = output_storage[:, :, :s, :]
+    assert not output.transpose(1, 2).is_contiguous()
+    amax = torch.empty(1, dtype=torch.float32, device=dev)
+
+    api = SdpaFwdDslSm100(
+        sample_q=q,
+        sample_k=k,
+        sample_v=v,
+        sample_o=output,
+        dtype_o=torch.float16,
+        scale_softmax=1.0 / math.sqrt(d),
+        **api_args,
+    )
+    assert api.check_support()
+    api.compile()
+
+    api.execute(q_tensor=q, k_tensor=k, v_tensor=v, o_tensor=output, amax_o=amax, **execute_args)
+    torch.cuda.synchronize()
+    expected_output, expected_amax = output.clone(), amax.clone()
+
+    output.fill_(float("nan"))
+    amax.fill_(float("nan"))
+    torch.cuda.synchronize()
+    side = torch.cuda.Stream()
+    with torch.cuda.stream(side):
+        torch.cuda._sleep(_SLEEP_CYCLES)
+    api.execute(
+        q_tensor=q,
+        k_tensor=k,
+        v_tensor=v,
+        o_tensor=output,
+        amax_o=amax,
+        current_stream=cuda_driver.CUstream(side.cuda_stream),
+        **execute_args,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(output, expected_output, atol=0, rtol=0)
+    torch.testing.assert_close(amax, expected_amax, atol=0, rtol=0)

--- a/test/python/sdpa/frost/test_sdpa_stream_ordering.py
+++ b/test/python/sdpa/frost/test_sdpa_stream_ordering.py
@@ -162,12 +162,11 @@ def test_fp8_dense_postprocessing_follows_explicit_stream(mxfp8):
     torch.cuda.synchronize()
     expected_output, expected_amax = output.clone(), amax.clone()
 
-    output.fill_(float("nan"))
-    amax.fill_(float("nan"))
-    torch.cuda.synchronize()
     side = torch.cuda.Stream()
     with torch.cuda.stream(side):
         torch.cuda._sleep(_SLEEP_CYCLES)
+        output.fill_(float("nan"))
+        amax.fill_(float("nan"))
     api.execute(
         q_tensor=q,
         k_tensor=k,


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches (see [root AGENTS.md § Reviewing a PR](https://github.com/NVIDIA/cudnn-frontend/blob/develop/AGENTS.md#reviewing-a-pr-human-or-agent)) and my changes comply.
- [x] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

FE OSS kernels or CuTeDSL

## Summary

Add native SM100 D256/D256 SDPA forward kernels for per-tensor FP8 and block-scaled MXFP8 inputs.

The D256 kernels support E4M3 and E5M2 Q/K/V with FP16, BF16, E4M3, or E5M2 output. Their applicable feature surface is aligned with the existing SM100 prefill siblings:

- no mask, top-left and bottom-right causal masks, right-band masks, and sliding-window attention;
- dense padding and per-sequence Q/KV lengths, including padded-Q O/LSE trimming;
- packed THD variable-length input with cumulative sequence lengths;
- GQA/MQA, packed GQA, and attention sinks;
- optional LSE/stats, strided stats, and output Amax;
- dense split-KV for the existing half-precision combine contract; and
- zero-length KV, partial tiles, and multi-wave launches.

The integration adds D256 to the existing SM100 FP8 and MXFP8 engines. D256 quantized kernels use their validated CTA1 topology, while the existing D256 FP16/BF16 sibling remains CTA2. Heuristics select measured defaults only when tuning knobs are unset; explicit scheduler and CGA choices remain authoritative.

## Why

Qwen 3.5 prefill uses `Dqk=Dv=256`. Before this change, the SM100 Frost engine did not have native D256 per-tensor FP8 or MXFP8 kernels, so these graphs could not use the corresponding optimized frontend path.

## Related issues

None.

## API and compatibility impact

No new public API is introduced. This extends the existing SM100 Frost SDPA engine and graph support surface for D256 FP8/MXFP8. Public D256 FP8 graph validation requires cuDNN backend 9.26 or newer. Existing D128, D192/D128, D256 FP16/BF16, and D512 kernel defaults are unchanged.

## Testing

Tested locally on GB100 with CUTLASS DSL 4.7.0a0 and cuDNN 9.26.

```bash
python3 -m pytest -q \
  test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py \
  test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py \
  test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm100.py \
  test/python/sdpa/frost/test_sdpa_fwd_heuristics.py \
  -k d256
```

Result: `75 passed, 361 deselected`.

- `pre-commit` passed for all changed files.
- Compute Sanitizer `synccheck`: 6/6 representative paths passed with `ERROR SUMMARY: 0 errors`.
- Compute Sanitizer `memcheck`: 6/6 representative paths passed with `ERROR SUMMARY: 0 errors`.
- Sanitizer coverage included per-tensor FP8 and MXFP8 no-mask, THD + sliding-window + bottom-right, and E5M2 split-KV causal paths.

## Performance

Local runs of `benchmark/attention_training/benchmark_single_sdpa.py` using the Qwen 3.5 CI model shape from `benchmark/attention_training/configs/qwen35.py`, extended to per-tensor FP8 and MXFP8 inputs. The checked-in Qwen 3.5 preset currently lists BF16 only.

All rows use `B=1`, `Hq/Hkv=32/2`, `Dqk/Dv=256/256`, `Sq=Skv`, top-left causal masking, and BF16 output. Each value is the median of three process-level medians, with 5 warmups and 20 measured iterations per process. Backend order was interleaved. Observed clocks were 847 MHz SM and 4000 MHz memory with default clock-control behavior.

| Sequence length | Input | cuDNN 9.26 (ms) | Frost OSS (ms) | Frost speedup |
|---:|---|---:|---:|---:|
| 2,048 | Per-tensor FP8 E4M3 | 0.153 | 0.089 | **1.719x** |
| 2,048 | MXFP8 E4M3 | N/A | 0.110 | N/A |
| 4,096 | Per-tensor FP8 E4M3 | 0.501 | 0.231 | **2.169x** |
| 4,096 | MXFP8 E4M3 | N/A | 0.257 | N/A |
| 8,192 | Per-tensor FP8 E4M3 | 1.836 | 0.737 | **2.491x** |
| 8,192 | MXFP8 E4M3 | N/A | 0.771 | N/A |
| 16,384 | Per-tensor FP8 E4M3 | 7.058 | 2.640 | **2.673x** |
| 16,384 | MXFP8 E4M3 | N/A | 2.703 | N/A |
| 32,768 | Per-tensor FP8 E4M3 | 27.678 | 9.983 | **2.773x** |
| 32,768 | MXFP8 E4M3 | N/A | 10.167 | N/A |

cuDNN 9.26 did not build a native D256 MXFP8 execution plan in any of the three attempts at each sequence length, so no native MXFP8 comparison is reported.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added FP8 and MXFP8 scaled dot-product attention support for 256-dimensional query, key, and value heads on supported Blackwell hardware.
  - Expanded support for grouped-query attention, packed and ragged sequences, query-length trimming, padded queries, and additional causal and windowed masking modes.
  - Added broader output data type and statistics support for D256 workloads.
  - Improved automatic scheduling across supported FP8 and MXFP8 execution paths.

- **Bug Fixes**
  - Updated validation to accept D256 FP8 shapes with cuDNN 9.26.0 and newer.
  - Ensured FP8 output and statistics processing respects the supplied CUDA stream.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->