### PR TITLE
test(torch_provider): guard the d256 aten-op test's backward too (fixes py_test sm80 red since #554)

### DIFF
--- a/test/python/sdpa/test_torch_provider.py
+++ b/test/python/sdpa/test_torch_provider.py
@@ -253,12 +253,18 @@ def test_d256_direct_aten_op():
     torch.manual_seed(0)
     q = torch.randn(2, 4, 384, 256, dtype=torch.bfloat16, device="cuda", requires_grad=True)
     k, v = torch.randn_like(q, requires_grad=True), torch.randn_like(q, requires_grad=True)
+    # Both directions must be servable: the forward may build while the
+    # BACKWARD graph is rejected at validate() (e.g. Ampere's native support
+    # surface caps the backward at d<=128 and runs before FROST routing, so
+    # the graph never reaches an OSS engine that could serve d=256). The
+    # frontend raises cudnnGraphNotSupportedError (a plain Exception, not a
+    # RuntimeError) for that, so catch both.
     try:
         out = torch.ops.aten._scaled_dot_product_cudnn_attention(q, k, v, None, True, 0.0, False)
-    except RuntimeError as e:
-        pytest.skip(f"no engine serves d=256 on this arch: {str(e).splitlines()[0][:80]}")
-    o = out[0]
-    o.backward(torch.ones_like(o))
+        o = out[0]
+        o.backward(torch.ones_like(o))
+    except (RuntimeError, cudnn.cudnnGraphNotSupportedError) as e:
+        pytest.skip(f"no engine serves d=256 fwd+bwd on this arch: {str(e).splitlines()[0][:80]}")
     o_ref, q_ref, _, _ = math_ref(q, k, v, False, None)
     o_ref.backward(torch.ones_like(o_ref))
     assert (o.float() - o_ref).abs().max().item() < 0.05

--- a/test/python/sdpa/test_torch_provider.py
+++ b/test/python/sdpa/test_torch_provider.py
@@ -250,21 +250,35 @@ def test_d256_direct_aten_op():
     """d=256: torch's C++ fused_sdp_choice still gates cuDNN to head_dim<=128,
     so F.sdpa cannot reach it — but the python path serves it through the aten
     op directly (what a fixed selection gate would dispatch to)."""
+    # Plan-time gates first, before any allocation (same floors as
+    # test_torch_ops.py's module gate): older stacks skip cleanly here rather
+    # than via a broad exception net below.
+    if torch.cuda.get_device_capability()[0] < 8:
+        pytest.skip("cuDNN SDPA requires sm80+")
+    if cudnn.backend_version() < 90600:
+        pytest.skip("requires cuDNN >= 9.6")
     torch.manual_seed(0)
     q = torch.randn(2, 4, 384, 256, dtype=torch.bfloat16, device="cuda", requires_grad=True)
     k, v = torch.randn_like(q, requires_grad=True), torch.randn_like(q, requires_grad=True)
     # Both directions must be servable: the forward may build while the
     # BACKWARD graph is rejected at validate() (e.g. Ampere's native support
     # surface caps the backward at d<=128 and runs before FROST routing, so
-    # the graph never reaches an OSS engine that could serve d=256). The
-    # frontend raises cudnnGraphNotSupportedError (a plain Exception, not a
-    # RuntimeError) for that, so catch both.
+    # the graph never reaches an OSS engine that could serve d=256 — #864).
+    # The frontend signals that with cudnnGraphNotSupportedError (a plain
+    # Exception, not a RuntimeError). A RuntimeError is a skip ONLY when it
+    # is the engine-selection rejection itself; anything else (allocation
+    # failures, autograd regressions) must surface as a failure.
     try:
         out = torch.ops.aten._scaled_dot_product_cudnn_attention(q, k, v, None, True, 0.0, False)
         o = out[0]
         o.backward(torch.ones_like(o))
-    except (RuntimeError, cudnn.cudnnGraphNotSupportedError) as e:
+    except cudnn.cudnnGraphNotSupportedError as e:
         pytest.skip(f"no engine serves d=256 fwd+bwd on this arch: {str(e).splitlines()[0][:80]}")
+    except RuntimeError as e:
+        msg = str(e).splitlines()[0]
+        if any(t in msg.lower() for t in ("not supported", "unsupported", "no valid engine", "no engine")):
+            pytest.skip(f"no engine serves d=256 fwd+bwd on this arch: {msg[:80]}")
+        raise
     o_ref, q_ref, _, _ = math_ref(q, k, v, False, None)
     o_ref.backward(torch.ones_like(o_ref))
     assert (o.float() - o_ref).abs().max().item() < 0.05


### PR DESCRIPTION
## Summary
`test/python/sdpa/test_torch_provider.py::test_d256_direct_aten_op` (added in #554) has been failing on Ampere in `py_test:rel:sm80` / `py_test:dev:sm80` on every PR since it merged (e.g. [job 421380222](https://gitlab-master.nvidia.com/cudnn/cudnn_frontend/-/jobs/421380222)):

```
cudnn._compiled_module.cudnnGraphNotSupportedError: Num hidden_dim should be less than or equal to 128 and hidden_dim should be multiple of 8
```

Two gaps in the test's skip guard:
- It wraps only the **forward** aten call. On Ampere the forward builds fine; the **backward** graph is what `validate()` rejects — Ampere falls into the native backward node's `d <= 128` branch (`scaled_dot_product_flash_attention.h`), and `pygraph.validate()` runs that C++ validation before any FROST routing, so the d=256 backward never reaches an OSS engine, with or without `CUDNN_FRONTEND_ENABLE_FROST_ENGINES=1` (verified both ways on an A100).
- It catches `RuntimeError`, but the frontend raises `cudnnGraphNotSupportedError`, which derives from `Exception`.

Fix: one guard around forward + backward, catching both, with a skip reason naming the arch gate. Verified on A100 (develop `22ed1b1fe`): the test now **skips** in both env modes; the whole `test_torch_provider.py` file is 16 passed / 1 skipped in the CI-like (no-FROST) env.

## Not in this PR
The underlying blind spot — the native support surface gating graphs that a FROST engine could serve (the SM80 backward row advertises `d <= 256`, so this exact d=256 case is servable) — is architectural (`pygraph.validate()` exempts only graphs with no native lowering or a caller-registered engine) and is tracked in #704, with #818 as the fix vehicle. Note this guard stays correct after #818: the `py_test` jobs run FROST-off, where classic C++ validation still applies; in a FROST-on run the test simply executes on the SM80 row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated d=256 direct ATen coverage to skip unsupported GPU architectures and cuDNN versions before allocation.
  * Tests continue to skip recognized cuDNN graph and engine-selection limitations while re-raising unrelated runtime failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
