### PR TITLE
Add D32 support to SM100 HSTU attention

### DIFF
--- a/docs/fe-oss-apis/attention/hstu.md
+++ b/docs/fe-oss-apis/attention/hstu.md
@@ -198,7 +198,7 @@ are kernel padding.
 
 For native FP16 and BF16 arbitrary-mask forward and backward, the interface
 automatically builds private block metadata from `func_tensor` on every
-execution. Forward uses Q-to-K metadata; fused D64/D128 backward uses K-to-Q
+execution. Forward uses Q-to-K metadata; fused D32/D64/D128 backward uses K-to-Q
 metadata. The D256 two-kernel backward builds Q-to-K and K-to-Q views together
 from one Q256-by-K128 classification. The device-only builder and attention
 kernels run in order on the caller's current CUDA stream; metadata is not
@@ -208,7 +208,7 @@ blocks retain the exact token predicate, and fully valid blocks avoid reading
 Rebuilding on every execution means an in-place change to `func_tensor` is
 visible, including during CUDA Graph replay.
 
-Both dtypes use device-built metadata for D64, D128, and D256. The API trusts
+Both dtypes use device-built metadata for D32, D64, D128, and D256. The API trusts
 device-resident boundary values and does not validate their ordering or range
 on the host.
 
@@ -232,8 +232,8 @@ on the GPU without host-side range or monotonicity checks.
 
 | Direction | Architecture | Dtype | Head dimension | Attention |
 | --- | --- | --- | --- | --- |
-| Forward | Blackwell SM100/SM103 | FP16, BF16 | 64, 128, 256 | MHA |
-| Backward | Blackwell SM100/SM103 | FP16, BF16 | 64, 128, 256 | MHA |
+| Forward | Blackwell SM100/SM103 | FP16, BF16 | 32, 64, 128, 256 | MHA |
+| Backward | Blackwell SM100/SM103 | FP16, BF16 | 32, 64, 128, 256 | MHA |
 
 ## Current limitations
 

--- a/python/cudnn/hstu_attention/_interface.py
+++ b/python/cudnn/hstu_attention/_interface.py
@@ -147,7 +147,7 @@ def _supports_bwd_original_qkv_layout(t: torch.Tensor) -> bool:
 def _supports_bwd_direct_grad_layout(t: torch.Tensor) -> bool:
     """Return whether the fused epilogue can write directly to ``t``.
 
-    The D64/D128 epilogue uses 128-bit stores, so the unit-stride head
+    The D32/D64/D128 epilogue uses 128-bit stores, so the unit-stride head
     dimension and the token/head offsets must remain 16-byte aligned.
     The kernel restores those dynamic-stride divisibility assumptions before
     constructing its output views.
@@ -187,7 +187,7 @@ def hstu_varlen_fwd_100(
     head_dim = q.shape[2]
     head_dim_v = v.shape[2]
     assert head_dim == head_dim_v, "head_dim and head_dim_v must be equal"
-    assert head_dim in (64, 128, 256), "Only support head_dim 64, 128 and 256"
+    assert head_dim in (32, 64, 128, 256), "Only support head_dim 32, 64, 128 and 256"
 
     kBlockM = 128
     kBlockN = 128
@@ -398,7 +398,7 @@ def hstu_varlen_bwd_100(
     head_dim = q.shape[2]
     num_heads_k = k.shape[1]
 
-    assert head_dim in (64, 128, 256), "Only support head_dim 64, 128 and 256"
+    assert head_dim in (32, 64, 128, 256), "Only support head_dim 32, 64, 128 and 256"
     assert num_heads == num_heads_k, "Number of heads in key/value and query must be equal"
     assert k.shape[2] == head_dim, "k and q must have the same head_dim"
     assert v.shape[2] == head_dim, "v and q must have the same head_dim"
@@ -444,7 +444,7 @@ def hstu_varlen_bwd_100(
     if use_auto_block_metadata:
         # Build on every execution so in-place func updates, including CUDA
         # Graph replay updates, are visible to the consumer.  The private K2Q
-        # layout is fixed by the fused D64/D128 backward tile contract.
+        # layout is fixed by the fused D32/D64/D128 backward tile contract.
         block_sparse_tensors = build_hstu_k2q_block_sparse(
             func,
             cu_seqlens_q,

--- a/python/cudnn/hstu_attention/api.py
+++ b/python/cudnn/hstu_attention/api.py
@@ -457,7 +457,7 @@ class HSTUFwdSm100(_HSTUBase):
     def check_support(self) -> bool:
         if self._is_supported:
             return True
-        self._check_common((64, 128, 256))
+        self._check_common((32, 64, 128, 256))
         q = self._sample_q
         o = self._sample_o
         _require_same_cuda_device(
@@ -707,7 +707,7 @@ class HSTUBwdSm100(_HSTUBase):
     def check_support(self) -> bool:
         if self._is_supported:
             return True
-        self._check_common((64, 128, 256))
+        self._check_common((32, 64, 128, 256))
         q = self._sample_q
         k = self._sample_k
         v = self._sample_v

--- a/test/python/fe_api/hstu_attention/test_hstu_attention.py
+++ b/test/python/fe_api/hstu_attention/test_hstu_attention.py
@@ -118,16 +118,6 @@ def _int32_alias(tensor: torch.Tensor, shape) -> torch.Tensor:
 
 
 @pytest.mark.L0
-def test_top_level_exports():
-    import cudnn
-
-    assert cudnn.HSTUFwdSm100 is HSTUFwdSm100
-    assert cudnn.HSTUBwdSm100 is HSTUBwdSm100
-    assert cudnn.hstu_attention_forward is hstu_attention_forward
-    assert cudnn.hstu_attention_backward is hstu_attention_backward
-
-
-@pytest.mark.L0
 def test_rejects_torch_stream_from_another_device(monkeypatch):
     class _FakeStream:
         device = torch.device("cuda:1")
@@ -907,7 +897,7 @@ def test_explicit_api_rejects_runtime_stride_change():
 @pytest.mark.L1
 @pytest.mark.skipif(not _IS_SM10X, reason="requires an SM10x Blackwell GPU")
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@pytest.mark.parametrize("head_dim", [32, 64, 128, 256])
 def test_forward_matches_pytorch(dtype, head_dim):
     q, k, v, _, cu = _inputs(dtype=dtype, head_dim=head_dim)
     alpha = 0.7
@@ -947,7 +937,7 @@ def test_forward_matches_pytorch(dtype, head_dim):
 @pytest.mark.L1
 @pytest.mark.skipif(not _IS_SM10X, reason="requires an SM10x Blackwell GPU")
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@pytest.mark.parametrize("head_dim", [32, 64, 128, 256])
 def test_backward_matches_pytorch(dtype, head_dim):
     q, k, v, do, cu = _inputs(dtype=dtype, head_dim=head_dim)
     alpha = 0.7
@@ -997,7 +987,7 @@ def test_backward_matches_pytorch(dtype, head_dim):
 
 @pytest.mark.L0
 @pytest.mark.skipif(not _IS_SM10X, reason="requires an SM10x Blackwell GPU")
-@pytest.mark.parametrize("head_dim", [64, 256])
+@pytest.mark.parametrize("head_dim", [32, 64, 256])
 def test_backward_supports_optional_gradient_outputs(head_dim, monkeypatch):
     cache = OrderedDict()
     monkeypatch.setattr(_api, "_BWD_CACHE", cache)
@@ -1413,7 +1403,7 @@ def test_d256_explicit_api_is_cuda_graph_capturable():
 
 @pytest.mark.L0
 @pytest.mark.skipif(not _IS_SM10X, reason="requires an SM10x Blackwell GPU")
-@pytest.mark.parametrize("head_dim", [64, 256])
+@pytest.mark.parametrize("head_dim", [32, 64, 256])
 def test_varlen_tail_and_asymmetric_lengths_match_pytorch(head_dim):
     torch.manual_seed(321)
     q_lengths = (37, 129)
@@ -1504,7 +1494,7 @@ def test_varlen_tail_and_asymmetric_lengths_match_pytorch(head_dim):
 @pytest.mark.L1
 @pytest.mark.skipif(not _IS_SM10X, reason="requires an SM10x Blackwell GPU")
 @pytest.mark.parametrize("mask_mode", ["full", "local", "arbitrary"])
-@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@pytest.mark.parametrize("head_dim", [32, 64, 128, 256])
 def test_mask_modes_match_pytorch(mask_mode, head_dim):
     q, k, v, do, cu = _inputs(heads=1, head_dim=head_dim)
     seqlen = q.shape[0]
@@ -1655,7 +1645,7 @@ def test_d256_full_tile_arbitrary_mask_is_not_skipped():
 
 @pytest.mark.L0
 @pytest.mark.skipif(not _IS_SM10X, reason="requires an SM10x Blackwell GPU")
-@pytest.mark.parametrize("head_dim", [64, 256])
+@pytest.mark.parametrize("head_dim", [32, 64, 256])
 def test_paged_kv_forward_matches_pytorch(head_dim):
     q, k, v, _, cu = _inputs(heads=1, seqlen=256, head_dim=head_dim)
     seqlen = q.shape[0]
@@ -1733,7 +1723,7 @@ def test_cache_hit_does_not_inspect_cuda_metadata_values(monkeypatch):
 
 @pytest.mark.L0
 @pytest.mark.skipif(not _IS_SM10X, reason="requires an SM10x Blackwell GPU")
-@pytest.mark.parametrize("head_dim", [64, 256])
+@pytest.mark.parametrize("head_dim", [32, 64, 256])
 def test_runtime_alpha_and_scaling_are_not_compile_time_constants(head_dim):
     q, k, v, do, cu = _inputs(heads=1, head_dim=head_dim)
     scalar_configs = ((0.35, 32.0), (1.1, 96.0))

--- a/test/python/fe_api/hstu_attention/test_hstu_block_sparse.py
+++ b/test/python/fe_api/hstu_attention/test_hstu_block_sparse.py
@@ -879,7 +879,7 @@ def test_d256_bwd_paired_builder_is_graph_replayable_after_func_mutation():
 @pytest.mark.L1
 @pytest.mark.skipif(not _IS_SM10X, reason="requires an SM10x Blackwell GPU")
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@pytest.mark.parametrize("head_dim", [32, 64, 128, 256])
 @pytest.mark.parametrize("pattern", ["empty", "full", "mask", "mixed"])
 def test_arbitrary_forward_packed_tails_match_pytorch(dtype, head_dim, pattern):
     q_lengths = (257, 129)
@@ -935,7 +935,7 @@ def test_arbitrary_forward_packed_tails_match_pytorch(dtype, head_dim, pattern):
 
 @pytest.mark.L1
 @pytest.mark.skipif(not _IS_SM10X, reason="requires an SM10x Blackwell GPU")
-@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@pytest.mark.parametrize("head_dim", [32, 64, 128, 256])
 @pytest.mark.parametrize(
     "dtype,func_num",
     [
@@ -1004,7 +1004,7 @@ def test_arbitrary_forward_handles_many_intervals(dtype, head_dim, func_num):
 @pytest.mark.skipif(not _IS_SM10X, reason="requires an SM10x Blackwell GPU")
 @pytest.mark.parametrize(
     "head_dim,expected_block_size",
-    [(64, (256, 128)), (256, (128, 128))],
+    [(32, (256, 128)), (64, (256, 128)), (256, (128, 128))],
 )
 def test_fp16_arbitrary_forward_uses_auto_metadata(
     monkeypatch,
@@ -1076,7 +1076,7 @@ def test_fp16_arbitrary_forward_uses_auto_metadata(
 
 @pytest.mark.L0
 @pytest.mark.skipif(not _IS_SM10X, reason="requires an SM10x Blackwell GPU")
-@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@pytest.mark.parametrize("head_dim", [32, 64, 128, 256])
 def test_bf16_forward_mixes_empty_and_nonempty_work_rows(head_dim):
     q_lengths = (300,)
     k_lengths = (385,)
@@ -1177,7 +1177,7 @@ def test_forward_graph_rebuilds_metadata_after_func_mutation(dtype):
 @pytest.mark.L1
 @pytest.mark.skipif(not _IS_SM10X, reason="requires an SM10x Blackwell GPU")
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@pytest.mark.parametrize("head_dim", [32, 64, 128, 256])
 @pytest.mark.parametrize("pattern", ["full", "mask", "mixed"])
 def test_arbitrary_backward_packed_tails_match_pytorch(
     dtype,
@@ -1245,6 +1245,8 @@ def test_arbitrary_backward_packed_tails_match_pytorch(
 @pytest.mark.parametrize(
     "head_dim,func_num",
     [
+        (32, 3),
+        (32, 9),
         (64, 3),
         (128, 9),
         (256, 3),
@@ -1350,7 +1352,7 @@ def test_arbitrary_overlapping_intervals_match_union_semantics(
 
 @pytest.mark.L1
 @pytest.mark.skipif(not _IS_SM10X, reason="requires an SM10x Blackwell GPU")
-@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@pytest.mark.parametrize("head_dim", [32, 64, 128, 256])
 @pytest.mark.parametrize(
     "dtype,func_num",
     [
@@ -1454,7 +1456,7 @@ def test_arbitrary_backward_endpoint_prefetch_tracks_each_query_row(
 @pytest.mark.L1
 @pytest.mark.skipif(not _IS_SM10X, reason="requires an SM10x Blackwell GPU")
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@pytest.mark.parametrize("head_dim", [32, 64, 128, 256])
 def test_arbitrary_backward_all_empty_is_exact_zero(dtype, head_dim):
     q_lengths = (257, 129)
     k_lengths = (385, 257)
@@ -1637,7 +1639,7 @@ def test_fp16_backward_exceeds_legacy_q_limit():
 @pytest.mark.L0
 @pytest.mark.skipif(not _IS_SM10X, reason="requires an SM10x Blackwell GPU")
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("head_dim", [64, 256])
+@pytest.mark.parametrize("head_dim", [32, 64, 256])
 def test_backward_graph_rebuilds_metadata_after_func_mutation(
     dtype,
     head_dim,
@@ -1709,7 +1711,7 @@ def test_backward_graph_rebuilds_metadata_after_func_mutation(
 
 @pytest.mark.L0
 @pytest.mark.skipif(not _IS_SM10X, reason="requires an SM10x Blackwell GPU")
-@pytest.mark.parametrize("head_dim", [64, 256])
+@pytest.mark.parametrize("head_dim", [32, 64, 256])
 def test_fp16_arbitrary_backward_uses_auto_metadata(monkeypatch, head_dim):
     q_lengths = (193, 65)
     k_lengths = (257, 129)
@@ -1893,7 +1895,7 @@ def test_auto_block_metadata_builder_cache_reuses_dynamic_shapes():
 
 @pytest.mark.L0
 @pytest.mark.skipif(not _IS_SM10X, reason="requires an SM10x Blackwell GPU")
-@pytest.mark.parametrize("head_dim", [64, 256])
+@pytest.mark.parametrize("head_dim", [32, 64, 256])
 def test_auto_block_metadata_consumer_cache_reuses_dynamic_shapes(head_dim):
     _interface.hstu_varlen_fwd_100.compile_cache.clear()
     _interface.hstu_varlen_bwd_100.compile_cache.clear()


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches, and the changes comply.
- [x] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*`.

## Affected area

FE OSS kernels or CuTeDSL

## Summary

- Enable head dimension 32 in the SM100 HSTU forward and backward API/interface support checks.
- Extend dense, variable-length, paged-KV, arbitrary-mask, metadata, and CUDA Graph coverage to D32.
- Update the HSTU support matrix and D32 block-metadata documentation.
- Remove the standalone top-level export identity test.

## Why

The existing generic SM100 HSTU kernels already execute D32 correctly; D32 was blocked by the frontend and interface allowlists. This change exposes that existing kernel capability and adds coverage across the supported execution modes.

## Related issues

Related to #369.

## API and compatibility impact

This is an additive support expansion: `HSTUFwdSm100`, `HSTUBwdSm100`, `hstu_attention_forward`, and `hstu_attention_backward` now accept D32 on Blackwell. There are no public signature changes and the existing D64/D128/D256 behavior is unchanged.

## Testing

- `PYTHONWARNINGS=ignore PYTHONPATH=<local HSTU overlay>:<temporary pytest install> python -m pytest -m 'L0 or L1' fe_api/hstu_attention/test_hstu_attention.py fe_api/hstu_attention/test_hstu_block_sparse.py`
  - `228 passed, 170 warnings in 1614.86s (0:26:54)` on NVIDIA B200, SM100, CUDA 13.2, cuDNN backend 9.22.0.
- `pre-commit run --files docs/fe-oss-apis/attention/hstu.md python/cudnn/hstu_attention/_interface.py python/cudnn/hstu_attention/api.py test/python/fe_api/hstu_attention/test_hstu_attention.py test/python/fe_api/hstu_attention/test_hstu_block_sparse.py`
  - Black, Black-Jupyter, and SPDX checks passed; clang-format had no applicable files.
- B200 performance sanity check at B=4, H=4, S=8192, D=32, BF16, causal, no RAB, using three trials with 200 ms warmup and 1000 ms measurement per trial:
  - Forward: 0.254080 ms, 270.5 effective TFLOP/s.
  - Backward: 0.363552 ms, 472.6 effective TFLOP/s.
  - Forward + backward: 0.617632 ms.

The benchmark was collected on the pre-rebase commit `37dbdc42`; the rebase onto current `develop` did not change the HSTU patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HSTU attention support for head dimension 32 on supported SM10x devices using native FP16 and BF16.
  * Extended arbitrary-mask, fused forward/backward, paged-KV, variable-length, and runtime-scalar scenarios to support head dimension 32.

* **Tests**
  * Expanded correctness, graph replay, metadata, caching, and block-sparse coverage for head dimension 32.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->