### PR TITLE
Fix SM100 blk64 BSA partial KV tails without padding

### DIFF
--- a/python/cudnn/block_sparse_attention/_interface.py
+++ b/python/cudnn/block_sparse_attention/_interface.py
@@ -260,6 +260,14 @@ def _sm100_blk64_requires_int64_kv_strides(
     return False
 
 
+def _sm100_blk64_has_partial_kv_tail(
+    k: torch.Tensor,
+    v: torch.Tensor,
+) -> bool:
+    """Return whether the final physical KV block is shorter than 64 rows."""
+    return k.shape[2] % 64 != 0 or v.shape[2] % 64 != 0
+
+
 def _tensor_layout_compile_key(t: torch.Tensor):
     return (tuple(t.dim_order()), tuple(s == 0 for s in t.stride()))
 
@@ -1396,7 +1404,8 @@ def bsa_attn_fwd_blk64_cutedsl(
     )
     if is_sage_fp8:
         assert q_bhsd.is_contiguous() and k_bhsd.is_contiguous() and v_bhsd.is_contiguous(), "Sage FP8 requires fully contiguous BHSD Q/K/V tensors"
-    use_exact_kv_layout = _sm100_blk64_requires_int64_kv_strides(k_bhsd, v_bhsd)
+    use_int64_kv_strides = _sm100_blk64_requires_int64_kv_strides(k_bhsd, v_bhsd)
+    use_exact_kv_layout = use_int64_kv_strides or _sm100_blk64_has_partial_kv_tail(k_bhsd, v_bhsd)
 
     if softmax_scale is None:
         softmax_scale = head_dim**-0.5
@@ -1504,6 +1513,7 @@ def bsa_attn_fwd_blk64_cutedsl(
             use_clc_scheduler,
             input_layout,
             use_exact_kv_layout,
+            use_int64_kv_strides,
             is_sage_fp8,
         ),
         (
@@ -1547,6 +1557,7 @@ def bsa_attn_fwd_blk64_cutedsl(
             has_block_sizes=has_block_sizes,
             num_splits=kv_splits_i,
             use_exact_kv_layout=use_exact_kv_layout,
+            use_int64_kv_strides=use_int64_kv_strides,
         )
 
         bsa_attn_fwd_blk64_cutedsl.compile_cache[compile_key] = cute.compile(

--- a/python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk64/bsa_fwd_sm100.py
+++ b/python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk64/bsa_fwd_sm100.py
@@ -69,6 +69,7 @@ class BlockSparseAttnForwardSm100Blk64:
         has_block_sizes: cutlass.Constexpr[bool] = True,
         num_splits: cutlass.Constexpr[int] = 1,
         use_exact_kv_layout: cutlass.Constexpr[bool] = False,
+        use_int64_kv_strides: cutlass.Constexpr[bool] = False,
     ):
         # padding head_dim to a multiple of 16 as k_block_size
         hdim_multiple_of = 16
@@ -128,6 +129,7 @@ class BlockSparseAttnForwardSm100Blk64:
         self.allow_empty_block_nums = allow_empty_block_nums
         self.has_block_sizes = has_block_sizes
         self.use_exact_kv_layout = use_exact_kv_layout
+        self.use_int64_kv_strides = use_int64_kv_strides
         self.qhead_per_kvhead = qhead_per_kvhead
         self.pack_gqa = pack_gqa
         if pack_gqa:
@@ -321,15 +323,20 @@ class BlockSparseAttnForwardSm100Blk64:
         num_splits = Int32(self.num_splits)
         mO = cute.make_tensor(mO.iterator, cute.select(mO.layout, mode=O_layout_transpose))
         mLSE = cute.make_tensor(mLSE.iterator, cute.select(mLSE.layout, mode=LSE_layout_transpose)) if const_expr(mLSE is not None) else None
-        # The normal layout maps physical 64-token KV blocks directly. Keep the
-        # exact rank-5 layout only for strides outside the TMA coordinate range.
+        # The normal layout maps physical 64-token KV blocks directly. Use an
+        # exact-boundary view for partial tails or wide strides.
         k_dim_half = self.head_dim_padded // 2
         v_dim_part = self.head_dim_v_padded // 2
         if const_expr(self.use_exact_kv_layout):
-            k_stride_s = Int64(mK_seq.layout.stride[0])
-            k_stride_d = Int64(mK_seq.layout.stride[1])
-            k_stride_h = Int64(mK_seq.layout.stride[2])
-            k_stride_b = Int64(mK_seq.layout.stride[3])
+            stride_dtype = Int64 if const_expr(self.use_int64_kv_strides) else Int32
+            k_stride_s = stride_dtype(mK_seq.layout.stride[0])
+            k_stride_d = stride_dtype(mK_seq.layout.stride[1])
+            k_stride_h = stride_dtype(mK_seq.layout.stride[2])
+            k_stride_b = stride_dtype(mK_seq.layout.stride[3])
+            # Keep a sixth logical mode so the exact-boundary descriptor uses
+            # the same efficient TMA coordinate form as the packed fast path.
+            # Unlike the packed view, the sequence extent remains exact, so a
+            # final partial 64-row tile is zero-filled by TMA.
             mK = cute.make_tensor(
                 mK_seq.iterator,
                 cute.make_layout(
@@ -339,6 +346,7 @@ class BlockSparseAttnForwardSm100Blk64:
                         2,
                         mK_seq.shape[2],
                         mK_seq.shape[3],
+                        1,
                     ),
                     stride=(
                         k_stride_s,
@@ -346,13 +354,14 @@ class BlockSparseAttnForwardSm100Blk64:
                         k_dim_half * k_stride_d,
                         k_stride_h,
                         k_stride_b,
+                        0,
                     ),
                 ),
             )
-            v_stride_s = Int64(mV_seq.layout.stride[0])
-            v_stride_d = Int64(mV_seq.layout.stride[1])
-            v_stride_h = Int64(mV_seq.layout.stride[2])
-            v_stride_b = Int64(mV_seq.layout.stride[3])
+            v_stride_s = stride_dtype(mV_seq.layout.stride[0])
+            v_stride_d = stride_dtype(mV_seq.layout.stride[1])
+            v_stride_h = stride_dtype(mV_seq.layout.stride[2])
+            v_stride_b = stride_dtype(mV_seq.layout.stride[3])
             mV = cute.make_tensor(
                 mV_seq.iterator,
                 cute.make_layout(
@@ -362,6 +371,7 @@ class BlockSparseAttnForwardSm100Blk64:
                         2,
                         mV_seq.shape[2],
                         mV_seq.shape[3],
+                        1,
                     ),
                     stride=(
                         v_stride_d,
@@ -369,6 +379,7 @@ class BlockSparseAttnForwardSm100Blk64:
                         v_dim_part * v_stride_d,
                         v_stride_h,
                         v_stride_b,
+                        0,
                     ),
                 ),
             )
@@ -852,8 +863,8 @@ class BlockSparseAttnForwardSm100Blk64:
     def kernel(
         self,
         mQ: cute.Tensor,  # (s_q, d, h, b)
-        mK: cute.Tensor,  # Rank-5 Int64 or rank-6 sparse-block view
-        mV: cute.Tensor,  # Rank-5 Int64 or rank-6 sparse-block view
+        mK: cute.Tensor,  # Exact-boundary or sparse-block view
+        mV: cute.Tensor,  # Exact-boundary or sparse-block view
         mO: cute.Tensor,
         mLSE: Optional[cute.Tensor],
         mQScale: Optional[cute.Tensor],
@@ -1414,10 +1425,16 @@ class BlockSparseAttnForwardSm100Blk64:
 
             head_idx_kv = head_idx // self.qhead_per_kvhead if const_expr(not self.pack_gqa) else head_idx
             if const_expr(self.use_exact_kv_layout):
-                mK_cur = mK[None, None, None, head_idx_kv, batch_idx]
-                mV_cur = mV[None, None, None, head_idx_kv, batch_idx]
-                gK_tma = cute.zipped_divide(mK_cur, (self.sparse_block_size, self.head_dim_padded // 2, 2))
-                gV_tma = cute.zipped_divide(mV_cur, (self.head_dim_v_padded // 2, self.sparse_block_size, 2))
+                mK_cur = mK[None, None, None, head_idx_kv, batch_idx, None]
+                mV_cur = mV[None, None, None, head_idx_kv, batch_idx, None]
+                gK_tma = cute.coalesce(
+                    cute.zipped_divide(mK_cur, (self.sparse_block_size, self.head_dim_padded // 2, 2, 1)),
+                    target_profile=((1, 1, 1, 1), 1),
+                )
+                gV_tma = cute.coalesce(
+                    cute.zipped_divide(mV_cur, (self.head_dim_v_padded // 2, self.sparse_block_size, 2, 1)),
+                    target_profile=((1, 1, 1, 1), 1),
+                )
             else:
                 mK_cur = mK[None, None, None, head_idx_kv, None, batch_idx]
                 mV_cur = mV[None, None, None, head_idx_kv, None, batch_idx]

--- a/test/python/fe_api/bsa/test_BSA_attention_forward.py
+++ b/test/python/fe_api/bsa/test_BSA_attention_forward.py
@@ -253,6 +253,71 @@ def test_bsa_attention_forward_sm100_blk64():
 
 
 @pytest.mark.L0
+@pytest.mark.parametrize(("seqlen_k", "expected"), [(4 * 64, False), (4 * 64 - 1, True)])
+def test_bsa_attention_forward_sm100_blk64_detects_partial_kv_tail(seqlen_k, expected):
+    _import_bsa()
+    interface = importlib.import_module("cudnn.block_sparse_attention._interface")
+    k = torch.empty((1, 2, seqlen_k, 128), dtype=torch.bfloat16)
+    v = torch.empty_like(k)
+
+    assert interface._sm100_blk64_has_partial_kv_tail(k, v) is expected
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=859)
+def test_bsa_attention_forward_sm100_blk64_partial_kv_tail_matches_reference():
+    if not torch.cuda.is_available():
+        pytest.skip("block sparse attention tests require CUDA")
+    major, _ = torch.cuda.get_device_capability()
+    if major not in {10, 11}:
+        pytest.skip("partial-tail exact KV layout is specific to SM100/SM110 blk64")
+
+    BSA = _import_bsa()
+    block_size = 64
+    batch, heads, seqlen_q, seqlen_k, dim = 1, 1, block_size, block_size + 1, 128
+    q = torch.randn((batch, heads, seqlen_q, dim), device="cuda", dtype=torch.bfloat16)
+    k = torch.randn((batch, heads, seqlen_k, dim), device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    q2k = torch.tensor([0, 1], device="cuda", dtype=torch.int32).view(1, 1, 1, 2)
+    block_sparse_num = 2
+    block_sizes = torch.tensor([block_size, 1], device="cuda", dtype=torch.int32)
+
+    result = BSA.block_sparse_attention_forward(
+        q,
+        k,
+        v,
+        q2k,
+        block_sparse_num,
+        block_sizes,
+        sparse_block_size=block_size,
+        use_clc=False,
+    )
+    mask = block_sparse_mask(q2k, block_sparse_num, block_sizes, seqlen_q, seqlen_k, block_size)
+    o_ref, lse_ref = attention_reference(q, k, v, mask)
+
+    assert torch.isfinite(result["o_tensor"]).all()
+    assert torch.isfinite(result["lse_tensor"]).all()
+    torch.testing.assert_close(result["o_tensor"].float(), o_ref, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(result["lse_tensor"], lse_ref, atol=2e-3, rtol=2e-3)
+
+    result_bshd = BSA.block_sparse_attention_forward(
+        q.transpose(1, 2),
+        k.transpose(1, 2),
+        v.transpose(1, 2),
+        q2k,
+        block_sparse_num,
+        block_sizes,
+        sparse_block_size=block_size,
+        layout="bshd",
+        use_clc=False,
+    )
+    assert torch.isfinite(result_bshd["o_tensor"]).all()
+    assert torch.isfinite(result_bshd["lse_tensor"]).all()
+    torch.testing.assert_close(result_bshd["o_tensor"].transpose(1, 2), result["o_tensor"], atol=0, rtol=0)
+    torch.testing.assert_close(result_bshd["lse_tensor"], result["lse_tensor"], atol=0, rtol=0)
+
+
+@pytest.mark.L0
 @torch_fork_set_rng(seed=2029)
 def test_bsa_attention_forward_sm100_blk64_split_kv_clc_persistent_tiles():
     if not torch.cuda.is_available():


### PR DESCRIPTION
Located by Humanize https://humanfia.ai/ and fixed via KDA https://github.com/mit-han-lab/kernel-design-agents


## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches and the changes comply.
- [x] Maintainer action: add `cat-bugfix`, `area:sparse_attention`, and `orig-nv-eng` (the PR author does not have label permissions).

## Affected area

FE OSS kernels or CuTeDSL

## Summary

Use an exact-boundary rank-6 K/V TMA view when the SM100 blk64 BSA input has a partial 64-token tail. Coalesce the tiled outer coordinate so TMA issue follows the existing packed fast path.

Add regression coverage for both BHSD and BSHD inputs with a one-token final block.

## Why

The packed K/V view rounds the sequence extent up to a complete 64-token block. TMA therefore considers rows beyond the physical allocation in-bounds, and address-sensitive data from those rows can produce non-finite output.

Keeping the true sequence extent lets TMA zero-fill the out-of-bounds rows. The extra logical mode preserves the efficient descriptor form, and coalescing the outer tile coordinate avoids the coordinate-expansion overhead of the prior exact-layout fallback.

KDA/IKET in-kernel profiling was used to isolate the overhead to the TMA issue path and verify that coalescing removed the coordinate-expansion cost. The profiling instrumentation is not included in the submitted code.

## Related issues

Fixes #859

## API and compatibility impact

No public API change. Aligned K/V lengths keep the existing path. On an NVIDIA B300, an uninstrumented 500-iteration comparison measured 1.973 ms median for the unpadded fixed path versus 1.983 ms for the physically padded fast-path reference; no performance regression was observed.

## Testing

- `python -m pytest -q test/python/fe_api/bsa/test_BSA_attention_forward.py::test_bsa_attention_forward_sm100_blk64_partial_kv_tail_matches_reference`: passed on B300.
- `python -m pytest -q test/python/fe_api/bsa/test_BSA_attention_forward.py::test_bsa_attention_forward_sm100_blk64`: passed on B300.
- Address-perturbation soak on the captured `B=1, H=7, Sk=37719, D=128` case: 1024/1024 finite for contiguous BHSD and 1024/1024 finite for non-contiguous BSHD.
- Split-KV soak: 128/128 finite with `kv_splits=2`.
- CLC soak: 128/128 finite with `use_clc=True`.
- Unpadded output was bit-identical to an explicitly zero-padded K/V reference.
- KDA/IKET traces verified the optimized exact-boundary path retained the packed TMA issue behavior; final performance numbers were collected without instrumentation.
- `pre-commit run --files python/cudnn/block_sparse_attention/_interface.py python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk64/bsa_fwd_sm100.py test/python/fe_api/bsa/test_BSA_attention_forward.py`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved block-sparse attention handling for KV sequences whose lengths are not multiples of 64.
  - Added support for large KV strides in applicable attention layouts.
  - Ensured partial KV tiles are handled safely with zero-filled values.

- **Tests**
  - Added coverage for partial KV-tail detection on supported GPU architectures.
  - Verified outputs against reference results and across supported tensor layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->