### PR TITLE
Mark Handle sketch as a text code fence

### DIFF
--- a/docs/handle_first_class_design.md
+++ b/docs/handle_first_class_design.md
@@ -73,7 +73,7 @@ becomes one consumer rather than the anchor.
 
 ## `Handle`
 
-```
+```text
 class Handle:
     backend_handle: int | None  # the wrapped cudnnHandle_t; None = pure-python (future)
     _ordinal: int | None        # CUDA device ordinal this handle is bound to


### PR DESCRIPTION
## Summary
- Change the `Handle` sketch in `docs/handle_first_class_design.md` from an untyped fence to ` ```text `.

## Why
- Downstream Sphinx/MyST docs builds treat untyped fences as C++. This sketch uses `#` comments, which fail highlighting (`misc.highlighting_failure`) when warnings are treated as errors.

## Validation
- Confirmed the equivalent change unblocks the published-docs build for frontend v1.28.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the `Handle` code example with text syntax highlighting for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->