### PR TITLE
frost: python-native validate() per engine family (SDPA, GEMM) — defer the C++ lowering when a python engine is a candidate; fixes it exposes on SM80 bwd and SM100 FP8

### DIFF
--- a/docs/python_graph_and_execution_backends.md
+++ b/docs/python_graph_and_execution_backends.md
@@ -32,7 +32,9 @@ configs or place it against the backend.
 ```text
 create_execution_plans([heur_mode.A, ...])                    _pygraph.py
 │
-├─ validate()                    lowers + freezes any graph the backend CAN lower
+├─ validate()                    family declares a validator AND a python engine is
+│                                a candidate → native semantic validation (no lowering);
+│                                otherwise lowers + freezes any graph the backend CAN lower
 ├─ _finalize_backend_layout()    backend layout inference lands, or records a decline
 ├─ _freeze()                     whole public surface sealed
 ├─ _attach_facts()               family_for → resolve_analyzer → ONE parse, hung on the graph
@@ -369,6 +371,18 @@ without being imported. Everything else is the engine's own `check_support()`.
   `("module", "callable")` pair kept as strings so the coarse key stays
   import-free. It is handed the facts, the family's offered ids and the
   backend's entries, and what it returns IS the plan list.
+- **A family may name a `validator` hook** — the same import-free pair,
+  `validate_graph(graph) -> bool`. When the manifest offers a python engine for
+  the graph, `validate()` runs it instead of the eager C++ lowering: it applies
+  the family's version- and arch-agnostic semantic rules with the classic error
+  types, and returns False (classic lowering) for a graph holding a node it does
+  not cover. It exists because the eager lowering coupled a graph a python
+  engine fully serves to the installed backend's version and per-arch gates
+  (issue #704); the backend's own verdict is not lost, only deferred to planning
+  (`_finalize_backend_layout` records the decline, `plan()` raises it if no
+  python engine proposes a plan either). A family without one validates
+  classically. `cudnn/_sdpa_validate.py` and `cudnn/_gemm_validate.py` are the
+  two today; both import only the IR.
 - **There is no registration call.** The manifest is the only way a python
   engine exists, and `_candidate_engines()` is the graph's family and nothing
   else. An engine handed over at runtime could never be ranked anyway: it
@@ -430,7 +444,8 @@ only to decline is why `closed_under` existed.
   `import cudnn.sdpa.graph_analyzer` costs 9 ms and 2 modules rather than
   1059 ms and 381.
 - The graph API pulls no framework at all: describing and validating a graph
-  imports neither torch nor cutlass.
+  imports neither torch nor cutlass — the family validators included (they see
+  only the IR).
 - A missing or too-old DSL is a DECLINE at `check_support()`, probed without
   executing the module (`importlib.util.find_spec`, `importlib.metadata`).
   `CUTEDSL_MIN_VERSION` in `frost/buffers.py` is the floor these engines want;
@@ -528,17 +543,22 @@ only to decline is why `closed_under` existed.
   `Tensor`/`Node`/`GraphContext`, dict writes on node ports/params
   (MappingProxy), in-place dim/stride edits (sealed to tuples). Inspection
   stays fully readable. `validate()` lowers and freezes any graph the backend
-  CAN lower (classic error timing), so the mutable-after-validate window is
-  exactly the ops with no backend node (GDN/KDA/…); a mutation in it
-  invalidates the validation. Planning freezes BEFORE it analyses, so facts
-  never describe a graph that can still change.
+  CAN lower (classic error timing) unless the graph's family validated it
+  natively (see *The manifest*), so the mutable-after-validate window is the ops
+  with no backend node (GDN/KDA/…) plus natively validated graphs; a mutation in
+  it invalidates the validation and drops the cached candidate list. Planning
+  freezes BEFORE it analyses, so facts never describe a graph that can still
+  change.
 - **Output layout contract**: only USER-assigned output dim/stride are pushed
   to the lowered graph; IR-inferred strides are provisional (row-major) and
   the backend keeps its classic per-op layout inference (e.g. channels-last
   conv). A unified layout resolver across python/cuDNN candidates belongs to
   the heuristics follow-up.
 - **Classic parity**: the public `cudnn.pygraph` surface behaves as before —
-  `cudnnGraphNotSupportedError` at `validate()`, conditional outputs return
+  `cudnnGraphNotSupportedError` at `validate()` for a semantically invalid
+  graph (natively or via the backend; with a python engine candidate, a
+  rejection the *backend* alone would raise — version or arch gate — surfaces
+  at `plan()` instead, and only if no python engine proposes a plan), conditional outputs return
   `None`, torch dtypes/`torch.Size` accepted, ragged (THD) offsets and
   multipliers on outputs, serialize/deserialize passthrough, plan queries
   delegate to the lowered graph.

--- a/python/cudnn/_gemm_validate.py
+++ b/python/cudnn/_gemm_validate.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Python-native semantic validation for the GEMM node family (issue #704).
+
+The frost_gemm family's ``EngineFamily.validator``: when a python engine is a
+candidate for a GEMM graph, ``pygraph.validate()`` runs these rules instead of
+eagerly lowering to C++ and asking the backend -- which couples a graph the
+FROST GEMM engine fully serves to the installed backend's version (the MoE
+grouped-matmul node needs cuDNN >= 9.15 forward / 9.22 backward *to validate*,
+attributes the backend would never execute for a FROST-served graph). The
+backend's own verdict is deferred to planning, exactly as for SDPA.
+
+Only the version- and arch-agnostic subset of the classic checks lives here:
+the C++ matmul node has no semantic pre-validation of its own (the backend
+judges shapes at plan time), so this module carries the structural facts a
+matmul must satisfy to mean anything -- and the MoE grouped-matmul node's
+ATTRIBUTE_NOT_SET checks with their classic messages. Nothing about device
+arch or backend version: those are support-surface answers each engine gives
+at planning.
+
+Error types match the classic surface: ``ValueError`` for ATTRIBUTE_NOT_SET /
+INVALID_VALUE parity, ``cudnn.cudnnGraphNotSupportedError`` for a graph the
+backend would decline as GRAPH_NOT_SUPPORTED.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._ir import NodeType
+
+_MOE_FWD_INPUTS = ("token", "weight", "first_token_offset")
+_MOE_BWD_INPUTS = ("doutput", "token", "first_token_offset")
+
+COVERED_NODE_TYPES = frozenset({NodeType.MATMUL, NodeType.MOE_GROUPED_MATMUL, NodeType.MOE_GROUPED_MATMUL_BWD})
+
+
+def _not_supported(message: str) -> Exception:
+    """Classic GRAPH_NOT_SUPPORTED parity: the error type callers catch to skip a config."""
+    import cudnn
+
+    return cudnn.cudnnGraphNotSupportedError(message)
+
+
+def _dims(t: Any):
+    d = t.get_dim() if t is not None else None
+    return list(d) if d else None
+
+
+def validate_graph(graph) -> bool:
+    """Validate every node when all of them are GEMM-family (MATMUL / MoE grouped
+    matmul fwd+bwd); return False without raising when the graph holds a node
+    this module does not cover (a pointwise epilogue, a reshape, ...), so the
+    caller falls back to the classic eager C++ lowering."""
+    nodes = list(graph._nodes)
+    if not nodes or any(n.node_type not in COVERED_NODE_TYPES for n in nodes):
+        return False
+    for node in nodes:
+        validate_node(node)
+    return True
+
+
+def validate_node(node) -> None:
+    """Dispatch one GEMM-family node to its rules."""
+    if node.node_type == NodeType.MATMUL:
+        _validate_matmul(node)
+    elif node.node_type == NodeType.MOE_GROUPED_MATMUL:
+        _validate_required(node, "MoeGroupedMatmul", _MOE_FWD_INPUTS, ("OUT_0",))
+    elif node.node_type == NodeType.MOE_GROUPED_MATMUL_BWD:
+        _validate_required(node, "MoeGroupedMatmulBwd", _MOE_BWD_INPUTS, ("dweight",))
+
+
+def _validate_matmul(node) -> None:
+    """C = A @ B with batch broadcasting: both operands bound, same rank >= 2,
+    the contraction extent agrees, batch extents equal or 1, and a user-declared
+    C carries the (M, N) the operands imply."""
+    a, b, c = node.inputs.get("A"), node.inputs.get("B"), node.outputs.get("C")
+    if a is None or b is None:
+        raise ValueError("Matmul inputs A and B must both be set.")
+    if c is None:
+        raise ValueError("Matmul output C not set.")
+    ad, bd = _dims(a), _dims(b)
+    if not ad or not bd:
+        raise ValueError("Matmul inputs A and B must have their dims set.")
+    if len(ad) != len(bd) or len(ad) < 2:
+        raise _not_supported(f"Matmul requires A and B of equal rank >= 2; got {ad} and {bd}")
+    if ad[-1] != bd[-2]:
+        raise _not_supported(f"Matmul contraction mismatch: A's last dim {ad[-1]} != B's second-to-last dim {bd[-2]}")
+    for i, (x, y) in enumerate(zip(ad[:-2], bd[:-2])):
+        if x != y and x != 1 and y != 1:
+            raise _not_supported(f"Matmul batch dim {i} not broadcastable: {x} vs {y}")
+    cd = _dims(c)
+    if cd:
+        if len(cd) != len(ad):
+            raise _not_supported(f"Matmul output rank {len(cd)} != operand rank {len(ad)}")
+        if cd[-2] != ad[-2] or cd[-1] != bd[-1]:
+            raise _not_supported(f"Matmul output dims {cd} do not match (M, N) = ({ad[-2]}, {bd[-1]})")
+
+
+def _validate_required(node, label: str, inputs, outputs) -> None:
+    """Classic ATTRIBUTE_NOT_SET parity for the MoE grouped-matmul nodes."""
+    for port in inputs:
+        if node.inputs.get(port) is None:
+            raise ValueError(f"{label} input {port} not set.")
+    for port in outputs:
+        if node.outputs.get(port) is None:
+            raise ValueError(f"{label} output {port} not set.")

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -845,8 +845,15 @@ class pygraph:
                     _sdpa_validate.validate_node(node)
             else:
                 self._lowered_graph = self._lower_to_cpp()
-                self._lowered_graph.validate()
-                self._verify_uid_ownership()
+                try:
+                    self._lowered_graph.validate()
+                    self._verify_uid_ownership()
+                except Exception:
+                    # A rejected lowering must not survive: the next validate()
+                    # would find _lowered_graph set, skip the backend check, and mark
+                    # the rejected graph valid.
+                    self._reset_lowered_state()
+                    raise
         # Only a graph that passed EVERY check above is validated: a rejection
         # (python-native or C++) leaves the flag False so build()/plan() re-run
         # validate() and raise again instead of planning a rejected graph.
@@ -1007,12 +1014,7 @@ class pygraph:
         except (cudnn.cudnnGraphNotSupportedError, RuntimeError, ImportError, AttributeError) as exc:
             _LOG.warning("backend could not build this graph, treating as a decline: %s", exc)
             self._backend_declined = exc
-            self._lowered_graph = None
-            self._cpp_tensors.clear()
-            self._cpp_bog_done = False
-            self._cpp_plans_created = False
-            self._backend_mode_spans.clear()
-            self._backend_entries = []
+            self._reset_lowered_state()
 
     def _attach_facts(self) -> None:
         """Describe this frozen graph in its family's vocabulary.
@@ -1126,12 +1128,7 @@ class pygraph:
             _LOG.warning("backend could not lower this graph, treating as a decline: %s", exc)
             # Roll back: a half-lowered graph makes a later build_operation_graph()
             # walk into the descriptor that just failed.
-            self._lowered_graph = None
-            self._cpp_tensors.clear()
-            self._cpp_bog_done = False
-            self._cpp_plans_created = False
-            self._backend_mode_spans.clear()
-            self._backend_entries = []
+            self._reset_lowered_state()
             return self._backend_entries
         try:
             # "Which engines does it offer?" — here only an unsupported-graph
@@ -1310,6 +1307,17 @@ class pygraph:
     def _build_context(self, handle: Any = None) -> Any:
         h = handle if handle is not None else self._handle
         return ExecutionContext(handle=h, stream=self._resolve_stream(h))
+
+    def _reset_lowered_state(self) -> None:
+        """Drop every artifact of a C++ lowering (graph, tensors, BOG/plan flags,
+        backend entries) so a later lowering starts from the IR, not from a
+        half-built or rejected descriptor."""
+        self._lowered_graph = None
+        self._cpp_tensors.clear()
+        self._cpp_bog_done = False
+        self._cpp_plans_created = False
+        self._backend_mode_spans.clear()
+        self._backend_entries = []
 
     def _verify_uid_ownership(self) -> None:
         # Verify the uid-ownership invariant (see _lower_to_cpp): every C++

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -407,8 +407,11 @@ class pygraph:
         if self._frozen:
             raise RuntimeError(f"cannot {what} after lowering/planning — the graph is frozen (planning is one-shot; build a new graph)")
         # a mutation while merely validated (python-engine graphs stay mutable
-        # until planning) must re-validate later — never run on stale inference
+        # until planning) must re-validate later — never run on stale inference,
+        # and never plan on candidates matched against the pre-mutation graph
+        # (validate() may have cached them before the freeze).
         self._is_validated = False
+        self._candidates = None
 
     def _freeze(self) -> None:
         """Freeze the ENTIRE public graph surface.

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -826,10 +826,37 @@ class pygraph:
         # rejects raises from validate() where callers catch it to skip. Skipped
         # only for a graph the backend has no lowering for (GDN/KDA/...), or when
         # the caller registered its own engine — the pre-existing exemption.
+        #
+        # SDPA-family graphs with a python engine candidate validate natively in
+        # python instead (issue #704): the eager C++ round-trip couples a graph
+        # a FROST engine fully serves to the installed backend's version (an
+        # attribute the backend is too old to *validate* but will never
+        # execute). Semantic validity is checked here by _sdpa_validate with
+        # classic error types; the backend's own verdict is deferred to
+        # planning, where a decline is recorded (backend_plan_entries) and
+        # surfaced by plan() only if no python engine proposes a plan either.
         if self._backend_lowerable() and self._lowered_graph is None:
-            self._lowered_graph = self._lower_to_cpp()
-            self._lowered_graph.validate()
-            self._verify_uid_ownership()
+            if self._python_native_validation():
+                from . import _sdpa_validate
+
+                for node in self._nodes:
+                    _sdpa_validate.validate_node(node)
+            else:
+                self._lowered_graph = self._lower_to_cpp()
+                self._lowered_graph.validate()
+                self._verify_uid_ownership()
+
+    def _python_native_validation(self) -> bool:
+        """Whether validate() may skip the eager C++ lowering: every node has a
+        python-native validator AND the manifest offers a python engine for this
+        graph (frost engines available and enabled). Without a candidate the
+        backend is the only possible server, so classic timing — raise its
+        rejection from validate() — must hold."""
+        from . import _sdpa_validate
+
+        if not self._nodes or any(n.node_type not in _sdpa_validate.COVERED_NODE_TYPES for n in self._nodes):
+            return False
+        return bool(self._candidate_engines())
 
     def build_operation_graph(self) -> None:
         """Validate the graph; lower to C++ when no python engines are registered.

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -824,7 +824,6 @@ class pygraph:
                 t.stride = _row_major_stride(t.dim)
             if not t.is_pass_by_value:
                 t.validate()
-        self._is_validated = True
         # Classic parity: C++ validation happens HERE, so a config the backend
         # rejects raises from validate() where callers catch it to skip. Skipped
         # only for a graph the backend has no lowering for (GDN/KDA/...), or when
@@ -848,6 +847,10 @@ class pygraph:
                 self._lowered_graph = self._lower_to_cpp()
                 self._lowered_graph.validate()
                 self._verify_uid_ownership()
+        # Only a graph that passed EVERY check above is validated: a rejection
+        # (python-native or C++) leaves the flag False so build()/plan() re-run
+        # validate() and raise again instead of planning a rejected graph.
+        self._is_validated = True
 
     def _python_native_validation(self) -> bool:
         """Whether validate() may skip the eager C++ lowering: every node has a

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -829,21 +829,19 @@ class pygraph:
         # only for a graph the backend has no lowering for (GDN/KDA/...), or when
         # the caller registered its own engine — the pre-existing exemption.
         #
-        # SDPA-family graphs with a python engine candidate validate natively in
-        # python instead (issue #704): the eager C++ round-trip couples a graph
-        # a FROST engine fully serves to the installed backend's version (an
-        # attribute the backend is too old to *validate* but will never
-        # execute). Semantic validity is checked here by _sdpa_validate with
-        # classic error types; the backend's own verdict is deferred to
-        # planning, where a decline is recorded (backend_plan_entries) and
-        # surfaced by plan() only if no python engine proposes a plan either.
+        # A graph whose engine family declares a python-native validator, and for
+        # which the manifest offers a python engine, validates natively instead
+        # (issue #704): the eager C++ round-trip couples a graph a FROST engine
+        # fully serves to the installed backend's version (an attribute the
+        # backend is too old to *validate* but will never execute). The family's
+        # validator runs its version- and arch-agnostic semantic rules with the
+        # classic error types and returns False -- classic lowering -- when the
+        # graph holds a node it does not cover. The backend's own verdict is
+        # deferred to planning, where a decline is recorded (backend_plan_entries)
+        # and surfaced by plan() only if no python engine proposes a plan either.
         if self._backend_lowerable() and self._lowered_graph is None:
-            if self._python_native_validation():
-                from . import _sdpa_validate
-
-                for node in self._nodes:
-                    _sdpa_validate.validate_node(node)
-            else:
+            validator = self._python_native_validator()
+            if not (validator is not None and validator(self)):
                 self._lowered_graph = self._lower_to_cpp()
                 try:
                     self._lowered_graph.validate()
@@ -859,17 +857,26 @@ class pygraph:
         # validate() and raise again instead of planning a rejected graph.
         self._is_validated = True
 
-    def _python_native_validation(self) -> bool:
-        """Whether validate() may skip the eager C++ lowering: every node has a
-        python-native validator AND the manifest offers a python engine for this
-        graph (frost engines available and enabled). Without a candidate the
-        backend is the only possible server, so classic timing — raise its
-        rejection from validate() — must hold."""
-        from . import _sdpa_validate
+    def _python_native_validator(self):
+        """The graph's family validator when validate() may skip the eager C++
+        lowering: the graph belongs to one engine family, that family declares a
+        python-native validator (manifest.EngineFamily.validator), AND the manifest
+        offers a python engine for it (frost engines available and enabled).
+        None otherwise: without a candidate the backend is the only possible
+        server, so classic timing -- raise its rejection from validate() -- must
+        hold. The validator itself still returns False for a graph holding a node
+        it does not cover, which also means classic lowering."""
+        from .engines import manifest
 
-        if not self._nodes or any(n.node_type not in _sdpa_validate.COVERED_NODE_TYPES for n in self._nodes):
-            return False
-        return bool(self._candidate_engines())
+        if not self._nodes:
+            return None
+        family = manifest.family_for(self)
+        if family is None:
+            return None
+        validator = manifest.resolve_validator(family)
+        if validator is None or not self._candidate_engines():
+            return None
+        return validator
 
     def build_operation_graph(self) -> None:
         """Validate the graph; lower to C++ when no python engines are registered.

--- a/python/cudnn/_sdpa_validate.py
+++ b/python/cudnn/_sdpa_validate.py
@@ -10,7 +10,11 @@ serves is rejected at validate() because the *backend* is too old to know an
 attribute it will never execute. This module is the replacement for the SDPA
 family: the graph-SEMANTIC subset of the classic C++ pre-validation (shape and
 stride invariants, ill-formed attribute combinations), expressed on the python
-IR with the classic error types and messages.
+IR with the classic error types and messages. It is wired in through the
+manifest -- ``EngineFamily.validator`` on the frost_sdpa families resolves to
+``validate_graph`` here (``cudnn._gemm_validate`` is the GEMM family's
+counterpart); ``pygraph.validate()`` consults it only when the manifest also
+offers a python engine for the graph.
 
 Deliberately absent: every backend-version gate (``get_backend_version() < X``)
 and device-arch gate (``prop_major == Y``) from the C++ surface. Those are
@@ -111,6 +115,19 @@ def _is_ragged(*tensors) -> bool:
 def _has(node, port: str) -> bool:
     """Whether an input port is bound."""
     return node.inputs.get(port) is not None
+
+
+def validate_graph(graph) -> bool:
+    """The frost_sdpa families' native validator (engines.manifest.EngineFamily.validator):
+    validate every node when all of them are SDPA-family; return False without
+    raising when the graph holds a node this module does not cover, so the caller
+    falls back to the classic eager C++ lowering."""
+    nodes = list(graph._nodes)
+    if not nodes or any(n.node_type not in COVERED_NODE_TYPES for n in nodes):
+        return False
+    for node in nodes:
+        validate_node(node)
+    return True
 
 
 def validate_node(node) -> None:

--- a/python/cudnn/_sdpa_validate.py
+++ b/python/cudnn/_sdpa_validate.py
@@ -43,17 +43,20 @@ COVERED_NODE_TYPES = frozenset(_FWD_TYPES + _BWD_TYPES)
 
 
 def _not_supported(message: str) -> Exception:
+    """Classic GRAPH_NOT_SUPPORTED parity: the error type callers catch to skip a config."""
     import cudnn
 
     return cudnn.cudnnGraphNotSupportedError(message)
 
 
 def _dtype_name(t: Any) -> Optional[str]:
+    """Enum name of a tensor's data type, or None when the tensor/dtype is unset."""
     dt = t.get_data_type() if t is not None else None
     return getattr(dt, "name", None)
 
 
 def _tensor(node, port: str):
+    """The tensor bound to ``port`` on either side of the node, or None."""
     return node.inputs.get(port) or node.outputs.get(port)
 
 
@@ -95,16 +98,18 @@ def _dropout(node) -> tuple:
     if not node.params.get("_dropout_n"):
         return None, False
     prob = node.params.get("dropout_0")
-    if isinstance(prob, float):
-        return prob, False
+    if isinstance(prob, (int, float)) and not isinstance(prob, bool):
+        return float(prob), False
     return None, "dropout_0" in node.inputs
 
 
 def _is_ragged(*tensors) -> bool:
+    """Whether any given tensor carries a ragged (packed THD) offset."""
     return any(t is not None and t.ragged_offset is not None for t in tensors)
 
 
 def _has(node, port: str) -> bool:
+    """Whether an input port is bound."""
     return node.inputs.get(port) is not None
 
 
@@ -190,6 +195,8 @@ def _validate_common(node, q, k, v, o, s_q, s_kv) -> None:
 
 
 def _validate_forward(node) -> None:
+    """SDPA / SDPA_FP8 / SDPA_MXFP8 forward: the classic C++ pre-validation rules that
+    do not depend on backend version or device arch."""
     params = node.params
     q, k, v = node.inputs.get("q"), node.inputs.get("k"), node.inputs.get("v")
     o = node.outputs.get("O")
@@ -215,7 +222,7 @@ def _validate_forward(node) -> None:
     if is_ragged and not (bool(params.get("use_padding_mask")) or score_mod):
         raise _not_supported("Ragged offsets are only supported with padding mask.")
 
-    alignment, left, right = _diagonal(params)
+    _alignment, left, right = _diagonal(params)
     if score_mod and (bool(params.get("use_alibi_mask")) or right is not None or bool(params.get("use_padding_mask")) or left is not None):
         raise _not_supported("Attention score mod enabled and hence other subgraphs are disabled.")
 
@@ -253,6 +260,8 @@ def _validate_forward(node) -> None:
 
 
 def _validate_mxfp8_descales(node, q, k, v, s_kv: int) -> None:
+    """MXFP8 block-scale descale tensors: F8_128x4 reordering and batch/head dims matching
+    their base operand."""
     b, h_q, _, d = q.get_dim()
     h_k, h_v = k.get_dim()[1], v.get_dim()[1]
     block_size = 32  # MXFP8 block size is fixed at 32
@@ -282,6 +291,8 @@ def _validate_mxfp8_descales(node, q, k, v, s_kv: int) -> None:
 
 
 def _validate_backward(node) -> None:
+    """SDPA_BWD / FP8 / MXFP8 backward: the version- and arch-agnostic classic rules,
+    including the s_q = s_kv = 1 rejection."""
     q, k, v = node.inputs.get("q"), node.inputs.get("k"), node.inputs.get("v")
     # sdpa_mxfp8_backward carries O as its f16 twin (port "o_f16")
     o = node.inputs.get("o") or node.inputs.get("o_f16")
@@ -298,7 +309,7 @@ def _validate_backward(node) -> None:
     _validate_common(node, q, k, v, o, s_q, s_kv)
 
     params = node.params
-    alignment, left, right = _diagonal(params)
+    _alignment, left, right = _diagonal(params)
     score_mod = params.get("score_mod") is not None
     if score_mod and (bool(params.get("use_alibi_mask")) or bool(params.get("use_padding_mask")) or right is not None or left is not None):
         raise _not_supported("Attention score mod enabled and hence other subgraphs are disabled.")

--- a/python/cudnn/_sdpa_validate.py
+++ b/python/cudnn/_sdpa_validate.py
@@ -1,0 +1,316 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Python-native validation for the SDPA op family (issue #704).
+
+``pygraph.validate()`` classically lowers every backend-lowerable graph to C++
+and runs the backend's ``validate()`` — which couples frontend-only (FROST)
+engines to the installed backend's version: a graph a python engine fully
+serves is rejected at validate() because the *backend* is too old to know an
+attribute it will never execute. This module is the replacement for the SDPA
+family: the graph-SEMANTIC subset of the classic C++ pre-validation (shape and
+stride invariants, ill-formed attribute combinations), expressed on the python
+IR with the classic error types and messages.
+
+Deliberately absent: every backend-version gate (``get_backend_version() < X``)
+and device-arch gate (``prop_major == Y``) from the C++ surface. Those are
+support-surface answers, not graph-validity answers — at planning time each
+python engine's ``check_support()`` gives its own, and the backend gives its
+own when it is lowered (declines recorded by ``backend_plan_entries()``, and
+surfaced by ``plan()`` only if no engine proposes a plan).
+
+Error-type parity with the pybind ``throw_if`` mapping:
+``GRAPH_NOT_SUPPORTED`` -> ``cudnn.cudnnGraphNotSupportedError`` (callers catch
+it to skip a config); ``ATTRIBUTE_NOT_SET`` / ``INVALID_VALUE`` ->
+``std::invalid_argument`` -> ``ValueError``.
+
+Import-light on purpose: only the IR types. Never import ``cudnn.sdpa`` (that
+pulls torch/cutlass) or the compiled binding at module scope.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from .graph_types import NodeType
+
+_FWD_TYPES = (NodeType.SDPA, NodeType.SDPA_FP8, NodeType.SDPA_MXFP8)
+_BWD_TYPES = (NodeType.SDPA_BWD, NodeType.SDPA_FP8_BWD, NodeType.SDPA_MXFP8_BWD)
+
+# Node types this module fully validates. pygraph.validate() may defer the C++
+# lowering only for graphs whose every node is covered here.
+COVERED_NODE_TYPES = frozenset(_FWD_TYPES + _BWD_TYPES)
+
+
+def _not_supported(message: str) -> Exception:
+    import cudnn
+
+    return cudnn.cudnnGraphNotSupportedError(message)
+
+
+def _dtype_name(t: Any) -> Optional[str]:
+    dt = t.get_data_type() if t is not None else None
+    return getattr(dt, "name", None)
+
+
+def _tensor(node, port: str):
+    return node.inputs.get(port) or node.outputs.get(port)
+
+
+def _check_dim_stride(node, port: str, t: Any) -> None:
+    """Classic parity: rank-4 dim/stride assigned, unit stride on the head dim."""
+    if t is None:
+        raise ValueError(f"{node.name}: required tensor {port} is missing")
+    if len(t.get_dim() or ()) != 4:
+        raise ValueError(f"The dim for {port} is invalid")
+    if len(t.get_stride() or ()) != 4:
+        raise ValueError(f"The stride for {port} is invalid")
+    if t.get_stride()[3] != 1:
+        raise _not_supported("The stride for the last dimension corresponding to the embedding size per head should be 1 for " + port)
+
+
+def _diagonal(params: dict) -> tuple:
+    """(alignment_name, left_bound, right_bound) with the pybind's spelling
+    precedence: the use_causal_mask* flags override diagonal_alignment and pin
+    right_bound to 0; diagonal_band_left_bound overrides sliding_window_length."""
+    causal_tl = bool(params.get("use_causal_mask"))
+    causal_br = bool(params.get("use_causal_mask_bottom_right"))
+    if causal_br:
+        alignment = "BOTTOM_RIGHT"
+    elif causal_tl:
+        alignment = "TOP_LEFT"
+    else:
+        alignment = getattr(params.get("diagonal_alignment"), "name", "TOP_LEFT")
+    right = 0 if (causal_tl or causal_br) else params.get("diagonal_band_right_bound")
+    left = params.get("diagonal_band_left_bound")
+    if left is None:
+        left = params.get("sliding_window_length")
+    return alignment, left, right
+
+
+def _dropout(node) -> tuple:
+    """(probability | None, has_custom_mask) from the captured dropout tuple:
+    (float prob, seed, offset) is probability form; an all-tensor tuple
+    ((mask, scale) / (mask, scale, scale_inv)) is the custom-mask form."""
+    if not node.params.get("_dropout_n"):
+        return None, False
+    prob = node.params.get("dropout_0")
+    if isinstance(prob, float):
+        return prob, False
+    return None, "dropout_0" in node.inputs
+
+
+def _is_ragged(*tensors) -> bool:
+    return any(t is not None and t.ragged_offset is not None for t in tensors)
+
+
+def _has(node, port: str) -> bool:
+    return node.inputs.get(port) is not None
+
+
+def validate_node(node) -> None:
+    """Validate one SDPA-family node, raising with classic error semantics."""
+    if node.node_type in _FWD_TYPES:
+        _validate_forward(node)
+    elif node.node_type in _BWD_TYPES:
+        _validate_backward(node)
+    else:
+        raise AssertionError(f"{node.node_type} is not an SDPA-family node")
+
+
+def _validate_common(node, q, k, v, o, s_q, s_kv) -> None:
+    """Checks shared verbatim by the forward and backward C++ surfaces."""
+    params = node.params
+    _, h_q, _, _ = q.get_dim()
+    h_k = k.get_dim()[1]
+    h_v = v.get_dim()[1]
+
+    if (h_q % h_k != 0) or (h_q % h_v != 0):
+        raise _not_supported("For group-query attention, number of heads for key and query must be a factor of number of heads for query")
+
+    alignment, left, right = _diagonal(params)
+    causal_br = alignment == "BOTTOM_RIGHT" and right is not None
+    padding = bool(params.get("use_padding_mask"))
+    score_mod = params.get("score_mod") is not None
+    alibi = bool(params.get("use_alibi_mask"))
+
+    if alibi and right != 0:
+        raise _not_supported("When alibi mask is used, diagonal_band_right_bound needs to be set to 0.")
+
+    bias = node.inputs.get("bias")
+    if bias is not None and _dtype_name(bias) == "BOOLEAN":
+        raise _not_supported("Bias mask data type cannot be boolean")
+
+    # Padding requires a per-sequence length tensor on each side; each side
+    # independently uses exactly one representation (per-batch or cumulative).
+    has_seq_q, has_cu_q = _has(node, "seq_len_q"), _has(node, "cu_seq_len_q")
+    has_seq_kv, has_cu_kv = _has(node, "seq_len_kv"), _has(node, "cu_seq_len_kv")
+    if has_seq_q and has_cu_q:
+        raise ValueError("seq_len_q and cu_seq_len_q cannot both be set.")
+    if has_seq_kv and has_cu_kv:
+        raise ValueError("seq_len_kv and cu_seq_len_kv cannot both be set.")
+    has_any_q, has_any_kv = has_seq_q or has_cu_q, has_seq_kv or has_cu_kv
+    if padding and not (has_any_q and has_any_kv):
+        raise ValueError("Padding mask requires seq_len_q/seq_len_kv (or cu_seq_len_q/cu_seq_len_kv) to be set.")
+    if (not padding and not score_mod) and (has_any_q or has_any_kv):
+        raise ValueError("seq_len_q/seq_len_kv (or cu_seq_len_q/cu_seq_len_kv) needs to be set only if padding mask is enabled.")
+    if has_any_q != has_any_kv:
+        raise ValueError(
+            "A Q-side and a KV-side sequence length tensor must be provided together " "(each side may independently use seq_len_* or cu_seq_len_*)."
+        )
+
+    is_ragged = _is_ragged(q, k, v, o)
+    if (params.get("max_total_seq_len_q") is not None or params.get("max_total_seq_len_kv") is not None) and not is_ragged:
+        raise _not_supported("max_total_seq_len_q/kv is only supported with packed (ragged) layout")
+
+    prob, custom_mask = _dropout(node)
+    if prob is not None and custom_mask:
+        raise ValueError("Using both, custom dropout mask and internal-mask generation using dropout probability, is ill-formed.")
+    if prob == 1.0:
+        raise ValueError("Dropout probability cannot be 1 as corresponding scale wont be well formed.")
+    is_dropout = prob is not None or custom_mask
+
+    if causal_br and not padding and s_kv is not None and s_q > s_kv:
+        raise _not_supported(
+            "Bottom right causal mask does not support max_s_q > max_s_kv. Please virtually slice the Q tensor and " "pass it as max_s_q == max_s_kv"
+        )
+    if causal_br and (bias is not None or alibi or is_dropout or (is_ragged and not padding)):
+        raise _not_supported(
+            "Bottom right causal mask is only supported with is_bias=False, is_alibi=False, is_dropout=False. "
+            "Further is_ragged==True is only allowed when padding_mask=True."
+        )
+
+    if left is not None:
+        if not padding and s_kv is not None and s_q > s_kv:
+            raise _not_supported("Sliding window attention is only supported with max_s_q <= max_s_kv.")
+        if is_ragged and not padding:
+            raise _not_supported("Left and right bounds with is_ragged==True is only allowed when padding_mask=True.")
+    if right is not None and right < 0:
+        raise ValueError("Right bound needs to be larger than or equal to zero")
+
+
+def _validate_forward(node) -> None:
+    params = node.params
+    q, k, v = node.inputs.get("q"), node.inputs.get("k"), node.inputs.get("v")
+    o = node.outputs.get("O")
+    for port, t in (("Q", q), ("K", k), ("V", v), ("O", o)):
+        _check_dim_stride(node, port, t)
+
+    _, _, s_q, d_qk = q.get_dim()
+    d_v = v.get_dim()[3]
+    paged = _has(node, "paged_attention_k_table") or _has(node, "paged_attention_v_table")
+    max_seq_kv = params.get("paged_attention_max_seq_len_kv")
+    # With paged caches K/V carry container extents; the logical s_kv is the
+    # explicit maximum when given, unknowable here otherwise.
+    s_kv = k.get_dim()[2] if not paged else max_seq_kv
+
+    _validate_common(node, q, k, v, o, s_q, s_kv)
+
+    stats = node.outputs.get("Stats")
+    if stats is not None and _dtype_name(stats) not in (None, "FLOAT"):
+        raise _not_supported("The Stats output of sdpa must be an FP32 tensor.")
+
+    is_ragged = _is_ragged(q, k, v, o)
+    score_mod = params.get("score_mod") is not None
+    if is_ragged and not (bool(params.get("use_padding_mask")) or score_mod):
+        raise _not_supported("Ragged offsets are only supported with padding mask.")
+
+    alignment, left, right = _diagonal(params)
+    if score_mod and (bool(params.get("use_alibi_mask")) or right is not None or bool(params.get("use_padding_mask")) or left is not None):
+        raise _not_supported("Attention score mod enabled and hence other subgraphs are disabled.")
+
+    if node.node_type == NodeType.SDPA:
+        if (d_qk % 8 != 0) or (d_v % 8 != 0):
+            raise _not_supported("hidden_dim should be multiple of 8")
+        if s_q == 1 and _has(node, "sink_token"):
+            raise _not_supported("decode only mode, i.e. s_q == 1, not supported with sink_token")
+
+        has_any_q = _has(node, "seq_len_q") or _has(node, "cu_seq_len_q")
+        has_any_kv = _has(node, "seq_len_kv") or _has(node, "cu_seq_len_kv")
+        if paged and not (has_any_q and has_any_kv):
+            raise _not_supported(
+                "Paged caches can only be used in combination with padding mask and variable sequence lengths "
+                "for both Q and KV (each side independently via seq_len_* or cu_seq_len_*)."
+            )
+        if not paged and max_seq_kv is not None:
+            raise _not_supported("When not using paged attention, there is no need to explicitly set max kv sequence length.")
+        if max_seq_kv is not None:
+            bias = node.inputs.get("bias")
+            if bias is not None and bias.get_dim()[3] != max_seq_kv:
+                raise _not_supported("Value set through set_paged_attention_max_seq_len_kv is incompatible with the sequence length of the bias")
+            rng_dump = node.outputs.get("rng_dump")
+            if rng_dump is not None and rng_dump.get_dim()[3] != max_seq_kv:
+                raise _not_supported("Value set through set_paged_attention_max_seq_len_kv is incompatible with the sequence length of the RNG_DUMP")
+
+    if node.node_type == NodeType.SDPA_FP8:
+        if node.inputs.get("bias") is not None:
+            raise _not_supported("SDPA FP8 does not support bias")
+        if (d_qk % 16 != 0) or (d_v % 16 != 0):
+            raise _not_supported("hidden_dim should be multiple of 16")
+
+    if node.node_type == NodeType.SDPA_MXFP8:
+        _validate_mxfp8_descales(node, q, k, v, s_kv if s_kv is not None else k.get_dim()[2])
+
+
+def _validate_mxfp8_descales(node, q, k, v, s_kv: int) -> None:
+    b, h_q, _, d = q.get_dim()
+    h_k, h_v = k.get_dim()[1], v.get_dim()[1]
+    block_size = 32  # MXFP8 block size is fixed at 32
+    d_scale = (d + block_size - 1) // block_size
+    s_scale = (s_kv + block_size - 1) // block_size
+
+    for port, h, small_axis, small_min in (
+        ("descale_q", h_q, 3, d_scale),
+        ("descale_k", h_k, 3, d_scale),
+        ("descale_v", h_v, 2, s_scale),
+    ):
+        t = node.inputs.get(port)
+        if t is None:
+            raise ValueError(f"{node.name}: MXFP8 SDPA requires {port}")
+        cap = port.title().replace("_q", "_Q").replace("_k", "_K").replace("_v", "_V")
+        if _dtype_name(t) != "FP8_E8M0":
+            raise ValueError(f"MXFP8 SDPA requires {cap} to have FP8_E8M0 data type")
+        if getattr(t.get_reordering_type(), "name", None) != "F8_128x4":
+            raise ValueError(f"MXFP8 SDPA requires {cap} to have F8_128x4 reordering")
+        dim = t.get_dim()
+        if dim[0] != b or dim[1] != h:
+            base = port.split("_")[1].upper()
+            raise ValueError(f"MXFP8 SDPA: {cap} batch/head dimensions must match {base}")
+        if dim[small_axis] < small_min:
+            what = "d_scale" if small_axis == 3 else "s_scale"
+            raise ValueError(f"MXFP8 SDPA: {cap} {what} dimension too small (expected >= {small_min})")
+
+
+def _validate_backward(node) -> None:
+    q, k, v = node.inputs.get("q"), node.inputs.get("k"), node.inputs.get("v")
+    # sdpa_mxfp8_backward carries O as its f16 twin (port "o_f16")
+    o = node.inputs.get("o") or node.inputs.get("o_f16")
+    dO = node.inputs.get("dO")
+    dQ, dK, dV = node.outputs.get("dQ"), node.outputs.get("dK"), node.outputs.get("dV")
+    for port, t in (("Q", q), ("K", k), ("V", v), ("O", o), ("dO", dO), ("dQ", dQ), ("dK", dK), ("dV", dV)):
+        _check_dim_stride(node, port, t)
+
+    s_q = q.get_dim()[2]
+    s_kv = v.get_dim()[2]
+    if s_q == 1 and s_kv == 1:
+        raise _not_supported("s_q = s_kv = 1 is not supported.")
+
+    _validate_common(node, q, k, v, o, s_q, s_kv)
+
+    params = node.params
+    alignment, left, right = _diagonal(params)
+    score_mod = params.get("score_mod") is not None
+    if score_mod and (bool(params.get("use_alibi_mask")) or bool(params.get("use_padding_mask")) or right is not None or left is not None):
+        raise _not_supported("Attention score mod enabled and hence other subgraphs are disabled.")
+
+    if left is not None and left <= 0:
+        raise ValueError("Left bound (Sliding window length) should be greater than zero when set.")
+
+    if node.outputs.get("dSink_token") is not None and node.inputs.get("sink_token") is None:
+        raise ValueError("dSink_token requires sink_token to be provided")
+
+    d_qk = q.get_dim()[3]
+    d_v = v.get_dim()[3]
+    if node.node_type == NodeType.SDPA_BWD:
+        if (d_qk % 8 != 0) or (d_v % 8 != 0):
+            raise _not_supported("hidden_dim should be multiple of 8")

--- a/python/cudnn/engines/manifest.py
+++ b/python/cudnn/engines/manifest.py
@@ -92,6 +92,13 @@ class EngineFamily:
     # can rank -- an engine cannot see its siblings. None falls back to one
     # default plan per accepting engine, ahead of the backend's.
     heuristics: Optional[Tuple[str, str]] = None
+    # ("module", "callable") validating a graph of this family natively in
+    # python -- ``validate_graph(graph) -> bool`` runs the family's version- and
+    # arch-agnostic semantic rules with the classic error types and returns False
+    # (having raised nothing) when the graph holds a node it does not cover, so
+    # pygraph.validate() takes the classic eager C++ lowering instead. None means
+    # the family has no native validator and always validates classically.
+    validator: Optional[Tuple[str, str]] = None
 
     @property
     def id_end(self) -> int:
@@ -178,6 +185,7 @@ MANIFEST: Tuple[EngineFamily, ...] = (
         "cudnn.gemm.frost.engine",
         "FrostGemmEngines",
         slots={"frost_gemm": EngineSlot(0, opt_in=True)},
+        validator=("cudnn._gemm_validate", "validate_graph"),
     ),
     EngineFamily(
         FROST_SDPA_FWD_ID_BASE,
@@ -201,6 +209,7 @@ MANIFEST: Tuple[EngineFamily, ...] = (
         },
         analyzer=("cudnn.sdpa.graph_analyzer", "analyze"),
         heuristics=("cudnn.sdpa.fwd.heuristics", "recommend"),
+        validator=("cudnn._sdpa_validate", "validate_graph"),
     ),
     EngineFamily(
         FROST_SDPA_BWD_ID_BASE,
@@ -214,6 +223,7 @@ MANIFEST: Tuple[EngineFamily, ...] = (
             "sdpa_bwd_sm100_mxfp8": EngineSlot(3, opt_in=True),
         },
         analyzer=("cudnn.sdpa.graph_analyzer", "analyze"),
+        validator=("cudnn._sdpa_validate", "validate_graph"),
     ),
 )
 
@@ -283,6 +293,12 @@ def resolve_analyzer(family: EngineFamily):
     family's heuristics and engines then read that same record back.
     """
     return _resolve(family, family.analyzer, "analyzer")
+
+
+def resolve_validator(family: EngineFamily):
+    """The family's python-native graph validator, or None (see EngineFamily.validator)."""
+
+    return _resolve(family, family.validator, "validator")
 
 
 def instantiate(family: EngineFamily, ids: Dict[str, int]):

--- a/python/cudnn/frost/README.md
+++ b/python/cudnn/frost/README.md
@@ -129,13 +129,18 @@ EngineFamily(
     slots={"sdpa_fwd_prefill_sm100_d128": EngineSlot(0, opt_in=True), ...},
     analyzer=("cudnn.sdpa.graph_analyzer", "analyze"),
     heuristics=("cudnn.sdpa.fwd.heuristics", "recommend"),
+    validator=("cudnn._sdpa_validate", "validate_graph"),
 ),
 ```
 
 - A family is **pure data**: strings and ints, zero imports of engine code.
   `import cudnn` must never pay the CuTe-DSL import (~1.2 s) merely to know an
-  engine exists. `analyzer` and `heuristics` are `(module, callable)` pairs for
-  the same reason, resolved only when something needs to rank.
+  engine exists. `analyzer`, `heuristics` and `validator` are `(module, callable)`
+  pairs for the same reason, resolved only when something needs them. The
+  `validator` is what lets `pygraph.validate()` skip the eager C++ lowering for
+  a graph a python engine may serve (it runs the family's semantic rules; the
+  backend's verdict is deferred to planning) — see
+  `docs/python_graph_and_execution_backends.md`, *The manifest*.
 - **A family is a KIND OF GRAPH**, not a group of engines that ship together.
   `_ANCHOR_NODE_TO_FAMILY` maps a node type to the one family that serves that
   kind of graph, so a graph belongs to exactly one family or to none, and

--- a/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
@@ -24,7 +24,8 @@ Two sub-groups of ``WARPS_PER_SG`` warps each (256 threads at the 4+4 default):
     both: dQ += dSᵀ · K   (sg0 = d-cols 0:d/2, sg1 = d/2:d)  → atomicAdd dQ_acc
 
 All S/dP/P/dS tiles are ``[TILE_KV, TILE_Q]``.  P and dS are exchanged through
-SMEM (``sP`` sg0→sg1; ``sdS`` for dK, ``sdSᵀ`` transposed for dQ's A operand).
+SMEM (``sP`` sg0→sg1 in fp32, so dS sees the unrounded P; ``sdSᵀ`` transposed
+for dQ's A operand).
 ``dV``/``dK`` accumulate in registers across the Q-loop and are written ONCE at
 CTA end (the CTA owns its KV slice → no atomics).  ``dQ`` is ``atomicAdd``-ed
 into a FP32 GMEM accumulator (every KV-tile contributes to every Q-row's dQ);
@@ -61,7 +62,7 @@ accumulator footprint (sg0 holds dV, sg1 holds dK — one shared LOCAL array).
 
 Named-"barrier" table (all ``nvvm.barrier_cta_sync()`` — full 256-thread CTA):
   * B0  after Q/dO ``cp.async`` load          (top of each Q-iter)
-  * B1  after sg0 writes ``sP``               (sg1's dS + sg0's dV both read sP)
+  * B1  after sg0 writes ``sP``               (sg1's dS reads it; dV's P operand is in regs)
   * B2  after sg1 writes ``sdS``/``sdSᵀ``     (dQ reads sdSᵀ; sP/sdO read done)
   * B2b after both sg stage ``sDQ``           (before the coalesced dQ atomicAdd)
   * B3  after dQ atomicAdds                    (before next Q-iter reloads Q/dO)
@@ -468,7 +469,10 @@ def _bprop_kernel(
     sV = cutlass.Array(io_dtype, tile_kv * d_v, alignment=128, space=cutlass.AddressSpace.smem)
     sQ = cutlass.Array(io_dtype, qo_stages * QSTAGE_Q, alignment=128, space=cutlass.AddressSpace.smem)
     sdO = cutlass.Array(io_dtype, qo_stages * QSTAGE_O, alignment=128, space=cutlass.AddressSpace.smem)
-    sP = cutlass.Array(io_dtype, PT, alignment=128, space=cutlass.AddressSpace.smem)  # sg0→sg1
+    # sP carries P sg0→sg1 in fp32: dS = (dP − do_dot)·P is formed from the
+    # unrounded softmax so only the MMA operands (bmm2_a / sdSᵀ) see a bf16
+    # rounding.  +PT*2 B of SMEM over the bf16 copy (fits every flavor).
+    sP = cutlass.Array(cutlass.Float32, PT, alignment=128, space=cutlass.AddressSpace.smem)
     sdST = cutlass.Array(io_dtype, tile_q * tile_kv, alignment=128, space=cutlass.AddressSpace.smem)
     # dQ atomicAdd-coalescing staging buffer (FP32 [tile_q, d_qk]).  The dQ MMA
     # C-fragment scatters across 8 rows per warp → 8 L2 sectors per atomic
@@ -793,12 +797,15 @@ def _bprop_kernel(
                 # BMM2 (dV) A-fragment, in registers (no ldmatrix round-trip).
                 bmm2_a[nf * 2 + 0] = h01
                 bmm2_a[nf * 2 + 1] = h23
-                # sP write — sg1 still reads P here to form dS.
+                # sP write (fp32 P; sg1 forms dS from it).  col is even, so the
+                # pair stays inside one 16 B swizzle chunk.
                 col = cutlass.Int32(nf * 8) + cutlass.Int32(2) * p_lane
-                a_top = sP.subview(kv_row_g * cutlass.Int32(tile_q) + swizzle_xor_128b(kv_row_g, col, elem_bytes=_ELEM_BYTES))
-                a_bot = sP.subview(kv_row_g8 * cutlass.Int32(tile_q) + swizzle_xor_128b(kv_row_g8, col, elem_bytes=_ELEM_BYTES))
-                Pointer(a_top.data_ptr(), dtype=cutlass.Int32).store(h01, alignment=4)
-                Pointer(a_bot.data_ptr(), dtype=cutlass.Int32).store(h23, alignment=4)
+                i_top = kv_row_g * cutlass.Int32(tile_q) + swizzle_xor_128b(kv_row_g, col, elem_bytes=4)
+                i_bot = kv_row_g8 * cutlass.Int32(tile_q) + swizzle_xor_128b(kv_row_g8, col, elem_bytes=4)
+                Pointer(sP.subview(i_top).data_ptr(), dtype=cutlass.Float32).store(p0)
+                Pointer(sP.subview(i_top + cutlass.Int32(1)).data_ptr(), dtype=cutlass.Float32).store(p1)
+                Pointer(sP.subview(i_bot).data_ptr(), dtype=cutlass.Float32).store(p2)
+                Pointer(sP.subview(i_bot + cutlass.Int32(1)).data_ptr(), dtype=cutlass.Float32).store(p3)
 
         # ---- B1: sP ready ---------------------------------------------------
         nvvm.barrier_cta_sync()
@@ -820,16 +827,16 @@ def _bprop_kernel(
                 dd0 = Pointer(DOT_view.data_ptr() + dot_head_base + qr0, dtype=cutlass.Float32).load()
                 dd1 = Pointer(DOT_view.data_ptr() + dot_head_base + qr1, dtype=cutlass.Float32).load()
                 col = cutlass.Int32(nf * 8) + cutlass.Int32(2) * p_lane
-                swz_top = swizzle_xor_128b(kv_row_g, col, elem_bytes=_ELEM_BYTES)
-                swz_bot = swizzle_xor_128b(kv_row_g8, col, elem_bytes=_ELEM_BYTES)
+                swz_top = swizzle_xor_128b(kv_row_g, col, elem_bytes=4)
+                swz_bot = swizzle_xor_128b(kv_row_g8, col, elem_bytes=4)
                 a_top = sP.subview(kv_row_g * cutlass.Int32(tile_q) + swz_top)
                 a_bot = sP.subview(kv_row_g8 * cutlass.Int32(tile_q) + swz_bot)
-                ptop = Pointer(a_top.data_ptr(), dtype=io_dtype).load(count=2)
-                pbot = Pointer(a_bot.data_ptr(), dtype=io_dtype).load(count=2)
-                p0 = ptop[0].to(cutlass.Float32)
-                p1 = ptop[1].to(cutlass.Float32)
-                p2 = pbot[0].to(cutlass.Float32)
-                p3 = pbot[1].to(cutlass.Float32)
+                ptop = Pointer(a_top.data_ptr(), dtype=cutlass.Float32).load(count=2)
+                pbot = Pointer(a_bot.data_ptr(), dtype=cutlass.Float32).load(count=2)
+                p0 = ptop[0]
+                p1 = ptop[1]
+                p2 = pbot[0]
+                p3 = pbot[1]
                 off = nf * 4
                 # Un-scaled softmax-input gradient = (dP − do_dot)·P.  This IS
                 # dBias (bias adds post-scale → dBias = dS').  dS for dQ/dK folds

--- a/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
@@ -239,6 +239,8 @@ def _bprop_kernel(
     sem_q_stride: cutlass.Int32,  # DQ_SEM per-(seq,head) stride = ceil(max_SQ/tile_q) (deterministic only)
 ):
     # ---- compile-time derived counts --------------------------------------
+    """SM80 SDPA backward main kernel: one CTA per (kv-tile, head, batch|sequence) owns dK/dV
+    and streams Q-tiles, accumulating dQ across CTAs (atomics or the deterministic relay)."""
     threads = 2 * warps_per_sg * 32
     DQK_CHUNKS = d_qk // 16  # BMM1 K-reduce over d (S = K·Qᵀ)
     DV_CHUNKS = d_v // 16  # BMM1' K-reduce over d (dP = V·dOᵀ)
@@ -469,7 +471,7 @@ def _bprop_kernel(
     sV = cutlass.Array(io_dtype, tile_kv * d_v, alignment=128, space=cutlass.AddressSpace.smem)
     sQ = cutlass.Array(io_dtype, qo_stages * QSTAGE_Q, alignment=128, space=cutlass.AddressSpace.smem)
     sdO = cutlass.Array(io_dtype, qo_stages * QSTAGE_O, alignment=128, space=cutlass.AddressSpace.smem)
-    # sP carries P sg0→sg1 in fp32: dS = (dP − do_dot)·P is formed from the
+    # sP carries P sg0->sg1 in fp32: dS = (dP - do_dot)*P is formed from the
     # unrounded softmax so only the MMA operands (bmm2_a / sdSᵀ) see a bf16
     # rounding.  +PT*2 B of SMEM over the bf16 copy (fits every flavor).
     sP = cutlass.Array(cutlass.Float32, PT, alignment=128, space=cutlass.AddressSpace.smem)

--- a/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
+++ b/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
@@ -66,7 +66,7 @@ MMA as d=512.
 | FP8 E4M3 / E5M2 (per-tensor descale) | ⚠️⁷ | ✅ | ✅ | ❌ | ✅ | ❌ |
 | MXFP8 (E4M3/E5M2 + per-32 E8M0 SF) | ❌⁸ | ✅ | ✅ | ❌ | ❌ | ✅ᵍ (E4M3 only, d=256) |
 | O dtype ≠ QKV dtype — **quantized graphs only**¹ | ✅ | ✅ | ✅ | — | ✅ | ✅ᵍ (fp16/bf16 gradients) |
-| Head-dim envelope (zero-padded below native) | **none — runs the d128 kernel**⁷ | f16 ×8 · fp8 ×16 · mxfp8 exact | f16 ×8 · fp8 ×16 · mxfp8 exact | f16 ×8 | f16 ×8 · fp8 ×16, floor 256² | f16 (256, 512] ×8ᵇ · mxfp8 exact 256ᵍ |
+| Head-dim envelope (zero-padded below native) | **none — runs the d128 kernel**⁷ | f16 ×8 · fp8 ×16 · mxfp8 exact | f16 ×8 · **fp8 exact (192, 128) only**¹⁰ · mxfp8 exact | f16 ×8 · **fp8 exact 256 only**¹⁰ | f16 ×8 · fp8 ×16, floor 256² | f16 (256, 512] ×8ᵇ · mxfp8 exact 256ᵍ |
 | **Layout** | | | | | | |
 | BSHD | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ᵇ ᵍ |
 | Arbitrary dense B/H/S stride order (`dense_flex`) | f16 only | f16 only | f16 only | ✅ | f16 only | ✅ᵇ ᶜ · ❌ᵍ |
@@ -181,6 +181,16 @@ none could be tested. Ragged backward lengths arrive as per-batch `seq_len_q/kv`
 quantized rows list `{(128,128), (512,512)}` (per-tensor) / `{(128,128)}`
 (MXFP8), so d=64 **THD on FP8/MXFP8 is declined**. f16/bf16 THD rides the
 envelope (`thd_d_shapes=None`) and works.
+¹⁰ The per-tensor FP8 d192×d128 and d256 flavors are **floored to their exact
+shapes** (`d_envelope_floors` `((192,128),128), ((256,256),255)`, mirrored in
+`fwd/api_dsl._SM100_FP8_ENVELOPE_FLOORS`): with d_qk zero-padded into d192×d128
+the kernel's output is wrong (4–19 % of elements off by O(1) in `test_mhas_v2`),
+and the d256 padded envelope is run-to-run nondeterministic on long causal
+e5m2/GQA/sink graphs. So an FP8 graph with head dims in (128, 256) that is not
+exactly (192, 128) or (256, 256) is declined by the engine and takes the classic
+backend verdict — the same envelope the C++ `validate()` always enforced. The
+d128 flavor's ×16 envelope and the d512 band² are unaffected. Lift the floors
+once the kernels' padded paths pass the battery.
 ᵍ **`sdpa_bwd_sm100_mxfp8` only — `sdpa_mxfp8_backward()` with E4M3 payloads,
 d_qk = d_v = 256 exactly, fp16/bf16 `o_f16`/`dO_f16`/dQ/dK/dV.** Serves MHA /
 GQA / MQA, any fixed S_q / S_kv (the kernels mask tile tails; S_q = 1 works),

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -111,7 +111,7 @@ def _sm100_fp8_shapes(pertensor: bool, device_cc: tuple[int, int]) -> frozenset[
 # smaller FP8 flavor reaches, at most 2x zero-padding. A smaller graph is
 # declined rather than routed onto a kernel whose cga4x1 role-split geometry is
 # tuned for d = 512.
-_SM100_FP8_ENVELOPE_FLOORS = {(512, 512): 256}
+_SM100_FP8_ENVELOPE_FLOORS = {(192, 128): 128, (256, 256): 255, (512, 512): 256}  # (192,128)/(256,256): exact shape only, see engines._sm100_fp8_spec
 
 
 def _fp8_envelope_covers(d_qk: int, d_v: int, shapes) -> bool:
@@ -1088,7 +1088,22 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         )
         # An FP8 graph must only land on a flavor that HAS an fp8 kernel: the
         # per-tensor and block-scale families have different native maps.
-        self.flavor = _pick_flavor(d_qk, d_v, tuple(f for f in _SM100_FLAVORS if f in fp8_shapes) if self._fp8 else None)
+        # The FP8 walk must agree with check_support: a flavor whose envelope
+        # floor excludes (d_qk, d_v) is skipped, so the graph lands on the next
+        # covering flavor instead of the one the floor exists to keep it off.
+        self.flavor = _pick_flavor(
+            d_qk,
+            d_v,
+            (
+                tuple(
+                    f
+                    for f in _SM100_FLAVORS
+                    if f in fp8_shapes and (f == (int(d_qk), int(d_v)) or min(int(d_qk), int(d_v)) > _SM100_FP8_ENVELOPE_FLOORS.get(f, 0))
+                )
+                if self._fp8
+                else None
+            ),
+        )
         self._value_error_if(
             self.sched_policy is not None and self.sched_policy not in (SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2),
             f"SM100 DSL SDPA sched_policy must be NATURAL/LPT/LPT_L2 (or None to derive); got {self.sched_policy}",

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -294,9 +294,17 @@ def _band_covers_kv_tail(facts: "ga.SdpaGraphFacts") -> bool:
 
 
 def _selected_d_shape(capabilities: Capabilities, facts: "ga.SdpaGraphFacts") -> Optional[tuple[int, int]]:
-    """Smallest native flavor whose envelope covers this graph."""
+    """Smallest native flavor whose envelope covers this graph -- honouring the
+    per-shape envelope floors, so the knob domains (cga, split) describe the
+    flavor the lowering will actually pick (api_dsl._pick_flavor walks the same
+    floors). An exact native shape is always its own selection."""
 
-    covering = [shape for shape in capabilities.d_shapes if facts.d_qk <= shape[0] and facts.d_v <= shape[1]]
+    floors = dict(capabilities.d_envelope_floors)
+    covering = [
+        shape
+        for shape in capabilities.d_shapes
+        if facts.d_qk <= shape[0] and facts.d_v <= shape[1] and ((facts.d_qk, facts.d_v) == shape or min(facts.d_qk, facts.d_v) > floors.get(shape, 0))
+    ]
     return min(covering, key=lambda shape: (shape[0], shape[1])) if covering else None
 
 
@@ -718,8 +726,19 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
             # the range no smaller FP8 flavor reaches, at most 2x zero-padding.
             # Below that floor it declines rather than swallowing e.g. a d256
             # graph onto a kernel whose cga4x1 role-split geometry is tuned for
-            # d = 512. Mirrored by api_dsl._SM100_FP8_ENVELOPE_FLOORS.
-            d_envelope_floors=() if rubin_row else (((512, 512), 256),),
+            # d = 512.  The d192x128 flavor serves ONLY its exact shape: with
+            # d_qk zero-padded into it (144/160/176) the kernel's output is wrong
+            # (4-19% of elements off by O(1) against the fp32 reference on
+            # SM100; d_v padding and the d128/d512 flavors' padding are exact),
+            # so a floor of 128 (min(d_qk, d_v) > 128 is unreachable at d_v <=
+            # 128) keeps every inexact graph off it until the kernel's Q/K
+            # padding is fixed.  Mirrored by api_dsl._SM100_FP8_ENVELOPE_FLOORS.
+            # The D256 flavor (#860) likewise serves only its exact shape for now: the
+            # classic battery routed onto its padded envelope (d_qk in (128, 256))
+            # shows run-to-run nondeterminism on long causal e5m2/GQA/sink graphs;
+            # min(d_qk, d_v) > 255 admits nothing inexact. Lift both floors once the
+            # kernels' padded paths are validated through test_mhas_v2.
+            d_envelope_floors=() if rubin_row else (((192, 128), 128), ((256, 256), 255), ((512, 512), 256)),
             thd_d_shapes=frozenset({(128, 128)}) if rubin_row else frozenset({(128, 128), (192, 128), (256, 256), (512, 512)}),
             dtypes=frozenset({cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2}),
             out_dtypes=frozenset({cudnn.data_type.HALF, cudnn.data_type.BFLOAT16, cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2}),

--- a/test/python/gemm/frost/test_gemm_python_validate.py
+++ b/test/python/gemm/frost/test_gemm_python_validate.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""pygraph.validate() for GEMM-family graphs through the manifest's per-family
+validator hook (issue #704): with a python engine candidate the frost_gemm
+validator runs instead of the eager C++ lowering; without one, or for a graph
+holding a node it does not cover, the classic lowering is unchanged. Device-free.
+"""
+
+import pytest
+
+import cudnn
+from cudnn.engines import manifest
+
+
+@pytest.fixture
+def frost_candidate(monkeypatch):
+    """Pretend the manifest offers a python engine for every graph."""
+    monkeypatch.setattr(manifest, "engines_for", lambda graph: [object()])
+
+
+@pytest.fixture
+def no_candidates(monkeypatch):
+    """Manifest offers no python engine (frost off / family unavailable)."""
+    monkeypatch.setattr(manifest, "engines_for", lambda graph: [])
+
+
+def _matmul_graph(a_dim=(2, 64, 32), b_dim=(2, 32, 48), c_dim=None):
+    """A minimal batched matmul pygraph; returns (graph, C)."""
+    g = cudnn.pygraph(io_data_type=cudnn.data_type.HALF, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+
+    def rm(d):
+        s, out = 1, []
+        for x in reversed(d):
+            out.append(s)
+            s *= x
+        return list(reversed(out))
+
+    a = g.tensor(name="A", dim=list(a_dim), stride=rm(a_dim))
+    b = g.tensor(name="B", dim=list(b_dim), stride=rm(b_dim))
+    c = g.matmul(A=a, B=b)
+    c.set_output(True)
+    if c_dim is not None:
+        c.set_dim(list(c_dim)).set_stride(rm(c_dim))
+    return g, c
+
+
+def test_family_declares_validator():
+    """frost_gemm and both SDPA families declare a resolvable native validator."""
+    by_name = {f.name: f for f in manifest.MANIFEST}
+    for name in ("frost_gemm", "frost_sdpa_fwd", "frost_sdpa_bwd"):
+        assert by_name[name].validator is not None, name
+        assert callable(manifest.resolve_validator(by_name[name])), name
+    for name in ("gdn", "kda", "gdn2", "gdp"):  # python_only families: never eagerly lowered anyway
+        assert by_name[name].validator is None
+
+
+def test_valid_matmul_does_not_lower(frost_candidate):
+    """With a python candidate, a GEMM graph validates natively (no C++ lowering)."""
+    g, _ = _matmul_graph()
+    g.validate()
+    assert g._lowered_graph is None
+
+
+def test_classic_path_without_candidates(no_candidates):
+    """No python candidate: the classic eager C++ lowering is unchanged."""
+    g, _ = _matmul_graph()
+    g.validate()
+    assert g._lowered_graph is not None
+
+
+def test_mixed_graph_still_lowers(frost_candidate):
+    """A node the GEMM validator does not cover (pointwise epilogue) keeps the
+    classic eager lowering even with a candidate: the rule is every-node-covered."""
+    g, c = _matmul_graph()
+    g.relu(input=c).set_output(True)
+    g.validate()
+    assert g._lowered_graph is not None
+
+
+def test_contraction_mismatch_rejected(frost_candidate):
+    """K disagreement between A and B is a GRAPH_NOT_SUPPORTED-class rejection from validate()."""
+    g, _ = _matmul_graph(a_dim=(2, 64, 32), b_dim=(2, 40, 48))
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="contraction mismatch"):
+        g.validate()
+    assert g._lowered_graph is None and g._is_validated is False
+
+
+def test_batch_broadcast_rules(frost_candidate):
+    """Batch extents must be equal or 1 (broadcast)."""
+    g, _ = _matmul_graph(a_dim=(1, 64, 32), b_dim=(4, 32, 48))
+    g.validate()  # broadcast OK
+    g, _ = _matmul_graph(a_dim=(3, 64, 32), b_dim=(4, 32, 48))
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="not broadcastable"):
+        g.validate()
+
+
+def test_declared_output_dims_checked(frost_candidate):
+    """A user-declared C must carry the (M, N) the operands imply."""
+    g, _ = _matmul_graph(c_dim=(2, 64, 40))
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="do not match"):
+        g.validate()
+
+
+def test_family_without_validator_lowers_classically(frost_candidate, monkeypatch):
+    """A family that declares no validator (or whose module is unavailable) keeps
+    the classic eager lowering even with a candidate."""
+    monkeypatch.setattr(manifest, "resolve_validator", lambda family: None)
+    g, _ = _matmul_graph()
+    g.validate()
+    assert g._lowered_graph is not None

--- a/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
+++ b/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
@@ -80,7 +80,7 @@ def test_per_tensor_fp8_rows_split_per_arch_line():
     # d512 carries an envelope FLOOR: it serves (256, 512] on both head dims,
     # so a smaller graph is declined rather than routed onto the d512 kernel at
     # a multiple-x zero-padding cost.  Rubin has no d512 flavor, hence no floor.
-    assert sm100.d_envelope_floors == (((512, 512), 256),)
+    assert sm100.d_envelope_floors == (((192, 128), 128), ((256, 256), 255), ((512, 512), 256))
     assert sm107.d_envelope_floors == ()
 
     # The f16x2 exponent arm is Rubin-row data, not a notch.
@@ -372,10 +372,16 @@ def test_fp8_envelope_mismatch_rules():
     sm100 = caps[engines.engine_name(fp8=True)]
     assert engines.mismatch(sm100, _fp8_facts()) is None
     assert engines.mismatch(sm100, _fp8_facts(d_qk=96, d_v=64)) is None
-    # The d192xd128 flavor serves its envelope too (kernel takes d_qk/d_v).
-    assert engines.mismatch(sm100, _fp8_facts(d_qk=160, d_v=96)) is None
-    # D256xD256 extends that envelope in both dimensions.
-    assert engines.mismatch(sm100, _fp8_facts(d_qk=160, d_v=160)) is None
+    # The d192xd128 and D256 flavors serve ONLY their exact shapes (floors 128 / 255):
+    # d_qk zero-padded into d192 is numerically wrong and the D256 padded envelope is
+    # nondeterministic in test_mhas_v2, so the row declines the whole (128, 256) inexact
+    # region and the classic backend verdict applies there.
+    assert engines.mismatch(sm100, _fp8_facts(d_qk=192, d_v=128)) is None
+    assert engines.mismatch(sm100, _fp8_facts(d_qk=256, d_v=256)) is None
+    for dq, dv in ((160, 96), (176, 128), (192, 96), (160, 160), (224, 208)):
+        assert "no kernel-flavor envelope" in engines.mismatch(sm100, _fp8_facts(d_qk=dq, d_v=dv)), (dq, dv)
+    assert engines._selected_d_shape(sm100, _fp8_facts(d_qk=192, d_v=128)) == (192, 128)
+    assert engines._selected_d_shape(sm100, _fp8_facts(d_qk=256, d_v=256)) == (256, 256)
     assert "no kernel-flavor envelope" in engines.mismatch(sm100, _fp8_facts(d_qk=272, d_v=256))
     assert "multiples of 16" in engines.mismatch(sm100, _fp8_facts(d_qk=88, d_v=88))
     assert "dense-only" in engines.mismatch(sm100, _fp8_facts(thd=True, padded=True))

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -523,60 +523,49 @@ def test_fp8_head_dim_envelope(dims, mask):
 
 @pytest.mark.L0
 @_skip_on_rubin
-@pytest.mark.parametrize(("d_qk", "d_v"), [(160, 96), (224, 208)], ids=["d192_envelope", "d256_envelope"])
-@torch_fork_set_rng(seed=0)
-def test_fp8_head_dim_envelope_large_flavors(d_qk, d_v):
-    """The D192/D128 and D256 flavors serve their dense envelopes through
-    TMA zero-padding on both head dimensions.
+def test_fp8_large_flavors_serve_exact_shapes_only():
+    """The d192xd128 and D256 per-tensor FP8 flavors serve ONLY their exact shapes.
+    With d_qk zero-padded into d192 (144/160/176) the output is wrong (test_mhas_v2
+    fp8 fwd: 4-19% of elements off by O(1)); the D256 padded envelope shows
+    run-to-run nondeterminism on long causal e5m2/GQA/sink graphs (a case passes
+    alone and fails in the battery). The engine row floors both (128 / 255), the
+    adapter mirrors the floors, and both flavor selections honour them, so the
+    inexact (128, 256) region is declined everywhere -- the classic backend verdict
+    applies -- while the d128 flavor's envelope and the d512 band are unchanged."""
+    from cudnn.sdpa.fwd import engines as eng
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm100, _SM100_FP8_ENVELOPE_FLOORS, _fp8_envelope_covers
 
-    Direct adapter API: the pygraph ``sdpa_fp8`` node validator still bounds
-    the GRAPH route at d_qk <= 128 (%16) / exact (192, 128) — a pre-FE-OSS
-    shape whitelist in the C++ frontend — so this region of the envelope is
-    reachable through the standalone API only until that validation is
-    relaxed to describe rather than judge."""
-    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm100
+    assert _SM100_FP8_ENVELOPE_FLOORS[(192, 128)] == 128 and _SM100_FP8_ENVELOPE_FLOORS[(256, 256)] == 255
+    spec = next(sp for sp in eng.ENGINE_SPECS if sp.name == "sdpa_fwd_prefill_sm100_fp8")
+    assert dict(spec.capabilities.d_envelope_floors) == {(192, 128): 128, (256, 256): 255, (512, 512): 256}
+    shapes = frozenset({(128, 128), (192, 128), (256, 256), (512, 512)})
+    for d_qk, d_v in ((160, 96), (176, 128), (192, 96), (160, 160), (224, 208)):
+        assert not _fp8_envelope_covers(d_qk, d_v, shapes), (d_qk, d_v)
+    for d_qk, d_v in ((96, 96), (128, 64), (320, 320)):
+        assert _fp8_envelope_covers(d_qk, d_v, shapes), (d_qk, d_v)
 
-    B, H, S = 2, 4, 384
-    dev = "cuda"
-    Q8 = (torch.randn(B, H, S, d_qk, device=dev) * 0.5).to(torch.float8_e4m3fn)
-    K8 = (torch.randn(B, H, S, d_qk, device=dev) * 0.5).to(torch.float8_e4m3fn)
-    V8 = (torch.randn(B, H, S, d_v, device=dev) * 0.5).to(torch.float8_e4m3fn)
-    out = torch.empty(B, H, S, d_v, device=dev, dtype=torch.bfloat16)
-    lse = torch.empty(B, H, S, device=dev, dtype=torch.float32)
-    scale = 1.0 / math.sqrt(d_qk)
+    B, H, S, dev = 2, 4, 384, "cuda"
 
-    api = SdpaFwdDslSm100(sample_q=Q8, sample_k=K8, sample_v=V8, sample_o=out, sample_lse=lse, scale_softmax=scale, pertensor_fp8=True)
-    assert api.check_support()
-    api.compile()
-    api.execute(q_tensor=Q8, k_tensor=K8, v_tensor=V8, o_tensor=out, lse_tensor=lse)
-    torch.cuda.synchronize()
+    def _api(d_qk, d_v):
+        Q8 = (torch.randn(B, H, S, d_qk, device=dev) * 0.5).to(torch.float8_e4m3fn)
+        K8 = (torch.randn(B, H, S, d_qk, device=dev) * 0.5).to(torch.float8_e4m3fn)
+        V8 = (torch.randn(B, H, S, d_v, device=dev) * 0.5).to(torch.float8_e4m3fn)
+        out = torch.empty(B, H, S, d_v, device=dev, dtype=torch.bfloat16)
+        lse = torch.empty(B, H, S, device=dev, dtype=torch.float32)
+        return SdpaFwdDslSm100(sample_q=Q8, sample_k=K8, sample_v=V8, sample_o=out, sample_lse=lse, scale_softmax=1.0 / math.sqrt(d_qk), pertensor_fp8=True)
 
-    o_ref = torch.softmax(Q8.float() @ K8.float().transpose(-1, -2) * scale, dim=-1) @ V8.float()
-    err = (out.float() - o_ref).abs().max().item()
-    assert err <= 5e-2 + 0.05 * o_ref.abs().max().item(), f"({d_qk},{d_v}) envelope mismatch: max err {err}"
-    assert not torch.isnan(out.float()).any()
-
-
-@pytest.mark.L0
-@torch_fork_set_rng(seed=0)
-def test_fp8_head_dim_envelope_padded():
-    """The envelope composed with the KV padding mask — the ViT production
-    shape (non-causal, seqlen padded up to a tile multiple, d=80)."""
-    out, o_ref, a_o, a_o_ref = _run(
-        2,
-        4,
-        4,
-        384,
-        384,
-        "e4m3",
-        torch.bfloat16,
-        scale=1.0 / math.sqrt(72),
-        sdpa_kwargs={},
-        seq_lens_kv=[384, 250],
-        d_qk=80,
-        d_v=80,
-    )
-    _check(out, o_ref, torch.bfloat16, "e4m3", a_o, a_o_ref)
+    for d_qk, d_v, want in ((192, 128, (192, 128)), (256, 256, (256, 256)), (96, 96, (128, 128))):
+        api = _api(d_qk, d_v)
+        assert api.check_support(), (d_qk, d_v)
+        assert tuple(api.flavor) == want, (d_qk, d_v, api.flavor)
+    for d_qk, d_v in ((160, 96), (224, 208)):
+        api = _api(d_qk, d_v)
+        try:
+            supported = api.check_support()
+        except ValueError as exc:  # the adapter may surface the envelope gate as a raise
+            supported = False
+            assert "floors" in str(exc), str(exc)
+        assert not supported, (d_qk, d_v)
 
 
 @pytest.mark.L0

--- a/test/python/sdpa/frost/test_sdpa_fwd_heuristics.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_heuristics.py
@@ -172,19 +172,18 @@ def test_quantized_cga_follows_selected_native_flavor(mxfp8, d_qk, d_v, expected
 
 @pytest.mark.L0
 def test_per_tensor_fp8_envelope_uses_d256_cga1():
-    """A non-native dense shape inherits the geometry of its covering flavor."""
+    """The D256 flavor's geometry (cga = 1) reaches the plan list for its exact
+    shape; a non-native shape in its padded envelope is declined (the flavor is
+    floored to exact shapes until its padded paths are validated), so no plan is
+    proposed for it at all."""
 
     name = engines.engine_name(fp8=True)
-    facts = _facts(
-        d_qk=224,
-        d_v=224,
-        dtype=cudnn.data_type.FP8_E4M3,
-        dtype_o=cudnn.data_type.HALF,
-        is_fp8=True,
-    )
-    plans = recommend("A", facts, {name: 20510})
+    exact = _facts(d_qk=256, d_v=256, dtype=cudnn.data_type.FP8_E4M3, dtype_o=cudnn.data_type.HALF, is_fp8=True)
+    plans = recommend("A", exact, {name: 20510})
     assert plans
     assert {plan.knobs.cga for plan in plans} == {1}
+    padded = _facts(d_qk=224, d_v=224, dtype=cudnn.data_type.FP8_E4M3, dtype_o=cudnn.data_type.HALF, is_fp8=True)
+    assert not recommend("A", padded, {name: 20510})
 
 
 @pytest.mark.L0

--- a/test/python/sdpa/frost/test_sdpa_python_validate.py
+++ b/test/python/sdpa/frost/test_sdpa_python_validate.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Python-native SDPA validation (issue #704).
+
+With a FROST engine candidate, ``pygraph.validate()`` must not lower to C++ —
+the eager backend validation is what coupled frontend-only engines to the
+installed backend's version. Semantic invalidity must still raise from
+validate(), with classic error types (``cudnnGraphNotSupportedError`` for
+GRAPH_NOT_SUPPORTED parity, ``ValueError`` for ATTRIBUTE_NOT_SET/INVALID_VALUE
+parity). Without a candidate, the classic eager-lowering timing is unchanged.
+
+Device-free: candidates are stubbed via ``manifest.engines_for``; nothing here
+builds plans or executes.
+"""
+
+import pytest
+
+import cudnn
+from cudnn.engines import manifest
+
+pytestmark = pytest.mark.L0
+
+
+@pytest.fixture
+def frost_candidate(monkeypatch):
+    """Pretend the manifest offers a python engine for every graph."""
+    monkeypatch.setattr(manifest, "engines_for", lambda graph: [object()])
+
+
+@pytest.fixture
+def no_candidates(monkeypatch):
+    monkeypatch.setattr(manifest, "engines_for", lambda graph: [])
+
+
+def _sdpa_graph(
+    b=1,
+    h_q=2,
+    h_kv=2,
+    s_q=64,
+    s_kv=64,
+    d=64,
+    **sdpa_kwargs,
+):
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.HALF,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    q = g.tensor(name="q", dim=[b, h_q, s_q, d], stride=[h_q * s_q * d, s_q * d, d, 1])
+    k = g.tensor(name="k", dim=[b, h_kv, s_kv, d], stride=[h_kv * s_kv * d, s_kv * d, d, 1])
+    v = g.tensor(name="v", dim=[b, h_kv, s_kv, d], stride=[h_kv * s_kv * d, s_kv * d, d, 1])
+    o, stats = g.sdpa(q, k, v, generate_stats=True, **sdpa_kwargs)
+    o.set_output(True)
+    if stats is not None:
+        stats.set_output(True).set_data_type(cudnn.data_type.FLOAT)
+    return g, dict(q=q, k=k, v=v, o=o, stats=stats)
+
+
+def test_valid_graph_does_not_lower(frost_candidate):
+    g, _ = _sdpa_graph(use_causal_mask=True)
+    g.validate()
+    assert g._lowered_graph is None, "validate() must not lower to C++ when a python engine is a candidate"
+
+
+def test_classic_path_still_lowers(no_candidates):
+    g, _ = _sdpa_graph(use_causal_mask=True)
+    g.validate()
+    assert g._lowered_graph is not None, "without python candidates the classic eager lowering must be unchanged"
+
+
+def test_gqa_head_divisibility(frost_candidate):
+    g, _ = _sdpa_graph(h_q=3, h_kv=2)
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="group-query attention"):
+        g.validate()
+    assert g._lowered_graph is None
+
+
+def test_bottom_right_causal_with_bias(frost_candidate):
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.HALF,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    dims = [1, 2, 64, 64]
+    strides = [2 * 64 * 64, 64 * 64, 64, 1]
+    q = g.tensor(name="q", dim=dims, stride=strides)
+    k = g.tensor(name="k", dim=dims, stride=strides)
+    v = g.tensor(name="v", dim=dims, stride=strides)
+    bias = g.tensor(name="bias", dim=[1, 1, 64, 64], stride=[64 * 64, 64 * 64, 64, 1])
+    o, _ = g.sdpa(q, k, v, bias=bias, use_causal_mask_bottom_right=True, generate_stats=False)
+    o.set_output(True)
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="Bottom right causal mask"):
+        g.validate()
+
+
+def test_padding_mask_requires_seq_lens(frost_candidate):
+    g, _ = _sdpa_graph(use_padding_mask=True)
+    with pytest.raises(ValueError, match="Padding mask requires"):
+        g.validate()
+
+
+def test_seq_lens_require_padding_mask(frost_candidate):
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.HALF,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    dims = [2, 2, 64, 64]
+    strides = [2 * 64 * 64, 64 * 64, 64, 1]
+    q = g.tensor(name="q", dim=dims, stride=strides)
+    k = g.tensor(name="k", dim=dims, stride=strides)
+    v = g.tensor(name="v", dim=dims, stride=strides)
+    seq_q = g.tensor(name="seq_q", dim=[2, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT32)
+    seq_kv = g.tensor(name="seq_kv", dim=[2, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT32)
+    o, _ = g.sdpa(q, k, v, seq_len_q=seq_q, seq_len_kv=seq_kv, generate_stats=False)
+    o.set_output(True)
+    with pytest.raises(ValueError, match="only if padding mask is enabled"):
+        g.validate()
+
+
+def test_dropout_probability_one_rejected(frost_candidate):
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.HALF,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    dims = [1, 2, 64, 64]
+    strides = [2 * 64 * 64, 64 * 64, 64, 1]
+    q = g.tensor(name="q", dim=dims, stride=strides)
+    k = g.tensor(name="k", dim=dims, stride=strides)
+    v = g.tensor(name="v", dim=dims, stride=strides)
+    seed = g.tensor(name="seed", dim=[1, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT64)
+    offset = g.tensor(name="offset", dim=[1, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT64)
+    o, _ = g.sdpa(q, k, v, dropout=(1.0, seed, offset), generate_stats=False)
+    o.set_output(True)
+    with pytest.raises(ValueError, match="Dropout probability cannot be 1"):
+        g.validate()
+
+
+def test_alibi_requires_causal(frost_candidate):
+    g, _ = _sdpa_graph(use_alibi_mask=True)
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="alibi"):
+        g.validate()
+
+
+def test_non_fp32_stats_rejected(frost_candidate):
+    g, ts = _sdpa_graph(use_causal_mask=True)
+    ts["stats"].set_data_type(cudnn.data_type.HALF)
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="Stats output of sdpa must be an FP32"):
+        g.validate()
+
+
+def test_head_dim_multiple_of_8(frost_candidate):
+    g, _ = _sdpa_graph(d=68, use_causal_mask=True)
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="multiple of 8"):
+        g.validate()
+
+
+def test_sliding_window_sq_gt_skv_rejected(frost_candidate):
+    g, _ = _sdpa_graph(s_q=128, s_kv=64, use_causal_mask=True, sliding_window_length=16)
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="Sliding window attention"):
+        g.validate()
+
+
+def test_bwd_sq1_skv1_rejected(frost_candidate):
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.HALF,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    dims = [1, 2, 1, 64]
+    strides = [2 * 64, 64, 64, 1]
+    q = g.tensor(name="q", dim=dims, stride=strides)
+    k = g.tensor(name="k", dim=dims, stride=strides)
+    v = g.tensor(name="v", dim=dims, stride=strides)
+    o = g.tensor(name="o", dim=dims, stride=strides)
+    dO = g.tensor(name="dO", dim=dims, stride=strides)
+    stats = g.tensor(name="stats", dim=[1, 2, 1, 1], stride=[2, 1, 1, 1], data_type=cudnn.data_type.FLOAT)
+    dQ, dK, dV = g.sdpa_backward(q, k, v, o, dO, stats)
+    for t in (dQ, dK, dV):
+        t.set_output(True)
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="s_q = s_kv = 1"):
+        g.validate()
+    assert g._lowered_graph is None

--- a/test/python/sdpa/frost/test_sdpa_python_validate.py
+++ b/test/python/sdpa/frost/test_sdpa_python_validate.py
@@ -82,6 +82,18 @@ def test_mixed_graph_still_lowers(frost_candidate):
     assert g._lowered_graph is not None, "a graph with an uncovered node must keep the classic eager lowering"
 
 
+def test_rejected_graph_stays_unvalidated(frost_candidate):
+    """A native-validation rejection leaves the graph unvalidated: the flag is set
+    only after every check passes, so build_operation_graph() re-validates and
+    raises the same error rather than planning a rejected graph."""
+    g, _ = _sdpa_graph(h_q=3, h_kv=2)
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="group-query attention"):
+        g.validate()
+    assert g._is_validated is False
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="group-query attention"):
+        g.build_operation_graph()
+
+
 def test_gqa_head_divisibility(frost_candidate):
     """h_q not a multiple of h_kv is rejected with the classic error type, without lowering."""
     g, _ = _sdpa_graph(h_q=3, h_kv=2)

--- a/test/python/sdpa/frost/test_sdpa_python_validate.py
+++ b/test/python/sdpa/frost/test_sdpa_python_validate.py
@@ -94,6 +94,19 @@ def test_rejected_graph_stays_unvalidated(frost_candidate):
         g.build_operation_graph()
 
 
+def test_rejected_classic_graph_stays_unvalidated(no_candidates):
+    """Classic path (no python candidate): a backend rejection rolls the lowering
+    back, so the retry re-runs the backend check and raises again instead of
+    finding a stale lowered graph and marking the rejected graph valid."""
+    g, _ = _sdpa_graph(h_q=3, h_kv=2)
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError):
+        g.validate()
+    assert g._is_validated is False and g._lowered_graph is None
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError):
+        g.build_operation_graph()
+    assert g._is_validated is False
+
+
 def test_gqa_head_divisibility(frost_candidate):
     """h_q not a multiple of h_kv is rejected with the classic error type, without lowering."""
     g, _ = _sdpa_graph(h_q=3, h_kv=2)

--- a/test/python/sdpa/frost/test_sdpa_python_validate.py
+++ b/test/python/sdpa/frost/test_sdpa_python_validate.py
@@ -30,6 +30,7 @@ def frost_candidate(monkeypatch):
 
 @pytest.fixture
 def no_candidates(monkeypatch):
+    """Manifest offers no python engine (frost off / family unavailable)."""
     monkeypatch.setattr(manifest, "engines_for", lambda graph: [])
 
 
@@ -42,6 +43,7 @@ def _sdpa_graph(
     d=64,
     **sdpa_kwargs,
 ):
+    """A minimal SDPA forward pygraph; returns (graph, tensors-by-name)."""
     g = cudnn.pygraph(
         io_data_type=cudnn.data_type.HALF,
         intermediate_data_type=cudnn.data_type.FLOAT,
@@ -58,18 +60,30 @@ def _sdpa_graph(
 
 
 def test_valid_graph_does_not_lower(frost_candidate):
+    """With a python candidate, validate() skips the eager C++ lowering."""
     g, _ = _sdpa_graph(use_causal_mask=True)
     g.validate()
     assert g._lowered_graph is None, "validate() must not lower to C++ when a python engine is a candidate"
 
 
 def test_classic_path_still_lowers(no_candidates):
+    """No python candidate: validate() keeps the classic eager C++ lowering."""
     g, _ = _sdpa_graph(use_causal_mask=True)
     g.validate()
     assert g._lowered_graph is not None, "without python candidates the classic eager lowering must be unchanged"
 
 
+def test_mixed_graph_still_lowers(frost_candidate):
+    """A node outside COVERED_NODE_TYPES (pointwise on O) forces the classic eager
+    lowering even with a python candidate: the routing rule is every-node-covered."""
+    g, ts = _sdpa_graph(use_causal_mask=True)
+    g.swish(ts["o"]).set_output(True)
+    g.validate()
+    assert g._lowered_graph is not None, "a graph with an uncovered node must keep the classic eager lowering"
+
+
 def test_gqa_head_divisibility(frost_candidate):
+    """h_q not a multiple of h_kv is rejected with the classic error type, without lowering."""
     g, _ = _sdpa_graph(h_q=3, h_kv=2)
     with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="group-query attention"):
         g.validate()
@@ -77,6 +91,7 @@ def test_gqa_head_divisibility(frost_candidate):
 
 
 def test_bottom_right_causal_with_bias(frost_candidate):
+    """Bottom-right causal + bias is a classic GRAPH_NOT_SUPPORTED combination."""
     g = cudnn.pygraph(
         io_data_type=cudnn.data_type.HALF,
         intermediate_data_type=cudnn.data_type.FLOAT,
@@ -95,12 +110,14 @@ def test_bottom_right_causal_with_bias(frost_candidate):
 
 
 def test_padding_mask_requires_seq_lens(frost_candidate):
+    """Padding mask without seq_len tensors is an ATTRIBUTE_NOT_SET-class ValueError."""
     g, _ = _sdpa_graph(use_padding_mask=True)
     with pytest.raises(ValueError, match="Padding mask requires"):
         g.validate()
 
 
 def test_seq_lens_require_padding_mask(frost_candidate):
+    """seq_len tensors without the padding mask are rejected (classic INVALID_VALUE parity)."""
     g = cudnn.pygraph(
         io_data_type=cudnn.data_type.HALF,
         intermediate_data_type=cudnn.data_type.FLOAT,
@@ -120,6 +137,7 @@ def test_seq_lens_require_padding_mask(frost_candidate):
 
 
 def test_dropout_probability_one_rejected(frost_candidate):
+    """Probability-form dropout with p = 1.0 is rejected at validate()."""
     g = cudnn.pygraph(
         io_data_type=cudnn.data_type.HALF,
         intermediate_data_type=cudnn.data_type.FLOAT,
@@ -139,12 +157,14 @@ def test_dropout_probability_one_rejected(frost_candidate):
 
 
 def test_alibi_requires_causal(frost_candidate):
+    """ALiBi without the causal mask is rejected."""
     g, _ = _sdpa_graph(use_alibi_mask=True)
     with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="alibi"):
         g.validate()
 
 
 def test_non_fp32_stats_rejected(frost_candidate):
+    """Stats must be FP32; a HALF Stats output is rejected."""
     g, ts = _sdpa_graph(use_causal_mask=True)
     ts["stats"].set_data_type(cudnn.data_type.HALF)
     with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="Stats output of sdpa must be an FP32"):
@@ -152,18 +172,21 @@ def test_non_fp32_stats_rejected(frost_candidate):
 
 
 def test_head_dim_multiple_of_8(frost_candidate):
+    """Head dim not a multiple of 8 is rejected."""
     g, _ = _sdpa_graph(d=68, use_causal_mask=True)
     with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="multiple of 8"):
         g.validate()
 
 
 def test_sliding_window_sq_gt_skv_rejected(frost_candidate):
+    """Sliding window with s_q > s_kv is rejected."""
     g, _ = _sdpa_graph(s_q=128, s_kv=64, use_causal_mask=True, sliding_window_length=16)
     with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="Sliding window attention"):
         g.validate()
 
 
 def test_bwd_sq1_skv1_rejected(frost_candidate):
+    """Backward with s_q = s_kv = 1 is rejected, without lowering."""
     g = cudnn.pygraph(
         io_data_type=cudnn.data_type.HALF,
         intermediate_data_type=cudnn.data_type.FLOAT,

--- a/test/python/sdpa/frost/test_sdpa_sm80_frontend_integration.py
+++ b/test/python/sdpa/frost/test_sdpa_sm80_frontend_integration.py
@@ -187,34 +187,33 @@ def test_fwd_engine_strided_stats_d256():
     _check_fwd_engine_strided_stats(256)
 
 
-@_SM80
-@pytest.mark.L0
-def test_bwd_engine_end_to_end():
+def _check_bwd_engine_end_to_end(d):
+    scale = 1.0 / math.sqrt(d)
     # Forward via the SM80 engine to produce O / stats.
-    g, q, k, v, o, stats = _build_fwd_graph()
+    g, q, k, v, o, stats = _build_fwd_graph(d=d)
     _native_then_pin(g, _FWD)
     torch.manual_seed(0)
-    q_buf, k_buf, v_buf = _buf(), _buf(), _buf()
+    q_buf, k_buf, v_buf = _buf(d), _buf(d), _buf(d)
     o_buf = torch.empty_like(q_buf)
     stats_buf = torch.empty(B, H, S, 1, dtype=torch.float32, device="cuda")
     g.execute({q: q_buf, k: k_buf, v: v_buf, o: o_buf, stats: stats_buf}, _ws(g))
 
     gb = cudnn.pygraph(io_data_type=_HALF, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
-    st = _bshd_stride(B, H, S, D)
-    qb = gb.tensor(name="q", dim=(B, H, S, D), stride=st, data_type=_HALF)
-    kb = gb.tensor(name="k", dim=(B, H, S, D), stride=st, data_type=_HALF)
-    vb = gb.tensor(name="v", dim=(B, H, S, D), stride=st, data_type=_HALF)
-    ob = gb.tensor(name="o", dim=(B, H, S, D), stride=st, data_type=_HALF)
-    dob = gb.tensor(name="dO", dim=(B, H, S, D), stride=st, data_type=_HALF)
+    st = _bshd_stride(B, H, S, d)
+    qb = gb.tensor(name="q", dim=(B, H, S, d), stride=st, data_type=_HALF)
+    kb = gb.tensor(name="k", dim=(B, H, S, d), stride=st, data_type=_HALF)
+    vb = gb.tensor(name="v", dim=(B, H, S, d), stride=st, data_type=_HALF)
+    ob = gb.tensor(name="o", dim=(B, H, S, d), stride=st, data_type=_HALF)
+    dob = gb.tensor(name="dO", dim=(B, H, S, d), stride=st, data_type=_HALF)
     statsb = gb.tensor(name="stats", dim=(B, H, S, 1), stride=(H * S, S, 1, 1), data_type=cudnn.data_type.FLOAT)
-    dq, dk, dv = gb.sdpa_backward(q=qb, k=kb, v=vb, o=ob, dO=dob, stats=statsb, attn_scale=_SCALE, use_causal_mask=True)
+    dq, dk, dv = gb.sdpa_backward(q=qb, k=kb, v=vb, o=ob, dO=dob, stats=statsb, attn_scale=scale, use_causal_mask=True)
     # Output layout is honored only when DECLARED (the graph invariant:
     # IR-inferred output strides are provisional) — bind BSHD-physical.
     for t in (dq, dk, dv):
         t.set_output(True).set_data_type(_HALF).set_stride(st)
     _native_then_pin(gb, _BWD)
 
-    do_buf = _buf()
+    do_buf = _buf(d)
     dq_buf, dk_buf, dv_buf = torch.empty_like(q_buf), torch.empty_like(k_buf), torch.empty_like(v_buf)
     gb.execute(
         {qb: q_buf, kb: k_buf, vb: v_buf, ob: o_buf, dob: do_buf, statsb: stats_buf, dq: dq_buf, dk: dk_buf, dv: dv_buf},
@@ -225,12 +224,32 @@ def test_bwd_engine_end_to_end():
     q_ref = q_buf.detach().float().requires_grad_()
     k_ref = k_buf.detach().float().requires_grad_()
     v_ref = v_buf.detach().float().requires_grad_()
-    o_ref = torch.nn.functional.scaled_dot_product_attention(q_ref, k_ref, v_ref, is_causal=True, scale=_SCALE)
+    o_ref = torch.nn.functional.scaled_dot_product_attention(q_ref, k_ref, v_ref, is_causal=True, scale=scale)
     o_ref.backward(do_buf.float())
 
     torch.testing.assert_close(dq_buf.float(), q_ref.grad, rtol=3e-2, atol=3e-2)
     torch.testing.assert_close(dk_buf.float(), k_ref.grad, rtol=3e-2, atol=3e-2)
     torch.testing.assert_close(dv_buf.float(), v_ref.grad, rtol=3e-2, atol=3e-2)
+
+
+@_SM80
+@pytest.mark.L0
+def test_bwd_engine_end_to_end():
+    _check_bwd_engine_end_to_end(D)
+
+
+@_SM80
+@pytest.mark.L0
+def test_bwd_engine_end_to_end_d256():
+    """d=256 backward through the GRAPH API on SM80 (issues #704 / #864).
+
+    Invariant: validate() must not apply the native backward node's Ampere
+    ``hidden_dim <= 128`` gate to a graph a python engine is a candidate for;
+    the SM80 backward row advertises d <= 256 and serves it. Without the
+    python-native validate() this raised cudnnGraphNotSupportedError from
+    g.validate() and the row was unreachable from the graph API / torch provider.
+    """
+    _check_bwd_engine_end_to_end(256)
 
 
 @_SM80

--- a/test/python/sdpa/frost/test_sdpa_sm80_frontend_integration.py
+++ b/test/python/sdpa/frost/test_sdpa_sm80_frontend_integration.py
@@ -188,6 +188,8 @@ def test_fwd_engine_strided_stats_d256():
 
 
 def _check_bwd_engine_end_to_end(d):
+    """Forward on the SM80 engine, then the backward graph pinned to sdpa_bwd_sm80 at head dim
+    ``d``; dQ/dK/dV against torch autograd."""
     scale = 1.0 / math.sqrt(d)
     # Forward via the SM80 engine to produce O / stats.
     g, q, k, v, o, stats = _build_fwd_graph(d=d)
@@ -235,6 +237,7 @@ def _check_bwd_engine_end_to_end(d):
 @_SM80
 @pytest.mark.L0
 def test_bwd_engine_end_to_end():
+    """Default (d=128) backward through the graph API on the SM80 engine."""
     _check_bwd_engine_end_to_end(D)
 
 


### PR DESCRIPTION
Fixes #704. Supersedes #818 (taken over from @vedaanta with their agreement; their commit is carried unchanged as the first commit).

## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches and my changes comply (Rule S2 update included).
- [x] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*`.

## Affected area

- Python frontend (`pygraph.validate()`, engine manifest)
- FE OSS kernels or CuTeDSL (SM80 SDPA backward; SM100 per-tensor FP8 engine table)
- Tests and the FROST SDPA support matrix

## Problem

`pygraph.validate()` lowers every backend-lowerable graph to C++ and runs the backend's `validate()`, even when a python (FROST) engine will serve the graph and the backend will never execute it. That couples frontend-only engines to the installed backend's version and to its per-arch gates:

- fp8/mxfp8 THD `cu_seq_len` graphs are rejected on backend < 9.25 although the FROST kernel serves them (#704);
- on an A100, a d=256 SDPA **backward** graph is rejected by the native node's Ampere `hidden_dim <= 128` gate although the SM80 FROST backward row serves it — so SM80 d>128 backward was unreachable from the graph API and the `cudnn.torch` provider (#864, folded into #704).

## What this PR does

**1. Native validation, resolved per engine family.** `EngineFamily` gains a `validator` `("module", "callable")` declaration next to `analyzer` / `heuristics`. `pygraph.validate()` asks the graph's family for it and validates natively **only when** the family declares one **and** the manifest offers a python engine for the graph (today the opt-in FROST rows, i.e. `CUDNN_FRONTEND_ENABLE_FROST_ENGINES=1`). Otherwise the classic eager C++ lowering runs byte-for-byte as before. The validator runs the family's version- and arch-agnostic semantic rules with the classic error types (`cudnnGraphNotSupportedError` / `ValueError`) and returns False — classic lowering — for a graph holding a node it does not cover (e.g. a pointwise epilogue). The backend's own verdict is deferred to planning, where a decline is recorded (`backend_plan_entries()`) and raised by `plan()` only if no python engine proposes a plan either.

Families wired:
- `frost_sdpa_fwd` / `frost_sdpa_bwd` → `cudnn/_sdpa_validate.py` (from #818: rank-4 dim/stride rules, GQA divisibility, mask combinations, padding/seq-len rules, dropout, ragged/paged constraints, FP32 Stats, MXFP8 descale layout; no backend-version or device-arch gates).
- `frost_gemm` → new `cudnn/_gemm_validate.py`: structural matmul facts (operands bound, equal rank ≥ 2, contraction agreement, broadcastable batch dims, a declared C matching (M, N)) and the MoE grouped-matmul nodes' ATTRIBUTE_NOT_SET checks. GEMM is the only other family that can hit the coupling: its MoE node needs cuDNN ≥ 9.15 (fwd) / 9.22 (bwd) just to *validate*. The linear-attention families are `python_only` and were never lowered eagerly; they declare no validator and are untouched.

Two validate()-ordering bugs found in review are fixed alongside: `_is_validated` is set only after every check passes, and a rejected C++ lowering is rolled back so a retry re-validates instead of reusing a rejected descriptor.

**2. Kernel-side fixes for regions this change newly exposes.** Routing the classic `test_mhas_v2` battery onto rows the C++ gate used to hide found two problems, fixed here so the battery is green with this PR (bundled deliberately — this PR is what makes the battery see them):
- **SM80 backward dS precision** (`bprop_f16_sm80.py`): the sub-group handoff of P through SMEM was bf16, so dS = scale·(dP − D)·P saw one rounding more than FlashAttention-2 (and our d=64 kernel). One d=256 bf16 case missed a dQ element by 2.4e-2 vs a 2e-2 tolerance. `sP` is fp32 now; the remaining bf16 roundings are the MMA operands. Timing equal or slightly better (s=4096: d=128 2.35→2.24 ms, d=256 7.59→7.55 ms on A100).
- **SM100 per-tensor FP8 envelope** (`fwd/engines.py`, `fwd/api_dsl.py`): the d192×128 flavor is numerically wrong with d_qk zero-padded into it (4–19 % of elements off by O(1)), and the D256 flavor's padded envelope is run-to-run nondeterministic on long causal e5m2/GQA/sink graphs. Both are floored to their exact shapes, and both flavor selections (`engines._selected_d_shape` for knob domains, `api_dsl._pick_flavor` for the lowering) honour the floors so a graph is never planned for one flavor and lowered onto another. Net: the inexact (128, 256) fp8 region is declined on every arch and the classic backend verdict applies there — develop's effective behaviour; the d128 flavor's envelope and the d512 band are unchanged. Support matrix updated (Rule S2).

## Behaviour and compatibility

- FROST disabled (default): no change anywhere.
- FROST enabled: SDPA and GEMM graphs with a python candidate skip the eager C++ validate. The manifest match is arch-blind, so on a GPU with no serving row (e.g. Hopper) a backend-rejected config now raises at `plan()` rather than `validate()`.
- **Fall-through to the backend is preserved.** The backend stays a candidate for every graph; only *when* its verdict is taken moves. Verified on A100 with FROST on: a plain causal graph is served by `sdpa_fwd_prefill_sm80`; a dropout graph (not served by the SM80 row) and an ALiBi graph (served by no FROST row) both skip the eager lowering at `validate()` and are served by the cuDNN backend at planning.
- New reachable capability: SM80 d>128 SDPA backward through the graph API and the torch provider (`test_d256_direct_aten_op` now passes on A100 instead of skipping).
- No public API change.

## Testing

- Device-free: `test_sdpa_python_validate.py` (15) and `test_gemm_python_validate.py` (9): native path with a candidate, classic path without one, mixed graphs, family without a validator, rejection types, `_is_validated` / rollback regressions.
- A100 (FROST on): `test_mhas_v2` L0 **1459 passed / 0 failed** (410 backward graphs on `sdpa_bwd_sm80`, develop routes 0); SM80 integration + backward wrapper suites incl. the new d=256 graph-API pin test; classic matmul/MoE tests identical FROST on/off.
- SM100 (FROST on): `test_mhas_v2` fp8 fwd L0 back to develop's 165 passed / 91 skipped (was 7 failed with the envelope unfloored); FROST GEMM suite identical to develop; SDPA engine/analyzer/heuristics suites green.
- CI: `frost-sdpa:cutlass-rel:{sm80,sm100}` green on the last pipelines; remaining reds are the develop-wide `py_test` ICE, `oss:` DSL-pin lanes (#917), and the sm120 forward-ragged mismatches.

## Commits (review in order)

1. python-native `validate()` for SDPA (#818, unchanged)
2. d=256 backward graph-API pin test on SM80
3. SM80 backward: dS from fp32 P
4. review: int dropout probability, candidate cache reset, mixed-graph test, docstrings
5. review: `_is_validated` set only after all checks pass
6. review: roll the C++ lowering back on backend rejection
7. SM100 per-tensor FP8 d192×128 / D256 flavors exact-shape only
8. native validation as a per-family manifest hook + GEMM validator (separable if we prefer to land SDPA-only first)
9. support-matrix update for 7 (Rule S2)
10. design docs kept true for the validator hook (`docs/python_graph_and_execution_backends.md`, FROST README; Rule 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

