### PR TITLE
frost(sdpa): SM80 backward THD + attention sinks, THD + deterministic dQ

### DIFF
--- a/python/cudnn/sdpa/bwd/api_dsl.py
+++ b/python/cudnn/sdpa/bwd/api_dsl.py
@@ -976,7 +976,7 @@ def _sm80_bwd_pad_last_dim(t: torch.Tensor, new_last: int) -> torch.Tensor:
 
 
 def _sm80_thd_backward(
-    q, k, v, o, do, lse, *, cu_q, cu_k, scale_softmax, is_causal, window_size, causal_bottom_right, sinks=None, deterministic=False, max_s_kv=None
+    q, k, v, o, do, lse, *, cu_q, cu_k, scale_softmax, is_causal, window_size, causal_bottom_right, sinks=None, deterministic=False, max_s_kv=None, max_s_q=None
 ):
     """THD / varlen backward: q/k/v/o/do are PACKED ``[1, T, H, D]`` (BSHD,
     B==1 — no transpose), ``lse`` is packed ``[1, H, T_q]`` (head-major,
@@ -990,12 +990,11 @@ def _sm80_thd_backward(
     The over-provisioned grid needs the longest per-sequence KV length:
     pass ``max_s_kv`` (any upper bound works — short tiles early-out) to keep
     the call fully async; without it the wrapper reads it from ``cu_k`` on
-    the HOST (a D2H sync — the wrapper-only Rule-3 residual).
+    the HOST (a D2H sync — the wrapper-only Rule-3 residual).  ``sinks``
+    ((H,) natural-log logits) adds a ``dsink_tensor`` output.  ``deterministic``
+    sizes the dQ relay counter from ``max_s_q`` (any upper bound on the
+    longest per-sequence Q length; the packed total when absent — no D2H).
     """
-    if sinks is not None:
-        raise NotImplementedError("SM80 THD bprop: attention sinks are dense-only")
-    if deterministic:
-        raise NotImplementedError("SM80 THD bprop: deterministic dQ is dense-only (no plan-time semaphore size under sym_int sq)")
     d_qk = q.shape[-1]
     d_v = v.shape[-1]
     h_q = q.shape[2]
@@ -1037,6 +1036,8 @@ def _sm80_thd_backward(
         is_causal=bool(is_causal),
         has_swa=has_swa,
         causal_bottom_right=bool(causal_bottom_right) and (bool(is_causal) or has_swa),
+        has_sink=sinks is not None,
+        deterministic=bool(deterministic),
         thd_varlen=True,
         sched_policy=_BWD_SCHED_NATURAL,  # LPT+THD is a future tweak
     )
@@ -1071,6 +1072,25 @@ def _sm80_thd_backward(
     dummy_i32 = torch.zeros(1, dtype=torch.int32, device=dev)
     dummy_f32 = torch.zeros(1, dtype=torch.float32, device=dev)
     c.do_dot(_fd_tvm(o), _fd_tvm(do), _fd_tvm(dot), _int32(h_q * t_q), stream)
+    dsink = None
+    if sinks is not None:
+        # Natural-log logits (the kernel applies log2e itself); one warp per
+        # (sequence, head) row over that sequence's tokens; zero-init target.
+        sinks_b = sinks.to(dtype=torch.float32, device=dev).reshape(h_q).contiguous()
+        dsink = torch.zeros(h_q, dtype=torch.float32, device=dev)
+        c.dsink(_fd_tvm(lse_t), _fd_tvm(dot), _fd_tvm(sinks_b), _fd_tvm(dsink), _fd_tvm(cu_q_t), _int32(n_seq * h_q), stream)
+    # Deterministic relay counter: one int32 per (sequence, head, q-tile),
+    # sized from the max_s_q hint (any upper bound) or, without one, from the
+    # packed total — host shape metadata, so no D2H read.  Fresh zeros every
+    # call: a stale counter deadlocks the relay's equality spin.
+    if deterministic:
+        q_bound = int(max_s_q) if max_s_q is not None else t_q
+        assert q_bound > 0, f"max_s_q must be > 0; got {q_bound}"
+        sem_q_stride = (q_bound + params.tile_q - 1) // params.tile_q
+        dq_sem = torch.zeros(n_seq * h_q * sem_q_stride, dtype=torch.int32, device=dev)
+    else:
+        sem_q_stride = 0
+        dq_sem = dummy_i32
     _sm80_bwd_call(
         c.main,
         q=q,
@@ -1089,14 +1109,14 @@ def _sm80_thd_backward(
         cu_q=cu_q_t,
         cu_k=cu_k_t,
         seq_q=dummy_i32,
-        dq_sem=dummy_i32,
+        dq_sem=dq_sem,
         n_q_tiles=(t_q + params.tile_q - 1) // params.tile_q,
         scale_log2=float(scale_softmax) * _BWD_LOG2E,
         attn_scale=float(scale_softmax),
         right_bound=right_bound,
         inv_scale=1.0 / float(scale_softmax),
         bias_bstride=0,
-        sem_q_stride=0,
+        sem_q_stride=sem_q_stride,
         grid_kv_tiles=(max_s_kv + params.tile_kv - 1) // params.tile_kv,
         grid_batch=n_seq,
         stream=stream,
@@ -1114,7 +1134,10 @@ def _sm80_thd_backward(
         dK_k = dK_k[..., :d_qk].contiguous()
     if pad_v:
         dV_k = dV_k[..., :d_v].contiguous()
-    return TupleDict(dq_tensor=dQ_k, dk_tensor=dK_k, dv_tensor=dV_k)
+    out = TupleDict(dq_tensor=dQ_k, dk_tensor=dK_k, dv_tensor=dV_k)
+    if dsink is not None:
+        out["dsink_tensor"] = dsink
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -1740,7 +1763,7 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
             # --- launch chain: do_dot → (dSink) → main → dQ cast → (GQA reduce)
             c.do_dot(_fd_tvm(O), _fd_tvm(dO), _fd_tvm(dot), _int32(b * hq * sq), launch_stream)
             if sink_tensor is not None:
-                c.dsink(_fd_tvm(lse), _fd_tvm(dot), _fd_tvm(sinks_b), _fd_tvm(dsink_acc), _int32(b * hq), launch_stream)
+                c.dsink(_fd_tvm(lse), _fd_tvm(dot), _fd_tvm(sinks_b), _fd_tvm(dsink_acc), _fd_tvm(cu_dummy), _int32(b * hq), launch_stream)
             _sm80_bwd_call(
                 c.main,
                 q=Q,
@@ -1818,6 +1841,7 @@ def sdpa_bwd_wrapper_sm80(
     cum_seqlen_k_tensor: Optional[torch.Tensor] = None,
     deterministic: bool = False,
     max_s_kv: Optional[int] = None,
+    max_s_q: Optional[int] = None,
 ) -> TupleDict:
     """SM80 (A100) SDPA backward.
 
@@ -1830,7 +1854,10 @@ def sdpa_bwd_wrapper_sm80(
 
     THD (``cum_seqlen_*``): pass ``max_s_kv`` (any upper bound on the
     longest per-sequence KV length) to keep the call fully async; without it
-    the wrapper reads the max from ``cu_k`` on the host (a D2H sync).
+    the wrapper reads the max from ``cu_k`` on the host (a D2H sync).  With
+    ``deterministic=True``, ``max_s_q`` (an upper bound on the longest
+    per-sequence Q length) sizes the dQ relay counter; the packed total is
+    used when absent.
     """
     # THD / varlen: q/k/v/o/dO are PACKED [1, T, H, D] (BSHD) + cu_seqlens;
     # lse is packed [1, H, T_q].  Dedicated path that skips the dense BHSD
@@ -1861,9 +1888,10 @@ def sdpa_bwd_wrapper_sm80(
                 sinks=sinks,
                 deterministic=deterministic,
                 max_s_kv=max_s_kv,
+                max_s_q=max_s_q,
             )
-    if max_s_kv is not None:
-        raise ValueError("max_s_kv is a THD grid hint; it requires cum_seqlen_q_tensor/cum_seqlen_k_tensor")
+    if max_s_kv is not None or max_s_q is not None:
+        raise ValueError("max_s_kv / max_s_q are THD hints; they require cum_seqlen_q_tensor/cum_seqlen_k_tensor")
     for nm, t in (("Q", q_tensor), ("V", v_tensor), ("O", o_tensor), ("dO", do_tensor)):
         if t.ndim != 4:
             raise ValueError(f"{nm} must be rank-4 BHSD; got {t.ndim}D")

--- a/python/cudnn/sdpa/bwd/api_dsl.py
+++ b/python/cudnn/sdpa/bwd/api_dsl.py
@@ -992,8 +992,11 @@ def _sm80_thd_backward(
     the call fully async; without it the wrapper reads it from ``cu_k`` on
     the HOST (a D2H sync — the wrapper-only Rule-3 residual).  ``sinks``
     ((H,) natural-log logits) adds a ``dsink_tensor`` output.  ``deterministic``
-    sizes the dQ relay counter from ``max_s_q`` (any upper bound on the
-    longest per-sequence Q length; the packed total when absent — no D2H).
+    sizes the dQ relay counter from ``max_s_q`` (an upper bound on the
+    longest per-sequence Q length, trimmed to the packed total; the packed
+    total when absent — no D2H).  Like ``max_s_kv``, the hint is a caller
+    contract: the wrapper cannot validate it without a D2H read, and an
+    undersized value indexes the relay counter out of bounds.
     """
     d_qk = q.shape[-1]
     d_v = v.shape[-1]
@@ -1084,7 +1087,12 @@ def _sm80_thd_backward(
     # packed total — host shape metadata, so no D2H read.  Fresh zeros every
     # call: a stale counter deadlocks the relay's equality spin.
     if deterministic:
-        q_bound = int(max_s_q) if max_s_q is not None else t_q
+        # The packed total bounds every per-sequence length, so an over-provisioned
+        # hint is trimmed to it; an UNDERSIZED hint is a contract violation the
+        # wrapper cannot detect without a D2H read of cu_q (same contract as
+        # max_s_kv) -- the relay indexes the counter by q-tile, so it would run
+        # off the end of dq_sem.
+        q_bound = min(int(max_s_q), t_q) if max_s_q is not None else t_q
         assert q_bound > 0, f"max_s_q must be > 0; got {q_bound}"
         sem_q_stride = (q_bound + params.tile_q - 1) // params.tile_q
         dq_sem = torch.zeros(n_seq * h_q * sem_q_stride, dtype=torch.int32, device=dev)
@@ -1608,6 +1616,9 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
         dbias_tensor: Optional[torch.Tensor] = None,
         rope_freqs: Optional[torch.Tensor] = None,
     ) -> None:
+        """Run the compiled SM80 backward on the adapter's carved workspace (Rule 1:
+        no per-call allocation; the dsink launch passes the dense dummy ``cu``).
+        """
         self._logger.debug("Entering execute")
         if self._compiled_kernel is None:
             raise RuntimeError("SdpaBwdDslSm80 is not compiled")
@@ -1857,7 +1868,10 @@ def sdpa_bwd_wrapper_sm80(
     the wrapper reads the max from ``cu_k`` on the host (a D2H sync).  With
     ``deterministic=True``, ``max_s_q`` (an upper bound on the longest
     per-sequence Q length) sizes the dQ relay counter; the packed total is
-    used when absent.
+    used when absent.  Both hints are caller contracts (validating them
+    would need the D2H read they exist to avoid): an undersized ``max_s_kv``
+    drops KV tiles, an undersized ``max_s_q`` indexes the relay counter out
+    of bounds.
     """
     # THD / varlen: q/k/v/o/dO are PACKED [1, T, H, D] (BSHD) + cu_seqlens;
     # lse is packed [1, H, T_q].  Dedicated path that skips the dense BHSD

--- a/python/cudnn/sdpa/bwd/config_sm80.py
+++ b/python/cudnn/sdpa/bwd/config_sm80.py
@@ -95,8 +95,9 @@ class TemplateParams:
     bias_broadcast: bool = True  # bias batch dim 1 (broadcast) vs B
     has_sink: bool = False  # sinks input => dSink output (standalone reduction)
     has_rope: bool = False
-    # Deterministic dQ: the kv-ordered gmem-semaphore relay (forces
-    # SCHED_DEFAULT; the semaphore is carved caller scratch).
+    # Deterministic dQ: the kv-ordered gmem-semaphore relay (requires
+    # SCHED_NATURAL; the semaphore is caller scratch — carved on the dense
+    # engine path, sized from max_s_q on the THD wrapper path).
     deterministic: bool = False
     # Packed varlen (wrapper-only today; the engine row declares thd=False).
     thd_varlen: bool = False
@@ -130,13 +131,8 @@ def validate_bwd_params(p: TemplateParams) -> None:
         raise ValueError("sm80 bwd: deterministic dQ requires SCHED_NATURAL (the kv-ordered semaphore relay)")
     if p.causal_bottom_right and not (p.is_causal or p.has_swa):
         raise ValueError("sm80 bwd: causal_bottom_right requires is_causal and/or has_swa (nothing to align otherwise)")
-    if p.thd_varlen and (p.has_bias or p.has_rope or p.has_sink or p.has_seq_kv_lens or p.has_seq_q_lens):
-        raise ValueError("sm80 bwd: THD carries lengths via cu_seqlens; bias / rope / sink / dense seq-lens are dense-only")
-    if p.thd_varlen and p.deterministic:
-        # The dQ-relay semaphore is sized at compile time from the dense sq;
-        # THD compiles sq as a dynamic sym_int so there is nothing to size it
-        # from (the FE support surface already rejects deterministic + ragged).
-        raise ValueError("sm80 bwd: deterministic dQ is dense-only (THD compiles sq dynamic; the relay semaphore has no plan-time size)")
+    if p.thd_varlen and (p.has_bias or p.has_rope or p.has_seq_kv_lens or p.has_seq_q_lens):
+        raise ValueError("sm80 bwd: THD carries lengths via cu_seqlens; bias / rope / dense seq-lens are dense-only")
 
 
 def bwd_params_for_flavor(flavor: str, **overrides) -> TemplateParams:

--- a/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
@@ -1250,36 +1250,48 @@ _do_dot_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 # ===========================================================================
 @cute.kernel
 def _dsink_kernel(
-    LSE: cute.Tensor,  # [B, H, SQ] fp32 (sink-aware, natural-log)
-    DO_DOT: cute.Tensor,  # [B, H, SQ] fp32
+    LSE: cute.Tensor,  # dense [B, H, SQ] fp32 (sink-aware, natural-log); THD packed [1, H, T_q]
+    DO_DOT: cute.Tensor,  # same shape, packed
     SINKS: cute.Tensor,  # [H] fp32 (natural-log sink logits)
     DSINK: cute.Tensor,  # [H] fp32 (atomicAdd target; zero-init)
-    SQ: cutlass.Constexpr[int],
-    n_bh: cutlass.Int32,  # B * H
+    CU_Q: cute.Tensor,  # THD: [n_seq + 1] int32 cumulative q seqlens; dense: 1-elem dummy
+    thd: cutlass.Constexpr[bool],
+    n_rows: cutlass.Int32,  # (B or n_seq) * H
 ):
     bx, _, _ = cute.arch.block_idx()
     tidx, _, _ = cute.arch.thread_idx()
     warp = tidx // 32
     lane = tidx % 32
-    row = bx * cutlass.Int32(_DODOT_WARPS) + warp  # = b*H + h
-    if row < n_bh:
+    row = bx * cutlass.Int32(_DODOT_WARPS) + warp  # = (batch | seq) * H + h
+    if row < n_rows:
         H = SINKS.shape[0]
         h = row % cutlass.Int32(H)
         b = row // cutlass.Int32(H)
         sink_h = Pointer(cutlass.make_array_view(SINKS).data_ptr() + h, dtype=cutlass.Float32).load()
-        base = row * cutlass.Int32(SQ)
-        # LSE is stride-aware (a graph Stats input may be any dense-compatible
-        # layout; compact strides fold to the packed math).  do_dot is an
-        # internal packed buffer.
-        lse_base = cutlass.Int64(b) * cutlass.Int64(LSE.stride[0]) + cutlass.Int64(h) * cutlass.Int64(LSE.stride[1])
+        SQ = cutlass.Int32(DO_DOT.shape[2])  # dense SQ, or the packed total T_q (dynamic)
+        # One warp per (batch | sequence, head) row: under THD the row covers the
+        # sequence's tokens [cu_q[b], cu_q[b+1]) of the packed [1, H, T_q]
+        # buffers (head stride T_q), so gap tokens are never read.  LSE is
+        # stride-aware on the dense path; do_dot is an internal packed buffer.
+        if cutlass.const_expr(thd):
+            cu_p = cutlass.make_array_view(CU_Q).data_ptr()
+            q_lo = Pointer(cu_p + b, dtype=cutlass.Int32).load()
+            n_q = Pointer(cu_p + b + cutlass.Int32(1), dtype=cutlass.Int32).load() - q_lo
+            base = cutlass.Int64(h) * cutlass.Int64(SQ) + cutlass.Int64(q_lo)
+            lse_base = cutlass.Int64(h) * cutlass.Int64(LSE.stride[1]) + cutlass.Int64(q_lo) * cutlass.Int64(LSE.stride[2])
+        else:
+            n_q = SQ
+            base = cutlass.Int64(row) * cutlass.Int64(SQ)
+            lse_base = cutlass.Int64(b) * cutlass.Int64(LSE.stride[0]) + cutlass.Int64(h) * cutlass.Int64(LSE.stride[1])
         lse_p = cutlass.make_array_view(LSE).data_ptr()
         dot_p = cutlass.make_array_view(DO_DOT).data_ptr()
         acc = cutlass.Float32(0.0)
-        for k in cutlass.range_constexpr((SQ + 31) // 32):
-            q = lane + cutlass.Int32(k * 32)
-            if q < cutlass.Int32(SQ):
+        n_chunks = (n_q + cutlass.Int32(31)) // cutlass.Int32(32)
+        for kk in cutlass.range(n_chunks, unroll=1):
+            q = lane + kk * cutlass.Int32(32)
+            if q < n_q:
                 lse_q = Pointer(lse_p + lse_base + cutlass.Int64(q) * cutlass.Int64(LSE.stride[2]), dtype=cutlass.Float32).load()
-                dd_q = Pointer(dot_p + base + q, dtype=cutlass.Float32).load()
+                dd_q = Pointer(dot_p + base + cutlass.Int64(q), dtype=cutlass.Float32).load()
                 # Padded / fully-masked q-rows have LSE = -inf (forward writes -inf
                 # for an empty softmax denom).  exp2((sink - (-inf))·log2e) = +inf →
                 # NaN dSink.  Those rows don't exist (or attend nothing) → contribute
@@ -1515,12 +1527,13 @@ def _dsink_host(
     DO_DOT: cute.Tensor,
     SINKS: cute.Tensor,
     DSINK: cute.Tensor,
-    SQ: cutlass.Constexpr[int],
-    n_bh: cutlass.Int32,
+    CU_Q: cute.Tensor,
+    thd: cutlass.Constexpr[bool],
+    n_rows: cutlass.Int32,
     stream: cuda.CUstream,
 ):
-    n_blocks = (n_bh + _DODOT_WARPS - 1) // _DODOT_WARPS
-    _dsink_kernel(LSE, DO_DOT, SINKS, DSINK, SQ, n_bh).launch(grid=(n_blocks, 1, 1), block=(_DODOT_WARPS * 32, 1, 1), stream=stream)
+    n_blocks = (n_rows + _DODOT_WARPS - 1) // _DODOT_WARPS
+    _dsink_kernel(LSE, DO_DOT, SINKS, DSINK, CU_Q, thd, n_rows).launch(grid=(n_blocks, 1, 1), block=(_DODOT_WARPS * 32, 1, 1), stream=stream)
 
 
 # ===========================================================================
@@ -1646,11 +1659,17 @@ def compile(  # noqa: A001 — the template contract's entry point
     else:
         _b, _sq, _skv = b, sq, skv
         n_seq = b
-    # Deterministic-dQ relay counter stride: ceil(max_SQ / tile_q). THD +
-    # deterministic is rejected upstream (the FE support surface), so the
-    # dense sq is always real here when deterministic is on.
-    sem_q_stride = ((sq + p.tile_q - 1) // p.tile_q) if p.deterministic else 0
-    sem_units = max(n_seq * h * sem_q_stride, 1)
+    # Deterministic-dQ relay counter stride: ceil(max_SQ / tile_q) — from the
+    # dense sq here, or caller-owned under THD (see below).
+    if p.deterministic and p.thd_varlen:
+        # The packed extents are dynamic, so the relay counter's size is the
+        # caller's: it passes sem_q_stride = ceil(max_s_q / tile_q) at launch
+        # and a DQ_SEM of n_seq * h * sem_q_stride (compiled as a sym extent).
+        sem_q_stride = 0
+        sem_units = None
+    else:
+        sem_q_stride = ((sq + p.tile_q - 1) // p.tile_q) if p.deterministic else 0
+        sem_units = max(n_seq * h * sem_q_stride, 1)
 
     def _fake(dtype, shape, order, align=16):
         return cute.runtime.make_fake_compact_tensor(dtype, shape, stride_order=order, assumed_align=align)
@@ -1680,7 +1699,7 @@ def compile(  # noqa: A001 — the template contract's entry point
     fcuq = _fake(cutlass.Int32, (_cu_len,), (0,), align=4)
     fcuk = _fake(cutlass.Int32, (_cu_len,), (0,), align=4)
     fsq = _fake(cutlass.Int32, (b if p.has_seq_q_lens else 1,), (0,), align=4)
-    fsem = _fake(cutlass.Int32, (sem_units,), (0,), align=4)
+    fsem = _fake(cutlass.Int32, (cute.sym_int(divisibility=1) if sem_units is None else sem_units,), (0,), align=4)
     fstream = cuda.CUstream(0)
 
     main = cute.compile(
@@ -1747,5 +1766,5 @@ def compile(  # noqa: A001 — the template contract's entry point
     if p.has_sink:
         fsinks = _fake(cutlass.Float32, (h,), (0,), align=4)
         fdsink = _fake(cutlass.Float32, (h,), (0,), align=4)
-        dsink = cute.compile(_dsink_host, fl, fdt, fsinks, fdsink, sq, cutlass.Int32(0), fstream, options="--enable-tvm-ffi")
+        dsink = cute.compile(_dsink_host, fl, fdt, fsinks, fdsink, fcuq, bool(p.thd_varlen), cutlass.Int32(0), fstream, options="--enable-tvm-ffi")
     return CompiledBwd(main=main, do_dot=do_dot, cast=cast, reduce_k=reduce_k, reduce_v=reduce_v, dsink=dsink, sem_q_stride=sem_q_stride)

--- a/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
@@ -1258,6 +1258,10 @@ def _dsink_kernel(
     thd: cutlass.Constexpr[bool],
     n_rows: cutlass.Int32,  # (B or n_seq) * H
 ):
+    """dSink[h] = -sum_rows exp(sink[h] - LSE) * (dO . O), one warp per (batch|sequence, head)
+    row.  Dense rows span ``SQ``; THD rows span ``[cu_q[b], cu_q[b+1])`` of the packed
+    ``[1, H, T_q]`` buffers with a runtime trip count.  ``-inf`` LSE rows contribute 0.
+    """
     bx, _, _ = cute.arch.block_idx()
     tidx, _, _ = cute.arch.thread_idx()
     warp = tidx // 32
@@ -1532,6 +1536,7 @@ def _dsink_host(
     n_rows: cutlass.Int32,
     stream: cuda.CUstream,
 ):
+    """Host launcher for :func:`_dsink_kernel`: ``n_rows`` = (batch|n_seq) * H warps."""
     n_blocks = (n_rows + _DODOT_WARPS - 1) // _DODOT_WARPS
     _dsink_kernel(LSE, DO_DOT, SINKS, DSINK, CU_Q, thd, n_rows).launch(grid=(n_blocks, 1, 1), block=(_DODOT_WARPS * 32, 1, 1), stream=stream)
 

--- a/test/python/fe_api/sdpa/test_sdpa_bwd_sm80.py
+++ b/test/python/fe_api/sdpa/test_sdpa_bwd_sm80.py
@@ -800,6 +800,7 @@ def test_sm80_bwd_thd_sinks_deterministic_compile_key():
     from cudnn.frost import template_loader
 
     def cache_totals():
+        """(misses, hits) summed over the loaded bprop template modules' compile caches."""
         mods = [m for (path, _params), m in template_loader._MODULES.items() if "bprop" in str(path)]
         infos = [m.compile.cache_info() for m in mods if hasattr(m.compile, "cache_info")]
         return sum(i.misses for i in infos), sum(i.hits for i in infos)

--- a/test/python/fe_api/sdpa/test_sdpa_bwd_sm80.py
+++ b/test/python/fe_api/sdpa/test_sdpa_bwd_sm80.py
@@ -47,8 +47,11 @@ def _bshd_randn(b, h, s, d, **kw):
     return torch.randn((b, s, h, d), **kw).permute(0, 2, 1, 3)
 
 
-def _ref_grads(q, k, v, do, *, is_causal, window_left, scale, causal_bottom_right=False):
-    """fp32 autograd reference; returns (o, dq, dk, dv).
+def _ref_grads(q, k, v, do, *, is_causal, window_left, scale, causal_bottom_right=False, sink=None):
+    """fp32 autograd reference; returns (o, dq, dk, dv) — or (o, dq, dk, dv,
+    dsink) when ``sink`` ((H,) fp32 natural-log logits) is given: one extra
+    softmax column per head that absorbs probability mass and contributes
+    nothing to ``o``.
 
     Mask semantics mirror the kernel's ``_mask_p``: the diagonal anchor is
     ``q`` (top-left) or ``q + (s_kv - s_q)`` (bottom-right); causal keeps
@@ -60,6 +63,7 @@ def _ref_grads(q, k, v, do, *, is_causal, window_left, scale, causal_bottom_righ
     q_ref = q.detach().to(torch.float32).requires_grad_()
     k_ref = k.detach().to(torch.float32).requires_grad_()
     v_ref = v.detach().to(torch.float32).requires_grad_()
+    sink_ref = sink.detach().to(torch.float32).requires_grad_() if sink is not None else None
 
     k_exp = k_ref.repeat_interleave(g, dim=1)
     v_exp = v_ref.repeat_interleave(g, dim=1)
@@ -74,9 +78,15 @@ def _ref_grads(q, k, v, do, *, is_causal, window_left, scale, causal_bottom_righ
         if window_left >= 0:
             keep &= (anchor - j) <= window_left
         scores = scores.masked_fill(~keep, float("-inf"))
-    probs = torch.softmax(scores, dim=-1)
+    if sink_ref is not None:
+        col = sink_ref.view(1, h_q, 1, 1).expand(scores.shape[0], h_q, s_q, 1)
+        probs = torch.softmax(torch.cat([scores, col], dim=-1), dim=-1)[..., :s_kv]
+    else:
+        probs = torch.softmax(scores, dim=-1)
     o = torch.matmul(probs, v_exp)
     o.backward(do.to(torch.float32))
+    if sink_ref is not None:
+        return o.detach(), q_ref.grad, k_ref.grad, v_ref.grad, sink_ref.grad
     return o.detach(), q_ref.grad, k_ref.grad, v_ref.grad
 
 
@@ -252,7 +262,7 @@ def test_sdpa_bwd_sm80_d64_fast_path(monkeypatch):
     torch.testing.assert_close(dv_d.float(), dv_g.float(), rtol=2e-2, atol=2e-2)
 
 
-def _thd_run_and_check(lens, h, d_qk, d_v, *, check_grads=True, window_left=-1):
+def _thd_run_and_check(lens, h, d_qk, d_v, *, check_grads=True, window_left=-1, sinks=None, deterministic=False, max_s_q=None):
     """Run the THD fwd+bwd wrappers on packed random inputs; when
     ``check_grads``, compare each sequence's dQ/dK/dV slice against the dense
     fp32 autograd reference (the existing ``_ref_grads`` pattern)."""
@@ -268,11 +278,27 @@ def _thd_run_and_check(lens, h, d_qk, d_v, *, check_grads=True, window_left=-1):
     v = torch.randn(1, t, h, d_v, dtype=torch.float16, device="cuda")
     do = torch.randn(1, t, h, d_v, dtype=torch.float16, device="cuda")
     window = (window_left, 0)
-    fwd = sdpa_fwd_wrapper_sm80(q, k, v, is_causal=True, window_size=window, cum_seqlen_q_tensor=cu, cum_seqlen_k_tensor=cu, max_s_q=int(max(lens)))
+    fwd = sdpa_fwd_wrapper_sm80(
+        q, k, v, is_causal=True, window_size=window, sinks=sinks, cum_seqlen_q_tensor=cu, cum_seqlen_k_tensor=cu, max_s_q=int(max(lens))
+    )
+    extra = {"max_s_q": max_s_q} if max_s_q is not None else {}
     out = sdpa_bwd_wrapper_sm80(
-        q, k, v, fwd["o_tensor"], do, fwd["lse_tensor"], is_causal=True, window_size=window, cum_seqlen_q_tensor=cu, cum_seqlen_k_tensor=cu
+        q,
+        k,
+        v,
+        fwd["o_tensor"],
+        do,
+        fwd["lse_tensor"],
+        is_causal=True,
+        window_size=window,
+        sinks=sinks,
+        deterministic=deterministic,
+        cum_seqlen_q_tensor=cu,
+        cum_seqlen_k_tensor=cu,
+        **extra,
     )
     if check_grads:
+        dsink_sum = torch.zeros(h, dtype=torch.float32, device="cuda") if sinks is not None else None
         for i in range(len(lens)):
             lo, hi = int(cu[i]), int(cu[i + 1])
 
@@ -280,12 +306,18 @@ def _thd_run_and_check(lens, h, d_qk, d_v, *, check_grads=True, window_left=-1):
             def _bhsd(x, _lo=lo, _hi=hi):
                 return x[0, _lo:_hi].permute(1, 0, 2).unsqueeze(0)
 
-            _, dq_ref, dk_ref, dv_ref = _ref_grads(
-                _bhsd(q), _bhsd(k), _bhsd(v), _bhsd(do), is_causal=True, window_left=window_left, scale=1.0 / math.sqrt(d_qk)
-            )
+            refs = _ref_grads(_bhsd(q), _bhsd(k), _bhsd(v), _bhsd(do), is_causal=True, window_left=window_left, scale=1.0 / math.sqrt(d_qk), sink=sinks)
+            _, dq_ref, dk_ref, dv_ref = refs[:4]
             torch.testing.assert_close(_bhsd(out["dq_tensor"]).to(torch.float32), dq_ref, rtol=3e-2, atol=3e-2)
             torch.testing.assert_close(_bhsd(out["dk_tensor"]).to(torch.float32), dk_ref, rtol=3e-2, atol=3e-2)
             torch.testing.assert_close(_bhsd(out["dv_tensor"]).to(torch.float32), dv_ref, rtol=3e-2, atol=3e-2)
+            if sinks is not None:
+                dsink_sum += refs[4]
+        if sinks is not None:
+            # dSink sums over every sequence's tokens; a NONZERO reference is
+            # required so an all-zero kernel result cannot pass.
+            assert dsink_sum.abs().max().item() > 0
+            torch.testing.assert_close(out["dsink_tensor"], dsink_sum, rtol=3e-2, atol=3e-2 * max(1.0, dsink_sum.abs().max().item()))
     return out
 
 
@@ -682,3 +714,108 @@ def test_sm80_bwd_swa_deterministic(bottom_right, s_q, s_kv):
     _, dq_ref, _, _ = _ref_grads(q, k, v, do, is_causal=True, window_left=w, scale=scale, causal_bottom_right=bottom_right)
     torch.testing.assert_close(a["dq_tensor"].to(torch.float32), dq_ref, rtol=3e-2, atol=3e-2)
     torch.testing.assert_close(a["dq_tensor"].to(torch.float32), nd["dq_tensor"].to(torch.float32), rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_sm80_bwd_thd_sinks():
+    """THD + attention sinks: dQ/dK/dV per sequence against the sink-aware
+    reference, and dSink (H,) against the sum of the per-sequence sink grads
+    (the reduction runs over each packed sequence's own tokens)."""
+    sinks = torch.randn(4, dtype=torch.float32, device="cuda")
+    try:
+        _thd_run_and_check([96, 320, 160], h=4, d_qk=128, d_v=128, sinks=sinks)
+    except ImportError as e:
+        pytest.skip(f"SM80 SDPA API not available: {e}")
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_sm80_bwd_thd_deterministic():
+    """THD + deterministic dQ: correct against the reference, bitwise
+    repeatable, and identical whether the relay semaphore is sized from an
+    exact max_s_q hint, an over-provisioned one, or (no hint) the packed
+    total."""
+    lens = [96, 640, 160]
+    try:
+        a = _thd_run_and_check(lens, h=4, d_qk=128, d_v=128, deterministic=True)
+    except ImportError as e:
+        pytest.skip(f"SM80 SDPA API not available: {e}")
+    torch.manual_seed(0)
+    b = _thd_run_and_check(lens, h=4, d_qk=128, d_v=128, deterministic=True, check_grads=False, max_s_q=max(lens))
+    torch.manual_seed(0)
+    c = _thd_run_and_check(lens, h=4, d_qk=128, d_v=128, deterministic=True, check_grads=False, max_s_q=sum(lens))
+    for key in ("dq_tensor", "dk_tensor", "dv_tensor"):
+        assert torch.equal(a[key], b[key]), key
+        assert torch.equal(a[key], c[key]), key
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_sm80_bwd_dense_sinks():
+    """Dense attention sinks through the wrapper -> adapter -> dSink kernel:
+    dQ/dK/dV and dSink (H,) against the sink-aware reference (dSink sums over
+    the batch, as the reference's shared sink leaf does)."""
+    try:
+        from cudnn.sdpa.bwd import sdpa_bwd_wrapper_sm80
+        from cudnn.sdpa.fwd import sdpa_fwd_wrapper_sm80
+    except ImportError as e:
+        pytest.skip(f"SM80 SDPA API not available: {e}")
+
+    b, h, s, d = 2, 4, 512, 128
+    scale = 1.0 / math.sqrt(d)
+    q = _bshd_randn(b, h, s, d, dtype=torch.float16, device="cuda")
+    k = _bshd_randn(b, h, s, d, dtype=torch.float16, device="cuda")
+    v = _bshd_randn(b, h, s, d, dtype=torch.float16, device="cuda")
+    do = _bshd_randn(b, h, s, d, dtype=torch.float16, device="cuda")
+    sinks = torch.randn(h, dtype=torch.float32, device="cuda")
+    fwd = sdpa_fwd_wrapper_sm80(q_tensor=q, k_tensor=k, v_tensor=v, is_causal=True, sinks=sinks, scale_softmax=scale)
+    out = sdpa_bwd_wrapper_sm80(
+        q_tensor=q,
+        k_tensor=k,
+        v_tensor=v,
+        o_tensor=fwd["o_tensor"],
+        do_tensor=do,
+        lse_tensor=fwd["lse_tensor"],
+        is_causal=True,
+        sinks=sinks,
+        scale_softmax=scale,
+    )
+    _, dq_ref, dk_ref, dv_ref, dsink_ref = _ref_grads(q, k, v, do, is_causal=True, window_left=-1, scale=scale, sink=sinks)
+    torch.testing.assert_close(out["dq_tensor"].to(torch.float32), dq_ref, rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(out["dk_tensor"].to(torch.float32), dk_ref, rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(out["dv_tensor"].to(torch.float32), dv_ref, rtol=3e-2, atol=3e-2)
+    assert dsink_ref.abs().max().item() > 0
+    torch.testing.assert_close(out["dsink_tensor"], dsink_ref, rtol=3e-2, atol=3e-2 * max(1.0, dsink_ref.abs().max().item()))
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_sm80_bwd_thd_sinks_deterministic_compile_key():
+    """Rule 4 for the two new THD specializations: sinks and deterministic each
+    mint exactly one bprop template compile (a new parameter set), and then
+    re-bind across different token totals — and, for deterministic, a
+    different max_s_q — without a new compile: neither T_q nor the relay
+    counter's size is part of the key."""
+    from cudnn.frost import template_loader
+
+    def cache_totals():
+        mods = [m for (path, _params), m in template_loader._MODULES.items() if "bprop" in str(path)]
+        infos = [m.compile.cache_info() for m in mods if hasattr(m.compile, "cache_info")]
+        return sum(i.misses for i in infos), sum(i.hits for i in infos)
+
+    sinks = torch.randn(4, dtype=torch.float32, device="cuda")
+    try:
+        _thd_run_and_check([96, 160], h=4, d_qk=128, d_v=128, sinks=sinks, check_grads=False)
+    except ImportError as e:
+        pytest.skip(f"SM80 SDPA API not available: {e}")
+    m0, h0 = cache_totals()
+    _thd_run_and_check([64, 256], h=4, d_qk=128, d_v=128, sinks=sinks, check_grads=False)  # same n_seq, other totals
+    m1, h1 = cache_totals()
+    assert m1 == m0 and h1 > h0, "THD+sinks re-bind must be a pure cache hit"
+
+    _thd_run_and_check([96, 160], h=4, d_qk=128, d_v=128, deterministic=True, check_grads=False, max_s_q=160)
+    m2, h2 = cache_totals()
+    _thd_run_and_check([64, 256], h=4, d_qk=128, d_v=128, deterministic=True, check_grads=False, max_s_q=512)  # other totals AND max_s_q
+    m3, h3 = cache_totals()
+    assert m3 == m2 and h3 > h2, "THD+deterministic re-bind (different totals and max_s_q) must be a pure cache hit"


### PR DESCRIPTION
## Summary
Lifts the two remaining THD feature gates on the SM80 backward wrapper path (`sdpa_bwd_wrapper_sm80` with `cum_seqlen_*`): **attention sinks** and **deterministic dQ**. Engine-path (graph) ragged routing is *not* in this PR — it depends on #704 / #818.

## Why
Post-#765/#766 the SM80 backward serves THD for plain varlen attention only; sinks and deterministic raised `NotImplementedError`. Both are device-side-ready already — the gaps were a compile-time-bounded dSink loop and a compile-time-sized relay counter.

## Changes
- **dSink kernel** (`bprop_f16_sm80.py`): takes `cu_seqlens_q`; under THD one warp per (sequence, head) row sums that sequence's tokens of the packed `[1, H, T_q]` LSE/do_dot buffers with a runtime trip count (the packed total is a `sym_int`). Dense keeps `row = b·H + h` and now reads `SQ` from the buffer shape. The main kernel is untouched (P is recomputed from the sink-aware LSE).
- **Deterministic relay under THD**: the device relay was already THD-agnostic; `compile()` now builds a sym-extent `DQ_SEM` fake under `thd_varlen and deterministic`, and the wrapper sizes the counter from a `max_s_q` hint (any upper bound) or, absent one, the packed total `T_q` — host shape metadata, **no D2H read** (Rule 3). Fresh zeros per call. `max_s_q` is appended after `max_s_kv` (append-only); the dense path rejects both hints.
- **Validator**: `thd_varlen` no longer excludes `has_sink` or `deterministic`; stale "rejected by the FE support surface" comments corrected.

## Rule notes
- Rule 1/5: new allocations (dsink zeros, relay counter, fp32 sink copy) are wrapper-path only; `SdpaBwdDslSm80.execute` is unchanged (its dsink launch gains the dummy `cu` arg for the new ABI).
- Rule 3: no new host reads — the deterministic fallback bound is `q.shape[1]`. The only D2H on this path remains the documented hint-less `max_s_kv` case.
- Rule 4: compile-key test proves sinks / deterministic each mint one bprop compile and then re-bind across token totals and `max_s_q`.
- Rule S1: the THD LSE contract stays packed head-major `[1, H, T_q]`; dSink addresses it as `h·stride[1] + cu_q[b]`, identical to the main kernel.
- dSink accumulates across sequences via atomics (as the dense path does across batch), so bitwise-repeatability claims are scoped to dQ/dK/dV.

## Tests (A100, `test/python/fe_api/sdpa/test_sdpa_bwd_sm80.py`)
- `test_sm80_bwd_thd_sinks` — per-sequence dQ/dK/dV vs the sink-aware reference; dSink vs the **nonzero** sum of per-sequence sink grads (guards the silent-zero failure mode of a compile-time-bounded loop).
- `test_sm80_bwd_thd_deterministic` — reference, bitwise repeatable, identical for exact / over-provisioned / absent `max_s_q`.
- `test_sm80_bwd_dense_sinks` — the dense wrapper → adapter → dSink path (ABI changed).
- `test_sm80_bwd_thd_sinks_deterministic_compile_key` — Rule 4.
- Red-first: both THD tests failed at the wrapper gates (`NotImplementedError`, `api_dsl.py:996/998`) before the change. Full backward file at L0–L2 green; integration + stream-respect suites 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added sink-gradient support for dense and variable-length (THD) attention backward passes.
  - Added deterministic backward execution for supported THD and sliding-window workloads.
  - Added sliding-window attention support, including causal and bottom-right alignment.
  - Added `max_s_q` as an optional sizing hint for THD execution.

- **Bug Fixes**
  - Improved handling of masked tiles and long-sequence sliding-window cases.
  - Expanded validation and gradient coverage across sink, deterministic, causal, and variable-length configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
