### PR TITLE
frost gemm heur: block-scale early pairing only when M is exact, not a MoE group average

### DIFF
--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -3484,6 +3484,7 @@ def plan_config(chain: FusionChain) -> TileConfig:
         b_n_major=chain.matmul.b_major == "n",
         b_elem_bytes=DTYPE_BYTES[chain.matmul.b_dtype],
         force_cta_group=force_cta_group,
+        m_is_group_average=chain.moe is not None,
     )
     # Re-target at the preferred family and MMA-inst K width; cta_group rides
     # the geometry and only moves when the family cannot serve it (sm120 is

--- a/python/cudnn/gemm/frost/tile_config.py
+++ b/python/cudnn/gemm/frost/tile_config.py
@@ -911,6 +911,7 @@ def select_config(
     b_elem_bytes: int = 2,
     sm_count: int | None = None,
     force_cta_group: int | None = None,
+    m_is_group_average: bool = False,
 ) -> TileConfig:
     """Pick a TileConfig from problem geometry.
 
@@ -973,7 +974,12 @@ def select_config(
         # Block-scale prefers the CTA pair even without a second M tile (halved per-CTA
         # B footprint buys pipeline depth) — but only while the pair's padded M row still
         # fits the machine in one wave; past that the padding costs a whole extra wave.
-        cta_group = 2 if (M > cta_m or (block_scale and 2 * (-(-N // cta_n)) <= sm)) else 1
+        # NOT when M is a per-group average (MoE): the pairing win was measured on dense
+        # block-scale GEMMs where M is exact, and a one-wave bound computed against the
+        # average of ragged runtime groups bounds nothing — grouped M-starved problems
+        # keep 1-CTA through the ordinary rule, as the MoE planner tests pin.
+        early_pair = block_scale and not m_is_group_average and 2 * (-(-N // cta_n)) <= sm
+        cta_group = 2 if (M > cta_m or early_pair) else 1
 
     if block_scale:
         cta_m = max(cta_m, 128)


### PR DESCRIPTION
Fixes the `cta_group` assert failure in `test_planner_uses_total_m_not_unobservable_moe_row_distribution` introduced by #844 (first seen in `frost-gemm:cutlass-rel:sm100`).

**Root cause.** #844's block-scale early-pairing rule takes the 2-CTA MMA pair without a second M tile while the padded pair row fits the machine in one wave. That wave bound is arithmetic over M — valid only when M is an exact problem dimension. `plan_config` hands MoE chains a **per-group average** M (the only plan-time bound on runtime-ragged expert groups), and for `M=2816, moe_groups=23` the averaged `tile_m=123` sits below the terminal-quantizer force's total-row bound lapse point, so the ordinary heuristic decides — and the new disjunct paired a chain the planner tests pin at 1-CTA. The pairing win was measured on dense block-scale GEMMs where M is exact; an average of ragged groups is outside that envelope.

**Fix.** `select_config` grows an append-only `m_is_group_average: bool = False` parameter; the early-pairing disjunct additionally requires it false. `plan_config` sets it from `chain.moe is not None`. The precondition lives on the rule that depends on it — no duplication of tile-selection internals in the planner, and `force_cta_group` precedence is untouched.

Verified against all pinned expectations: MoE `groups=23` → 1-CTA, `groups=2` (`tile_m=1408 > cta_m`) → 2-CTA, dense block-scale M-starved keeps the measured pairing win, forced 1-CTA still overrides, dense batch cases unchanged.

(The `test_sm120_warp_grid_axis` failures in the same job are unrelated — TMEM-column overflow from #816.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic GEMM configuration selection for mixture-of-experts workloads using per-group average sizes.
  - Prevented inappropriate 2-CTA selection for block-scaled workloads when the reported size represents a group average.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->