### PR TITLE
Fix flash_attention (FA2) no-window call for flash-attn 2.7+

### DIFF
--- a/benchmark/attention_training/benchmark_single_sdpa.py
+++ b/benchmark/attention_training/benchmark_single_sdpa.py
@@ -1356,7 +1356,9 @@ else:
 
         # Flash Attention Native
         def flash_attention_sdpa(query, key, value):
-            window_size = (args.sliding_window_size, 0) if args.sliding_window_size else (None, None)
+            # flash-attn 2.7+ requires ints here: (-1, -1) is its no-window
+            # sentinel; passing None fails the SymInt cast in the op schema.
+            window_size = (args.sliding_window_size, 0) if args.sliding_window_size else (-1, -1)
             return flash_attn_func(
                 query,
                 key,


### PR DESCRIPTION
One-line fix: the flash_attention (FA2) backend passed window_size=(None, None) when no sliding window is configured, but flash-attn 2.7+ declares window_size_left/right as SymInt and fails the cast on None (RuntimeError: Expected a value of type int ... found NoneType). (-1, -1) is the library's no-window sentinel. Windowed configs (gpt_oss) already passed ints and were unaffected — which is why, after #852 enabled FA2 on Ampere, only the non-windowed models produced failed FA2 rows.

Verified on an A100 in the 26.07 container (flash-attn 2.7.4.post1): with this change the llama3.1 case that previously failed produces a valid measurement (fwd 0.752 ms / 183 TFLOPS, bwd 2.440 ms / 141 TFLOPS, batch 2, seq 2048, bf16, causal).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Flash Attention handling for cases without a sliding window, while preserving explicit sliding-window behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->