### PR TITLE
frost(sdpa): SM100 d=512 backward (f16/bf16) — three-stage chain, masks, GQA, any seqlen

### DIFF
--- a/benchmark/attention_training/benchmark_single_sdpa.py
+++ b/benchmark/attention_training/benchmark_single_sdpa.py
@@ -1978,8 +1978,29 @@ else:
     except Exception:
         pass
 
-    fwd_sol_str = f", {fwd_tflops / _peak_mma_tflops * 100:.1f}% SOL" if _peak_mma_tflops and fwd_tflops > 0 else ""
-    bwd_sol_str = f", {bwd_tflops / _peak_mma_tflops * 100:.1f}% SOL" if _peak_mma_tflops and bwd_tflops > 0 else ""
+    def _sol(tflops):
+        """SOL% against the dense-MMA peak, or an explicit note when we cannot
+        compute it.
+
+        The peak needs a sampled boost clock, which needs ``pynvml``. When that
+        import is missing the SOL suffix used to vanish entirely and an
+        impossible TFLOPS number printed unremarked -- the only cross-check this
+        harness has on its own arithmetic, silently disabled by a missing
+        optional dependency. Say so instead, and shout when a number exceeds the
+        hardware: >100% SOL means the FLOP model or the timing is wrong, never
+        that the kernel is fast.
+        """
+        if tflops <= 0:
+            return ""
+        if not _peak_mma_tflops:
+            return ", SOL n/a (no clock sample -- pip install pynvml)"
+        pct = tflops / _peak_mma_tflops * 100
+        if pct > 100.0:
+            return f", {pct:.1f}% SOL -- ABOVE HARDWARE PEAK, MEASUREMENT IS WRONG"
+        return f", {pct:.1f}% SOL"
+
+    fwd_sol_str = _sol(fwd_tflops)
+    bwd_sol_str = _sol(bwd_tflops)
 
     if args.format_output:
         print(

--- a/benchmark/attention_training/benchmark_single_sdpa.py
+++ b/benchmark/attention_training/benchmark_single_sdpa.py
@@ -1969,31 +1969,40 @@ else:
     # Compute MMA SOL% using the per-arch FLOPs/clk/SM table and the actual
     # sampled boost clock observed during the benchmark window.
     _peak_mma_tflops = None
+    # Why the peak is unavailable, when it is -- the two causes need different
+    # advice and conflating them sends the user after the wrong one.
+    _peak_unavailable = "unavailable"
     try:
         _flops_per_clk_per_sm = _peak_flops_per_clock_per_sm(args.data_type)
         _num_sms = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
         _sampled_mhz = _clock_sampler.peak_mhz()
-        if _flops_per_clk_per_sm is not None and _sampled_mhz is not None:
+        if _flops_per_clk_per_sm is None:
+            # No dense-MMA peak modelled for this dtype / arch (e.g. --data_type float).
+            _peak_unavailable = f"no MMA peak modelled for {args.data_type} on this arch"
+        elif _sampled_mhz is None:
+            _peak_unavailable = "no clock sample -- pip install pynvml"
+        else:
             _peak_mma_tflops = _flops_per_clk_per_sm * _num_sms * _sampled_mhz / 1e6
-    except Exception:
-        pass
+    except Exception as _e:
+        _peak_unavailable = f"peak lookup failed ({type(_e).__name__})"
 
     def _sol(tflops):
         """SOL% against the dense-MMA peak, or an explicit note when we cannot
         compute it.
 
-        The peak needs a sampled boost clock, which needs ``pynvml``. When that
-        import is missing the SOL suffix used to vanish entirely and an
-        impossible TFLOPS number printed unremarked -- the only cross-check this
-        harness has on its own arithmetic, silently disabled by a missing
-        optional dependency. Say so instead, and shout when a number exceeds the
-        hardware: >100% SOL means the FLOP model or the timing is wrong, never
-        that the kernel is fast.
+        The peak needs both a modelled dense-MMA rate for the dtype and a
+        sampled boost clock (which needs ``pynvml``). When either is missing the
+        SOL suffix used to vanish entirely and an impossible TFLOPS number
+        printed unremarked -- the only cross-check this harness has on its own
+        arithmetic, silently disabled. Say so instead, naming WHICH of the two
+        is missing, and shout when a number exceeds the hardware: >100% SOL
+        means the FLOP model or the timing is wrong, never that the kernel is
+        fast.
         """
         if tflops <= 0:
             return ""
         if not _peak_mma_tflops:
-            return ", SOL n/a (no clock sample -- pip install pynvml)"
+            return f", SOL n/a ({_peak_unavailable})"
         pct = tflops / _peak_mma_tflops * 100
         if pct > 100.0:
             return f", {pct:.1f}% SOL -- ABOVE HARDWARE PEAK, MEASUREMENT IS WRONG"

--- a/include/cudnn_frontend/backend/plan_helpers.h
+++ b/include/cudnn_frontend/backend/plan_helpers.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <sstream>
 #include <vector>
 
 #include "cudnn.h"
@@ -208,8 +209,24 @@ create_engine_config(ManagedOpaqueDescriptor& engine_config,
                                                    knob_choices.size(),
                                                    backend_knob_choices.data()));
 
-    // Finalizing the descriptor
-    _CUDNN_CHECK_CUDNN_ERROR(detail::finalize(engine_config->get_backend_descriptor()));
+    // Finalizing the descriptor.
+    //
+    // NOT_SUPPORTED here means exactly that: this engine cannot serve this
+    // operation graph. Map it to GRAPH_NOT_SUPPORTED rather than letting
+    // _CUDNN_CHECK_CUDNN_ERROR fold it into CUDNN_BACKEND_API_FAILED -- the
+    // latter reaches Python as a bare RuntimeError, so callers (and every test
+    // harness, which skips on cudnnGraphNotSupportedError and FAILS on
+    // anything else) cannot tell "unsupported" from "the backend broke".
+    // Any other status stays an API failure.
+    if (auto const status = detail::finalize(engine_config->get_backend_descriptor()); status != CUDNN_STATUS_SUCCESS) {
+        std::stringstream error_msg;
+        error_msg << "Finalizing the engine config failed with message: " << detail::get_last_error_string_()
+                  << ", and code: " << detail::get_error_string(status);
+        CUDNN_FE_LOG_LABEL_ENDL("ERROR: " << error_msg.str() << " at " << __FILE__ << ":" << __LINE__);
+        return {status == CUDNN_STATUS_NOT_SUPPORTED ? error_code_t::GRAPH_NOT_SUPPORTED
+                                                     : error_code_t::CUDNN_BACKEND_API_FAILED,
+                error_msg.str()};
+    }
 
     return {error_code_t::OK, ""};
 }

--- a/include/cudnn_frontend/node/scaled_dot_product_flash_attention.h
+++ b/include/cudnn_frontend/node/scaled_dot_product_flash_attention.h
@@ -1343,9 +1343,25 @@ class CompositeSDPABackwardNode : public NodeCRTP<CompositeSDPABackwardNode> {
                 is_d256_on_blackwell = true;
                 attributes.is_deterministic_algorithm = true;
             } else {
-                RETURN_CUDNN_FRONTEND_ERROR_IF((d_qk > 128) || (d_qk % 8 != 0) || (d_v > 128) || (d_v % 8 != 0),
+                // Head dims in (256, 512] on BOTH sides are served by the
+                // frontend-only FROST SM100 backward engine (sdpa_bwd_sm100),
+                // which runs the band through its native d = 512 tiles: the TMA
+                // descriptors carry the real extent and the overshoot is
+                // hardware zero-filled, so the padded lanes contribute nothing.
+                // The floor is the engine's -- below it the d256 flavors are the
+                // right kernel and this one would pad by more than 2x. Multiple
+                // of 8 rather than the forward surface's 16: the backward's
+                // stage-3 epilogue narrows its store vector from 32 B to 16 B
+                // when d is not also a multiple of 16, which the forward has no
+                // equivalent lever for. As on the forward path, the cuDNN
+                // backend itself has no plan for the band, so a graph that does
+                // not select that engine still fails at plan creation.
+                bool const d512_supported =
+                    (d_qk > 256) && (d_qk <= 512) && (d_v > 256) && (d_v <= 512) && (d_qk % 8 == 0) && (d_v % 8 == 0);
+                RETURN_CUDNN_FRONTEND_ERROR_IF(((d_qk > 128) || (d_qk % 8 != 0) || (d_v > 128) || (d_v % 8 != 0)) && !d512_supported,
                                             error_code_t::GRAPH_NOT_SUPPORTED,
-                                            "Num hidden_dim should be less than or equal to 128 and hidden_dim should be multiple of 8 when d_qk != d_v");
+                                            "Num hidden_dim should be less than or equal to 128 and hidden_dim should be multiple of 8 when d_qk != d_v, "
+                                            "unless both head dims are in (256, 512] and multiples of 8");
             }
         } else {
             // validate basic dimension requirements

--- a/include/cudnn_frontend/node/scaled_dot_product_flash_attention.h
+++ b/include/cudnn_frontend/node/scaled_dot_product_flash_attention.h
@@ -1176,6 +1176,11 @@ class CompositeSDPABackwardNode : public NodeCRTP<CompositeSDPABackwardNode> {
     // sequence length). Set at expand time when eligible.
     mutable bool use_sm90_ordered_dq_deterministic = false;
     mutable bool is_d256_on_blackwell              = false;  // Will be edited in pre_validate_node()
+    // Head dims in (256, 512] on Blackwell. This band has NO cuDNN backend
+    // plan -- it is served only by the frontend-only FROST engine
+    // (sdpa_bwd_sm100), which is opt-in. Recorded so override_heuristics_query()
+    // does not pin a backend engine that cannot possibly finalize here.
+    mutable bool is_d512_on_blackwell = false;  // Will be edited in pre_validate_node()
 
     // Promote any 1-D seq_len / ragged-offset index tensors to the 4-D
     // [n, 1, 1, 1] form the cuDNN backend requires (see promote_1d_index_tensor_to_4d).
@@ -1358,6 +1363,7 @@ class CompositeSDPABackwardNode : public NodeCRTP<CompositeSDPABackwardNode> {
                 // not select that engine still fails at plan creation.
                 bool const d512_supported =
                     (d_qk > 256) && (d_qk <= 512) && (d_v > 256) && (d_v <= 512) && (d_qk % 8 == 0) && (d_v % 8 == 0);
+                is_d512_on_blackwell = d512_supported;
                 RETURN_CUDNN_FRONTEND_ERROR_IF(((d_qk > 128) || (d_qk % 8 != 0) || (d_v > 128) || (d_v % 8 != 0)) && !d512_supported,
                                             error_code_t::GRAPH_NOT_SUPPORTED,
                                             "Num hidden_dim should be less than or equal to 128 and hidden_dim should be multiple of 8 when d_qk != d_v, "
@@ -2225,6 +2231,17 @@ class CompositeSDPABackwardNode : public NodeCRTP<CompositeSDPABackwardNode> {
 
     std::pair<int64_t, std::unordered_map<KnobType_t, int64_t>>
     override_heuristics_query() const {
+        // The (256, 512] band has no cuDNN backend plan at all -- only the
+        // opt-in frontend FROST engine serves it. Pinning a backend engine id
+        // here bypasses the heuristics query entirely, and the pinned config
+        // then fails to finalize with CUDNN_STATUS_NOT_SUPPORTED, which
+        // surfaces as a generic backend-API error rather than "not supported".
+        // Decline the override and let heuristics run: it returns no configs
+        // and create_execution_plans reports GRAPH_NOT_SUPPORTED, which is what
+        // a caller (and every test harness) can act on.
+        if (is_d512_on_blackwell) {
+            return {-1, {}};
+        }
         int32_t const sm_version = context.get_sm_version();
         bool const use_new_knobs = detail::get_backend_version() >= 92300;
         // {128,128} bprop: tileM=3, tileN=2, kernelCfg=2(bprop warp), streamK=0, cgaM=0

--- a/python/cudnn/engines/manifest.py
+++ b/python/cudnn/engines/manifest.py
@@ -209,6 +209,7 @@ MANIFEST: Tuple[EngineFamily, ...] = (
         slots={
             "sdpa_bwd_sm120": EngineSlot(0, opt_in=True),
             "sdpa_bwd_sm80": EngineSlot(1, opt_in=True),
+            "sdpa_bwd_sm100": EngineSlot(2, opt_in=True),
         },
         analyzer=("cudnn.sdpa.graph_analyzer", "analyze"),
     ),

--- a/python/cudnn/frost/tile_dsl/mask.py
+++ b/python/cudnn/frost/tile_dsl/mask.py
@@ -2,7 +2,10 @@
 # SPDX-License-Identifier: MIT
 
 
+from typing import NamedTuple
+
 import cutlass
+import cutlass.cute as cute
 from cutlass._mlir.dialects import arith
 
 from .constants import MASK_CAUSAL, MASK_NONE, MASK_PADDED, MASK_SWA  # noqa: F401
@@ -70,3 +73,113 @@ def apply_mask_chunk(
         )
         elems.append(val)
     return cutlass.Vector.from_elements(tuple(elems), cutlass.Float32)
+
+
+# ---------------------------------------------------------------------------
+# Tile-level mask bounds: which kv TILES a q tile has to visit at all.
+# ---------------------------------------------------------------------------
+#
+# `apply_mask_chunk` above is the per-CELL mask. This is the per-TILE one, and
+# it is where the work actually gets saved: under a causal band a q tile only
+# intersects the kv tiles up to its own diagonal, so the whole upper triangle of
+# tiles is never issued -- roughly half the MMAs at causal. The returned range
+# also splits into a middle sub-range `[unmasked_lo, unmasked_hi)` where no cell
+# can be masked, so only the diagonal (and padding-tail) tiles pay for
+# `apply_mask_chunk` at all.
+#
+# Lives here rather than beside one pass's kernels because both the forward and
+# the backward need exactly this arithmetic, and it is pure: it reads mask
+# parameters and tile geometry, nothing pass-specific.
+
+
+class KvLoopBounds(NamedTuple):
+    left: object
+    unmasked_lo: object
+    unmasked_hi: object
+    right: object
+
+
+def _div_up(a, b):
+    return (a + cutlass.Int32(b - 1)) // cutlass.Int32(b)
+
+
+def compute_kv_loop_bounds(
+    q_row_coord,
+    seqlen_q,
+    seq_kv_len,
+    window_left: int,
+    mask_flags: int,
+    tile_n: int,
+    cga_tile_m: int,
+    bottom_right: bool = False,
+    window_right: int = 0,
+) -> KvLoopBounds:
+    # window_right: compile-time diagonal-band right bound (cuDNN
+    # diagonal_band_right_bound) — the causal upper limit is widened by
+    # window_right columns. 0 = plain causal; folds out entirely.
+    left = cutlass.Int32(0)
+    right = _div_up(seq_kv_len, tile_n)
+
+    if cutlass.const_expr(bottom_right):
+        causal_diag = seq_kv_len - seqlen_q
+    else:
+        causal_diag = cutlass.Int32(0)
+
+    if cutlass.const_expr(mask_flags & MASK_CAUSAL):
+        kv_hi_caus = _div_up(q_row_coord + cutlass.Int32(cga_tile_m + window_right) + causal_diag, tile_n)
+        right = cute.math.min(right, kv_hi_caus)
+
+    if cutlass.const_expr(mask_flags & MASK_SWA):
+        # The whole band shifts with the diagonal: under BOTTOM_RIGHT the SWA
+        # lower bound is q + (S_kv - S_q) - W, same anchor the causal upper
+        # bound uses (causal_diag folds to 0 for top-left).
+        swa_base = q_row_coord + causal_diag
+        cond = swa_base > cutlass.Int32(window_left)
+        delta = swa_base - cutlass.Int32(window_left)
+        kv_lo_swa = cutlass.Int32(
+            arith.select(
+                cond.ir_value(),
+                (delta // cutlass.Int32(tile_n)).ir_value(),
+                cutlass.Int32(0).ir_value(),
+            )
+        )
+        left = cute.math.max(left, kv_lo_swa)
+
+    unmasked_hi = right
+    if cutlass.const_expr(mask_flags & MASK_PADDED):
+        unaligned = (seq_kv_len % cutlass.Int32(tile_n)) != cutlass.Int32(0)
+        lo_pad = cutlass.Int32(
+            arith.select(
+                unaligned.ir_value(),
+                (right - cutlass.Int32(1)).ir_value(),
+                right.ir_value(),
+            )
+        )
+        unmasked_hi = cute.math.min(unmasked_hi, lo_pad)
+    if cutlass.const_expr(mask_flags & MASK_CAUSAL):
+        lo_caus = (q_row_coord + cutlass.Int32(window_right) + causal_diag) // cutlass.Int32(tile_n)
+        unmasked_hi = cute.math.min(unmasked_hi, lo_caus)
+    unmasked_hi = cute.math.max(unmasked_hi, left)
+
+    unmasked_lo = left
+    if cutlass.const_expr(mask_flags & MASK_SWA):
+        anchor = q_row_coord + causal_diag + cutlass.Int32(cga_tile_m - 1 - window_left)
+        swa_unmasked_lo = _div_up(anchor, tile_n)
+        cond = anchor > cutlass.Int32(0)
+        swa_unmasked_lo = cutlass.Int32(
+            arith.select(
+                cond.ir_value(),
+                swa_unmasked_lo.ir_value(),
+                cutlass.Int32(0).ir_value(),
+            )
+        )
+        unmasked_lo = cute.math.max(unmasked_lo, swa_unmasked_lo)
+
+    unmasked_lo = cute.math.min(unmasked_lo, unmasked_hi)
+
+    return KvLoopBounds(
+        left=left,
+        unmasked_lo=unmasked_lo,
+        unmasked_hi=unmasked_hi,
+        right=right,
+    )

--- a/python/cudnn/sdpa/bwd/api_dsl.py
+++ b/python/cudnn/sdpa/bwd/api_dsl.py
@@ -2085,6 +2085,13 @@ class SdpaBwdDslSm100(SdpaBwdDsl):
         self.head_dim_v = int(tuple(self.v_desc.shape)[3])
         self.dtype = self.q_desc.dtype
         self._bpe = 2
+        # attn_scale is OPTIONAL on the graph, so `scale_softmax` arrives None
+        # when the caller omits it. Default it here, as the SM120 and SM80
+        # adapters do -- without this the row admits the graph, check_support
+        # passes, and execute dies on `None * log2(e)`. Found by review on the
+        # d512 bring-up PR; regression test `test_default_attn_scale`.
+        if self.scale_softmax is None or self.scale_softmax == 0.0:
+            self.scale_softmax = 1.0 / math.sqrt(self.head_dim_qk)
         # Tile-rounded COMPILE shape. The kernel's grid and workspace are tiled,
         # so a sequence length that is not a multiple runs on the next multiple
         # up and the tail is masked. Q/K/V/dO ride their real TMA extents, whose

--- a/python/cudnn/sdpa/bwd/api_dsl.py
+++ b/python/cudnn/sdpa/bwd/api_dsl.py
@@ -2211,14 +2211,20 @@ class SdpaBwdDslSm100(SdpaBwdDsl):
         #      skipped region at all -- the zero-fill, not the trim, is what
         #      makes the causal path correct. See `_causal_k_range`.
         self._zero_ws = lo != CAUSAL_K_NONE or hi != CAUSAL_K_NONE
+        # dtype_qkv must match stage 2's: stage 3 reads the S/dS workspace stage
+        # 2 wrote, and stores the gradients in the graph's io dtype.
         mm_lo = load_template(
             _sm100_kernel_path(_SM100_MATMUL_FILE),
-            MatmulTemplateParams(a_is_m_major=True, b_is_n_major=True, causal_mode=lo, causal_gran=gran, causal_shift=shift, vec_bytes_epi=vec),
+            MatmulTemplateParams(
+                a_is_m_major=True, b_is_n_major=True, causal_mode=lo, causal_gran=gran, causal_shift=shift, vec_bytes_epi=vec, dtype_qkv=dtype_code
+            ),
             tag="sdpa_bwd_sm100_mm_lo",
         )
         mm_hi = load_template(
             _sm100_kernel_path(_SM100_MATMUL_FILE),
-            MatmulTemplateParams(a_is_m_major=False, b_is_n_major=True, causal_mode=hi, causal_gran=gran, causal_shift=shift, vec_bytes_epi=vec),
+            MatmulTemplateParams(
+                a_is_m_major=False, b_is_n_major=True, causal_mode=hi, causal_gran=gran, causal_shift=shift, vec_bytes_epi=vec, dtype_qkv=dtype_code
+            ),
             tag="sdpa_bwd_sm100_mm_hi",
         )
         stage2 = stage2_mod.compile(

--- a/python/cudnn/sdpa/bwd/api_dsl.py
+++ b/python/cudnn/sdpa/bwd/api_dsl.py
@@ -2327,9 +2327,13 @@ class SdpaBwdDslSm100(SdpaBwdDsl):
             # straddle the written boundary and read residue. That showed up as a
             # 1-in-6 catastrophic dK/dV (cos 0.0006), not a numerics drift,
             # because it depends on whatever was in the buffer.
-            if self._zero_ws or self._is_padded:
-                # The padded tail is walked by stage 3's tile-rounded M/K in the
-                # same way a mask-skipped tile is, so it gets the same treatment.
+            if self._zero_ws:
+                # NOT for padding: stage 2 writes its own zeros there. Its kv
+                # bound is div_up(REAL S_kv, TILE_N), so the tail tile IS visited
+                # and apply_mask_chunk zeroes the columns past the real length;
+                # the padded q rows are visited too (the grid is sized on the
+                # rounded S_q) and row_scale zeroes them. Only a MASK-SKIPPED
+                # tile is genuinely never written.
                 s_ws_full.zero_()
                 ds_ws_full.zero_()
 

--- a/python/cudnn/sdpa/bwd/api_dsl.py
+++ b/python/cudnn/sdpa/bwd/api_dsl.py
@@ -2201,9 +2201,15 @@ class SdpaBwdDslSm100(SdpaBwdDsl):
         # A non-zero shift breaks the alignment that lets stage 3 read only what
         # stage 2 wrote, so the skipped region has to be ZEROED first -- see
         # _zero_ws_needed.
-        # Zero whenever the trim is ACTIVE, not just when shift != 0: the
-        # never-empty clamp above means a structurally-masked M tile reads one
-        # k-tile of workspace and must see zeros there.
+        # Zero whenever the trim is ACTIVE, not just when shift != 0. TWO
+        # independent reasons, either of which alone would require it:
+        #   1. the never-empty clamp in `_causal_k_range` means a structurally
+        #      masked M tile still reads one k-tile of workspace, and must see
+        #      zeros there;
+        #   2. stage 3's cluster M tile (512) is WIDER than stage 2's write
+        #      block (`gran`, 256), so a per-tile K range cannot exclude the
+        #      skipped region at all -- the zero-fill, not the trim, is what
+        #      makes the causal path correct. See `_causal_k_range`.
         self._zero_ws = lo != CAUSAL_K_NONE or hi != CAUSAL_K_NONE
         mm_lo = load_template(
             _sm100_kernel_path(_SM100_MATMUL_FILE),

--- a/python/cudnn/sdpa/bwd/api_dsl.py
+++ b/python/cudnn/sdpa/bwd/api_dsl.py
@@ -2085,6 +2085,13 @@ class SdpaBwdDslSm100(SdpaBwdDsl):
         self.head_dim_v = int(tuple(self.v_desc.shape)[3])
         self.dtype = self.q_desc.dtype
         self._bpe = 2
+        # Tile-rounded COMPILE shape. The kernel's grid and workspace are tiled,
+        # so a sequence length that is not a multiple runs on the next multiple
+        # up and the tail is masked. Q/K/V/dO ride their real TMA extents, whose
+        # overshoot is HW zero-filled; only S/dS are actually allocated padded.
+        self._sq_pad = -(-self.s_q_max // 256) * 256
+        self._skv_pad = -(-self.s_k_max // 128) * 128
+        self._is_padded = self._sq_pad != self.s_q_max or self._skv_pad != self.s_k_max
         self._compiled = None
         self._dot_fn = None
         self._reduce_fn = None
@@ -2094,7 +2101,7 @@ class SdpaBwdDslSm100(SdpaBwdDsl):
         # partial per Q head and a separate reduce folds the group. group == 1
         # (MHA) skips both the partial buffers and the reduce entirely.
         self._gqa_group = self.h_q // self.h_kv
-        self._qh_chunk = _sm100_head_chunk(self.batch_size, self.h_q, self.s_q_max, self.s_k_max, self._bpe, group=self._gqa_group)
+        self._qh_chunk = _sm100_head_chunk(self.batch_size, self.h_q, self._sq_pad, self._skv_pad, self._bpe, group=self._gqa_group)
         # The kernels read/write BSHD-physical buffers. Any io tensor that is not
         # already one gets a staging copy carved from the workspace -- decided
         # HERE, from the descs' declared strides, so scratch_workspace_bytes()
@@ -2123,8 +2130,8 @@ class SdpaBwdDslSm100(SdpaBwdDsl):
             self.head_dim_qk % 8 != 0, f"SM100 bwd: d must be a multiple of 8 (TMA 16-byte innermost extent at 2 B/elem); got {self.head_dim_qk}"
         )
         self._value_error_if(self.h_q % self.h_kv != 0, f"SM100 bwd: h_q ({self.h_q}) must be a multiple of h_kv ({self.h_kv})")
-        self._value_error_if(self.s_q_max % 256 != 0, f"SM100 bwd: S_q must be a multiple of 256 (TILE_M * CTA_MMA); got {self.s_q_max}")
-        self._value_error_if(self.s_k_max % 128 != 0, f"SM100 bwd: S_kv must be a multiple of 128 (TILE_N); got {self.s_k_max}")
+        # No S_q / S_kv tile rule any more: a non-multiple is served by rounding
+        # the compile shape up and masking the tail.
         # SWA and bottom-right causal ARE implemented (the tile bounds and the
         # per-cell mask both come from the shared mask helpers). Padding is not:
         # it needs the per-batch kv length, and this kernel threads a scalar.
@@ -2139,8 +2146,8 @@ class SdpaBwdDslSm100(SdpaBwdDsl):
         per-execute allocation: the executor carves all of it from the caller's
         buffer, which is what keeps the plan CUDA-graph friendly.
         """
-        delta = ws_align(self.batch_size * self.h_q * self.s_q_max * 4)
-        ws = ws_align(self.batch_size * self._qh_chunk * self.s_q_max * self.s_k_max * self._bpe)
+        delta = ws_align(self.batch_size * self.h_q * (-(-self.s_q_max // 128) * 128) * 4)
+        ws = ws_align(self.batch_size * self._qh_chunk * self._sq_pad * self._skv_pad * self._bpe)
         total = delta + 2 * ws
         for name in self._stage_in + self._stage_out:
             s_len = self.s_k_max if name in ("k", "v", "dK", "dV") else self.s_q_max
@@ -2211,11 +2218,13 @@ class SdpaBwdDslSm100(SdpaBwdDsl):
         stage2 = stage2_mod.compile(
             b=self.batch_size,
             qh=self.h_q,
-            sq=self.s_q_max,
-            skv=self.s_k_max,
+            sq=self._sq_pad,
+            skv=self._skv_pad,
             qh_chunk=self._qh_chunk,
             d=self.head_dim_qk,
             qh_kv=self.h_kv,
+            sq_real=self.s_q_max,
+            skv_real=self.s_k_max,
         )
         self._compiled = (dot_do_o_host, stage2_mod, stage2, mm_lo, mm_hi)
         return self._compiled
@@ -2264,10 +2273,17 @@ class SdpaBwdDslSm100(SdpaBwdDsl):
         stream = self._get_default_stream(current_stream)
         with _torch_stream_context(current_stream, q_tensor.device):
             carver = WorkspaceCarver(workspace, self.scratch_workspace_bytes(), "sdpa_bwd_sm100")
-            delta = carver.take(b * h * sq, torch.float32).reshape(b, h, sq)
+            # ROW_ROUND: dot_do_o_kernel strides delta by ceil(S_q/128)*128.
+            sq_dot = -(-sq // 128) * 128
+            delta = carver.take(b * h * sq_dot, torch.float32).reshape(b, h, sq_dot)
             chunk = self._qh_chunk
-            s_ws = carver.take(b * chunk * sq * skv, self.dtype).view(b, chunk, sq, skv)
-            ds_ws = carver.take(b * chunk * sq * skv, self.dtype).view(b, chunk, sq, skv)
+            # Allocated at the PADDED extent, because that is what stage 2's
+            # tiled grid writes; stage 3 consumes a REAL-extent slice, so the
+            # padded tail never reaches a GEMM's M/N/K at all.
+            sqp, skvp = self._sq_pad, self._skv_pad
+            s_ws_full = carver.take(b * chunk * sqp * skvp, self.dtype).view(b, chunk, sqp, skvp)
+            ds_ws_full = carver.take(b * chunk * sqp * skvp, self.dtype).view(b, chunk, sqp, skvp)
+            s_ws, ds_ws = s_ws_full[:, :, :sq, :skv], ds_ws_full[:, :, :sq, :skv]
 
             # Layout normalisation. A conforming tensor is used in place (the
             # permute is a view); a non-conforming one gets a BSHD staging buffer
@@ -2311,9 +2327,11 @@ class SdpaBwdDslSm100(SdpaBwdDsl):
             # straddle the written boundary and read residue. That showed up as a
             # 1-in-6 catastrophic dK/dV (cos 0.0006), not a numerics drift,
             # because it depends on whatever was in the buffer.
-            if self._zero_ws:
-                s_ws.zero_()
-                ds_ws.zero_()
+            if self._zero_ws or self._is_padded:
+                # The padded tail is walked by stage 3's tile-rounded M/K in the
+                # same way a mask-skipped tile is, so it gets the same treatment.
+                s_ws_full.zero_()
+                ds_ws_full.zero_()
 
             gqa = self._gqa_group > 1
             if gqa:
@@ -2360,17 +2378,19 @@ class SdpaBwdDslSm100(SdpaBwdDsl):
                 hs = slice(hb, hb + chunk)
                 # STAGE 2: head_base offsets every full-tensor read; the S/dS
                 # workspace stays chunk-local at origin.
+                # Stage 2 gets the FULL padded workspace and the REAL seq
+                # lengths; it computes the tail tile and masks it.
                 stage2(
                     q,
                     k,
                     v,
                     do,
-                    s_ws,
-                    ds_ws,
+                    s_ws_full,
+                    ds_ws_full,
                     lse,
                     delta,
                     seq_kv,
-                    (b, h, sq, skv, chunk, self.h_kv),
+                    (b, h, sqp, skvp, chunk, self.h_kv, sq, skv),
                     float(scale),
                     float(scale_log2),
                     float(scale),

--- a/python/cudnn/sdpa/bwd/api_dsl.py
+++ b/python/cudnn/sdpa/bwd/api_dsl.py
@@ -2010,3 +2010,435 @@ def sdpa_bwd_wrapper_sm80(
     if dsink is not None:
         out["dsink_tensor"] = dsink
     return out
+
+
+# ---------------------------------------------------------------------------
+# SM100 (Blackwell) large-head-dim backward: the three-stage chain
+# ---------------------------------------------------------------------------
+
+_SM100_KERNEL_DIR = "cudnn/sdpa/bwd/kernels"
+_SM100_STAGE2_FILE = "bprop_d512_f16_sm100.py"
+_SM100_MATMUL_FILE = "bprop_matmul_sm100.py"
+# do_dot's inner loop is `n_chunks = D_V // chunk_elems` with no tail, so D_V is
+# always passed ROUNDED UP to this and the kernel's padded-head-dim guard covers
+# the remainder. 64 keeps 8 threads/row, which is a 2x throughput cliff over 32.
+_SM100_DOT_CHUNK_ELEMS = 64
+_SM100_DOT_Q_TILE = 128
+# Workspace budget for S + dS. Above this the head chunk shrinks; the loop then
+# runs more launches over the same total work (plan section 5).
+_SM100_WS_BUDGET_BYTES = 4 << 30
+
+
+def _sm100_kernel_path(fname: str) -> str:
+    import cudnn.sdpa.bwd.kernels as _k
+
+    return os.path.join(os.path.dirname(_k.__file__), fname)
+
+
+def _sm100_head_chunk(b: int, h_q: int, s_q: int, s_kv: int, bpe: int, budget: int = _SM100_WS_BUDGET_BYTES, group: int = 1) -> int:
+    """Largest DIVISOR of ``h_q`` whose S+dS chunk fits ``budget``.
+
+    A divisor, not a floor: even chunks mean no ragged tail, so one compiled
+    artifact serves every chunk and the host just varies ``head_base``. Returns
+    1 when even a single head does not fit -- the caller then requests what one
+    head needs and the size is still honest.
+    """
+    per_head = 2 * b * s_q * s_kv * bpe
+    # Under GQA the chunk must also be a MULTIPLE OF THE GROUP, so a chunk's Q
+    # heads map onto whole KV heads and the dQ group-slice below stays exact.
+    cands = [c for c in range(1, h_q + 1) if h_q % c == 0 and c % group == 0]
+    for c in sorted(cands, reverse=True):
+        if per_head * c <= budget:
+            return c
+    return group
+
+
+class SdpaBwdDslSm100(SdpaBwdDsl):
+    """d in (256, 512] backward on Blackwell, as do_dot -> S/dS -> three GEMMs.
+
+    Why three stages and not one kernel: a fused d=512 backward needs dV
+    [128 kv, 512] fp32 = 512 TMEM columns AND dK = 512 more, plus the S/dS
+    accumulators, against 512 columns per CTA. It does not fit, so S and dS go
+    to a GMEM workspace and the gradients are three plain batched GEMMs over it.
+
+    Sub-512 head dims need no kernel change: the TMA descriptors carry the real
+    ``d`` and a box reading past it is HW zero-filled, so the padded lanes
+    contribute 0 to both BMMs. We pay the full 512-wide MMA for that.
+    """
+
+    @staticmethod
+    def _bshd_physical_ok(desc: TensorDesc) -> bool:
+        """True when a logical-BHSD desc sits on compact BSHD storage.
+
+        Same predicate the SM120 adapter uses; defined here rather than shared
+        because that one is private to its class and this row's staging decision
+        is the only other caller.
+        """
+        b, h, s, d = (int(x) for x in desc.shape)
+        return tuple(int(x) for x in desc.stride) == (s * h * d, d, h * d, 1)
+
+    def _initialize_implementation(self) -> None:
+        q_shape = tuple(int(x) for x in self.q_desc.shape)  # logical BHSD
+        k_shape = tuple(int(x) for x in self.k_desc.shape)
+        self.batch_size, self.h_q, self.s_q_max, self.head_dim_qk = q_shape
+        self.h_kv, self.s_k_max = int(k_shape[1]), int(k_shape[2])
+        self.head_dim_v = int(tuple(self.v_desc.shape)[3])
+        self.dtype = self.q_desc.dtype
+        self._bpe = 2
+        self._compiled = None
+        self._dot_fn = None
+        self._reduce_fn = None
+        self._zero_ws = False
+        # GQA / MQA: stage 3 cannot write dK/dV straight to the output, because
+        # every Q head in a group contributes to the SAME KV head. It writes one
+        # partial per Q head and a separate reduce folds the group. group == 1
+        # (MHA) skips both the partial buffers and the reduce entirely.
+        self._gqa_group = self.h_q // self.h_kv
+        self._qh_chunk = _sm100_head_chunk(self.batch_size, self.h_q, self.s_q_max, self.s_k_max, self._bpe, group=self._gqa_group)
+        # The kernels read/write BSHD-physical buffers. Any io tensor that is not
+        # already one gets a staging copy carved from the workspace -- decided
+        # HERE, from the descs' declared strides, so scratch_workspace_bytes()
+        # stays an honest build-time function. In practice this is usually just
+        # dO: a caller that builds it with torch.randn(o.shape) rather than
+        # empty_like(o) loses o's memory format and lands BHSD-contiguous.
+        self._stage_in = tuple(
+            name
+            for name, desc in (("q", self.q_desc), ("k", self.k_desc), ("v", self.v_desc), ("o", self.o_desc), ("dO", self.do_desc))
+            if not self._bshd_physical_ok(desc)
+        )
+        self._stage_out = tuple(name for name, desc in (("dQ", self.dq_desc), ("dK", self.dk_desc), ("dV", self.dv_desc)) if not self._bshd_physical_ok(desc))
+
+    # --- capability backstop -------------------------------------------------
+    def check_support(self) -> bool:
+        """Re-check what the Capabilities row promised.
+
+        Reaching a raise here means the row lied -- these are backstops, not the
+        gate (engine contract section 1). They are ValueError, never assert: an
+        assert vanishes under -O and an import-time crash is undebuggable from
+        the frontend.
+        """
+        self._value_error_if(self.head_dim_qk != self.head_dim_v, f"SM100 bwd: d_qk must equal d_v; got {self.head_dim_qk} / {self.head_dim_v}")
+        self._value_error_if(not (256 < self.head_dim_qk <= 512), f"SM100 bwd: d must be in (256, 512]; got {self.head_dim_qk}")
+        self._value_error_if(
+            self.head_dim_qk % 8 != 0, f"SM100 bwd: d must be a multiple of 8 (TMA 16-byte innermost extent at 2 B/elem); got {self.head_dim_qk}"
+        )
+        self._value_error_if(self.h_q % self.h_kv != 0, f"SM100 bwd: h_q ({self.h_q}) must be a multiple of h_kv ({self.h_kv})")
+        self._value_error_if(self.s_q_max % 256 != 0, f"SM100 bwd: S_q must be a multiple of 256 (TILE_M * CTA_MMA); got {self.s_q_max}")
+        self._value_error_if(self.s_k_max % 128 != 0, f"SM100 bwd: S_kv must be a multiple of 128 (TILE_N); got {self.s_k_max}")
+        # SWA and bottom-right causal ARE implemented (the tile bounds and the
+        # per-cell mask both come from the shared mask helpers). Padding is not:
+        # it needs the per-batch kv length, and this kernel threads a scalar.
+        self._value_error_if(self.seq_kv_lens_present or self.seq_q_lens_present, "SM100 bwd: padding masks (seq lens) are not implemented")
+        self._value_error_if(self.deterministic, "SM100 bwd: deterministic mode is not implemented")
+        return True
+
+    def scratch_workspace_bytes(self) -> int:
+        """delta + one head chunk of S and dS.
+
+        A pure function of (B, H, S_q, S_kv, dtype) known at build time, with no
+        per-execute allocation: the executor carves all of it from the caller's
+        buffer, which is what keeps the plan CUDA-graph friendly.
+        """
+        delta = ws_align(self.batch_size * self.h_q * self.s_q_max * 4)
+        ws = ws_align(self.batch_size * self._qh_chunk * self.s_q_max * self.s_k_max * self._bpe)
+        total = delta + 2 * ws
+        for name in self._stage_in + self._stage_out:
+            s_len = self.s_k_max if name in ("k", "v", "dK", "dV") else self.s_q_max
+            total += ws_align(self.batch_size * s_len * self.h_q * self.head_dim_qk * self._bpe)
+        if self._gqa_group > 1:
+            # One dK and one dV partial per Q head, reduced to the KV heads at
+            # the end. Sized on h_q, not h_kv -- that is the whole point.
+            total += 2 * ws_align(self.batch_size * self.s_k_max * self.h_q * self.head_dim_qk * self._bpe)
+        return total
+
+    # --- compilation ---------------------------------------------------------
+    def compile(self) -> None:
+        """Plan-time JIT for the whole chain: stage 2's specialized module plus
+        the two stage-3 GEMM specializations (dV/dK share one; dQ needs the other
+        operand-major and the other causal K-trim direction).  Stage 1 is
+        compiled at execute, where the real O/dO tensors are in hand."""
+        self._ensure_support_checked()
+        if self._compiled is not None:
+            return self._compiled
+        from cudnn.sdpa.bwd.config_sm100 import (
+            CAUSAL_K_HI,
+            CAUSAL_K_LO,
+            CAUSAL_K_NONE,
+            MatmulTemplateParams,
+            TemplateParams,
+            vec_bytes_epi_for,
+        )
+        from cudnn.sdpa.bwd.kernels.bprop_chain_f16_sm120 import dot_do_o_host
+
+        dtype_code = DTYPE_BF16 if self.dtype == torch.bfloat16 else DTYPE_FP16
+        stage2_mod = load_template(
+            _sm100_kernel_path(_SM100_STAGE2_FILE),
+            TemplateParams(
+                dtype_qkv=dtype_code,
+                window_right=(self.window_size_right if self.window_size_right is not None else 0) if self.is_causal else None,
+                window_left=self.window_size_left,
+                bottom_right=self.causal_bottom_right,
+            ),
+            tag="sdpa_bwd_sm100_stage2",
+        )
+        gran = stage2_mod.CFG.TILE_M * stage2_mod.CFG.CTA_MMA
+        lo = CAUSAL_K_LO if self.is_causal else CAUSAL_K_NONE
+        hi = CAUSAL_K_HI if self.is_causal else CAUSAL_K_NONE
+        vec = vec_bytes_epi_for(self.head_dim_qk, self._bpe)
+        # How far past the plain kv <= q diagonal stage 2 actually writes. Band
+        # widening and bottom-right alignment both push it out, and they add; a
+        # stage-3 trim that ignores them cuts away real data.
+        shift = (self.window_size_right or 0) if self.is_causal else 0
+        if self.causal_bottom_right:
+            shift += self.s_k_max - self.s_q_max
+        # A non-zero shift breaks the alignment that lets stage 3 read only what
+        # stage 2 wrote, so the skipped region has to be ZEROED first -- see
+        # _zero_ws_needed.
+        # Zero whenever the trim is ACTIVE, not just when shift != 0: the
+        # never-empty clamp above means a structurally-masked M tile reads one
+        # k-tile of workspace and must see zeros there.
+        self._zero_ws = lo != CAUSAL_K_NONE or hi != CAUSAL_K_NONE
+        mm_lo = load_template(
+            _sm100_kernel_path(_SM100_MATMUL_FILE),
+            MatmulTemplateParams(a_is_m_major=True, b_is_n_major=True, causal_mode=lo, causal_gran=gran, causal_shift=shift, vec_bytes_epi=vec),
+            tag="sdpa_bwd_sm100_mm_lo",
+        )
+        mm_hi = load_template(
+            _sm100_kernel_path(_SM100_MATMUL_FILE),
+            MatmulTemplateParams(a_is_m_major=False, b_is_n_major=True, causal_mode=hi, causal_gran=gran, causal_shift=shift, vec_bytes_epi=vec),
+            tag="sdpa_bwd_sm100_mm_hi",
+        )
+        stage2 = stage2_mod.compile(
+            b=self.batch_size,
+            qh=self.h_q,
+            sq=self.s_q_max,
+            skv=self.s_k_max,
+            qh_chunk=self._qh_chunk,
+            d=self.head_dim_qk,
+            qh_kv=self.h_kv,
+        )
+        self._compiled = (dot_do_o_host, stage2_mod, stage2, mm_lo, mm_hi)
+        return self._compiled
+
+    # --- execution -----------------------------------------------------------
+    def execute(
+        self,
+        q_tensor: torch.Tensor,
+        k_tensor: torch.Tensor,
+        v_tensor: torch.Tensor,
+        o_tensor: torch.Tensor,
+        do_tensor: torch.Tensor,
+        stats_tensor: torch.Tensor,
+        dq_tensor: torch.Tensor,
+        dk_tensor: torch.Tensor,
+        dv_tensor: torch.Tensor,
+        scale_softmax: Optional[float] = None,
+        workspace: Optional[torch.Tensor] = None,
+        current_stream: Optional[cuda.CUstream] = None,
+        seq_q_lens: Optional[torch.Tensor] = None,
+        seq_kv_lens: Optional[torch.Tensor] = None,
+        sink_tensor: Optional[torch.Tensor] = None,
+        dsink_tensor: Optional[torch.Tensor] = None,
+        bias_tensor: Optional[torch.Tensor] = None,
+        dbias_tensor: Optional[torch.Tensor] = None,
+    ) -> None:
+        import cutlass
+        from cutlass.cute.runtime import from_dlpack, make_fake_stream
+
+        # Declared so the shared lowering can pass them positionally/by keyword,
+        # then refused: the Capabilities row does not claim any of them, so a
+        # non-None here means the row and this method disagree.
+        for _t_name, _t_val in (("sink", sink_tensor), ("dSink", dsink_tensor), ("bias", bias_tensor), ("dBias", dbias_tensor)):
+            self._value_error_if(_t_val is not None, f"SM100 bwd: {_t_name} is not implemented")
+        self._value_error_if(seq_q_lens is not None or seq_kv_lens is not None, "SM100 bwd: padding masks (seq lens) are not implemented")
+
+        dot_host, stage2_mod, stage2, mm_lo, mm_hi = self.compile()
+        b, h, sq, skv, d = self.batch_size, self.h_q, self.s_q_max, self.s_k_max, self.head_dim_qk
+        scale = self.scale_softmax if scale_softmax is None or scale_softmax == 0.0 else float(scale_softmax)
+        scale_log2 = scale * math.log2(math.e)
+
+        # Logical BHSD over BSHD storage -> the [B, S, H, D] view the kernels
+        # declare. A permutation, never a copy.
+        as_bshd = lambda t: t.permute(0, 2, 1, 3)
+
+        stream = self._get_default_stream(current_stream)
+        with _torch_stream_context(current_stream, q_tensor.device):
+            carver = WorkspaceCarver(workspace, self.scratch_workspace_bytes(), "sdpa_bwd_sm100")
+            delta = carver.take(b * h * sq, torch.float32).reshape(b, h, sq)
+            chunk = self._qh_chunk
+            s_ws = carver.take(b * chunk * sq * skv, self.dtype).view(b, chunk, sq, skv)
+            ds_ws = carver.take(b * chunk * sq * skv, self.dtype).view(b, chunk, sq, skv)
+
+            # Layout normalisation. A conforming tensor is used in place (the
+            # permute is a view); a non-conforming one gets a BSHD staging buffer
+            # from the workspace -- copied IN for reads, and copied back OUT
+            # after the chain for the gradients.
+            def _stage(t, name, is_out):
+                if name not in (self._stage_out if is_out else self._stage_in):
+                    return as_bshd(t), None
+                bt, ht, st, dd = t.shape[0], t.shape[1], t.shape[2], t.shape[3]
+                # `buf` is the BSHD-physical [B, S, H, D] buffer the kernels
+                # want; `view` is its logical-BHSD alias, used only to copy
+                # against the caller's tensor. Returning `view` here instead of
+                # `buf` hands the kernel [B, H, S, D] and it rejects the shape.
+                buf = carver.take(int(bt) * int(st) * int(ht) * int(dd), self.dtype).view(int(bt), int(st), int(ht), int(dd))
+                view = buf.permute(0, 2, 1, 3)
+                if not is_out:
+                    view.copy_(t)
+                return buf, (view, t)
+
+            q, _ = _stage(q_tensor, "q", False)
+            k, _ = _stage(k_tensor, "k", False)
+            v, _ = _stage(v_tensor, "v", False)
+            o, _ = _stage(o_tensor, "o", False)
+            do, _ = _stage(do_tensor, "dO", False)
+            dq, dq_back = _stage(dq_tensor, "dQ", True)
+            dk, dk_back = _stage(dk_tensor, "dK", True)
+            dv, dv_back = _stage(dv_tensor, "dV", True)
+
+            # Under GQA the stage-3 dK/dV GEMMs write ONE PARTIAL PER Q HEAD and
+            # a separate reduce folds the group afterwards. Writing straight to
+            # dk/dv would have the group's Q heads overwrite each other instead
+            # of summing. MHA (group == 1) skips both the buffers and the reduce.
+            # Zero the S/dS workspace when the stage-3 K-trim can straddle the
+            # boundary of what stage 2 wrote.
+            #
+            # With shift == 0 it cannot: the trim starts at (m0 // 256) * 256 ==
+            # m0, and every q-cluster from there wrote the whole 256-wide M tile,
+            # so the skipped tiles are never read (the poisoned-workspace test
+            # proves it at 43.8% skipped). A non-zero shift -- band widening or
+            # bottom-right -- pulls the start BELOW m0, and then an M tile can
+            # straddle the written boundary and read residue. That showed up as a
+            # 1-in-6 catastrophic dK/dV (cos 0.0006), not a numerics drift,
+            # because it depends on whatever was in the buffer.
+            if self._zero_ws:
+                s_ws.zero_()
+                ds_ws.zero_()
+
+            gqa = self._gqa_group > 1
+            if gqa:
+                dk_part = carver.take(b * skv * h * d, self.dtype).view(b, skv, h, d)
+                dv_part = carver.take(b * skv * h * d, self.dtype).view(b, skv, h, d)
+                # Already [B, S_kv, H_q, D] -- the same BSHD orientation `_stage`
+                # hands back, so the `hs` head slice below hits the same axis.
+                dk_tgt, dv_tgt = dk_part, dv_part
+            else:
+                dk_tgt, dv_tgt = dk, dv
+
+            _t = lambda x: from_dlpack(x, assumed_align=16, enable_tvm_ffi=True)
+            # STAGE 1, hoisted out of the chunk loop: one streaming pass over O
+            # and dO instead of n_chunks passes. Nothing in the loop feeds it.
+            #
+            # The compiled artifact is CACHED on the adapter. Building it here on
+            # every call cost ~250 ms of WALL time per execute while device time
+            # stayed at 0.1 ms -- invisible to a device-time benchmark, ruinous
+            # for anything that measures the real call.
+            if self._dot_fn is None:
+                d_padded = -(-d // _SM100_DOT_CHUNK_ELEMS) * _SM100_DOT_CHUNK_ELEMS
+                self._dot_fn = cutlass.cute.compile(
+                    dot_host,
+                    _t(o),
+                    _t(do),
+                    _t(delta),
+                    None,
+                    None,
+                    _SM100_DOT_Q_TILE,
+                    d_padded,
+                    d_padded,
+                    _SM100_DOT_CHUNK_ELEMS,
+                    False,
+                    False,
+                    make_fake_stream(use_tvm_ffi_env_stream=False),
+                    options="--enable-tvm-ffi",
+                )
+            self._dot_fn(_t(o), _t(do), _t(delta), None, None, stream)
+
+            lse = stats_tensor.reshape(b, h, sq)
+            seq_kv = torch.full((b,), skv, device=q.device, dtype=torch.int32)
+            for c in range(h // chunk):
+                hb = c * chunk
+                hs = slice(hb, hb + chunk)
+                # STAGE 2: head_base offsets every full-tensor read; the S/dS
+                # workspace stays chunk-local at origin.
+                stage2(
+                    q,
+                    k,
+                    v,
+                    do,
+                    s_ws,
+                    ds_ws,
+                    lse,
+                    delta,
+                    seq_kv,
+                    (b, h, sq, skv, chunk, self.h_kv),
+                    float(scale),
+                    float(scale_log2),
+                    float(scale),
+                    hb,
+                    0,
+                    stream,
+                )
+                # STAGE 3: consume the chunk workspace, write the full output's
+                # head slice. Every operand is a permuted view.
+                mm_lo.matmul_bh(
+                    s_ws.permute(3, 2, 1, 0),
+                    do[:, :, hs, :].permute(3, 1, 2, 0),
+                    dv_tgt[:, :, hs, :].permute(1, 3, 2, 0),
+                    n_head=chunk,
+                    n_batch=b,
+                    stream=stream,
+                )
+                mm_lo.matmul_bh(
+                    ds_ws.permute(3, 2, 1, 0),
+                    q[:, :, hs, :].permute(3, 1, 2, 0),
+                    dk_tgt[:, :, hs, :].permute(1, 3, 2, 0),
+                    n_head=chunk,
+                    n_batch=b,
+                    stream=stream,
+                )
+                # dQ = dS.K. Under GQA the K head is shared by `group` Q heads,
+                # so the GEMM runs once per group MEMBER: taking every `group`-th
+                # Q head lines A and the output up with the KV heads exactly, and
+                # every operand stays a strided view (no expand, no copy).
+                kv_lo, kv_n = hb // self._gqa_group, chunk // self._gqa_group
+                kvs = slice(kv_lo, kv_lo + kv_n)
+                for gi in range(self._gqa_group):
+                    a_g = ds_ws[:, gi :: self._gqa_group] if gqa else ds_ws
+                    o_g = dq[:, :, hs, :][:, :, gi :: self._gqa_group, :] if gqa else dq[:, :, hs, :]
+                    mm_hi.matmul_bh(
+                        a_g.permute(2, 3, 1, 0),
+                        k[:, :, kvs, :].permute(3, 1, 2, 0),
+                        o_g.permute(1, 3, 2, 0),
+                        n_head=kv_n,
+                        n_batch=b,
+                        stream=stream,
+                    )
+
+            if gqa:
+                # Fold the Q-head partials onto the KV heads. Reused verbatim
+                # from the SM120 chain: arch-neutral, one thread per 16 B output
+                # vector, fixed-order fp32 accumulation (so it is deterministic).
+                from cudnn.sdpa.bwd.kernels.bprop_chain_f16_sm120 import dkv_reduce_host
+
+                io_dt = cutlass.BFloat16 if self.dtype == torch.bfloat16 else cutlass.Float16
+                if self._reduce_fn is None:
+                    self._reduce_fn = cutlass.cute.compile(
+                        dkv_reduce_host,
+                        _t(dk_part),
+                        _t(dv_part),
+                        _t(dk),
+                        _t(dv),
+                        d,
+                        d,
+                        self._gqa_group,
+                        io_dt,
+                        False,
+                        make_fake_stream(use_tvm_ffi_env_stream=False),
+                        options="--enable-tvm-ffi",
+                    )
+                self._reduce_fn(_t(dk_part), _t(dv_part), _t(dk), _t(dv), stream)
+
+            for back in (dq_back, dk_back, dv_back):
+                if back is not None:
+                    staged, dest = back
+                    dest.copy_(staged)

--- a/python/cudnn/sdpa/bwd/config_sm100.py
+++ b/python/cudnn/sdpa/bwd/config_sm100.py
@@ -136,6 +136,23 @@ class MatmulTemplateParams:
     # bodies are textually identical), which is why it is a plain knob here.
     # Use `vec_bytes_epi_for(d, bpe)` rather than setting it by hand.
     vec_bytes_epi: int = 32
+    # IO dtype of A/B/D, as a DTYPE_* code.  Must match the stage-2 template's
+    # `dtype_qkv`: stage 3 reads the S/dS workspace stage 2 wrote and stores the
+    # gradients in the graph's io dtype.  Both are 2 B/element, so this changes
+    # only the dtype TOKENS in the rendered body -- every byte-size constant
+    # (swizzle, box dims, SMEM staging) is width-driven and unaffected.
+    dtype_qkv: int = DTYPE_BF16
+
+
+def validate_matmul_params(params: MatmulTemplateParams) -> None:
+    """Backstop on the stage-3 GEMM params, mirroring ``make_cfg_d512``'s role
+    for stage 2. Public because the template calls it; reaching a raise here
+    means the adapter built a record the Capabilities row should not have
+    admitted."""
+    if params.dtype_qkv not in (DTYPE_BF16, DTYPE_FP16):
+        raise ValueError(f"SM100 SDPA bwd d512 stage 3: dtype_qkv must be DTYPE_BF16 ({DTYPE_BF16}) or DTYPE_FP16 ({DTYPE_FP16}); got {params.dtype_qkv}.")
+    if params.vec_bytes_epi not in (16, 32):
+        raise ValueError(f"SM100 SDPA bwd d512 stage 3: vec_bytes_epi must be 16 or 32; got {params.vec_bytes_epi}.")
 
 
 def vec_bytes_epi_for(d: int, bpe: int = 2) -> int:

--- a/python/cudnn/sdpa/bwd/config_sm100.py
+++ b/python/cudnn/sdpa/bwd/config_sm100.py
@@ -1,0 +1,488 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Kernel configuration for the FROST SM100 SDPA-backward stage-2 flavor (d512).
+
+Stage 2 of the three-stage backward: it consumes Q / K / V / dO / LSE / do_dot
+and produces the ``S`` and ``dS`` workspaces that stage 3's three GEMMs reduce
+into dV / dK / dQ.
+
+Geometry is fixed here; the per-graph compile-time parameters (dtype, mask,
+padding, scheduler policy) arrive as a :class:`TemplateParams` built by the
+adapter in :mod:`cudnn.sdpa.bwd.api_dsl`. Nothing in this module reads an
+environment variable.
+
+All configuration errors raise :class:`ValueError`. Anything a *user-built
+graph* could trip must be rejected earlier by the engine's ``Capabilities`` —
+a ``ValueError`` from here means that row has a gap.
+
+Layout rationale: the
+Rubin SM107 backward's 320 KiB single-CTA layout does not fit SM100's 227 KiB.
+This flavor instead forks the *forward* d512 SM100 kernel's cga4x1 role split —
+sub-group 0 runs BMM1 (Q.K^T -> S_acc) and the softmax, sub-group 1 runs BMM2
+(dO.V^T -> dS_acc) and the dS epilogue — which gives each sub-group its own
+227 KiB of SMEM and its own 512 TMEM columns. That is what makes the operand
+resident in TMEM on BOTH sides (Q on sg0, dO on sg1) and restores the
+accumulator double-buffer the Rubin kernel had to drop.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Stage-3 causal K-trim modes (see MatmulTemplateParams.causal_mode).
+CAUSAL_K_NONE = 0
+CAUSAL_K_LO = 1
+CAUSAL_K_HI = 2
+from typing import Optional, Tuple
+
+from cudnn.frost.tile_dsl.constants import (
+    DTYPE_BF16,
+    DTYPE_E5M2,
+    DTYPE_FP16,
+    MASK_CAUSAL,
+    MASK_NONE,
+    MASK_PADDED,
+    MASK_SWA,
+    SCHED_LPT,
+    SCHED_LPT_L2,
+    SCHED_NATURAL,
+)
+
+# SM100 usable dynamic SMEM per CTA (228 KiB physical, 227 KiB usable).  Mirrors
+# ``sdpa.fwd.config_sm100._SM100_MAX_DYN_SMEM``; duplicated rather than imported
+# so the backward pass does not depend on the forward's config module.
+_SM100_MAX_DYN_SMEM = 227 * 1024
+
+# TMEM columns on Blackwell.  576 is Rubin, and needs ``is_exclusive=True``,
+# which is fenced out of the public cutlass-dsl wheel — do not raise this.
+_SM100_TMEM_COLS = 512
+
+
+@dataclass(frozen=True)
+class TemplateParams:
+    """Per-graph compile-time parameters threaded into the stage-2 template.
+
+    Shapes are deliberately absent: they ride the template's per-shape
+    ``compile()`` cache. Batch and head are absent for the same reason *and*
+    because they are host-loop coordinates — the kernel takes ``head_base`` /
+    ``batch_base`` as runtime Int32 arguments.
+    """
+
+    dtype_qkv: int = DTYPE_BF16
+    # Mask band. ``window_right`` set => causal; ``window_left`` set => SWA.
+    window_left: Optional[int] = None
+    window_right: Optional[int] = None
+    bottom_right: bool = False
+    seq_kv_lens_present: bool = False
+    seq_q_lens_present: bool = False
+    sched_policy: int = SCHED_NATURAL
+    # Tuning knob: halves of the fp32 S tile shipped sg0 -> sg1 per kv step.
+    # 2 keeps the cross-sub-group ring 2-deep at an identical byte footprint;
+    # 1 ships the whole tile and hard-stalls sg0 on sg1.
+    xfer_halves: int = 2
+
+
+@dataclass(frozen=True)
+class MatmulTemplateParams:
+    """Per-GEMM compile-time parameters for the stage-3 gradient GEMMs.
+
+    Lives HERE rather than in the kernel file because a template loaded through
+    ``frost.template_loader`` is executed before it is registered in
+    ``sys.modules``, and a module-scope ``@dataclass`` needs its own module to be
+    importable while the decorator runs. Same reason ``TemplateParams`` above is
+    defined here and not in the stage-2 template.
+
+    Only the operand-major pair varies: the three stage-3 GEMMs share one tile
+    config, and the rendered bodies for the different majors are textually
+    identical apart from ten constants (see the kernel's ``_MAJOR_CONSTS``).
+
+        dV = S^T.dO, dK = dS^T.Q -> a_is_m_major=True   (kv is contiguous and is M)
+        dQ = dS.K                -> a_is_m_major=False  (kv is contiguous and is K)
+
+    ``b_is_n_major`` is True for all three: D is contiguous in BSHD and D is N.
+    """
+
+    a_is_m_major: bool = False
+    b_is_n_major: bool = True
+    # Causal K-trim.  Stage 2 under a causal mask leaves the tiles above the
+    # diagonal UNWRITTEN, so this is a correctness requirement before it is an
+    # optimization: a stage-3 GEMM must not read them.
+    #
+    #   CAUSAL_K_NONE  dense -- full K range.
+    #   CAUSAL_K_LO    dV = S^T.dO and dK = dS^T.Q.  Output row is kv; S[q,kv]
+    #                  is written only for q >= the stage-2 block containing kv,
+    #                  so K (= q) STARTS there.
+    #   CAUSAL_K_HI    dQ = dS.K.  Output row is q; dS[q,kv] is written only for
+    #                  kv < the end of q's stage-2 block, so K (= kv) ENDS there.
+    #
+    # ``causal_gran`` is stage 2's write granularity in elements -- its
+    # ``TILE_M * CTA_MMA`` (256), because its kv bound is taken over the whole
+    # cluster q span.  Rounding to it is what makes "never read an unwritten
+    # tile" exact rather than approximate.
+    causal_mode: int = CAUSAL_K_NONE
+    causal_gran: int = 0
+    # How far the non-zero band extends PAST the plain kv <= q diagonal, in
+    # elements.  Two things push it out and they add:
+    #   * `diagonal_band_right_bound` (band widening) -- kv <= q + W;
+    #   * bottom-right alignment      -- kv <= q + (S_kv - S_q).
+    # Stage 2 writes those columns, so a trim that ignores them cuts away real
+    # data. Negative is legal (bottom-right with S_kv < S_q pulls the band IN).
+    causal_shift: int = 0
+    # Epilogue store vector, in BYTES.  The output N is the head dim, and the
+    # epilogue stores N in `vec_bytes_epi / sizeof(out)` element chunks -- so 32
+    # requires d % 16 == 0 and 16 only d % 8 == 0.  Rendering the upstream
+    # template at an N % 8 shape changes THIS CONSTANT AND NOTHING ELSE (the
+    # bodies are textually identical), which is why it is a plain knob here.
+    # Use `vec_bytes_epi_for(d, bpe)` rather than setting it by hand.
+    vec_bytes_epi: int = 32
+
+
+def vec_bytes_epi_for(d: int, bpe: int = 2) -> int:
+    """Widest legal stage-3 epilogue store vector for a head dim of ``d``.
+
+    The epilogue writes the output's N (= the head dim) in
+    ``vec_bytes_epi / bpe`` element chunks, and the compiled artifact declares
+    that as a symbolic divisibility -- so a mismatched d fails at CALL time with
+    *"expected to be divisible by 16"*, not at build time.  32 B is the fast
+    path and needs ``d % 16 == 0``; 16 B relaxes that to ``d % 8 == 0``.
+    """
+    per32 = 32 // bpe
+    return 32 if d % per32 == 0 else 16
+
+
+def _validate_params(params: TemplateParams) -> None:
+    if params.dtype_qkv not in (DTYPE_BF16, DTYPE_FP16):
+        raise ValueError(
+            f"SM100 SDPA bwd d512: dtype_qkv must be DTYPE_BF16 ({DTYPE_BF16}) or DTYPE_FP16 ({DTYPE_FP16}); "
+            f"got {params.dtype_qkv}. FP8/MXFP8 backward is not implemented on this arch."
+        )
+    if params.window_left is not None and params.window_left < 0:
+        raise ValueError(f"SM100 SDPA bwd d512: window_left must be non-negative; got {params.window_left}")
+    if params.window_right is not None and params.window_right < 0:
+        raise ValueError(f"SM100 SDPA bwd d512: window_right must be non-negative; got {params.window_right}")
+    if params.bottom_right and params.window_right is None:
+        raise ValueError("SM100 SDPA bwd d512: bottom_right alignment requires a causal upper bound (window_right)")
+    if params.seq_q_lens_present and not params.seq_kv_lens_present:
+        raise ValueError("SM100 SDPA bwd d512: seq_q_lens_present requires seq_kv_lens_present (padding mask)")
+    if params.sched_policy not in (SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2):
+        raise ValueError(f"SM100 SDPA bwd d512: sched_policy must be one of NATURAL/LPT/LPT_L2; got {params.sched_policy}")
+    if params.xfer_halves not in (1, 2):
+        raise ValueError(f"SM100 SDPA bwd d512: xfer_halves must be 1 or 2; got {params.xfer_halves}")
+
+
+def _mask_flags_from(params: TemplateParams) -> int:
+    flags = MASK_NONE
+    if params.window_right is not None:
+        flags |= MASK_CAUSAL
+    if params.window_left is not None:
+        flags |= MASK_SWA
+    if params.seq_kv_lens_present:
+        flags |= MASK_PADDED
+    return flags
+
+
+def bpe(dtype: int) -> int:
+    return 1 if dtype <= DTYPE_E5M2 else 2
+
+
+@dataclass(frozen=True)
+class CfgBwdD512:
+    """Stage-2 geometry: d_qk = d_v = 512, SM100, cga4x1 role split.
+
+    Identifiers are keyed by op geometry, not by the model this was tuned for
+    (frost-engine-contract.md §8).
+    """
+
+    TILE_M: int = 128  # q rows per CTA
+    TILE_N: int = 128  # kv cols per kernel tile (collective MMA N)
+    TILE_K: int = 512  # d_qk
+    TILE_O: int = 512  # d_v
+
+    DTYPE_QKV: int = DTYPE_BF16
+    BPE: int = 2
+
+    # cga4x1 = two sub-groups of two CTAs.  sg0: BMM1 + softmax; sg1: BMM2 + dS.
+    CGA_M: int = 4
+    CGA_N: int = 1
+    CTA_MMA: int = 2
+
+    Q_SWZ_BYTES: int = 128
+    K_SWZ_BYTES: int = 128
+    V_SWZ_BYTES: int = 128
+    DO_SWZ_BYTES: int = 128
+    S_SWZ_BYTES: int = 128
+
+    # f16/bf16 is 1-chunk only on SM10x; 2-chunk (32) is silently wrong.
+    TILE_K_HW_BMM1: int = 16
+    TILE_K_HW_BMM2: int = 16
+
+    STAGES_KV: int = 2  # K ring on sg0 / V ring on sg1 (SMEM-cap driven)
+    STAGES_ACC: int = 2  # S_acc / dS_acc parity slots (TMEM-cap driven)
+    XFER_HALVES: int = 2  # fp32 S halves shipped sg0 -> sg1
+    SCHEDULER_STAGES: int = 2
+
+    SOFTMAX_WARPGROUPS: int = 1
+    SOFTMAX_WG_WARPS: int = 4
+    CORRECTION_WARPS: int = 0
+
+    SOFTMAX_REGS: int = 240
+    CORRECTION_REGS: int = 0
+    MMA_REGS: int = 40
+    TMALDG_REGS: int = 40
+    TMASTG_REGS: int = 40
+    SCHEDULER_REGS: int = 40
+    OTHER_REGS: int = 40
+
+    TOTAL_WARPS: int = 8
+    THREADS_PER_CTA: int = 8 * 32
+    SOFTMAX_WG0_BASE: int = 0
+    MMA_WARP_ID: int = 4
+    TMALDG_WARP_ID: int = 5
+    TMASTG_WARP_ID: int = 6
+    SCHED_WARP_ID: int = 7
+
+    # --- mbarrier arrival counts ---------------------------------------
+    # P3: an init count must equal the EXACT sum of producer arrivals per
+    # phase, and the constant belongs next to its derivation.  Note
+    # ``.arrive()`` fires on every LANE of the calling warp, not once per warp.
+    ONE_LANE: int = 1  # a single elect_sync'd lane
+    ONE_WARP: int = 32  # an un-elected THREAD arrive from one warp
+    COMPUTE_LANES: int = 4 * 32  # SOFTMAX_WG_WARPS * 32, the compute warp group
+    # *_acc_empty: every lane of the compute WG on BOTH CTAs of the pair
+    # arrive_on_peer's the pair leader.
+    ACC_EMPTY_ARRIVERS: int = 4 * 32 * 2  # COMPUTE_LANES * CTA_MMA
+
+    # Scheduler ring.  Each calling warp delivers exactly ONE arrive to each
+    # CTA of the cluster, so this is the count of (warp, CTA) instances that
+    # call read_tile_id_arrive.  EVERY warp role except the scheduler warp
+    # itself calls it, on every CTA of the cluster:
+    #     (SOFTMAX_WG_WARPS + TMA-LDG + TMA-STG + MMA) * CGA_SIZE
+    #   = (4 + 1 + 1 + 1) * 4 = 28
+    # The MMA term counts BOTH arms: the non-leader is a quiet warp but it
+    # still runs the persistent loop and must stay in step, so it arrives too.
+    #
+    # The forward d512's 25 is NOT comparable and must not be copied: its
+    # TMA-STG runs on sg1 only, and only its sg1 non-leader MMA warp arrives.
+    #
+    # Getting this too LOW is the dangerous direction: the barrier completes
+    # before every role has read the payload, so the ring advances a tile early
+    # every iteration and the kernel wedges intermittently -- it does not fail
+    # cleanly (P3).  An init of 26 against 28 arrivers cost a debugging session.
+    READ_TILE_ARRIVERS: int = 28
+
+    MASK_FLAGS: int = MASK_NONE
+    WINDOW_LEFT: int = 0
+    WINDOW_RIGHT: int = 0
+    BOTTOM_RIGHT: int = 0
+    SEQ_KV_LENS_PRESENT: int = 0
+    SEQ_Q_LENS_PRESENT: int = 0
+
+    L2_SIZE_MIB: int = 60
+    SCHEDULER_POLICY: int = SCHED_NATURAL
+
+
+# ---------------------------------------------------------------------------
+# Resource derivations — the single source of truth for both the validator
+# below and the kernel's allocation block.  Never inline these numbers.
+# ---------------------------------------------------------------------------
+
+
+def operand_bytes(cfg: CfgBwdD512) -> Tuple[int, int, int, int]:
+    """(Q, dO, K-per-stage, V-per-stage) SMEM bytes for ONE CTA.
+
+    K and V are split along the collective MMA-N across the CTA pair, so each
+    CTA holds ``TILE_N / CTA_MMA`` rows of them; Q and dO are whole-block.
+    """
+    q = cfg.TILE_M * cfg.TILE_K * cfg.BPE
+    do = cfg.TILE_M * cfg.TILE_O * cfg.BPE
+    k = (cfg.TILE_N * cfg.TILE_K // cfg.CTA_MMA) * cfg.BPE
+    v = (cfg.TILE_N * cfg.TILE_O // cfg.CTA_MMA) * cfg.BPE
+    return q, do, k, v
+
+
+def xfer_bytes(cfg: CfgBwdD512) -> int:
+    """fp32 S staged for the cross-sub-group ship, summed over the ring.
+
+    fp32 and not the io dtype on purpose: the Rubin reference never transfers S
+    at all (it multiplies the fp32 register copy straight into dS), so shipping
+    a rounded S across the role split would be an accuracy regression the
+    reference does not have.  Halving the tile keeps the ring 2-deep
+    at an identical footprint.
+    """
+    return cfg.XFER_HALVES * cfg.TILE_M * (cfg.TILE_N // cfg.XFER_HALVES) * 4
+
+
+def s_tma_iters(cfg: CfgBwdD512) -> int:
+    """Workspace TMA subtiles per stored tile.
+
+    One row of a subtile must be exactly one swizzle atom, so this is
+    ``(TILE_N * BPE) // S_SWZ_BYTES`` -- 2 at bf16/TILE_N=128/128 B.  The
+    validator pins ``XFER_HALVES`` to it: one shipped fp32 half is exactly one
+    stored subtile is exactly one softmax chunk.
+    """
+    return (cfg.TILE_N * cfg.BPE) // cfg.S_SWZ_BYTES
+
+
+def cast_bytes(cfg: CfgBwdD512) -> int:
+    """io-dtype staging for one workspace tile (S on sg0, dS on sg1).
+
+    Separate from the fp32 xfer buffer so the fp32 ring slot is released on
+    cast completion instead of on ``tma_store_wait``.
+    """
+    return cfg.TILE_M * cfg.TILE_N * cfg.BPE
+
+
+def smem_bytes(cfg: CfgBwdD512) -> Tuple[int, int]:
+    """(sg0, sg1) SMEM tensor bytes per CTA.
+
+    Each sub-group's operand slab is a max-union alias, not a sum: the Q (resp.
+    dO) staging buffer is dead once the UTCCP has moved it to TMEM, so the K
+    (resp. V) ring reuses those exact bytes behind the alias-seam barrier.
+    """
+    q, do, k, v = operand_bytes(cfg)
+    sg0_alias = max(q, cfg.STAGES_KV * k)
+    sg1_alias = max(do, cfg.STAGES_KV * v)
+    common = xfer_bytes(cfg) + cast_bytes(cfg)
+    return sg0_alias + common, sg1_alias + common
+
+
+def tmem_cols(cfg: CfgBwdD512) -> Tuple[int, int]:
+    """(sg0, sg1) TMEM columns.
+
+    An accumulator is fp32 and TILE_N wide => TILE_N columns per parity slot.
+    A 16-bit operand packs 2 elements per 32-bit column, so [TILE_M x d] costs
+    ``d * BPE / 4`` columns -- 256 at d=512, which is exactly what leaves room
+    for the two accumulator slots under the 512-column cap.
+    """
+    acc = cfg.STAGES_ACC * cfg.TILE_N
+    return acc + (cfg.TILE_K * cfg.BPE) // 4, acc + (cfg.TILE_O * cfg.BPE) // 4
+
+
+def _validate_cfg_d512(cfg: CfgBwdD512) -> None:
+    """Consistency checks on the (mostly hardcoded) stage-2 d512 geometry."""
+    sg0_smem, sg1_smem = smem_bytes(cfg)
+    sg0_tmem, sg1_tmem = tmem_cols(cfg)
+    checks = (
+        # --- register split: all four are hardware constraints -------------
+        (cfg.MMA_REGS == cfg.TMALDG_REGS == cfg.TMASTG_REGS == cfg.SCHEDULER_REGS, "bwd d512: MMA/TMALDG/TMASTG/Scheduler regs must match"),
+        (cfg.MMA_REGS + cfg.CORRECTION_REGS + cfg.SOFTMAX_WARPGROUPS * cfg.SOFTMAX_REGS <= 512, "bwd d512: register budget over 512"),
+        (
+            cfg.MMA_REGS % 8 == 0 and cfg.CORRECTION_REGS % 8 == 0 and cfg.SOFTMAX_REGS % 8 == 0,
+            "bwd d512: per-role regs must be multiples of 8",
+        ),
+        (24 <= cfg.SOFTMAX_REGS <= 256 and 24 <= cfg.MMA_REGS <= 256, "bwd d512: per-warp regs must be within [24, 256]"),
+        # --- geometry ------------------------------------------------------
+        (cfg.TILE_M == 128 and cfg.TILE_N == 128, "bwd d512: TILE_M = TILE_N = 128"),
+        (cfg.TILE_K == 512 and cfg.TILE_O == 512, "bwd d512: d_qk = d_v = 512"),
+        (cfg.CGA_M == 4 and cfg.CGA_N == 1 and cfg.CTA_MMA == 2, "bwd d512: cga4x1 / CTA_MMA=2 only"),
+        (cfg.CGA_M // cfg.CTA_MMA == 2, "bwd d512 (role split): exactly two sub-groups (CGA_M / CTA_MMA == 2)"),
+        (cfg.SOFTMAX_WARPGROUPS == 1 and cfg.CORRECTION_WARPS == 0, "bwd d512 (role split): one softmax warpgroup, no correction warp"),
+        (cfg.TILE_N % cfg.XFER_HALVES == 0, "bwd d512: XFER_HALVES must divide TILE_N"),
+        # A four-way alignment that the store layout, the ship ring and the
+        # softmax register budget all depend on: one fp32 S half == one softmax
+        # chunk == one workspace TMA subtile == one 128 B swizzle atom per row.
+        # (TILE_N * BPE) // S_SWZ_BYTES is the subtile count; at TILE_N=128,
+        # BPE=2, 128 B swizzle that is 2, and XFER_HALVES=2 matches it.  The
+        # forward asserts the same coincidence as P_TMA_ITERS == P_XFER_HALVES.
+        (
+            cfg.XFER_HALVES == (cfg.TILE_N * cfg.BPE) // cfg.S_SWZ_BYTES,
+            f"bwd d512: XFER_HALVES ({cfg.XFER_HALVES}) must equal the workspace TMA subtile count "
+            f"({(cfg.TILE_N * cfg.BPE) // cfg.S_SWZ_BYTES}) -- one ship half must be exactly one stored subtile",
+        ),
+        # --- MMA: bf16/fp16 is 1-chunk only on SM10x -----------------------
+        (
+            cfg.TILE_K_HW_BMM1 == 16 and cfg.TILE_K_HW_BMM2 == 16,
+            "bwd d512 f16/bf16: TILE_K_HW must be 16 (1-chunk only on SM10x -- 2-chunk silently wrong)",
+        ),
+        (cfg.BPE == bpe(cfg.DTYPE_QKV), "bwd d512: BPE must match DTYPE_QKV"),
+        # The workspace dtype IS the io dtype.  An earlier Rubin revision tied
+        # it to an independent output dtype and produced a silent mismatch
+        # against the stage-3 GEMMs, which read the workspace as the io dtype.
+        (cfg.DTYPE_QKV in (DTYPE_BF16, DTYPE_FP16), "bwd d512: workspace/io dtype must be BF16 or FP16"),
+        # --- swizzle -------------------------------------------------------
+        (
+            cfg.Q_SWZ_BYTES == 128 and cfg.K_SWZ_BYTES == 128 and cfg.V_SWZ_BYTES == 128 and cfg.DO_SWZ_BYTES == 128,
+            "bwd d512: Q/K/V/dO swizzle must all be 128B",
+        ),
+        # --- caps ----------------------------------------------------------
+        (
+            sg0_smem <= _SM100_MAX_DYN_SMEM,
+            f"bwd d512: sg0 SMEM {sg0_smem / 1024:.1f} KiB over the SM100 {_SM100_MAX_DYN_SMEM // 1024} KiB per-CTA cap",
+        ),
+        (
+            sg1_smem <= _SM100_MAX_DYN_SMEM,
+            f"bwd d512: sg1 SMEM {sg1_smem / 1024:.1f} KiB over the SM100 {_SM100_MAX_DYN_SMEM // 1024} KiB per-CTA cap",
+        ),
+        (
+            sg0_tmem <= _SM100_TMEM_COLS,
+            f"bwd d512: sg0 TMEM carve {sg0_tmem} over the {_SM100_TMEM_COLS}-column Blackwell cap",
+        ),
+        (
+            sg1_tmem <= _SM100_TMEM_COLS,
+            f"bwd d512: sg1 TMEM carve {sg1_tmem} over the {_SM100_TMEM_COLS}-column Blackwell cap",
+        ),
+        # --- masks ---------------------------------------------------------
+        (not (cfg.BOTTOM_RIGHT and not (cfg.MASK_FLAGS & MASK_CAUSAL)), "bwd d512: bottom_right requires a causal band"),
+        (
+            cfg.READ_TILE_ARRIVERS == (cfg.SOFTMAX_WG_WARPS + 3) * cfg.CGA_M * cfg.CGA_N,
+            f"bwd d512: READ_TILE_ARRIVERS ({cfg.READ_TILE_ARRIVERS}) must equal "
+            f"{(cfg.SOFTMAX_WG_WARPS + 3) * cfg.CGA_M * cfg.CGA_N} "
+            "= (softmax warps + TMA-LDG + TMA-STG + MMA) * CGA_SIZE -- every role but the scheduler, on every CTA",
+        ),
+        (cfg.COMPUTE_LANES == cfg.SOFTMAX_WG_WARPS * 32, "bwd d512: COMPUTE_LANES must be SOFTMAX_WG_WARPS * 32"),
+        # v1 scope, deliberately narrow so the engine row cannot over-promise:
+        # dense only, natural (grid-mapped) schedule.  Masks and persistence are
+        # Phase 4 / Phase 5; each needs its own capabilities row + reject test.
+        # Causal is implemented (tile-level triangular skip + a post-exp2
+        # per-cell mask on the diagonal tiles).  SWA and padding are NOT, and
+        # neither is bottom-right alignment: under bottom-right with
+        # S_kv < S_q the leading q tiles get an EMPTY kv range, and this
+        # kernel has no empty-tile path -- every cross-CTA ring would have to
+        # fire a bookkeeping arrive so the four CTAs stay in step.  Top-left
+        # causal always keeps kv_right >= 1, which is why it needs none.
+        # Causal (top-left and bottom-right) and SWA are implemented: the tile
+        # bounds come from the shared `compute_kv_loop_bounds` and the per-cell
+        # mask from `apply_mask_chunk`, both driven by MASK_FLAGS.
+        #
+        # An EMPTY kv range (which bottom-right and SWA both admit) needs no
+        # special path here: every ring except the per-tile operand one is
+        # per-kv-iteration, so a zero-trip loop fires nothing, and
+        # `_residual_depth(0, stages)` is 0. The three conditions that make that
+        # safe all hold -- all four CTAs derive IDENTICAL bounds (they are keyed
+        # on the cluster's q span), `read_tile_id_arrive` sits ABOVE the kv loop,
+        # and the cast/xfer buffers are not aliased into the operand slab.
+        #
+        # Padding (`seq_kv_lens`) is still out: it needs the PER-BATCH kv length
+        # at the bounds and mask sites, and this kernel threads only the scalar.
+        (
+            not (cfg.MASK_FLAGS & MASK_PADDED),
+            "bwd d512: padding masks (seq_kv_lens / seq_q_lens) are not implemented -- the kernel threads a scalar S_kv, not the per-batch length",
+        ),
+        # LPT / LPT_L2 need lpt_tile_coords and its L2-residency model, which
+        # bwd/kernels/_common_sm100.py deliberately does not copy.
+        (cfg.SCHEDULER_POLICY == SCHED_NATURAL, "bwd d512 v1: only SCHED_NATURAL is implemented (LPT/LPT_L2 need the L2 tile-coord model)"),
+        (cfg.ACC_EMPTY_ARRIVERS == cfg.COMPUTE_LANES * cfg.CTA_MMA, "bwd d512: ACC_EMPTY_ARRIVERS must be COMPUTE_LANES * CTA_MMA"),
+    )
+    for ok, msg in checks:
+        if not ok:
+            raise ValueError(msg)
+
+
+def make_cfg_d512(params: TemplateParams) -> CfgBwdD512:
+    _validate_params(params)
+    b = bpe(params.dtype_qkv)
+    cfg = CfgBwdD512(
+        DTYPE_QKV=params.dtype_qkv,
+        BPE=b,
+        XFER_HALVES=params.xfer_halves,
+        MASK_FLAGS=_mask_flags_from(params),
+        WINDOW_LEFT=params.window_left or 0,
+        WINDOW_RIGHT=params.window_right or 0,
+        BOTTOM_RIGHT=int(params.bottom_right),
+        SEQ_KV_LENS_PRESENT=int(params.seq_kv_lens_present),
+        SEQ_Q_LENS_PRESENT=int(params.seq_q_lens_present),
+        SCHEDULER_POLICY=params.sched_policy,
+    )
+    _validate_cfg_d512(cfg)
+    return cfg

--- a/python/cudnn/sdpa/bwd/config_sm100.py
+++ b/python/cudnn/sdpa/bwd/config_sm100.py
@@ -455,10 +455,12 @@ def _validate_cfg_d512(cfg: CfgBwdD512) -> None:
         #
         # Padding (`seq_kv_lens`) is still out: it needs the PER-BATCH kv length
         # at the bounds and mask sites, and this kernel threads only the scalar.
-        (
-            not (cfg.MASK_FLAGS & MASK_PADDED),
-            "bwd d512: padding masks (seq_kv_lens / seq_q_lens) are not implemented -- the kernel threads a scalar S_kv, not the per-batch length",
-        ),
+        # Padding IS implemented, for a UNIFORM length: the engine rounds the
+        # compile shape up to the tile and passes the real S_q / S_kv, and the
+        # kernel masks the tail (kv side through apply_mask_chunk, q side by
+        # zeroing the row). That is what makes a sequence length which is not a
+        # multiple of the tile work at all. A PER-BATCH seq_len still needs the
+        # per-batch value threaded to the bounds and mask sites.
         # LPT / LPT_L2 need lpt_tile_coords and its L2-residency model, which
         # bwd/kernels/_common_sm100.py deliberately does not copy.
         (cfg.SCHEDULER_POLICY == SCHED_NATURAL, "bwd d512 v1: only SCHED_NATURAL is implemented (LPT/LPT_L2 need the L2 tile-coord model)"),

--- a/python/cudnn/sdpa/bwd/engines.py
+++ b/python/cudnn/sdpa/bwd/engines.py
@@ -99,6 +99,12 @@ class Capabilities:
     # (sm120's TMA 16-byte global-stride rule at 2 B/elem -> 8; sm80's
     # host-side padding has no such constraint -> 1).
     d_pad_multiple: int = 1
+    # EXCLUSIVE lower bound on an envelope row: head dims must be > this. An
+    # envelope with no floor silently claims every small head dim too, and pads
+    # it onto the big kernel -- for the sm100 d512 backward that is the whole
+    # 512-wide MMA for a d=128 graph, when a d256 flavor exists. 0 = no floor
+    # (the sm120/sm80 rows are continuum kernels and want none).
+    d_envelope_floor: int = 0
     # When True the lowering serves rectangular head dims with D_QK >= D_V
     # (e.g. 192/128); False requires D_QK == D_V.
     dqk_ge_dv: bool = False
@@ -190,6 +196,9 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", requested: 
         m = capabilities.d_pad_multiple
         if m > 1 and (facts.d_qk % m != 0 or facts.d_v % m != 0):
             return f"the envelope serves head-dim multiples of {m} (TMA 16-byte global-stride rule); graph has D_QK={facts.d_qk}/D_V={facts.d_v}"
+        fl = capabilities.d_envelope_floor
+        if fl and min(facts.d_qk, facts.d_v) <= fl:
+            return f"the envelope's floor is D > {fl} (a smaller flavor owns these); graph has D_QK={facts.d_qk}/D_V={facts.d_v}"
     elif facts.d_qk not in capabilities.d:
         return f"serves D in {sorted(capabilities.d)}; graph has D={facts.d_qk}"
     elif facts.d_v not in capabilities.d:
@@ -589,6 +598,7 @@ def _sm100_spec() -> EngineSpec:
             d=frozenset({512}),
             d_envelope=True,
             d_pad_multiple=8,
+            d_envelope_floor=256,  # <= 256 belongs to the d256 flavors
             dtypes=frozenset({cudnn.data_type.HALF, cudnn.data_type.BFLOAT16}),
             causal=True,
             bottom_right=True,

--- a/python/cudnn/sdpa/bwd/engines.py
+++ b/python/cudnn/sdpa/bwd/engines.py
@@ -31,6 +31,7 @@ from cudnn.sdpa import graph_analyzer as ga
 # importing them here would drag the CuTe DSL into every support check.
 _SM120 = "SdpaBwdDslSm120"
 _SM80 = "SdpaBwdDslSm80"
+_SM100 = "SdpaBwdDslSm100"
 
 
 def _adapter(name: str):
@@ -556,6 +557,55 @@ def _sm80_spec() -> EngineSpec:
     )
 
 
+def _sm100_spec() -> EngineSpec:
+    """SM100 (Blackwell) large-head-dim backward row.
+
+    A three-stage chain rather than one fused kernel, because a fused d=512
+    backward does not fit: dV [128 kv, 512] fp32 needs 512 TMEM columns and dK
+    another 512, plus the S/dS accumulators -- against 512 per CTA.
+
+        stage 1  do_dot = rowsum(dO * O)          (shared with the sm120 chain)
+        stage 2  S and dS workspaces              bprop_d512_f16_sm100.py
+        stage 3  dV = S^T.dO, dK = dS^T.Q, dQ = dS.K   bprop_matmul_sm100.py
+
+    ``d`` is an ENVELOPE: the kernel's tiles are fixed at 512 and a smaller head
+    dim rides the TMA descriptors' real extent, whose overshoot is HW
+    zero-filled, so the padded lanes contribute nothing. That costs the full
+    512-wide MMA at any d, which is why the lower bound is 264 -- below that the
+    d256 flavors are the right kernel. ``d_pad_multiple=8`` is TMA's 16-byte
+    innermost-extent rule at 2 B/elem; the stage-3 epilogue store vector narrows
+    from 32 B to 16 B when d is not also a multiple of 16.
+
+    Everything else is declined for now and each rejection is asserted by a
+    test: GQA (needs the dK/dV group reduce wired), the non-causal masks, THD
+    (the workspace goes ragged and stage 3 becomes a variable-K grouped GEMM),
+    bias/dbias/sink/dsink, deterministic, and decode.
+    """
+    return EngineSpec(
+        name="sdpa_bwd_sm100",
+        capabilities=Capabilities(
+            sm_lo=100,
+            sm_hi=103,
+            d=frozenset({512}),
+            d_envelope=True,
+            d_pad_multiple=8,
+            dtypes=frozenset({cudnn.data_type.HALF, cudnn.data_type.BFLOAT16}),
+            causal=True,
+            bottom_right=True,
+            swa=True,
+            right_band_widening=True,
+            gqa=True,  # per-Q-head dK/dV partials + the shared dkv_reduce group fold
+            # Any dense layout: the adapter uses a BSHD-physical tensor in place
+            # (a permuted view, zero copy) and stages a non-conforming one
+            # through the workspace. That is not hypothetical -- a caller that
+            # builds dO as torch.randn(o.shape) instead of empty_like(o) loses
+            # o's memory format and hands over a BHSD-contiguous dO.
+            layouts=frozenset({"bshd", "dense_flex"}),
+        ),
+        lower=partial(lower_dsl_bwd, api_type=_SM100),
+    )
+
+
 def engine_name(arch: str = "sm120") -> str:
     """The shipped engine name for a coverage cell (test/user convenience)."""
 
@@ -564,6 +614,6 @@ def engine_name(arch: str = "sm120") -> str:
 
 # Preference order: the ranked plan list offers these in this order (see
 # cudnn/sdpa/bwd/engine.py, which wraps each spec as a BaseEngine).
-ENGINE_SPECS = (_sm120_spec(), _sm80_spec())
+ENGINE_SPECS = (_sm120_spec(), _sm80_spec(), _sm100_spec())
 
 __all__ = ["ENGINE_SPECS", "Capabilities", "EngineSpec", "SdpaBwdKnobs", "analyze_for", "engine_name", "mismatch"]

--- a/python/cudnn/sdpa/bwd/kernels/_common_sm100.py
+++ b/python/cudnn/sdpa/bwd/kernels/_common_sm100.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Shared helpers for the FROST SM100 SDPA-backward kernels.
+
+Today this is the persistent-scheduler tile decode. It is a deliberate copy of
+the ``SCHED_NATURAL`` / ``SPLIT_PIPELINE == 1`` arm of
+``cudnn.sdpa.fwd.kernels._common_sm100.make_sdpa_helpers`` rather than an import
+of it: that factory also carries split-KV, pack-GQA and THD, none of which the
+backward has, and cross-pass imports between kernel trees are the coupling the
+FROST engine contract warns about. The arithmetic below is identical, so the two
+must stay in step -- if the forward's natural decode changes, change this too.
+
+The LPT / LPT_L2 policies are NOT copied; they need ``lpt_tile_coords`` and its
+L2-residency model. ``config_sm100._validate_cfg_d512`` rejects them, so the
+missing arms are unreachable rather than silently wrong.
+"""
+
+from __future__ import annotations
+
+import cutlass
+import cutlass.cute as cute
+
+
+def make_bwd_decode(CFG):
+    """Return ``(decode_initial, decode_payload)`` for a role-split cluster.
+
+    Both map a cluster coordinate to ``(q_block, head, batch)`` where
+    ``q_block`` is in units of TILE_M rows and already carries ``cta_in_pair``.
+
+    The two sub-groups of a cluster deliberately land on the SAME q rows: sg1's
+    CTA k must hold the row-block sg0's CTA k holds, because the fp32 S ship is
+    lane-to-lane across ``cross_sg_peer = cta_id ^ CTA_MMA``. That falls out of
+    keying the row on ``cta_in_pair`` (0/1 within a pair) rather than on the
+    cluster-wide CTA id.
+    """
+
+    @cute.jit
+    def decode_initial(bidx, bidy, bidz, cta_in_pair):
+        """From blockIdx, for the first tile."""
+        q_block = (bidx // cutlass.Int32(CFG.CGA_M)) * cutlass.Int32(CFG.CTA_MMA) + cta_in_pair
+        return q_block, bidy, bidz
+
+    @cute.jit
+    def decode_payload(t0, t1, cta_in_pair):
+        """From a CLC response: ``t0`` is the cancelled cluster's blockIdx.x,
+        ``t1`` packs head in the low 16 bits and batch in the high 16."""
+        q_block = (t0 // cutlass.Int32(CFG.CGA_M)) * cutlass.Int32(CFG.CTA_MMA) + cta_in_pair
+        head = t1 & cutlass.Int32(0xFFFF)
+        batch = (t1 >> cutlass.Int32(16)) & cutlass.Int32(0xFFFF)
+        return q_block, head, batch
+
+    return decode_initial, decode_payload
+
+
+__all__ = ["make_bwd_decode"]

--- a/python/cudnn/sdpa/bwd/kernels/bprop_d512_f16_sm100.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_d512_f16_sm100.py
@@ -59,7 +59,7 @@ from cudnn.frost.tile_dsl.barrier import (
     cga_wait,
 )
 from cudnn.frost.tile_dsl.handles import GmemTileTma, MmaDesc, SmemTile
-from cudnn.frost.tile_dsl.mask import MASK_CAUSAL, MASK_NONE, apply_mask_chunk, compute_kv_loop_bounds
+from cudnn.frost.tile_dsl.mask import MASK_CAUSAL, MASK_NONE, MASK_PADDED, apply_mask_chunk, compute_kv_loop_bounds
 from cudnn.frost.tile_dsl.mma import mma_ts
 from cudnn.frost.tile_dsl.scheduler import Sched, read_tile_id_arrive, scheduler_warp_loop
 from cudnn.frost.tile_dsl.tma import (
@@ -93,6 +93,11 @@ _decode_initial, _decode_payload = make_bwd_decode(CFG)
 # Does any tile in this specialization need the per-cell mask at all?  Folds the
 # whole mask apparatus out of the dense build.
 _MASKED = CFG.MASK_FLAGS != MASK_NONE
+# Padding covers two things at once: a per-batch seq_len, and a sequence
+# length that is not a multiple of the tile (the engine rounds the COMPILE
+# shape up and passes the real length, so the tail tile is computed then
+# masked). Both reduce to "mask everything past seqlen".
+_PADDED = bool(CFG.MASK_FLAGS & MASK_PADDED)
 
 
 @cute.jit
@@ -694,6 +699,7 @@ def _compute_kv_iter(
     attn_scale_for_dS,
     seqlen_q,
     seqlen_kv,
+    row_scale,
     kv_loop,
     acc_state,
     smem_state,
@@ -754,6 +760,13 @@ def _compute_kv_iter(
                     mask_value=0.0,
                     window_right=CFG.WINDOW_RIGHT,
                 )
+            # Rows past the real S_q: zero the whole row. Their LSE came from a
+            # CLAMPED index and is meaningless, so the value must be discarded
+            # rather than trusted. This is OUTSIDE the apply_mask branch on
+            # purpose -- a padded q row is invalid on EVERY kv tile, including
+            # the interior ones that carry no mask code.
+            if cutlass.const_expr(_PADDED):
+                s_post = s_post * row_scale
 
             # The fp32 ship, sg0 -> sg1.  This buffer is UNSWIZZLED and
             # linear on purpose: unlike the forward's P it is never an
@@ -871,10 +884,23 @@ def _compute_warp_group(
         head_g = head_idx + head_base
         batch_g = batch_idx + batch_base
 
+        # Padding, q side. Two separate problems:
+        #  * lse / do_dot are [B, H, S_q] at the REAL length, so a lane whose row
+        #    sits past it would read OUT OF BOUNDS -- clamp the INDEX;
+        #  * that lane's S must come out 0, so carry a 0/1 factor rather than
+        #    trusting the clamped row's value. sg1 needs nothing: its dS is a
+        #    product with the S it receives, so the zero propagates.
+        if cutlass.const_expr(_PADDED):
+            q_row_safe = cute.math.min(q_row, seqlen_q - cutlass.Int32(1))
+            row_scale = cutlass.Float32(arith.select((q_row < seqlen_q).ir_value(), cutlass.Float32(1.0).ir_value(), cutlass.Float32(0.0).ir_value()))
+        else:
+            q_row_safe = q_row
+            row_scale = cutlass.Float32(1.0)
+
         # Per-q-row scalars, hoisted once per tile.  Both arrive RAW: the host
         # folds no log2e into the LSE and no attn_scale into the dot.
-        lse_q_log2e = lse_tensor[batch_g, head_g, q_row] * cutlass.Float32(LOG2E)
-        scaled_do_dot_q = do_dot_tensor[batch_g, head_g, q_row] * attn_scale_in
+        lse_q_log2e = lse_tensor[batch_g, head_g, q_row_safe] * cutlass.Float32(LOG2E)
+        scaled_do_dot_q = do_dot_tensor[batch_g, head_g, q_row_safe] * attn_scale_in
 
         kv_left, kv_unmasked_lo, kv_unmasked_hi, kv_right = _kv_tile_bounds(q_block, cta_in_pair, seqlen_q, seqlen_kv, n_kv)
 
@@ -897,6 +923,7 @@ def _compute_warp_group(
                     attn_scale_for_dS,
                     seqlen_q,
                     seqlen_kv,
+                    row_scale,
                     _kv_loop,
                     acc_state,
                     smem_state,
@@ -1181,7 +1208,7 @@ def _host(
     lse_tensor: cute.Tensor,
     do_dot_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
-    problem_size: Tuple[int, int, int, int, int, int],  # (B, QH, S_q, S_kv, QH_chunk, QH_kv)
+    problem_size: Tuple[int, int, int, int, int, int, int, int],  # (B, QH, S_q_pad, S_kv_pad, QH_chunk, QH_kv, S_q, S_kv)
     attn_scale_in: cutlass.Float32,
     attn_scale_log2e: cutlass.Float32,
     attn_scale_for_dS: cutlass.Float32,
@@ -1189,7 +1216,10 @@ def _host(
     batch_base: cutlass.Int32,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
-    B, QH, SQ, SKV, QH_CHUNK, QH_KV = problem_size
+    # SQ / SKV are the TILE-ROUNDED extents the grid and the workspace use;
+    # SQ_REAL / SKV_REAL are the lengths the masks compare against. They differ
+    # only when the caller's sequence length is not a multiple of the tile.
+    B, QH, SQ, SKV, QH_CHUNK, QH_KV, SQ_REAL, SKV_REAL = problem_size
 
     # Q/K/V/dO are BSHD [B, S, H, D]; the workspaces are [B, H_chunk, S_q, S_kv].
     # stride_order is innermost-first, so the coords the kernel passes are
@@ -1237,8 +1267,8 @@ def _host(
         lse_tensor,
         do_dot_tensor,
         seq_kv_lens_tensor,
-        cutlass.Int32(SQ),
-        cutlass.Int32(SKV),
+        cutlass.Int32(SQ_REAL),
+        cutlass.Int32(SKV_REAL),
         # GQA ratio, 1 for MHA. Q-head // this = the shared KV head.
         cutlass.Int32(QH // QH_KV),
         cutlass.Int32(SKV // CFG.TILE_N),
@@ -1266,6 +1296,8 @@ def compile(  # noqa: A001
     qh_chunk: int = 1,
     d: Optional[int] = None,
     qh_kv: Optional[int] = None,
+    sq_real: Optional[int] = None,
+    skv_real: Optional[int] = None,
 ) -> Callable:
     """Per-shape compile cache.
 
@@ -1287,6 +1319,10 @@ def compile(  # noqa: A001
     # the full TILE_K-wide MMA and get the right answer.  The only hard rule is
     # TMA's: the innermost extent must be 16-byte aligned, i.e. d * BPE % 16 == 0.
     qh_kv = qh if qh_kv is None else int(qh_kv)
+    # sq / skv are the TILE-ROUNDED compile extents; the real lengths drive the
+    # masks and the operand tensors' own extents.
+    sq_real = sq if sq_real is None else int(sq_real)
+    skv_real = skv if skv_real is None else int(skv_real)
     if qh % qh_kv != 0:
         raise ValueError(f"bwd d512: qh ({qh}) must be a multiple of qh_kv ({qh_kv})")
     d = CFG.TILE_K if d is None else int(d)
@@ -1298,17 +1334,24 @@ def compile(  # noqa: A001
     def _fake_bshd(shape, dtype=STORAGE_DTYPE):
         return cute.runtime.make_fake_compact_tensor(dtype, shape, stride_order=(3, 2, 1, 0), assumed_align=16)
 
-    fake_q = _fake_bshd((b, sq, qh, d))
+    # Q/K/V/dO carry the REAL sequence length: a tile reading past it is TMA
+    # zero-filled, which is exactly what the tail mask expects to see.
+    fake_q = _fake_bshd((b, sq_real, qh, d))
     # K/V are indexed by the KV head, so their head extent is qh_kv.
-    fake_k = _fake_bshd((b, skv, qh_kv, d))
-    fake_v = _fake_bshd((b, skv, qh_kv, d))
-    fake_do = _fake_bshd((b, sq, qh, d))
+    fake_k = _fake_bshd((b, skv_real, qh_kv, d))
+    fake_v = _fake_bshd((b, skv_real, qh_kv, d))
+    fake_do = _fake_bshd((b, sq_real, qh, d))
     # Chunk-local workspaces, [B, H_chunk, S_q, S_kv] at the io dtype.
     fake_s = _fake_bshd((b, qh_chunk, sq, skv), dtype=WORKSPACE_DTYPE)
     fake_ds = _fake_bshd((b, qh_chunk, sq, skv), dtype=WORKSPACE_DTYPE)
     # Plain per-lane reads, one q-row per lane -- no TMA, no barriers.
-    fake_lse = cute.runtime.make_fake_compact_tensor(cutlass.Float32, (b, qh, sq), stride_order=(2, 1, 0), assumed_align=16)
-    fake_do_dot = cute.runtime.make_fake_compact_tensor(cutlass.Float32, (b, qh, sq), stride_order=(2, 1, 0), assumed_align=16)
+    fake_lse = cute.runtime.make_fake_compact_tensor(cutlass.Float32, (b, qh, sq_real), stride_order=(2, 1, 0), assumed_align=16)
+    # do_dot's producer (dot_do_o_kernel) indexes delta with a row stride of
+    # ceil(S_q / 128) * 128, NOT S_q -- so the buffer, and this view of it, must
+    # use the same rounding. They coincide whenever S_q is a multiple of 128,
+    # which is why a non-multiple was the only shape that exposed it.
+    sq_dot = -(-sq_real // 128) * 128
+    fake_do_dot = cute.runtime.make_fake_compact_tensor(cutlass.Float32, (b, qh, sq_dot), stride_order=(2, 1, 0), assumed_align=16)
     fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (b,), stride_order=(0,), assumed_align=16)
 
     return cute.compile(
@@ -1322,7 +1365,7 @@ def compile(  # noqa: A001
         fake_lse,
         fake_do_dot,
         fake_seq_kv_lens,
-        (b, qh, sq, skv, qh_chunk, qh_kv),
+        (b, qh, sq, skv, qh_chunk, qh_kv, sq_real, skv_real),
         cutlass.Float32(0.0),
         cutlass.Float32(0.0),
         cutlass.Float32(0.0),

--- a/python/cudnn/sdpa/bwd/kernels/bprop_d512_f16_sm100.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_d512_f16_sm100.py
@@ -1,0 +1,1336 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""SDPA backward stage 2, d_qk = d_v = 512, bf16/fp16, SM100 (Blackwell).
+
+Produces the ``S`` and ``dS`` workspaces that stage 3's three GEMMs reduce into
+dV / dK / dQ.  Computes no gradient itself::
+
+    S  = exp2(attn_scale_log2e * S_acc  - lse * log2e)      then masked to 0.0
+    dS = (attn_scale_for_dS * dS_acc - do_dot * attn_scale_in) * S
+
+**cga4x1 role split** (CGA_M=4, CTA_MMA=2 -> two sub-groups of two CTAs):
+
+    sg0 = {CTA 0,1}   BMM1  mma_ts(Q from TMEM, K from SMEM) -> S_acc
+                      softmax -> S ; bf16 S -> workspace ; fp32 S -> sg1
+    sg1 = {CTA 2,3}   BMM2  mma_ts(dO from TMEM, V from SMEM) -> dS_acc
+                      dS epilogue ; bf16 dS -> workspace
+
+The split is what makes this fit: each sub-group gets its own 227 KiB of SMEM
+and its own 512 TMEM columns, so the operand is TMEM-resident on BOTH sides
+(Q on sg0, dO on sg1) and both accumulators are double-buffered.  The Rubin
+SM107 sibling holds Q and dO on one CTA and pays 320 KiB for it, which does not
+fit here.
+
+**There is no online softmax.**  LSE arrives as a kernel input, so there is no
+running max, no rescale, no alpha/stats ship, no correction warp.
+
+**The mask is applied to S AFTER exp2, with 0.0 (not -inf before).**  dS is a
+product with S, so zeroing S zeroes dS for free -- one mask application covers
+both workspaces, and it survives the role split unchanged.  Do not move it.
+
+**Every mbarrier init count is a named ``CFG`` constant, and the comment beside
+it names the ARRIVE SITES it counts and the guard each one fires under.**  Keep
+that pairing when changing either side: the counts and the elect/predicate
+guards are one decision, and a mismatch here is undefined behaviour rather than
+a crash -- it surfaces as an intermittent hang whose output is correct on every
+launch that completes.
+"""
+
+from functools import lru_cache
+from typing import Callable, NamedTuple, Optional, Tuple
+
+import cuda.bindings.driver as _cuda_driver
+import cutlass
+import cutlass.cute as cute
+from cutlass.experimental import primitives as nvvm
+from cutlass.experimental import primitives as prims
+from cutlass._mlir.dialects import arith
+from cutlass.experimental.cuda import tensor_map as tmap
+
+from cudnn.frost.tile_dsl.barrier import (
+    MBarrier,
+    wait,
+    PipelineState,
+    Producer,
+    Scope,
+    advance,
+    cga_arrive,
+    cga_wait,
+)
+from cudnn.frost.tile_dsl.handles import GmemTileTma, MmaDesc, SmemTile
+from cudnn.frost.tile_dsl.mask import MASK_CAUSAL, MASK_NONE, apply_mask_chunk, compute_kv_loop_bounds
+from cudnn.frost.tile_dsl.mma import mma_ts
+from cudnn.frost.tile_dsl.scheduler import Sched, read_tile_id_arrive, scheduler_warp_loop
+from cudnn.frost.tile_dsl.tma import (
+    cp_async_bulk_shared_cluster_shared_cta,
+    tma_load_tile,
+    tma_store_commit,
+    tma_store_tile,
+    tma_store_wait,
+)
+from cudnn.frost.tile_dsl.pointwise import tmem_load_tile
+from cudnn.frost.tile_dsl.tmem import tmem_alloc, tmem_dealloc
+from cudnn.sdpa.bwd.kernels._common_sm100 import make_bwd_decode
+from cudnn.sdpa.bwd.config_sm100 import (
+    TemplateParams,
+    cast_bytes,
+    make_cfg_d512,
+    operand_bytes,
+    s_tma_iters,
+    smem_bytes,
+    tmem_cols,
+    xfer_bytes,
+)
+
+# Injected by the loader before this body executes; a plain import gets the
+# all-defaults config (dense bf16), which keeps `python bprop_d512_f16_sm100.py`
+# usable as a standalone benchmark.
+PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
+CFG = make_cfg_d512(PARAMS)
+_decode_initial, _decode_payload = make_bwd_decode(CFG)
+
+# Does any tile in this specialization need the per-cell mask at all?  Folds the
+# whole mask apparatus out of the dense build.
+_MASKED = CFG.MASK_FLAGS != MASK_NONE
+
+
+@cute.jit
+def _kv_tile_bounds(q_block, cta_in_pair, seqlen_q, seqlen_kv, n_kv):
+    """The kv TILE range this cluster visits, plus where the mask starts biting.
+
+    Two things make this different from the forward's use of the same helper:
+
+    * **Keyed on the CLUSTER's q span, not the CTA's.**  ``cta_in_pair`` 0 and 1
+      hold adjacent q row-blocks, so a per-CTA causal bound would give them
+      different iteration counts -- and every barrier here is a cross-CTA
+      protocol whose count must match on all four CTAs.  Taking the bound over
+      the whole ``CTA_MMA * TILE_M`` span makes all four agree.  The CTA holding
+      the earlier rows then computes a few fully-masked tiles; the per-cell mask
+      zeroes them, so it costs work, not correctness.
+    * **Dense folds to the whole range** at trace time, so the dense build is
+      byte-identical to before masks existed.
+
+    Returns ``(left, unmasked_lo, unmasked_hi, right)``.  Only
+    ``[unmasked_lo, unmasked_hi)`` is guaranteed free of masked cells; the tiles
+    on EITHER side of it are band edges and must run ``apply_mask_chunk``.
+    """
+    if cutlass.const_expr(not _MASKED):
+        return cutlass.Int32(0), cutlass.Int32(0), n_kv, n_kv
+    cluster_q_row = (q_block - cta_in_pair) * cutlass.Int32(CFG.TILE_M)
+    b = compute_kv_loop_bounds(
+        cluster_q_row,
+        seqlen_q,
+        seqlen_kv,
+        CFG.WINDOW_LEFT,
+        CFG.MASK_FLAGS,
+        CFG.TILE_N,
+        CFG.TILE_M * CFG.CTA_MMA,
+        bottom_right=CFG.BOTTOM_RIGHT,
+        window_right=CFG.WINDOW_RIGHT,
+    )
+    return b.left, b.unmasked_lo, b.unmasked_hi, b.right
+
+
+def _residual_depth(n_iters, stages: int):
+    """Unconsumed producer arrives on a pre-armed ring at end of tile.
+
+    A consumer started with ``PipelineState.start(phase=1)`` gets its first
+    ``stages`` waits for free, so over ``n_iters`` iterations it consumes only
+    ``max(0, n_iters - stages)`` of the ``n_iters`` arrives the producer made.
+    The residual is therefore ``min(n_iters, stages)`` -- NOT ``stages``.
+
+    Draining a fixed ``stages`` deep hangs whenever ``n_iters < stages``: the
+    extra waits sit on ring slots that were never armed for this tile.
+    """
+    return cutlass.Int32(arith.select((n_iters < cutlass.Int32(stages)).ir_value(), n_iters.ir_value(), cutlass.Int32(stages).ir_value()))
+
+
+def _require(cond, msg):
+    """Geometry sanity check; raises instead of assert (asserts vanish under -O)."""
+    if not cond:
+        raise ValueError(f"bprop_d512_f16_sm100: {msg}")
+
+
+# ---------------------------------------------------------------------------
+# dtype
+# ---------------------------------------------------------------------------
+
+if CFG.DTYPE_QKV == 2:
+    STORAGE_DTYPE = cutlass.BFloat16
+elif CFG.DTYPE_QKV == 3:
+    STORAGE_DTYPE = cutlass.Float16
+else:  # pragma: no cover - make_cfg_d512 rejects everything else
+    raise ValueError(f"bprop_d512_f16_sm100: DTYPE_QKV={CFG.DTYPE_QKV} not supported (expected 2=BF16 or 3=FP16)")
+# The workspace dtype IS the io dtype: stage 3 reads S/dS at input precision.
+# An earlier Rubin revision tied it to an independent output dtype and produced
+# a silent mismatch against the stage-3 GEMMs.
+WORKSPACE_DTYPE = STORAGE_DTYPE
+MMA_KIND = nvvm.Tcgen05MMAKind.F16
+
+CGA_SIZE = CFG.CGA_M * CFG.CGA_N
+CTA_GROUP_KIND = nvvm.CTAGroup.CTA_2 if CFG.CTA_MMA == 2 else nvvm.CTAGroup.CTA_1
+LOG2E = 1.4426950408889634
+
+# ---------------------------------------------------------------------------
+# Buffer geometry -- all of it derived from the config's own functions so the
+# validator and the kernel can never disagree.
+# ---------------------------------------------------------------------------
+
+qBytes, doBytes, kBytesPerStage, vBytesPerStage = operand_bytes(CFG)
+qBufferElems = qBytes // CFG.BPE
+doBufferElems = doBytes // CFG.BPE
+kBufferElems = kBytesPerStage // CFG.BPE
+vBufferElems = vBytesPerStage // CFG.BPE
+
+# One max-union alias slab per sub-group: the Q (resp. dO) staging buffer is
+# dead once the UTCCP has moved it to TMEM, so the K (resp. V) ring reuses those
+# exact bytes behind the alias-seam barrier.  Sized in ELEMENTS of a single
+# dtype -- legal only because every tenant here is STORAGE_DTYPE.  If a future
+# tenant has a different BPE, size this in BYTES and view it as the wider dtype
+# (frost-tile-dsl.md §6; the fp8 forward sibling had exactly that bug).
+_ALIAS_ELEMS = max(qBufferElems, doBufferElems, CFG.STAGES_KV * kBufferElems, CFG.STAGES_KV * vBufferElems)
+
+# fp32 S ship, sg0 -> sg1.  fp32 and not the io dtype on purpose: the Rubin
+# reference never transfers S at all (it multiplies the fp32 register copy
+# straight into dS), so shipping a rounded S across the role split would be an
+# accuracy regression the reference does not have.
+S_TMA_ITERS = s_tma_iters(CFG)
+S_D_BLOCK = CFG.TILE_N // S_TMA_ITERS
+S_SUBTILE_SLAB = CFG.TILE_M * S_D_BLOCK
+sXferHalfElems = CFG.TILE_M * S_D_BLOCK
+sXferHalfBytes = sXferHalfElems * 4
+sXferElems = CFG.XFER_HALVES * sXferHalfElems
+castElems = CFG.TILE_M * CFG.TILE_N
+
+_require(S_TMA_ITERS == CFG.XFER_HALVES, f"one shipped fp32 half must be exactly one stored subtile ({S_TMA_ITERS} vs {CFG.XFER_HALVES})")
+_require(sXferElems * 4 == xfer_bytes(CFG), "xfer element count disagrees with config xfer_bytes()")
+_require(castElems * CFG.BPE == cast_bytes(CFG), "cast element count disagrees with config cast_bytes()")
+
+# cga2: a cta_group::2 tensor TMA routes ALL bytes to the leader's mbar, so the
+# transaction size counts BOTH peers' buffers.
+qTmaTransactionBytes = qBufferElems * CFG.BPE * CFG.CTA_MMA
+doTmaTransactionBytes = doBufferElems * CFG.BPE * CFG.CTA_MMA
+kTmaTransactionBytes = kBufferElems * CFG.BPE * CFG.CTA_MMA
+vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
+
+# TMA subtiling of the d=512 operands: inner byte extent / swizzle atom.
+TMA_QK_ITERS = (CFG.TILE_K * CFG.BPE) // CFG.Q_SWZ_BYTES
+TMA_QK_GRANU_ELEMS = CFG.TILE_K // TMA_QK_ITERS
+TMA_VO_ITERS = (CFG.TILE_O * CFG.BPE) // CFG.V_SWZ_BYTES
+TMA_VO_GRANU_ELEMS = CFG.TILE_O // TMA_VO_ITERS
+
+_SWZ_ENUM = {128: 2, 64: 4, 32: 6}
+_SWZ_B = {128: 3, 64: 2, 32: 1}
+SMEM_LAYOUT_QK = _SWZ_ENUM[CFG.Q_SWZ_BYTES]
+SMEM_LAYOUT_V = _SWZ_ENUM[CFG.V_SWZ_BYTES]
+SMEM_LAYOUT_S = _SWZ_ENUM[CFG.S_SWZ_BYTES]
+S_SMEM_SWIZZLE = cutlass.Swizzle(_SWZ_B[CFG.S_SWZ_BYTES], 4, 3)
+
+_CORE_MATRIX_ROWS = 8
+LEADING_BYTE_OFFSET_QK = 0
+STRIDE_BYTE_OFFSET_QK = _CORE_MATRIX_ROWS * CFG.Q_SWZ_BYTES
+LEADING_BYTE_OFFSET_V = 0
+STRIDE_BYTE_OFFSET_V = _CORE_MATRIX_ROWS * CFG.V_SWZ_BYTES
+
+# Softmax register budget: each compute warp lane owns one q-row, walked in
+# chunks of S_D_BLOCK columns.  One chunk == one shipped half == one stored
+# subtile == one swizzle atom per row.
+SOFTMAX_N_CHUNKS = CFG.TILE_N // S_D_BLOCK
+_require(SOFTMAX_N_CHUNKS == S_TMA_ITERS, "softmax chunk count must equal the store subtile count")
+
+# ---------------------------------------------------------------------------
+# TMEM
+# ---------------------------------------------------------------------------
+
+
+class KernelTmemLayout(NamedTuple):
+    """Per-sub-group TMEM carve.  Both sub-groups use the SAME shape with
+    different tenants: sg0 = [S_acc p0 | S_acc p1 | Q], sg1 = [dS_acc p0 |
+    dS_acc p1 | dO].  An accumulator is fp32 and TILE_N wide -> TILE_N columns;
+    a 16-bit operand packs 2 elements per 32-bit column -> d * BPE / 4 = 256."""
+
+    TOTAL_COLS: int = 512
+    ACC_COLS: int = CFG.TILE_N
+    ACC_PARITY0_OFF: int = 0
+    ACC_PARITY1_OFF: int = CFG.TILE_N
+    OPERAND_OFF: int = CFG.STAGES_ACC * CFG.TILE_N
+    OPERAND_COLS: int = (CFG.TILE_K * CFG.BPE) // 4
+
+
+LAYOUT = KernelTmemLayout()
+
+_sg0_tmem, _sg1_tmem = tmem_cols(CFG)
+_require(LAYOUT.OPERAND_OFF == CFG.STAGES_ACC * LAYOUT.ACC_COLS, "accumulator parities must abut the operand")
+_require(LAYOUT.OPERAND_OFF + LAYOUT.OPERAND_COLS == LAYOUT.TOTAL_COLS, f"TMEM carve must be exactly {LAYOUT.TOTAL_COLS} columns")
+_require(_sg0_tmem == LAYOUT.TOTAL_COLS and _sg1_tmem == LAYOUT.TOTAL_COLS, "kernel TMEM carve disagrees with config tmem_cols()")
+_require(CFG.TILE_K == CFG.TILE_O, "d_qk must equal d_v for the symmetric sg0/sg1 operand carve")
+
+# UTCCP: whole operand SMEM -> TMEM, turning both BMMs into mma_ts.  SHAPE_128X128B
+# moves 128 rows x 128 bits = 16 B/row = 4 fp32 TMEM columns per call.  Descriptor
+# arithmetic is in 16-BYTE units and SUBTILE-MAJOR, matching the TMA-laid SMEM.
+_UTCCP_BYTES_PER_CALL = 16
+_UTCCP_TMEM_COLS_PER_CALL = _UTCCP_BYTES_PER_CALL // 4
+_UTCCP_PER_SUBTILE = CFG.Q_SWZ_BYTES // _UTCCP_BYTES_PER_CALL
+_UTCCP_SUBTILE_DESC_STRIDE = (CFG.TILE_M * CFG.Q_SWZ_BYTES) // _UTCCP_BYTES_PER_CALL
+_UTCCP_N_CALLS = LAYOUT.OPERAND_COLS // _UTCCP_TMEM_COLS_PER_CALL
+_require(_UTCCP_N_CALLS == TMA_QK_ITERS * _UTCCP_PER_SUBTILE, f"UTCCP call count {_UTCCP_N_CALLS} != subtiles x per-subtile")
+
+# ---------------------------------------------------------------------------
+# SMEM budget -- assert the COMPUTED total, never a inherited constant.
+# ---------------------------------------------------------------------------
+
+_SG0_SMEM_BYTES, _SG1_SMEM_BYTES = smem_bytes(CFG)
+_require(_ALIAS_ELEMS * CFG.BPE + xfer_bytes(CFG) + cast_bytes(CFG) == _SG0_SMEM_BYTES, "kernel alias sizing disagrees with config smem_bytes()")
+_require(_SG0_SMEM_BYTES == _SG1_SMEM_BYTES, "the role split is symmetric; sg0 and sg1 must budget identically")
+
+# ---------------------------------------------------------------------------
+# Barriers.  Each init_count is a named CFG constant; the comment beside it
+# names the arrive sites it counts and the guard each fires under.
+# ---------------------------------------------------------------------------
+
+
+class Bars(NamedTuple):
+    # Operand staging + the alias seam (Q on sg0, dO on sg1).
+    mb_tma_op_full: object
+    mb_tma_op_empty: object
+    mb_op_utccp_done: object
+    # The streamed ring (K on sg0, V on sg1).
+    mb_tma_ring_full: object
+    mb_tma_ring_empty: object
+    # MMA -> compute, and the accumulator release back to the MMA leader.
+    mb_bmm_done: object
+    mb_acc_empty: object
+    # compute -> TMA-STG for the workspace store (S on sg0, dS on sg1).
+    mb_smem_full: object
+    mb_smem_empty: object
+    # The cross-sub-group fp32 S ship.
+    mb_s_xfer_full: object
+    mb_s_xfer_empty: object
+    mb_tmem_dealloc: object
+
+
+def _make_bwd_d512_sm100_bars(CFG) -> Bars:
+    def _alloc(n):
+        return cutlass.Array(cutlass.Int64, n, alignment=16, space=cutlass.AddressSpace.smem)
+
+    return Bars(
+        mb_tma_op_full=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_tma_op_empty=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.MMA_COMMIT),
+        mb_op_utccp_done=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.MMA_COMMIT),
+        mb_tma_ring_full=MBarrier(_alloc(CFG.STAGES_KV), stages=CFG.STAGES_KV, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_tma_ring_empty=MBarrier(_alloc(CFG.STAGES_KV), stages=CFG.STAGES_KV, init_count=CFG.ONE_LANE, producer=Producer.MMA_COMMIT),
+        mb_bmm_done=MBarrier(_alloc(CFG.STAGES_ACC), stages=CFG.STAGES_ACC, init_count=CFG.ONE_LANE, producer=Producer.MMA_COMMIT),
+        # Every lane of the compute WG on BOTH CTAs of the pair arrives on the
+        # pair leader, after its tcgen05_wait(LOAD).
+        mb_acc_empty=MBarrier(_alloc(CFG.STAGES_ACC), stages=CFG.STAGES_ACC, init_count=CFG.ACC_EMPTY_ARRIVERS, producer=Producer.LEADER, scope=Scope.LEADER),
+        # THREAD arrive from all four compute warps -> COMPUTE_LANES.
+        mb_smem_full=MBarrier(_alloc(S_TMA_ITERS), stages=S_TMA_ITERS, init_count=CFG.COMPUTE_LANES, producer=Producer.THREAD),
+        # THREAD arrive from the single TMA-STG warp, NOT elect-gated -> all 32
+        # lanes fire.  ONE_LANE here would under-count by 31 and hang.
+        mb_smem_empty=MBarrier(_alloc(S_TMA_ITERS), stages=S_TMA_ITERS, init_count=CFG.ONE_WARP, producer=Producer.THREAD),
+        # DSMEM bulk-copy bytes stay LOCAL to the receiving CTA, and S is a
+        # pointwise multiplier rather than a leader-only MMA operand, so there is
+        # no cross-CTA forwarding and no runtime per-CTA init: each sg1 CTA arms
+        # its own expect_tx from its own lead warp's single lane.
+        mb_s_xfer_full=MBarrier(_alloc(CFG.XFER_HALVES), stages=CFG.XFER_HALVES, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        # One lane arrives on the cross-sg peer, behind the named barrier that
+        # proves all four compute warps have read S into registers.
+        mb_s_xfer_empty=MBarrier(_alloc(CFG.XFER_HALVES), stages=CFG.XFER_HALVES, init_count=CFG.ONE_LANE, producer=Producer.THREAD),
+        mb_tmem_dealloc=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.THREAD),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Warp bodies.  Both sub-groups run the SAME shape with different tensors --
+# sg0 drives (Q, K) -> S_acc -> S, sg1 drives (dO, V) -> dS_acc -> dS -- so each
+# body is one `if is_sg0:` selecting descriptors/buffers over shared logic.
+#
+# K and V have IDENTICAL TMA geometry here ([TILE_N/CTA_MMA, 512] at
+# kv_row_base + cta_in_pair*(TILE_N/CTA_MMA)), and so do Q and dO.  That is a
+# consequence of both BMMs being A[q,d] x B[kv,d]^T; the forward's V splits on
+# the O column axis instead because its BMM2 is P.V.  Do not copy that offset.
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def _tmaldg_warp_group(
+    bars,
+    sched,
+    sOperand,
+    sRing,
+    tma_q,
+    tma_k,
+    tma_v,
+    tma_do,
+    cta_in_pair,
+    is_leader,
+    is_sg0,
+    tma_mcast_mask,
+    n_kv,
+    seqlen_q,
+    seqlen_kv,
+    gqa_ratio,
+    head_base,
+    batch_base,
+):
+    q_block, head_idx, batch_idx = _decode_initial(sched.bidx_init, sched.bidy_init, sched.bidz_init, cta_in_pair)
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+    # Pre-armed: nothing has consumed the operand or the ring yet, so the first
+    # wait must fall through with no producer arrive.
+    op_empty_state = PipelineState.start(phase=1)
+    op_utccp_state = PipelineState.start()
+    ring_state = PipelineState.start(phase=1)
+    # Seeded from the initial tile so the end-of-kernel drain can read them:
+    # a value FIRST assigned inside the persistent loop does not survive it.
+    kv_left, kv_unmasked_lo, kv_unmasked_hi, kv_right = _kv_tile_bounds(q_block, cta_in_pair, seqlen_q, seqlen_kv, n_kv)
+
+    # Per-CTA slice of the streamed operand along the collective MMA-N axis.
+    RING_ROW_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_N // CFG.CTA_MMA)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        q_row_base = cute.arch.make_warp_uniform(q_block * cutlass.Int32(CFG.TILE_M))
+        head_g = head_idx + head_base
+        batch_g = batch_idx + batch_base
+        # GQA / MQA: Q and dO are per Q-head; K and V live at the shared KV head.
+        # gqa_ratio is 1 for MHA, so this folds to head_g and the dense path is
+        # unchanged.  It is a runtime divide, but once per TILE, not per row.
+        kv_head_g = head_g // gqa_ratio
+
+        # --- the resident operand: Q on sg0, dO on sg1 --------------------
+        bars.mb_tma_op_empty.wait(op_empty_state.phase)
+        op_empty_state = advance(op_empty_state, 1)
+        bars.mb_tma_op_full.arrive(n_bytes=qTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+        if is_sg0:
+            tma_load_tile(
+                sOperand[0],
+                tma_q(cutlass.Int32(0), head_g, q_row_base, batch_g),
+                bars.mb_tma_op_full.smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+        else:
+            tma_load_tile(
+                sOperand[0],
+                tma_do(cutlass.Int32(0), head_g, q_row_base, batch_g),
+                bars.mb_tma_op_full.smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+
+        # --- THE ALIAS SEAM ----------------------------------------------
+        # The ring shares the operand's bytes.  Loading it before the UTCCP has
+        # drained clobbers the operand mid-copy.  This wait is not an
+        # optimization and must not be hoisted or removed.
+        bars.mb_op_utccp_done.wait(op_utccp_state.phase)
+        op_utccp_state = advance(op_utccp_state, 1)
+
+        # --- the streamed ring: K on sg0, V on sg1 ------------------------
+        # Same bounds on all four CTAs (see _kv_tile_bounds): the tiles skipped
+        # here are never loaded, never MMA'd and never stored.
+        kv_left, kv_unmasked_lo, kv_unmasked_hi, kv_right = _kv_tile_bounds(q_block, cta_in_pair, seqlen_q, seqlen_kv, n_kv)
+        for kv_loop in cutlass.range(kv_left, kv_right, 1, unroll=1):
+            kv_row_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+            bars.mb_tma_ring_empty[ring_state.idx].wait(ring_state.phase)
+            bars.mb_tma_ring_full[ring_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            if is_sg0:
+                tma_load_tile(
+                    sRing[ring_state.idx],
+                    tma_k(cutlass.Int32(0), kv_head_g, kv_row_base + RING_ROW_OFFSET_PEER, batch_g),
+                    bars.mb_tma_ring_full[ring_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+            else:
+                tma_load_tile(
+                    sRing[ring_state.idx],
+                    tma_v(cutlass.Int32(0), kv_head_g, kv_row_base + RING_ROW_OFFSET_PEER, batch_g),
+                    bars.mb_tma_ring_full[ring_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+            ring_state = advance(ring_state, CFG.STAGES_KV)
+
+        # --- next tile ----------------------------------------------------
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0)).load())
+        nxt_hb = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1)).load())
+        nxt_v = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2)).load())
+        q_block, head_idx, batch_idx = _decode_payload(nxt_q, nxt_hb, cta_in_pair)
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+    # --- cross-CTA drains, OUTSIDE the persistent loop --------------------
+    # Both rings are fired by a cross-CTA MMA_COMMIT, so the last iteration's
+    # commit is still in flight when this warp exits.  Staying resident until it
+    # lands is what stops the teardown fault.
+    if cutlass.const_expr(CFG.CTA_MMA > 1):
+        _ring_residual = _residual_depth(kv_right - kv_left, CFG.STAGES_KV)
+        for _ in cutlass.range(cutlass.Int32(0), _ring_residual, 1, unroll=1):
+            bars.mb_tma_ring_empty[ring_state.idx].wait(ring_state.phase)
+            ring_state = advance(ring_state, CFG.STAGES_KV)
+        # One operand load per tile, so exactly one residual arrive.
+        bars.mb_tma_op_empty.wait(op_empty_state.phase)
+        op_empty_state = advance(op_empty_state, 1)
+
+
+@cute.jit
+def _mma_warp_leader(bars, sched, sOperand, sRing, tmem_ptr_i32, cta_in_pair, is_sg0, mcast_mask, n_kv, seqlen_q, seqlen_kv):
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+    # Publish the TMEM base to this CTA's compute WG.  Without it their base
+    # load races the alloc on a cold cache -> garbage base, misaligned address.
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WG_WARPS + 1))
+    tmem_raw = nvvm.make_tmem_ptr(tmem_ptr_i32.load(), cutlass.Int8)
+    tmem_operand = tmem_raw.subview(cutlass.Int32(LAYOUT.OPERAND_OFF))
+
+    # Both BMMs are the same MMA: A[TILE_M, d] from TMEM x B[TILE_N/CTA_MMA, d]^T
+    # from SMEM, K = d.  No k_dim at bf16/fp16 (default 0, TILE_K_HW = 16).
+    idesc = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_N,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+    )
+    bmm_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_N,
+        K=CFG.TILE_K,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=CFG.TILE_K_HW_BMM1,
+        btranspose=False,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc,
+        kind=MMA_KIND,
+    )
+
+    q_block, _head, _batch = _decode_initial(sched.bidx_init, sched.bidy_init, sched.bidz_init, cta_in_pair)
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+    op_full_state = PipelineState.start()
+    ring_state = PipelineState.start()
+    acc_state = PipelineState.start(phase=1)
+    # Seeded from the initial tile so the end-of-kernel drain can read them:
+    # a value FIRST assigned inside the persistent loop does not survive it.
+    kv_left, kv_unmasked_lo, kv_unmasked_hi, kv_right = _kv_tile_bounds(q_block, cta_in_pair, seqlen_q, seqlen_kv, n_kv)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        bars.mb_tma_op_full.wait(op_full_state.phase)
+        op_full_state = advance(op_full_state, 1)
+
+        # --- UTCCP: whole operand SMEM -> TMEM, turning the BMM into mma_ts.
+        # Leader-only: tcgen05.cp.cta_group::2 is a SELF-FILL broadcast, so one
+        # issue makes each SM copy its OWN SMEM into its own TMEM.  A
+        # "defensive" non-leader copy would re-copy the same data.
+        # Loop AND commit share one elect block (frost-tile-dsl.md §8).
+        desc_operand = sOperand[0].desc()
+        if nvvm.elect_sync():
+            for _qk in cutlass.range(0, _UTCCP_N_CALLS, 1, unroll_full=True):
+                _s = _qk // _UTCCP_PER_SUBTILE
+                _kk = _qk % _UTCCP_PER_SUBTILE
+                _desc_off = _s * _UTCCP_SUBTILE_DESC_STRIDE + _kk
+                nvvm.tcgen05_cp(
+                    nvvm.Tcgen05CpShape.SHAPE_128X128B,
+                    tmem_operand.subview(_qk * _UTCCP_TMEM_COLS_PER_CALL),
+                    desc_operand + _desc_off,
+                    group=CTA_GROUP_KIND,
+                )
+            # The alias seam.  MMA_COMMIT, never arrive_on_peer: the commit
+            # fires after the tcgen05 pipeline drains, so TMA-LDG cannot
+            # overwrite the operand while the UTCCP still reads it.
+            bars.mb_op_utccp_done.arrive(cta_group=CFG.CTA_MMA, mcast_mask=mcast_mask)
+
+        kv_left, kv_unmasked_lo, kv_unmasked_hi, kv_right = _kv_tile_bounds(q_block, cta_in_pair, seqlen_q, seqlen_kv, n_kv)
+        for _kv_loop in cutlass.range(kv_left, kv_right, 1, unroll=1):
+            bars.mb_tma_ring_full[ring_state.idx].wait(ring_state.phase)
+            bars.mb_acc_empty[acc_state.idx].wait(acc_state.phase)
+            desc_ring = sRing[ring_state.idx].desc()
+            # accumulate=False is correct: K = TILE_K reduces entirely INSIDE
+            # this one call (num_k_steps = TILE_K // TILE_K_HW), so there is no
+            # outer k-loop to accumulate across.
+            mma_ts(
+                bmm_desc,
+                tmem_operand,
+                desc_ring,
+                tmem_raw.subview(cutlass.Int32(LAYOUT.ACC_PARITY0_OFF) + acc_state.idx * cutlass.Int32(LAYOUT.ACC_COLS)),
+                accumulate=False,
+            )
+            # ONE lane commits.  commit_mma() does NOT elect internally
+            # (barrier.py:112 -> nvvm.tcgen05_commit), so an un-predicated
+            # arrive issues 32 commits against init_count=1: the phase flips 32
+            # times and a consumer polling try_wait.parity either catches an odd
+            # flip and runs on, or misses the window and spins forever.  That is
+            # the intermittent hang, not a style nit.  Every MMA_COMMIT arrive in
+            # the shipped forward is pred= or elect-wrapped.
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm_done[acc_state.idx].arrive(cta_group=CFG.CTA_MMA, mcast_mask=mcast_mask, pred=elect_p)
+            bars.mb_tma_ring_empty[ring_state.idx].arrive(cta_group=CFG.CTA_MMA, mcast_mask=mcast_mask, pred=elect_p)
+            ring_state = advance(ring_state, CFG.STAGES_KV)
+            acc_state = advance(acc_state, CFG.STAGES_ACC)
+
+        bars.mb_tma_op_empty.arrive(cta_group=CFG.CTA_MMA, mcast_mask=mcast_mask, pred=nvvm.elect_sync())
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        # The q block is read on this arm too: the causal kv bound depends on it.
+        nxt_q = sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0)).load()
+        nxt_hb = sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1)).load()
+        nxt_v = sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2)).load()
+        q_block, _head, _batch = _decode_payload(nxt_q, nxt_hb, cta_in_pair)
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+    if cutlass.const_expr(CFG.CTA_MMA > 1):
+        _acc_residual = _residual_depth(kv_right - kv_left, CFG.STAGES_ACC)
+        for _ in cutlass.range(cutlass.Int32(0), _acc_residual, 1, unroll=1):
+            bars.mb_acc_empty[acc_state.idx].wait(acc_state.phase)
+            acc_state = advance(acc_state, CFG.STAGES_ACC)
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _mma_warp_non_leader(bars, sched, tmem_ptr_i32, cta_in_pair):
+    """Quiet -- but NOT an empty body.
+
+    It still owns this CTA's TMEM allocation and the base publish that releases
+    its own compute warp group; deleting either hangs that group and leaks TMEM.
+    It issues no MMA and no UTCCP (the leader's cta_group::2 UTCCP is a
+    self-fill broadcast that already filled this CTA's TMEM).
+    """
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WG_WARPS + 1))
+
+    _q_block, _head, _batch = _decode_initial(sched.bidx_init, sched.bidy_init, sched.bidz_init, cta_in_pair)
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_v = sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2)).load()
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _tmastg_warp_group(bars, sched, sCast, tma_s, tma_ds, cta_in_pair, is_sg0, n_kv, seqlen_q, seqlen_kv, head_base, batch_base):
+    q_block, head_idx, batch_idx = _decode_initial(sched.bidx_init, sched.bidy_init, sched.bidz_init, cta_in_pair)
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+    smem_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        q_row_base = q_block * cutlass.Int32(CFG.TILE_M)
+        # The workspace is CHUNK-LOCAL: head_base / batch_base offset every
+        # full-tensor access but NOT this store.
+        head_ws = head_idx
+        batch_ws = batch_idx
+
+        kv_left, kv_unmasked_lo, kv_unmasked_hi, kv_right = _kv_tile_bounds(q_block, cta_in_pair, seqlen_q, seqlen_kv, n_kv)
+        for kv_loop in cutlass.range(kv_left, kv_right, 1, unroll=1):
+            # kv is the ABSOLUTE tile index, so this is the right workspace
+            # column even once masks make kv_left > 0.  In ELEMENTS: the fp8
+            # "byte == elem" coincidence does not hold at BPE = 2.
+            kv_col = kv_loop * cutlass.Int32(CFG.TILE_N)
+            # ONE store per kv tile, NOT one per chunk.  tma_store_tile walks
+            # all S_TMA_ITERS subtiles itself (num_iters = tma_loads_per_tile,
+            # coord advancing by i*granu_elems), so a per-chunk call stores the
+            # whole tile twice: the second call re-lays subtile 0 over columns
+            # [S_D_BLOCK, TILE_N) and pushes subtile 1 past the tile.
+            for chunk in cutlass.range_constexpr(S_TMA_ITERS):
+                bars.mb_smem_full[chunk].wait(smem_state.phase)
+            if is_sg0:
+                tma_store_tile(sCast[0], tma_s(kv_col, q_row_base, head_ws, batch_ws))
+            else:
+                tma_store_tile(sCast[0], tma_ds(kv_col, q_row_base, head_ws, batch_ws))
+            tma_store_commit()
+            tma_store_wait(0)
+            # Plain THREAD arrives: all 32 lanes fire, which is what
+            # init_count = ONE_WARP counts.
+            for chunk in cutlass.range_constexpr(S_TMA_ITERS):
+                bars.mb_smem_empty[chunk].arrive()
+            smem_state = advance(smem_state, 1)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0)).load()
+        nxt_hb = sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1)).load()
+        nxt_v = sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2)).load()
+        q_block, head_idx, batch_idx = _decode_payload(nxt_q, nxt_hb, cta_in_pair)
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+
+@cute.jit
+def _compute_kv_iter(
+    bars,
+    sXfer_raw,
+    sCast_raw,
+    tmem_base_addr,
+    tid_in_wg,
+    q_row,
+    is_lead_warp,
+    is_sg0,
+    leader_cta_id,
+    cross_sg_peer,
+    lse_q_log2e,
+    scaled_do_dot_q,
+    attn_scale_log2e,
+    attn_scale_for_dS,
+    seqlen_q,
+    seqlen_kv,
+    kv_loop,
+    acc_state,
+    smem_state,
+    xfer_empty_state,
+    xfer_full_state,
+    apply_mask: cutlass.Constexpr[bool],
+):
+    """One kv tile of the compute warp group: TMEM -> S (sg0) / dS (sg1) -> SMEM.
+
+    ``apply_mask`` is a PYTHON constant, so this traces twice -- once without any
+    mask code for the tiles strictly below the diagonal band, once with it for
+    the diagonal tiles.  That is why it is a module-level function taking every
+    value explicitly rather than a closure: the DSL rejects closure capture
+    inside a staged loop (SCOPE_CLOSURE_CAPTURE), and a runtime ``if`` would not
+    fold the mask away.
+
+    Pipeline states go in and come back out; the caller rebinds them.
+    """
+    bars.mb_bmm_done[acc_state.idx].wait(acc_state.phase)
+    acc_col_base = cutlass.Int32(LAYOUT.ACC_PARITY0_OFF) + acc_state.idx * cutlass.Int32(LAYOUT.ACC_COLS)
+
+    for chunk in cutlass.range_constexpr(S_TMA_ITERS):
+        reg_acc = tmem_load_tile(tmem_base_addr + acc_col_base + cutlass.Int32(chunk * S_D_BLOCK), num_elems=S_D_BLOCK)
+        # Commit the TMEM read BEFORE releasing the accumulator, or the
+        # leader's next MMA overwrites it mid-flight.  Needed on BOTH
+        # sub-group arms, masked or not.
+        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+        if cutlass.const_expr(chunk == S_TMA_ITERS - 1):
+            bars.mb_acc_empty[acc_state.idx].arrive(cta_group=CFG.CTA_MMA, leader_cta_id=leader_cta_id)
+
+        # Subtile-major SMEM offsets: the whole of subtile 0 (all
+        # TILE_M rows) precedes any of subtile 1, which is what TMA
+        # walks with tma_subtile_stride_elems.
+        cast_off = cutlass.Int32(chunk * S_SUBTILE_SLAB) + tid_in_wg * cutlass.Int32(S_D_BLOCK)
+        xfer_off = cutlass.Int32(chunk * sXferHalfElems) + tid_in_wg * cutlass.Int32(S_D_BLOCK)
+
+        if is_sg0:
+            # S = exp2(attn_scale_log2e * S_acc - lse * log2e), fp32.
+            s_post = cute.math.exp2(reg_acc.vec * attn_scale_log2e - lse_q_log2e, fastmath=True)
+
+            # Mask AFTER exp2, to 0.0 -- not to -inf before it.  With
+            # LSE supplied there is no running max to protect, and dS is
+            # a PRODUCT with S, so zeroing S zeroes dS for free: one
+            # application covers both workspaces and survives the role
+            # split (sg1 receives the already-masked S).  `q_row` is this
+            # CTA's own row; only the tile bound is cluster-wide.
+            if cutlass.const_expr(apply_mask):
+                s_post = apply_mask_chunk(
+                    s_post,
+                    q_row,
+                    kv_loop * cutlass.Int32(CFG.TILE_N) + cutlass.Int32(chunk * S_D_BLOCK),
+                    seqlen_kv,
+                    CFG.WINDOW_LEFT,
+                    CFG.MASK_FLAGS,
+                    N=S_D_BLOCK,
+                    bottom_right=1 if CFG.BOTTOM_RIGHT else 0,
+                    causal_diag=(seqlen_kv - seqlen_q) if CFG.BOTTOM_RIGHT else None,
+                    mask_value=0.0,
+                    window_right=CFG.WINDOW_RIGHT,
+                )
+
+            # The fp32 ship, sg0 -> sg1.  This buffer is UNSWIZZLED and
+            # linear on purpose: unlike the forward's P it is never an
+            # MMA operand and never TMA'd, so a swizzled read path would
+            # buy nothing and cost a matching load.
+            bars.mb_s_xfer_empty[chunk].wait(xfer_empty_state.phase)
+            for _i in cutlass.range_constexpr(S_D_BLOCK):
+                sXfer_raw.subview(xfer_off + cutlass.Int32(_i)).store(s_post[_i])
+
+            # The workspace store staging.  Deferred wait: the exp2 above
+            # overlaps the previous TMA-STG drain.
+            bars.mb_smem_empty[chunk].wait(smem_state.phase)
+            sCast_raw.subview(cast_off).data_ptr().store_swizzled(s_post.to(WORKSPACE_DTYPE), alignment=64, swizzle=S_SMEM_SWIZZLE)
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_smem_full[chunk].arrive()
+
+            # The named barrier is KEPT -- the ship's operand is all
+            # four warps' stores.  mapa BOTH the pointer and the mbar.
+            nvvm.barrier_cta_sync(barrier_id=8, thread_count=CFG.COMPUTE_LANES)
+            ship_pred = is_lead_warp & nvvm.elect_sync()
+            local_src = sXfer_raw.subview(cutlass.Int32(chunk * sXferHalfElems))
+            peer_dst = nvvm.mapa(local_src, cross_sg_peer, addrspace=7)
+            peer_mbar = nvvm.mapa(bars.mb_s_xfer_full[chunk].smem_ptr, cross_sg_peer, addrspace=7)
+            cp_async_bulk_shared_cluster_shared_cta(peer_dst, local_src, peer_mbar, sXferHalfBytes, pred=ship_pred)
+        else:
+            # Arm expect_tx from ONE lane of the LEAD warp: this is a
+            # 4-warp group, so a bare elect_sync() would give one arrive
+            # per warp -- 4 against init=1.
+            bars.mb_s_xfer_full[chunk].arrive(n_bytes=sXferHalfBytes, pred=is_lead_warp & nvvm.elect_sync())
+            bars.mb_s_xfer_full[chunk].wait(xfer_full_state.phase)
+
+            # dS = (attn_scale_for_dS * dS_acc - do_dot*attn_scale) * S.
+            # S is read at fp32 -- rounding it to the io dtype here is
+            # exactly the accuracy the Rubin reference does not lose.
+            ds_elems = tuple(
+                (reg_acc[_i] * attn_scale_for_dS - scaled_do_dot_q) * sXfer_raw.subview(xfer_off + cutlass.Int32(_i)).load() for _i in range(S_D_BLOCK)
+            )
+            ds_post = cutlass.Vector.from_elements(ds_elems, cutlass.Float32)
+
+            bars.mb_smem_empty[chunk].wait(smem_state.phase)
+            sCast_raw.subview(cast_off).data_ptr().store_swizzled(ds_post.to(WORKSPACE_DTYPE), alignment=64, swizzle=S_SMEM_SWIZZLE)
+            nvvm.fence_proxy("async.shared", space="cta")
+            bars.mb_smem_full[chunk].arrive()
+
+            # Release the ship slot only once all four warps have read
+            # S out of it, then one lane arrives on the peer.
+            nvvm.barrier_cta_sync(barrier_id=8, thread_count=CFG.COMPUTE_LANES)
+            if is_lead_warp:
+                if nvvm.elect_sync():
+                    bars.mb_s_xfer_empty[chunk].arrive_on_peer(cross_sg_peer)
+
+    smem_state = advance(smem_state, 1)
+    xfer_empty_state = advance(xfer_empty_state, 1)
+    xfer_full_state = advance(xfer_full_state, 1)
+    acc_state = advance(acc_state, CFG.STAGES_ACC)
+    return acc_state, smem_state, xfer_empty_state, xfer_full_state
+
+
+@cute.jit
+def _compute_warp_group(
+    bars,
+    sched,
+    sXfer_raw,
+    sCast_raw,
+    tmem_ptr_i32,
+    lse_tensor,
+    do_dot_tensor,
+    cta_in_pair,
+    is_sg0,
+    leader_cta_id,
+    cross_sg_peer,
+    cta_id_x,
+    n_kv,
+    seqlen_q,
+    seqlen_kv,
+    attn_scale_in,
+    attn_scale_log2e,
+    attn_scale_for_dS,
+    head_base,
+    batch_base,
+):
+    """sg0: S = exp2(scale*S_acc - lse), store bf16 S, ship fp32 S to sg1.
+    sg1: dS = (scale*dS_acc - do_dot) * S_recv, store bf16 dS.
+
+    One lane == one q-row (tid_in_wg 0..127 is both the row and the TMEM lane).
+    The TILE_N columns are walked in S_TMA_ITERS chunks of S_D_BLOCK, and that
+    chunk is simultaneously one shipped fp32 half, one stored TMA subtile and
+    one 128 B swizzle atom per row -- the alignment the config asserts.
+    """
+    # Must precede the TMEM base read: pairs with the MMA warp's
+    # barrier_cta_arrive right after tmem_alloc.  Without it the base load
+    # races the alloc on a cold cache.
+    nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WG_WARPS + 1))
+    tmem_base_addr = tmem_ptr_i32.load()
+
+    tid_in_wg = cute.arch.thread_idx()[0]
+    is_lead_warp = (tid_in_wg // cutlass.Int32(32)) == cutlass.Int32(0)
+
+    q_block, head_idx, batch_idx = _decode_initial(sched.bidx_init, sched.bidy_init, sched.bidz_init, cta_in_pair)
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+    acc_state = PipelineState.start()
+    smem_state = PipelineState.start(phase=1)
+    # Two states, not one: sg0 consumes mb_s_xfer_EMPTY (pre-armed, nothing has
+    # freed a slot yet) while sg1 consumes mb_s_xfer_FULL (a real producer
+    # arrive).  Sharing one state makes sg1's first wait fall through before the
+    # data lands -- silent garbage, not a hang.
+    xfer_empty_state = PipelineState.start(phase=1)
+    xfer_full_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        q_row = q_block * cutlass.Int32(CFG.TILE_M) + tid_in_wg
+        head_g = head_idx + head_base
+        batch_g = batch_idx + batch_base
+
+        # Per-q-row scalars, hoisted once per tile.  Both arrive RAW: the host
+        # folds no log2e into the LSE and no attn_scale into the dot.
+        lse_q_log2e = lse_tensor[batch_g, head_g, q_row] * cutlass.Float32(LOG2E)
+        scaled_do_dot_q = do_dot_tensor[batch_g, head_g, q_row] * attn_scale_in
+
+        kv_left, kv_unmasked_lo, kv_unmasked_hi, kv_right = _kv_tile_bounds(q_block, cta_in_pair, seqlen_q, seqlen_kv, n_kv)
+
+        def _run(lo, hi, apply_mask, acc_state, smem_state, xfer_empty_state, xfer_full_state):
+            for _kv_loop in cutlass.range(lo, hi, 1, unroll=1):
+                acc_state, smem_state, xfer_empty_state, xfer_full_state = _compute_kv_iter(
+                    bars,
+                    sXfer_raw,
+                    sCast_raw,
+                    tmem_base_addr,
+                    tid_in_wg,
+                    q_row,
+                    is_lead_warp,
+                    is_sg0,
+                    leader_cta_id,
+                    cross_sg_peer,
+                    lse_q_log2e,
+                    scaled_do_dot_q,
+                    attn_scale_log2e,
+                    attn_scale_for_dS,
+                    seqlen_q,
+                    seqlen_kv,
+                    _kv_loop,
+                    acc_state,
+                    smem_state,
+                    xfer_empty_state,
+                    xfer_full_state,
+                    apply_mask=apply_mask,
+                )
+            return acc_state, smem_state, xfer_empty_state, xfer_full_state
+
+        # THREE ranges, in kv order: the band's LOW edge, the interior, the HIGH
+        # edge.  Only the interior is provably free of masked cells.  Dropping
+        # the low edge is a real bug under SWA -- there `unmasked_lo > left` and
+        # those tiles carry the band's left boundary.  Under causal-only
+        # `unmasked_lo == left`, so the low range is empty and a two-range split
+        # looked correct until SWA was switched on.
+        #
+        # `apply_mask` is a Python constant, so each range traces separately and
+        # the interior contains no mask code at all.
+        if cutlass.const_expr(_MASKED):
+            acc_state, smem_state, xfer_empty_state, xfer_full_state = _run(
+                kv_left, kv_unmasked_lo, True, acc_state, smem_state, xfer_empty_state, xfer_full_state
+            )
+        acc_state, smem_state, xfer_empty_state, xfer_full_state = _run(
+            kv_unmasked_lo, kv_unmasked_hi, False, acc_state, smem_state, xfer_empty_state, xfer_full_state
+        )
+        if cutlass.const_expr(_MASKED):
+            acc_state, smem_state, xfer_empty_state, xfer_full_state = _run(
+                kv_unmasked_hi, kv_right, True, acc_state, smem_state, xfer_empty_state, xfer_full_state
+            )
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0)).load())
+        nxt_hb = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1)).load())
+        nxt_v = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2)).load())
+        q_block, head_idx, batch_idx = _decode_payload(nxt_q, nxt_hb, cta_in_pair)
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+    # --- sg0 owns the cross-sub-group drain ------------------------------
+    # mb_s_xfer_empty is an ASYNC cross-CTA arrive from sg1.  If sg0 exits
+    # before sg1's last arrive lands, that write hits a dead peer ->
+    # CUDA_EXCEPTION_17: an intermittent launch failure that PASSES validation
+    # whenever it does not crash, because it is a teardown race and not a math
+    # bug.  The cross-sub-group ring is the one most easily missed.
+    if cutlass.const_expr(CFG.CTA_MMA > 1):
+        if is_sg0:
+            for _chunk in cutlass.range_constexpr(CFG.XFER_HALVES):
+                bars.mb_s_xfer_empty[_chunk].wait(xfer_empty_state.phase)
+            xfer_empty_state = advance(xfer_empty_state, 1)
+
+    # Releases this CTA's MMA warp to dealloc TMEM.  ^1 is the PAIR partner,
+    # not cross_sg_peer.
+    if is_lead_warp:
+        if nvvm.elect_sync():
+            bars.mb_tmem_dealloc.arrive_on_peer(cta_id_x ^ cutlass.Int32(1))
+
+
+# ---------------------------------------------------------------------------
+# Kernel entry: cluster identity, allocation, barrier init, warp dispatch.
+# ---------------------------------------------------------------------------
+
+
+@cute.kernel
+def _kernel(
+    tma_q_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_k_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_v_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_do_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_s_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_ds_desc: cutlass.GridConstant[tmap.TensorMap],
+    # Plain per-lane GMEM reads, one q-row per lane -- NOT TMA, and therefore
+    # carrying no barriers at all.  sg0 reads lse, sg1 reads do_dot.  Both
+    # arrive RAW: this kernel applies * log2e and * attn_scale_in itself.
+    lse_tensor: cute.Tensor,
+    do_dot_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    seqlen_q: cutlass.Int32,
+    seqlen_kv: cutlass.Int32,
+    gqa_ratio: cutlass.Int32,
+    n_kv: cutlass.Int32,
+    n_qh: cutlass.Int32,
+    n_batch: cutlass.Int32,
+    attn_scale_in: cutlass.Float32,
+    attn_scale_log2e: cutlass.Float32,
+    attn_scale_for_dS: cutlass.Float32,
+    # Host-loop coordinates.  These offset every FULL-TENSOR access (Q/K/V/dO/
+    # lse/do_dot); the chunk-local S/dS workspace stays at origin.
+    head_base: cutlass.Int32,
+    batch_base: cutlass.Int32,
+) -> None:
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    tidx, _, _ = cute.arch.thread_idx()
+
+    bidx = cute.arch.block_idx()[0]
+    bidy = cute.arch.block_idx()[1]
+    bidz = cute.arch.block_idx()[2]
+
+    # --- cluster identity ------------------------------------------------
+    # Five const_expr ternaries, not if/else blocks: a local assigned in only
+    # one arm is not reliably visible afterwards (frost-gotchas.md).
+    cta_id_x = cute.arch.block_idx_in_cluster() if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    cta_in_pair = cta_id_x & 1
+    leader_cta_id = cta_id_x & ~1
+    mcast_mask = cutlass.Int32(3) << leader_cta_id  # 0x3 on sg0, 0xC on sg1
+    tma_mcast_mask = cutlass.Int16(1) << cta_id_x  # SELF-ONLY; bytes still route to the leader
+    is_leader = cta_in_pair == 0
+    sg_id = cta_id_x // CFG.CTA_MMA
+    is_sg0 = sg_id == 0
+    cross_sg_peer = cta_id_x ^ CFG.CTA_MMA  # 0<->2, 1<->3, mirrored lane-to-lane
+    is_cga_first_cta = cta_id_x == 0
+
+    # --- SMEM ------------------------------------------------------------
+    # One max-union alias slab: Q|K-ring on sg0, dO|V-ring on sg1.  Both
+    # sub-groups allocate the SAME shape -- the role split is symmetric, so
+    # there is one allocation block, not two.
+    sAliased_raw = cutlass.Array(STORAGE_DTYPE, _ALIAS_ELEMS, alignment=1024, space=cutlass.AddressSpace.smem)
+    sOperand_raw = sAliased_raw  # Q on sg0, dO on sg1 (dead after the UTCCP)
+    sRing_raw = sAliased_raw  # K on sg0, V on sg1
+    # fp32 S ship staging.  Separate from the cast buffer so this slot is
+    # released on cast completion rather than on tma_store_wait.
+    sXfer_raw = cutlass.Array(cutlass.Float32, sXferElems, alignment=128, space=cutlass.AddressSpace.smem)
+    # io-dtype staging for the workspace store: S on sg0, dS on sg1.
+    sCast_raw = cutlass.Array(WORKSPACE_DTYPE, castElems, alignment=128, space=cutlass.AddressSpace.smem)
+
+    sOperand = SmemTile(
+        base=sOperand_raw,
+        elems_per_stage=qBufferElems,
+        stages=1,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QK,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+    )
+    sRing = SmemTile(
+        base=sRing_raw,
+        elems_per_stage=kBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QK,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+    )
+    sCast = SmemTile(
+        base=sCast_raw,
+        elems_per_stage=castElems,
+        stages=1,
+        leading_byte_offset=0,
+        stride_byte_offset=_CORE_MATRIX_ROWS * CFG.S_SWZ_BYTES,
+        layout=SMEM_LAYOUT_S,
+        tma_loads_per_tile=S_TMA_ITERS,
+        tma_granu_elems=S_D_BLOCK,
+        tma_subtile_stride_elems=S_SUBTILE_SLAB,
+    )
+
+    tma_q = GmemTileTma(tma_q_desc)
+    tma_k = GmemTileTma(tma_k_desc)
+    tma_v = GmemTileTma(tma_v_desc)
+    tma_do = GmemTileTma(tma_do_desc)
+    tma_s = GmemTileTma(tma_s_desc)
+    tma_ds = GmemTileTma(tma_ds_desc)
+
+    tmem_ptr_i32 = cutlass.Array(cutlass.Int32, 1, alignment=16, space=cutlass.AddressSpace.smem)
+    sched = Sched(
+        mb_scheduler=cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+        mb_read_tile_id=cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+        tile_id_smem=cutlass.Array(cutlass.Int32, CFG.SCHEDULER_STAGES * 8, alignment=16, space=cutlass.AddressSpace.smem),
+        bidx_init=bidx,
+        bidy_init=bidy,
+        bidz_init=bidz,
+    )
+    bars = _make_bwd_d512_sm100_bars(CFG)
+
+    # --- barrier init: init -> fence -> CTA sync -> cga sync -> arrives
+    if warp_idx == 0:
+        # ONE lane initialises.  `mbarrier.init` from all 32 lanes of the warp
+        # is 32 concurrent inits of the same mbarrier object -- PTX leaves that
+        # undefined, and the shipped forward (prefill_d512_f16_sm100.py:475)
+        # elect-gates the whole block for exactly this reason.
+        #
+        # MBarrier.init() initialises exactly ONE stage (base_ptr at
+        # stage_idx=0) -- it is not a whole-ring init.  Every stage of every
+        # multi-stage ring must be initialised explicitly, or stages 1.. sit on
+        # uninitialised SMEM and the first wait on them faults the launch.
+        if nvvm.elect_sync():
+            for _f in bars:
+                for _i in cutlass.range_constexpr(_f.stages):
+                    _f[_i].init()
+            for _i in cutlass.range_constexpr(CFG.SCHEDULER_STAGES):
+                nvvm.mbarrier_init(sched.mb_scheduler.subview(_i), CFG.ONE_LANE)
+                nvvm.mbarrier_init(sched.mb_read_tile_id.subview(_i), CFG.READ_TILE_ARRIVERS)
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync()
+    # Required before ANY cross-CTA arrive: skipping it lets one land on
+    # uninitialized SMEM under in-flight pressure.
+    if cutlass.const_expr(CGA_SIZE > 1):
+        cga_arrive()
+        cga_wait()
+
+    # --- warp dispatch ---------------------------------------------------
+    if warp_idx < CFG.SOFTMAX_WG_WARPS:
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        _compute_warp_group(
+            bars,
+            sched,
+            sXfer_raw,
+            sCast_raw,
+            tmem_ptr_i32,
+            lse_tensor,
+            do_dot_tensor,
+            cta_in_pair,
+            is_sg0,
+            leader_cta_id,
+            cross_sg_peer,
+            cta_id_x,
+            n_kv,
+            seqlen_q,
+            seqlen_kv,
+            attn_scale_in,
+            attn_scale_log2e,
+            attn_scale_for_dS,
+            head_base,
+            batch_base,
+        )
+    elif warp_idx == CFG.MMA_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        if is_leader:
+            _mma_warp_leader(bars, sched, sOperand, sRing, tmem_ptr_i32, cta_in_pair, is_sg0, mcast_mask, n_kv, seqlen_q, seqlen_kv)
+        else:
+            _mma_warp_non_leader(bars, sched, tmem_ptr_i32, cta_in_pair)
+    elif warp_idx == CFG.TMALDG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _tmaldg_warp_group(
+            bars,
+            sched,
+            sOperand,
+            sRing,
+            tma_q,
+            tma_k,
+            tma_v,
+            tma_do,
+            cta_in_pair,
+            is_leader,
+            is_sg0,
+            tma_mcast_mask,
+            n_kv,
+            seqlen_q,
+            seqlen_kv,
+            gqa_ratio,
+            head_base,
+            batch_base,
+        )
+    elif warp_idx == CFG.TMASTG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _tmastg_warp_group(bars, sched, sCast, tma_s, tma_ds, cta_in_pair, is_sg0, n_kv, seqlen_q, seqlen_kv, head_base, batch_base)
+    else:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
+
+
+# ---------------------------------------------------------------------------
+# Host wrapper + per-shape compile cache
+# ---------------------------------------------------------------------------
+
+
+def _tma_swz(byte_w: int):
+    return tmap.TensorMapSwizzle.s128b if byte_w == 128 else tmap.TensorMapSwizzle.s64b if byte_w == 64 else tmap.TensorMapSwizzle.s32b
+
+
+@cute.jit
+def _host(
+    q_tensor: cute.Tensor,
+    k_tensor: cute.Tensor,
+    v_tensor: cute.Tensor,
+    do_tensor: cute.Tensor,
+    s_tensor: cute.Tensor,
+    ds_tensor: cute.Tensor,
+    lse_tensor: cute.Tensor,
+    do_dot_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    problem_size: Tuple[int, int, int, int, int, int],  # (B, QH, S_q, S_kv, QH_chunk, QH_kv)
+    attn_scale_in: cutlass.Float32,
+    attn_scale_log2e: cutlass.Float32,
+    attn_scale_for_dS: cutlass.Float32,
+    head_base: cutlass.Int32,
+    batch_base: cutlass.Int32,
+    stream: _cuda_driver.CUstream = None,
+) -> None:
+    B, QH, SQ, SKV, QH_CHUNK, QH_KV = problem_size
+
+    # Q/K/V/dO are BSHD [B, S, H, D]; the workspaces are [B, H_chunk, S_q, S_kv].
+    # stride_order is innermost-first, so the coords the kernel passes are
+    # (d, head, seq, batch) for the operands and (kv, q, head, batch) for the
+    # workspaces.
+    stride_order = (3, 2, 1, 0)
+    op_box = (1, CFG.TILE_M, 1, TMA_QK_GRANU_ELEMS)  # Q and dO: whole q-block
+    ring_box = (1, CFG.TILE_N // CFG.CTA_MMA, 1, TMA_QK_GRANU_ELEMS)  # K and V: per-CTA N slice
+    # One workspace subtile.  S_D_BLOCK * BPE == the swizzle atom exactly; a
+    # full TILE_N row would be 256 B and exceed it, which is the
+    # cuTensorMapEncodeTiled INVALID_VALUE / CUDA_EXCEPTION_27 trap.
+    ws_box = (1, 1, CFG.TILE_M, S_D_BLOCK)
+
+    tma_q_desc = tmap.create_tensor_map_tiled_from_view(
+        q_tensor, box_dims=op_box, stride_order=stride_order, swizzle=_tma_swz(CFG.Q_SWZ_BYTES), l2_promotion=tmap.TensorMapL2Promotion.l2_128b
+    )
+    tma_k_desc = tmap.create_tensor_map_tiled_from_view(
+        k_tensor, box_dims=ring_box, stride_order=stride_order, swizzle=_tma_swz(CFG.K_SWZ_BYTES), l2_promotion=tmap.TensorMapL2Promotion.l2_128b
+    )
+    tma_v_desc = tmap.create_tensor_map_tiled_from_view(
+        v_tensor, box_dims=ring_box, stride_order=stride_order, swizzle=_tma_swz(CFG.V_SWZ_BYTES), l2_promotion=tmap.TensorMapL2Promotion.l2_128b
+    )
+    tma_do_desc = tmap.create_tensor_map_tiled_from_view(
+        do_tensor, box_dims=op_box, stride_order=stride_order, swizzle=_tma_swz(CFG.DO_SWZ_BYTES), l2_promotion=tmap.TensorMapL2Promotion.l2_128b
+    )
+    tma_s_desc = tmap.create_tensor_map_tiled_from_view(
+        s_tensor, box_dims=ws_box, stride_order=stride_order, swizzle=_tma_swz(CFG.S_SWZ_BYTES), l2_promotion=tmap.TensorMapL2Promotion.l2_128b
+    )
+    tma_ds_desc = tmap.create_tensor_map_tiled_from_view(
+        ds_tensor, box_dims=ws_box, stride_order=stride_order, swizzle=_tma_swz(CFG.S_SWZ_BYTES), l2_promotion=tmap.TensorMapL2Promotion.l2_128b
+    )
+
+    # One cluster covers CTA_MMA * TILE_M q-rows; CGA_M CTAs per cluster.
+    rows_per_cluster = CFG.TILE_M * CFG.CTA_MMA
+    q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
+    grid_shape = (q_clusters * CFG.CGA_M, QH_CHUNK, B)
+
+    _kernel(
+        tma_q_desc,
+        tma_k_desc,
+        tma_v_desc,
+        tma_do_desc,
+        tma_s_desc,
+        tma_ds_desc,
+        lse_tensor,
+        do_dot_tensor,
+        seq_kv_lens_tensor,
+        cutlass.Int32(SQ),
+        cutlass.Int32(SKV),
+        # GQA ratio, 1 for MHA. Q-head // this = the shared KV head.
+        cutlass.Int32(QH // QH_KV),
+        cutlass.Int32(SKV // CFG.TILE_N),
+        cutlass.Int32(QH_CHUNK),
+        cutlass.Int32(B),
+        attn_scale_in,
+        attn_scale_log2e,
+        attn_scale_for_dS,
+        head_base,
+        batch_base,
+    ).launch(
+        grid=grid_shape,
+        block=[CFG.THREADS_PER_CTA, 1, 1],
+        cluster=(CFG.CGA_M, CFG.CGA_N, 1),
+        stream=stream,
+    )
+
+
+@lru_cache(maxsize=None)
+def compile(  # noqa: A001
+    b: int = 1,
+    qh: int = 1,
+    sq: int = 256,
+    skv: int = 128,
+    qh_chunk: int = 1,
+    d: Optional[int] = None,
+    qh_kv: Optional[int] = None,
+) -> Callable:
+    """Per-shape compile cache.
+
+    ``qh_chunk`` decouples the workspace's head extent from the tensors': the
+    host loop chunks the flattened (b, h) index to hold S+dS under the workspace
+    cap, so Q/K/V/dO carry the full ``qh`` while the workspaces carry only the
+    chunk.  ``head_base`` / ``batch_base`` are RUNTIME args, so one
+    compiled artifact serves every chunk.
+    """
+    if sq % (CFG.TILE_M * CFG.CTA_MMA) != 0:
+        raise ValueError(f"bwd d512: S_q must be a multiple of TILE_M*CTA_MMA ({CFG.TILE_M * CFG.CTA_MMA}); got {sq}")
+    if skv % CFG.TILE_N != 0:
+        raise ValueError(f"bwd d512: S_kv must be a multiple of TILE_N ({CFG.TILE_N}); got {skv}")
+    if qh % qh_chunk != 0:
+        raise ValueError(f"bwd d512: qh_chunk ({qh_chunk}) must divide qh ({qh}) -- even chunks keep one compiled artifact")
+    # Head dims below TILE_K need NO kernel change: the TMA descriptors are built
+    # `from_view`, so global_dims carries the REAL d, and a box reading past it is
+    # HW zero-filled.  The zeros then contribute nothing to either BMM -- we pay
+    # the full TILE_K-wide MMA and get the right answer.  The only hard rule is
+    # TMA's: the innermost extent must be 16-byte aligned, i.e. d * BPE % 16 == 0.
+    qh_kv = qh if qh_kv is None else int(qh_kv)
+    if qh % qh_kv != 0:
+        raise ValueError(f"bwd d512: qh ({qh}) must be a multiple of qh_kv ({qh_kv})")
+    d = CFG.TILE_K if d is None else int(d)
+    if not (0 < d <= CFG.TILE_K):
+        raise ValueError(f"bwd d512: d must be in (0, {CFG.TILE_K}]; got {d}")
+    if (d * CFG.BPE) % 16 != 0:
+        raise ValueError(f"bwd d512: d * {CFG.BPE} B must be a multiple of 16 (TMA innermost extent); got d={d}")
+
+    def _fake_bshd(shape, dtype=STORAGE_DTYPE):
+        return cute.runtime.make_fake_compact_tensor(dtype, shape, stride_order=(3, 2, 1, 0), assumed_align=16)
+
+    fake_q = _fake_bshd((b, sq, qh, d))
+    # K/V are indexed by the KV head, so their head extent is qh_kv.
+    fake_k = _fake_bshd((b, skv, qh_kv, d))
+    fake_v = _fake_bshd((b, skv, qh_kv, d))
+    fake_do = _fake_bshd((b, sq, qh, d))
+    # Chunk-local workspaces, [B, H_chunk, S_q, S_kv] at the io dtype.
+    fake_s = _fake_bshd((b, qh_chunk, sq, skv), dtype=WORKSPACE_DTYPE)
+    fake_ds = _fake_bshd((b, qh_chunk, sq, skv), dtype=WORKSPACE_DTYPE)
+    # Plain per-lane reads, one q-row per lane -- no TMA, no barriers.
+    fake_lse = cute.runtime.make_fake_compact_tensor(cutlass.Float32, (b, qh, sq), stride_order=(2, 1, 0), assumed_align=16)
+    fake_do_dot = cute.runtime.make_fake_compact_tensor(cutlass.Float32, (b, qh, sq), stride_order=(2, 1, 0), assumed_align=16)
+    fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (b,), stride_order=(0,), assumed_align=16)
+
+    return cute.compile(
+        _host,
+        fake_q,
+        fake_k,
+        fake_v,
+        fake_do,
+        fake_s,
+        fake_ds,
+        fake_lse,
+        fake_do_dot,
+        fake_seq_kv_lens,
+        (b, qh, sq, skv, qh_chunk, qh_kv),
+        cutlass.Float32(0.0),
+        cutlass.Float32(0.0),
+        cutlass.Float32(0.0),
+        cutlass.Int32(0),
+        cutlass.Int32(0),
+        stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
+        options="--enable-tvm-ffi",
+    )
+
+
+__all__ = ["CFG", "PARAMS", "Bars", "LAYOUT", "STORAGE_DTYPE", "WORKSPACE_DTYPE", "_kernel", "_host", "compile"]

--- a/python/cudnn/sdpa/bwd/kernels/bprop_matmul_sm100.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_matmul_sm100.py
@@ -1,42 +1,44 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-"""sm100 GEMM kernel: persistent + double-TMEM + CLC dynamic scheduler (2-stage ring).
+"""SM100 batched GEMM with a 2-D ``(batch, head)`` batch — SDPA-backward stage 3.
 
-Serves both MMA modes; ``cta_group`` is an injected tile constant.
+Computes dV = S^T.dO, dK = dS^T.Q and dQ = dS.K.  All three are plain batched
+bf16 GEMMs; at bf16 there is no descale epilogue, so nothing is fused here.
 
-  cta_group=1  single-CTA MMA — every CTA runs its own MMA on its own
-               SMEM/TMEM, no leader-follower pair.
-  cta_group=2  2-CTA MMA cluster pair — the leader CTA issues the MMA while the
-               follower CLC-consumes only; both CTAs load their operand slice.
+WHY THIS EXISTS -- the one thing the generic GEMM cannot express
+---------------------------------------------------------------
+``gemm/frost/kernel_templates/sm100_matmul.py`` carries a single batch axis
+``l`` with ONE uniform stride.  The SDPA operands are BSHD ``[B, S, H, D]``, so
+the batch element is the PAIR ``(b, h)`` at offset ``b*(S*H*D) + h*D`` -- a
+two-level stride that no single uniform stride can express.  Flattening it
+host-side would need a copy of every operand, per chunk, against a workspace
+measured in GiB.
 
-The CTA tile may span several MMA instructions along M (``mma_size_m``, each
-``mma_inst_shape_mnk``): the TMA still loads the whole tile in one go, the MMA
-warp issues one instruction per (M, N) sub-block into its own TMEM column
-region, and the epilogue drains one MMA-M block per pass.
+So the operands stay exactly as the user laid them out and the TMA descriptors
+become **4-D** ``[k, m, h, b]`` (``cuTensorMapEncodeTiled`` allows 5), with
+``h`` and ``b`` as separate coordinates.  The CLC scheduler still rasterizes a
+single flat ``l`` -- ``_decode_bh`` splits it only where a TMA coordinate is
+formed, which is the whole change.
 
-Warp layout (8 warps × 32 = 256 threads/CTA):
-  warps 0–3 : epilogue (warp 0 also allocates TMEM)  — setmaxnreg.inc 216
-  warp  4   : MMA driver (cta_group=2: leader runs the MMA, follower
-              CLC-consumes only)  — setmaxnreg.dec 40
-  warp  5   : TMA producer (cta_group=2: both CTAs load their slice)  — setmaxnreg.dec 40
-  warp  6   : CLC scheduler (leader CTA issues queries; every CTA waits + reads + arrives empty)  — setmaxnreg.dec 40
-  warp  7   : unused donor — setmaxnreg.dec 40
+KEEP IN SYNC WITH ``gemm/frost/kernel_templates/sm100_matmul.py``
+-----------------------------------------------------------------
+This file is a FORK of that template, taken from its rendered dense-bf16
+expansion (config ``sm100_128x256x128_128x256x32_cluster2x1_2ctamma``, no
+epilogue fusion, TMA-store epilogue).  The mainloop, the CLC scheduler, the
+TMEM/accumulator pipeline and the epilogue are otherwise unchanged.
 
-FORKED BY ``sdpa/bwd/kernels/bprop_matmul_sm100.py``
-----------------------------------------------------
-The SDPA backward's stage-3 gradient GEMMs need a 2-D ``(batch, head)`` batch:
-their operands are BSHD ``[B, S, H, D]``, so the batch element is the PAIR
-``(b, h)`` at offset ``b*(S*H*D) + h*D`` -- a two-level stride that the single
-uniform batch stride here cannot express, and that cannot be normalised
-host-side without copying a multi-GiB workspace per chunk.  That fork takes a
-rendered dense-bf16 expansion of this template and widens the TMA descriptors
-to 4-D ``[k, m, h, b]``.  It is otherwise identical: same mainloop, same CLC
-scheduler, same TMEM pipeline, same epilogue.
+**Any correctness fix or performance improvement to either file should be
+applied to BOTH.**  The generic template carries the same note.  The diff
+against it is deliberately narrow, so a `diff` against a fresh rendering of
+that config is the intended way to review a change:
+  * ``_decode_bh`` and its four call sites;
+  * ``h``/``b`` in place of ``l`` in every TMA coordinate tuple;
+  * 4-D descriptors and one extra stride per operand;
+  * ``problem_size`` carrying ``(n_head, n_batch)`` and 4 strides per operand.
 
-**Any correctness fix or performance improvement here should be applied there
-too, and vice versa.**  The fork carries the matching note and a list of the
-points where the two intentionally differ.
+Everything else in this file is generated output; do not hand-tune it in place
+without making the same change upstream.
 """
 
 from __future__ import annotations
@@ -61,7 +63,102 @@ from cutlass.cute.runtime import make_fake_stream
 from cuda.bindings import driver as _cuda
 from cutlass.cute.arch import clc as cute_clc
 
-# @@INJECT_TILE_CONSTANTS@@
+from cudnn.sdpa.bwd.config_sm100 import CAUSAL_K_HI, CAUSAL_K_LO, CAUSAL_K_NONE, MatmulTemplateParams
+
+PARAMS = globals().get("FROST_TEMPLATE_PARAMS", MatmulTemplateParams())
+
+# Tile config: CONFIG_sm100_128x256x128_128x256x32_cluster2x1_2ctamma
+mma_inst_shape_mnk = (256, 256, 16)
+cta_group = 2
+cgrp_tile_mnk = (256, 256, 64)
+cta_tile_mnk = (128, 128, 64)
+epi_tile_mn = (128, 32)
+threads_per_cta = 256
+cluster_shape_mnk = (2, 1, 1)
+# Upstream carries the rendering's batch size here purely to detect a BROADCAST
+# operand (== 1 means "one batch element, reuse it for all"). No stage-3 GEMM
+# broadcasts, so both are simply "batched"; the real extents are runtime.
+matmul_a_batch = 0
+matmul_b_batch = 0
+# --- operand major, per FROST_TEMPLATE_PARAMS -------------------------------
+# The three stage-3 GEMMs do NOT share one operand-major combination:
+#   dV = S^T.dO  and  dK = dS^T.Q :  A m-major (S/dS's kv is contiguous and is M)
+#   dQ = dS.K                     :  A k-major (dS's kv is contiguous and is K)
+# B is n-major in all three (D is contiguous in BSHD, and D is N).
+#
+# Rendering the upstream template for each combination produces bodies that are
+# textually IDENTICAL -- the whole difference is the ten constants below.  So one
+# fork serves all three; the loader instantiates this module once per params set
+# and every use is `cutlass.const_expr`, so each instance traces specialized code.
+a_is_m_major = bool(PARAMS.a_is_m_major)
+b_is_n_major = bool(PARAMS.b_is_n_major)
+causal_mode = int(PARAMS.causal_mode)
+causal_gran = int(PARAMS.causal_gran)
+causal_shift = int(PARAMS.causal_shift)
+mma_a_major = 1 if a_is_m_major else 0
+mma_b_major = 1 if b_is_n_major else 0
+ab_stages = 7
+b_collector_ok = False
+multicast_a = False
+multicast_b = False
+a_mcast_slices = 1
+b_mcast_slices = 1
+ab_empty_full_mask = False
+ab_smem_swizzle = cutlass.experimental.primitives.Tcgen05SmemSwizzle.SWIZZLE_128B
+# MN-major packs 64 elements per TMA group and walks K in 2048-byte steps;
+# K-major loads one group and steps 32 bytes.  Values lifted verbatim from the
+# upstream renderings of the same tile config -- do not hand-derive them.
+_MAJOR_CONSTS = {
+    # is_mn_major: (desc_leading_byte_offset, k_step_bytes, tma_group_elems)
+    False: (16, 32, 1),
+    True: (8192, 2048, 64),
+}
+a_smem_desc_leading_byte_offset, a_smem_k_step_bytes, a_tma_group_elems = _MAJOR_CONSTS[a_is_m_major]
+b_smem_desc_leading_byte_offset, b_smem_k_step_bytes, b_tma_group_elems = _MAJOR_CONSTS[b_is_n_major]
+a_smem_desc_stride_byte_offset = 1024
+b_smem_desc_stride_byte_offset = 1024
+a_smem_m_step_bytes = 16384
+mma_size_m = 1
+mma_size_n = 1
+mma_size_k = 4
+ab_tma_swizzle = _tma.TensorMapSwizzle.s128b
+
+# Dtype family: A=bf16->MMAbf16, B=bf16->MMAbf16, out=bf16 (K_BYTES=128)
+ab_dtype = cutlass.BFloat16
+cd_dtype = cutlass.BFloat16
+mma_a_dtype = cutlass.BFloat16
+mma_b_dtype = cutlass.BFloat16
+mma_c_dtype = cutlass.Float32
+acc_widen_to_fp32 = False
+ab_tma_dtype = cutlass.BFloat16
+mma_kind = nvvm.Tcgen05MMAKind.F16
+epi_n = 32
+epi_row_elems = 32
+tile_swizzle_n = 0
+swizzle_l2_budget_bytes = 44214954
+num_gemms = 1
+num_a_operands = 1
+num_b_operands = 1
+gemm_a_idx = (0,)
+gemm_b_idx = (0,)
+num_tmem_alloc_cols = 512
+tmem_alloc_exclusive = False
+acc_stages = 2  # 256 acc cols/stage
+vec_bytes_epi = int(PARAMS.vec_bytes_epi)
+frost_compile_options = "--enable-tvm-ffi --gpu-arch sm_100a"
+n_tma_outputs = 1
+moe_aligned_offsets = False
+epi_slot_widen = 1
+epi_packed_lanes = False
+epi_dp22 = False
+epi_stage_rows = 128
+epi_chunk_elems = 32
+ab_stages = 6  # SMEM-D 16400B fixed + cast LOAD 0B/stage + multi-GEMM 0B/stage
+fallback_cluster_shape_mnk = None
+mixed_a_pattern_pref = 1
+mixed_b_pattern_pref = 1
+mixed_a_pattern_fb = 1
+mixed_b_pattern_fb = 1
 
 # Rank decomposition below uses shifts and masks instead of runtime integer
 # division.  The catalog satisfies this; keep synthesized configs from silently
@@ -139,23 +236,80 @@ def _b_collector_op(mi):
     return nvvm.Tcgen05MMACollectorOp.USE
 
 
+@cute.jit
+def _decode_bh(l, n_head):
+    """Flat CLC batch index -> ``(head, batch)``.
+
+    The CLC scheduler rasterizes ONE batch axis, so ``l`` stays flat there and
+    the tile hand-out is unchanged.  The pair is only needed where a TMA
+    coordinate is formed -- see the module docstring for why the tensors are
+    not flattened instead.
+    """
+    return l % n_head, l // n_head
+
+
+@cute.jit
+def _causal_k_range(coord_m_cgrp, num_k_tiles):
+    """The K-tile range this M tile may read, under stage 2's causal skip.
+
+    Stage 2 leaves the tiles above the diagonal UNWRITTEN, so this is first a
+    correctness bound and only then an optimization -- reading outside it reads
+    whatever was in the workspace.
+
+    Keyed on the CLUSTER's M tile base (``tile_m * cgrp_tile_m``), which is
+    identical on both CTAs of a pair, and rounded to ``causal_gran`` -- stage
+    2's own write granularity.  Rounding OUTWARD (down for the low bound, up for
+    the high one) is what keeps the range a subset of what stage 2 wrote while
+    still covering every structurally non-zero tile.
+    """
+    # num_k_tiles is Int64 (it derives from the Int64 `k`); normalise so the
+    # two bounds and the min() below share one numeric type.
+    nkt = cutlass.Int32(num_k_tiles)
+    if cutlass.const_expr(causal_mode == CAUSAL_K_NONE):
+        return cutlass.Int32(0), nkt
+    blk = cutlass.Int32(causal_gran)
+    tk = cutlass.Int32(cta_tile_mnk[2])
+    m0 = cutlass.Int32(coord_m_cgrp)
+    shift = cutlass.Int32(causal_shift)
+    # NEVER return an empty range. The mainloop would run zero iterations, but
+    # the EPILOGUE still stores the accumulator -- and `scale_d` starts False, so
+    # with no MMA the accumulator is uninitialised TMEM and the output row is
+    # garbage. One k-tile of a ZEROED workspace contributes exactly 0, which is
+    # the answer those rows want anyway (they are structurally masked out).
+    # This is why the caller must zero S/dS whenever the trim is active.
+    if cutlass.const_expr(causal_mode == CAUSAL_K_LO):
+        # dV / dK: output row is kv, so K (= q) starts at the stage-2 block
+        # holding kv -- pulled EARLIER by the shift, because S[q, kv] is
+        # non-zero for q >= kv - shift.  Clamped at 0.
+        lo = m0 - shift
+        lo = cute.math.max(lo, cutlass.Int32(0))
+        k_lo = ((lo // blk) * blk) // tk
+        return cute.math.min(k_lo, nkt - cutlass.Int32(1)), nkt
+    # dQ: output row is q, so K (= kv) ends after q's stage-2 block, pushed
+    # LATER by the shift (kv <= q + shift).
+    hi = ((m0 + cutlass.Int32(cgrp_tile_mnk[0] - 1) + shift) // blk + cutlass.Int32(1)) * blk
+    hi = cute.math.max(hi, blk)
+    k_hi = cute.math.min((hi + tk - cutlass.Int32(1)) // tk, nkt)
+    return cutlass.Int32(0), cute.math.max(k_hi, cutlass.Int32(1))
+
+
 @cute.kernel
-def _kernel(
+def _bprop_matmul_bh_sm100_kernel(
     m: cutlass.Int64,
     n: cutlass.Int64,
     k: cutlass.Int64,
-    # @@INJECT_KERNEL_AB_DESC_PARAMS@@
-    # @@INJECT_KERNEL_TAP_PARAMS@@
-    # @@INJECT_KERNEL_REDUCTION_STRIDE_PARAMS@@
-    # @@INJECT_KERNEL_AUX_PARAMS@@
-    # @@TMA_STORE_ONLY:BEGIN@@
-    # @@INJECT_KERNEL_TMA_C_PARAMS@@
-    # @@TMA_STORE_ONLY:END@@
+    tma_a_desc_0: cutlass.GridConstant[_tma.TensorMap],
+    tma_b_desc_0: cutlass.GridConstant[_tma.TensorMap],
+    out_stride_m_0: cutlass.Int64,
+    out_stride_n_0: cutlass.Int64,
+    out_stride_h_0: cutlass.Int64,
+    out_stride_b_0: cutlass.Int64,
+    n_head: cutlass.Int32,
+    tma_c_desc_0: cutlass.GridConstant[_tma.TensorMap],
 ) -> None:
-    # @@INJECT_AB_DESC_LISTS@@
-    # @@TMA_STORE_ONLY:BEGIN@@
-    # @@INJECT_TMA_C_LISTS@@
-    # @@TMA_STORE_ONLY:END@@
+    tma_a_descs = [tma_a_desc_0]
+    tma_b_descs = [tma_b_desc_0]
+    tma_c_descs = [tma_c_desc_0]
 
     mma_warp_id = 4
     tma_warp_id = 5
@@ -232,10 +386,8 @@ def _kernel(
         for _j in cutlass.range_constexpr(num_b_operands):
             nvvm.prefetch_tensormap(tma_b_descs[_j].get_ptr())
 
-        # @@TMA_STORE_ONLY:BEGIN@@
         for _ci in cutlass.range_constexpr(n_tma_outputs):
             nvvm.prefetch_tensormap(tma_c_descs[_ci].get_ptr())
-        # @@TMA_STORE_ONLY:END@@
 
     init_raw_m = bidx >> _preferred_cluster_m_shift
     init_raw_n = bidy >> _preferred_cluster_n_shift
@@ -329,7 +481,6 @@ def _kernel(
         for _ in range(num_b_operands)
     ]
 
-    # @@TMA_STORE_ONLY:BEGIN@@
     # One epilogue subtile = one MMA-M block x 32 cols; the M blocks reuse it.
     # The ring slot is indexed by `tidx`, so its row count is the EPILOGUE THREAD
     # count -- which is epi_tile_mn[0] only when the MMA M block is 128.
@@ -340,7 +491,6 @@ def _kernel(
         space=cutlass.AddressSpace.smem,
         alignment=1024,
     )
-    # @@TMA_STORE_ONLY:END@@
 
     acc_empty_count = num_epilogue_warps * cta_group
     if cutlass.const_expr(ab_empty_full_mask):
@@ -429,8 +579,6 @@ def _kernel(
         nvvm.barrier_cluster_wait()
         nvvm.barrier_cta_sync(0)
 
-    # @@INJECT_TAP_PTRS@@
-
     vsize = epi_chunk_elems
 
     M = m
@@ -507,6 +655,7 @@ def _kernel(
         tile_m = init_tile_m
         tile_n = init_tile_n
         tile_l = init_tile_l
+        tile_h, tile_b = _decode_bh(tile_l, n_head)
         tile_iter = cutlass.Int32(0)
         is_valid = cutlass.Int32(1)
         clc_full_phase_tma = cutlass.Int32(0)
@@ -516,16 +665,23 @@ def _kernel(
                 coord_n_per_cta = tile_n * cgrp_tile_n_cur + n_rank * cta_tile_mnk[1]
             else:
                 coord_n_per_cta = tile_n * cgrp_tile_n_cur + n_rank * logical_cta_tile_n + pair_member * cta_tile_mnk[1]
+            # Broadcast operands sit at (h, b) = (0, 0); batched ones carry the
+            # decoded pair.  Same const_expr shape as upstream, one coord wider.
             if cutlass.const_expr(matmul_a_batch == 1):
-                tile_l_a = cutlass.Int32(0)
+                tile_h_a = cutlass.Int32(0)
+                tile_b_a = cutlass.Int32(0)
             else:
-                tile_l_a = tile_l
+                tile_h_a = tile_h
+                tile_b_a = tile_b
             if cutlass.const_expr(matmul_b_batch == 1):
-                tile_l_b = cutlass.Int32(0)
+                tile_h_b = cutlass.Int32(0)
+                tile_b_b = cutlass.Int32(0)
             else:
-                tile_l_b = tile_l
+                tile_h_b = tile_h
+                tile_b_b = tile_b
 
-            for k_tile_idx in range(num_k_tiles):
+            k_begin, k_end = _causal_k_range(tile_m * cgrp_tile_m_cur, num_k_tiles)
+            for k_tile_idx in range(k_begin, k_end):
                 stage = ab_iter % ab_stages
                 if stage == 0 and ab_iter != 0:
                     ab_empty_phase_bit = ab_empty_phase_bit ^ 1
@@ -547,7 +703,7 @@ def _kernel(
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sA_stage.subview(n_rank * _a_rows * cta_tile_mnk[2]),
                                     tma_a_desc.get_ptr(),
-                                    (coord_k, coord_m_per_cta + n_rank * _a_rows, tile_l_a),
+                                    (coord_k, coord_m_per_cta + n_rank * _a_rows, tile_h_a, tile_b_a),
                                     ab_full_mbar_ptr.subview(stage),
                                     [],
                                     multicast_mask=tma_mcast_mask_a,
@@ -563,7 +719,7 @@ def _kernel(
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sA_stage.subview(_a_idx * _a_rows * cta_tile_mnk[2]),
                                         tma_a_desc.get_ptr(),
-                                        (coord_k, coord_m_per_cta + _a_idx * _a_rows, tile_l_a),
+                                        (coord_k, coord_m_per_cta + _a_idx * _a_rows, tile_h_a, tile_b_a),
                                         ab_full_mbar_ptr.subview(stage),
                                         [],
                                         multicast_mask=tma_mcast_mask_a,
@@ -580,7 +736,8 @@ def _kernel(
                                             (
                                                 coord_m_per_cta + m_group * a_tma_group_elems,
                                                 coord_k,
-                                                tile_l_a,
+                                                tile_h_a,
+                                                tile_b_a,
                                             ),
                                             ab_full_mbar_ptr.subview(stage),
                                             [],
@@ -592,7 +749,7 @@ def _kernel(
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sA_stage,
                                         tma_a_desc.get_ptr(),
-                                        (coord_k, coord_m_per_cta, tile_l_a),
+                                        (coord_k, coord_m_per_cta, tile_h_a, tile_b_a),
                                         ab_full_mbar_ptr.subview(stage),
                                         [],
                                         multicast_mask=tma_mcast_mask_a,
@@ -608,7 +765,8 @@ def _kernel(
                                         (
                                             coord_m_per_cta + m_group * a_tma_group_elems,
                                             coord_k,
-                                            tile_l_a,
+                                            tile_h_a,
+                                            tile_b_a,
                                         ),
                                         ab_full_mbar_ptr.subview(stage),
                                         [],
@@ -620,7 +778,7 @@ def _kernel(
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sA_stage,
                                     tma_a_desc.get_ptr(),
-                                    (coord_k, coord_m_per_cta, tile_l_a),
+                                    (coord_k, coord_m_per_cta, tile_h_a, tile_b_a),
                                     ab_full_mbar_ptr.subview(stage),
                                     [],
                                     multicast_mask=tma_mcast_mask_a,
@@ -637,7 +795,7 @@ def _kernel(
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sB_stage.subview(pair_m_idx * _b_rows * cta_tile_mnk[2]),
                                     tma_b_desc.get_ptr(),
-                                    (coord_k, coord_n_per_cta + pair_m_idx * _b_rows, tile_l_b),
+                                    (coord_k, coord_n_per_cta + pair_m_idx * _b_rows, tile_h_b, tile_b_b),
                                     ab_full_mbar_ptr.subview(stage),
                                     [],
                                     multicast_mask=tma_mcast_mask_b,
@@ -653,7 +811,7 @@ def _kernel(
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage.subview(_b_idx * _b_rows * cta_tile_mnk[2]),
                                         tma_b_desc.get_ptr(),
-                                        (coord_k, coord_n_per_cta + _b_idx * _b_rows, tile_l_b),
+                                        (coord_k, coord_n_per_cta + _b_idx * _b_rows, tile_h_b, tile_b_b),
                                         ab_full_mbar_ptr.subview(stage),
                                         [],
                                         multicast_mask=tma_mcast_mask_b,
@@ -670,7 +828,8 @@ def _kernel(
                                             (
                                                 coord_n_per_cta + n_group * b_tma_group_elems,
                                                 coord_k,
-                                                tile_l_b,
+                                                tile_h_b,
+                                                tile_b_b,
                                             ),
                                             ab_full_mbar_ptr.subview(stage),
                                             [],
@@ -682,7 +841,7 @@ def _kernel(
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage,
                                         tma_b_desc.get_ptr(),
-                                        (coord_k, coord_n_per_cta, tile_l_b),
+                                        (coord_k, coord_n_per_cta, tile_h_b, tile_b_b),
                                         ab_full_mbar_ptr.subview(stage),
                                         [],
                                         multicast_mask=tma_mcast_mask_b,
@@ -698,7 +857,8 @@ def _kernel(
                                         (
                                             coord_n_per_cta + n_group * b_tma_group_elems,
                                             coord_k,
-                                            tile_l_b,
+                                            tile_h_b,
+                                            tile_b_b,
                                         ),
                                         ab_full_mbar_ptr.subview(stage),
                                         [],
@@ -710,7 +870,7 @@ def _kernel(
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sB_stage,
                                     tma_b_desc.get_ptr(),
-                                    (coord_k, coord_n_per_cta, tile_l_b),
+                                    (coord_k, coord_n_per_cta, tile_h_b, tile_b_b),
                                     ab_full_mbar_ptr.subview(stage),
                                     [],
                                     multicast_mask=tma_mcast_mask_b,
@@ -750,6 +910,7 @@ def _kernel(
                 identity=tile_swizzle_n == 1,
             )
             tile_l = l_idx
+            tile_h, tile_b = _decode_bh(tile_l, n_head)
             nvvm.bar_warp_sync(0xFFFFFFFF)
             if elect_one:
                 empty_remote = nvvm.mapa(clc_empty_mbar_ptr.subview(consumer_stage), 0)
@@ -809,6 +970,9 @@ def _kernel(
             is_valid = cutlass.Int32(1)
             clc_full_phase_mma = cutlass.Int32(0)
             acc_stage = cutlass.Int32(0)
+            # The MMA warp tracks its own tile_m now: the causal K range depends on
+            # it, and this arm must walk exactly the range the TMA warp walks.
+            tile_m = init_tile_m
             # Descriptor metadata and the SMEM allocation base are invariant
             # across persistent tiles.  Only the encoded start address advances.
             desc_a_roots = [
@@ -856,8 +1020,12 @@ def _kernel(
                     for g in range(num_gemms)
                 ]
 
+                # Same range as the TMA producer above, or the ab ring
+                # desynchronises.  scale_d starts False here, so the accumulator
+                # is overwritten on the first k-block wherever the range begins.
+                k_begin, k_end = _causal_k_range(tile_m * cgrp_tile_m_cur, num_k_tiles)
                 scale_d = cutlass.Boolean(False)
-                for k_tile_idx in range(num_k_tiles):
+                for k_tile_idx in range(k_begin, k_end):
                     stage = ab_iter % ab_stages
                     if stage == 0 and ab_iter != 0:
                         ab_full_phase_bit = ab_full_phase_bit ^ 1
@@ -919,6 +1087,17 @@ def _kernel(
                 ):
                     pass
                 _m_idx, _n_idx, _l_idx, vld = cute_clc.clc_response(clc_response_ptr_base + consumer_stage)
+                mma_raw_m = _m_idx >> _preferred_cluster_m_shift
+                mma_raw_n = _n_idx >> _preferred_cluster_n_shift
+                mma_nt_m = gridx >> _preferred_cluster_m_shift
+                mma_nt_n = gridy >> _preferred_cluster_n_shift
+                if cutlass.const_expr(fallback_cluster_shape_mnk is not None):
+                    if (cluster_m != cluster_shape_mnk[0]) | (cluster_n != cluster_shape_mnk[1]):
+                        mma_raw_m = _m_idx >> _fallback_cluster_m_shift
+                        mma_raw_n = _n_idx >> _fallback_cluster_n_shift
+                        mma_nt_m = gridx >> _fallback_cluster_m_shift
+                        mma_nt_n = gridy >> _fallback_cluster_n_shift
+                tile_m, _tile_n_mma = _l2_swizzle_tile(mma_raw_m, mma_raw_n, mma_nt_m, mma_nt_n, swizzle_w, identity=tile_swizzle_n == 1)
                 cute.arch.fence_proxy("async.shared", space="cta")
                 is_valid = vld
                 nvvm.bar_warp_sync(0xFFFFFFFF)
@@ -1009,10 +1188,10 @@ def _kernel(
         tile_m = init_tile_m
         tile_n = init_tile_n
         tile_l = init_tile_l
+        tile_h, tile_b = _decode_bh(tile_l, n_head)
         is_valid = cutlass.Int32(1)
         clc_full_phase_epi = cutlass.Int32(0)
 
-        # @@EPILOGUE_SETUP:BEGIN@@
         if cutlass.const_expr(epi_packed_lanes):
             row_id_with_warp_offset = base_row_id
         else:
@@ -1027,15 +1206,11 @@ def _kernel(
             shape = nvvm.Tcgen05LdStShape.SHAPE_32X32B
             ld_half_off = None
         lane = tidx % 32
-        # @@EPILOGUE_SETUP:END@@
 
-        # @@TMA_STORE_ONLY:BEGIN@@
         epi_stage_idx = cutlass.Int32(EPI_SMEM_STAGES - 1)
-        # @@TMA_STORE_ONLY:END@@
 
         while is_valid != 0:
             coord_m_tile = tile_m * cgrp_tile_m_cur + m_rank * cta_tile_mnk[0]
-            # @@EPILOGUE_DRAIN:BEGIN@@
             coord_n_c = tile_n * cgrp_tile_n_cur + n_rank * pair_n_size
             if cutlass.const_expr(epi_dp22):
                 coord_n_c = coord_n_c + (warp_idx // 2) * epi_cols_per_mma_m
@@ -1063,8 +1238,6 @@ def _kernel(
                 else:
                     row = coord_m + tidx
                     row_active = True
-
-                # @@INJECT_AUX_VIEWS@@
 
                 for subtile_idx in cutlass.range_constexpr(subtile_cnt):
                     subtile_col_offset, subtile_w = epi_spans[subtile_idx]
@@ -1096,29 +1269,30 @@ def _kernel(
 
                     col = coord_n_c + subtile_col_offset
 
-                    # @@TMA_STORE_ONLY:BEGIN@@
                     vec_f32 = c_rmem_vec
                     col_j = col
-                    linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
+                    linear_idx = tile_b * out_stride_b_0 + tile_h * out_stride_h_0 + row * out_stride_m_0 + col_j * out_stride_n_0
 
-                    # @@INJECT_EPILOGUE@@
+                    _r_mm = (vec_f32).to(cutlass.BFloat16)
+                    vec_out = (_r_mm).to(cutlass.BFloat16)
 
-                    # @@INJECT_TMA_STORE_SEQUENCE@@
-                    # @@TMA_STORE_ONLY:END@@
+                    epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
+                    _tsv_0 = cutlass.Array(base=smem_d_ptr.data_ptr(epi_stage_idx * epi_subtile_elems), shape=4096, dtype=cutlass.BFloat16)
+                    _tsv_0.data_ptr(tidx * 32).store_swizzled(vec_out, alignment=64, swizzle=cutlass.Swizzle(2, 4, 3))
+                    cute.arch.fence_view_async_shared()
+                    nvvm.barrier_cta_sync(barrier_id=EPI_SYNC_BAR_ID, thread_count=num_epilogue_warps * 32)
+                    if warp_idx == 0:
+                        if elect_one:
+                            nvvm.cp_async_bulk_tensor_global_shared_cta(
+                                tma_c_descs[0].get_ptr(),
+                                _tsv_0.data_ptr(),
+                                (col, coord_m, tile_h, tile_b),
+                            )
+                        if elect_one:
+                            nvvm.cp_async_bulk_commit_group()
+                        nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
+                    nvvm.barrier_cta_sync(barrier_id=EPI_SYNC_BAR_ID, thread_count=num_epilogue_warps * 32)
 
-                    # @@STG_ONLY:BEGIN@@
-                    if row_active and row < M:
-                        for j in cutlass.range_constexpr(subtile_w // vsize):
-                            col_j = col + j * vsize
-                            if col_j + vsize <= N:
-                                vec_f32 = c_rmem_vec[j * vsize : (j + 1) * vsize]
-
-                                # @@INJECT_STG_VEC_BINDINGS@@
-
-                                # @@INJECT_EPILOGUE@@
-                    # @@STG_ONLY:END@@
-
-            # @@EPILOGUE_DRAIN:END@@
             consumer_stage = tile_iter % CLC_SCHED_STAGES
             if consumer_stage == 0 and tile_iter != 0:
                 clc_full_phase_epi = clc_full_phase_epi ^ 1
@@ -1150,6 +1324,7 @@ def _kernel(
                 identity=tile_swizzle_n == 1,
             )
             tile_l = l_idx
+            tile_h, tile_b = _decode_bh(tile_l, n_head)
             nvvm.bar_warp_sync(0xFFFFFFFF)
             if elect_one:
                 empty_remote = nvvm.mapa(clc_empty_mbar_ptr.subview(consumer_stage), 0)
@@ -1157,35 +1332,34 @@ def _kernel(
 
             tile_iter += 1
 
-        # @@TMA_STORE_ONLY:BEGIN@@
         if warp_idx == 0:
             nvvm.cp_async_bulk_wait_group(0, read=True)
-        # @@TMA_STORE_ONLY:END@@
 
     if warp_idx == unused_warp_id:
         nvvm.setmaxregister(prod_reg_count, nvvm.SetMaxRegisterAction.DECREASE)
 
 
-_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
-
-
 @cute.jit
 def _host(
     problem_size: tuple,
-    # @@INJECT_HOST_AB_PARAMS@@
-    # @@INJECT_HOST_TAP_PARAMS@@
-    # @@INJECT_HOST_AUX_PARAMS@@
-    # @@TMA_STORE_ONLY:BEGIN@@
-    # @@INJECT_HOST_TMA_C_PARAMS@@
-    # @@TMA_STORE_ONLY:END@@
+    a_0: cute.Tensor,
+    b_0: cute.Tensor,
+    c_0: cute.Tensor,
     stream: _cuda.CUstream,
 ) -> None:
-    # @@INJECT_HOST_AB_LISTS@@
+    _a_operands = [a_0]
+    _b_operands = [b_0]
     m = problem_size[0]
     n = problem_size[1]
     k_sym = problem_size[2]
-    batch = problem_size[3]
-    _stride_idx = 4
+    # The 2-D batch: (n_head, n_batch) where upstream carries one flat `batch`,
+    # and FOUR strides per operand (m/n, k, h, b) where upstream carries three.
+    # `batch` stays as the product because the CLC scheduler and the grid still
+    # rasterize one flat axis; only the TMA coordinates are 2-D.
+    n_head = problem_size[3]
+    n_batch = problem_size[4]
+    batch = n_head * n_batch
+    _stride_idx = 5
     _a_stride_sets = []
     for _ in cutlass.range_constexpr(num_a_operands):
         _a_stride_sets.append(
@@ -1193,9 +1367,10 @@ def _host(
                 problem_size[_stride_idx],
                 problem_size[_stride_idx + 1],
                 problem_size[_stride_idx + 2],
+                problem_size[_stride_idx + 3],
             )
         )
-        _stride_idx += 3
+        _stride_idx += 4
     _b_stride_sets = []
     for _ in cutlass.range_constexpr(num_b_operands):
         _b_stride_sets.append(
@@ -1203,34 +1378,41 @@ def _host(
                 problem_size[_stride_idx],
                 problem_size[_stride_idx + 1],
                 problem_size[_stride_idx + 2],
+                problem_size[_stride_idx + 3],
             )
         )
-        _stride_idx += 3
-    # @@INJECT_HOST_REDUCTION_STRIDES@@
+        _stride_idx += 4
+    out_stride_m_0 = problem_size[_stride_idx]
+    out_stride_n_0 = problem_size[_stride_idx + 1]
+    out_stride_h_0 = problem_size[_stride_idx + 2]
+    out_stride_b_0 = problem_size[_stride_idx + 3]
+    _stride_idx += 4
 
+    # A broadcast operand collapses BOTH batch extents, not just one.
     if cutlass.const_expr(matmul_a_batch == 1):
-        a_batch = 1
+        a_h, a_b = 1, 1
     else:
-        a_batch = batch
+        a_h, a_b = n_head, n_batch
     if cutlass.const_expr(matmul_b_batch == 1):
-        b_batch = 1
+        b_h, b_b = 1, 1
     else:
-        b_batch = batch
+        b_h, b_b = n_head, n_batch
 
     tma_a_desc_list = []
     for _a_idx, _a_op in enumerate(_a_operands):
-        a_stride_m, a_stride_k, a_stride_l = _a_stride_sets[_a_idx]
+        a_stride_m, a_stride_k, a_stride_h, a_stride_b = _a_stride_sets[_a_idx]
         if cutlass.const_expr(a_is_m_major):
             tma_a_desc_list.append(
                 _tma.create_tensor_map_tiled(
                     global_address=_a_op.iterator.toint(),
                     dtype=ab_tma_dtype,
-                    global_dims=[m, k_sym, a_batch],
+                    global_dims=[m, k_sym, a_h, a_b],
                     global_strides=[
                         a_stride_k * ab_dtype.width // 128,
-                        a_stride_l * ab_dtype.width // 128,
+                        a_stride_h * ab_dtype.width // 128,
+                        a_stride_b * ab_dtype.width // 128,
                     ],
-                    box_dims=[a_tma_group_elems, cta_tile_mnk[2], 1],
+                    box_dims=[a_tma_group_elems, cta_tile_mnk[2], 1, 1],
                     swizzle=ab_tma_swizzle,
                 )
             )
@@ -1239,29 +1421,31 @@ def _host(
                 _tma.create_tensor_map_tiled(
                     global_address=_a_op.iterator.toint(),
                     dtype=ab_tma_dtype,
-                    global_dims=[k_sym, m, a_batch],
+                    global_dims=[k_sym, m, a_h, a_b],
                     global_strides=[
                         a_stride_m * ab_dtype.width // 128,
-                        a_stride_l * ab_dtype.width // 128,
+                        a_stride_h * ab_dtype.width // 128,
+                        a_stride_b * ab_dtype.width // 128,
                     ],
-                    box_dims=[cta_tile_mnk[2], cta_tile_mnk[0] // a_mcast_slices, 1],
+                    box_dims=[cta_tile_mnk[2], cta_tile_mnk[0] // a_mcast_slices, 1, 1],
                     swizzle=ab_tma_swizzle,
                 )
             )
     tma_b_desc_list = []
     for _b_idx, _b_op in enumerate(_b_operands):
-        b_stride_n, b_stride_k, b_stride_l = _b_stride_sets[_b_idx]
+        b_stride_n, b_stride_k, b_stride_h, b_stride_b = _b_stride_sets[_b_idx]
         if cutlass.const_expr(b_is_n_major):
             tma_b_desc_list.append(
                 _tma.create_tensor_map_tiled(
                     global_address=_b_op.iterator.toint(),
                     dtype=ab_tma_dtype,
-                    global_dims=[n, k_sym, b_batch],
+                    global_dims=[n, k_sym, b_h, b_b],
                     global_strides=[
                         b_stride_k * ab_dtype.width // 128,
-                        b_stride_l * ab_dtype.width // 128,
+                        b_stride_h * ab_dtype.width // 128,
+                        b_stride_b * ab_dtype.width // 128,
                     ],
-                    box_dims=[b_tma_group_elems, cta_tile_mnk[2], 1],
+                    box_dims=[b_tma_group_elems, cta_tile_mnk[2], 1, 1],
                     swizzle=ab_tma_swizzle,
                 )
             )
@@ -1270,20 +1454,32 @@ def _host(
                 _tma.create_tensor_map_tiled(
                     global_address=_b_op.iterator.toint(),
                     dtype=ab_tma_dtype,
-                    global_dims=[k_sym, n, b_batch],
+                    global_dims=[k_sym, n, b_h, b_b],
                     global_strides=[
                         b_stride_n * ab_dtype.width // 128,
-                        b_stride_l * ab_dtype.width // 128,
+                        b_stride_h * ab_dtype.width // 128,
+                        b_stride_b * ab_dtype.width // 128,
                     ],
-                    box_dims=[cta_tile_mnk[2], cta_tile_mnk[1] // b_mcast_slices, 1],
+                    box_dims=[cta_tile_mnk[2], cta_tile_mnk[1] // b_mcast_slices, 1, 1],
                     swizzle=ab_tma_swizzle,
                 )
             )
 
-    # @@TMA_STORE_ONLY:BEGIN@@
-    # @@INJECT_HOST_TMA_C_LISTS@@
-    # @@INJECT_HOST_TMA_C_DESCS@@
-    # @@TMA_STORE_ONLY:END@@
+    _tma_c_outputs = [c_0]
+    _c0 = _tma_c_outputs[0]
+    tma_c_desc_0 = _tma.create_tensor_map_tiled(
+        global_address=_c0.iterator.toint(),
+        dtype=cutlass.BFloat16,
+        global_dims=[n, m, n_head, n_batch],
+        global_strides=[
+            out_stride_m_0 * 16 // 128,
+            out_stride_h_0 * 16 // 128,
+            out_stride_b_0 * 16 // 128,
+        ],
+        box_dims=[32, epi_tile_mn[0], 1, 1],
+        swizzle=_tma.TensorMapSwizzle.s64b,
+    )
+    tma_c_desc_list = [tma_c_desc_0]
 
     cluster_m = cluster_shape_mnk[0]
     cluster_n = cluster_shape_mnk[1]
@@ -1294,17 +1490,18 @@ def _host(
     grid_x = num_tile_m_host * cluster_m
     grid_y = num_tile_n_host * cluster_n
     grid_shape = (grid_x, grid_y, batch)
-    launch = _kernel(
+    launch = _bprop_matmul_bh_sm100_kernel(
         problem_size[0],
         problem_size[1],
         problem_size[2],
-        # @@INJECT_HOST_KERNEL_DESC_PASS@@
-        # @@INJECT_HOST_TAP_PASS@@
-        # @@INJECT_HOST_REDUCTION_STRIDE_PASS@@
-        # @@INJECT_HOST_AUX_PASS@@
-        # @@TMA_STORE_ONLY:BEGIN@@
-        # @@INJECT_HOST_TMA_C_PASS@@
-        # @@TMA_STORE_ONLY:END@@
+        tma_a_desc_list[0],
+        tma_b_desc_list[0],
+        out_stride_m_0,
+        out_stride_n_0,
+        out_stride_h_0,
+        out_stride_b_0,
+        n_head,
+        tma_c_desc_list[0],
     )
     # Mixed CGA: `cluster` is the preferred (wide) shape and `fallback_cluster`
     # the regular one the device groups blocks into when a preferred cluster does
@@ -1339,47 +1536,50 @@ def compile() -> Callable:
     # extent makes a partial box HW zero-filled. The only real K rule is the 16-byte
     # TMA contiguous-extent one, already gated by _tma_alignment_reject.
     sym_k = cute.sym_int64()
-    sym_l = cute.sym_int64()
+    # Two symbolic batch extents instead of one flat `sym_l`.
+    sym_h = cute.sym_int64()
+    sym_b = cute.sym_int64()
     if matmul_a_batch == 1:
-        sym_a_l = 1
+        sym_a_h, sym_a_b = 1, 1
     else:
-        sym_a_l = sym_l
+        sym_a_h, sym_a_b = sym_h, sym_b
     if matmul_b_batch == 1:
-        sym_b_l = 1
+        sym_b_h, sym_b_b = 1, 1
     else:
-        sym_b_l = sym_l
+        sym_b_h, sym_b_b = sym_h, sym_b
 
     def _make_fake_a():
         return make_fake_compact_tensor(
             mma_a_dtype,
-            (sym_m, sym_k, sym_a_l),
-            stride_order=(0, 1, 2) if a_is_m_major else (1, 0, 2),
+            (sym_m, sym_k, sym_a_h, sym_a_b),
+            stride_order=(0, 1, 2, 3) if a_is_m_major else (1, 0, 2, 3),
             assumed_align=16,
         )
 
     def _make_fake_b():
         return make_fake_compact_tensor(
             mma_b_dtype,
-            (sym_n, sym_k, sym_b_l),
-            stride_order=(0, 1, 2) if b_is_n_major else (1, 0, 2),
+            (sym_n, sym_k, sym_b_h, sym_b_b),
+            stride_order=(0, 1, 2, 3) if b_is_n_major else (1, 0, 2, 3),
             assumed_align=16,
         )
 
-    # @@TMA_STORE_ONLY:BEGIN@@
     def _make_fake_c(_dt, _div, _mm):
         return make_fake_compact_tensor(
             _dt,
-            (sym_m, sym_n // _div, sym_l),
-            stride_order=(0, 1, 2) if _mm else (1, 0, 2),
+            (sym_m, sym_n // _div, sym_h, sym_b),
+            stride_order=(0, 1, 2, 3) if _mm else (1, 0, 2, 3),
             assumed_align=16,
         )
 
-    # @@INJECT_COMPILE_TMA_C_FAKES@@
-    # @@TMA_STORE_ONLY:END@@
+    fake_c_0 = _make_fake_c(cutlass.BFloat16, 1, False)
+
     def _sym_operand_strides(is_mn_major: bool) -> tuple:
-        # Operand is permuted to (M|N, K, L): the unit stride is mode 0 when MN-major, mode 1 when K-major, and never reaches TMA.
+        # Operand is permuted to (M|N, K, H, B): the unit stride is mode 0 when
+        # MN-major, mode 1 when K-major, and never reaches TMA.  Four modes now,
+        # since the batch is the (h, b) pair.
         unit = 0 if is_mn_major else 1
-        return tuple(cute.sym_int64() if i == unit else cute.sym_int64(divisibility=ab_stride_elems) for i in range(3))
+        return tuple(cute.sym_int64() if i == unit else cute.sym_int64(divisibility=ab_stride_elems) for i in range(4))
 
     sym_a_strides = []
     for _ in range(num_a_operands):
@@ -1387,29 +1587,71 @@ def compile() -> Callable:
     sym_b_strides = []
     for _ in range(num_b_operands):
         sym_b_strides.extend(_sym_operand_strides(b_is_n_major))
-    # @@INJECT_COMPILE_REDUCTION_STRIDE_DECLS@@
-    # @@INJECT_COMPILE_AB_FAKES@@
-    # @@INJECT_COMPILE_TAP_FAKES@@
+    sym_out_stride_m_0 = cute.sym_int64()
+    sym_out_stride_n_0 = cute.sym_int64()
+    sym_out_stride_h_0 = cute.sym_int64()
+    sym_out_stride_b_0 = cute.sym_int64()
+    fake_a_0 = _make_fake_a()
+    fake_b_0 = _make_fake_b()
     problem_size = (
         sym_m,
         sym_n,
         sym_k,
-        sym_l,
+        sym_h,
+        sym_b,
         *sym_a_strides,
         *sym_b_strides,
-        # @@INJECT_COMPILE_REDUCTION_STRIDE_SYMBOLS@@
+        sym_out_stride_m_0,
+        sym_out_stride_n_0,
+        sym_out_stride_h_0,
+        sym_out_stride_b_0,
     )
-    # @@INJECT_COMPILE_AUX_FAKES@@
     _fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
     return cute.compile(
         _host,
         problem_size,
-        # @@INJECT_COMPILE_AB_PASS@@
-        # @@INJECT_COMPILE_TAP_PASS@@
-        # @@INJECT_COMPILE_AUX_PASS@@
-        # @@TMA_STORE_ONLY:BEGIN@@
-        # @@INJECT_COMPILE_TMA_C_PASS@@
-        # @@TMA_STORE_ONLY:END@@
+        fake_a_0,
+        fake_b_0,
+        fake_c_0,
         stream=_fake_stream,
         options=frost_compile_options,
     )
+
+
+# ---------------------------------------------------------------------------
+# SDPA-backward stage 3: the three gradient GEMMs over a 2-D (batch, head) batch
+# ---------------------------------------------------------------------------
+
+
+def _permuted(t, mn_dim: int, k_dim: int, h_dim: int, b_dim: int):
+    """Permute a caller tensor to the kernel's ``(M|N, K, H, B)`` operand order.
+
+    A view, never a copy -- which is the point of the 4-D descriptor: the
+    workspace is measured in GiB and a per-chunk normalising copy would cost
+    more than the GEMM.  The strides ride to the kernel through
+    ``problem_size``, so any layout the permutation can express is legal.
+    """
+    return t.permute(mn_dim, k_dim, h_dim, b_dim)
+
+
+def matmul_bh(a, b, out, *, n_head: int, n_batch: int, stream=None):
+    """Run one ``(batch, head)``-batched GEMM.
+
+    ``a`` / ``b`` / ``out`` are already permuted to ``(M|N, K, H, B)`` /
+    ``(M, N, H, B)``.  M, N, K and every stride are runtime values, so one
+    compiled artifact serves every stage-3 shape at a given dtype and layout.
+    """
+    fn = compile()
+    m, k = int(a.shape[0]), int(a.shape[1])
+    n = int(b.shape[0])
+    problem_size = (
+        m,
+        n,
+        k,
+        n_head,
+        n_batch,
+        *(int(s) for s in a.stride()),
+        *(int(s) for s in b.stride()),
+        *(int(s) for s in out.stride()),
+    )
+    return fn(problem_size, a, b, out, stream=stream)

--- a/python/cudnn/sdpa/bwd/kernels/bprop_matmul_sm100.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_matmul_sm100.py
@@ -63,9 +63,17 @@ from cutlass.cute.runtime import make_fake_stream
 from cuda.bindings import driver as _cuda
 from cutlass.cute.arch import clc as cute_clc
 
-from cudnn.sdpa.bwd.config_sm100 import CAUSAL_K_HI, CAUSAL_K_LO, CAUSAL_K_NONE, MatmulTemplateParams
+from cudnn.frost.tile_dsl.constants import DTYPE_FP16
+from cudnn.sdpa.bwd.config_sm100 import CAUSAL_K_HI, CAUSAL_K_LO, CAUSAL_K_NONE, MatmulTemplateParams, validate_matmul_params
 
 PARAMS = globals().get("FROST_TEMPLATE_PARAMS", MatmulTemplateParams())
+validate_matmul_params(PARAMS)
+
+# A/B/D io dtype.  BF16 and FP16 are both 2 B/element and both take the
+# Tcgen05MMAKind.F16 path, so this is a token swap: nothing byte-sized below
+# changes.  It must agree with the stage-2 template's `dtype_qkv` -- stage 3
+# reads the S/dS workspace stage 2 wrote.
+_IO_DTYPE = cutlass.Float16 if int(PARAMS.dtype_qkv) == DTYPE_FP16 else cutlass.BFloat16
 
 # Tile config: CONFIG_sm100_256x256x128_128x256x32_cluster2x2_2ctamma
 # (was ...cluster2x1...; swapped on request. Every constant below is lifted
@@ -130,14 +138,15 @@ mma_size_n = 1
 mma_size_k = 4
 ab_tma_swizzle = _tma.TensorMapSwizzle.s128b
 
-# Dtype family: A=bf16->MMAbf16, B=bf16->MMAbf16, out=bf16 (K_BYTES=128)
-ab_dtype = cutlass.BFloat16
-cd_dtype = cutlass.BFloat16
-mma_a_dtype = cutlass.BFloat16
-mma_b_dtype = cutlass.BFloat16
+# Dtype family: A=f16->MMAf16, B=f16->MMAf16, out=f16 (K_BYTES=128).
+# `_IO_DTYPE` is BF16 or FP16 per PARAMS.dtype_qkv; the MMA kind is the same.
+ab_dtype = _IO_DTYPE
+cd_dtype = _IO_DTYPE
+mma_a_dtype = _IO_DTYPE
+mma_b_dtype = _IO_DTYPE
 mma_c_dtype = cutlass.Float32
 acc_widen_to_fp32 = False
-ab_tma_dtype = cutlass.BFloat16
+ab_tma_dtype = _IO_DTYPE
 mma_kind = nvvm.Tcgen05MMAKind.F16
 epi_n = 64
 epi_row_elems = 64
@@ -1307,11 +1316,11 @@ def _bprop_matmul_bh_sm100_kernel(
                     col_j = col
                     linear_idx = tile_b * out_stride_b_0 + tile_h * out_stride_h_0 + row * out_stride_m_0 + col_j * out_stride_n_0
 
-                    _r_mm = (vec_f32).to(cutlass.BFloat16)
-                    vec_out = (_r_mm).to(cutlass.BFloat16)
+                    _r_mm = (vec_f32).to(cd_dtype)
+                    vec_out = (_r_mm).to(cd_dtype)
 
                     epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                    _tsv_0 = cutlass.Array(base=smem_d_ptr.data_ptr(epi_stage_idx * epi_subtile_elems), shape=8192, dtype=cutlass.BFloat16)
+                    _tsv_0 = cutlass.Array(base=smem_d_ptr.data_ptr(epi_stage_idx * epi_subtile_elems), shape=8192, dtype=cd_dtype)
                     _tsv_0.data_ptr(tidx * 64).store_swizzled(vec_out, alignment=128, swizzle=cutlass.Swizzle(3, 4, 3))
                     cute.arch.fence_view_async_shared()
                     nvvm.barrier_cta_sync(barrier_id=EPI_SYNC_BAR_ID, thread_count=num_epilogue_warps * 32)
@@ -1503,12 +1512,14 @@ def _host(
     _c0 = _tma_c_outputs[0]
     tma_c_desc_0 = _tma.create_tensor_map_tiled(
         global_address=_c0.iterator.toint(),
-        dtype=cutlass.BFloat16,
+        dtype=cd_dtype,
         global_dims=[n, m, n_head, n_batch],
         global_strides=[
-            out_stride_m_0 * 16 // 128,
-            out_stride_h_0 * 16 // 128,
-            out_stride_b_0 * 16 // 128,
+            # `cd_dtype.width`, not a literal 16: the A/B descriptors above already
+            # derive it, and this one is now dtype-parameterized too.
+            out_stride_m_0 * cd_dtype.width // 128,
+            out_stride_h_0 * cd_dtype.width // 128,
+            out_stride_b_0 * cd_dtype.width // 128,
         ],
         box_dims=[64, epi_tile_mn[0], 1, 1],
         swizzle=_tma.TensorMapSwizzle.s128b,
@@ -1606,7 +1617,7 @@ def compile() -> Callable:
             assumed_align=16,
         )
 
-    fake_c_0 = _make_fake_c(cutlass.BFloat16, 1, False)
+    fake_c_0 = _make_fake_c(cd_dtype, 1, False)
 
     def _sym_operand_strides(is_mn_major: bool) -> tuple:
         # Operand is permuted to (M|N, K, H, B): the unit stride is mode 0 when

--- a/python/cudnn/sdpa/bwd/kernels/bprop_matmul_sm100.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_matmul_sm100.py
@@ -67,14 +67,16 @@ from cudnn.sdpa.bwd.config_sm100 import CAUSAL_K_HI, CAUSAL_K_LO, CAUSAL_K_NONE,
 
 PARAMS = globals().get("FROST_TEMPLATE_PARAMS", MatmulTemplateParams())
 
-# Tile config: CONFIG_sm100_128x256x128_128x256x32_cluster2x1_2ctamma
+# Tile config: CONFIG_sm100_256x256x128_128x256x32_cluster2x2_2ctamma
+# (was ...cluster2x1...; swapped on request. Every constant below is lifted
+# verbatim from the upstream rendering of THIS config -- do not hand-derive.)
 mma_inst_shape_mnk = (256, 256, 16)
 cta_group = 2
-cgrp_tile_mnk = (256, 256, 64)
-cta_tile_mnk = (128, 128, 64)
-epi_tile_mn = (128, 32)
+cgrp_tile_mnk = (512, 512, 64)
+cta_tile_mnk = (256, 128, 64)
+epi_tile_mn = (128, 64)
 threads_per_cta = 256
-cluster_shape_mnk = (2, 1, 1)
+cluster_shape_mnk = (2, 2, 1)
 # Upstream carries the rendering's batch size here purely to detect a BROADCAST
 # operand (== 1 means "one batch element, reuse it for all"). No stage-3 GEMM
 # broadcasts, so both are simply "batched"; the real extents are runtime.
@@ -97,13 +99,18 @@ causal_gran = int(PARAMS.causal_gran)
 causal_shift = int(PARAMS.causal_shift)
 mma_a_major = 1 if a_is_m_major else 0
 mma_b_major = 1 if b_is_n_major else 0
-ab_stages = 7
+ab_stages = 4
 b_collector_ok = False
-multicast_a = False
+multicast_a = True
 multicast_b = False
-a_mcast_slices = 1
+# Under a cluster with cga_n > 1 the A operand's MULTICAST also follows its
+# major -- a K-major A is split across the cluster's N columns (2 slices) while
+# an M-major A is broadcast whole. That was invisible at cluster2x1, where both
+# are 1, and it is why this table cannot be reused across cluster shapes
+# unchanged. Values lifted from the two upstream renderings of this config.
+_A_MCAST = {False: (2, False), True: (1, True)}  # is_m_major: (slices, empty_full_mask)
+a_mcast_slices, ab_empty_full_mask = _A_MCAST[a_is_m_major]
 b_mcast_slices = 1
-ab_empty_full_mask = False
 ab_smem_swizzle = cutlass.experimental.primitives.Tcgen05SmemSwizzle.SWIZZLE_128B
 # MN-major packs 64 elements per TMA group and walks K in 2048-byte steps;
 # K-major loads one group and steps 32 bytes.  Values lifted verbatim from the
@@ -118,7 +125,7 @@ b_smem_desc_leading_byte_offset, b_smem_k_step_bytes, b_tma_group_elems = _MAJOR
 a_smem_desc_stride_byte_offset = 1024
 b_smem_desc_stride_byte_offset = 1024
 a_smem_m_step_bytes = 16384
-mma_size_m = 1
+mma_size_m = 2
 mma_size_n = 1
 mma_size_k = 4
 ab_tma_swizzle = _tma.TensorMapSwizzle.s128b
@@ -132,9 +139,9 @@ mma_c_dtype = cutlass.Float32
 acc_widen_to_fp32 = False
 ab_tma_dtype = cutlass.BFloat16
 mma_kind = nvvm.Tcgen05MMAKind.F16
-epi_n = 32
-epi_row_elems = 32
-tile_swizzle_n = 0
+epi_n = 64
+epi_row_elems = 64
+tile_swizzle_n = 1
 swizzle_l2_budget_bytes = 44214954
 num_gemms = 1
 num_a_operands = 1
@@ -143,7 +150,7 @@ gemm_a_idx = (0,)
 gemm_b_idx = (0,)
 num_tmem_alloc_cols = 512
 tmem_alloc_exclusive = False
-acc_stages = 2  # 256 acc cols/stage
+acc_stages = 1  # 512 acc cols/stage
 vec_bytes_epi = int(PARAMS.vec_bytes_epi)
 frost_compile_options = "--enable-tvm-ffi --gpu-arch sm_100a"
 n_tma_outputs = 1
@@ -152,10 +159,16 @@ epi_slot_widen = 1
 epi_packed_lanes = False
 epi_dp22 = False
 epi_stage_rows = 128
-epi_chunk_elems = 32
-ab_stages = 6  # SMEM-D 16400B fixed + cast LOAD 0B/stage + multi-GEMM 0B/stage
+epi_chunk_elems = 64
+ab_stages = 4  # SMEM-D 32784B fixed + cast LOAD 0B/stage + multi-GEMM 0B/stage
+# Upstream renders (2, 1, 1) here -- a mixed-CGA fallback the driver may pick
+# per cluster when the preferred shape does not fit. Pinned to None in this
+# fork: `_host` always sizes the grid as a multiple of the preferred cluster, so
+# the fallback is unreachable by construction, and its paths carry their own
+# coordinate/multicast logic that the 2-D (b, h) batch rewrite has never
+# exercised.
 fallback_cluster_shape_mnk = None
-mixed_a_pattern_pref = 1
+mixed_a_pattern_pref = 5
 mixed_b_pattern_pref = 1
 mixed_a_pattern_fb = 1
 mixed_b_pattern_fb = 1
@@ -252,15 +265,36 @@ def _decode_bh(l, n_head):
 def _causal_k_range(coord_m_cgrp, num_k_tiles):
     """The K-tile range this M tile may read, under stage 2's causal skip.
 
-    Stage 2 leaves the tiles above the diagonal UNWRITTEN, so this is first a
-    correctness bound and only then an optimization -- reading outside it reads
-    whatever was in the workspace.
+    Stage 2 leaves the tiles above the diagonal UNWRITTEN, so what is outside
+    this range is whatever the caller left in the workspace.
+
+    Whether that makes the range a CORRECTNESS bound or only an optimization
+    depends on the tight-trim invariant::
+
+        cgrp_tile_mnk[0] <= causal_gran
+
+    i.e. one cluster M tile fits inside one stage-2 write block. It HELD at the
+    2x1 cluster config (256 <= 256) and does NOT hold at the 2x2 config now in
+    use (512 > 256): a 512-row M tile straddles two 256-row stage-2 blocks, and
+    since the bounds below are per-tile, no range can cover the tile's live rows
+    without also covering its neighbour's skipped ones.
+
+    So at 2x2 this is an OPTIMIZATION ONLY, and the caller's zero-fill is what
+    makes it correct -- `api_dsl` sets `_zero_ws` whenever the trim is active,
+    which is exactly the condition under which any of this runs. Do not weaken
+    that zero-fill to "only when shift != 0" on the theory that the trim
+    protects the aligned case; at 2x2 it does not.
+
+    The 2x2 config is kept despite the looser trim because it measures faster
+    BOTH ways at B=1 H=128 S=8192 d=512 bf16: +3.5% no_mask, +7.8% causal (the
+    wider tile more than pays for the extra k-tiles it reads).
 
     Keyed on the CLUSTER's M tile base (``tile_m * cgrp_tile_m``), which is
     identical on both CTAs of a pair, and rounded to ``causal_gran`` -- stage
     2's own write granularity.  Rounding OUTWARD (down for the low bound, up for
-    the high one) is what keeps the range a subset of what stage 2 wrote while
-    still covering every structurally non-zero tile.
+    the high one) is what keeps the range covering every structurally non-zero
+    tile; under the tight-trim invariant that outward rounding also keeps it a
+    subset of what stage 2 wrote.
     """
     # num_k_tiles is Int64 (it derives from the Int64 `k`); normalise so the
     # two bounds and the min() below share one numeric type.
@@ -1277,8 +1311,8 @@ def _bprop_matmul_bh_sm100_kernel(
                     vec_out = (_r_mm).to(cutlass.BFloat16)
 
                     epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                    _tsv_0 = cutlass.Array(base=smem_d_ptr.data_ptr(epi_stage_idx * epi_subtile_elems), shape=4096, dtype=cutlass.BFloat16)
-                    _tsv_0.data_ptr(tidx * 32).store_swizzled(vec_out, alignment=64, swizzle=cutlass.Swizzle(2, 4, 3))
+                    _tsv_0 = cutlass.Array(base=smem_d_ptr.data_ptr(epi_stage_idx * epi_subtile_elems), shape=8192, dtype=cutlass.BFloat16)
+                    _tsv_0.data_ptr(tidx * 64).store_swizzled(vec_out, alignment=128, swizzle=cutlass.Swizzle(3, 4, 3))
                     cute.arch.fence_view_async_shared()
                     nvvm.barrier_cta_sync(barrier_id=EPI_SYNC_BAR_ID, thread_count=num_epilogue_warps * 32)
                     if warp_idx == 0:
@@ -1476,8 +1510,8 @@ def _host(
             out_stride_h_0 * 16 // 128,
             out_stride_b_0 * 16 // 128,
         ],
-        box_dims=[32, epi_tile_mn[0], 1, 1],
-        swizzle=_tma.TensorMapSwizzle.s64b,
+        box_dims=[64, epi_tile_mn[0], 1, 1],
+        swizzle=_tma.TensorMapSwizzle.s128b,
     )
     tma_c_desc_list = [tma_c_desc_0]
 

--- a/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
+++ b/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
@@ -33,24 +33,34 @@ plan time · — not applicable · ⁿ footnote.
 ## SM100 / SM103 (Blackwell, cc 10.0–10.6)
 
 Engines: `sdpa_fwd_prefill_sm100` (f16/bf16), `sdpa_fwd_prefill_sm100_fp8`,
-`sdpa_fwd_prefill_sm100_mxfp8`. **No backward engine on SM100** — an
-`sdpa_backward()` graph falls through to the cuDNN backend.
+`sdpa_fwd_prefill_sm100_mxfp8`, `sdpa_bwd_sm100`. The backward engine serves
+**only the large-head-dim band, d ∈ (256, 512]** — every other
+`sdpa_backward()` shape still falls through to the cuDNN backend.
+
+The backward is a **three-stage chain**, not one fused kernel: a fused d=512
+backward needs 512 TMEM columns for dV and 512 more for dK against 512 per CTA,
+so S and dS go to a GMEM workspace and the gradients are three batched GEMMs
+over it (`do_dot` → `bprop_d512_f16_sm100` → `bprop_matmul_sm100`). Two
+consequences a user can see: the workspace is `2·B·H_chunk·S_q·S_kv·2 B` (the
+host loops over head chunks to hold it under 4 GiB), and everything in the band
+is **envelope-served** — the tiles are fixed at 512, so d=264 costs the same
+MMA as d=512.
 
 | Feature | d64 (GPT-OSS)<br>FPROP | d128 (Llama)<br>FPROP | d192×d128 (DSv3 MLA)<br>FPROP | d256 (Qwen)<br>FPROP | d512 (DSv4)<br>FPROP | BPROP |
 |---|:--:|:--:|:--:|:--:|:--:|:--:|
 | **Data types** | | | | | | |
-| FP16 / BF16 | ⚠️⁷ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| FP16 / BF16 | ⚠️⁷ | ✅ | ✅ | ✅ | ✅ | ✅ᵇ |
 | FP8 E4M3 / E5M2 (per-tensor descale) | ⚠️⁷ | ✅ | ✅ | ❌ | ✅ | ❌ |
 | MXFP8 (E4M3/E5M2 + per-32 E8M0 SF) | ❌⁸ | ✅ | ✅ | ❌ | ❌ | ❌ |
 | O dtype ≠ QKV dtype — **quantized graphs only**¹ | ✅ | ✅ | ✅ | — | ✅ | — |
 | Head-dim envelope (zero-padded below native) | **none — runs the d128 kernel**⁷ | f16 ×8 · fp8 ×16 · mxfp8 exact | f16 ×8 · fp8 ×16 · mxfp8 exact | f16 ×8 | f16 ×8 · fp8 ×16, floor 256² | — |
 | **Layout** | | | | | | |
-| BSHD | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| Arbitrary dense B/H/S stride order (`dense_flex`) | f16 only | f16 only | f16 only | ✅ | f16 only | ❌ |
+| BSHD | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ᵇ |
+| Arbitrary dense B/H/S stride order (`dense_flex`) | f16 only | f16 only | f16 only | ✅ | f16 only | ✅ᵇ ᶜ |
 | THD / ragged (packed varlen) | f16 only⁹ | ✅ | f16 only³ | ✅ | f16 + fp8³ | ❌ |
 | `cu_seq_len_q/kv` prefix sums (THD only) | f16 only⁹ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | **Masks / features** | | | | | | |
-| Causal (top-left) | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Causal (top-left) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ᵇ ᵈ |
 | Causal bottom-right | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | Causal right-band widening | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | Sliding window (left) | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
@@ -84,6 +94,23 @@ supported head tile) — SM100 is the gap.
 ⁸ MXFP8 sets `d_pad_multiple=0` (exact native shapes only — the scale-factor
 plumbing is not audited for envelope zero-padding), so a d=64 MXFP8 graph is
 declined at plan time rather than padded.
+ᵇ **`sdpa_bwd_sm100` only — d ∈ (256, 512], multiples of 8, f16/bf16.** Read
+this column as "the backward engine, which happens to live at the d512 end of
+the row"; it does NOT follow the per-flavor columns to its left. Below 257 the
+d256 flavors are the right kernel and the engine declines. The whole band is
+**envelope-served** on 512-wide tiles, so d=264 pays d=512's MMA cost. Multiples
+of 8 rather than the forward's 16: the stage-3 epilogue narrows its store vector
+from 32 B to 16 B when d is not also a multiple of 16.
+ᶜ A non-BSHD io tensor is staged through the workspace (one copy in, and one
+back out for a gradient); a BSHD-physical one is used in place. This is not
+hypothetical — building dO as `torch.randn(o.shape)` instead of
+`torch.empty_like(o)` loses o's memory format and yields a BHSD-contiguous dO.
+ᵈ Top-left only. Bottom-right is declined because under `S_kv < S_q` the leading
+q tiles get an EMPTY kv range and this kernel has no empty-tile path — every
+cross-CTA ring would need a bookkeeping arrive to keep the four CTAs in step.
+Causal also skips whole kv tiles above the diagonal (~44 % of them at S=2048),
+which means those workspace tiles are never written and stage 3 must trim its K
+range to match — a correctness requirement, not just an optimization.
 ⁹ `thd_d_shapes` is an **exact** membership test, not an envelope: the
 quantized rows list `{(128,128), (512,512)}` (per-tensor) / `{(128,128)}`
 (MXFP8), so d=64 **THD on FP8/MXFP8 is declined**. f16/bf16 THD rides the
@@ -207,7 +234,10 @@ feature-free d=64 graph.
 
 | Missing | Where |
 |---|---|
-| Backward pass entirely | SM100, SM103, SM107 |
+| Backward pass entirely | SM107 |
+| Backward outside d ∈ (256, 512] | SM100, SM103 — the only backward engine there serves that band |
+| Backward GQA / MQA (`H_q ≠ H_kv`) | SM100, SM103 (the `dkv_reduce` group reduce is not wired to it yet) |
+| Backward SWA / padding / bottom-right causal | SM100, SM103 |
 | f16/bf16 forward | SM107 (Rubin) |
 | MXFP8 forward | SM107, SM120, SM80 |
 | FP8 / MXFP8 backward | every arch |

--- a/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
+++ b/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
@@ -61,15 +61,16 @@ MMA as d=512.
 | `cu_seq_len_q/kv` prefix sums (THD only) | f16 only⁹ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | **Masks / features** | | | | | | |
 | Causal (top-left) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ᵇ ᵈ |
-| Causal bottom-right | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| Causal right-band widening | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| Sliding window (left) | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Causal bottom-right | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ᵇ ᵈ |
+| Causal right-band widening | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ᵇ |
+| Sliding window (left) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ᵇ |
 | Padding mask (`seq_len_q/kv`) | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | Padding mask + stats (per-batch LSE trim) | ✅ | f16/fp8 only⁴ | f16/fp8 only⁴ | ✅ | f16/fp8 only⁴ | ❌ |
 | Dense padded-Q trim (O:=0, LSE:=−inf) | f16 only⁵ | f16 only⁵ | f16 only⁵ | ✅ | f16 only⁵ | ❌ |
 | Attention sink | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| GQA / MQA (`H_q ≠ H_kv`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ᵇ ᶠ |
 | Bias / dBias | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Ragged `S_kv` (non-multiple of 128) | ✅⁶ | ✅⁶ | ✅⁶ | ✅⁶ | ✅⁶ | ❌ |
+| Ragged `S_kv` (non-multiple of 128) | ✅⁶ | ✅⁶ | ✅⁶ | ✅⁶ | ✅⁶ | ✅ᵇ ᵉ |
 | Decode-shaped (`S_q == 1`) | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 
 ¹ **Reads as: on a quantized (fp8/mxfp8) graph in this column, O may be FP16,
@@ -105,9 +106,17 @@ from 32 B to 16 B when d is not also a multiple of 16.
 back out for a gradient); a BSHD-physical one is used in place. This is not
 hypothetical — building dO as `torch.randn(o.shape)` instead of
 `torch.empty_like(o)` loses o's memory format and yields a BHSD-contiguous dO.
-ᵈ Top-left only. Bottom-right is declined because under `S_kv < S_q` the leading
-q tiles get an EMPTY kv range and this kernel has no empty-tile path — every
-cross-CTA ring would need a bookkeeping arrive to keep the four CTAs in step.
+ᵉ **Any S_q and S_kv, not just tile multiples.** The engine rounds the COMPILE
+shape up to the tile (256 in q, 128 in kv), lets stage 2 compute the tail and
+mask it, and hands stage 3 a real-extent slice so the padding never reaches a
+GEMM's M/N/K. Note this is the UNIFORM length only -- a per-batch
+`seq_len_q/kv` padding mask is still declined (`padded=False`).
+ᶠ dK/dV are accumulated as one partial per Q head and folded onto the KV heads
+by the shared `dkv_reduce` kernel (deterministic, fixed-order fp32). dQ runs one
+GEMM per group member so the shared K head lines up without an expand or a copy.
+The head chunk is forced to a multiple of the group.
+ᵈ Top-left AND bottom-right. The empty kv range bottom-right admits needs no
+special path: every ring is per-kv-iteration, so a zero-trip loop fires nothing.
 Causal also skips whole kv tiles above the diagonal (~44 % of them at S=2048),
 which means those workspace tiles are never written and stage 3 must trim its K
 range to match — a correctness requirement, not just an optimization.
@@ -236,8 +245,8 @@ feature-free d=64 graph.
 |---|---|
 | Backward pass entirely | SM107 |
 | Backward outside d ∈ (256, 512] | SM100, SM103 — the only backward engine there serves that band |
-| Backward GQA / MQA (`H_q ≠ H_kv`) | SM100, SM103 (the `dkv_reduce` group reduce is not wired to it yet) |
-| Backward SWA / padding / bottom-right causal | SM100, SM103 |
+| Backward per-batch padding mask (`seq_len_q/kv`) | SM100, SM103 — a UNIFORM non-tile-multiple length is served; a per-batch one is not |
+| Backward sink / dSink, bias / dBias, deterministic, decode | SM100, SM103 |
 | f16/bf16 forward | SM107 (Rubin) |
 | MXFP8 forward | SM107, SM120, SM80 |
 | FP8 / MXFP8 backward | every arch |

--- a/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
@@ -15,7 +15,18 @@ from cudnn.frost.tile_dsl.scheduler import (
     lpt_tile_coords,
     lpt_l2_tile_coords,
 )
-from cudnn.frost.tile_dsl.mask import MASK_CAUSAL, MASK_PADDED, MASK_SWA
+
+# KvLoopBounds / compute_kv_loop_bounds moved to frost.tile_dsl.mask (the
+# backward needs the same tile-level bounds); re-exported here so the twelve
+# prefill kernels that import them from this module keep working.
+from cudnn.frost.tile_dsl.mask import (  # noqa: F401
+    MASK_CAUSAL,
+    MASK_PADDED,
+    MASK_SWA,
+    KvLoopBounds,
+    compute_kv_loop_bounds,
+    _div_up,
+)
 from cudnn.frost.tile_dsl.barrier import MBarrier, Producer, Scope
 
 
@@ -191,17 +202,6 @@ def make_classic_bars(CFG) -> Bars:
     )
 
 
-class KvLoopBounds(NamedTuple):
-    left: object
-    unmasked_lo: object
-    unmasked_hi: object
-    right: object
-
-
-def _div_up(a, b):
-    return (a + cutlass.Int32(b - 1)) // cutlass.Int32(b)
-
-
 def row_max_for_exp2(total_max):
     """Canonical masked-softmax row-max guard (FlashAttention / cuDNN form).
 
@@ -244,88 +244,6 @@ def assert_tile_n_supported(CFG):
     require N_BMM2_CHUNKS == 2 (TILE_N == 128)."""
     if CFG.N_BMM2_CHUNKS != 2:
         raise NotImplementedError(f"this kernel currently requires TILE_N=128 (got TILE_N={CFG.TILE_N})")
-
-
-def compute_kv_loop_bounds(
-    q_row_coord,
-    seqlen_q,
-    seq_kv_len,
-    window_left: int,
-    mask_flags: int,
-    tile_n: int,
-    cga_tile_m: int,
-    bottom_right: bool = False,
-    window_right: int = 0,
-) -> KvLoopBounds:
-    # window_right: compile-time diagonal-band right bound (cuDNN
-    # diagonal_band_right_bound) — the causal upper limit is widened by
-    # window_right columns. 0 = plain causal; folds out entirely.
-    left = cutlass.Int32(0)
-    right = _div_up(seq_kv_len, tile_n)
-
-    if cutlass.const_expr(bottom_right):
-        causal_diag = seq_kv_len - seqlen_q
-    else:
-        causal_diag = cutlass.Int32(0)
-
-    if cutlass.const_expr(mask_flags & MASK_CAUSAL):
-        kv_hi_caus = _div_up(q_row_coord + cutlass.Int32(cga_tile_m + window_right) + causal_diag, tile_n)
-        right = cute.math.min(right, kv_hi_caus)
-
-    if cutlass.const_expr(mask_flags & MASK_SWA):
-        # The whole band shifts with the diagonal: under BOTTOM_RIGHT the SWA
-        # lower bound is q + (S_kv - S_q) - W, same anchor the causal upper
-        # bound uses (causal_diag folds to 0 for top-left).
-        swa_base = q_row_coord + causal_diag
-        cond = swa_base > cutlass.Int32(window_left)
-        delta = swa_base - cutlass.Int32(window_left)
-        kv_lo_swa = cutlass.Int32(
-            arith.select(
-                cond.ir_value(),
-                (delta // cutlass.Int32(tile_n)).ir_value(),
-                cutlass.Int32(0).ir_value(),
-            )
-        )
-        left = cute.math.max(left, kv_lo_swa)
-
-    unmasked_hi = right
-    if cutlass.const_expr(mask_flags & MASK_PADDED):
-        unaligned = (seq_kv_len % cutlass.Int32(tile_n)) != cutlass.Int32(0)
-        lo_pad = cutlass.Int32(
-            arith.select(
-                unaligned.ir_value(),
-                (right - cutlass.Int32(1)).ir_value(),
-                right.ir_value(),
-            )
-        )
-        unmasked_hi = cute.math.min(unmasked_hi, lo_pad)
-    if cutlass.const_expr(mask_flags & MASK_CAUSAL):
-        lo_caus = (q_row_coord + cutlass.Int32(window_right) + causal_diag) // cutlass.Int32(tile_n)
-        unmasked_hi = cute.math.min(unmasked_hi, lo_caus)
-    unmasked_hi = cute.math.max(unmasked_hi, left)
-
-    unmasked_lo = left
-    if cutlass.const_expr(mask_flags & MASK_SWA):
-        anchor = q_row_coord + causal_diag + cutlass.Int32(cga_tile_m - 1 - window_left)
-        swa_unmasked_lo = _div_up(anchor, tile_n)
-        cond = anchor > cutlass.Int32(0)
-        swa_unmasked_lo = cutlass.Int32(
-            arith.select(
-                cond.ir_value(),
-                swa_unmasked_lo.ir_value(),
-                cutlass.Int32(0).ir_value(),
-            )
-        )
-        unmasked_lo = cute.math.max(unmasked_lo, swa_unmasked_lo)
-
-    unmasked_lo = cute.math.min(unmasked_lo, unmasked_hi)
-
-    return KvLoopBounds(
-        left=left,
-        unmasked_lo=unmasked_lo,
-        unmasked_hi=unmasked_hi,
-        right=right,
-    )
 
 
 class SplitHelpers(NamedTuple):

--- a/test/python/sdpa/frost/test_sdpa_bwd_dsl_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_bwd_dsl_sm100.py
@@ -31,6 +31,16 @@ _D = 512
 _TOL_COS = 0.9999
 _TOL_REL = 2e-2
 
+# The row claims HALF and BFLOAT16. Both get run: the two differ only by one
+# ternary in the adapter (`dtype_code`), which is exactly the kind of line that
+# is easy to leave pointing at the wrong template.
+_DTYPES = (torch.bfloat16, torch.float16)
+_DTYPE_IDS = ("bf16", "fp16")
+
+
+def _io_dtype(dt):
+    return cudnn.data_type.HALF if dt == torch.float16 else cudnn.data_type.BFLOAT16
+
 
 def _bshd_stride(shape):
     """cuDNN declares logical BHSD; the engine needs BSHD-physical storage."""
@@ -68,9 +78,10 @@ def _reference(q, k, v, do, keep=None, group=1):
     return o, lse, all_masked, dq, dk_q, dv_q
 
 
-def _build_graph(b, hq, hkv, sq, skv, d, scale, **sdpa_kwargs):
+def _build_graph(b, hq, hkv, sq, skv, d, scale, dt=torch.bfloat16, **sdpa_kwargs):
+    io = _io_dtype(dt)
     g = cudnn.pygraph(
-        io_data_type=cudnn.data_type.BFLOAT16,
+        io_data_type=io,
         intermediate_data_type=cudnn.data_type.FLOAT,
         compute_data_type=cudnn.data_type.FLOAT,
     )
@@ -79,7 +90,7 @@ def _build_graph(b, hq, hkv, sq, skv, d, scale, **sdpa_kwargs):
     t["stats"] = g.tensor(name="stats", dim=[b, hq, sq, 1], stride=[hq * sq, sq, 1, 1], data_type=cudnn.data_type.FLOAT)
     dq, dk, dv = g.sdpa_backward(name="bwd", q=t["q"], k=t["k"], v=t["v"], o=t["o"], dO=t["do"], stats=t["stats"], attn_scale=scale, **sdpa_kwargs)
     for out, sh in ((dq, shq), (dk, shk), (dv, shk)):
-        out.set_output(True).set_data_type(cudnn.data_type.BFLOAT16).set_stride(_bshd_stride(sh))
+        out.set_output(True).set_data_type(io).set_stride(_bshd_stride(sh))
     g.validate()
     g.build_operation_graph()
     g.create_execution_plans([cudnn.heur_mode.A])
@@ -93,25 +104,25 @@ def _plan_index(g, name=_ENGINE):
     return None
 
 
-def _run(b=2, hq=2, hkv=None, sq=512, skv=512, d=_D, keep=None, **sdpa_kwargs):
+def _run(b=2, hq=2, hkv=None, sq=512, skv=512, d=_D, keep=None, dt=torch.bfloat16, **sdpa_kwargs):
     """Build, pin the engine, execute, and compare against fp32 torch."""
     hkv = hq if hkv is None else hkv
     group = hq // hkv
     scale = 1.0 / math.sqrt(d)
-    q, do = _bshd(b, sq, hq, d), _bshd(b, sq, hq, d)
-    k, v = _bshd(b, skv, hkv, d), _bshd(b, skv, hkv, d)
+    q, do = _bshd(b, sq, hq, d, dt=dt), _bshd(b, sq, hq, d, dt=dt)
+    k, v = _bshd(b, skv, hkv, d, dt=dt), _bshd(b, skv, hkv, d, dt=dt)
     o_ref, lse, all_masked, dq_r, dk_r, dv_r = _reference(q, k, v, do, keep, group)
-    o = _bshd(b, sq, hq, d, fill=False)
-    o.copy_(o_ref.to(torch.bfloat16))
+    o = _bshd(b, sq, hq, d, dt=dt, fill=False)
+    o.copy_(o_ref.to(dt))
 
-    g, t, (dq_t, dk_t, dv_t) = _build_graph(b, hq, hkv, sq, skv, d, scale, **sdpa_kwargs)
+    g, t, (dq_t, dk_t, dv_t) = _build_graph(b, hq, hkv, sq, skv, d, scale, dt=dt, **sdpa_kwargs)
     idx = _plan_index(g)
     assert idx is not None, f"{_ENGINE} not offered; plans = {[g.get_plan_name_at_index(i) for i in range(g.get_execution_plan_count())]}"
     g.select_plan(idx)
     g.check_support()
     g.build_plans()
     ws = torch.empty(max(g.get_workspace_size(), 1), device="cuda", dtype=torch.uint8)
-    dq, dk, dv = _bshd(b, sq, hq, d, fill=False), _bshd(b, skv, hkv, d, fill=False), _bshd(b, skv, hkv, d, fill=False)
+    dq, dk, dv = _bshd(b, sq, hq, d, dt=dt, fill=False), _bshd(b, skv, hkv, d, dt=dt, fill=False), _bshd(b, skv, hkv, d, dt=dt, fill=False)
     stats = (lse if all_masked is None else lse.masked_fill(all_masked, 0.0)).unsqueeze(-1).contiguous()
     g.execute(
         {t["q"]: q, t["k"]: k, t["v"]: v, t["o"]: o, t["do"]: do, t["stats"]: stats, dq_t: dq, dk_t: dk, dv_t: dv},
@@ -139,8 +150,17 @@ def _causal_keep(sq, skv, dev="cuda", bottom_right=False, left=None, right=0):
 # --------------------------------------------------------------------------- #
 
 
-def test_dense():
-    _run()
+@pytest.mark.parametrize("dt", _DTYPES, ids=_DTYPE_IDS)
+def test_dense(dt):
+    _run(dt=dt)
+
+
+@pytest.mark.parametrize("dt", _DTYPES, ids=_DTYPE_IDS)
+def test_causal_dtypes(dt):
+    """Both dtypes through the masked path too: the causal chain reads the
+    workspace back in the io dtype, so a dtype mix-up shows up here and not in
+    the dense case."""
+    _run(dt=dt, keep=_causal_keep(512, 512), use_causal_mask=True)
 
 
 @pytest.mark.parametrize("d", [264, 320, 384, 511 - 7, _D])
@@ -344,6 +364,93 @@ def test_reject_bias():
 
 def test_reject_deterministic():
     assert _decline_reason(use_deterministic_algorithm=True) is not None
+
+
+def test_reject_padding_mask():
+    """Per-batch seq_len is declined: the kernel threads a scalar length.
+
+    Asserted on a REAL graph, not just on the Capabilities field, because the
+    decline has to survive the analyzer too. When per-batch lengths land, this
+    test inverts (assert the decline is None) rather than being deleted.
+    """
+    from cudnn.sdpa import graph_analyzer as ga
+    from cudnn.sdpa.bwd.engines import ENGINE_SPECS, mismatch
+
+    b, hq, sq, skv = 2, 2, 256, 256
+    shq = [b, hq, sq, _D]
+    g = cudnn.pygraph(io_data_type=cudnn.data_type.BFLOAT16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    t = {n: g.tensor(name=n, dim=shq, stride=_bshd_stride(shq)) for n in ("q", "k", "v", "o", "do")}
+    st = g.tensor(name="stats", dim=[b, hq, sq, 1], stride=[hq * sq, sq, 1, 1], data_type=cudnn.data_type.FLOAT)
+    slq = g.tensor(name="seq_len_q", dim=[b, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT32)
+    slk = g.tensor(name="seq_len_kv", dim=[b, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT32)
+    try:
+        dq, dk, dv = g.sdpa_backward(
+            name="bwd",
+            q=t["q"],
+            k=t["k"],
+            v=t["v"],
+            o=t["o"],
+            dO=t["do"],
+            stats=st,
+            attn_scale=1.0 / math.sqrt(_D),
+            use_padding_mask=True,
+            seq_len_q=slq,
+            seq_len_kv=slk,
+        )
+        for out in (dq, dk, dv):
+            out.set_output(True).set_data_type(cudnn.data_type.BFLOAT16).set_stride(_bshd_stride(shq))
+        g.validate()
+        g.build_operation_graph()
+    except cudnn.cudnnGraphNotSupportedError:
+        return  # refused before engine selection is also a decline
+    facts = ga.analyze(g)
+    spec = next(s_ for s_ in ENGINE_SPECS if s_.name == _ENGINE)
+    assert facts is None or mismatch(spec.capabilities, facts) is not None
+
+
+def test_reject_thd():
+    """THD/ragged is declined: stage 3 would need a variable-K grouped GEMM.
+
+    Same shape as the forward's THD test -- packed data behind dense-sized
+    descriptors plus a per-operand ragged_offset. Inverts when THD lands.
+    """
+    from cudnn.sdpa import graph_analyzer as ga
+    from cudnn.sdpa.bwd.engines import ENGINE_SPECS, mismatch
+
+    b, hq, s_max = 2, 2, 256
+    shq = [b, hq, s_max, _D]
+    stride = [s_max * hq * _D, _D, hq * _D, 1]
+    g = cudnn.pygraph(io_data_type=cudnn.data_type.BFLOAT16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    t = {n: g.tensor(name=n, dim=shq, stride=stride) for n in ("q", "k", "v", "o", "do")}
+    st = g.tensor(name="stats", dim=[b, hq, s_max, 1], stride=[hq * s_max, s_max, 1, 1], data_type=cudnn.data_type.FLOAT)
+    slq = g.tensor(name="seq_len_q", dim=[b, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT32)
+    slk = g.tensor(name="seq_len_kv", dim=[b, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT32)
+    for n in ("q", "k", "v", "o", "do"):
+        t[n].set_ragged_offset(g.tensor(name=f"{n}_ro", dim=[b + 1, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT64))
+    try:
+        dq, dk, dv = g.sdpa_backward(
+            name="bwd",
+            q=t["q"],
+            k=t["k"],
+            v=t["v"],
+            o=t["o"],
+            dO=t["do"],
+            stats=st,
+            attn_scale=1.0 / math.sqrt(_D),
+            use_padding_mask=True,
+            seq_len_q=slq,
+            seq_len_kv=slk,
+        )
+        for out in (dq, dk, dv):
+            out.set_output(True).set_data_type(cudnn.data_type.BFLOAT16).set_stride(stride)
+            out.set_ragged_offset(g.tensor(name=f"{out.get_name()}_ro", dim=[b + 1, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT64))
+        g.validate()
+        g.build_operation_graph()
+    except cudnn.cudnnGraphNotSupportedError:
+        return  # refused before engine selection is also a decline
+    facts = ga.analyze(g)
+    spec = next(s_ for s_ in ENGINE_SPECS if s_.name == _ENGINE)
+    assert facts is None or mismatch(spec.capabilities, facts) is not None
 
 
 def test_capabilities_match_what_is_implemented():

--- a/test/python/sdpa/frost/test_sdpa_bwd_dsl_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_bwd_dsl_sm100.py
@@ -88,7 +88,10 @@ def _build_graph(b, hq, hkv, sq, skv, d, scale, dt=torch.bfloat16, **sdpa_kwargs
     shq, shk = [b, hq, sq, d], [b, hkv, skv, d]
     t = {n: g.tensor(name=n, dim=sh, stride=_bshd_stride(sh)) for n, sh in (("q", shq), ("k", shk), ("v", shk), ("o", shq), ("do", shq))}
     t["stats"] = g.tensor(name="stats", dim=[b, hq, sq, 1], stride=[hq * sq, sq, 1, 1], data_type=cudnn.data_type.FLOAT)
-    dq, dk, dv = g.sdpa_backward(name="bwd", q=t["q"], k=t["k"], v=t["v"], o=t["o"], dO=t["do"], stats=t["stats"], attn_scale=scale, **sdpa_kwargs)
+    # scale=None omits attn_scale entirely -- it is optional on the graph.
+    if scale is not None:
+        sdpa_kwargs["attn_scale"] = scale
+    dq, dk, dv = g.sdpa_backward(name="bwd", q=t["q"], k=t["k"], v=t["v"], o=t["o"], dO=t["do"], stats=t["stats"], **sdpa_kwargs)
     for out, sh in ((dq, shq), (dk, shk), (dv, shk)):
         out.set_output(True).set_data_type(io).set_stride(_bshd_stride(sh))
     g.validate()
@@ -104,11 +107,13 @@ def _plan_index(g, name=_ENGINE):
     return None
 
 
-def _run(b=2, hq=2, hkv=None, sq=512, skv=512, d=_D, keep=None, dt=torch.bfloat16, **sdpa_kwargs):
+def _run(b=2, hq=2, hkv=None, sq=512, skv=512, d=_D, keep=None, dt=torch.bfloat16, omit_scale=False, **sdpa_kwargs):
     """Build, pin the engine, execute, and compare against fp32 torch."""
     hkv = hq if hkv is None else hkv
     group = hq // hkv
-    scale = 1.0 / math.sqrt(d)
+    # None => omit attn_scale on the graph; the engine must then default it to
+    # 1/sqrt(d), which is what _reference assumes either way.
+    scale = None if omit_scale else 1.0 / math.sqrt(d)
     q, do = _bshd(b, sq, hq, d, dt=dt), _bshd(b, sq, hq, d, dt=dt)
     k, v = _bshd(b, skv, hkv, d, dt=dt), _bshd(b, skv, hkv, d, dt=dt)
     o_ref, lse, all_masked, dq_r, dk_r, dv_r = _reference(q, k, v, do, keep, group)
@@ -208,6 +213,51 @@ def test_non_tile_multiple_seqlens(sq, skv):
 @pytest.mark.parametrize("sq,skv", [(500, 500), (1000, 1000)])
 def test_non_tile_multiple_causal(sq, skv):
     _run(sq=sq, skv=skv, keep=_causal_keep(sq, skv), use_causal_mask=True)
+
+
+def test_default_attn_scale():
+    """attn_scale is OPTIONAL on the graph; omitting it must mean 1/sqrt(d).
+
+    The adapter used to leave `scale_softmax` at None and die in execute with
+    `TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'`,
+    after the row had already admitted the graph and check_support had passed.
+    _reference always uses 1/sqrt(d), so a wrong default fails the comparison
+    rather than merely not raising.
+    """
+    _run(omit_scale=True)
+
+
+def test_reject_rectangular_head_dims():
+    """d_qk != d_v is declined: the kernel asserts d_qk == d_v.
+
+    The C++ node validation's d512 exception is deliberately permissive here
+    (it admits any pair in the band), so `mismatch()` is the only thing keeping
+    a rectangular graph away from an adapter that would raise on it.
+    """
+    assert _decline_reason(d=_D) is None, "sanity: the square case must be served"
+    from cudnn.sdpa import graph_analyzer as ga
+    from cudnn.sdpa.bwd.engines import ENGINE_SPECS, mismatch
+
+    b, hq, sq, skv = 2, 2, 256, 256
+    shq, shk = [b, hq, sq, 384], [b, hq, skv, 384]
+    shv = [b, hq, skv, 320]
+    g = cudnn.pygraph(io_data_type=cudnn.data_type.BFLOAT16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    t = {
+        n: g.tensor(name=n, dim=sh, stride=_bshd_stride(sh))
+        for n, sh in (("q", shq), ("k", shk), ("v", shv), ("o", [b, hq, sq, 320]), ("do", [b, hq, sq, 320]))
+    }
+    st = g.tensor(name="stats", dim=[b, hq, sq, 1], stride=[hq * sq, sq, 1, 1], data_type=cudnn.data_type.FLOAT)
+    try:
+        dq, dk, dv = g.sdpa_backward(name="bwd", q=t["q"], k=t["k"], v=t["v"], o=t["o"], dO=t["do"], stats=st, attn_scale=1.0 / math.sqrt(384))
+        for out, sh in ((dq, shq), (dk, shk), (dv, shv)):
+            out.set_output(True).set_data_type(cudnn.data_type.BFLOAT16).set_stride(_bshd_stride(sh))
+        g.validate()
+        g.build_operation_graph()
+    except cudnn.cudnnGraphNotSupportedError:
+        return  # refused before engine selection is also a decline
+    facts = ga.analyze(g)
+    spec = next(s_ for s_ in ENGINE_SPECS if s_.name == _ENGINE)
+    assert facts is None or mismatch(spec.capabilities, facts) is not None
 
 
 def test_non_bshd_do_is_staged():

--- a/test/python/sdpa/frost/test_sdpa_bwd_dsl_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_bwd_dsl_sm100.py
@@ -503,6 +503,32 @@ def test_reject_thd():
     assert facts is None or mismatch(spec.capabilities, facts) is not None
 
 
+def test_unserved_band_graph_declines_as_not_supported():
+    """An unserved d512 backward must raise cudnnGraphNotSupportedError.
+
+    Regression test for the error TYPE, not the message. The C++ node admits
+    d in (256, 512] so the FROST engine can claim it, but a graph in the band
+    that NO engine serves (here: deterministic, which this row declines and the
+    backend has no plan for) used to reach plan build via
+    `override_heuristics_query()`, which pins a backend engine id and bypasses
+    the heuristics query entirely. That pinned config then failed to finalize
+    with CUDNN_STATUS_NOT_SUPPORTED, which `_CUDNN_CHECK_CUDNN_ERROR` folded
+    into CUDNN_BACKEND_API_FAILED -- reaching Python as a bare RuntimeError.
+
+    That distinction is load-bearing: every SDPA harness in this repo skips on
+    cudnnGraphNotSupportedError and FAILS on anything else, so the wrong type
+    turned "nobody serves this" into 91 red cases in
+    test_mhas_v2.py::test_sdpa_random_bwd_L0 as soon as its head-dim sweep was
+    widened to 512.
+    """
+    b, hq, sq, skv = 2, 2, 256, 256
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError):
+        g = _build_graph_only(b, hq, hq, sq, skv, _D, 1.0 / math.sqrt(_D), use_deterministic_algorithm=True)
+        g.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
+        g.check_support()
+        g.build_plans()
+
+
 def test_capabilities_match_what_is_implemented():
     """The row must not claim anything the adapter would refuse at build. Guards
     against a Capabilities field being flipped on without the lowering."""

--- a/test/python/sdpa/frost/test_sdpa_bwd_dsl_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_bwd_dsl_sm100.py
@@ -1,0 +1,372 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``sdpa_bwd_sm100``: the SM100 large-head-dim backward chain.
+
+Every capability the row claims gets an ACCEPT test that runs the kernel against
+a torch reference, and every capability it declines gets a REJECT test that
+asserts the decline -- per the engine contract, an unsupported feature is
+asserted, never skipped, so a row that quietly grows a capability fails here.
+
+The engine is a three-stage chain (do_dot -> S/dS workspace -> three GEMMs), so
+these are end-to-end graph-API tests: a unit test of one stage would not catch
+the seams, which is where every bug in this kernel has actually lived.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from frost_test_utils import requires_dsl, requires_pre_rubin_blackwell
+
+import cudnn
+
+pytestmark = [pytest.mark.L0, requires_pre_rubin_blackwell, requires_dsl]
+
+_ENGINE = "sdpa_bwd_sm100"
+_D = 512
+_TOL_COS = 0.9999
+_TOL_REL = 2e-2
+
+
+def _bshd_stride(shape):
+    """cuDNN declares logical BHSD; the engine needs BSHD-physical storage."""
+    b, h, s, d = shape
+    return [s * h * d, d, h * d, 1]
+
+
+def _bshd(b, s, h, d, dev="cuda", dt=torch.bfloat16, fill=True):
+    """A [B, H, S, D] view over BSHD memory -- what the engine expects."""
+    t = torch.randn(b, s, h, d, device=dev, dtype=dt) if fill else torch.zeros(b, s, h, d, device=dev, dtype=dt)
+    return t.mul_(0.1).permute(0, 2, 1, 3) if fill else t.permute(0, 2, 1, 3)
+
+
+def _reference(q, k, v, do, keep=None, group=1):
+    """fp32 attention backward. ``keep`` is a [S_q, S_kv] bool mask."""
+    kx = k.repeat_interleave(group, dim=1) if group > 1 else k
+    vx = v.repeat_interleave(group, dim=1) if group > 1 else v
+    scale = 1.0 / math.sqrt(q.shape[3])
+    sa = (q.float() @ kx.float().transpose(-1, -2)) * scale
+    if keep is not None:
+        sa = sa.masked_fill(~keep, float("-inf"))
+    lse = torch.logsumexp(sa, dim=-1)
+    S = torch.exp(sa - lse.unsqueeze(-1)).nan_to_num_(0.0)
+    o = S @ vx.float()
+    dd = (o * do.float()).sum(-1)
+    dS = scale * (do.float() @ vx.float().transpose(-1, -2) - dd.unsqueeze(-1)) * S
+    dq = dS @ kx.float()
+    dk_q = dS.transpose(-1, -2) @ q.float()
+    dv_q = S.transpose(-1, -2) @ do.float()
+    if group > 1:
+        hkv = k.shape[1]
+        dk_q = dk_q.view(dk_q.shape[0], hkv, group, dk_q.shape[2], dk_q.shape[3]).sum(2)
+        dv_q = dv_q.view(dv_q.shape[0], hkv, group, dv_q.shape[2], dv_q.shape[3]).sum(2)
+    all_masked = (~keep.any(-1)) if keep is not None else None
+    return o, lse, all_masked, dq, dk_q, dv_q
+
+
+def _build_graph(b, hq, hkv, sq, skv, d, scale, **sdpa_kwargs):
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.BFLOAT16,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    shq, shk = [b, hq, sq, d], [b, hkv, skv, d]
+    t = {n: g.tensor(name=n, dim=sh, stride=_bshd_stride(sh)) for n, sh in (("q", shq), ("k", shk), ("v", shk), ("o", shq), ("do", shq))}
+    t["stats"] = g.tensor(name="stats", dim=[b, hq, sq, 1], stride=[hq * sq, sq, 1, 1], data_type=cudnn.data_type.FLOAT)
+    dq, dk, dv = g.sdpa_backward(name="bwd", q=t["q"], k=t["k"], v=t["v"], o=t["o"], dO=t["do"], stats=t["stats"], attn_scale=scale, **sdpa_kwargs)
+    for out, sh in ((dq, shq), (dk, shk), (dv, shk)):
+        out.set_output(True).set_data_type(cudnn.data_type.BFLOAT16).set_stride(_bshd_stride(sh))
+    g.validate()
+    g.build_operation_graph()
+    g.create_execution_plans([cudnn.heur_mode.A])
+    return g, t, (dq, dk, dv)
+
+
+def _plan_index(g, name=_ENGINE):
+    for i in range(g.get_execution_plan_count()):
+        if name in g.get_plan_name_at_index(i):
+            return i
+    return None
+
+
+def _run(b=2, hq=2, hkv=None, sq=512, skv=512, d=_D, keep=None, **sdpa_kwargs):
+    """Build, pin the engine, execute, and compare against fp32 torch."""
+    hkv = hq if hkv is None else hkv
+    group = hq // hkv
+    scale = 1.0 / math.sqrt(d)
+    q, do = _bshd(b, sq, hq, d), _bshd(b, sq, hq, d)
+    k, v = _bshd(b, skv, hkv, d), _bshd(b, skv, hkv, d)
+    o_ref, lse, all_masked, dq_r, dk_r, dv_r = _reference(q, k, v, do, keep, group)
+    o = _bshd(b, sq, hq, d, fill=False)
+    o.copy_(o_ref.to(torch.bfloat16))
+
+    g, t, (dq_t, dk_t, dv_t) = _build_graph(b, hq, hkv, sq, skv, d, scale, **sdpa_kwargs)
+    idx = _plan_index(g)
+    assert idx is not None, f"{_ENGINE} not offered; plans = {[g.get_plan_name_at_index(i) for i in range(g.get_execution_plan_count())]}"
+    g.select_plan(idx)
+    g.check_support()
+    g.build_plans()
+    ws = torch.empty(max(g.get_workspace_size(), 1), device="cuda", dtype=torch.uint8)
+    dq, dk, dv = _bshd(b, sq, hq, d, fill=False), _bshd(b, skv, hkv, d, fill=False), _bshd(b, skv, hkv, d, fill=False)
+    stats = (lse if all_masked is None else lse.masked_fill(all_masked, 0.0)).unsqueeze(-1).contiguous()
+    g.execute(
+        {t["q"]: q, t["k"]: k, t["v"]: v, t["o"]: o, t["do"]: do, t["stats"]: stats, dq_t: dq, dk_t: dk, dv_t: dv},
+        ws,
+    )
+    torch.cuda.synchronize()
+    for name, got, ref in (("dQ", dq, dq_r), ("dK", dk, dk_r), ("dV", dv, dv_r)):
+        cos = torch.nn.functional.cosine_similarity(got.float().flatten(), ref.flatten(), dim=0).item()
+        rel = ((got.float() - ref).abs().max() / max(ref.abs().max().item(), 1e-30)).item()
+        assert cos > _TOL_COS and rel < _TOL_REL, f"{name}: cos={cos:.6f} max_rel_err={rel:.2e}"
+
+
+def _causal_keep(sq, skv, dev="cuda", bottom_right=False, left=None, right=0):
+    qi = torch.arange(sq, device=dev).view(-1, 1)
+    ki = torch.arange(skv, device=dev).view(1, -1)
+    diag = (skv - sq) if bottom_right else 0
+    keep = ki <= qi + diag + right
+    if left is not None:
+        keep &= ki >= qi + diag - (left - 1)
+    return keep
+
+
+# --------------------------------------------------------------------------- #
+# ACCEPT — every capability the row claims                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_dense():
+    _run()
+
+
+@pytest.mark.parametrize("d", [264, 320, 384, 511 - 7, _D])
+def test_head_dim_band(d):
+    """d in (256, 512], any multiple of 8. 264 and 504 are not multiples of 16,
+    which narrows the stage-3 epilogue store vector from 32 B to 16 B."""
+    _run(sq=256, skv=256, d=d)
+
+
+@pytest.mark.parametrize("hq,hkv", [(8, 8), (8, 4), (8, 2), (8, 1), (6, 3)])
+def test_gqa_mqa(hq, hkv):
+    _run(hq=hq, hkv=hkv, sq=256, skv=256)
+
+
+def test_causal_top_left():
+    _run(keep=_causal_keep(512, 512), use_causal_mask=True)
+
+
+def test_causal_bottom_right():
+    _run(keep=_causal_keep(512, 512, bottom_right=True), use_causal_mask_bottom_right=True)
+
+
+def test_causal_bottom_right_rectangular():
+    """S_kv > S_q shifts the diagonal, which the stage-3 K-trim has to follow."""
+    _run(sq=512, skv=1024, keep=_causal_keep(512, 1024, bottom_right=True), use_causal_mask_bottom_right=True)
+
+
+def test_sliding_window():
+    _run(keep=_causal_keep(512, 512, left=256), use_causal_mask=True, diagonal_band_left_bound=256)
+
+
+def test_right_band_widening():
+    """`diagonal_band_right_bound` alone -- passing use_causal_mask with it
+    forces the bound back to 0 and the widening is silently dropped."""
+    _run(keep=_causal_keep(512, 512, right=64), diagonal_band_right_bound=64)
+
+
+@pytest.mark.parametrize("sq,skv", [(500, 500), (300, 200), (257, 129), (384, 640)])
+def test_non_tile_multiple_seqlens(sq, skv):
+    """Neither S_q nor S_kv has to be a tile multiple: the compile shape rounds
+    up and the tail is masked."""
+    _run(sq=sq, skv=skv)
+
+
+@pytest.mark.parametrize("sq,skv", [(500, 500), (1000, 1000)])
+def test_non_tile_multiple_causal(sq, skv):
+    _run(sq=sq, skv=skv, keep=_causal_keep(sq, skv), use_causal_mask=True)
+
+
+def test_non_bshd_do_is_staged():
+    """A BHSD-contiguous dO must be staged, not declined and not misread.
+
+    This is the exact shape benchmark_single_sdpa produces: building dO with
+    torch.randn(o.shape) instead of torch.empty_like(o) loses o's memory format.
+    The stride is DECLARED as BHSD here -- declaring BSHD over a BHSD buffer is
+    simply a lie to the engine, and it would then (correctly) read the wrong
+    elements.
+    """
+    b, hq, sq, skv, d = 2, 2, 256, 256, _D
+    scale = 1.0 / math.sqrt(d)
+    q, k, v = _bshd(b, sq, hq, d), _bshd(b, skv, hq, d), _bshd(b, skv, hq, d)
+    do = torch.randn(b, hq, sq, d, device="cuda", dtype=torch.bfloat16).mul_(0.1)  # BHSD-contiguous
+    bhsd_stride = [hq * sq * d, sq * d, d, 1]
+    assert tuple(do.stride()) == tuple(bhsd_stride)
+
+    o_ref, lse, _, dq_r, _, _ = _reference(q, k, v, do)
+    o = _bshd(b, sq, hq, d, fill=False)
+    o.copy_(o_ref.to(torch.bfloat16))
+
+    g = cudnn.pygraph(io_data_type=cudnn.data_type.BFLOAT16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    shq, shk = [b, hq, sq, d], [b, hq, skv, d]
+    t = {n: g.tensor(name=n, dim=sh, stride=_bshd_stride(sh)) for n, sh in (("q", shq), ("k", shk), ("v", shk), ("o", shq))}
+    t["do"] = g.tensor(name="do", dim=shq, stride=bhsd_stride)  # the odd one out
+    t["stats"] = g.tensor(name="stats", dim=[b, hq, sq, 1], stride=[hq * sq, sq, 1, 1], data_type=cudnn.data_type.FLOAT)
+    dq_t, dk_t, dv_t = g.sdpa_backward(name="bwd", q=t["q"], k=t["k"], v=t["v"], o=t["o"], dO=t["do"], stats=t["stats"], attn_scale=scale)
+    for out, sh in ((dq_t, shq), (dk_t, shk), (dv_t, shk)):
+        out.set_output(True).set_data_type(cudnn.data_type.BFLOAT16).set_stride(_bshd_stride(sh))
+    g.validate()
+    g.build_operation_graph()
+    g.create_execution_plans([cudnn.heur_mode.A])
+    idx = _plan_index(g)
+    assert idx is not None, "a BHSD dO must be served (staged), not declined"
+    g.select_plan(idx)
+    g.check_support()
+    g.build_plans()
+    ws = torch.empty(max(g.get_workspace_size(), 1), device="cuda", dtype=torch.uint8)
+    dq, dk, dv = (_bshd(b, s_, hq, d, fill=False) for s_ in (sq, skv, skv))
+    g.execute(
+        {t["q"]: q, t["k"]: k, t["v"]: v, t["o"]: o, t["do"]: do, t["stats"]: lse.unsqueeze(-1).contiguous(), dq_t: dq, dk_t: dk, dv_t: dv},
+        ws,
+    )
+    torch.cuda.synchronize()
+    cos = torch.nn.functional.cosine_similarity(dq.float().flatten(), dq_r.flatten(), dim=0).item()
+    assert cos > _TOL_COS, f"dQ cos={cos:.6f}"
+
+
+def test_workspace_is_build_time_honest():
+    """get_workspace_size() must be a pure function of the shape, not grow at
+    execute -- that is what makes the plan CUDA-graph friendly."""
+    b, hq, sq, skv = 2, 2, 256, 256
+    g, _, _ = _build_graph(b, hq, hq, sq, skv, _D, 1.0 / math.sqrt(_D))
+    idx = _plan_index(g)
+    assert idx is not None
+    g.select_plan(idx)
+    g.check_support()
+    g.build_plans()
+    assert g.get_workspace_size() == g.get_workspace_size()
+    assert g.get_workspace_size() > 0
+
+
+# --------------------------------------------------------------------------- #
+# REJECT — asserted, never skipped                                             #
+# --------------------------------------------------------------------------- #
+
+
+def _decline_reason(**kw):
+    """Why this engine declines the graph, or None if it would serve it.
+
+    Asks the row's own ``mismatch()`` rather than walking the ranked plan list:
+    the plan list also contains BACKEND plans, so "my engine is absent" there is
+    confounded by whatever the backend does (it serves d=128/256 backward, and
+    it raises outright on some graphs). This tests exactly the contract -- the
+    Capabilities row rejecting the facts -- and nothing else.
+    """
+    from cudnn.sdpa import graph_analyzer as ga
+    from cudnn.sdpa.bwd.engines import ENGINE_SPECS, mismatch
+
+    b, hq, hkv = kw.pop("b", 2), kw.pop("hq", 2), kw.pop("hkv", 2)
+    sq, skv, d = kw.pop("sq", 256), kw.pop("skv", 256), kw.pop("d", _D)
+    spec = next(s for s in ENGINE_SPECS if s.name == _ENGINE)
+    try:
+        g = _build_graph_only(b, hq, hkv, sq, skv, d, 1.0 / math.sqrt(d), **kw)
+    except cudnn.cudnnGraphNotSupportedError as e:
+        return f"frontend refused the graph: {e}"
+    facts = ga.analyze(g)
+    if facts is None:
+        return "analyzer did not recognise the graph"
+    return mismatch(spec.capabilities, facts)
+
+
+def _build_graph_only(b, hq, hkv, sq, skv, d, scale, **sdpa_kwargs):
+    """_build_graph without create_execution_plans (which would involve the backend)."""
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.BFLOAT16,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    shq, shk = [b, hq, sq, d], [b, hkv, skv, d]
+    t = {n: g.tensor(name=n, dim=sh, stride=_bshd_stride(sh)) for n, sh in (("q", shq), ("k", shk), ("v", shk), ("o", shq), ("do", shq))}
+    t["stats"] = g.tensor(name="stats", dim=[b, hq, sq, 1], stride=[hq * sq, sq, 1, 1], data_type=cudnn.data_type.FLOAT)
+    dq, dk, dv = g.sdpa_backward(name="bwd", q=t["q"], k=t["k"], v=t["v"], o=t["o"], dO=t["do"], stats=t["stats"], attn_scale=scale, **sdpa_kwargs)
+    for out, sh in ((dq, shq), (dk, shk), (dv, shk)):
+        out.set_output(True).set_data_type(cudnn.data_type.BFLOAT16).set_stride(_bshd_stride(sh))
+    g.validate()
+    g.build_operation_graph()
+    return g
+
+
+@pytest.mark.parametrize("d", [128, 256])
+def test_reject_head_dim_at_or_below_256(d):
+    """The d256 flavors own these; routing them here would pad by >2x."""
+    assert _decline_reason(d=d) is not None
+
+
+def test_reject_head_dim_not_multiple_of_8():
+    """TMA's innermost extent must be 16-byte aligned; at 2 B/elem that is d%8."""
+    assert _decline_reason(d=260) is not None
+
+
+def test_reject_head_dim_above_512():
+    assert _decline_reason(d=576) is not None
+
+
+def test_reject_gqa_ratio_not_integer():
+    assert _decline_reason(hq=6, hkv=4) is not None
+
+
+def test_reject_bias():
+    """A bias input is not implemented; the row must not claim it."""
+    from cudnn.sdpa import graph_analyzer as ga
+    from cudnn.sdpa.bwd.engines import ENGINE_SPECS, mismatch
+
+    b, hq, sq, skv = 2, 2, 256, 256
+    shq = [b, hq, sq, _D]
+    g = cudnn.pygraph(io_data_type=cudnn.data_type.BFLOAT16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    t = {n: g.tensor(name=n, dim=shq, stride=_bshd_stride(shq)) for n in ("q", "k", "v", "o", "do")}
+    st = g.tensor(name="stats", dim=[b, hq, sq, 1], stride=[hq * sq, sq, 1, 1], data_type=cudnn.data_type.FLOAT)
+    bias = g.tensor(name="bias", dim=[1, 1, sq, skv], stride=[sq * skv, sq * skv, skv, 1])
+    try:
+        dq, dk, dv = g.sdpa_backward(name="bwd", q=t["q"], k=t["k"], v=t["v"], o=t["o"], dO=t["do"], stats=st, bias=bias, attn_scale=1.0 / math.sqrt(_D))
+        for out in (dq, dk, dv):
+            out.set_output(True).set_data_type(cudnn.data_type.BFLOAT16).set_stride(_bshd_stride(shq))
+        g.validate()
+        g.build_operation_graph()
+    except cudnn.cudnnGraphNotSupportedError:
+        return  # refused before engine selection is also a decline
+    facts = ga.analyze(g)
+    spec = next(s_ for s_ in ENGINE_SPECS if s_.name == _ENGINE)
+    assert facts is None or mismatch(spec.capabilities, facts) is not None
+
+
+def test_reject_deterministic():
+    assert _decline_reason(use_deterministic_algorithm=True) is not None
+
+
+def test_capabilities_match_what_is_implemented():
+    """The row must not claim anything the adapter would refuse at build. Guards
+    against a Capabilities field being flipped on without the lowering."""
+    from cudnn.sdpa.bwd.engines import ENGINE_SPECS
+
+    spec = next(s for s in ENGINE_SPECS if s.name == _ENGINE)
+    c = spec.capabilities
+    assert c.causal and c.bottom_right and c.swa and c.right_band_widening
+    assert c.gqa
+    assert c.d_envelope and c.d_pad_multiple == 8 and max(c.d) == 512
+    assert c.d_envelope_floor == 256, "an envelope with no floor silently claims every small head dim"
+    assert not c.thd, "THD needs a variable-K grouped GEMM in stage 3"
+    assert not c.padded, "per-batch seq_len is not threaded; only a uniform length is"
+    assert not c.bias and not c.dbias and not c.sink and not c.dsink
+    assert not c.deterministic
+    assert c.sm_lo == 100 and c.sm_hi == 103
+
+
+def test_engine_is_registered_and_opt_in():
+    from cudnn.engines.manifest import MANIFEST
+
+    fam = next(f for f in MANIFEST if f.name == "frost_sdpa_bwd")
+    assert _ENGINE in fam.slots
+    assert fam.slots[_ENGINE].opt_in, "new engines stay opt-in until they earn arch coverage + benchmarks"

--- a/test/python/test_mhas_v2.py
+++ b/test/python/test_mhas_v2.py
@@ -180,7 +180,7 @@ def test_sdpa_random_bwd_L0(env_info, test_no, request, cudnn_handle):
     with RandomizationContext(
         batches=RandomBatchSize(min=8, max=16),
         s_q_s_kv = RandomSequenceLength(s_q_min=1, s_q_max=4096, s_kv_min=1, s_kv_max=4096, s_q_distribution={"s_q=1":0, "s_q=s_kv":5, "s_q=random":10, "s_q>s_kv":3}),
-        d_qk_d_v=RandomHiddenDimSize(d_qk_min=1, d_qk_max=256, d_v_min=1, d_v_max=256, head_dim_distribution={"d_qk=d_v":5, "d_qk=random":1}, with_high_probability=[(64,64), (128,128), (192,128), (256,256)]),
+        d_qk_d_v=RandomHiddenDimSize(d_qk_min=1, d_qk_max=512, d_v_min=1, d_v_max=512, head_dim_distribution={"d_qk=d_v":5, "d_qk=random":1}, with_high_probability=[(64,64), (128,128), (192,128), (256,256), (512,512)]),
         head_count=RandomHeadGenerator(min=1, max=8, head_group_options=(1, 4, 1)),
         data_type=RandomChoice({torch.float16 : 1, torch.bfloat16 : 2}),
         with_sliding_mask=SlidingWindowMaskGenerator(causal=10, left_window_only=5, right_window_only=5, band_around_diag=10, no_mask=10),


### PR DESCRIPTION
## SM100 d=512 SDPA backward (f16 / bf16)

Adds `sdpa_bwd_sm100`, a FROST backward engine for the large-head-dim band
**d ∈ (256, 512]** on Blackwell. Before this, every `sdpa_backward()` on SM100
fell through to the cuDNN backend, which does not serve that band.

It is a **three-stage chain, not one fused kernel**. A fused d=512 backward
needs 512 TMEM columns for dV and 512 more for dK against 512 per CTA, so it
does not fit: S and dS go to a GMEM workspace and the gradients become three
batched GEMMs over it (`do_dot` → `bprop_d512_f16_sm100` → `bprop_matmul_sm100`).
Stage 2 forks the *forward* d512 SM100 kernel's cga4x1 role split, which gives
each sub-group its own 227 KiB of SMEM and its own 512 TMEM columns.

Two consequences a user can see, both documented in the support matrix:
the workspace is `2·B·H_chunk·S_q·S_kv·2 B` (the host loops over head chunks to
hold it under 4 GiB), and the whole band is **envelope-served** — tiles are
fixed at 512, so d=264 pays d=512's MMA cost.

### What it serves

f16/bf16 · d ∈ (256, 512] in multiples of 8 · GQA/MQA · causal (top-left and
bottom-right) · SWA · right-band widening · arbitrary S_q/S_kv (not just tile
multiples) · BSHD and arbitrary dense stride order (`dense_flex`).

Declined, each with an asserted reject test: THD/ragged, per-batch seq_len,
bias/dbias, sinks, deterministic mode, FP8/MXFP8, and d outside the band.

### Commits

| | |
|---|---|
| `3e62b316` | Bring-up: the kernel chain, engine row, manifest slot, GQA, causal/SWA/band masks |
| `a407a668` | Arbitrary seqlen, the new `d_envelope_floor` capability, and the 33-case test module |
| `43d51836` | Drop padding from the workspace memset (~3 % at B1 H128 S8192 causal) |
| `1ce1a474` | Stage-3 GEMM 2x1 → 2x2 cluster |
| `d1edf029` | Honor FP16 in the stage-3 GEMM |

### Notes for review

**`d_envelope_floor` is a new `Capabilities` field.** An envelope with no floor
silently claimed every small head dim and padded it onto the 512-wide kernel —
a d=128 graph would have taken the whole 512 MMA with a d256 flavor sitting
right there. Only the adapter's `check_support` caught it, i.e. *after*
eligibility, so the row was lying. It defaults to 0, so the sm120/sm80 rows are
unchanged. `SUPPORT_MATRIX_TRACKER.md` is updated in the same commit (Rule S2).

**Causal correctness rests on the zero-fill, not the trim.** At the 2x2 cluster
config the stage-3 M tile (512) is wider than stage 2's write block (256), so a
512-row tile straddles two blocks and no per-tile K range can exclude the
skipped region. The trim is an optimization; `_zero_ws` is what makes the causal
path correct. Two docstrings previously claimed otherwise and are corrected —
please do not narrow that zero-fill later without re-reading them.

**The stage-3 cluster change was not a pure constants swap.** Beyond the
tile/cluster/stage constants it needed the epilogue's SMEM staging widened
*and* the matching output TMA descriptor (`box_dims` 32 → 64, `s64b` → `s128b`).
Missing only the descriptor half leaves the epilogue writing a 128 B swizzle
through a 64 B descriptor: no crash, no launch failure, just `cos ≈ 0.006` on
all three GEMMs. The epilogue store and its descriptor are one unit.

**The FP16 fix is worth a look** (`d1edf029`): the row claimed `{HALF, BFLOAT16}`
while the stage-3 template hardcoded `cutlass.BFloat16` in seven places, so every
fp16 graph was accepted and then failed at execute. All 33 tests passed over it
because all 33 ran bf16. The tests are now parametrized per dtype.

### Performance

Stage-3 GEMM at 2x2, measured B=1 H=128 S=8192 d=512 bf16, paired alternating
A/B/B/A so clock drift cannot pick a winner:

| mask | 2x2 | 2x1 | |
|---|---|---|---|
| no_mask | **732.3** TFLOPS | 707.8 | +3.5 % (4/4 rounds) |
| causal | **653.5** TFLOPS | 606.0 | +7.8 % (2/2 rounds) |

The three products are within 1 % of each other at ~41.4 % of the boost-clock
SOL *bound* (a lower bound — `pynvml` is unavailable on the node, so this is not
a sampled-clock figure). An earlier isolated-GEMM A/B read the same change as a
coin flip; it was measuring the GEMM out of context, on boosted clocks against a
warm cache, and is superseded by the paired end-to-end numbers.

Broader perf tuning and THD support are the planned follow-ups.

### Testing

`test/python/sdpa/frost/test_sdpa_bwd_dsl_sm100.py` — **38 cases**, accept AND
reject for every claim, marked `L0`. Reject tests ask the row's own `mismatch()`
rather than walking the ranked plan list, which is confounded by the backend
(it serves d=128/256 backward and raises outright on some graphs). The THD and
padding-mask rejects are asserted on real graphs so they exercise the analyzer,
and both invert when those features land rather than being deleted.

Validated on Blackwell (cc 10.0, cuDNN 9.27): 38/38 over 3 consecutive runs,
plus the full `sdpa/frost/` suite (1100 passed) to check for regressions.

Two bugs the tests found during development, both listed here because the
signatures are reusable:

* `do_dot` writes `delta` with a row stride of `ceil(S_q/128)*128`, not `S_q`,
  so the buffer and stage 2's view of it must round identically. They coincide
  at every tile-multiple S_q, which is why only a ragged length exposed it —
  and the signature was exact: **dV correct, dQ and dK wrong**, because dV is
  the one gradient that does not consume `do_dot`.
* The envelope floor above, found by a reject test rather than by review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added SDPA backward support on Blackwell SM100–SM103 GPUs for FP16/BF16 head dimensions greater than 256 and up to 512.
  - Supports causal and sliding-window masking, GQA/MQA, dense layouts, and irregular sequence lengths.
  - Omitted attention scales now default based on the query/key head dimension.

- **Bug Fixes**
  - Benchmark diagnostics now distinguish unsupported configurations, missing clock samples, and peak lookup failures.
  - Unsupported backend plans now report clear “graph not supported” results.

- **Documentation**
  - Updated the support matrix with SM100/SM103 capabilities and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->