### PR TITLE
feat(bsa): extend BSA SM100 blk128 with per token masking

### DIFF
--- a/python/cudnn/block_sparse_attention/_interface.py
+++ b/python/cudnn/block_sparse_attention/_interface.py
@@ -1724,6 +1724,9 @@ def bsa_attn_fwd(
     lse: Optional[torch.Tensor] = None,
     layout: str = "bhsd",
     kv_splits: int | str = 1,
+    token_mask_bounds: Optional[torch.Tensor] = None,
+    token_mask_flags: Optional[torch.Tensor] = None,
+    q_stage: int = 1,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Forward pass for BSA block-sparse attention (SM90/SM100, non-causal, non-varlen).
 
@@ -1928,6 +1931,8 @@ def bsa_attn_fwd(
     current_stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
 
     has_variable_block_nums = q2k_block_nums is not None
+    has_token_mask = token_mask_bounds is not None
+    assert has_token_mask == (token_mask_flags is not None)
     if layout == "bhsd":
         q_kernel, k_kernel, v_kernel, out_kernel = q, k, v, out
     else:
@@ -1944,6 +1949,8 @@ def bsa_attn_fwd(
         pack_gqa=pack_gqa,
         allow_empty_block_nums=allow_empty_block_nums and has_variable_block_nums,
         has_block_sizes=has_block_sizes,
+        has_token_mask=has_token_mask,
+        q_stage=q_stage,
     )
 
     compile_key = _dynamic_tensors_compile_key(
@@ -1963,6 +1970,8 @@ def bsa_attn_fwd(
             has_variable_block_nums,
             allow_empty_block_nums and has_variable_block_nums,
             has_block_sizes,
+            has_token_mask,
+            q_stage,
             "bhsd_kernel_boundary",
         ),
         (
@@ -1974,6 +1983,8 @@ def bsa_attn_fwd(
             q2k_block_index,
             block_sizes,
             q2k_block_nums,
+            token_mask_bounds,
+            token_mask_flags,
         ),
     )
 
@@ -1996,6 +2007,8 @@ def bsa_attn_fwd(
         )
         block_sizes_tensor = _to_cute_tensor_with_dynamic_modes(block_sizes, dynamic_modes=0) if has_block_sizes else None
         block_nums_tensor = _to_cute_tensor_with_dynamic_modes(q2k_block_nums, dynamic_modes=(0, 1, 2)) if has_variable_block_nums else None
+        token_mask_bounds_tensor = _to_cute_tensor(token_mask_bounds, assumed_align=4) if has_token_mask else None
+        token_mask_flags_tensor = _to_cute_tensor(token_mask_flags, assumed_align=4) if has_token_mask else None
 
         bsa_attn_fwd.compile_cache[compile_key] = cute.compile(
             bsa_fwd_kernel,
@@ -2009,6 +2022,8 @@ def bsa_attn_fwd(
             block_sizes_tensor,
             block_sparse_num,
             block_nums_tensor,
+            token_mask_bounds_tensor,
+            token_mask_flags_tensor,
             cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
             options="--enable-tvm-ffi",
         )
@@ -2025,6 +2040,8 @@ def bsa_attn_fwd(
             block_sizes.detach() if has_block_sizes else None,
             block_sparse_num,
             q2k_block_nums.detach() if has_variable_block_nums else None,
+            token_mask_bounds.detach() if has_token_mask else None,
+            token_mask_flags.detach() if has_token_mask else None,
             current_stream,
         )
 
@@ -2052,6 +2069,10 @@ def bsa_attn_bwd(
     bucket_size_blocks: Optional[int] = None,
     sparse_block_size: Optional[int] = None,
     layout: str = "bhsd",
+    bucketed_k2q_offsets: Optional[torch.Tensor] = None,
+    bucketed_k2q_indices: Optional[torch.Tensor] = None,
+    token_mask_bounds: Optional[torch.Tensor] = None,
+    token_mask_flags: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Backward pass for BSA block-sparse attention.
 
@@ -2077,6 +2098,15 @@ def bsa_attn_bwd(
             q/k/v. When None, fresh zero-initialized tensors are allocated.
         bucket_size_blocks: Optional number of Q blocks per bucketed k2q CSR
             group. ``None`` selects the architecture default.
+        bucketed_k2q_offsets, bucketed_k2q_indices: Optional prebuilt int32
+            K-to-Q CSR tensors. Supply both to reuse CPU-prepared metadata.
+        token_mask_bounds: Optional packed int32 intervals. Shape
+            ``(partial_tiles, 128)`` stores one K interval per Q row; shape
+            ``(partial_tiles, 256)`` stores two Q bands per K row. Low/high
+            16 bits encode ``[lo, hi)``.
+        token_mask_flags: Optional blk128 int32 dense physical-tile lookup with
+            shape ``(batch, heads, num_q_blocks, num_kv_blocks)``. Values are
+            compact bound rows; negative values select the full-tile fast path.
         sparse_block_size: Explicit sparse block size. SM90 requires 64;
             SM100/SM110 accepts 64 or 128. When omitted, legacy direct callers
             retain shape-based inference on SM100/SM110.
@@ -2192,6 +2222,14 @@ def bsa_attn_bwd(
 
     if softmax_scale is None:
         softmax_scale = 1.0 / math.sqrt(head_dim)
+    has_token_mask = token_mask_bounds is not None
+    assert has_token_mask == (token_mask_flags is not None)
+    if has_token_mask:
+        assert arch // 10 in {10, 11} and sparse_block_size == SM100_BLK128_BWD_SPARSE_BLOCK_SIZE
+        assert token_mask_bounds.dtype == torch.int32 and token_mask_bounds.shape[1] in (128, 256)
+        assert token_mask_flags.dtype == torch.int32
+        assert token_mask_flags.shape == (batch_size, num_heads, num_q_blocks, num_kv_blocks)
+        assert token_mask_bounds.is_cuda and token_mask_flags.is_cuda
 
     if arch // 10 != 9 and sparse_block_size == SM100_BLK128_BWD_SPARSE_BLOCK_SIZE:
         if bucket_size_blocks is None or bucket_size_blocks <= 0:
@@ -2199,13 +2237,17 @@ def bsa_attn_bwd(
                 num_q_blocks,
                 num_heads,
             )
-        bucketed_k2q_offsets, bucketed_k2q_indices, _num_q_groups, _max_k2q_rows_per_group = _build_bucketed_k2q_csr(
-            q2k_block_index,
-            block_sparse_num,
-            num_kv_blocks,
-            bucket_size_blocks=bucket_size_blocks,
-            q2k_block_nums=q2k_block_nums,
-        )
+        if bucketed_k2q_offsets is None:
+            assert bucketed_k2q_indices is None
+            bucketed_k2q_offsets, bucketed_k2q_indices, _num_q_groups, _max_k2q_rows_per_group = _build_bucketed_k2q_csr(
+                q2k_block_index,
+                block_sparse_num,
+                num_kv_blocks,
+                bucket_size_blocks=bucket_size_blocks,
+                q2k_block_nums=q2k_block_nums,
+            )
+        else:
+            assert bucketed_k2q_indices is not None
         dq_out, dk_out, dv_out = bsa_sm100_blk128_bwd_bucketed_k2q_csr(
             dout_bwd,
             q_bwd,
@@ -2215,6 +2257,8 @@ def bsa_attn_bwd(
             lse,
             bucketed_k2q_offsets,
             bucketed_k2q_indices,
+            token_mask_bounds=token_mask_bounds,
+            token_mask_flags=token_mask_flags,
             softmax_scale=softmax_scale,
             dq=dq_bwd,
             dk=dk_bwd,

--- a/python/cudnn/block_sparse_attention/api.py
+++ b/python/cudnn/block_sparse_attention/api.py
@@ -183,6 +183,11 @@ def block_sparse_attention_forward(
     layout: str = "bhsd",
     kv_splits: int | str = 1,
     use_clc: Optional[bool] = None,
+    token_mask_bounds: Optional[torch.Tensor] = None,
+    token_mask_flags: Optional[torch.Tensor] = None,
+    out: Optional[torch.Tensor] = None,
+    lse: Optional[torch.Tensor] = None,
+    q_stage: int = 1,
 ) -> TupleDict:
     """Run non-causal block-sparse scaled dot-product attention.
 
@@ -192,6 +197,8 @@ def block_sparse_attention_forward(
 
     Sparse metadata values are a caller contract; see the "Sparse metadata"
     section of ``docs/fe-oss-apis/bsa.md`` for the required value ranges.
+    ``out`` and ``lse`` may be supplied to reuse destination buffers in
+    steady-state execution.
     """
 
     batch, num_q_heads, num_kv_heads, seqlen_q, seqlen_k, head_dim, value_dim = _canonical_shapes(q_tensor, k_tensor, v_tensor, layout)
@@ -204,6 +211,10 @@ def block_sparse_attention_forward(
         sparse_block_size = 64 if arch_family in {9, 12} else 128
     if sparse_block_size not in {64, 128}:
         raise ValueError("sparse_block_size must be 64 or 128")
+    if q_stage not in {1, 2}:
+        raise ValueError("q_stage must be 1 or 2")
+    if q_stage == 2 and not (arch_family in {10, 11} and sparse_block_size == 128):
+        raise NotImplementedError("q_stage=2 is supported only by the SM100/SM110 blk128 forward path")
     if arch_family == 9:
         if isinstance(kv_splits, str) or not 1 <= int(kv_splits) <= 256:
             raise ValueError("SM90 kv_splits must be an integer in [1, 256]")
@@ -234,12 +245,15 @@ def block_sparse_attention_forward(
     pack_gqa_effective = (
         arch_family in {10, 11} and sparse_block_size == 128 and (gqa_ratio > 1 if pack_gqa is None else bool(pack_gqa)) and 128 % gqa_ratio == 0
     )
+    if q_stage == 2 and gqa_ratio != 1:
+        raise NotImplementedError("q_stage=2 currently supports MHA only")
+    q_metadata_block_size = sparse_block_size * q_stage
     if pack_gqa_effective:
         metadata_heads = num_kv_heads
-        metadata_q_blocks = (seqlen_q * gqa_ratio + sparse_block_size - 1) // sparse_block_size
+        metadata_q_blocks = (seqlen_q * gqa_ratio + q_metadata_block_size - 1) // q_metadata_block_size
     else:
         metadata_heads = num_q_heads
-        metadata_q_blocks = (seqlen_q + sparse_block_size - 1) // sparse_block_size
+        metadata_q_blocks = (seqlen_q + q_metadata_block_size - 1) // q_metadata_block_size
     expected_prefix = (batch, metadata_heads, metadata_q_blocks)
     num_kv_blocks = (seqlen_k + sparse_block_size - 1) // sparse_block_size
     allowed_block_size_ranks = (1, 2, 3) if arch_family in {9, 12} else (1,)
@@ -252,6 +266,24 @@ def block_sparse_attention_forward(
         device=q_tensor.device,
         allowed_block_size_ranks=allowed_block_size_ranks,
     )
+    has_token_mask = token_mask_bounds is not None or token_mask_flags is not None
+    if has_token_mask:
+        if not (arch_family in {10, 11} and sparse_block_size == 128):
+            raise NotImplementedError("token_mask_bounds/token_mask_flags are supported only by " "the SM100/SM110 blk128 forward path")
+        if gqa_ratio != 1:
+            raise NotImplementedError("SM100/SM110 blk128 token masks currently support MHA only")
+        if token_mask_bounds is None or token_mask_flags is None:
+            raise ValueError("token_mask_bounds and token_mask_flags must be supplied together")
+        if token_mask_bounds.dtype != torch.int32 or token_mask_bounds.ndim != 2 or token_mask_bounds.shape[1] != q_metadata_block_size:
+            raise ValueError("blk128 token_mask_bounds must be packed int32 with shape " "(partial_tiles, q_block_size)")
+        if token_mask_flags.dtype != torch.int32 or tuple(token_mask_flags.shape) != (batch, metadata_q_blocks, q2k_block_index.shape[-1]):
+            raise ValueError("blk128 token_mask_flags must be int32 partial-bound indices " "with shape (B, Q_blocks, K_max); use -1 for full tiles")
+        for tensor, name in (
+            (token_mask_bounds, "token_mask_bounds"),
+            (token_mask_flags, "token_mask_flags"),
+        ):
+            if not tensor.is_cuda or tensor.device != q_tensor.device:
+                raise ValueError(f"{name} must be on the same CUDA device as q")
 
     if block_sparse_num is None:
         block_sparse_num = int(q2k_block_index.shape[-1])
@@ -298,8 +330,13 @@ def block_sparse_attention_forward(
                 softmax_scale=softmax_scale,
                 pack_gqa=pack_gqa,
                 return_lse=True,
+                out=out,
+                lse=lse,
                 layout=layout,
                 kv_splits=kv_splits,
+                token_mask_bounds=token_mask_bounds,
+                token_mask_flags=token_mask_flags,
+                q_stage=q_stage,
             )
 
     return TupleDict(o_tensor=out, lse_tensor=lse)
@@ -384,11 +421,19 @@ def block_sparse_attention_backward(
     bucket_size_blocks: Optional[int] = None,
     sparse_block_size: Optional[int] = None,
     layout: str = "bhsd",
+    bucketed_k2q_offsets: Optional[torch.Tensor] = None,
+    bucketed_k2q_indices: Optional[torch.Tensor] = None,
+    token_mask_bounds: Optional[torch.Tensor] = None,
+    token_mask_flags: Optional[torch.Tensor] = None,
 ) -> TupleDict:
     """Compute explicit dQ, dK, and dV for block-sparse attention.
 
     Sparse metadata values are a caller contract; see the "Sparse metadata"
     section of ``docs/fe-oss-apis/bsa.md`` for the required value ranges.
+    Packed row bounds, full/partial tile flags, and bucketed K-to-Q CSR may
+    be prepared once on CPU, copied to CUDA, and reused across calls.
+    Bounds width 128 stores Q-row-to-K intervals; width 256 stores two
+    CPU-built Q bands for every K row and is optimized for backward traversal.
     """
 
     batch, num_q_heads, num_kv_heads, seqlen_q, seqlen_k, head_dim, value_dim = _canonical_shapes(q_tensor, k_tensor, v_tensor, layout)
@@ -439,6 +484,39 @@ def block_sparse_attention_backward(
             require_even=sparse_block_size == 128,
         )
 
+    num_q_blocks = expected_prefix[2]
+    num_kv_blocks = (seqlen_k + sparse_block_size - 1) // sparse_block_size
+    num_kv_blocks = int(num_kv_blocks)
+    has_prebuilt_k2q = bucketed_k2q_offsets is not None or bucketed_k2q_indices is not None
+    if has_prebuilt_k2q:
+        if bucketed_k2q_offsets is None or bucketed_k2q_indices is None:
+            raise ValueError("bucketed K-to-Q tensors must be supplied together")
+        if (
+            bucketed_k2q_offsets.dtype != torch.int32
+            or bucketed_k2q_offsets.ndim != 4
+            or tuple(bucketed_k2q_offsets.shape[:2]) != (batch, num_q_heads)
+            or bucketed_k2q_offsets.shape[-1] != num_kv_blocks + 1
+        ):
+            raise ValueError("bucketed_k2q_offsets has an invalid shape or dtype")
+        if bucketed_k2q_indices.dtype != torch.int32 or bucketed_k2q_indices.ndim != 3 or tuple(bucketed_k2q_indices.shape[:2]) != (batch, num_q_heads):
+            raise ValueError("bucketed_k2q_indices has an invalid shape or dtype")
+        if bucketed_k2q_offsets.device != q_tensor.device or bucketed_k2q_indices.device != q_tensor.device:
+            raise ValueError("bucketed K-to-Q tensors must be on the same CUDA device as q")
+
+    has_token_mask = token_mask_bounds is not None or token_mask_flags is not None
+    if has_token_mask:
+        if sparse_block_size != 128 or arch_family not in {10, 11}:
+            raise NotImplementedError("row masks require the SM100/SM110 blk128 backward path")
+        if token_mask_bounds is None or token_mask_flags is None:
+            raise ValueError("token_mask_bounds and token_mask_flags must be supplied together")
+        expected_flags_shape = (batch, num_q_heads, num_q_blocks, num_kv_blocks)
+        if token_mask_bounds.dtype != torch.int32 or token_mask_bounds.ndim != 2 or token_mask_bounds.shape[1] not in (128, 256):
+            raise ValueError("backward token_mask_bounds must have shape (partial_tiles, 128 or 256)")
+        if token_mask_flags.dtype != torch.int32 or tuple(token_mask_flags.shape) != expected_flags_shape:
+            raise ValueError(f"backward token_mask_flags must have shape {expected_flags_shape}")
+        if token_mask_bounds.device != q_tensor.device or token_mask_flags.device != q_tensor.device:
+            raise ValueError("row-mask tensors must be on the same CUDA device as q")
+
     expected_lse_shape = (batch, num_q_heads, seqlen_q)
     if tuple(lse_tensor.shape) != expected_lse_shape:
         raise ValueError(f"lse_tensor shape must be {expected_lse_shape}, got {tuple(lse_tensor.shape)}")
@@ -473,7 +551,11 @@ def block_sparse_attention_backward(
             dk=dk_tensor,
             dv=dv_tensor,
             bucket_size_blocks=bucket_size_blocks,
+            bucketed_k2q_offsets=bucketed_k2q_offsets,
+            bucketed_k2q_indices=bucketed_k2q_indices,
             sparse_block_size=sparse_block_size,
+            token_mask_bounds=token_mask_bounds,
+            token_mask_flags=token_mask_flags,
             layout=layout,
         )
     return TupleDict(dq_tensor=dq, dk_tensor=dk, dv_tensor=dv)

--- a/python/cudnn/block_sparse_attention/csrc/bwd/sm100_blk128/bsa_bwd_sm100.py
+++ b/python/cudnn/block_sparse_attention/csrc/bwd/sm100_blk128/bsa_bwd_sm100.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025, Ted Zadouri, Markus Hoehnerbach, Jay Shah, Tri Dao.
 # SPDX-License-Identifier: MIT
 import math
-from typing import Callable, NamedTuple, Optional, Tuple
+from typing import Callable, NamedTuple, Optional, Protocol, Tuple
 from functools import partial
 
 import cuda.bindings.driver as cuda
@@ -10,7 +10,7 @@ import torch
 
 import cutlass
 import cutlass.cute as cute
-from cutlass import Boolean, Float32, Int32, Int64, const_expr
+from cutlass import Boolean, Float32, Int32, Int64, Uint32, const_expr
 from cutlass.utils import LayoutEnum
 from cutlass.cute.nvgpu import OperandMajorMode, cpasync, tcgen05
 import cutlass.utils.blackwell_helpers as sm100_utils_basic
@@ -42,12 +42,50 @@ from cudnn.block_sparse_attention.csrc.utils.tile_scheduler import (
 
 from cudnn.block_sparse_attention.csrc.utils.named_barrier import NamedBarrierBwdSm100
 
+MASK_R2P_CHUNK_SIZE = 32
+
+
+class MaskGenFn(Protocol):
+    def __call__(self, chunk_idx: int) -> Uint32: ...
+
+
+@cute.jit
+def r2p_bitmask_below(limit: Int32, chunk_idx: int) -> Uint32:
+    shift = max((chunk_idx + 1) * MASK_R2P_CHUNK_SIZE - limit, 0)
+    return utils.shr_u32(Uint32(0xFFFFFFFF), Uint32(shift))
+
+
+@cute.jit
+def r2p_bitmask_above(limit: Int32, chunk_idx: int) -> Uint32:
+    return r2p_bitmask_below(limit, chunk_idx) ^ Uint32(0xFFFFFFFF)
+
+
+@cute.jit
+def row_to_r2p_idx(row: Int32, num_rep: int, num_wg: int) -> Int32:
+    return row // (num_rep * num_wg) * num_rep + min(row % (num_rep * num_wg), num_rep)
+
+
+@cute.jit
+def mask_r2p_lambda(
+    values: cute.Tensor,
+    mask_gen_fn: cutlass.Constexpr[MaskGenFn],
+) -> None:
+    size = const_expr(cute.size(values))
+    for chunk_idx in cutlass.range_constexpr(cute.ceil_div(size, MASK_R2P_CHUNK_SIZE)):
+        mask = mask_gen_fn(chunk_idx)
+        for bit in cutlass.range_constexpr(min(MASK_R2P_CHUNK_SIZE, size - chunk_idx * MASK_R2P_CHUNK_SIZE)):
+            index = chunk_idx * MASK_R2P_CHUNK_SIZE + bit
+            keep = cutlass.Boolean(mask & (Uint32(1) << bit))
+            values[index] = values[index] if keep else -Float32.inf
+
 
 class BsaK2qCsrTensors(NamedTuple):
     """BSA bucketed k2q CSR tensors for the blk128 backward path."""
 
     bucketed_k2q_offsets: cute.Tensor
     bucketed_k2q_indices: cute.Tensor
+    token_mask_bounds: cute.Tensor
+    token_mask_flags: cute.Tensor
 
     def __new_from_mlir_values__(self, values):
         return BsaK2qCsrTensors(*values)
@@ -62,7 +100,7 @@ def get_total_q_block_count_bsa_k2q_csr(
     n_block,
 ):
     """Return the number of Q tiles contributing to one KV tile."""
-    bucketed_k2q_offsets, _ = bsa_k2q_csr_tensors
+    bucketed_k2q_offsets = bsa_k2q_csr_tensors.bucketed_k2q_offsets
     begin = bucketed_k2q_offsets[batch_idx, head_idx, q_group, n_block]
     end = bucketed_k2q_offsets[batch_idx, head_idx, q_group, n_block + 1]
     return end - begin
@@ -74,7 +112,7 @@ def get_bsa_k2q_csr_tile_coord(
     bsa_k2q_csr_tensors: BsaK2qCsrTensors,
 ):
     """Map scheduler N tile to (q_group, kv_block) for BSA k2q CSR."""
-    bucketed_k2q_offsets, _ = bsa_k2q_csr_tensors
+    bucketed_k2q_offsets = bsa_k2q_csr_tensors.bucketed_k2q_offsets
     num_kv_blocks = cute.size(bucketed_k2q_offsets.shape[3]) - 1
     q_group = sched_n_block // num_kv_blocks
     n_block = sched_n_block - q_group * num_kv_blocks
@@ -94,7 +132,8 @@ def get_bsa_k2q_csr_iteration_info_bwd(
     For BSA CSR, curr_q_cnt carries the CSR begin offset and curr_q_idx is the
     full per-head edge vector.
     """
-    bucketed_k2q_offsets, bucketed_k2q_indices = bsa_k2q_csr_tensors
+    bucketed_k2q_offsets = bsa_k2q_csr_tensors.bucketed_k2q_offsets
+    bucketed_k2q_indices = bsa_k2q_csr_tensors.bucketed_k2q_indices
     begin = bucketed_k2q_offsets[batch_idx, head_idx, q_group, n_block]
     end = bucketed_k2q_offsets[batch_idx, head_idx, q_group, n_block + 1]
     curr_q_idx = bucketed_k2q_indices[batch_idx, head_idx, None]
@@ -157,6 +196,9 @@ def produce_bsa_k2q_csr_q_loads_bwd_sm100(
             m_block_safe = cutlass.min(m_block, m_block_max - 1)
 
         if iter_idx == 0:
+            # Q/LSE has two stages while dO/dPsum is single-buffered. Issue
+            # Q first so a busy dO stage cannot serialize the independent Q
+            # prefetch behind its producer_acquire.
             pipeline_Q.producer_acquire(producer_state_Q_LSE, extra_tx_count=tma_copy_bytes_K)
             load_K(tma_bar_ptr=pipeline_Q.producer_get_barrier(producer_state_Q_LSE))
             load_Q(m_block_safe, producer_state=producer_state_Q_LSE)
@@ -182,6 +224,7 @@ def produce_bsa_k2q_csr_q_loads_bwd_sm100(
                     mbar_ptr=pipeline_dPsum.producer_get_barrier(producer_state_dO_dPsum),
                 )
             producer_state_dO_dPsum.advance()
+
         else:
             pipeline_Q.producer_acquire(producer_state_Q_LSE)
             load_Q(m_block_safe, producer_state=producer_state_Q_LSE)
@@ -217,6 +260,8 @@ class BlockSparseAttnBackwardSm100Blk128:
         self,
         head_dim: int,
         force_dkv_postprocess: cutlass.Constexpr = False,
+        has_token_mask: cutlass.Constexpr = False,
+        inverse_token_mask: cutlass.Constexpr = False,
     ):
         assert head_dim in (64, 128), f"SM100 blk128 bwd supports head_dim in {{64, 128}}, got {head_dim}"
         # tile_hdim drives the K reduction of S/P/dV/dK mma's and the dQ accumulator
@@ -244,6 +289,8 @@ class BlockSparseAttnBackwardSm100Blk128:
         self.acc_dtype = Float32
 
         self.force_dkv_postprocess = force_dkv_postprocess
+        self.has_token_mask = has_token_mask
+        self.inverse_token_mask = inverse_token_mask
 
         self.reduce_warp_ids = (0, 1, 2, 3)
         self.compute_warp_ids = (4, 5, 6, 7, 8, 9, 10, 11)
@@ -637,7 +684,7 @@ class BlockSparseAttnBackwardSm100Blk128:
         self.tma_copy_bytes["dKacc"] = self.tile_n * self.dK_reduce_ncol * Float32.width // 8
 
         TileScheduler = SingleTileScheduler
-        bucketed_k2q_offsets, _ = bsa_k2q_csr_tensors
+        bucketed_k2q_offsets = bsa_k2q_csr_tensors.bucketed_k2q_offsets
         num_sched_n_blocks = (cute.size(bucketed_k2q_offsets.shape[3]) - 1) * cute.size(bucketed_k2q_offsets.shape[2])
         tile_sched_args = TileSchedulerArguments(
             num_sched_n_blocks,  # num_blocks
@@ -1594,19 +1641,71 @@ class BlockSparseAttnBackwardSm100Blk128:
         return t[coord]
 
     @cute.jit
-    def apply_seqlen_k_mask(
+    def apply_score_mask(
         self,
         acc_S: cute.Tensor,
         tScS_t2r: cute.Tensor,
+        bsa_k2q_csr_tensors: BsaK2qCsrTensors,
+        batch_idx: Int32,
+        head_idx: Int32,
+        m_block: Int32,
         n_block: Int32,
         seqlen,
     ):
-        col = 0
-        thr_col_offset = tScS_t2r[0][col]
-        seqlenk_col_limit = seqlen.seqlen_k - n_block * self.tile_n - thr_col_offset
-        if seqlenk_col_limit <= 0:
-            for i in cutlass.range(cute.size(acc_S.shape), unroll_full=True):
-                acc_S[i] = -cutlass.Float32.inf
+        """Mask the native K tail and optional exact per-Q-row interval."""
+        if const_expr(self.has_token_mask):
+            partial_index = cute.arch.make_warp_uniform(Int32(bsa_k2q_csr_tensors.token_mask_flags[batch_idx, head_idx, m_block, n_block]))
+            if partial_index >= Int32(0):
+                if const_expr(self.inverse_token_mask):
+                    k_row = Int32(tScS_t2r[0][0])
+                    packed1 = Uint32(bsa_k2q_csr_tensors.token_mask_bounds[partial_index, Int32(2) * k_row])
+                    packed2 = Uint32(bsa_k2q_csr_tensors.token_mask_bounds[partial_index, Int32(2) * k_row + Int32(1)])
+                    band1_left = Int32(packed1 & Uint32(0xFFFF))
+                    band1_right = Int32(utils.shr_u32(packed1, Uint32(16)))
+                    band2_left = Int32(packed2 & Uint32(0xFFFF))
+                    band2_right = Int32(utils.shr_u32(packed2, Uint32(16)))
+                    if n_block * self.tile_n + k_row >= seqlen.seqlen_k:
+                        band1_left, band1_right = Int32(0), Int32(0)
+                        band2_left, band2_right = Int32(0), Int32(0)
+
+                    q_thread_origin = Int32(tScS_t2r[0][1])
+                    band1_left = cutlass.min(cutlass.max(band1_left - q_thread_origin, Int32(0)), Int32(self.tile_m))
+                    band1_right = cutlass.max(cutlass.min(band1_right - q_thread_origin, Int32(self.tile_m)), Int32(0))
+                    band2_left = cutlass.min(cutlass.max(band2_left - q_thread_origin, Int32(0)), Int32(self.tile_m))
+                    band2_right = cutlass.max(cutlass.min(band2_right - q_thread_origin, Int32(self.tile_m)), Int32(0))
+
+                    num_rep = cute.size(tScS_t2r, mode=[0])
+                    num_wg = 2
+                    band1_left = row_to_r2p_idx(band1_left, num_rep, num_wg)
+                    band1_right = row_to_r2p_idx(band1_right, num_rep, num_wg)
+                    band2_left = row_to_r2p_idx(band2_left, num_rep, num_wg)
+                    band2_right = row_to_r2p_idx(band2_right, num_rep, num_wg)
+
+                    def inverse_mask_gen_fn(chunk_idx: int) -> Uint32:
+                        band1 = r2p_bitmask_above(band1_left, chunk_idx) & r2p_bitmask_below(band1_right, chunk_idx)
+                        band2 = r2p_bitmask_above(band2_left, chunk_idx) & r2p_bitmask_below(band2_right, chunk_idx)
+                        return band1 | band2
+
+                    mask_r2p_lambda(acc_S, inverse_mask_gen_fn)
+                else:
+                    for i in cutlass.range_constexpr(cute.size(acc_S.shape)):
+                        k_row = Int32(tScS_t2r[i][0])
+                        q_row = Int32(tScS_t2r[i][1])
+                        packed = Uint32(bsa_k2q_csr_tensors.token_mask_bounds[partial_index, q_row])
+                        lo = Int32(packed & Uint32(0xFFFF))
+                        hi = Int32(utils.shr_u32(packed, Uint32(16)))
+                        valid = n_block * self.tile_n + k_row < seqlen.seqlen_k and k_row >= lo and k_row < hi
+                        acc_S[i] = acc_S[i] if valid else -cutlass.Float32.inf
+            else:
+                k_row = Int32(tScS_t2r[0][0])
+                if n_block * self.tile_n + k_row >= seqlen.seqlen_k:
+                    for i in cutlass.range_constexpr(cute.size(acc_S.shape)):
+                        acc_S[i] = -cutlass.Float32.inf
+        else:
+            k_row = Int32(tScS_t2r[0][0])
+            if n_block * self.tile_n + k_row >= seqlen.seqlen_k:
+                for i in cutlass.range_constexpr(cute.size(acc_S.shape)):
+                    acc_S[i] = -cutlass.Float32.inf
 
     @cute.jit
     def compute_loop(
@@ -1749,12 +1848,21 @@ class BlockSparseAttnBackwardSm100Blk128:
                 tSrS_t2r = cute.make_rmem_tensor(tScS_t2r.shape, Float32)
                 cute.copy(thr_copy_t2r, tStS_t2r, tSrS_t2r)
 
-                self.apply_seqlen_k_mask(tSrS_t2r, tScS_t2r, n_block, seqlen)
                 num_stages = cute.size(tScS_t2r, mode=[1])
                 tSrP_r2t_f32 = cute.make_rmem_tensor(tScP_r2t.shape, Float32)  # 64
                 tSrP_r2t = cute.recast_tensor(tSrP_r2t_f32, self.q_dtype)
                 for stage in cutlass.range_constexpr(num_stages):
                     tSrS_cur = tSrS_t2r[None, stage, 0, 0]
+                    self.apply_score_mask(
+                        tSrS_cur,
+                        tScS_t2r[None, stage, 0, 0],
+                        bsa_k2q_csr_tensors,
+                        batch_idx,
+                        head_idx,
+                        m_block,
+                        n_block,
+                        seqlen,
+                    )
                     tSsLSE_cur = tSsLSE[None, stage, 0, 0, consumer_state_LSE.index]
                     cute.autovec_copy(tSsLSE_cur, tSrLSE_s2r)
                     tSrLSE = tSrLSE_s2r
@@ -2192,6 +2300,8 @@ def bsa_sm100_blk128_bwd_bucketed_k2q_csr(
     dq: Optional[torch.Tensor] = None,
     dk: Optional[torch.Tensor] = None,
     dv: Optional[torch.Tensor] = None,
+    token_mask_bounds: Optional[torch.Tensor] = None,
+    token_mask_flags: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """SM100/SM110 blk128 bwd entry receiving BSA bucketed k2q CSR."""
     assert q.dtype == torch.bfloat16, "SM100 blk128 bwd only supports bfloat16"
@@ -2200,6 +2310,13 @@ def bsa_sm100_blk128_bwd_bucketed_k2q_csr(
     assert _get_device_arch() // 10 in [10, 11]
     assert bucketed_k2q_offsets.dtype == torch.int32
     assert bucketed_k2q_indices.dtype == torch.int32
+    has_token_mask = token_mask_bounds is not None
+    assert has_token_mask == (token_mask_flags is not None)
+    if has_token_mask:
+        assert token_mask_bounds.dtype == torch.int32 and token_mask_bounds.ndim == 2
+        assert token_mask_bounds.shape[1] in (SM100_BLK128_BWD_SPARSE_BLOCK_SIZE, 2 * SM100_BLK128_BWD_SPARSE_BLOCK_SIZE)
+        assert token_mask_flags.dtype == torch.int32 and token_mask_flags.ndim == 4
+        assert token_mask_bounds.is_cuda and token_mask_flags.is_cuda
 
     batch_size, num_heads, seqlen_q, head_dim = q.shape
     seqlen_k = k.shape[2]
@@ -2216,6 +2333,11 @@ def bsa_sm100_blk128_bwd_bucketed_k2q_csr(
     assert bucketed_k2q_indices.shape[:2] == (batch_size, num_heads)
     num_q_groups = bucketed_k2q_offsets.shape[2]
     use_dkv_postprocess = num_q_groups > 1
+    if has_token_mask:
+        assert token_mask_flags.shape == (batch_size, num_heads, num_q_blocks, num_kv_blocks)
+    else:
+        token_mask_bounds = torch.empty((1, SM100_BLK128_BWD_SPARSE_BLOCK_SIZE), dtype=torch.int32, device=q.device)
+        token_mask_flags = torch.empty((1, 1, 1, 1), dtype=torch.int32, device=q.device)
 
     if softmax_scale is None:
         softmax_scale = 1.0 / math.sqrt(head_dim)
@@ -2300,6 +2422,8 @@ def bsa_sm100_blk128_bwd_bucketed_k2q_csr(
         get_broadcast_dims(v_bshd),
         get_broadcast_dims(dout_bshd),
         use_dkv_postprocess,
+        has_token_mask,
+        token_mask_bounds.shape[1] if has_token_mask else 0,
     )
     cache = bsa_sm100_blk128_bwd_bucketed_k2q_csr.compile_cache
     if compile_key not in cache:
@@ -2311,10 +2435,14 @@ def bsa_sm100_blk128_bwd_bucketed_k2q_csr(
         bsa_csr_tensors = BsaK2qCsrTensors(
             to_cute_tensor(bucketed_k2q_offsets, assumed_align=4),
             to_cute_tensor(bucketed_k2q_indices, assumed_align=4),
+            to_cute_tensor(token_mask_bounds, assumed_align=4),
+            to_cute_tensor(token_mask_flags, assumed_align=4),
         )
         bwd_kernel = BlockSparseAttnBackwardSm100Blk128(
             head_dim,
             force_dkv_postprocess=use_dkv_postprocess,
+            has_token_mask=has_token_mask,
+            inverse_token_mask=has_token_mask and token_mask_bounds.shape[1] == 256,
         )
         current_stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
         cache[compile_key] = cute.compile(
@@ -2345,7 +2473,7 @@ def bsa_sm100_blk128_bwd_bucketed_k2q_csr(
         dk_accum if use_dkv_postprocess else dk_bshd,
         dv_accum if use_dkv_postprocess else dv_bshd,
         float(softmax_scale),
-        (bucketed_k2q_offsets, bucketed_k2q_indices),
+        (bucketed_k2q_offsets, bucketed_k2q_indices, token_mask_bounds, token_mask_flags),
     )
 
     _bwd_postprocess_convert(

--- a/python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk128/bsa_fwd_sm100.py
+++ b/python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk128/bsa_fwd_sm100.py
@@ -12,6 +12,7 @@
 
 import math
 import types
+
 from dataclasses import dataclass
 from functools import partial
 from typing import Callable, Literal, Optional, Tuple, TypeAlias
@@ -38,7 +39,7 @@ from cudnn.block_sparse_attention.csrc.utils import (
 )
 from cudnn.block_sparse_attention.csrc.utils.tcgen05_mma_helpers import i64_to_i32x2
 from cudnn.block_sparse_attention.csrc.utils.block_sparse_tile_scheduler import (
-    BlockSparsePersistentTileScheduler as StaticPersistentTileScheduler,
+    BlockSparsePersistentTileScheduler,
     TileSchedulerProtocol,
 )
 from cudnn.block_sparse_attention.csrc.utils.cute_dsl_utils import (
@@ -73,6 +74,8 @@ class BlockSparseAttnForwardSm100Blk128:
         pack_gqa: Optional[bool] = None,
         allow_empty_block_nums: bool = False,
         has_block_sizes: bool = True,
+        has_token_mask: bool = False,
+        q_stage: int = 1,
     ):
         # padding head_dim to a multiple of 16 as k_block_size
         hdim_multiple_of = 16
@@ -83,7 +86,8 @@ class BlockSparseAttnForwardSm100Blk128:
         self.check_hdim_v_oob = head_dim_v != self.head_dim_v_padded
         self.m_block_size = self.tile_m
         self.n_block_size = self.tile_n
-        self.q_stage = 1
+        assert q_stage in (1, 2), "q_stage must be 1 or 2"
+        self.q_stage = q_stage
         # If split_P_arrive, the softmax warps write some columns of P first, signal to the MMA warp
         # to being the P @ V MMA, then write the rest of P and signal again. This allows some overlap
         # between compute the last couple columns of P and the P @ V MMA.
@@ -92,9 +96,9 @@ class BlockSparseAttnForwardSm100Blk128:
         assert self.split_P_arrive % 32 == 0
         assert self.split_P_arrive < self.n_block_size
         self.arch = BaseDSL._get_dsl().get_arch_enum()
-        assert self.arch >= Arch.sm_100 and self.arch <= Arch.sm_110f, "Only SM 10.x and 11.x are supported"
+        assert self.arch.is_family_of(Arch.sm_100f) or self.arch.is_family_of(Arch.sm_110f), "Only SM 10.x and 11.x are supported"
 
-        self.cta_tiler = (self.m_block_size, self.n_block_size, self.head_dim_padded)
+        self.cta_tiler = (self.q_stage * self.m_block_size, self.n_block_size, self.head_dim_padded)
         self.mma_tiler_qk = (
             self.m_block_size,
             self.n_block_size,
@@ -108,12 +112,13 @@ class BlockSparseAttnForwardSm100Blk128:
         self.qk_acc_dtype = Float32
         self.pv_acc_dtype = Float32
         self.is_persistent = self.is_persistent_default
-        # CLC persistent scheduling
+        # Hardware CLC is the production policy for the exact-mask workload.
         self.use_clc_scheduler = self.use_clc_scheduler_default
         self.sched_stages = 1
         self.scheduling_mode = SchedulingMode.CLC if self.use_clc_scheduler else SchedulingMode.STATIC
         self.allow_empty_block_nums = allow_empty_block_nums
         self.has_block_sizes = has_block_sizes
+        self.has_token_mask = has_token_mask
         self.qhead_per_kvhead = qhead_per_kvhead
         if pack_gqa is None:
             pack_gqa = qhead_per_kvhead > 1
@@ -122,8 +127,8 @@ class BlockSparseAttnForwardSm100Blk128:
         self.pack_gqa = pack_gqa
         if pack_gqa:
             assert self.m_block_size % self.qhead_per_kvhead == 0, "For PackGQA, m_block_size must be divisible by qhead_per_kvhead"
-        is_sm103 = self.arch >= Arch.sm_103 and self.arch <= Arch.sm_103f
-        self.enable_ex2_emu = self.head_dim_padded <= 128 and not is_sm103
+        self.is_sm103 = self.arch >= Arch.sm_103 and self.arch <= Arch.sm_103f
+        self.enable_ex2_emu = self.head_dim_padded <= 128 and not self.is_sm103
         self.overlap_sO_sQ = self.head_dim_padded == 192 and self.head_dim_v_padded >= 64
         if self.overlap_sO_sQ:
             self.is_persistent = False
@@ -166,14 +171,8 @@ class BlockSparseAttnForwardSm100Blk128:
             self.num_regs_correction = 64
             self.num_regs_other = 48
         else:
-            if not self.enable_ex2_emu:
-                self.num_regs_softmax = 184
-            else:
-                self.num_regs_softmax = 184
-            if not self.enable_ex2_emu:
-                self.num_regs_correction = 88
-            else:
-                self.num_regs_correction = 88
+            self.num_regs_softmax = 184
+            self.num_regs_correction = 88
             self.num_regs_other = 56
 
         self.buffer_align_bytes = 1024
@@ -224,6 +223,8 @@ class BlockSparseAttnForwardSm100Blk128:
         mBlockSizes: cute.Tensor,  # (num_kv_blocks,), int32
         block_sparse_num: Int32,  # runtime scalar, even, >= 2
         mBlockNums: Optional[cute.Tensor],  # (batch, heads, num_q_blocks), int32 or None
+        mTokenMaskBounds: Optional[cute.Tensor],
+        mTokenMaskFlags: Optional[cute.Tensor],
         stream: cuda.CUstream,
     ):
         """Execute the Fused Multi-Head Attention operation on the provided tensors.
@@ -398,11 +399,11 @@ class BlockSparseAttnForwardSm100Blk128:
             gmem_tiled_copy_O = cute.make_tiled_copy_tv(atom_universal_copy, tO_layout, vO_layout)
 
         if const_expr(self.use_clc_scheduler):
-            TileScheduler = StaticPersistentTileScheduler
+            TileScheduler = BlockSparsePersistentTileScheduler
         elif const_expr(not self.is_persistent):
             TileScheduler = SingleTileScheduler
         else:
-            TileScheduler = StaticPersistentTileScheduler
+            TileScheduler = BlockSparsePersistentTileScheduler
         tile_sched_args = TileSchedulerArguments(
             cute.ceil_div(cute.size(mQ.shape[0]), self.cta_tiler[0]),
             cute.size(mQ.shape[2]),
@@ -488,6 +489,8 @@ class BlockSparseAttnForwardSm100Blk128:
             mBlockSizes,
             block_sparse_num,
             mBlockNums,
+            mTokenMaskBounds,
+            mTokenMaskFlags,
         ).launch(
             grid=grid_dim,
             block=[self.threads_per_cta, 1, 1],
@@ -523,6 +526,8 @@ class BlockSparseAttnForwardSm100Blk128:
         mBlockSizes: cute.Tensor,
         block_sparse_num: Int32,
         mBlockNums: Optional[cute.Tensor],
+        mTokenMaskBounds: Optional[cute.Tensor],
+        mTokenMaskFlags: Optional[cute.Tensor],
     ):
         """The device kernel implementation of the Fused Multi-Head Attention.
 
@@ -815,6 +820,8 @@ class BlockSparseAttnForwardSm100Blk128:
                 mBlockSizes=mBlockSizes,
                 block_sparse_num=block_sparse_num,
                 mBlockNums=mBlockNums,
+                mTokenMaskBounds=mTokenMaskBounds,
+                mTokenMaskFlags=mTokenMaskFlags,
             )
 
             stage = Int32(0 if warp_idx < self.softmax1_warp_ids[0] else 1)
@@ -966,7 +973,7 @@ class BlockSparseAttnForwardSm100Blk128:
             if const_expr(mBlockNums is not None):
                 raw_block_count = mBlockNums[batch_idx, head_idx, m_block]
                 process_tile = raw_block_count > Int32(0) if const_expr(self.allow_empty_block_nums) else True
-                block_iter_count = (raw_block_count + 1) & ~1
+                block_iter_count = raw_block_count if const_expr(self.q_stage == 2) else (raw_block_count + 1) & ~1
                 n_block = partial(block_info.get_n_block_idx, mBlockIndex, batch_idx, head_idx, m_block, max_i=cutlass.max(raw_block_count - 1, Int32(0)))
             else:
                 process_tile = True
@@ -974,36 +981,36 @@ class BlockSparseAttnForwardSm100Blk128:
                 n_block = partial(block_info.get_n_block_idx, mBlockIndex, batch_idx, head_idx, m_block)
 
             if process_tile:
-                load_K(block=n_block(block_iter_count - 1), producer_state=kv_producer_state, page_idx=None)  # K0
+                load_K(block=n_block(block_iter_count - 1), producer_state=kv_producer_state, page_idx=None)
+                kv_producer_state.advance()
                 if const_expr(len(self.load_warp_ids) == 1) or warp_idx == self.load_warp_ids[0]:
-                    pipeline_q.producer_acquire_w_index_phase(0, q_producer_phase)
-                    tma_bar_ptr = pipeline_q.sync_object_full.get_barrier(0)
-                    load_Q_fn(src_idx=0, dst_idx=0, tma_bar_ptr=tma_bar_ptr)
-                kv_producer_state.advance()
-
-                # q_stage=1 intra-warp overlap
-                # Load order: K[N-1], Q, K[N-2], {V[N-1-i], K[N-3-i]}x(N-2), V[1], V[0]
-                block_loop_count = block_iter_count - 2
+                    for stage in cutlass.range_constexpr(self.q_stage):
+                        pipeline_q.producer_acquire_w_index_phase(stage, q_producer_phase)
+                        tma_bar_ptr = pipeline_q.sync_object_full.get_barrier(stage)
+                        load_Q_fn(src_idx=stage, dst_idx=stage, tma_bar_ptr=tma_bar_ptr)
                 q_producer_phase ^= 1
-
-                # Prologue: K[N-2]
-                load_K(block=n_block(block_iter_count - 2), producer_state=kv_producer_state, page_idx=None)
-                kv_producer_state.advance()
-
-                # Flat main loop: N-2 iterations, each loads V then K
-                for i in cutlass.range(block_loop_count, unroll=1):
-                    # V[N-1-i]: V for the block whose S was computed earlier
-                    load_V(block=n_block(block_iter_count - 1 - i), producer_state=kv_producer_state, page_idx=None)
+                if const_expr(self.q_stage == 2):
+                    load_V(block=n_block(block_iter_count - 1), producer_state=kv_producer_state, page_idx=None)
                     kv_producer_state.advance()
-                    # K[N-3-i]: K for the next QK GEMM
-                    load_K(block=n_block(block_iter_count - 3 - i), producer_state=kv_producer_state, page_idx=None)
+                    for i in cutlass.range(block_iter_count - 1, unroll=1):
+                        logical_n = block_iter_count - 2 - i
+                        load_K(block=n_block(logical_n), producer_state=kv_producer_state, page_idx=None)
+                        kv_producer_state.advance()
+                        load_V(block=n_block(logical_n), producer_state=kv_producer_state, page_idx=None)
+                        kv_producer_state.advance()
+                else:
+                    block_loop_count = block_iter_count - 2
+                    load_K(block=n_block(block_iter_count - 2), producer_state=kv_producer_state, page_idx=None)
                     kv_producer_state.advance()
-
-                # Epilogue: last 2 V loads
-                load_V(block=n_block(1), producer_state=kv_producer_state, page_idx=None)
-                kv_producer_state.advance()
-                load_V(block=n_block(0), producer_state=kv_producer_state, page_idx=None)
-                kv_producer_state.advance()
+                    for i in cutlass.range(block_loop_count, unroll=1):
+                        load_V(block=n_block(block_iter_count - 1 - i), producer_state=kv_producer_state, page_idx=None)
+                        kv_producer_state.advance()
+                        load_K(block=n_block(block_iter_count - 3 - i), producer_state=kv_producer_state, page_idx=None)
+                        kv_producer_state.advance()
+                    load_V(block=n_block(1), producer_state=kv_producer_state, page_idx=None)
+                    kv_producer_state.advance()
+                    load_V(block=n_block(0), producer_state=kv_producer_state, page_idx=None)
+                    kv_producer_state.advance()
 
             tile_scheduler.prefetch_next_work()
             work_tile = tile_scheduler.consumer_advance()
@@ -1036,8 +1043,7 @@ class BlockSparseAttnForwardSm100Blk128:
         tSrQ = tiled_mma_qk.make_fragment_A(sQ)
         tSrK = tiled_mma_qk.make_fragment_B(sK)
         tOrV = tiled_mma_pv.make_fragment_B(sV)
-        # q_stage=1: both stages use the same Q (intra-warp overlap across n_blocks)
-        tSrQs = (tSrQ[None, None, None, 0], tSrQ[None, None, None, 0])
+        tSrQs = (tSrQ[None, None, None, 0], tSrQ[None, None, None, 1] if const_expr(self.q_stage == 2) else tSrQ[None, None, None, 0])
 
         qk_mma_op, pv_mma_op = tiled_mma_qk.op, tiled_mma_pv.op
         qk_mma_idesc, pv_mma_idesc = sm100_desc.mma_op_to_idesc(qk_mma_op), sm100_desc.mma_op_to_idesc(pv_mma_op)
@@ -1062,7 +1068,9 @@ class BlockSparseAttnForwardSm100Blk128:
         sm100_utils.declare_ptx_idesc(qk_mma_op, var_name="bsa_fwd_qk_mma_idesc")
         sm100_utils.declare_ptx_idesc(pv_mma_op, var_name="bsa_fwd_pv_mma_idesc")
 
-        sQ_stage_stride = 0  # q_stage=1
+        sQ_stage_stride = (sQ.layout.stride[-1] * sQ.element_type.width // 8) >> 4
+        if const_expr(self.q_stage == 1):
+            sQ_stage_stride = 0
         gemm_Si = [
             partial(
                 sm100_utils.gemm_ptx_precomputed_varname,
@@ -1106,12 +1114,12 @@ class BlockSparseAttnForwardSm100Blk128:
             if const_expr(mBlockNums is not None):
                 raw_block_count = mBlockNums[batch_idx, head_idx, m_block]
                 process_tile = raw_block_count > Int32(0) if const_expr(self.allow_empty_block_nums) else True
-                block_iter_count = (raw_block_count + 1) & ~1
+                block_iter_count = raw_block_count if const_expr(self.q_stage == 2) else (raw_block_count + 1) & ~1
             else:
                 process_tile = True
                 block_iter_count = block_sparse_num
 
-            if process_tile:
+            if process_tile and const_expr(self.q_stage == 1):
                 # ================================================================
                 # q_stage=1: intra-warp overlap across n_block direction
                 # Pipeline KV order: K0, K1, V0, K2, V1, K3, V2, ...
@@ -1231,6 +1239,73 @@ class BlockSparseAttnForwardSm100Blk128:
                 phase_s0 ^= 1
                 phase_s1 ^= 1
 
+            if process_tile and const_expr(self.q_stage == 2):
+                for stage in cutlass.range_constexpr(self.q_stage):
+                    pipeline_q.consumer_wait_w_index_phase(stage, mma_q_consumer_phase)
+                    if const_expr(stage == 0):
+                        pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                    Ki_index, Ki_phase = mma_kv_consumer_state.index, mma_kv_consumer_state.phase
+                    sK_cur = sK[None, None, None, Ki_index]
+                    if const_expr(self.uneven_kv_smem):
+                        sK_cur = self.offset_kv_smem(sK_cur, Ki_index, Ki_phase)
+                    gemm_Si[stage](smem_desc_start_b=sm100_desc.make_smem_desc_start_addr(sK_cur.iterator))
+                    pipeline_s_p_o.producer_commit_w_index(stage)
+                mma_q_consumer_phase ^= 1
+                pipeline_kv.consumer_release(mma_kv_consumer_state)
+                mma_kv_consumer_state.advance()
+                O_should_accumulate = False
+                for i in cutlass.range(block_iter_count - 1, unroll=1):
+                    pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                    v_release_state = mma_kv_consumer_state.clone()
+                    Vi_index, Vi_phase = mma_kv_consumer_state.index, mma_kv_consumer_state.phase
+                    tOrVi = tOrV[None, None, None, Vi_index]
+                    sV_cur = sV[None, None, None, Vi_index]
+                    if const_expr(self.uneven_kv_smem):
+                        sV_cur = self.offset_kv_smem(sV_cur, Vi_index, Vi_phase)
+                    mma_kv_consumer_state.advance()
+                    pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                    Ki_index, Ki_phase = mma_kv_consumer_state.index, mma_kv_consumer_state.phase
+                    sK_cur = sK[None, None, None, Ki_index]
+                    if const_expr(self.uneven_kv_smem):
+                        sK_cur = self.offset_kv_smem(sK_cur, Ki_index, Ki_phase)
+                    for stage in cutlass.range_constexpr(self.q_stage):
+                        pipeline_s_p_o.producer_acquire_w_index_phase(stage, P_full_O_rescaled_phase)
+                        gemm_Pi[stage](
+                            tCrB=tOrVi,
+                            sB=sV_cur,
+                            zero_init=not O_should_accumulate,
+                            mbar_ptr=pipeline_p_lastsplit.sync_object_full.get_barrier(stage) if self.split_P_arrive > 0 else None,
+                            mbar_phase=P_full_O_rescaled_phase,
+                        )
+                        gemm_Si[stage](smem_desc_start_b=sm100_desc.make_smem_desc_start_addr(sK_cur.iterator))
+                        pipeline_s_p_o.producer_commit_w_index(stage)
+                    pipeline_kv.consumer_release(v_release_state)
+                    pipeline_kv.consumer_release(mma_kv_consumer_state)
+                    mma_kv_consumer_state.advance()
+                    P_full_O_rescaled_phase ^= 1
+                    O_should_accumulate = True
+                for stage in cutlass.range_constexpr(self.q_stage):
+                    pipeline_q.consumer_release_w_index(stage)
+                pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                Vi_index, Vi_phase = mma_kv_consumer_state.index, mma_kv_consumer_state.phase
+                tOrVi = tOrV[None, None, None, Vi_index]
+                sV_cur = sV[None, None, None, Vi_index]
+                if const_expr(self.uneven_kv_smem):
+                    sV_cur = self.offset_kv_smem(sV_cur, Vi_index, Vi_phase)
+                for stage in cutlass.range_constexpr(self.q_stage):
+                    pipeline_s_p_o.producer_acquire_w_index_phase(stage, P_full_O_rescaled_phase)
+                    gemm_Pi[stage](
+                        tCrB=tOrVi,
+                        sB=sV_cur,
+                        zero_init=not O_should_accumulate,
+                        mbar_ptr=pipeline_p_lastsplit.sync_object_full.get_barrier(stage) if self.split_P_arrive > 0 else None,
+                        mbar_phase=P_full_O_rescaled_phase,
+                    )
+                    pipeline_o_acc.producer_commit_w_index(stage)
+                P_full_O_rescaled_phase ^= 1
+                pipeline_kv.consumer_release(mma_kv_consumer_state)
+                mma_kv_consumer_state.advance()
+
             # Advance to next tile
             work_tile = tile_scheduler.consumer_advance()
         # End of persistent scheduler loop
@@ -1238,6 +1313,39 @@ class BlockSparseAttnForwardSm100Blk128:
         # We don't need pipeline_s_p_o.producer_tail() since there's no dangling mbarrier at the end
         # We don't need pipeline_o_acc.producer_tail() since we don't call
         # pipeline_o_acc.producer_acquire() inside the loop.
+
+    @cute.jit
+    def get_softmax_mask_metadata(
+        self,
+        logical_block: Int32,
+        raw_block_count: Int32,
+        n_block: Callable,
+        mBlockSizes: Optional[cute.Tensor],
+        mTokenMaskBounds: cute.Tensor,
+        mTokenMaskFlags: cute.Tensor,
+        batch_idx: Int32,
+        m_block: Int32,
+        q_row: Int32,
+    ) -> Tuple[Int32, Int32, Int32, Int32]:
+        valid = logical_block < raw_block_count
+        max_logical = cutlass.max(raw_block_count - 1, Int32(0))
+        safe_logical = cutlass.min(logical_block, max_logical)
+        block_id = n_block(logical_block)
+        if const_expr(self.has_block_sizes):
+            block_size = mBlockSizes[block_id] if valid else Int32(0)
+        else:
+            block_size = Int32(self.n_block_size) if valid else Int32(0)
+        partial_index_value = Int32(mTokenMaskFlags[batch_idx, m_block, safe_logical])
+        partial_index = cute.arch.make_warp_uniform(partial_index_value if valid else Int32(-1))
+        flag = Int32(2) if partial_index < Int32(0) else Int32(1)
+        flag = flag if valid else Int32(0)
+        interval_lo = Int32(0)
+        interval_hi = Int32(self.n_block_size)
+        if flag == Int32(1):
+            packed_bounds = Uint32(mTokenMaskBounds[partial_index, q_row])
+            interval_lo = Int32(packed_bounds & Uint32(0xFFFF))
+            interval_hi = Int32(utils.shr_u32(packed_bounds, Uint32(16)))
+        return block_size, flag, interval_lo, interval_hi
 
     # for both softmax0 and softmax1 warp group
     @cute.jit
@@ -1260,6 +1368,8 @@ class BlockSparseAttnForwardSm100Blk128:
         mBlockSizes: cute.Tensor,
         block_sparse_num: Int32,
         mBlockNums: Optional[cute.Tensor],
+        mTokenMaskBounds: Optional[cute.Tensor],
+        mTokenMaskFlags: Optional[cute.Tensor],
     ):
         """Compute softmax on attention scores from QK matrix multiplication.
 
@@ -1344,21 +1454,41 @@ class BlockSparseAttnForwardSm100Blk128:
                 # WG0 (stage=0): logical indices N-1, N-3, ... (stride 2)
                 # WG1 (stage=1): logical indices N-2, N-4, ... (stride 2)
                 if const_expr(mBlockNums is not None):
-                    block_iter_count = (raw_block_count + 1) & ~1
+                    block_iter_count = raw_block_count if const_expr(self.q_stage == 2) else (raw_block_count + 1) & ~1
                 else:
                     block_iter_count = block_sparse_num
-                wg_count = block_iter_count // 2
-                # logical_first is the first logical index for this WG
-                logical_first = block_iter_count - 1 - stage
+                wg_count = block_iter_count if const_expr(self.q_stage == 2) else block_iter_count // 2
+                logical_first = block_iter_count - 1 if const_expr(self.q_stage == 2) else block_iter_count - 1 - stage
+                logical_stride = 1 if const_expr(self.q_stage == 2) else self.s_stage
+                q_row = tidx + stage * self.m_block_size if const_expr(self.q_stage == 2) else tidx
 
-                # 1st block — phantom block (logical_first >= raw_block_count) uses block_size=0
+                # First block for this softmax warpgroup.
                 n_block_first = n_block(logical_first)
-                if const_expr(self.has_block_sizes):
+                first_token_block_size = Int32(self.n_block_size)
+                first_token_flag = Int32(2)
+                first_token_lo = Int32(0)
+                first_token_hi = Int32(self.n_block_size)
+                if const_expr(self.has_token_mask):
+                    first_block_size, first_flag, first_lo, first_hi = self.get_softmax_mask_metadata(
+                        logical_first,
+                        raw_block_count,
+                        n_block,
+                        mBlockSizes,
+                        mTokenMaskBounds,
+                        mTokenMaskFlags,
+                        batch_idx,
+                        m_block,
+                        q_row,
+                    )
+                    first_mask_fn = None
+                    first_token_block_size = first_block_size
+                    first_token_flag = first_flag
+                    first_token_lo = first_lo
+                    first_token_hi = first_hi
+                elif const_expr(self.has_block_sizes):
                     first_block_size = Int32(0) if const_expr(mBlockNums is not None) and logical_first >= raw_block_count else mBlockSizes[n_block_first]
                     first_mask_fn = partial(apply_block_size_mask, block_size=first_block_size, n_block_size=self.n_block_size)
                 elif const_expr(mBlockNums is not None):
-                    # No block_sizes but var block nums: phantom block still needs block_size=0 mask;
-                    # real blocks get n_block_size which is a no-op in apply_block_size_mask
                     first_block_size = Int32(0) if logical_first >= raw_block_count else Int32(self.n_block_size)
                     first_mask_fn = partial(apply_block_size_mask, block_size=first_block_size, n_block_size=self.n_block_size)
                 else:
@@ -1367,13 +1497,38 @@ class BlockSparseAttnForwardSm100Blk128:
                     mma_si_consumer_phase,
                     sm_stats_producer_phase,
                     mask_fn=first_mask_fn,
+                    token_block_size=first_token_block_size,
+                    token_mask_flag=first_token_flag,
+                    token_interval_lo=first_token_lo,
+                    token_interval_hi=first_token_hi,
                     is_first=True,
                 )
-                # Remaining blocks with stride 2 — always valid (logical_n < raw_block_count)
+                # Remaining blocks with stride 2 are always valid.
                 for n_tile in cutlass.range(wg_count - 1, unroll=1):
-                    logical_n = logical_first - self.s_stage * (n_tile + 1)
+                    logical_n = logical_first - logical_stride * (n_tile + 1)
                     n_block_cur = n_block(logical_n)
-                    if const_expr(self.has_block_sizes):
+                    token_block_size_n = Int32(self.n_block_size)
+                    token_flag_n = Int32(2)
+                    token_interval_lo_n = Int32(0)
+                    token_interval_hi_n = Int32(self.n_block_size)
+                    if const_expr(self.has_token_mask):
+                        block_size_n, flag_n, interval_lo_n, interval_hi_n = self.get_softmax_mask_metadata(
+                            logical_n,
+                            raw_block_count,
+                            n_block,
+                            mBlockSizes,
+                            mTokenMaskBounds,
+                            mTokenMaskFlags,
+                            batch_idx,
+                            m_block,
+                            q_row,
+                        )
+                        remaining_mask_fn = None
+                        token_block_size_n = block_size_n
+                        token_flag_n = flag_n
+                        token_interval_lo_n = interval_lo_n
+                        token_interval_hi_n = interval_hi_n
+                    elif const_expr(self.has_block_sizes):
                         remaining_mask_fn = partial(apply_block_size_mask, block_size=mBlockSizes[n_block_cur], n_block_size=self.n_block_size)
                     else:
                         remaining_mask_fn = None
@@ -1381,6 +1536,10 @@ class BlockSparseAttnForwardSm100Blk128:
                         mma_si_consumer_phase,
                         sm_stats_producer_phase,
                         mask_fn=remaining_mask_fn,
+                        token_block_size=token_block_size_n,
+                        token_mask_flag=token_flag_n,
+                        token_interval_lo=token_interval_lo_n,
+                        token_interval_hi=token_interval_hi_n,
                     )
 
                 sScale[tidx + stage * self.m_block_size] = softmax.row_sum[0]
@@ -1415,6 +1574,10 @@ class BlockSparseAttnForwardSm100Blk128:
         tStP_r2t: cute.Tensor,
         sScale: cute.Tensor,
         stage: int | Int32,
+        token_block_size: Int32,
+        token_mask_flag: Int32,
+        token_interval_lo: Int32,
+        token_interval_hi: Int32,
         mask_fn: Optional[Callable] = None,
         is_first: bool = False,
     ) -> Tuple[cute.Int32, cute.Int32]:
@@ -1446,7 +1609,12 @@ class BlockSparseAttnForwardSm100Blk128:
         tSrS_t2r = cute.make_rmem_tensor(thr_tmem_load.partition_D(tScS).shape, self.qk_acc_dtype)
         cute.copy(thr_tmem_load, tStS_t2r, tSrS_t2r)
 
-        if const_expr(mask_fn is not None):
+        if const_expr(self.has_token_mask):
+            effective_lo = cutlass.max(Int32(0), token_interval_lo)
+            effective_hi = cutlass.max(Int32(0), cutlass.min(token_interval_hi, token_block_size))
+            if token_mask_flag != Int32(2):
+                apply_interval_mask_r2p(tSrS_t2r, effective_lo, effective_hi)
+        elif const_expr(mask_fn is not None):
             mask_fn(tSrS_t2r)
         row_max, acc_scale = softmax.update_row_max(tSrS_t2r.load(), is_first)
 
@@ -1539,25 +1707,35 @@ class BlockSparseAttnForwardSm100Blk128:
                 sm_stats_barrier.arrive_and_wait_w_index(index=1 * 4 + warp_idx)
                 sm_stats_consumer_phase ^= 1
 
-                # q_stage=1 correction loop
+                # Correction loop: one Q row group for q_stage=1, two for q_stage=2
                 if const_expr(mBlockNums is not None):
-                    block_iter_count = (mBlockNums[batch_idx, head_idx, m_block] + 1) & ~1
+                    raw_count = mBlockNums[batch_idx, head_idx, m_block]
+                    block_iter_count = raw_count if const_expr(self.q_stage == 2) else (raw_count + 1) & ~1
                 else:
                     block_iter_count = block_sparse_num
-                corr_pair_count = (block_iter_count - 2) // 2
-                # Rescale the two alternating stages as a pair.
-                for i in cutlass.range(corr_pair_count, unroll=1):
-                    for stage in cutlass.range_constexpr(self.s_stage):
-                        sm_stats_barrier.arrive_and_wait_w_index(index=stage * 4 + warp_idx)
-                        scale = sScale[tidx + stage * self.m_block_size]
-                        should_rescale = cute.arch.vote_ballot_sync(scale < 1.0) != 0
-                        if should_rescale:
-                            self.correction_rescale(thr_mma_pv, tOtO[None, None, None, stage], tidx, scale)
-                        pipeline_s_p_o.consumer_release_w_index(stage)
-                        pipeline_sm_stats.consumer_release_w_index(self.s_stage - 1 - stage)
-                    sm_stats_consumer_phase ^= 1
-                # N even: no remainder. Release final sm_stats stage 1.
-                pipeline_sm_stats.consumer_release_w_index(1)
+                if const_expr(self.q_stage == 2):
+                    for i in cutlass.range(block_iter_count - 1, unroll=1):
+                        for stage in cutlass.range_constexpr(self.q_stage):
+                            sm_stats_barrier.arrive_and_wait_w_index(index=stage * 4 + warp_idx)
+                            scale = sScale[tidx + stage * self.m_block_size]
+                            if cute.arch.vote_ballot_sync(scale < 1.0) != 0:
+                                self.correction_rescale(thr_mma_pv, tOtO[None, None, None, stage], tidx, scale)
+                            pipeline_s_p_o.consumer_release_w_index(stage)
+                            pipeline_sm_stats.consumer_release_w_index(self.q_stage - 1 - stage)
+                        sm_stats_consumer_phase ^= 1
+                    pipeline_sm_stats.consumer_release_w_index(1)
+                else:
+                    corr_pair_count = (block_iter_count - 2) // 2
+                    for i in cutlass.range(corr_pair_count, unroll=1):
+                        for stage in cutlass.range_constexpr(self.s_stage):
+                            sm_stats_barrier.arrive_and_wait_w_index(index=stage * 4 + warp_idx)
+                            scale = sScale[tidx + stage * self.m_block_size]
+                            if cute.arch.vote_ballot_sync(scale < 1.0) != 0:
+                                self.correction_rescale(thr_mma_pv, tOtO[None, None, None, stage], tidx, scale)
+                            pipeline_s_p_o.consumer_release_w_index(stage)
+                            pipeline_sm_stats.consumer_release_w_index(self.s_stage - 1 - stage)
+                        sm_stats_consumer_phase ^= 1
+                    pipeline_sm_stats.consumer_release_w_index(1)
                 # End of seqlen_corr_loop_steps
 
                 # Even in the case of self.overlap_sO_sQ, we can write to stage 0 of sO without
@@ -1576,45 +1754,37 @@ class BlockSparseAttnForwardSm100Blk128:
                     acc_O_mn_row_is_zero_or_nan = row_sum == 0.0 or row_sum != row_sum
                     stats[stage] = (row_sum, row_max, acc_O_mn_row_is_zero_or_nan)
 
-                # q_stage=1: combine O0 and O1, then write single output
-                row_sum0, row_max0, zero_or_nan0 = stats[0]
-                row_sum1, row_max1, zero_or_nan1 = stats[1]
-
-                # Compute combined scales for the two partial O accumulators
-                # row_max is in original S space (unscaled). To compute rescale
-                # factors we need exp2((row_max - max_combined) * scale_log2).
-                # For empty/padding stages (zero_or_nan=True), row_max may be 0.0 instead of -inf
-                # due to softmax's safe_max clamping. Use -inf for those to avoid polluting max_combined.
-                rm0 = row_max0 if not zero_or_nan0 else -Float32.inf
-                rm1 = row_max1 if not zero_or_nan1 else -Float32.inf
-                max_combined = cutlass.max(rm0, rm1)
-                max_safe = max_combined if max_combined != -Float32.inf else Float32(0.0)
-                scale0 = cute.math.exp2((rm0 - max_safe) * softmax_scale_log2, fastmath=True) if not zero_or_nan0 else Float32(0.0)
-                scale1 = cute.math.exp2((rm1 - max_safe) * softmax_scale_log2, fastmath=True) if not zero_or_nan1 else Float32(0.0)
-                sum_combined = row_sum0 * scale0 + row_sum1 * scale1
-                combined_zero_or_nan = sum_combined == 0.0 or sum_combined != sum_combined
-                inv_sum = cute.arch.rcp_approx(sum_combined if not combined_zero_or_nan else 1.0)
-                final_scale0 = scale0 * inv_sum
-                final_scale1 = scale1 * inv_sum
-
-                # Wait for both O accumulators from MMA warp
-                for stage in cutlass.range_constexpr(self.s_stage):
-                    pipeline_o_acc.consumer_wait_w_index_phase(stage, o_corr_consumer_phase)
-                pipeline_o_epi.producer_acquire_w_index_phase(0, corr_epi_producer_phase)
-                self.correction_epilogue_combine(
-                    thr_mma_pv,
-                    tOtO[None, None, None, 0],
-                    tOtO[None, None, None, 1],
-                    tidx,
-                    final_scale0,
-                    final_scale1,
-                    sO[None, None, 0],
-                )
-                # Release both O buffers in tmem
-                for stage in cutlass.range_constexpr(self.s_stage):
-                    pipeline_s_p_o.consumer_release_w_index(stage)
-                pipeline_o_epi.producer_commit_w_index(0)
-
+                if const_expr(self.q_stage == 2):
+                    for stage in cutlass.range_constexpr(self.q_stage):
+                        row_sum, row_max, zero_or_nan = stats[stage]
+                        final_scale = cute.arch.rcp_approx(row_sum if not zero_or_nan else 1.0) if not zero_or_nan else Float32(0.0)
+                        pipeline_o_acc.consumer_wait_w_index_phase(stage, o_corr_consumer_phase)
+                        pipeline_o_epi.producer_acquire_w_index_phase(stage, corr_epi_producer_phase)
+                        self.correction_epilogue_combine(
+                            thr_mma_pv, tOtO[None, None, None, stage], tOtO[None, None, None, stage], tidx, final_scale, Float32(0.0), sO[None, None, stage]
+                        )
+                        pipeline_s_p_o.consumer_release_w_index(stage)
+                        pipeline_o_epi.producer_commit_w_index(stage)
+                else:
+                    row_sum0, row_max0, zero_or_nan0 = stats[0]
+                    row_sum1, row_max1, zero_or_nan1 = stats[1]
+                    rm0 = row_max0 if not zero_or_nan0 else -Float32.inf
+                    rm1 = row_max1 if not zero_or_nan1 else -Float32.inf
+                    max_combined = cutlass.max(rm0, rm1)
+                    max_safe = max_combined if max_combined != -Float32.inf else Float32(0.0)
+                    scale0 = cute.math.exp2((rm0 - max_safe) * softmax_scale_log2, fastmath=True) if not zero_or_nan0 else Float32(0.0)
+                    scale1 = cute.math.exp2((rm1 - max_safe) * softmax_scale_log2, fastmath=True) if not zero_or_nan1 else Float32(0.0)
+                    sum_combined = row_sum0 * scale0 + row_sum1 * scale1
+                    inv_sum = cute.arch.rcp_approx(sum_combined if sum_combined != 0.0 and sum_combined == sum_combined else 1.0)
+                    for stage in cutlass.range_constexpr(self.s_stage):
+                        pipeline_o_acc.consumer_wait_w_index_phase(stage, o_corr_consumer_phase)
+                    pipeline_o_epi.producer_acquire_w_index_phase(0, corr_epi_producer_phase)
+                    self.correction_epilogue_combine(
+                        thr_mma_pv, tOtO[None, None, None, 0], tOtO[None, None, None, 1], tidx, scale0 * inv_sum, scale1 * inv_sum, sO[None, None, 0]
+                    )
+                    for stage in cutlass.range_constexpr(self.s_stage):
+                        pipeline_s_p_o.consumer_release_w_index(stage)
+                    pipeline_o_epi.producer_commit_w_index(0)
                 o_corr_consumer_phase ^= 1
                 sm_stats_consumer_phase ^= 1
                 corr_epi_producer_phase ^= 1
@@ -1625,44 +1795,52 @@ class BlockSparseAttnForwardSm100Blk128:
                     sm_stats_barrier.arrive_and_wait_w_index(index=stage_idx * 4 + warp_idx)
                     pipeline_sm_stats.consumer_release_w_index(stage_idx)
                 sm_stats_consumer_phase ^= 1
-                # Write O=0 via correction_epilogue_combine with scale=0.
-                # Note: reads tmem which may have values from a previous tile;
-                # 0.0 * finite = 0.0. For the very first tile, tmem is hardware-zero-initialized.
-                pipeline_o_epi.producer_acquire_w_index_phase(0, corr_epi_producer_phase)
-                self.correction_epilogue_combine(
-                    thr_mma_pv,
-                    tOtO[None, None, None, 0],
-                    tOtO[None, None, None, 1],
-                    tidx,
-                    Float32(0.0),
-                    Float32(0.0),
-                    sO[None, None, 0],
-                )
-                # Do NOT release pipeline_s_p_o (MMA didn't commit)
-                pipeline_o_epi.producer_commit_w_index(0)
-                # o_corr_consumer_phase NOT toggled (pipeline_o_acc not touched)
+                if const_expr(self.q_stage == 2):
+                    for stage in cutlass.range_constexpr(self.q_stage):
+                        pipeline_o_epi.producer_acquire_w_index_phase(stage, corr_epi_producer_phase)
+                        self.correction_epilogue_combine(
+                            thr_mma_pv, tOtO[None, None, None, stage], tOtO[None, None, None, stage], tidx, Float32(0.0), Float32(0.0), sO[None, None, stage]
+                        )
+                        pipeline_o_epi.producer_commit_w_index(stage)
+                else:
+                    pipeline_o_epi.producer_acquire_w_index_phase(0, corr_epi_producer_phase)
+                    self.correction_epilogue_combine(
+                        thr_mma_pv, tOtO[None, None, None, 0], tOtO[None, None, None, 1], tidx, Float32(0.0), Float32(0.0), sO[None, None, 0]
+                    )
+                    pipeline_o_epi.producer_commit_w_index(0)
                 corr_epi_producer_phase ^= 1
 
             if const_expr(mLSE is not None):
                 mLSE_cur = mLSE[None, head_idx, batch_idx]
-                # q_stage=1: compute combined LSE from two partial softmax stats
-                m_tile_idx = m_block
-                gLSE = cute.local_tile(mLSE_cur, (self.m_block_size,), (m_tile_idx,))
-                row_sum0, row_max0, zero_or_nan0 = stats[0]
-                row_sum1, row_max1, zero_or_nan1 = stats[1]
-                rm0_lse = row_max0 if not zero_or_nan0 else -Float32.inf
-                rm1_lse = row_max1 if not zero_or_nan1 else -Float32.inf
-                max_combined = cutlass.max(rm0_lse, rm1_lse)
-                max_safe = max_combined if max_combined != -Float32.inf else Float32(0.0)
-                s0 = cute.math.exp2((rm0_lse - max_safe) * softmax_scale_log2, fastmath=True) if not zero_or_nan0 else Float32(0.0)
-                s1 = cute.math.exp2((rm1_lse - max_safe) * softmax_scale_log2, fastmath=True) if not zero_or_nan1 else Float32(0.0)
-                sum_comb = row_sum0 * s0 + row_sum1 * s1
-                comb_zero_or_nan = sum_comb == 0.0 or sum_comb != sum_comb
                 LN2 = math.log(2.0)
-                lse = (max_safe * softmax_scale_log2 + cute.math.log2(sum_comb, fastmath=True)) * LN2 if not comb_zero_or_nan else -Float32.inf
-                seqlen_q = seqlen.seqlen_q if const_expr(not self.pack_gqa) else seqlen.seqlen_q * self.qhead_per_kvhead
-                if tidx < seqlen_q - m_tile_idx * self.m_block_size:
-                    gLSE[tidx] = lse
+                if const_expr(self.q_stage == 2):
+                    for stage in cutlass.range_constexpr(self.q_stage):
+                        m_tile_idx = m_block * self.q_stage + stage
+                        gLSE = cute.local_tile(mLSE_cur, (self.m_block_size,), (m_tile_idx,))
+                        row_sum, row_max, zero_or_nan = stats[stage]
+                        lse_value = (row_max * softmax_scale_log2 + cute.math.log2(row_sum, fastmath=True)) * LN2 if not zero_or_nan else -Float32.inf
+                        if tidx < seqlen.seqlen_q - m_tile_idx * self.m_block_size:
+                            gLSE[tidx] = lse_value
+                else:
+                    m_tile_idx = m_block
+                    gLSE = cute.local_tile(mLSE_cur, (self.m_block_size,), (m_tile_idx,))
+                    row_sum0, row_max0, zero_or_nan0 = stats[0]
+                    row_sum1, row_max1, zero_or_nan1 = stats[1]
+                    rm0_lse = row_max0 if not zero_or_nan0 else -Float32.inf
+                    rm1_lse = row_max1 if not zero_or_nan1 else -Float32.inf
+                    max_combined = cutlass.max(rm0_lse, rm1_lse)
+                    max_safe = max_combined if max_combined != -Float32.inf else Float32(0.0)
+                    s0 = cute.math.exp2((rm0_lse - max_safe) * softmax_scale_log2, fastmath=True) if not zero_or_nan0 else Float32(0.0)
+                    s1 = cute.math.exp2((rm1_lse - max_safe) * softmax_scale_log2, fastmath=True) if not zero_or_nan1 else Float32(0.0)
+                    sum_comb = row_sum0 * s0 + row_sum1 * s1
+                    lse_value = (
+                        (max_safe * softmax_scale_log2 + cute.math.log2(sum_comb, fastmath=True)) * LN2
+                        if sum_comb != 0.0 and sum_comb == sum_comb
+                        else -Float32.inf
+                    )
+                    seqlen_q = seqlen.seqlen_q if const_expr(not self.pack_gqa) else seqlen.seqlen_q * self.qhead_per_kvhead
+                    if tidx < seqlen_q - m_tile_idx * self.m_block_size:
+                        gLSE[tidx] = lse_value
 
             # Advance to next tile
             work_tile = tile_scheduler.consumer_advance()
@@ -2322,8 +2500,40 @@ MaskGenFn: TypeAlias = Callable[[int], Uint32]
 
 
 @cute.jit
+def mask_f32x32_by_u32_branch(acc_s: cute.Tensor, mask: Uint32, base: cutlass.Constexpr[int]) -> Tuple[Float32, ...]:
+    mask_ops = "\n\t".join(f"and.b32 tmp, $64, {hex(1 << i)};\n\t" "setp.eq.u32 p, tmp, 0;\n\t" f"@p mov.f32 ${i}, neg_inf;" for i in range(32))
+    zero_ops = "\n\t".join(f"mov.f32 ${i}, neg_inf;" for i in range(32))
+    out = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32()] * 32),
+        [Float32(acc_s[base + i]).ir_value() for i in range(32)] + [Uint32(mask).ir_value()],
+        "{\n\t"
+        ".reg .pred p;\n\t"
+        ".reg .pred full;\n\t"
+        ".reg .pred zero;\n\t"
+        ".reg .u32 tmp;\n\t"
+        ".reg .f32 neg_inf;\n\t"
+        "setp.eq.u32 full, $64, 0xffffffff;\n\t"
+        "@full bra.uni MASK_DONE;\n\t"
+        "mov.f32 neg_inf, 0fFF800000;\n\t"
+        "setp.eq.u32 zero, $64, 0;\n\t"
+        "@!zero bra.uni MASK_PARTIAL;\n\t"
+        f"{zero_ops}\n\t"
+        "bra.uni MASK_DONE;\n\t"
+        "MASK_PARTIAL:\n\t"
+        f"{mask_ops}\n\t"
+        "MASK_DONE:\n\t"
+        "}\n",
+        ",".join(["=f"] * 32 + [str(i) for i in range(32)] + ["r"]),
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+    return tuple(Float32(llvm.extractvalue(T.f32(), out, [i])) for i in range(32))
+
+
+@cute.jit
 def predicate_bitmask_below(limit: Int32, s: int) -> Uint32:
-    """32-bit register-to-predicate bitmask keeping positions < limit."""
+    """32-bit R2P bitmask keeping positions < limit (exclusive upper bound)."""
     m = max((s + 1) * PREDICATE_MASK_CHUNK_SIZE - limit, 0)
     return utils.shr_u32(Uint32(0xFFFFFFFF), Uint32(m))
 
@@ -2347,6 +2557,20 @@ def apply_predicate_mask(
             else:
                 for r in cutlass.range_constexpr(cute.size(X.shape[0])):
                     X[r, c] = X[r, c] if in_bound else -Float32.inf
+
+
+@cute.jit
+def apply_interval_mask_r2p(acc_s: cute.Tensor, interval_start: Int32, interval_end: Int32) -> None:
+    """Keep [start, end) using one 32-bit predicate mask per register chunk."""
+    assert cute.size(acc_s) % PREDICATE_MASK_CHUNK_SIZE == 0
+    for s in cutlass.range_constexpr(cute.size(acc_s) // PREDICATE_MASK_CHUNK_SIZE):
+        below_end = predicate_bitmask_below(interval_end, s)
+        below_start = predicate_bitmask_below(interval_start, s)
+        mask = below_end & (below_start ^ Uint32(0xFFFFFFFF))
+        vals = mask_f32x32_by_u32_branch(acc_s, mask, s * PREDICATE_MASK_CHUNK_SIZE)
+        for i in cutlass.range_constexpr(PREDICATE_MASK_CHUNK_SIZE):
+            idx = s * PREDICATE_MASK_CHUNK_SIZE + i
+            acc_s[idx] = vals[i]
 
 
 @cute.jit

--- a/test/python/fe_api/bsa/test_BSA_attention_backward.py
+++ b/test/python/fe_api/bsa/test_BSA_attention_backward.py
@@ -208,3 +208,117 @@ def test_bsa_attention_backward_blk128_dk_zero_init_accumulate_transition(num_q_
     torch.testing.assert_close(backward["dk_tensor"].float(), dk_ref, atol=3e-2, rtol=3e-2)
     torch.testing.assert_close(backward["dq_tensor"].float(), dq_ref, atol=3e-2, rtol=3e-2)
     torch.testing.assert_close(backward["dv_tensor"].float(), dv_ref, atol=3e-2, rtol=3e-2)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=11)
+def test_bsa_attention_backward_blk128_exact_intervals_native_tail():
+    """Exact per-row intervals mask partial tiles and the physical K tail."""
+    if not torch.cuda.is_available():
+        pytest.skip("block sparse attention tests require CUDA")
+    major, _ = torch.cuda.get_device_capability()
+    if major not in {10, 11}:
+        pytest.skip("blk128 backward is specific to SM100/SM110")
+
+    BSA = _import_bsa()
+    block_size = 128
+    batch, heads, seqlen_q, seqlen_k, dim = 1, 1, 256, 230, 128
+    q = torch.randn((batch, heads, seqlen_q, dim), device="cuda", dtype=torch.bfloat16)
+    k = torch.randn((batch, heads, seqlen_k, dim), device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    do = torch.randn_like(q)
+
+    q2k = torch.tensor([0, 1], dtype=torch.int32, device="cuda").view(1, 1, 1, 2).expand(1, 1, 2, 2).contiguous()
+    q2k_nums = torch.full((1, 1, 2), 2, dtype=torch.int32, device="cuda")
+    block_sizes = torch.tensor([128, seqlen_k - 128], dtype=torch.int32, device="cuda")
+    bounds = torch.zeros((4, block_size), dtype=torch.int32, device="cuda")
+    sparse_flags = torch.empty((1, 2, 2), dtype=torch.int32, device="cuda")
+    dense_flags = torch.full((1, 1, 2, 2), -1, dtype=torch.int32, device="cuda")
+    mask = torch.full((seqlen_q, seqlen_k), float("-inf"), dtype=torch.float32, device="cuda")
+    for qb in range(2):
+        for kb in range(2):
+            partial = qb * 2 + kb
+            sparse_flags[0, qb, kb] = partial
+            dense_flags[0, 0, qb, kb] = partial
+            for row in range(block_size):
+                q_row = qb * block_size + row
+                hi_global = min(seqlen_k, 80 + q_row)
+                lo = 0
+                hi = max(0, min(block_size, hi_global - kb * block_size))
+                bounds[partial, row] = lo | (hi << 16)
+                if hi:
+                    mask[q_row, kb * block_size : kb * block_size + hi] = 0.0
+    mask = mask.view(1, 1, seqlen_q, seqlen_k)
+    _, _, dq_ref, dk_ref, dv_ref = attention_backward_reference(q, k, v, do, mask)
+
+    forward = BSA.block_sparse_attention_forward(
+        q,
+        k,
+        v,
+        q2k,
+        2,
+        block_sizes,
+        q2k_block_nums=q2k_nums,
+        sparse_block_size=block_size,
+        token_mask_bounds=bounds,
+        token_mask_flags=sparse_flags,
+        q_stage=1,
+    )
+    backward = BSA.block_sparse_attention_backward(
+        do,
+        q,
+        k,
+        v,
+        forward["o_tensor"],
+        forward["lse_tensor"],
+        q2k,
+        2,
+        None,
+        q2k_block_nums=q2k_nums,
+        sparse_block_size=block_size,
+        token_mask_bounds=bounds,
+        token_mask_flags=dense_flags,
+    )
+    torch.testing.assert_close(backward["dq_tensor"].float(), dq_ref, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(backward["dk_tensor"].float(), dk_ref, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(backward["dv_tensor"].float(), dv_ref, atol=3e-2, rtol=3e-2)
+
+    bounds_cpu = bounds.cpu()
+    inverse_cpu = torch.zeros((4, 2 * block_size), dtype=torch.int32)
+    for partial in range(4):
+        for k_row in range(block_size):
+            rows = []
+            for q_row in range(block_size):
+                packed = int(bounds_cpu[partial, q_row])
+                lo = packed & 0xFFFF
+                hi = (packed >> 16) & 0xFFFF
+                if lo <= k_row < hi:
+                    rows.append(q_row)
+            ranges = []
+            for row in rows:
+                if not ranges or row != ranges[-1][1]:
+                    ranges.append([row, row + 1])
+                else:
+                    ranges[-1][1] += 1
+            assert len(ranges) <= 2
+            for band, (lo, hi) in enumerate(ranges):
+                inverse_cpu[partial, 2 * k_row + band] = lo | (hi << 16)
+    inverse = inverse_cpu.cuda()
+    backward_inverse = BSA.block_sparse_attention_backward(
+        do,
+        q,
+        k,
+        v,
+        forward["o_tensor"],
+        forward["lse_tensor"],
+        q2k,
+        2,
+        None,
+        q2k_block_nums=q2k_nums,
+        sparse_block_size=block_size,
+        token_mask_bounds=inverse,
+        token_mask_flags=dense_flags,
+    )
+    torch.testing.assert_close(backward_inverse["dq_tensor"].float(), dq_ref, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(backward_inverse["dk_tensor"].float(), dk_ref, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(backward_inverse["dv_tensor"].float(), dv_ref, atol=3e-2, rtol=3e-2)

--- a/test/python/fe_api/bsa/test_BSA_attention_forward.py
+++ b/test/python/fe_api/bsa/test_BSA_attention_forward.py
@@ -585,3 +585,96 @@ def test_bsa_attention_forward_rejects_invalid_metadata():
             block_sizes,
             sparse_block_size=block_size,
         )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=16)
+def test_bsa_attention_forward_sm100_blk128_exact_token_mask():
+    major, _ = torch.cuda.get_device_capability()
+    if major not in (10, 11):
+        pytest.skip("blk128 exact masking is specific to SM100/SM110")
+
+    BSA = _import_bsa()
+    block_size = 128
+    batch, heads = 1, 2
+    seqlen_q, seqlen_k, dim = 2 * block_size, 4 * block_size, 128
+    q = torch.randn((batch, heads, seqlen_q, dim), device="cuda", dtype=torch.bfloat16)
+    k = torch.randn((batch, heads, seqlen_k, dim), device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    q2k, block_sparse_num, block_sizes = make_fixed_metadata(batch, heads, seqlen_q, seqlen_k, block_size)
+    mask = block_sparse_mask(q2k, block_sparse_num, block_sizes, seqlen_q, seqlen_k, block_size)
+    q_blocks = seqlen_q // block_size
+    flags = torch.full(
+        (batch, q_blocks, block_sparse_num),
+        -1,
+        device=q.device,
+        dtype=torch.int32,
+    )
+    bounds = torch.zeros((q_blocks, block_size), device=q.device, dtype=torch.int32)
+    for q_block in range(q_blocks):
+        flags[:, q_block, 1] = q_block
+        for q_row in range(block_size):
+            start = q_row // 2
+            end = min(start + 64, block_size)
+            bounds[q_block, q_row] = (end << 16) | start
+            query = q_block * block_size + q_row
+            mask[:, :, query, 2 * block_size : 3 * block_size] = float("-inf")
+            mask[:, :, query, 2 * block_size + start : 2 * block_size + end] = 0.0
+
+    result = BSA.block_sparse_attention_forward(
+        q,
+        k,
+        v,
+        q2k,
+        block_sparse_num,
+        block_sizes,
+        sparse_block_size=block_size,
+        token_mask_bounds=bounds,
+        token_mask_flags=flags,
+    )
+    o_ref, lse_ref = attention_reference(q, k, v, mask)
+    torch.testing.assert_close(result["o_tensor"].float(), o_ref, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(result["lse_tensor"], lse_ref, atol=2e-3, rtol=2e-3)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=17)
+def test_bsa_attention_forward_sm100_blk128_qstage2_structural_and_exact_mask():
+    major, _ = torch.cuda.get_device_capability()
+    if major not in (10, 11):
+        pytest.skip("blk128 q_stage=2 is specific to SM100/SM110")
+    BSA = _import_bsa()
+    block_size, q_tile = 128, 256
+    batch, heads, seqlen_q, seqlen_k, dim = 1, 2, 512, 512, 128
+    q = torch.randn((batch, heads, seqlen_q, dim), device="cuda", dtype=torch.bfloat16)
+    k = torch.randn((batch, heads, seqlen_k, dim), device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    q_blocks = seqlen_q // q_tile
+    selected = torch.tensor((0, 2), device=q.device, dtype=torch.int32)
+    q2k = selected.view(1, 1, 1, 2).expand(batch, heads, q_blocks, 2).contiguous()
+    block_sizes = torch.full((seqlen_k // block_size,), block_size, device=q.device, dtype=torch.int32)
+    structural_mask = torch.full((batch, heads, seqlen_q, seqlen_k), float("-inf"), device=q.device)
+    structural_mask[..., :block_size] = 0.0
+    structural_mask[..., 2 * block_size : 3 * block_size] = 0.0
+    structural = BSA.block_sparse_attention_forward(q, k, v, q2k, 2, block_sizes, sparse_block_size=block_size, q_stage=2)
+    o_ref, lse_ref = attention_reference(q, k, v, structural_mask)
+    torch.testing.assert_close(structural["o_tensor"].float(), o_ref, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(structural["lse_tensor"], lse_ref, atol=2e-3, rtol=2e-3)
+    flags = torch.full((batch, q_blocks, 2), -1, device=q.device, dtype=torch.int32)
+    flags[..., 1] = torch.arange(q_blocks, device=q.device, dtype=torch.int32)
+    bounds = torch.zeros((q_blocks, q_tile), device=q.device, dtype=torch.int32)
+    exact_mask = structural_mask.clone()
+    for q_block in range(q_blocks):
+        for q_row in range(q_tile):
+            start = q_row // 4
+            end = min(start + 64, block_size)
+            bounds[q_block, q_row] = (end << 16) | start
+            query = q_block * q_tile + q_row
+            exact_mask[:, :, query, 2 * block_size : 3 * block_size] = float("-inf")
+            exact_mask[:, :, query, 2 * block_size + start : 2 * block_size + end] = 0.0
+    exact = BSA.block_sparse_attention_forward(
+        q, k, v, q2k, 2, block_sizes, sparse_block_size=block_size, q_stage=2, token_mask_bounds=bounds, token_mask_flags=flags
+    )
+    o_ref, lse_ref = attention_reference(q, k, v, exact_mask)
+    torch.testing.assert_close(exact["o_tensor"].float(), o_ref, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(exact["lse_tensor"], lse_ref, atol=2e-3, rtol=2e-3)


### PR DESCRIPTION
Add Q-stage-2 forward execution, compact packed token bounds, R2P predicates, inverse backward masking, reusable K-to-Q metadata, and focused tests.

## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [  ] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches (see [root AGENTS.md § Reviewing a PR](https://github.com/NVIDIA/cudnn-frontend/blob/develop/AGENTS.md#reviewing-a-pr-human-or-agent)) and my changes comply, or I explain the exception below.
- [  ] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area
- FE OSS kernels or CuTeDSL

## Summary

  This PR adds optimized exact token-range masking to the SM100/SM110 blk128
  block-sparse attention forward and backward paths.

  The existing block-sparse topology continues to select physical KV blocks.
  Optional token-mask metadata can now further restrict selected blocks at token
  granularity using packed half-open intervals `[lo, hi)`.

  Highlights:

  - Compact mask metadata stored only for partial tiles.
  - A full-tile fast path that skips bounds loads and interval predicates.
  - Register-to-predicate masking using 32-bit predicate chunks.
  - Optional Q256 × K128 forward execution through `q_stage=2`.
  - Exact token masking in backward before probability reconstruction.
  - An optimized inverse two-band representation for backward traversal.
  - Optional reuse of prebuilt K-to-Q CSR metadata.
  - Optional reuse of forward output and LSE destination tensors.
  - Focused forward and backward correctness and validation tests.

  All new API arguments are optional. Existing callers continue to use the
  original behavior.

## Why

  Block-level sparsity cannot represent token boundaries that fall inside a
  selected sparse block. Applications currently need to pad, split blocks, or
  apply additional masking outside the block-sparse kernel.

  This change allows callers to retain coarse block-sparse topology while
  describing exact valid token ranges inside partial blocks.

  The representation is intentionally generic. It does not encode a particular
  attention pattern: callers construct sparse block lists and packed token
  intervals for masks that can be represented as contiguous ranges within each
  selected tile.

## Related issues

None currently 

## API and compatibility impact

The forward API appends the following optional keyword arguments:

  ```python
  token_mask_bounds=None
  token_mask_flags=None
  out=None
  lse=None
  q_stage=1

  The backward API appends:

  bucketed_k2q_offsets=None
  bucketed_k2q_indices=None
  token_mask_bounds=None
  token_mask_flags=None

  Compatibility notes:

  - Existing calls are unchanged.
  - Exact token masking is supported by the SM100/SM110 blk128 path.
  - q_stage=2 currently supports MHA.
  - Backward continues to require BF16 and MHA on the blk128 path.
  - Mask metadata must be int32, CUDA-resident, and on the same device as Q.

## Testing

  Focused block-sparse attention tests:

  ```bash
  cd test/python

  pytest \
    fe_api/bsa/test_BSA_attention_forward.py \
    fe_api/bsa/test_BSA_attention_backward.py \
    -q

  The tests cover:

  - Existing forward and backward behavior without token masking.
  - Full-tile and partial-tile execution.
  - Packed per-row token intervals.
  - Q128 and Q256 (q_stage=2) forward execution.
  - Forward output and LSE comparison against a dense reference.
  - Direct and inverse backward interval representations.
  - dQ, dK, and dV comparison against a dense reference.
  - Non-block-aligned sequence tails.
  - SM100/SM110 capability gating.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional token-level masking for block-sparse attention on supported hardware.
  * Added configurable query staging with one- or two-stage processing.
  * Added reusable output and log-sum-exp buffers for forward attention.
  * Added support for reusing prebuilt backward-attention mapping metadata.
* **Bug Fixes**
  * Improved handling of partial tiles, key-length tails, and interval-based masks.
* **Tests**
  * Added coverage for exact and inverse token masks, query staging, partial tiles, and backward gradients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->