### PR TITLE
fix-benchmark-config-selection

### DIFF
--- a/benchmark/gemm/frost/benchmark_block_scale_matmul.py
+++ b/benchmark/gemm/frost/benchmark_block_scale_matmul.py
@@ -40,7 +40,7 @@ from benchmark_utils import (
 
 
 def _build_spec_map():
-    """Legacy label -> (geometry cfg, cta_group) for block-scale
+    """Canonical label -> (geometry cfg, cta_group) for block-scale
     strategies (geometry must satisfy the SF 128x4 swizzle; K-tile bytes are
     arch-keyed: 128 on sm100, 384 on sm103)."""
     m = {}
@@ -48,10 +48,7 @@ def _build_spec_map():
         kb_want = 384 if cfg.pipeline == "sm103" else 128
         if cfg.mma_tile_m % 128 or cfg.mma_tile_n % 128 or cfg.cta_tile_k_bytes != kb_want:
             continue
-        for cg in (1, 2):
-            if cg == 2 and (cfg.cga_size_m % 2 or cfg.cta_tile_m == 64):
-                continue
-            m[f"{cfg.name}_{cg}ctamma"] = (cfg, cg)
+        m[cfg.name] = (cfg, cfg.cta_group)
     return m
 
 
@@ -64,9 +61,8 @@ def _vp_bs(handles, a, b, c, sfa, sfb):
     return {A: a, B: b, SFA: sfa, SFB: sfb, C: c}
 
 
-def _build_plan(g, cfg, name):
+def _build_plan(g, cfg, _name):
     """JIT-compile the recorded graph with a forced tile config."""
-    _, cta_group = spec_for(name, _SPEC_MAP)
     return jit_from_cudnn_graph(g, config=cfg)
 
 

--- a/benchmark/gemm/frost/benchmark_matmul.py
+++ b/benchmark/gemm/frost/benchmark_matmul.py
@@ -73,9 +73,8 @@ def _vp(handles, a, b, c):
     return {A: a, B: b, C: c}
 
 
-def _build_plan(g, cfg, name):
+def _build_plan(g, cfg, _name):
     """JIT-compile the recorded graph with a forced tile config."""
-    _, cta_group = spec_for(name, _SPEC_MAP)
     return jit_from_cudnn_graph(g, config=cfg)
 
 

--- a/benchmark/gemm/frost/benchmark_matmul_mixed_input.py
+++ b/benchmark/gemm/frost/benchmark_matmul_mixed_input.py
@@ -96,9 +96,8 @@ def _vp(handles, a, b, c):
     return {A: a, B: b, C: c}
 
 
-def _build_plan(g, cfg, name):
+def _build_plan(g, cfg, _name):
     """JIT-compile the graph with a forced tile config -> callable kernel."""
-    _, cta_group = spec_for(name, _SPEC_MAP)
     return jit_from_cudnn_graph(g, config=cfg)
 
 

--- a/benchmark/gemm/frost/benchmark_moe_block_scale_matmul.py
+++ b/benchmark/gemm/frost/benchmark_moe_block_scale_matmul.py
@@ -49,9 +49,8 @@ def _vp_moe_bs(handles, token, weight, sfa, sfb, fto, output):
     return {TOK: token, W: weight, SFA: sfa, SFB: sfb, FTO: fto, OUT: output}
 
 
-def _build_plan(g, cfg, name):
+def _build_plan(g, cfg, _name):
     """JIT-compile the recorded graph with a forced tile config -> compiled kernel."""
-    _, cta_group = spec_for(name, _SPEC_MAP)
     return jit_from_cudnn_graph(g, config=cfg)
 
 

--- a/benchmark/gemm/frost/benchmark_moe_grouped_matmul.py
+++ b/benchmark/gemm/frost/benchmark_moe_grouped_matmul.py
@@ -51,9 +51,8 @@ def _vp_moe(handles, token, weight, fto, output):
     return {TOK: token, W: weight, FTO: fto, OUT: output}
 
 
-def _build_plan(g, cfg, name):
+def _build_plan(g, cfg, _name):
     """JIT-compile the recorded graph with a forced tile config."""
-    _, cta_group = spec_for(name, _SPEC_MAP)
     return jit_from_cudnn_graph(g, config=cfg)
 
 

--- a/benchmark/gemm/frost/benchmark_utils.py
+++ b/benchmark/gemm/frost/benchmark_utils.py
@@ -30,26 +30,23 @@ from cudnn.gemm.frost.tile_config import by_name as _by_name
 
 # Config selection
 
-LABEL_RE = re.compile(r"^(CONFIG_sm\d+_\d+x\d+x\d+_\d+x\d+x\d+_cluster\d+x\d+)_([12])ctamma$")
-
 
 def spec_for(label, spec_map):
-    """(geometry cfg, cta_group) for a --configs label, or None.
+    """(config, cta_group) for a --configs label, or None.
 
     The sweep map comes from the registry funnel over CATALOG; a label naming a
     geometry outside it (e.g. a mma_size_m > 1 tile, which `by_name` synthesizes) is
-    still runnable, so parse it rather than calling it unsweepable."""
+    still runnable, so parse the complete canonical name rather than calling it
+    unsweepable.  ``cta_group`` is part of TileConfig geometry; do not strip its
+    suffix and carry a second, potentially inconsistent value beside the config."""
     spec = spec_map.get(label)
     if spec is not None:
         return spec
-    m = LABEL_RE.match(label)
-    if m is None:
-        return None
     try:
-        cfg = _by_name(m.group(1))
+        cfg = _by_name(label)
     except (KeyError, NotImplementedError):
         return None
-    return cfg, int(m.group(2))
+    return cfg, getattr(cfg, "cta_group", 1)
 
 
 def select_configs(arg, spec_map):


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches (see [root AGENTS.md § Reviewing a PR](https://github.com/NVIDIA/cudnn-frontend/blob/develop/AGENTS.md#reviewing-a-pr-human-or-agent)) and my changes comply, or I explain the exception below.
- [x] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

Fix a benchmark script config selection bug that prevents the desired config to be selected

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Benchmark configurations now use their native catalog names and associated settings.
  * Custom or uncatalogued configuration labels are resolved more consistently.
  * Matrix multiplication benchmarks compile directly from the supplied configuration, improving consistency across standard, mixed-input, block-scaled, and grouped workloads.
  * Unsupported or unknown configurations continue to be handled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->