### PR TITLE
Tune Rubin split-KV factors for GR100 wave occupancy

### DIFF
--- a/python/cudnn/sdpa/fwd/heuristics.py
+++ b/python/cudnn/sdpa/fwd/heuristics.py
@@ -128,7 +128,7 @@ class _SplitKvLaunch(NamedTuple):
     ctas_per_tile: int
 
 
-def split_kv_candidates(*, sm_count: int, kv_tiles: int) -> List[int]:
+def split_kv_candidates(*, sm_count: int, kv_tiles: int, dense_through: int = 1) -> List[int]:
     """The splits worth scoring on this device, ascending, always starting at 1.
 
     THE single split-KV list -- what a row can BUILD is a separate boolean
@@ -139,9 +139,11 @@ def split_kv_candidates(*, sm_count: int, kv_tiles: int) -> List[int]:
     CTA-tiles than the machine has SMs, so that is where the occupancy argument
     for splitting runs out. Rounding UP rather than down offers the first
     over-subscribing point and lets the cost model reject it on the wave term,
-    instead of the bound pre-judging it. Powers of two because ``split_kv`` is a
-    TemplateParams field and so a kernel-module cache key -- an unrestricted
-    choice mints a compiled specialization per shape.
+    instead of the bound pre-judging it. Powers of two are the default because
+    ``split_kv`` is a TemplateParams field and so a kernel-module cache key --
+    an unrestricted choice mints a compiled specialization per shape.
+    ``dense_through`` additionally admits every integer through a small,
+    measured device-specific limit while retaining the power-of-two tail.
 
     Also bounded by ``kv_tiles // _SPLIT_KV_MIN_TILES``. The chunking hands the
     remainder to the LEADING splits, so the thinnest gets ``floor(kv_tiles/s)``
@@ -157,11 +159,11 @@ def split_kv_candidates(*, sm_count: int, kv_tiles: int) -> List[int]:
         return [1]
     hi = 1 << max(0, (sm_count - 1).bit_length())  # 2**ceil(log2(sm_count))
     hi = min(hi, max(1, kv_tiles // _SPLIT_KV_MIN_TILES))
-    out, s = [], 1
+    out, s = list(range(1, min(hi, max(1, dense_through)) + 1)), 1
     while s <= hi:
         out.append(s)
         s <<= 1
-    return out
+    return sorted(set(out))
 
 
 def choose_split_kv(
@@ -610,6 +612,14 @@ def _split_points(
             kv_tiles=_ceil_div(facts.s_kv, unsplit_knobs.tile_n or 128),
             ctas_per_tile=unsplit_knobs.cga or 1,
         )
+    # GR100's 208 SMs leave common context grids closest to a full wave at
+    # factors 3, 5, or 6. Keep the shared power-of-two tail, but score every
+    # small factor measured on the Rubin kernel.
+    candidates = split_kv_candidates(
+        sm_count=sm_count,
+        kv_tiles=split_launch.kv_tiles,
+        dense_through=8 if caps.sm_lo == 107 else 1,
+    )
     split = choose_split_kv(
         q_tiles=split_launch.q_tiles,
         heads_q=split_launch.heads_q,
@@ -622,6 +632,7 @@ def _split_points(
         # graph's own output.
         combine_rows=facts.s_q * facts.h_q * facts.b,
         ctas_per_tile=split_launch.ctas_per_tile,
+        candidates=candidates,
         unsplit_launch=unsplit_launch,
     )
     if split <= 1:

--- a/test/python/sdpa/frost/test_split_kv_heuristic.py
+++ b/test/python/sdpa/frost/test_split_kv_heuristic.py
@@ -324,6 +324,40 @@ def test_split_points_feeds_the_exact_cluster_extent():
     assert points[-1] == 1, "no-split must remain reachable behind the chosen split"
 
 
+@pytest.mark.parametrize(
+    "s_q,s_kv,q_heads,kv_heads,expected",
+    [
+        (1024, 131072, 8, 1, 6),
+        (1024, 131072, 16, 2, 3),
+        (1024, 131072, 32, 4, 3),
+        (985, 62208, 9, 9, 5),
+        (8192, 8192, 8, 1, 1),
+    ],
+)
+def test_rubin_scores_small_non_power_of_two_splits(s_q, s_kv, q_heads, kv_heads, expected):
+    """Pin the GR100 wave-filling factors measured on context workloads."""
+    import cudnn
+    from cudnn.sdpa import graph_analyzer as ga
+    from cudnn.sdpa.fwd.engines import ENGINE_SPECS
+    from cudnn.sdpa.fwd.heuristics import _split_points
+
+    caps = next(sp for sp in ENGINE_SPECS if sp.name == "sdpa_fwd_prefill_sm107_fp8").capabilities
+    facts = ga.SdpaGraphFacts(
+        b=1,
+        h_q=q_heads,
+        h_kv=kv_heads,
+        s_q=s_q,
+        s_kv=s_kv,
+        d_qk=128,
+        d_v=128,
+        dtype=cudnn.data_type.FP8_E4M3,
+        dtype_o=cudnn.data_type.BFLOAT16,
+        device_sm_count=208,
+        device_cc=(10, 7),
+    )
+    assert _split_points(caps, facts, 128, 128, 2)[0] == expected
+
+
 # --- the candidate ladder ---------------------------------------------------
 
 
@@ -335,6 +369,12 @@ def test_ladder_is_derived_from_the_device(sm_count, top):
     got = split_kv_candidates(sm_count=sm_count, kv_tiles=1 << 20)
     assert got[0] == 1 and got[-1] == top
     assert got == [1 << i for i in range(len(got))]
+
+
+def test_dense_candidate_prefix_retains_the_power_of_two_tail():
+    got = split_kv_candidates(sm_count=208, kv_tiles=1 << 20, dense_through=8)
+    assert got[:8] == list(range(1, 9))
+    assert got[8:] == [16, 32, 64, 128, 256]
 
 
 def test_ladder_is_bounded_by_the_thinnest_split():


### PR DESCRIPTION
## Summary

- retain the shared power-of-two split-KV candidate ladder
- let the SM107 FP8 prefill row additionally score every factor from 1 through 8
- pin the measured GR100 choices for Llama 3.1 context, AR-DiT context, and the saturated 8K control

## Why

GR100 has 208 SMs. Common context grids land much closer to a full wave with
factors 3, 5, or 6 than with the existing power-of-two-only choices. The
additional candidates are limited to the SM107 row and to four new small
specializations (3, 5, 6, and 7); the existing power-of-two tail remains
available for more severely underfilled shapes.

## GR100 performance

Direct public Rubin D128 FP8 CuTe kernel, FP8 E4M3 Q/K/V, BF16 O, median of 3
repeats with 5 warmups and 30 timed iterations. End-to-end includes the main
and split-combine kernel launches.

```text
Shape                     Old factor  Old ms   New factor  New ms   Latency reduction  vs unsplit
------------------------  ----------  -------  ----------  -------  -----------------  ----------
Llama 3.1 TP8, 1Kx128K             4   0.4004           6   0.2911              27.3%      4.639x
Llama 3.1 TP4, 1Kx128K             2   0.7804           3   0.5498              29.5%      2.513x
Llama 3.1 TP2, 1Kx128K             4   1.1845           3   1.1175               5.7%      1.265x
AR-DiT, 985x62208                  4   0.2191           5   0.1931              11.9%      3.459x
Llama 3.1 TP8, full 8Kx8K          1   0.1329           1   0.1329               0.0%      1.000x
```

No NaNs were observed. Maximum absolute differences from the unsplit BF16
output at the selected split factors were 0.000252, 0.000237, 0.000241, and
0.000366 for the four split context cases, respectively.

## Validation

- `pytest test/python/sdpa/frost/test_split_kv_heuristic.py test/python/sdpa/frost/test_sdpa_fwd_heuristics.py`: 130 passed, 2 deselected
- Black 26.3.1: both changed files left unchanged
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved attention workload scheduling for select newer GPU configurations.
  * Added more granular split choices for applicable FP8 context workloads, which may improve performance across varying workload sizes.

* **Tests**
  * Added coverage for expanded split-selection behavior and newer GPU configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->