### PR TITLE
Allow KV split with a quantized output

### DIFF
--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -896,27 +896,98 @@ class SdpaFwdDsl(APIBase):
 
     # -- KV-split shared helpers (SM100 + SM120 dense split paths) -----------
 
-    def _o_itemsize(self) -> int:
-        return 2  # f16 / bf16; the split path is half-precision-O only
+    def _o_dtype(self):
+        """The torch dtype O is STORED as.
 
-    def _combine_dtype_tag(self) -> str:
-        # The combine reduces INTO the O dtype: the graph's dtype_o on the
-        # quantized rows (half-gated by check_support), Q's dtype elsewhere.
-        # self.dtype is the fp8 INPUT type on those rows, so falling back to it
-        # would compile an f16 combine for a bf16 output; not every arch's
-        # check_support populates dtype_o, so read the O descriptor when it does
-        # not (SM100 sets it and is unaffected).
-        # Read the O DESCRIPTOR, not self.dtype_o: the latter is a cudnn.data_type
-        # enum on some rows (SM120 fp8) and a torch dtype on others, so comparing
-        # it against torch.bfloat16 silently yields "f16" and compiles a
-        # half-precision combine for a bf16 output. self.dtype is the fp8 INPUT
-        # type on the quantized rows, so it cannot stand in either.
+        Read the O DESCRIPTOR, not self.dtype_o: the latter is a cudnn.data_type
+        enum on some rows (SM120 fp8) and a torch dtype on others, so comparing
+        it against a torch dtype silently misclassifies those rows.  self.dtype
+        is the fp8 INPUT type on the quantized rows, so it cannot stand in
+        either; it is only the fallback for the non-quantized rows, where O
+        follows Q.
+        """
         o_dtype = getattr(self.o_desc, "dtype", None) if self._fp8 else self.dtype
         if o_dtype is None:
             o_dtype = self.dtype_o if self.dtype_o is not None else self.dtype
+        return o_dtype
+
+    def _quantized_split(self) -> bool:
+        """A split whose O is stored quantized: the partials stay wide and the
+        cast down to the FP8 O moves from the kernel epilogue to the combine."""
+        return self.split_kv > 1 and self._fp8 and self._o_dtype() in _SM100_FP8_DTYPES
+
+    def _split_scale_o(self) -> bool:
+        """Whether that cast also applies a scalar scale_o.
+
+        Only the per-tensor rows have one.  Block-scaled (MXFP8) O carries its
+        scaling in the SF tensors, not a scalar, so its combine casts unscaled —
+        exactly what its single-pass epilogue does.
+        """
+        return self._quantized_split() and self._pertensor
+
+    def _partial_torch_dtype(self) -> torch.dtype:
+        """The type the split kernels WRITE.
+
+        Never narrower than O, so the rounding down to O's dtype happens once,
+        on the recombined value, rather than once per split.  fp32 where the
+        kernel can store its accumulator registers straight to the workspace
+        (see :meth:`_fp32_partial_split`), half elsewhere."""
+        if self._fp32_partial_split():
+            return torch.float32
+        # A quantized O has no half counterpart to inherit, so pick f16 -- its
+        # 10-bit mantissa carries the partials more precisely than bf16's 7, and
+        # the range that would favour bf16 is what scale_o already handles.
+        return torch.bfloat16 if self._o_dtype() == torch.bfloat16 else torch.float16
+
+    def _fp32_partial_split(self) -> bool:
+        """Whether this launch's partials are fp32.
+
+        Not a tuning knob: a split-capable SM100 kernel stores fp32 partials
+        unconditionally.  The exclusions below are all the same fact -- those
+        kernels are compiled WITHOUT the extra partial-tensor slot, so handing
+        one the fp32 buffer passes an argument it does not declare:
+
+        * SM120: its ``sO`` aliases ``sKV``, so there is no room to widen the O
+          tile, and it keeps half partials.
+        * SM107 (Rubin) outside per-tensor FP8 d128: this adapter routes EVERY
+          dtype family on cc10.7 to an SM107 sibling, and only that one sibling
+          carries the split plumbing.
+        * MXFP8 d512: sm100/prefill_d512_mxfp8 wires SplitHelpers but was
+          written against the staged epilogue, so it keeps half partials until
+          it is ported.
+
+        Tracking the wired FLAVOR rather than the arch is what keeps this true
+        to the kernels; test_every_split_capable_sm100_kernel_has_the_slot fails
+        if a new kernel arrives split-capable without the slot."""
+        if type(self).__name__ != "SdpaFwdDslSm100":
+            return False
+        if self.split_kv <= 1:
+            return False
+        if self._device_cc == (10, 7):
+            return bool(self._fp8 and self._pertensor and self.flavor == (128, 128))
+        if self._fp8 and not self._pertensor and self.flavor == (512, 512):
+            return False  # MXFP8 d512: split-capable, no o_partial_f32 slot
+        return True
+
+    def _partial_dtype_tag(self) -> str:
+        d = self._partial_torch_dtype()
+        if d == torch.float32:
+            return "f32"
+        return "bf16" if d == torch.bfloat16 else "f16"
+
+    def _o_itemsize(self) -> int:
+        return self._partial_torch_dtype().itemsize
+
+    def _combine_dtype_tag(self) -> str:
+        # The combine reduces INTO the O dtype.  A quantized O is a legal split
+        # target: this pass performs the single cast down to it, from half
+        # partials (see _partial_dtype_tag).
+        o_dtype = self._o_dtype()
+        if o_dtype in _SM100_FP8_DTYPES:
+            return "e5m2" if o_dtype == torch.float8_e5m2 else "e4m3"
         return "bf16" if o_dtype == torch.bfloat16 else "f16"
 
-    def _split_partials(self, workspace, o_like, device, current_stream=None):
+    def _split_partials(self, workspace, device, current_stream=None):
         """The split-major (O, LSE) partial buffers, carved from the caller's
         workspace when there is one and torch-allocated otherwise (standalone
         use, matching what the rest of this adapter does).
@@ -929,14 +1000,18 @@ class SdpaFwdDsl(APIBase):
         rows = self.split_kv * self.batch_size
         o_shape = (rows, self.s_q_max, self.h_q, self.head_dim_v)
         lse_shape = (rows, self.h_q, self.s_q_max)
+        # NOT o_like.dtype: a quantized O is stored narrower than its partials,
+        # which stay wide (fp32 on SM100, half on SM120) so the reduction runs
+        # wider than the final cast.
+        o_dtype = self._partial_torch_dtype()
         if workspace is None:
             with _torch_stream_context(current_stream, device):
                 return (
-                    torch.empty(o_shape, dtype=o_like.dtype, device=device),
+                    torch.empty(o_shape, dtype=o_dtype, device=device),
                     torch.empty(lse_shape, dtype=torch.float32, device=device),
                 )
         carver = WorkspaceCarver(workspace, self.scratch_workspace_bytes(), f"{type(self).__name__} (KV split)")
-        o_part = carver.take(rows * self.s_q_max * self.h_q * self.head_dim_v, o_like.dtype).view(o_shape)
+        o_part = carver.take(rows * self.s_q_max * self.h_q * self.head_dim_v, o_dtype).view(o_shape)
         lse_part = carver.take(rows * self.h_q * self.s_q_max, torch.float32).view(lse_shape)
         return o_part, lse_part
 
@@ -1242,15 +1317,20 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             # sm100/split_combine (which also owns the FP8 amax of the
             # recombined O). Structural limits mirror mismatch()'s
             # facts x knobs gate so the standalone API declines identically.
-            self._not_implemented_error_if(
-                self._fp8 and self.dtype_o not in (torch.float16, torch.bfloat16),
-                "split_kv > 1 on a quantized graph requires a bf16/fp16 O (the combine reduces half-precision partials)",
-            )
             self._not_implemented_error_if(self.thd, "split_kv > 1 is dense-only (THD packs its own flat grid)")
             self._value_error_if(self.has_sink, "split_kv > 1 with an attention sink is not supported")
             self._value_error_if(
                 self.seq_kv_lens_present or self.seq_q_lens_present,
                 "split_kv > 1 serves unpadded dense graphs only",
+            )
+            # cc10.7 routes every family to an SM107 sibling, and only the
+            # per-tensor FP8 d128 one wires SplitHelpers -- the rest would load
+            # a kernel that silently ignores split_kv and is shaped for an
+            # unsplit O. Decline here so the standalone API matches the engine
+            # row's split_d_shapes instead of failing inside template loading.
+            self._not_implemented_error_if(
+                self._device_cc == (10, 7) and not (self._fp8 and self._pertensor and self.flavor == (128, 128)),
+                "split_kv > 1 on cc10.7 is wired only for per-tensor FP8 d128 (the other SM107 siblings carry no SplitHelpers)",
             )
 
         swa_left = self.window_size_left
@@ -1408,7 +1488,9 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
 
         params = Sm100TemplateParams(
             dtype_qkv=_SM100_DTYPE_QKV_CODE[self.dtype],
-            dtype_o=_SM100_DTYPE_QKV_CODE[self.dtype_o],
+            # A quantized-O split compiles the kernel to write HALF partials;
+            # the combine performs the single cast to the real O dtype.
+            dtype_o=(_SM100_DTYPE_QKV_CODE[torch.float16] if self._quantized_split() else _SM100_DTYPE_QKV_CODE[self.dtype_o]),
             window_left=self.window_left,
             window_right=self.window_right,
             bottom_right=self.causal_bottom_right,
@@ -1553,6 +1635,8 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 d_v=self.head_dim_v,
                 splits=self.split_kv,
                 dtype_o=self._combine_dtype_tag(),
+                dtype_partial=self._partial_dtype_tag(),
+                has_scale_o=self._split_scale_o(),
                 has_lse=self.lse_desc is not None,
                 has_amax=self._fp8,
                 lse_stride=self._lse_stride,
@@ -1590,9 +1674,9 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             return 0  # dense FP8/MXFP8: no per-execute scratch (dummies are cached one-time)
         if self.split_kv > 1:
             # Split-major partial slabs the main kernel writes and the combine
-            # pass reduces: O_s [splits*B, S_q, H, d_v] in the O dtype (half —
-            # the split path requires a bf16/fp16 O even on the FP8 families)
-            # and lse_s [splits*B, H, S_q] fp32. Carved from the caller's
+            # pass reduces: O_s [splits*B, S_q, H, d_v] in the PARTIAL dtype
+            # (wider than O -- fp32 on SM100, half on SM120; the combine owns
+            # the cast down) and lse_s [splits*B, H, S_q] fp32. Carved from the caller's
             # workspace — zero per-execute allocations (Hard Rule 1).
             o_bytes = self.split_kv * b * self.s_q_max * qh * self.head_dim_v * self._o_itemsize()
             lse_bytes = self.split_kv * b * qh * self.s_q_max * 4
@@ -1774,7 +1858,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             # No zero-fill: the split kernel writes EVERY (split, batch) slot,
             # emitting O := 0 / lse := -inf for empty split ranges itself.
             s, b, h, sq, dv = self.split_kv, self.batch_size, self.h_q, self.s_q_max, self.head_dim_v
-            o_partial, lse_partial = self._split_partials(workspace, o_arg, device, current_stream)
+            o_partial, lse_partial = self._split_partials(workspace, device, current_stream)
             self._compiled_kernel(
                 Q,
                 K,
@@ -1788,6 +1872,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 cutlass.Float32(scale_softmax_log2),
                 cutlass.Int32(0),
                 seq_q_t,
+                **({"o_partial_f32": o_partial} if self._fp32_partial_split() else {}),
                 stream=current_stream,
             )
             self._combine_kernel(
@@ -1796,6 +1881,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 o_arg,
                 lse_arg,
                 None,
+                None,  # dense half O: no amax, and never a quantized cast
                 (b, h, sq, dv),
                 cutlass.Int32(s),
                 stream=current_stream,
@@ -1814,6 +1900,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 cutlass.Float32(scale_softmax_log2),
                 cutlass.Int32(0),
                 seq_q_t,
+                **({"o_partial_f32": o_partial} if self._fp32_partial_split() else {}),
                 stream=current_stream,
             )
         if o_needs_copy_back:
@@ -2299,7 +2386,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         # caller's O/LSE and owns the recombined amax.
         O_dst, lse_dst = O, lse
         if self.split_kv > 1:
-            O_dst, lse_dst = self._split_partials(workspace, O, device, current_stream)
+            O_dst, lse_dst = self._split_partials(workspace, device, current_stream)
         dense_q_lens_args = (seq_q_t,) if self._quantized_q_lens_abi else ()
         self._compiled_kernel(
             Q,
@@ -2318,6 +2405,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             cutlass.Float32(scale_softmax_log2),
             cutlass.Int32(0),
             *dense_q_lens_args,
+            **({"o_partial_f32": O_dst} if self._fp32_partial_split() else {}),
             stream=current_stream,
         )
         if self.split_kv > 1:
@@ -2327,6 +2415,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 O,
                 lse,
                 amax_o_buf,
+                None,  # block-scaled O: no scalar scale to apply at the cast
                 (b, h_q, sq, self.head_dim_v),
                 cutlass.Int32(self.split_kv),
                 stream=current_stream,
@@ -2377,6 +2466,10 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         dk_t = self._scale_view(descale_k, "descale_k", device)
         dv_t = self._scale_view(descale_v, "descale_v", device)
         so_t = self._scale_view(scale_o, "scale_o", device)
+        # Under a quantized split the kernel writes UNSCALED half partials and
+        # the combine applies scale_o once, at its single cast; bind the
+        # identity here so the epilogue folds nothing in.
+        so_kernel = self._scale_view(None, "scale_o", device) if self._split_scale_o() else so_t
         scale_softmax_log2 = scale_val * math.log2(math.e)
         o_scale_fused = 1.0
 
@@ -2474,7 +2567,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         # the recombined amax.
         O_dst, lse_dst = O, lse
         if self.split_kv > 1:
-            O_dst, lse_dst = self._split_partials(workspace, O, device, current_stream)
+            O_dst, lse_dst = self._split_partials(workspace, device, current_stream)
         dense_q_lens_args = (seq_q_t,) if self._quantized_q_lens_abi else ()
         self._compiled_kernel(
             Q,
@@ -2492,9 +2585,10 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             dq_t,
             dk_t,
             dv_t,
-            so_t,
+            so_kernel,
             amax_o_buf,
             *dense_q_lens_args,
+            **({"o_partial_f32": O_dst} if self._fp32_partial_split() else {}),
             stream=current_stream,
         )
         if self.split_kv > 1:
@@ -2504,6 +2598,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 O,
                 lse,
                 amax_o_buf,
+                so_t if self._split_scale_o() else None,
                 (b, h_q, sq, self.head_dim_v),
                 cutlass.Int32(self.split_kv),
                 stream=current_stream,
@@ -2515,7 +2610,10 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 # Device divisor: the same div_ as before, minus the readback.
                 # scale_o > 0 is caller contract (backend parity); None bound a
                 # cached 1.0 above.
-                amax_o_buf.div_(so_t)
+                # Not under a quantized split: the combine measured the amax
+                # PRE-scale, so it is already the pre-quant value.
+                if not self._split_scale_o():
+                    amax_o_buf.div_(so_t)
         self._logger.debug("execute (FP8 per-tensor) completed")
 
 
@@ -3000,10 +3098,10 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             # backstop additionally bars a split under the LPT remaps —
             # validated at compile via make_cfg, and the heuristic's split
             # sets ride SCHED_NATURAL.
-            self._value_error_if(
-                self._fp8 and self.o_desc.dtype not in (torch.float16, torch.bfloat16),
-                "split_kv > 1 on a quantized graph requires a bf16/fp16 O (the combine reduces half-precision partials)",
-            )
+            #
+            # Partials stay half here (see _fp32_partial_split): sO aliases sKV
+            # on this arch, so there is no room to widen the O tile the way the
+            # SM100 kernels do.
             self._not_implemented_error_if(self.thd, "split_kv > 1 is dense-only (THD packs its own flat grid)")
             self._value_error_if(self.has_sink, "split_kv > 1 with an attention sink is not supported")
             self._value_error_if(
@@ -3057,7 +3155,9 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
                 )
         params = Sm120TemplateParams(
             dtype_qkv=_SM120_DTYPE_QKV_CODE[self.dtype],
-            dtype_o=_SM120_DTYPE_QKV_CODE[self.o_desc.dtype],
+            # A quantized-O split writes HALF partials; the combine performs
+            # the single cast to the real O dtype.
+            dtype_o=(_SM120_DTYPE_QKV_CODE[torch.float16] if self._quantized_split() else _SM120_DTYPE_QKV_CODE[self.o_desc.dtype]),
             sched_policy=sched_policy,
             window_left=self.window_left,
             window_right=self.window_right,
@@ -3111,6 +3211,8 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
                 d_v=self.head_dim_v,
                 splits=self.split_kv,
                 dtype_o=self._combine_dtype_tag(),
+                dtype_partial=self._partial_dtype_tag(),
+                has_scale_o=self._split_scale_o(),
                 has_lse=self.lse_desc is not None,
                 # The quantized rows stand their in-kernel amax down under a split,
                 # so the combine owns the amax of the RECOMBINED O.
@@ -3241,7 +3343,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         # the shared combine reduces them into the caller's O/LSE.
         o_dst, lse_dst = o, lse
         if self.split_kv > 1:
-            o_dst, lse_dst = self._split_partials(workspace, o, q_tensor.device, current_stream)
+            o_dst, lse_dst = self._split_partials(workspace, q_tensor.device, current_stream)
         self._compiled_kernel(
             q,
             k,
@@ -3269,6 +3371,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
                 o,
                 lse,
                 None,
+                None,  # dense half O: never a quantized cast
                 (self.batch_size, self.h_q, self.s_q_max, self.head_dim_v),
                 cutlass.Int32(self.split_kv),
                 stream=current_stream,
@@ -3317,6 +3420,10 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         dk_t = self._scale_view(descale_k, "descale_k", device)
         dv_t = self._scale_view(descale_v, "descale_v", device)
         so_t = self._scale_view(scale_o, "scale_o", device)
+        # Under a quantized split the kernel writes UNSCALED half partials and
+        # the combine applies scale_o once, at its single cast; bind the
+        # identity here so the epilogue folds nothing in.
+        so_kernel = self._scale_view(None, "scale_o", device) if self._split_scale_o() else so_t
         scale_softmax_log2 = scale_val * math.log2(math.e)
         o_scale_fused = 1.0
 
@@ -3405,7 +3512,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         # combine below owns both the reduction and the amax.
         o_dst, lse_dst = o, lse
         if self.split_kv > 1:
-            o_dst, lse_dst = self._split_partials(workspace, o, q_tensor.device, current_stream)
+            o_dst, lse_dst = self._split_partials(workspace, q_tensor.device, current_stream)
 
         fn = self._compiled_kernel
         if pack is not None:
@@ -3428,7 +3535,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             dq_t,
             dk_t,
             dv_t,
-            so_t,
+            so_kernel,
             cutlass.Int32(pack.max_sq if pack is not None else 0),
             pack.q_lens_dev if pack is not None else None,
             pack.kv_lens_dev if pack is not None else None,
@@ -3451,6 +3558,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
                 # expects a tensor -- _amax_slot hands back a cached dummy when
                 # the caller supplied nothing. Same as the SM100 arms.
                 amax_o_buf,
+                so_t if self._split_scale_o() else None,
                 (self.batch_size, self.h_q, self.s_q_max, self.head_dim_v),
                 cutlass.Int32(self.split_kv),
                 stream=current_stream,
@@ -3461,7 +3569,10 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             if amax_o is not None:
                 # Device divisor: same div_, minus the readback; scale_o > 0
                 # is caller contract (None bound a cached 1.0 above).
-                amax_o_buf.div_(so_t)
+                # Not under a quantized split: the combine measured the amax
+                # PRE-scale, so it is already the pre-quant value.
+                if not self._split_scale_o():
+                    amax_o_buf.div_(so_t)
         self._logger.debug("execute (SM120 FP8 per-tensor) completed")
 
     def _thd_compile_kwargs(self) -> dict:

--- a/python/cudnn/sdpa/fwd/config_sm100.py
+++ b/python/cudnn/sdpa/fwd/config_sm100.py
@@ -106,6 +106,11 @@ class TemplateParams:
     # chunks, each run as its own persistent tile writing a partial (O, LSE)
     # that kernels/sm100/split_combine.py reduces.  1 = off (byte-identical
     # codegen to the single-pass kernel).
+    #
+    # A split writes its partials as fp32, straight from the epilogue's
+    # accumulator registers and bypassing the SMEM O tile and its TMA store, so
+    # the combine reduces an unrounded input and performs the only rounding to
+    # O's dtype.  Partial-only: the caller-visible O is unchanged.
     split_kv: int = 1
     # MMA cluster width: 2 = cga2 collective tcgen05.mma.cta_group::2 (a CTA
     # pair share one MMA, each holding half of every K/V tile); 1 = cga1, one

--- a/python/cudnn/sdpa/fwd/config_sm107.py
+++ b/python/cudnn/sdpa/fwd/config_sm107.py
@@ -272,9 +272,17 @@ def _mask_flags_from(params: TemplateParams) -> int:
     return flags
 
 
-def _validate_params(flavor: str, k: TemplateParams) -> None:
+def _validate_params(flavor: str, k: TemplateParams, *, split_wired: bool = False) -> None:
     """Guard the TemplateParams a Rubin flavor can express. Every rejection here
-    must also be a Capabilities decline — reaching this is an engine-row bug."""
+    must also be a Capabilities decline — reaching this is an engine-row bug.
+
+    ``split_wired`` says whether THIS flavor's kernel carries make_split_helpers.
+    It is per-flavor rather than blanket because exactly one Rubin kernel does:
+    prefill_d128_fp8_sm107.py, which was ported from its SM100 twin before the
+    other nine siblings existed. Rejecting the split for that one contradicted
+    the engine row, which advertises split_d_shapes={(128, 128)} — so a long-KV
+    Rubin graph could be handed an automatically proposed split plan and then
+    fail here at compile."""
     if k.dtype_qkv not in (_DTYPE_E4M3, _DTYPE_E5M2, _DTYPE_BF16, _DTYPE_FP16):
         raise ValueError(f"{flavor}: dtype_qkv must be 0=E4M3/1=E5M2/2=BF16/3=FP16 (got {k.dtype_qkv}); Rubin has no TF32 prefill kernel")
     dtype_o = resolve_dtype_o(k)
@@ -286,8 +294,8 @@ def _validate_params(flavor: str, k: TemplateParams) -> None:
         raise ValueError(f"{flavor}: sched_policy must be NATURAL/LPT/LPT_L2 or None (got {k.sched_policy})")
     if k.qh_per_kh < 1:
         raise ValueError(f"{flavor}: qh_per_kh ({k.qh_per_kh}) must be >= 1")
-    if k.split_kv and k.split_kv > 1:
-        raise ValueError(f"{flavor}: split_kv > 1 is not wired in the SM107 kernels (no SplitHelpers)")
+    if k.split_kv and k.split_kv > 1 and not split_wired:
+        raise ValueError(f"{flavor}: split_kv > 1 is not wired in this SM107 kernel (no SplitHelpers)")
     # THD/varlen is per-FLAVOR on the Rubin line, not per-dtype.  Every
     # QUANTIZED flavor carries it; on the f16/bf16 side only the flavors whose
     # BODY has been ported to the FROST setup-kernel contract do -- the rest
@@ -606,7 +614,15 @@ def _stages_kv_d128(dtype_qkv: int, cta_mma: int, *, mxfp8: bool, tile_k: int) -
 
 
 def _make_cfg_d128_family(params: TemplateParams, *, flavor: str, tile_k: int, tile_o: int, mxfp8: bool):
-    _validate_params(flavor, params)
+    # Per-tensor FP8 d128 is the Rubin cell the engine row's split_d_shapes
+    # names, and the gate tracks the ROW rather than merely "has SplitHelpers":
+    # sm107/prefill_d192_d128_fp8 wires them too, but the row does not advertise
+    # it and its body carries no o_partial_f32 slot, so a split there would be
+    # untested capability. This entry point also serves the d128 HALF kernel and
+    # (at tile_k=192) the d192 one -- hence the dtype and tile checks rather than
+    # keying on the flavor string.
+    split_wired = not mxfp8 and tile_k == 128 and tile_o == 128 and params.dtype_qkv in (_DTYPE_E4M3, _DTYPE_E5M2)
+    _validate_params(flavor, params, split_wired=split_wired)
     cta_mma = params.cta_mma
     dtype_o = resolve_dtype_o(params)
     b, b_o = bpe(params.dtype_qkv), bpe(dtype_o)

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -387,11 +387,8 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
                 # path the split cannot ride. Mirror lower_dsl_prefill's
                 # synth_kv_padding predicate so the plan is never listed.
                 return "split_kv > 1 cannot ride the synthesized KV-tail padding this S_kv needs"
-            if (facts.is_fp8 or facts.is_mxfp8) and facts.dtype_o not in (cudnn.data_type.HALF, cudnn.data_type.BFLOAT16):
-                # The combine reduces partials in half precision; reducing
-                # QUANTIZED partials would lose what the split must be
-                # numerically neutral about.
-                return "split_kv > 1 on a quantized graph requires a bf16/fp16 O"
+            # No gate on the O dtype: the partials are never narrower than it,
+            # and the combine performs the only cast down to it.
             if capabilities.split_d_shapes is not None and not any(facts.d_qk <= sq and facts.d_v <= sv for sq, sv in capabilities.split_d_shapes):
                 return (
                     f"split_kv > 1 is wired only in the {sorted(capabilities.split_d_shapes)} kernel " f"flavors; graph has D_QK={facts.d_qk}/D_V={facts.d_v}"
@@ -920,8 +917,6 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
             # path (MUFU EX2.F16x2 exists below cc10.7 but no other file wires
             # it). FLOAT is the f32 pipeline every flavor already runs.
             softmax_precisions=(frozenset({cudnn.data_type.FLOAT, cudnn.data_type.HALF}) if rubin_row else frozenset({cudnn.data_type.FLOAT})),
-            # Split partials reduce in half precision, so mismatch()'s
-            # facts x knobs gate additionally requires a bf16/fp16 O.
             split_kv_supported=True,
             split_d_shapes=(frozenset({(128, 128)}) if rubin_row else frozenset({(128, 128), (192, 128), (256, 256)})),
             pack_gqas=frozenset({False, True}),

--- a/python/cudnn/sdpa/fwd/heuristics.py
+++ b/python/cudnn/sdpa/fwd/heuristics.py
@@ -118,7 +118,22 @@ _SPLIT_KV_CTA_COST = 21.0
 # one fixed kernel, so blocks/SM is a constant, and folding it in keeps a
 # cuOccupancy query -- which would need a compiled CUfunction -- off the
 # planning path. Empirical: re-measure if sm100/split_combine changes.
-_SPLIT_KV_COMBINE_COST = 0.2
+#
+# Re-measured for the fp32 partials the SM100 split kernels now write (was 0.2,
+# fitted when partials were half). Widening them turned out to cost the combine
+# almost nothing -- 1.05x on a 148-row x 512-split sweep, because the pass is
+# not purely bandwidth-bound -- so the move is NOT a consequence of the extra
+# bytes. It corrects a coefficient that was too large for the shapes this model
+# is asked about: the split kernel also stopped staging O through SMEM and TMA,
+# which made splitting cheaper on the main-kernel side.
+#
+# Two independent fits agree. Timing the combine directly against one KV tile of
+# main-kernel work, with the partials large enough to live in HBM rather than
+# L2, gives 0.037 (f16) / 0.039 (f32). Minimising regret over the end-to-end
+# sweep in test_split_kv_heuristic._B300_FIT gives an optimum PLATEAU of
+# [0.04, 0.155] -- every value in it makes the same 12 choices. 0.1 is that
+# plateau's midpoint, so it is the value furthest from flipping either way.
+_SPLIT_KV_COMBINE_COST = 0.1
 
 
 class _SplitKvLaunch(NamedTuple):
@@ -655,13 +670,8 @@ def _split_points(
         # This S_kv would be served through the synthesized KV-tail padding,
         # which the split cannot ride (mismatch declines the same combination).
         return [no_split]
-    if (facts.is_fp8 or facts.is_mxfp8) and facts.dtype_o not in (
-        cudnn.data_type.HALF,
-        cudnn.data_type.BFLOAT16,
-    ):
-        # The combine reduces partials in half precision; reducing QUANTIZED
-        # partials would lose what the split is meant to be neutral about.
-        return [no_split]
+    # A quantized O is a legal split target: the partials stay WIDER than the
+    # O dtype whatever it is, and the combine performs the only cast down to it.
     sm_count = facts.device_sm_count or 0
     if sm_count <= 0:
         return [no_split]

--- a/python/cudnn/sdpa/fwd/kernels/_common_blackwell.py
+++ b/python/cudnn/sdpa/fwd/kernels/_common_blackwell.py
@@ -246,6 +246,60 @@ def assert_tile_n_supported(CFG):
         raise NotImplementedError(f"this kernel currently requires TILE_N=128 (got TILE_N={CFG.TILE_N})")
 
 
+@cute.jit
+def store_fp32_partial_tile(
+    o_partial_f32,
+    tmem_base,
+    tmem_o_off,
+    inv_sum,
+    row_dead,
+    row_valid,
+    o_batch,
+    q_row_global,
+    row_head_idx,
+    tile_o: cutlass.Constexpr[int],
+    chunk: cutlass.Constexpr[int],
+) -> None:
+    """Store one Q row's O tile as fp32, straight from TMEM to the workspace.
+
+    The staged path casts the accumulator into the SMEM O tile and TMA-stores
+    that, which ties the partial's width to the tile's.  Here the accumulator
+    goes to global directly, so the partial can be fp32 while the tile -- and
+    therefore the SMEM budget -- is untouched.  Shared by every flavor whose
+    epilogue holds its O accumulator in TMEM.
+
+    ``chunk`` must be the flavor's OWN TMEM read width (its ``O_CHUNK``): the
+    O region is not uniformly addressable across flavors, so reading it in a
+    different stride than the staged epilogue does silently returns the wrong
+    columns rather than failing.
+
+    ``row_dead`` cannot be dropped in favour of the zeroed ``inv_sum`` every
+    caller already computes: an empty mainloop never wrote O TMEM, so the load
+    can return NaN, and ``NaN * 0.0`` is NaN, not zero.  The staged paths avoid
+    this by not loading at all for such rows; here the select does it.
+    """
+    op = cutlass.make_array_view(o_partial_f32)
+    # The slab carries the graph's ACTUAL d_v, which an ENVELOPE flavor routinely
+    # exceeds -- d_v=64 runs on the d128 tile, so tile_o overshoots each row by 64
+    # columns.  The staged TMA path clipped that to the tensor extent; a direct
+    # store has to bound itself or it writes into the next head's row, and off the
+    # end of the slab on the last one.  Read off the tensor rather than passed in,
+    # so it cannot drift from the buffer actually bound.
+    d_v = cutlass.const_expr(o_partial_f32.shape[3])
+    for blk in cutlass.range_constexpr(tile_o // chunk):
+        addr = tmem_base + cutlass.Int32(tmem_o_off + blk * chunk)
+        vals = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(addr, cutlass.Float32), num=chunk)
+        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+        scaled = vals * inv_sum
+        if row_valid:
+            row_out = op[o_batch, q_row_global, row_head_idx, :]
+            for j in cutlass.range_constexpr(chunk):
+                if cutlass.const_expr(blk * chunk + j < d_v):
+                    row_out[cutlass.Int32(blk * chunk + j)] = cutlass.Float32(
+                        arith.select(row_dead.ir_value(), cutlass.Float32(0.0).ir_value(), scaled[j].ir_value())
+                    )
+
+
 class SplitHelpers(NamedTuple):
     """Split-aware decode / bounds closures, plus the two flags kernels fold on."""
 

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d128_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d128_f16.py
@@ -165,6 +165,7 @@ else:
 from cudnn.sdpa.fwd.kernels._common_blackwell import (
     Bars,
     make_split_helpers,
+    store_fp32_partial_tile as _store_fp32_partial_tile,
     KvLoopBounds,
     make_classic_bars,
     compute_kv_loop_bounds,
@@ -252,6 +253,9 @@ _split_h = make_split_helpers(
     dispatch_decode_payload=_dispatch_decode_payload,
 )
 SPLIT_KV = _split_h.SPLIT_KV
+# A split writes fp32 partials, replacing the SMEM/TMA O path rather than
+# widening it; the combine performs the only cast to O's dtype.
+_FP32_PARTIALS = SPLIT_KV > 1
 MAY_BE_EMPTY = _split_h.MAY_BE_EMPTY
 _decode_initial_split = _split_h.decode_initial_split
 _decode_payload_split = _split_h.decode_payload_split
@@ -330,6 +334,7 @@ def _kernel(
     # CFG.SEQ_Q_LENS_PRESENT — the DSL specializes on None, so the flag-off
     # ABI is unchanged.
     seq_q_lens_tensor: Optional[cute.Tensor] = None,
+    o_partial_f32: Optional[cute.Tensor] = None,
 ) -> None:
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
     tidx, _, _ = cute.arch.thread_idx()
@@ -533,6 +538,7 @@ def _kernel(
             cta_in_pair=cta_in_pair,
             cta_id_x=cta_id_x,
             qh_per_kh=qh_per_kh,
+            o_partial_f32=o_partial_f32,
         )
 
     elif warp_idx == CFG.MMA_WARP_ID:
@@ -962,34 +968,38 @@ def _tmastg_warp_group(
 
         for qs in cutlass.range_constexpr(CFG.TILES_Q):
             bars.mb_o_full[qs].wait(o_full_phase)
-
-            # O TMA params follow O's swizzle (NOT V's) — under gptoss cga2 V drops to Swz64B while O stays Swz128B.
-            if cutlass.const_expr(CFG.THD_VARLEN):
-                # THD: store each Q slab through this batch's pre-built descriptor
-                # (base at the sequence's packed row, seq extent = S_q_b → a box
-                # past S_q_b is OOB-clipped).  q_row coord is sequence-local; the
-                # batch coord collapses to 0.  Both slabs share one descriptor.
-                # DEAD unit (batch == n_batch, over-launched grid — issue #552):
-                # no O rows exist and descriptor slot n_batch is never built, so
-                # skip the store; the barrier protocol below still runs.
-                if batch_idx < n_batch:
-                    o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
-                    o_slice = tma_slice_runtime_desc(
-                        o_desc_ptr,
-                        cutlass.Int32(0),
-                        q_head_idx,
-                        q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE),
-                        cutlass.Int32(0),
+            # fp32 partials wrote the workspace directly, so there is nothing
+            # staged to copy.  Skip ONLY the store: the arrive below and the
+            # QO_ALIAS handshake after it must still run, or this warp laps
+            # the loader and the parity waits deadlock.
+            if cutlass.const_expr(not _FP32_PARTIALS):
+                # O TMA params follow O's swizzle (NOT V's) — under gptoss cga2 V drops to Swz64B while O stays Swz128B.
+                if cutlass.const_expr(CFG.THD_VARLEN):
+                    # THD: store each Q slab through this batch's pre-built descriptor
+                    # (base at the sequence's packed row, seq extent = S_q_b → a box
+                    # past S_q_b is OOB-clipped).  q_row coord is sequence-local; the
+                    # batch coord collapses to 0.  Both slabs share one descriptor.
+                    # DEAD unit (batch == n_batch, over-launched grid — issue #552):
+                    # no O rows exist and descriptor slot n_batch is never built, so
+                    # skip the store; the barrier protocol below still runs.
+                    if batch_idx < n_batch:
+                        o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                        o_slice = tma_slice_runtime_desc(
+                            o_desc_ptr,
+                            cutlass.Int32(0),
+                            q_head_idx,
+                            q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE),
+                            cutlass.Int32(0),
+                        )
+                        tma_store_tile(sO[qs], o_slice)
+                else:
+                    tma_store_tile(
+                        sO[qs],
+                        tma_o(cutlass.Int32(0), q_head_idx, q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE), o_batch),
                     )
-                    tma_store_tile(sO[qs], o_slice)
-            else:
-                tma_store_tile(
-                    sO[qs],
-                    tma_o(cutlass.Int32(0), q_head_idx, q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE), o_batch),
-                )
 
-            tma_store_commit()
-            tma_store_wait(0)
+                tma_store_commit()
+                tma_store_wait(0)
 
             bars.mb_o_empty[qs].arrive()
             # QO_ALIAS: O[qs] has drained to GMEM → the shared Q∪O slab is free
@@ -1819,6 +1829,7 @@ def _correction_warp_group(
     cta_in_pair,
     cta_id_x,
     qh_per_kh,
+    o_partial_f32=None,
 ):
     """Correction warp group: 4 warps x 32 lanes = 128 lanes, 1 lane per O row.
 
@@ -1960,6 +1971,10 @@ def _correction_warp_group(
             bars.mb_stats_read[qs].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
 
             inv_sum = cutlass.Float32(0.0)  # pre-declare for DSL if-staging
+            # Same reason: row_dead is only bound under some mask/sink configs, but
+            # the fp32-partial store reads it unconditionally.  False here means
+            # 'not dead'; the branches below override it where it is meaningful.
+            row_dead = cutlass.Float32(0.0) > cutlass.Float32(1.0)
             lse_val = cutlass.Float32(0.0)
             q_row_global = (
                 q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE) + cutlass.Int32(qs * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
@@ -2033,37 +2048,53 @@ def _correction_warp_group(
 
             sO_sub_base = sO[qs].base
 
-            for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
-                o_fp16 = cutlass.Vector.from_elements(
-                    tuple(STORAGE_DTYPE(0.0) for _ in range(O_CHUNK)),
-                    STORAGE_DTYPE,
+            if cutlass.const_expr(_FP32_PARTIALS):
+                _store_fp32_partial_tile(
+                    o_partial_f32,
+                    tmem_base_epi,
+                    tmem_O_off,
+                    inv_sum,
+                    row_dead,
+                    q_row_global < seqlen_q,
+                    _partial_batch(batch_idx, split_idx, n_batch),
+                    q_row_global,
+                    row_head_idx,
+                    CFG.TILE_O,
+                    O_CHUNK,
                 )
-                if cutlass.const_expr(not MAY_BE_EMPTY) or (bounds.right > bounds.left):
-                    o_addr = tmem_base_epi + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
-                    o_chunk = nvvm.tcgen05_ld(
-                        "32x32b",
-                        nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
-                        num=O_CHUNK,
+                bars.mb_o_empty[qs].wait(o_empty_phase)
+            else:
+                for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                    o_fp16 = cutlass.Vector.from_elements(
+                        tuple(STORAGE_DTYPE(0.0) for _ in range(O_CHUNK)),
+                        STORAGE_DTYPE,
                     )
-                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-                    o_scaled = o_chunk * inv_sum
-                    o_fp16 = o_scaled.to(STORAGE_DTYPE)
+                    if cutlass.const_expr(not MAY_BE_EMPTY) or (bounds.right > bounds.left):
+                        o_addr = tmem_base_epi + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
+                        o_chunk = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                            num=O_CHUNK,
+                        )
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                        o_scaled = o_chunk * inv_sum
+                        o_fp16 = o_scaled.to(STORAGE_DTYPE)
 
-                col_offset_const = (chunk_idx * O_CHUNK) % D_BLOCK_SIZE
-                block_idx_const = (chunk_idx * O_CHUNK) // D_BLOCK_SIZE
-                block_offset_const = block_idx_const * TMA_O_GRANU_ELEMS
-                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
+                    col_offset_const = (chunk_idx * O_CHUNK) % D_BLOCK_SIZE
+                    block_idx_const = (chunk_idx * O_CHUNK) // D_BLOCK_SIZE
+                    block_offset_const = block_idx_const * TMA_O_GRANU_ELEMS
+                    smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
 
-                smem_ptr = sO_sub_base.subview(smem_offset).data_ptr()
-                # mb_o_empty[qs] wait gates the FIRST SMEM store (not the
-                # earlier TMEM-load loop), keeping TMEM-load/FFMA/cast overlapped
-                # with TMA-STG draining the prior persistent tile.
-                if chunk_idx == 0:
-                    bars.mb_o_empty[qs].wait(o_empty_phase)
-                smem_ptr.store_swizzled(o_fp16, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+                    smem_ptr = sO_sub_base.subview(smem_offset).data_ptr()
+                    # mb_o_empty[qs] wait gates the FIRST SMEM store (not the
+                    # earlier TMEM-load loop), keeping TMEM-load/FFMA/cast overlapped
+                    # with TMA-STG draining the prior persistent tile.
+                    if chunk_idx == 0:
+                        bars.mb_o_empty[qs].wait(o_empty_phase)
+                    smem_ptr.store_swizzled(o_fp16, alignment=64, swizzle=_O_SMEM_SWIZZLE)
 
-            # fence_proxy needed before TMA reads SMEM written by tcgen05_st (via store_swizzled).
-            nvvm.fence_proxy("async.shared", space="cta")
+                # fence_proxy needed before TMA reads SMEM written by tcgen05_st (via store_swizzled).
+                nvvm.fence_proxy("async.shared", space="cta")
 
             bars.mb_o_full[qs].arrive()
 
@@ -2131,6 +2162,7 @@ def _host(
     thd_q_lens_tensor: Optional[cute.Tensor] = None,
     thd_kv_lens_tensor: Optional[cute.Tensor] = None,
     thd_lens_form: Optional[cutlass.Int32] = None,
+    o_partial_f32: Optional[cute.Tensor] = None,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
     B, QH, KH, SQ, SKV, _ = problem_size
@@ -2181,9 +2213,14 @@ def _host(
         swizzle=_v_tma_swz,
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
     )
+    _o_box = list(vo_box_o)
+    if _FP32_PARTIALS:
+        # fp32 is 4 bytes; scale the box by the O element's own width so
+        # the inner dimension stays inside the swizzle's byte limit.
+        _o_box[-1] = max(1, _o_box[-1] * CFG.BPE_O // 4)
     tma_o_desc = tmap.create_tensor_map_tiled_from_view(
         o_tensor,
-        box_dims=vo_box_o,
+        box_dims=tuple(_o_box),
         stride_order=stride_order,
         swizzle=_tma_swz(CFG.O_SWZ_BYTES),
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
@@ -2257,6 +2294,7 @@ def _host(
         cutlass.Int32(QH // KH),
         scale_softmax_log2,
         seq_q_lens_tensor,
+        o_partial_f32,
     ).launch(
         grid=grid_shape,
         block=[CFG.THREADS_PER_CTA, 1, 1],
@@ -2353,7 +2391,7 @@ def compile(  # noqa: A001
     fake_q = _fake_bshd((_fake_batch, sq, qh, d_qk), q_stride)
     fake_k = _fake_bshd((_fake_batch, skv, kh, d_qk), k_stride)
     fake_v = _fake_bshd((_fake_batch, skv, kh, d_v), v_stride)
-    fake_o = _fake_bshd((_o_batch, sq, qh, d_v), o_stride, dtype=STORAGE_DTYPE)
+    fake_o = _fake_bshd((_o_batch, sq, qh, d_v), o_stride, dtype=cutlass.Float32 if _FP32_PARTIALS else STORAGE_DTYPE)
     if not has_lse:
         # No Stats output: the LSE argument is None-specialized and the store
         # is compiled out entirely — no dummy buffer exists at any level.
@@ -2474,6 +2512,7 @@ def compile(  # noqa: A001
         fake_thd_q_lens,
         fake_thd_kv_lens,
         fake_thd_lens_form,
+        *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d128_fp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d128_fp8.py
@@ -162,6 +162,7 @@ else:
 
 from cudnn.sdpa.fwd.kernels._common_blackwell import (
     make_split_helpers,
+    store_fp32_partial_tile as _store_fp32_partial_tile,
     Bars,
     KvLoopBounds,
     make_classic_bars,
@@ -252,6 +253,9 @@ _split_h = make_split_helpers(
     dispatch_decode_payload=_dispatch_decode_payload,
 )
 SPLIT_KV = _split_h.SPLIT_KV
+# A split writes fp32 partials, replacing the SMEM/TMA O path rather than
+# widening it; the combine performs the only cast to O's dtype.
+_FP32_PARTIALS = SPLIT_KV > 1
 MAY_BE_EMPTY = _split_h.MAY_BE_EMPTY
 _decode_initial_split = _split_h.decode_initial_split
 _decode_payload_split = _split_h.decode_payload_split
@@ -322,6 +326,7 @@ def _kernel(
     descale_v_t: cute.Tensor,
     scale_o_t: cute.Tensor,
     amax_o_tensor: cute.Tensor,
+    o_partial_f32: Optional[cute.Tensor],
 ) -> None:
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
     tidx, _, _ = cute.arch.thread_idx()
@@ -518,6 +523,7 @@ def _kernel(
             cta_id_x=cta_id_x,
             o_scale_fused=o_scale_fused,
             amax_o_tensor=amax_o_tensor,
+            o_partial_f32=o_partial_f32,
             qh_per_kh=qh_per_kh,
         )
 
@@ -930,31 +936,35 @@ def _tmastg_warp_group(
 
         for qs in cutlass.range_constexpr(CFG.TILES_Q):
             bars.mb_o_full[qs].wait(o_full_phase)
+            # fp32 partials wrote the workspace directly, so nothing is staged
+            # to copy.  Skip ONLY the store: the arrive below and any QO_ALIAS
+            # handshake after it must still run, or this warp laps the loader
+            # and the parity waits deadlock.
+            if cutlass.const_expr(not _FP32_PARTIALS):
+                # O TMA params follow O's swizzle, not V's (V and O swizzles may differ).
+                if cutlass.const_expr(CFG.THD_VARLEN):
+                    # THD: store each Q slab through this batch's pre-built descriptor
+                    # (base at the sequence's packed row, seq extent = S_q_b → a box
+                    # past S_q_b is OOB-clipped).  q_row coord is sequence-local; the
+                    # batch coord collapses to 0.  Both slabs share one descriptor.
+                    # (split_kv is dense-only — the config backstop rejects THD —
+                    # so o_batch never applies here.)
+                    # DEAD unit (batch == n_batch, over-launched envelope grid —
+                    # issue #552): no O rows exist and descriptor slot n_batch is
+                    # never built, so skip the store; the barrier protocol below
+                    # still runs.
+                    if batch_idx < n_batch:
+                        o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                        o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), cutlass.Int32(0))
+                        tma_store_tile(sO[qs], o_slice)
+                else:
+                    tma_store_tile(
+                        sO[qs],
+                        tma_o(cutlass.Int32(0), q_head_idx, q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE), o_batch),
+                    )
 
-            # O TMA params follow O's swizzle, not V's (V and O swizzles may differ).
-            if cutlass.const_expr(CFG.THD_VARLEN):
-                # THD: store each Q slab through this batch's pre-built descriptor
-                # (base at the sequence's packed row, seq extent = S_q_b → a box
-                # past S_q_b is OOB-clipped).  q_row coord is sequence-local; the
-                # batch coord collapses to 0.  Both slabs share one descriptor.
-                # (split_kv is dense-only — the config backstop rejects THD —
-                # so o_batch never applies here.)
-                # DEAD unit (batch == n_batch, over-launched envelope grid —
-                # issue #552): no O rows exist and descriptor slot n_batch is
-                # never built, so skip the store; the barrier protocol below
-                # still runs.
-                if batch_idx < n_batch:
-                    o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
-                    o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), cutlass.Int32(0))
-                    tma_store_tile(sO[qs], o_slice)
-            else:
-                tma_store_tile(
-                    sO[qs],
-                    tma_o(cutlass.Int32(0), q_head_idx, q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE), o_batch),
-                )
-
-            tma_store_commit()
-            tma_store_wait(0)
+                tma_store_commit()
+                tma_store_wait(0)
 
             bars.mb_o_empty[qs].arrive()
 
@@ -1731,6 +1741,7 @@ def _correction_warp_group(
     o_scale_fused,
     amax_o_tensor,
     qh_per_kh,
+    o_partial_f32=None,
 ):
     """Correction warp group: 4 warps × 32 lanes = 128, one lane per O row.
 
@@ -1876,6 +1887,10 @@ def _correction_warp_group(
             bars.mb_stats_read[qs].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
 
             inv_sum = cutlass.Float32(0.0)  # pre-declare for DSL if-staging
+            # Same reason: row_dead is only bound under some mask/sink configs, but
+            # the fp32-partial store reads it unconditionally.  False here means
+            # 'not dead'; the branches below override it where it is meaningful.
+            row_dead = cutlass.Float32(0.0) > cutlass.Float32(1.0)
             lse_val = cutlass.Float32(0.0)  # pre-declare; computed in both branches
             q_row_global = (
                 q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE) + cutlass.Int32(qs * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
@@ -1949,7 +1964,26 @@ def _correction_warp_group(
 
             sO_sub_base = sO[qs].base
 
-            if cutlass.const_expr(CFG.DTYPE_O <= 1):
+            if cutlass.const_expr(_FP32_PARTIALS):
+                # fp32 partials: the accumulator goes straight to the workspace,
+                # so the SMEM O tile and its TMA store are both bypassed.
+                _store_fp32_partial_tile(
+                    o_partial_f32,
+                    tmem_base_epi,
+                    tmem_O_off,
+                    inv_sum,
+                    row_dead,
+                    _row_valid,
+                    _partial_batch(batch_idx, split_idx, n_batch),
+                    q_row_global,
+                    row_head_idx,
+                    CFG.TILE_O,
+                    O_CHUNK,
+                )
+                # The TMA-store warp group still runs its handshake; release the
+                # slot even though nothing was staged.
+                bars.mb_o_empty[qs].wait(o_empty_phase)
+            elif cutlass.const_expr(CFG.DTYPE_O <= 1):
                 # FP8 output (DTYPE_O ∈ {0,1}): hand-rolled 16:4 fp8 pack +
                 # STS.128 — forces F2FP outputs into a register quad so STS.128
                 # needs no PRMT to gather them (vs the DSL store_swizzled which
@@ -2122,6 +2156,7 @@ def _host(
     thd_q_lens_tensor: Optional[cute.Tensor] = None,
     thd_kv_lens_tensor: Optional[cute.Tensor] = None,
     thd_lens_form: Optional[cutlass.Int32] = None,
+    o_partial_f32: Optional[cute.Tensor] = None,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
     B, QH, KH, SQ, SKV, _ = problem_size
@@ -2167,9 +2202,18 @@ def _host(
         swizzle=_tma_swz(CFG.V_SWZ_BYTES),
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
     )
+    # Under fp32 partials the epilogue writes o_tensor directly and this
+    # descriptor is never used -- but it still has to BUILD, and an fp32 element
+    # doubles the box's inner byte width past what the O swizzle allows.  Halve
+    # the box so the descriptor stays legal; nothing reads it.
+    _o_box = list(vo_box_o)
+    if _FP32_PARTIALS:
+        # fp32 is 4 bytes; scale the box by the O element's own width so
+        # the inner dimension stays inside the swizzle's byte limit.
+        _o_box[-1] = max(1, _o_box[-1] * CFG.BPE_O // 4)
     tma_o_desc = tmap.create_tensor_map_tiled_from_view(
         o_tensor,
-        box_dims=vo_box_o,
+        box_dims=tuple(_o_box),
         stride_order=stride_order,
         swizzle=_tma_swz(CFG.O_SWZ_BYTES),
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
@@ -2249,6 +2293,7 @@ def _host(
         descale_v_t,
         scale_o_t,
         amax_o_tensor,
+        o_partial_f32,
     ).launch(
         grid=grid_shape,
         block=[CFG.THREADS_PER_CTA, 1, 1],
@@ -2335,7 +2380,9 @@ def compile(  # noqa: A001
         assumed_align=16,
     )
     fake_o = cute.runtime.make_fake_compact_tensor(
-        OUT_STORAGE_DTYPE,
+        # Under fp32 partials o_tensor IS the fp32 split workspace: the epilogue
+        # writes it directly and the TMA descriptor built from it goes unused.
+        cutlass.Float32 if _FP32_PARTIALS else OUT_STORAGE_DTYPE,
         (_o_batch, sq, qh, d_v),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
@@ -2461,6 +2508,9 @@ def compile(  # noqa: A001
         fake_thd_q_lens,
         fake_thd_kv_lens,
         fake_thd_lens_form,
+        # o_partial_f32 is LAST so the THD tensors keep their slots when the
+        # mode is off -- a mid-signature slot shifts them by one.
+        *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d128_mxfp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d128_mxfp8.py
@@ -207,6 +207,7 @@ SF_CONST_VALUE = 0x7F
 
 from cudnn.sdpa.fwd.kernels._common_blackwell import (
     make_split_helpers,
+    store_fp32_partial_tile as _store_fp32_partial_tile,
     Bars,
     KvLoopBounds,
     make_classic_bars,
@@ -308,6 +309,9 @@ _split_h = make_split_helpers(
     dispatch_decode_payload=_dispatch_decode_payload,
 )
 SPLIT_KV = _split_h.SPLIT_KV
+# A split writes fp32 partials, replacing the SMEM/TMA O path rather than
+# widening it; the combine performs the only cast to O's dtype.
+_FP32_PARTIALS = SPLIT_KV > 1
 MAY_BE_EMPTY = _split_h.MAY_BE_EMPTY
 _decode_initial_split = _split_h.decode_initial_split
 _decode_payload_split = _split_h.decode_payload_split
@@ -422,6 +426,7 @@ def _kernel(
     n_batch: cutlass.Int32,
     qh_per_kh: cutlass.Int32,  # GQA group size = n_qh / n_kh.
     scale_softmax_log2: cutlass.Float32,
+    o_partial_f32: Optional[cute.Tensor] = None,
 ) -> None:
 
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
@@ -667,6 +672,7 @@ def _kernel(
             cta_in_pair=cta_in_pair,
             cta_id_x=cta_id_x,
             qh_per_kh=qh_per_kh,
+            o_partial_f32=o_partial_f32,
         )
 
     elif warp_idx == CFG.MMA_WARP_ID:
@@ -1179,31 +1185,35 @@ def _tmastg_warp_group(
 
         for qs in cutlass.range_constexpr(CFG.TILES_Q):
             bars.mb_o_full[qs].wait(o_full_phase)
+            # fp32 partials wrote the workspace directly, so nothing is staged
+            # to copy.  Skip ONLY the store: the arrive below and any QO_ALIAS
+            # handshake after it must still run, or this warp laps the loader
+            # and the parity waits deadlock.
+            if cutlass.const_expr(not _FP32_PARTIALS):
+                # O TMA params follow O's swizzle, NOT V's — required when V_SWZ_B != O_SWZ_B.
+                if cutlass.const_expr(CFG.THD_VARLEN):
+                    # THD: store each Q slab through this batch's pre-built descriptor
+                    # (base at the sequence's packed row, seq extent = S_q_b → a box
+                    # past S_q_b is OOB-clipped).  q_row coord is sequence-local; the
+                    # batch coord collapses to 0.  Both slabs share one descriptor.
+                    # (split_kv is dense-only — the config backstop rejects THD —
+                    # so o_batch never applies here.)
+                    # DEAD unit (batch == n_batch, over-launched envelope grid —
+                    # issue #552): no O rows exist and descriptor slot n_batch is
+                    # never built, so skip the store; the barrier protocol below
+                    # still runs.
+                    if batch_idx < n_batch:
+                        o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                        o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), cutlass.Int32(0))
+                        tma_store_tile(sO[qs], o_slice)
+                else:
+                    tma_store_tile(
+                        sO[qs],
+                        tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), o_batch),
+                    )
 
-            # O TMA params follow O's swizzle, NOT V's — required when V_SWZ_B != O_SWZ_B.
-            if cutlass.const_expr(CFG.THD_VARLEN):
-                # THD: store each Q slab through this batch's pre-built descriptor
-                # (base at the sequence's packed row, seq extent = S_q_b → a box
-                # past S_q_b is OOB-clipped).  q_row coord is sequence-local; the
-                # batch coord collapses to 0.  Both slabs share one descriptor.
-                # (split_kv is dense-only — the config backstop rejects THD —
-                # so o_batch never applies here.)
-                # DEAD unit (batch == n_batch, over-launched envelope grid —
-                # issue #552): no O rows exist and descriptor slot n_batch is
-                # never built, so skip the store; the barrier protocol below
-                # still runs.
-                if batch_idx < n_batch:
-                    o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
-                    o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), cutlass.Int32(0))
-                    tma_store_tile(sO[qs], o_slice)
-            else:
-                tma_store_tile(
-                    sO[qs],
-                    tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), o_batch),
-                )
-
-            tma_store_commit()
-            tma_store_wait(0)
+                tma_store_commit()
+                tma_store_wait(0)
 
             bars.mb_o_empty[qs].arrive()
 
@@ -2162,6 +2172,7 @@ def _correction_warp_group(
     leader_cta_id,
     cta_in_pair,
     cta_id_x,
+    o_partial_f32=None,
 ):
     """Correction warp group — α-rescale O + epilogue cast/store + LSE.
 
@@ -2358,55 +2369,73 @@ def _correction_warp_group(
 
             sO_sub_base = sO[qs].base
 
-            _amax_o_ptr = Pointer(amax_o_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
-            _amax_o_local = cutlass.Float32(0.0)
-
-            for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
-                o_addr = tmem_base_epi + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
-                o_chunk = nvvm.tcgen05_ld(
-                    "32x32b",
-                    nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
-                    num=O_CHUNK,
+            if cutlass.const_expr(_FP32_PARTIALS):
+                # fp32 partials: the accumulator goes straight to the workspace,
+                # bypassing the SMEM O tile and its TMA store.
+                _store_fp32_partial_tile(
+                    o_partial_f32,
+                    tmem_base_epi,
+                    tmem_O_off,
+                    inv_sum,
+                    row_dead,
+                    _row_valid,
+                    _partial_batch(batch_idx, split_idx, n_batch),
+                    q_row_global,
+                    head_idx,
+                    CFG.TILE_O,
+                    O_CHUNK,
                 )
-                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-                o_scaled = o_chunk * inv_sum
-                # Dead-row sanitize: an empty mainloop never writes O TMEM,
-                # so o_chunk is garbage (possibly NaN) and `* inv_sum(=0)`
-                # cannot zero it — select 0 explicitly (keeps amax_o clean).
-                _zero_f = cutlass.Float32(0.0)
-                o_scaled = cutlass.Vector.from_elements(
-                    tuple(cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled[i].ir_value())) for i in range(O_CHUNK)),
-                    cutlass.Float32,
-                )
-                for _i in cutlass.range_constexpr(O_CHUNK):
-                    _e = o_scaled[_i]
-                    _amax_o_local = cute.math.max(_amax_o_local, cute.math.max(_e, -_e))
-                o_out = o_scaled.to(OUT_STORAGE_DTYPE)
+                bars.mb_o_empty[qs].wait(o_empty_phase)
+            else:
+                _amax_o_ptr = Pointer(amax_o_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
+                _amax_o_local = cutlass.Float32(0.0)
 
-                col_offset_const = (chunk_idx * O_CHUNK) % D_BLOCK_SIZE
-                block_idx_const = (chunk_idx * O_CHUNK) // D_BLOCK_SIZE
-                block_offset_const = block_idx_const * TMA_O_GRANU_ELEMS
-                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
+                for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                    o_addr = tmem_base_epi + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
+                    o_chunk = nvvm.tcgen05_ld(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                        num=O_CHUNK,
+                    )
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                    o_scaled = o_chunk * inv_sum
+                    # Dead-row sanitize: an empty mainloop never writes O TMEM,
+                    # so o_chunk is garbage (possibly NaN) and `* inv_sum(=0)`
+                    # cannot zero it — select 0 explicitly (keeps amax_o clean).
+                    _zero_f = cutlass.Float32(0.0)
+                    o_scaled = cutlass.Vector.from_elements(
+                        tuple(cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled[i].ir_value())) for i in range(O_CHUNK)),
+                        cutlass.Float32,
+                    )
+                    for _i in cutlass.range_constexpr(O_CHUNK):
+                        _e = o_scaled[_i]
+                        _amax_o_local = cute.math.max(_amax_o_local, cute.math.max(_e, -_e))
+                    o_out = o_scaled.to(OUT_STORAGE_DTYPE)
 
-                smem_ptr = sO_sub_base.subview(smem_offset).data_ptr()
-                # Gate FIRST SMEM store (not earlier TMEM-load loop) — keeps load/FFMA/cast overlapped with prior TMA-STG drain.
-                if chunk_idx == 0:
-                    bars.mb_o_empty[qs].wait(o_empty_phase)
-                smem_ptr.store_swizzled(o_out, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+                    col_offset_const = (chunk_idx * O_CHUNK) % D_BLOCK_SIZE
+                    block_idx_const = (chunk_idx * O_CHUNK) // D_BLOCK_SIZE
+                    block_offset_const = block_idx_const * TMA_O_GRANU_ELEMS
+                    smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
 
-            # One atomic per valid row (invalid/OOB rows must not poison the global amax).
-            #
-            # Under KV split this epilogue sees only its OWN partial, and the
-            # recombined O is a convex combination of the partials -- so a max
-            # over partials over-reports the output amax.  split_combine_sm100
-            # computes it over the recombined O instead; this write has to stay
-            # out of the way, since atomicMax only grows.
-            if cutlass.const_expr(SPLIT_KV == 1):
-                if _row_valid:
-                    nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
+                    smem_ptr = sO_sub_base.subview(smem_offset).data_ptr()
+                    # Gate FIRST SMEM store (not earlier TMEM-load loop) — keeps load/FFMA/cast overlapped with prior TMA-STG drain.
+                    if chunk_idx == 0:
+                        bars.mb_o_empty[qs].wait(o_empty_phase)
+                    smem_ptr.store_swizzled(o_out, alignment=64, swizzle=_O_SMEM_SWIZZLE)
 
-            # fence_proxy needed before TMA reads SMEM written by tcgen05_st.
-            nvvm.fence_proxy("async.shared", space="cta")
+                # One atomic per valid row (invalid/OOB rows must not poison the global amax).
+                #
+                # Under KV split this epilogue sees only its OWN partial, and the
+                # recombined O is a convex combination of the partials -- so a max
+                # over partials over-reports the output amax.  split_combine_sm100
+                # computes it over the recombined O instead; this write has to stay
+                # out of the way, since atomicMax only grows.
+                if cutlass.const_expr(SPLIT_KV == 1):
+                    if _row_valid:
+                        nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
+
+                # fence_proxy needed before TMA reads SMEM written by tcgen05_st.
+                nvvm.fence_proxy("async.shared", space="cta")
 
             bars.mb_o_full[qs].arrive()
 
@@ -2472,6 +2501,7 @@ def _host(
     thd_q_lens_tensor: Optional[cute.Tensor] = None,
     thd_kv_lens_tensor: Optional[cute.Tensor] = None,
     thd_lens_form: Optional[cutlass.Int32] = None,
+    o_partial_f32: Optional[cute.Tensor] = None,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
     """MXFP8 host launcher — builds TMA descriptors for Q/K/V/O + SF tensors.
@@ -2525,9 +2555,16 @@ def _host(
         swizzle=_tma_swz(CFG.V_SWZ_BYTES),
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
     )
+    # Unused under fp32 partials, but it must still BUILD: an fp32 element
+    # doubles the box's inner byte width past what the O swizzle allows.
+    _o_box = list(vo_box_o)
+    if _FP32_PARTIALS:
+        # fp32 is 4 bytes; scale the box by the O element's own width so
+        # the inner dimension stays inside the swizzle's byte limit.
+        _o_box[-1] = max(1, _o_box[-1] * CFG.BPE_O // 4)
     tma_o_desc = tmap.create_tensor_map_tiled_from_view(
         o_tensor,
-        box_dims=vo_box_o,
+        box_dims=tuple(_o_box),
         stride_order=stride_order,
         swizzle=_tma_swz(CFG.O_SWZ_BYTES),
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
@@ -2644,6 +2681,7 @@ def _host(
         cutlass.Int32(B),
         cutlass.Int32(QH // KH),
         scale_softmax_log2,
+        o_partial_f32,
     ).launch(
         grid=grid_shape,
         block=[CFG.THREADS_PER_CTA, 1, 1],
@@ -2720,7 +2758,7 @@ def compile(  # noqa: A001
         assumed_align=16,
     )
     fake_o = cute.runtime.make_fake_compact_tensor(
-        OUT_STORAGE_DTYPE,
+        cutlass.Float32 if _FP32_PARTIALS else OUT_STORAGE_DTYPE,
         (_o_batch, sq, qh, CFG.TILE_O),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
@@ -2854,6 +2892,7 @@ def compile(  # noqa: A001
         fake_thd_q_lens,
         fake_thd_kv_lens,
         fake_thd_lens_form,
+        *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d192_d128_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d192_d128_f16.py
@@ -154,6 +154,7 @@ else:
 from cudnn.sdpa.fwd.kernels._common_blackwell import (
     KvLoopBounds,
     make_split_helpers,
+    store_fp32_partial_tile as _store_fp32_partial_tile,
     make_classic_bars,
     row_max_for_exp2,
     make_sdpa_helpers,
@@ -262,6 +263,9 @@ _split_h = make_split_helpers(
     dispatch_decode_payload=_dispatch_decode_payload,
 )
 SPLIT_KV = _split_h.SPLIT_KV
+# A split writes fp32 partials, replacing the SMEM/TMA O path rather than
+# widening it; the combine performs the only cast to O's dtype.
+_FP32_PARTIALS = SPLIT_KV > 1
 MAY_BE_EMPTY = _split_h.MAY_BE_EMPTY
 _decode_initial_split = _split_h.decode_initial_split
 _decode_payload_split = _split_h.decode_payload_split
@@ -620,6 +624,7 @@ def _kernel(
     # CFG.SEQ_Q_LENS_PRESENT — the DSL specializes on None, so the flag-off
     # ABI is unchanged.
     seq_q_lens_tensor: Optional[cute.Tensor] = None,
+    o_partial_f32: Optional[cute.Tensor] = None,
 ) -> None:
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
     tidx, _, _ = cute.arch.thread_idx()
@@ -848,6 +853,7 @@ def _kernel(
             cta_in_pair=cta_in_pair,
             cta_id_x=cta_id_x,
             qh_per_kh=qh_per_kh,
+            o_partial_f32=o_partial_f32,
         )
 
     elif warp_idx == CFG.MMA_WARP_ID:
@@ -1318,34 +1324,38 @@ def _tmastg_warp_group(
 
         for qs in cutlass.range_constexpr(CFG.TILES_Q):
             _wait_mbarrier(bars.mb_o_full[qs], o_full_phase)
-
-            # O TMA params follow O's swizzle (NOT V's) — under gptoss cga2 V drops to Swz64B while O stays Swz128B.
-            if cutlass.const_expr(CFG.THD_VARLEN):
-                # THD: store each Q slab through this batch's pre-built descriptor
-                # (base at the sequence's packed row, seq extent = S_q_b → a box
-                # past S_q_b is OOB-clipped).  q_row coord is sequence-local; the
-                # batch coord collapses to 0.  Both slabs share one descriptor.
-                # DEAD unit (batch == n_batch, envelope grid — issue #552): no O
-                # rows exist and descriptor slot n_batch is never built, so skip
-                # the store; the barrier protocol below still runs.
-                if batch_idx < n_batch:
-                    o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
-                    o_slice = tma_slice_runtime_desc(
-                        o_desc_ptr,
-                        cutlass.Int32(0),
-                        q_head_idx,
-                        q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE),
-                        cutlass.Int32(0),
+            # fp32 partials wrote the workspace directly, so there is nothing
+            # staged to copy.  Skip ONLY the store: the arrive below and the
+            # QO_ALIAS handshake after it must still run, or this warp laps
+            # the loader and the parity waits deadlock.
+            if cutlass.const_expr(not _FP32_PARTIALS):
+                # O TMA params follow O's swizzle (NOT V's) — under gptoss cga2 V drops to Swz64B while O stays Swz128B.
+                if cutlass.const_expr(CFG.THD_VARLEN):
+                    # THD: store each Q slab through this batch's pre-built descriptor
+                    # (base at the sequence's packed row, seq extent = S_q_b → a box
+                    # past S_q_b is OOB-clipped).  q_row coord is sequence-local; the
+                    # batch coord collapses to 0.  Both slabs share one descriptor.
+                    # DEAD unit (batch == n_batch, envelope grid — issue #552): no O
+                    # rows exist and descriptor slot n_batch is never built, so skip
+                    # the store; the barrier protocol below still runs.
+                    if batch_idx < n_batch:
+                        o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                        o_slice = tma_slice_runtime_desc(
+                            o_desc_ptr,
+                            cutlass.Int32(0),
+                            q_head_idx,
+                            q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE),
+                            cutlass.Int32(0),
+                        )
+                        tma_store_tile(sO[qs], o_slice)
+                else:
+                    tma_store_tile(
+                        sO[qs],
+                        tma_o(cutlass.Int32(0), q_head_idx, q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE), o_batch),
                     )
-                    tma_store_tile(sO[qs], o_slice)
-            else:
-                tma_store_tile(
-                    sO[qs],
-                    tma_o(cutlass.Int32(0), q_head_idx, q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE), o_batch),
-                )
 
-            tma_store_commit()
-            tma_store_wait(0)
+                tma_store_commit()
+                tma_store_wait(0)
 
             bars.mb_o_empty[qs].arrive()
             # QO_ALIAS: O[qs] has drained to GMEM → the shared Q∪O slab is free
@@ -2354,6 +2364,7 @@ def _correction_warp_group(
     cta_in_pair,
     cta_id_x,
     qh_per_kh,
+    o_partial_f32=None,
 ):
     """Correction warp group: 4 warps x 32 lanes = 128 lanes, 1 lane per O row.
 
@@ -2476,6 +2487,10 @@ def _correction_warp_group(
                 bars.mb_stat_empty[qs].arrive()
 
             inv_sum = cutlass.Float32(0.0)  # pre-declare for DSL if-staging
+            # Same reason: row_dead is only bound under some mask/sink configs, but
+            # the fp32-partial store reads it unconditionally.  False here means
+            # 'not dead'; the branches below override it where it is meaningful.
+            row_dead = cutlass.Float32(0.0) > cutlass.Float32(1.0)
             lse_val = cutlass.Float32(0.0)
             q_row_global = (
                 q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE) + cutlass.Int32(qs * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
@@ -2549,42 +2564,67 @@ def _correction_warp_group(
 
             sO_sub_base = sO[qs].base
 
-            if cutlass.const_expr(not CAN_HAVE_EMPTY_KV) or (bounds.right > bounds.left):
-                # The final stats live in the S_acc slot and can be consumed
-                # before BMM2 retires. Only the O TMEM loads need this wait.
-                _wait_mbarrier(bars.mb_bmm2_done[qs], bmm2_done_phase)
-
-            for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
-                o_fp16 = cutlass.Vector.from_elements(
-                    tuple(STORAGE_DTYPE(0.0) for _ in range(O_CHUNK)),
-                    STORAGE_DTYPE,
-                )
+            if cutlass.const_expr(_FP32_PARTIALS):
+                # fp32 partials: the accumulator goes straight to the workspace,
+                # bypassing the SMEM O tile and its TMA store.
+                # The O TMEM loads need BMM2 retired -- the staged branch waits for
+                # exactly this before its own loads.
+                # An empty split chunk never ran BMM2, so nothing will arrive on
+                # mb_bmm2_done and waiting on it hangs.  Its partial is never read
+                # either: the chunk's lse is -inf, which the combine skips.
                 if cutlass.const_expr(not CAN_HAVE_EMPTY_KV) or (bounds.right > bounds.left):
-                    o_addr = tmem_base_epi + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
-                    o_chunk = nvvm.tcgen05_ld(
-                        "32x32b",
-                        nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
-                        num=O_CHUNK,
+                    _wait_mbarrier(bars.mb_bmm2_done[qs], bmm2_done_phase)
+                    _store_fp32_partial_tile(
+                        o_partial_f32,
+                        tmem_base_epi,
+                        tmem_O_off,
+                        inv_sum,
+                        row_dead,
+                        q_row_global < seqlen_q,
+                        _partial_batch(batch_idx, split_idx, n_batch),
+                        q_row_global,
+                        row_head_idx,
+                        CFG.TILE_O,
+                        O_CHUNK,
                     )
-                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-                    o_scaled = vec_scale_pair(o_chunk, inv_sum, O_CHUNK)
-                    o_fp16 = o_scaled.to(STORAGE_DTYPE)
+                bars.mb_o_empty[qs].wait(o_empty_phase)
+            else:
+                if cutlass.const_expr(not CAN_HAVE_EMPTY_KV) or (bounds.right > bounds.left):
+                    # The final stats live in the S_acc slot and can be consumed
+                    # before BMM2 retires. Only the O TMEM loads need this wait.
+                    _wait_mbarrier(bars.mb_bmm2_done[qs], bmm2_done_phase)
 
-                col_offset_const = (chunk_idx * O_CHUNK) % D_BLOCK_SIZE
-                block_idx_const = (chunk_idx * O_CHUNK) // D_BLOCK_SIZE
-                block_offset_const = block_idx_const * TMA_O_GRANU_ELEMS
-                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
+                for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                    o_fp16 = cutlass.Vector.from_elements(
+                        tuple(STORAGE_DTYPE(0.0) for _ in range(O_CHUNK)),
+                        STORAGE_DTYPE,
+                    )
+                    if cutlass.const_expr(not CAN_HAVE_EMPTY_KV) or (bounds.right > bounds.left):
+                        o_addr = tmem_base_epi + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
+                        o_chunk = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                            num=O_CHUNK,
+                        )
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                        o_scaled = vec_scale_pair(o_chunk, inv_sum, O_CHUNK)
+                        o_fp16 = o_scaled.to(STORAGE_DTYPE)
 
-                smem_ptr = sO_sub_base.subview(smem_offset).data_ptr()
-                # mb_o_empty[qs] wait gates the FIRST SMEM store (not the
-                # earlier TMEM-load loop), keeping TMEM-load/FFMA/cast overlapped
-                # with TMA-STG draining the prior persistent tile.
-                if chunk_idx == 0:
-                    _wait_mbarrier(bars.mb_o_empty[qs], o_empty_phase)
-                smem_ptr.store_swizzled(o_fp16, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+                    col_offset_const = (chunk_idx * O_CHUNK) % D_BLOCK_SIZE
+                    block_idx_const = (chunk_idx * O_CHUNK) // D_BLOCK_SIZE
+                    block_offset_const = block_idx_const * TMA_O_GRANU_ELEMS
+                    smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
 
-            # fence_proxy needed before TMA reads SMEM written by tcgen05_st (via store_swizzled).
-            nvvm.fence_proxy("async.shared", space="cta")
+                    smem_ptr = sO_sub_base.subview(smem_offset).data_ptr()
+                    # mb_o_empty[qs] wait gates the FIRST SMEM store (not the
+                    # earlier TMEM-load loop), keeping TMEM-load/FFMA/cast overlapped
+                    # with TMA-STG draining the prior persistent tile.
+                    if chunk_idx == 0:
+                        _wait_mbarrier(bars.mb_o_empty[qs], o_empty_phase)
+                    smem_ptr.store_swizzled(o_fp16, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+
+                # fence_proxy needed before TMA reads SMEM written by tcgen05_st (via store_swizzled).
+                nvvm.fence_proxy("async.shared", space="cta")
 
             bars.mb_o_full[qs].arrive()
 
@@ -2650,6 +2690,7 @@ def _host(
     thd_q_lens_tensor: Optional[cute.Tensor] = None,
     thd_kv_lens_tensor: Optional[cute.Tensor] = None,
     thd_lens_form: Optional[cutlass.Int32] = None,
+    o_partial_f32: Optional[cute.Tensor] = None,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
     B, QH, KH, SQ, SKV, _ = problem_size
@@ -2700,9 +2741,16 @@ def _host(
         swizzle=_v_tma_swz,
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
     )
+    # Unused under fp32 partials, but it must still BUILD: an fp32 element
+    # doubles the box's inner byte width past what the O swizzle allows.
+    _o_box = list(vo_box_o)
+    if _FP32_PARTIALS:
+        # fp32 is 4 bytes; scale the box by the O element's own width so
+        # the inner dimension stays inside the swizzle's byte limit.
+        _o_box[-1] = max(1, _o_box[-1] * CFG.BPE_O // 4)
     tma_o_desc = tmap.create_tensor_map_tiled_from_view(
         o_tensor,
-        box_dims=vo_box_o,
+        box_dims=tuple(_o_box),
         stride_order=stride_order,
         swizzle=_tma_swz(CFG.O_SWZ_BYTES),
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
@@ -2774,6 +2822,7 @@ def _host(
         cutlass.Int32(QH // KH),
         scale_softmax_log2,
         seq_q_lens_tensor,
+        o_partial_f32,
     ).launch(
         grid=grid_shape,
         block=[CFG.THREADS_PER_CTA, 1, 1],
@@ -2861,7 +2910,7 @@ def compile(  # noqa: A001
     fake_q = _fake_bshd((_fake_batch, sq, qh, d_qk), q_stride)
     fake_k = _fake_bshd((_fake_batch, skv, kh, d_qk), k_stride)
     fake_v = _fake_bshd((_fake_batch, skv, kh, d_v), v_stride)
-    fake_o = _fake_bshd((_o_batch, sq, qh, d_v), o_stride, dtype=STORAGE_DTYPE)
+    fake_o = _fake_bshd((_o_batch, sq, qh, d_v), o_stride, dtype=cutlass.Float32 if _FP32_PARTIALS else STORAGE_DTYPE)
     if not has_lse:
         # No Stats output: the LSE argument is None-specialized and the store
         # is compiled out entirely — no dummy buffer exists at any level.
@@ -2983,6 +3032,7 @@ def compile(  # noqa: A001
         fake_thd_q_lens,
         fake_thd_kv_lens,
         fake_thd_lens_form,
+        *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d192_d128_fp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d192_d128_fp8.py
@@ -261,6 +261,7 @@ else:
 from cudnn.sdpa.fwd.kernels._common_blackwell import (
     KvLoopBounds,
     make_split_helpers,
+    store_fp32_partial_tile as _store_fp32_partial_tile,
     make_classic_bars,
     make_sdpa_helpers,
 )
@@ -352,6 +353,9 @@ _split_h = make_split_helpers(
     dispatch_decode_payload=_dispatch_decode_payload,
 )
 SPLIT_KV = _split_h.SPLIT_KV
+# A split writes fp32 partials, replacing the SMEM/TMA O path rather than
+# widening it; the combine performs the only cast to O's dtype.
+_FP32_PARTIALS = SPLIT_KV > 1
 MAY_BE_EMPTY = _split_h.MAY_BE_EMPTY
 _decode_initial_split = _split_h.decode_initial_split
 _decode_payload_split = _split_h.decode_payload_split
@@ -670,6 +674,7 @@ def _kernel(
     descale_v_t: cute.Tensor,
     scale_o_t: cute.Tensor,
     amax_o_tensor: cute.Tensor,
+    o_partial_f32: Optional[cute.Tensor] = None,
 ) -> None:
 
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
@@ -942,6 +947,7 @@ def _kernel(
             cta_id_x=cta_id_x,
             o_scale_fused=o_scale_corr,
             amax_o_tensor=amax_o_tensor,
+            o_partial_f32=o_partial_f32,
         )
 
     # cga2 non-leader runs quiet body (alloc+dealloc only); cga1 folds to full path.
@@ -1341,31 +1347,35 @@ def _tmastg_warp_group(
         for qs in cutlass.range_constexpr(CFG.TILES_Q):
             _wait_mbarrier(bars.mb_o_full[qs], o_full_phase)
 
-            # THD uses one runtime O descriptor per logical sequence. Its base
-            # is the packed cu_q offset and its row extent is the sequence's
-            # own Q length, so tail rows are hardware-clipped. Envelope-only
-            # dead units decode batch_idx == n_batch and skip the store while
-            # preserving the barrier protocol.
-            if cutlass.const_expr(CFG.THD_VARLEN):
-                if batch_idx < n_batch:
-                    o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
-                    o_slice = tma_slice_runtime_desc(
-                        o_desc_ptr,
-                        cutlass.Int32(0),
-                        q_head_idx,
-                        q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE),
-                        cutlass.Int32(0),
+            # fp32 partials wrote the workspace directly, so nothing is staged
+            # to copy.  Skip ONLY the store: the arrive and any QO_ALIAS
+            # handshake after it must still run or the loader deadlocks.
+            if cutlass.const_expr(not _FP32_PARTIALS):
+                # THD uses one runtime O descriptor per logical sequence. Its base
+                # is the packed cu_q offset and its row extent is the sequence's
+                # own Q length, so tail rows are hardware-clipped. Envelope-only
+                # dead units decode batch_idx == n_batch and skip the store while
+                # preserving the barrier protocol.
+                if cutlass.const_expr(CFG.THD_VARLEN):
+                    if batch_idx < n_batch:
+                        o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                        o_slice = tma_slice_runtime_desc(
+                            o_desc_ptr,
+                            cutlass.Int32(0),
+                            q_head_idx,
+                            q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE),
+                            cutlass.Int32(0),
+                        )
+                        tma_store_tile(sO[qs], o_slice)
+                else:
+                    o_batch = _partial_batch(batch_idx, split_idx, n_batch)
+                    tma_store_tile(
+                        sO[qs],
+                        tma_o(cutlass.Int32(0), q_head_idx, q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE), o_batch),
                     )
-                    tma_store_tile(sO[qs], o_slice)
-            else:
-                o_batch = _partial_batch(batch_idx, split_idx, n_batch)
-                tma_store_tile(
-                    sO[qs],
-                    tma_o(cutlass.Int32(0), q_head_idx, q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE), o_batch),
-                )
 
-            tma_store_commit()
-            tma_store_wait(0)
+                tma_store_commit()
+                tma_store_wait(0)
 
             bars.mb_o_empty[qs].arrive()
 
@@ -2312,6 +2322,7 @@ def _correction_warp_group(
     cta_id_x,
     o_scale_fused,
     amax_o_tensor,
+    o_partial_f32=None,
 ):
     """Correction warp group: 4 warps × 32 lanes = 128, one lane per O row.
 
@@ -2426,6 +2437,10 @@ def _correction_warp_group(
             bars.mb_stat_empty[qs].arrive()
 
             inv_sum = cutlass.Float32(0.0)  # pre-declare for DSL if-staging
+            # Same reason: row_dead is only bound under some mask/sink configs, but
+            # the fp32-partial store reads it unconditionally.  False here means
+            # 'not dead'; the branches below override it where it is meaningful.
+            row_dead = cutlass.Float32(0.0) > cutlass.Float32(1.0)
             beta = cutlass.Float32(0.0)  # pre-declare for DSL if-staging
             lse_val = cutlass.Float32(0.0)  # pre-declare; computed in both branches
             LN2 = cutlass.Float32(0.6931471805599453)
@@ -2505,132 +2520,157 @@ def _correction_warp_group(
 
             sO_sub_base = sO[qs].base
 
-            if cutlass.const_expr(CFG.DTYPE_O <= 1):
-                # FP8 output (DTYPE_O ∈ {0,1}): hand-rolled 16:4 fp8 pack +
-                # STS.128 — forces F2FP outputs into a register quad so STS.128
-                # needs no PRMT to gather them (vs the DSL store_swizzled which
-                # folds the swizzle XOR via byte-level PRMT).  Bit-identical to
-                # the DTYPE_O == DTYPE_QKV path.
-                _SWZ_BYTES_C = CFG.O_SWZ_BYTES
-                _SWZ_SHIFT_C = 3 - _O_SWZ_B
-                _SWZ_MASK_C = (1 << _O_SWZ_B) - 1
-                _SUBTILE_BYTES_C = CFG.TILE_M * _SWZ_BYTES_C
+            if cutlass.const_expr(_FP32_PARTIALS):
+                # fp32 partials: the accumulator goes straight to the workspace,
+                # bypassing the SMEM O tile and its TMA store.
+                _store_fp32_partial_tile(
+                    o_partial_f32,
+                    tmem_base_epi,
+                    tmem_O_off,
+                    inv_sum,
+                    row_dead,
+                    _row_valid,
+                    _partial_batch(batch_idx, split_idx, n_batch),
+                    q_row_global,
+                    row_head_idx,
+                    CFG.TILE_O,
+                    O_CHUNK,
+                )
+                # The staged branch releases the stats slot from inside its loop; the
+                # next persistent tile's prologue waits on it, so it must happen here
+                # too or the second tile deadlocks.
+                bars.mb_stats_read[qs].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+                bars.mb_o_empty[qs].wait(o_empty_phase)
+            else:
+                if cutlass.const_expr(CFG.DTYPE_O <= 1):
+                    # FP8 output (DTYPE_O ∈ {0,1}): hand-rolled 16:4 fp8 pack +
+                    # STS.128 — forces F2FP outputs into a register quad so STS.128
+                    # needs no PRMT to gather them (vs the DSL store_swizzled which
+                    # folds the swizzle XOR via byte-level PRMT).  Bit-identical to
+                    # the DTYPE_O == DTYPE_QKV path.
+                    _SWZ_BYTES_C = CFG.O_SWZ_BYTES
+                    _SWZ_SHIFT_C = 3 - _O_SWZ_B
+                    _SWZ_MASK_C = (1 << _O_SWZ_B) - 1
+                    _SUBTILE_BYTES_C = CFG.TILE_M * _SWZ_BYTES_C
 
-                row_base_bytes = tid_in_wg * cutlass.Int32(_SWZ_BYTES_C)
-                row_xor_field = ((tid_in_wg >> cutlass.Int32(_SWZ_SHIFT_C)) & cutlass.Int32(_SWZ_MASK_C)) << cutlass.Int32(4)
+                    row_base_bytes = tid_in_wg * cutlass.Int32(_SWZ_BYTES_C)
+                    row_xor_field = ((tid_in_wg >> cutlass.Int32(_SWZ_SHIFT_C)) & cutlass.Int32(_SWZ_MASK_C)) << cutlass.Int32(4)
 
-                for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
-                    o_addr = tmem_base_epi + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
-                    o_chunk = nvvm.tcgen05_ld(
-                        "32x32b",
-                        nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
-                        num=O_CHUNK,
-                    )
+                    for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                        o_addr = tmem_base_epi + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
+                        o_chunk = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                            num=O_CHUNK,
+                        )
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                        if cutlass.const_expr(chunk_idx == N_CHUNKS_O - 1):
+                            bars.mb_stats_read[qs].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+                        o_scaled = o_chunk * inv_sum
+                        _zero_f = cutlass.Float32(0.0)
+                        o_scaled = cutlass.Vector.from_elements(
+                            tuple(cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled[i].ir_value())) for i in range(O_CHUNK)),
+                            cutlass.Float32,
+                        )
+
+                        _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled), ftz=True)
+
+                        # Plain range (not range_constexpr) — extraction at Python trace time.
+                        o_packed_v = fp32_to_fp8_pack(
+                            [o_scaled[i] for i in range(16)],
+                            dtype=OUT_STORAGE_DTYPE,
+                        )
+
+                        col_elems = chunk_idx * O_CHUNK
+                        block_idx = col_elems // D_BLOCK_SIZE
+                        col_in_block_bytes = (col_elems % D_BLOCK_SIZE) * CFG.BPE_O
+                        block_off_bytes = block_idx * _SUBTILE_BYTES_C
+
+                        swizzled_in_row = row_xor_field ^ cutlass.Int32(col_in_block_bytes)
+                        addr_off_bytes = cutlass.Int32(block_off_bytes) + row_base_bytes + swizzled_in_row
+
+                        # Re-type pointer to Int32 so 4-i32 store maps to one st.shared.v4.b32.
+                        fp8_ptr = sO_sub_base.subview(addr_off_bytes).data_ptr()
+                        i32_ptr = Pointer(fp8_ptr, dtype=cutlass.Int32)
+                        if chunk_idx == 0:
+                            _wait_mbarrier(bars.mb_o_empty[qs], o_empty_phase)
+                        i32_ptr.store(o_packed_v, alignment=16)
+                else:
+                    # BF16 / FP16 output (DTYPE_O ∈ {2,3}): the 16:4 fp8 pack does
+                    # not apply — cast fp32 → OUT_STORAGE_DTYPE and swizzled-store,
+                    # matching the BPE_O-sized TMA-O box.  Mirrors the dsv4 d512 fp8
+                    # generic epilogue (prefill_sdpa_d512_fp8.py).
+                    O_EPI_BLOCK_SIZE = 64 // CFG.BPE_O  # 32 elems (half-out)
+                    O_D_BLOCK = CFG.O_SWZ_BYTES // CFG.BPE_O  # TMA chunk elems
+                    O_TMA_GRANU_ELEMS = CFG.TILE_M * O_D_BLOCK
+                    o_addr0 = tmem_base_epi + cutlass.Int32(tmem_O_off)
+                    o_addr1 = tmem_base_epi + cutlass.Int32(tmem_O_off + O_EPI_BLOCK_SIZE)
+                    o_addr2 = tmem_base_epi + cutlass.Int32(tmem_O_off + 2 * O_EPI_BLOCK_SIZE)
+                    o_addr3 = tmem_base_epi + cutlass.Int32(tmem_O_off + 3 * O_EPI_BLOCK_SIZE)
+
+                    o_chunk0 = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(o_addr0, cutlass.Float32), num=O_EPI_BLOCK_SIZE)
                     nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-                    if cutlass.const_expr(chunk_idx == N_CHUNKS_O - 1):
-                        bars.mb_stats_read[qs].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
-                    o_scaled = o_chunk * inv_sum
+
+                    o_chunk1 = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(o_addr1, cutlass.Float32), num=O_EPI_BLOCK_SIZE)
+                    o_scaled0 = o_chunk0 * inv_sum
                     _zero_f = cutlass.Float32(0.0)
-                    o_scaled = cutlass.Vector.from_elements(
-                        tuple(cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled[i].ir_value())) for i in range(O_CHUNK)),
+                    o_scaled0 = cutlass.Vector.from_elements(
+                        tuple(cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled0[i].ir_value())) for i in range(O_EPI_BLOCK_SIZE)),
                         cutlass.Float32,
                     )
+                    _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled0), ftz=True)
+                    o_half0 = o_scaled0.to(OUT_STORAGE_DTYPE)
+                    _wait_mbarrier(bars.mb_o_empty[qs], o_empty_phase)
+                    sO_sub_base.subview(tid_in_wg * cutlass.Int32(O_D_BLOCK)).data_ptr().store_swizzled(o_half0, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
 
-                    _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled), ftz=True)
+                    o_chunk2 = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(o_addr2, cutlass.Float32), num=O_EPI_BLOCK_SIZE)
+                    o_scaled1 = o_chunk1 * inv_sum
+                    o_scaled1 = cutlass.Vector.from_elements(
+                        tuple(cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled1[i].ir_value())) for i in range(O_EPI_BLOCK_SIZE)),
+                        cutlass.Float32,
+                    )
+                    _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled1), ftz=True)
+                    o_half1 = o_scaled1.to(OUT_STORAGE_DTYPE)
+                    sO_sub_base.subview(cutlass.Int32(O_EPI_BLOCK_SIZE) + tid_in_wg * cutlass.Int32(O_D_BLOCK)).data_ptr().store_swizzled(
+                        o_half1, alignment=64, swizzle=_O_SMEM_SWIZZLE
+                    )
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
 
-                    # Plain range (not range_constexpr) — extraction at Python trace time.
-                    o_packed_v = fp32_to_fp8_pack(
-                        [o_scaled[i] for i in range(16)],
-                        dtype=OUT_STORAGE_DTYPE,
+                    o_chunk3 = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(o_addr3, cutlass.Float32), num=O_EPI_BLOCK_SIZE)
+                    o_scaled2 = o_chunk2 * inv_sum
+                    o_scaled2 = cutlass.Vector.from_elements(
+                        tuple(cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled2[i].ir_value())) for i in range(O_EPI_BLOCK_SIZE)),
+                        cutlass.Float32,
+                    )
+                    _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled2), ftz=True)
+                    o_half2 = o_scaled2.to(OUT_STORAGE_DTYPE)
+                    sO_sub_base.subview(cutlass.Int32(O_TMA_GRANU_ELEMS) + tid_in_wg * cutlass.Int32(O_D_BLOCK)).data_ptr().store_swizzled(
+                        o_half2, alignment=64, swizzle=_O_SMEM_SWIZZLE
+                    )
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+
+                    bars.mb_stats_read[qs].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                    o_scaled3 = o_chunk3 * inv_sum
+                    o_scaled3 = cutlass.Vector.from_elements(
+                        tuple(cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled3[i].ir_value())) for i in range(O_EPI_BLOCK_SIZE)),
+                        cutlass.Float32,
+                    )
+                    o_half3 = o_scaled3.to(OUT_STORAGE_DTYPE)
+                    sO_sub_base.subview(cutlass.Int32(O_TMA_GRANU_ELEMS + O_EPI_BLOCK_SIZE) + tid_in_wg * cutlass.Int32(O_D_BLOCK)).data_ptr().store_swizzled(
+                        o_half3, alignment=64, swizzle=_O_SMEM_SWIZZLE
                     )
 
-                    col_elems = chunk_idx * O_CHUNK
-                    block_idx = col_elems // D_BLOCK_SIZE
-                    col_in_block_bytes = (col_elems % D_BLOCK_SIZE) * CFG.BPE_O
-                    block_off_bytes = block_idx * _SUBTILE_BYTES_C
-
-                    swizzled_in_row = row_xor_field ^ cutlass.Int32(col_in_block_bytes)
-                    addr_off_bytes = cutlass.Int32(block_off_bytes) + row_base_bytes + swizzled_in_row
-
-                    # Re-type pointer to Int32 so 4-i32 store maps to one st.shared.v4.b32.
-                    fp8_ptr = sO_sub_base.subview(addr_off_bytes).data_ptr()
-                    i32_ptr = Pointer(fp8_ptr, dtype=cutlass.Int32)
-                    if chunk_idx == 0:
-                        _wait_mbarrier(bars.mb_o_empty[qs], o_empty_phase)
-                    i32_ptr.store(o_packed_v, alignment=16)
-            else:
-                # BF16 / FP16 output (DTYPE_O ∈ {2,3}): the 16:4 fp8 pack does
-                # not apply — cast fp32 → OUT_STORAGE_DTYPE and swizzled-store,
-                # matching the BPE_O-sized TMA-O box.  Mirrors the dsv4 d512 fp8
-                # generic epilogue (prefill_sdpa_d512_fp8.py).
-                O_EPI_BLOCK_SIZE = 64 // CFG.BPE_O  # 32 elems (half-out)
-                O_D_BLOCK = CFG.O_SWZ_BYTES // CFG.BPE_O  # TMA chunk elems
-                O_TMA_GRANU_ELEMS = CFG.TILE_M * O_D_BLOCK
-                o_addr0 = tmem_base_epi + cutlass.Int32(tmem_O_off)
-                o_addr1 = tmem_base_epi + cutlass.Int32(tmem_O_off + O_EPI_BLOCK_SIZE)
-                o_addr2 = tmem_base_epi + cutlass.Int32(tmem_O_off + 2 * O_EPI_BLOCK_SIZE)
-                o_addr3 = tmem_base_epi + cutlass.Int32(tmem_O_off + 3 * O_EPI_BLOCK_SIZE)
-
-                o_chunk0 = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(o_addr0, cutlass.Float32), num=O_EPI_BLOCK_SIZE)
-                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-
-                o_chunk1 = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(o_addr1, cutlass.Float32), num=O_EPI_BLOCK_SIZE)
-                o_scaled0 = o_chunk0 * inv_sum
-                _zero_f = cutlass.Float32(0.0)
-                o_scaled0 = cutlass.Vector.from_elements(
-                    tuple(cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled0[i].ir_value())) for i in range(O_EPI_BLOCK_SIZE)),
-                    cutlass.Float32,
-                )
-                _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled0), ftz=True)
-                o_half0 = o_scaled0.to(OUT_STORAGE_DTYPE)
-                _wait_mbarrier(bars.mb_o_empty[qs], o_empty_phase)
-                sO_sub_base.subview(tid_in_wg * cutlass.Int32(O_D_BLOCK)).data_ptr().store_swizzled(o_half0, alignment=64, swizzle=_O_SMEM_SWIZZLE)
-                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-
-                o_chunk2 = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(o_addr2, cutlass.Float32), num=O_EPI_BLOCK_SIZE)
-                o_scaled1 = o_chunk1 * inv_sum
-                o_scaled1 = cutlass.Vector.from_elements(
-                    tuple(cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled1[i].ir_value())) for i in range(O_EPI_BLOCK_SIZE)),
-                    cutlass.Float32,
-                )
-                _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled1), ftz=True)
-                o_half1 = o_scaled1.to(OUT_STORAGE_DTYPE)
-                sO_sub_base.subview(cutlass.Int32(O_EPI_BLOCK_SIZE) + tid_in_wg * cutlass.Int32(O_D_BLOCK)).data_ptr().store_swizzled(
-                    o_half1, alignment=64, swizzle=_O_SMEM_SWIZZLE
-                )
-                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-
-                o_chunk3 = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(o_addr3, cutlass.Float32), num=O_EPI_BLOCK_SIZE)
-                o_scaled2 = o_chunk2 * inv_sum
-                o_scaled2 = cutlass.Vector.from_elements(
-                    tuple(cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled2[i].ir_value())) for i in range(O_EPI_BLOCK_SIZE)),
-                    cutlass.Float32,
-                )
-                _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled2), ftz=True)
-                o_half2 = o_scaled2.to(OUT_STORAGE_DTYPE)
-                sO_sub_base.subview(cutlass.Int32(O_TMA_GRANU_ELEMS) + tid_in_wg * cutlass.Int32(O_D_BLOCK)).data_ptr().store_swizzled(
-                    o_half2, alignment=64, swizzle=_O_SMEM_SWIZZLE
-                )
-                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-
-                bars.mb_stats_read[qs].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
-
-                o_scaled3 = o_chunk3 * inv_sum
-                o_scaled3 = cutlass.Vector.from_elements(
-                    tuple(cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled3[i].ir_value())) for i in range(O_EPI_BLOCK_SIZE)),
-                    cutlass.Float32,
-                )
-                o_half3 = o_scaled3.to(OUT_STORAGE_DTYPE)
-                sO_sub_base.subview(cutlass.Int32(O_TMA_GRANU_ELEMS + O_EPI_BLOCK_SIZE) + tid_in_wg * cutlass.Int32(O_D_BLOCK)).data_ptr().store_swizzled(
-                    o_half3, alignment=64, swizzle=_O_SMEM_SWIZZLE
-                )
-
-            # fence_proxy needed before TMA reads SMEM written by stores above.
-            nvvm.fence_proxy("async.shared", space="cta")
+                # fence_proxy needed before TMA reads SMEM written by stores above.
+                nvvm.fence_proxy("async.shared", space="cta")
 
             bars.mb_o_full[qs].arrive()
 
-            if cutlass.const_expr(CFG.DTYPE_O > 1):
+            # This reads the staged epilogue's own values, which the fp32 path
+            # never produces -- and it feeds an amax the combine owns under a
+            # split anyway (see the SPLIT_KV == 1 guard below).
+            if cutlass.const_expr(CFG.DTYPE_O > 1 and not _FP32_PARTIALS):
                 _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled3), ftz=True)
 
             if cutlass.const_expr(SPLIT_KV == 1):
@@ -2688,6 +2728,7 @@ def _host(
     thd_q_lens_tensor: Optional[cute.Tensor] = None,
     thd_kv_lens_tensor: Optional[cute.Tensor] = None,
     thd_lens_form: Optional[cutlass.Int32] = None,
+    o_partial_f32: Optional[cute.Tensor] = None,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
     B, QH, KH, SQ, SKV, _ = problem_size
@@ -2749,9 +2790,16 @@ def _host(
         swizzle=_tma_swz(CFG.V_SWZ_BYTES),
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
     )
+    # Unused under fp32 partials, but it must still BUILD: an fp32 element
+    # doubles the box's inner byte width past what the O swizzle allows.
+    _o_box = list(vo_box_o)
+    if _FP32_PARTIALS:
+        # fp32 is 4 bytes; scale the box by the O element's own width so
+        # the inner dimension stays inside the swizzle's byte limit.
+        _o_box[-1] = max(1, _o_box[-1] * CFG.BPE_O // 4)
     tma_o_desc = tmap.create_tensor_map_tiled_from_view(
         o_tensor,
-        box_dims=vo_box_o,
+        box_dims=tuple(_o_box),
         stride_order=stride_order,
         swizzle=_tma_swz(CFG.O_SWZ_BYTES),
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
@@ -2814,6 +2862,7 @@ def _host(
         descale_v_t,
         scale_o_t,
         amax_o_tensor,
+        o_partial_f32,
     ).launch(
         grid=grid_shape,
         block=[CFG.THREADS_PER_CTA, 1, 1],
@@ -2885,7 +2934,7 @@ def compile(  # noqa: A001
         assumed_align=16,
     )
     fake_o = cute.runtime.make_fake_compact_tensor(
-        OUT_STORAGE_DTYPE,
+        cutlass.Float32 if _FP32_PARTIALS else OUT_STORAGE_DTYPE,
         (_o_batch, sq, qh, d_v),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
@@ -2989,6 +3038,7 @@ def compile(  # noqa: A001
         fake_thd_q_lens,
         fake_thd_kv_lens,
         fake_thd_lens_form,
+        *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d192_d128_mxfp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d192_d128_mxfp8.py
@@ -342,6 +342,7 @@ SF_CONST_VALUE = 0x7F
 
 from cudnn.sdpa.fwd.kernels._common_blackwell import (
     make_split_helpers,
+    store_fp32_partial_tile as _store_fp32_partial_tile,
     make_classic_bars,
     make_sdpa_helpers,
     assert_tile_n_supported,
@@ -468,6 +469,9 @@ _split_h = make_split_helpers(
     dispatch_decode_payload=_dispatch_decode_payload,
 )
 SPLIT_KV = _split_h.SPLIT_KV
+# A split writes fp32 partials, replacing the SMEM/TMA O path rather than
+# widening it; the combine performs the only cast to O's dtype.
+_FP32_PARTIALS = SPLIT_KV > 1
 MAY_BE_EMPTY = _split_h.MAY_BE_EMPTY
 _decode_initial_split = _split_h.decode_initial_split
 _decode_payload_split = _split_h.decode_payload_split
@@ -737,6 +741,7 @@ def _kernel(
     n_batch: cutlass.Int32,
     qh_per_kh: cutlass.Int32,  # GQA group size = n_qh / n_kh.
     scale_softmax_log2: cutlass.Float32,
+    o_partial_f32: Optional[cute.Tensor] = None,
 ) -> None:
 
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
@@ -1057,6 +1062,7 @@ def _kernel(
             leader_cta_id=leader_cta_id,
             cta_in_pair=cta_in_pair,
             cta_id_x=cta_id_x,
+            o_partial_f32=o_partial_f32,
         )
 
     elif warp_idx == CFG.MMA_WARP_ID:
@@ -1590,23 +1596,27 @@ def _tmastg_warp_group(
 
         for qs in cutlass.range_constexpr(CFG.TILES_Q):
             bars.mb_o_full[qs].wait(o_full_phase)
+            # fp32 partials wrote the workspace directly, so nothing is staged
+            # to copy.  Skip ONLY the store: the arrive below and any QO_ALIAS
+            # handshake after it must still run, or this warp laps the loader
+            # and the parity waits deadlock.
+            if cutlass.const_expr(not _FP32_PARTIALS):
+                # O TMA params follow O's swizzle, NOT V's — required when V_SWZ_B != O_SWZ_B.
+                if cutlass.const_expr(CFG.THD_VARLEN):
+                    # The setup kernel built one packed-O descriptor per live
+                    # sequence. Dead envelope units use batch == n_batch and skip.
+                    if batch_idx < n_batch:
+                        o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                        o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), cutlass.Int32(0))
+                        tma_store_tile(sO[qs], o_slice)
+                else:
+                    tma_store_tile(
+                        sO[qs],
+                        tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), o_batch),
+                    )
 
-            # O TMA params follow O's swizzle, NOT V's — required when V_SWZ_B != O_SWZ_B.
-            if cutlass.const_expr(CFG.THD_VARLEN):
-                # The setup kernel built one packed-O descriptor per live
-                # sequence. Dead envelope units use batch == n_batch and skip.
-                if batch_idx < n_batch:
-                    o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
-                    o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), cutlass.Int32(0))
-                    tma_store_tile(sO[qs], o_slice)
-            else:
-                tma_store_tile(
-                    sO[qs],
-                    tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), o_batch),
-                )
-
-            tma_store_commit()
-            tma_store_wait(0)
+                tma_store_commit()
+                tma_store_wait(0)
 
             bars.mb_o_empty[qs].arrive()
 
@@ -2843,6 +2853,7 @@ def _correction_warp_group(
     leader_cta_id,
     cta_in_pair,
     cta_id_x,
+    o_partial_f32=None,
 ):
     """Correction warp group — α-rescale O + epilogue cast/store + LSE.
 
@@ -3011,41 +3022,63 @@ def _correction_warp_group(
 
             sO_sub_base = sO[qs].base
 
-            _amax_o_ptr = Pointer(amax_o_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
-            _amax_o_local = cutlass.Float32(0.0)
-
-            for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
-                o_addr = tmem_base_epi + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
-                o_chunk = nvvm.tcgen05_ld(
-                    "32x32b",
-                    nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
-                    num=O_CHUNK,
+            if cutlass.const_expr(_FP32_PARTIALS):
+                # fp32 partials: the accumulator goes straight to the workspace,
+                # bypassing the SMEM O tile and its TMA store.
+                _store_fp32_partial_tile(
+                    o_partial_f32,
+                    tmem_base_epi,
+                    tmem_O_off,
+                    inv_sum,
+                    row_dead,
+                    _row_valid,
+                    _partial_batch(batch_idx, split_idx, n_batch),
+                    q_row_global,
+                    head_idx,
+                    CFG.TILE_O,
+                    O_CHUNK,
                 )
-                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-                if cutlass.const_expr(chunk_idx == N_CHUNKS_O - 1):
-                    bars.mb_stats_read[qs].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
-                o_scaled = o_chunk * inv_sum
-                _zero_f = cutlass.Float32(0.0)
-                o_scaled = cutlass.Vector.from_elements(
-                    tuple(cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled[i].ir_value())) for i in range(O_CHUNK)),
-                    cutlass.Float32,
-                )
-                _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled), ftz=True)
-                o_out = o_scaled.to(OUT_STORAGE_DTYPE)
+                # The staged branch releases the stats slot from inside its loop; the
+                # next persistent tile's prologue waits on it, so it must happen here
+                # too or the second tile deadlocks.
+                bars.mb_stats_read[qs].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+                bars.mb_o_empty[qs].wait(o_empty_phase)
+            else:
+                _amax_o_ptr = Pointer(amax_o_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
+                _amax_o_local = cutlass.Float32(0.0)
 
-                col_offset_const = (chunk_idx * O_CHUNK) % D_BLOCK_SIZE
-                block_idx_const = (chunk_idx * O_CHUNK) // D_BLOCK_SIZE
-                block_offset_const = block_idx_const * TMA_O_GRANU_ELEMS
-                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
+                for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                    o_addr = tmem_base_epi + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
+                    o_chunk = nvvm.tcgen05_ld(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                        num=O_CHUNK,
+                    )
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                    if cutlass.const_expr(chunk_idx == N_CHUNKS_O - 1):
+                        bars.mb_stats_read[qs].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+                    o_scaled = o_chunk * inv_sum
+                    _zero_f = cutlass.Float32(0.0)
+                    o_scaled = cutlass.Vector.from_elements(
+                        tuple(cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled[i].ir_value())) for i in range(O_CHUNK)),
+                        cutlass.Float32,
+                    )
+                    _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled), ftz=True)
+                    o_out = o_scaled.to(OUT_STORAGE_DTYPE)
 
-                smem_ptr = sO_sub_base.subview(smem_offset).data_ptr()
-                # Gate FIRST SMEM store (not earlier TMEM-load loop) — keeps load/FFMA/cast overlapped with prior TMA-STG drain.
-                if chunk_idx == 0:
-                    bars.mb_o_empty[qs].wait(o_empty_phase)
-                smem_ptr.store_swizzled(o_out, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+                    col_offset_const = (chunk_idx * O_CHUNK) % D_BLOCK_SIZE
+                    block_idx_const = (chunk_idx * O_CHUNK) // D_BLOCK_SIZE
+                    block_offset_const = block_idx_const * TMA_O_GRANU_ELEMS
+                    smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
 
-            # fence_proxy needed before TMA reads SMEM written by tcgen05_st.
-            nvvm.fence_proxy("async.shared", space="cta")
+                    smem_ptr = sO_sub_base.subview(smem_offset).data_ptr()
+                    # Gate FIRST SMEM store (not earlier TMEM-load loop) — keeps load/FFMA/cast overlapped with prior TMA-STG drain.
+                    if chunk_idx == 0:
+                        bars.mb_o_empty[qs].wait(o_empty_phase)
+                    smem_ptr.store_swizzled(o_out, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+
+                # fence_proxy needed before TMA reads SMEM written by tcgen05_st.
+                nvvm.fence_proxy("async.shared", space="cta")
             bars.mb_o_full[qs].arrive()
 
             # The global amax is independent of the O TMA store.  Publish O
@@ -3112,6 +3145,7 @@ def _host(
     thd_q_lens_tensor: Optional[cute.Tensor] = None,
     thd_kv_lens_tensor: Optional[cute.Tensor] = None,
     thd_lens_form: Optional[cutlass.Int32] = None,
+    o_partial_f32: Optional[cute.Tensor] = None,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
     """Build dense or packed-THD Q/K/V/O and block-scale descriptors."""
@@ -3176,9 +3210,16 @@ def _host(
         swizzle=_tma_swz(CFG.V_SWZ_BYTES),
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
     )
+    # Unused under fp32 partials, but it must still BUILD: an fp32 element
+    # doubles the box's inner byte width past what the O swizzle allows.
+    _o_box = list(vo_box_o)
+    if _FP32_PARTIALS:
+        # fp32 is 4 bytes; scale the box by the O element's own width so
+        # the inner dimension stays inside the swizzle's byte limit.
+        _o_box[-1] = max(1, _o_box[-1] * CFG.BPE_O // 4)
     tma_o_desc = tmap.create_tensor_map_tiled_from_view(
         o_tensor,
-        box_dims=vo_box_o,
+        box_dims=tuple(_o_box),
         stride_order=stride_order,
         swizzle=_tma_swz(CFG.O_SWZ_BYTES),
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
@@ -3274,6 +3315,7 @@ def _host(
         cutlass.Int32(B),
         cutlass.Int32(QH // KH),
         scale_softmax_log2,
+        o_partial_f32,
     ).launch(
         grid=grid_shape,
         block=[CFG.THREADS_PER_CTA, 1, 1],
@@ -3333,7 +3375,7 @@ def compile(  # noqa: A001
         assumed_align=16,
     )
     fake_o = cute.runtime.make_fake_compact_tensor(
-        OUT_STORAGE_DTYPE,
+        cutlass.Float32 if _FP32_PARTIALS else OUT_STORAGE_DTYPE,
         (_o_batch, sq, qh, CFG.TILE_O),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
@@ -3447,6 +3489,7 @@ def compile(  # noqa: A001
         fake_thd_q_lens,
         fake_thd_kv_lens,
         fake_thd_lens_form,
+        *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d256_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d256_f16.py
@@ -85,6 +85,7 @@ OUT_STORAGE_DTYPE = STORAGE_DTYPE
 
 from cudnn.sdpa.fwd.kernels._common_blackwell import (
     make_split_helpers,
+    store_fp32_partial_tile as _store_fp32_partial_tile,
     D256Bars as Bars,
     KvLoopBounds,
     make_d256_bars,
@@ -159,6 +160,9 @@ _split_h = make_split_helpers(
     dispatch_decode_payload=_dispatch_decode_payload,
 )
 SPLIT_KV = _split_h.SPLIT_KV
+# A split writes fp32 partials, replacing the SMEM/TMA O path rather than
+# widening it; the combine performs the only cast to O's dtype.
+_FP32_PARTIALS = SPLIT_KV > 1
 MAY_BE_EMPTY = _split_h.MAY_BE_EMPTY
 _decode_initial_split = _split_h.decode_initial_split
 _decode_payload_split = _split_h.decode_payload_split
@@ -231,6 +235,7 @@ def _kernel(
     # CFG.SEQ_Q_LENS_PRESENT — the DSL specializes on None, so the flag-off
     # ABI is unchanged.
     seq_q_lens_tensor: Optional[cute.Tensor] = None,
+    o_partial_f32: Optional[cute.Tensor] = None,
 ) -> None:
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
     tidx, _, _ = cute.arch.thread_idx()
@@ -389,6 +394,7 @@ def _kernel(
             cta_in_pair=cta_in_pair,
             cta_id_x=cta_id_x,
             qh_per_kh=qh_per_kh,
+            o_partial_f32=o_partial_f32,
         )
 
     elif warp_idx == CFG.MMA_WARP_ID:
@@ -730,21 +736,25 @@ def _tmastg_warp_group(
         # only a shifted batch coord.  Folds to batch_idx at SPLIT_KV == 1.
         o_batch = _partial_batch(batch_idx, split_idx, n_batch)
 
-        if cutlass.const_expr(CFG.THD_VARLEN):
-            # DEAD unit (batch == n_batch, over-launched grid — issue #552):
-            # no O rows exist and descriptor slot n_batch is never built, so
-            # skip the store; the barrier protocol below still runs.
-            if batch_idx < n_batch:
-                o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
-                o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), q_head_idx, q_row_coord, cutlass.Int32(0))
-                tma_store_tile(sO[0], o_slice)
-        else:
-            tma_store_tile(
-                sO[0],
-                tma_o(cutlass.Int32(0), q_head_idx, q_row_coord, o_batch),
-            )
-        tma_store_commit()
-        tma_store_wait(0)
+        # fp32 partials wrote the workspace directly, so nothing is staged to
+        # copy.  Skip ONLY the store: the arrives below, the QO_ALIAS
+        # handshake and the phase flips must all still run.
+        if cutlass.const_expr(not _FP32_PARTIALS):
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # DEAD unit (batch == n_batch, over-launched grid — issue #552):
+                # no O rows exist and descriptor slot n_batch is never built, so
+                # skip the store; the barrier protocol below still runs.
+                if batch_idx < n_batch:
+                    o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                    o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), q_head_idx, q_row_coord, cutlass.Int32(0))
+                    tma_store_tile(sO[0], o_slice)
+            else:
+                tma_store_tile(
+                    sO[0],
+                    tma_o(cutlass.Int32(0), q_head_idx, q_row_coord, o_batch),
+                )
+            tma_store_commit()
+            tma_store_wait(0)
 
         bars.mb_o_empty.arrive()
         if nvvm.elect_sync():
@@ -1467,6 +1477,7 @@ def _correction_warp_group(
     cta_in_pair,
     cta_id_x,
     qh_per_kh,
+    o_partial_f32=None,
 ):
     nvvm.barrier_cta_sync(barrier_id=2, thread_count=32 * (CFG.CORRECTION_WARPS + 1))
 
@@ -1662,39 +1673,62 @@ def _correction_warp_group(
         CHUNKS_PER_BLK = O_EPI_BLK // O_CHUNK
 
         sO_base = sO[0].base
-        epi_o_full_block_idx = 0
-
-        for block_idx in cutlass.range_constexpr(N_BLOCKS_EPI):
-            for sub in cutlass.range_constexpr(CHUNKS_PER_BLK):
-                chunk_idx_total = block_idx * CHUNKS_PER_BLK + sub
-                o_out = cutlass.Vector.from_elements(
-                    tuple(OUT_STORAGE_DTYPE(0.0) for _ in range(O_CHUNK)),
-                    OUT_STORAGE_DTYPE,
-                )
-                if cutlass.const_expr(not MAY_BE_EMPTY) or (bounds.right > bounds.left):
-                    o_addr = tmem_base_epi + cutlass.Int32(LAYOUT.O_OFF + chunk_idx_total * O_CHUNK)
-                    o_chunk = nvvm.tcgen05_ld(
-                        "32x32b",
-                        nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
-                        num=O_CHUNK,
-                    )
-                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-                    o_scaled = o_chunk * inv_sum
-                    o_out = o_scaled.to(OUT_STORAGE_DTYPE)
-
-                col_offset_const = (chunk_idx_total * O_CHUNK) % D_BLOCK_SIZE
-                block_offset_const = ((chunk_idx_total * O_CHUNK) // D_BLOCK_SIZE) * TMA_O_GRANU_ELEMS_LOCAL
-                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
-                smem_ptr = sO_base.subview(smem_offset).data_ptr()
-
-                if block_idx == 0 and sub == 0:
-                    bars.mb_o_empty.wait(epilogue_state)
-                smem_ptr.store_swizzled(o_out, alignment=64, swizzle=_O_SMEM_SWIZZLE)
-
-            fire_now = (block_idx % 2 == 1) or (CFG.TILE_O == O_EPI_BLK)
-            if cutlass.const_expr(fire_now):
+        if cutlass.const_expr(_FP32_PARTIALS):
+            # fp32 partials: accumulator straight to the workspace, no SMEM
+            # staging and no TMA.  The staged path's barrier traffic still has
+            # to happen: it consumes mb_o_empty once and publishes every
+            # mb_o_full chunk, and the store warp waits on all of them.
+            _store_fp32_partial_tile(
+                o_partial_f32,
+                tmem_base_epi,
+                LAYOUT.O_OFF,
+                inv_sum,
+                row_dead,
+                q_row_global < seqlen_q,
+                _partial_batch(batch_idx, split_idx, n_batch),
+                q_row_global,
+                row_head_idx,
+                CFG.TILE_O,
+                O_CHUNK,
+            )
+            bars.mb_o_empty.wait(epilogue_state)
+            for _chunk in cutlass.range_constexpr(N_O_CHUNKS):
                 nvvm.fence_proxy("async.shared", space="cta")
-                bars.mb_o_full[(block_idx // 2)].arrive()
+                bars.mb_o_full[_chunk].arrive()
+        else:
+            epi_o_full_block_idx = 0
+
+            for block_idx in cutlass.range_constexpr(N_BLOCKS_EPI):
+                for sub in cutlass.range_constexpr(CHUNKS_PER_BLK):
+                    chunk_idx_total = block_idx * CHUNKS_PER_BLK + sub
+                    o_out = cutlass.Vector.from_elements(
+                        tuple(OUT_STORAGE_DTYPE(0.0) for _ in range(O_CHUNK)),
+                        OUT_STORAGE_DTYPE,
+                    )
+                    if cutlass.const_expr(not MAY_BE_EMPTY) or (bounds.right > bounds.left):
+                        o_addr = tmem_base_epi + cutlass.Int32(LAYOUT.O_OFF + chunk_idx_total * O_CHUNK)
+                        o_chunk = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                            num=O_CHUNK,
+                        )
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                        o_scaled = o_chunk * inv_sum
+                        o_out = o_scaled.to(OUT_STORAGE_DTYPE)
+
+                    col_offset_const = (chunk_idx_total * O_CHUNK) % D_BLOCK_SIZE
+                    block_offset_const = ((chunk_idx_total * O_CHUNK) // D_BLOCK_SIZE) * TMA_O_GRANU_ELEMS_LOCAL
+                    smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
+                    smem_ptr = sO_base.subview(smem_offset).data_ptr()
+
+                    if block_idx == 0 and sub == 0:
+                        bars.mb_o_empty.wait(epilogue_state)
+                    smem_ptr.store_swizzled(o_out, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+
+                fire_now = (block_idx % 2 == 1) or (CFG.TILE_O == O_EPI_BLK)
+                if cutlass.const_expr(fire_now):
+                    nvvm.fence_proxy("async.shared", space="cta")
+                    bars.mb_o_full[(block_idx // 2)].arrive()
 
         epilogue_state = epilogue_state ^ cutlass.Int32(1)
 
@@ -1750,6 +1784,7 @@ def _host(
     thd_q_lens_tensor: Optional[cute.Tensor] = None,
     thd_kv_lens_tensor: Optional[cute.Tensor] = None,
     thd_lens_form: Optional[cutlass.Int32] = None,
+    o_partial_f32: Optional[cute.Tensor] = None,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
     B, QH, KH, SQ, SKV, _ = problem_size
@@ -1787,7 +1822,12 @@ def _host(
     tma_q_desc = _create_tma_desc(q_tensor, qk_box_q, _tma_swz(CFG.Q_SWZ_BYTES))
     tma_k_desc = _create_tma_desc(k_tensor, qk_box_k, _tma_swz(CFG.K_SWZ_BYTES))
     tma_v_desc = _create_tma_desc(v_tensor, vo_box_v, _tma_swz(CFG.V_SWZ_BYTES))
-    tma_o_desc = _create_tma_desc(o_tensor, vo_box_o, _tma_swz(CFG.O_SWZ_BYTES))
+    _o_box = list(vo_box_o)
+    if _FP32_PARTIALS:
+        # fp32 is 4 bytes; scale the box by the O element's own width so
+        # the inner dimension stays inside the swizzle's byte limit.
+        _o_box[-1] = max(1, _o_box[-1] * CFG.BPE_O // 4)
+    tma_o_desc = _create_tma_desc(o_tensor, tuple(_o_box), _tma_swz(CFG.O_SWZ_BYTES))
 
     # PackGQA: SQ*G packed rows per packed head, and QH/G packed heads.
     rows_per_cluster = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
@@ -1852,6 +1892,7 @@ def _host(
         cutlass.Int32(QH // KH),
         scale_softmax_log2,
         seq_q_lens_tensor,
+        o_partial_f32,
     ).launch(
         grid=grid_shape,
         block=[CFG.THREADS_PER_CTA, 1, 1],
@@ -1931,7 +1972,12 @@ def compile(  # noqa: A001
     fake_q = _fake_bshd((_fake_batch, sq, qh, d_qk), q_stride)
     fake_k = _fake_bshd((_fake_batch, skv, kh, d_qk), k_stride)
     fake_v = _fake_bshd((_fake_batch, skv, kh, d_v), v_stride)
-    fake_o = _fake_bshd((_o_batch, sq, qh, d_v), o_stride, dtype=OUT_STORAGE_DTYPE, bpe=CFG.BPE_O)
+    fake_o = _fake_bshd(
+        (_o_batch, sq, qh, d_v),
+        o_stride,
+        dtype=cutlass.Float32 if _FP32_PARTIALS else OUT_STORAGE_DTYPE,
+        bpe=4 if _FP32_PARTIALS else CFG.BPE_O,
+    )
     if not has_lse:
         # No Stats output: the LSE argument is None-specialized and the store
         # is compiled out entirely — no dummy buffer exists at any level.
@@ -2047,6 +2093,7 @@ def compile(  # noqa: A001
         fake_thd_q_lens,
         fake_thd_kv_lens,
         fake_thd_lens_form,
+        *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d256_fp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d256_fp8.py
@@ -103,6 +103,7 @@ else:
 
 from cudnn.sdpa.fwd.kernels._common_blackwell import (
     make_split_helpers,
+    store_fp32_partial_tile as _store_fp32_partial_tile,
     KvLoopBounds,
     make_d256_bars,
     row_max_for_exp2,
@@ -220,6 +221,9 @@ _split_h = make_split_helpers(
     dispatch_decode_payload=_dispatch_decode_payload,
 )
 SPLIT_KV = _split_h.SPLIT_KV
+# A split writes fp32 partials, replacing the SMEM/TMA O path rather than
+# widening it; the combine performs the only cast to O's dtype.
+_FP32_PARTIALS = SPLIT_KV > 1
 MAY_BE_EMPTY = _split_h.MAY_BE_EMPTY
 _decode_initial_split = _split_h.decode_initial_split
 _decode_payload_split = _split_h.decode_payload_split
@@ -512,6 +516,7 @@ def _kernel(
     # CFG.SEQ_Q_LENS_PRESENT — the DSL specializes on None, so the flag-off
     # ABI is unchanged.
     seq_q_lens_tensor: Optional[cute.Tensor] = None,
+    o_partial_f32: Optional[cute.Tensor] = None,
 ) -> None:
 
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
@@ -759,6 +764,7 @@ def _kernel(
             o_scale_fused=o_scale_fused,
             amax_o_tensor=amax_o_tensor,
             softmax_exchange=softmax_exchange,
+            o_partial_f32=o_partial_f32,
         )
 
     elif warp_idx == CFG.MMA_WARP_ID:
@@ -1154,38 +1160,47 @@ def _tmastg_warp_group(
         q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
         o_batch = _partial_batch(batch_idx, split_idx, n_batch)
 
-        if cutlass.const_expr(CFG.THD_VARLEN):
-            o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+        # fp32 partials wrote the workspace directly, so only the TMA copy is
+        # dead.  This warp must still CONSUME every mb_o_full the epilogue
+        # published and arrive on the QO_ALIAS gate, or the loader stalls.
+        if cutlass.const_expr(_FP32_PARTIALS):
+            for chunk in cutlass.range_constexpr(N_O_CHUNKS):
+                bars.mb_o_full[chunk].wait(o_full_phase)
+            if nvvm.elect_sync():
+                bars.mb_q_o_alias.arrive()
         else:
-            o_slice = tma_o(cutlass.Int32(0), q_head_idx, q_row_coord, o_batch)
-            o_desc_ptr = o_slice.tma_desc.get_ptr()
-        for chunk in cutlass.range_constexpr(N_O_CHUNKS):
-            bars.mb_o_full[chunk].wait(o_full_phase)
-            smem_chunk = sO[0].base.subview(chunk * sO[0].tma_subtile_stride_elems)
-            d_coord = cutlass.Int32(chunk * TMA_O_GRANU_ELEMS_HOST)
             if cutlass.const_expr(CFG.THD_VARLEN):
-                if batch_idx < n_batch:
+                o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+            else:
+                o_slice = tma_o(cutlass.Int32(0), q_head_idx, q_row_coord, o_batch)
+                o_desc_ptr = o_slice.tma_desc.get_ptr()
+            for chunk in cutlass.range_constexpr(N_O_CHUNKS):
+                bars.mb_o_full[chunk].wait(o_full_phase)
+                smem_chunk = sO[0].base.subview(chunk * sO[0].tma_subtile_stride_elems)
+                d_coord = cutlass.Int32(chunk * TMA_O_GRANU_ELEMS_HOST)
+                if cutlass.const_expr(CFG.THD_VARLEN):
+                    if batch_idx < n_batch:
+                        nvvm.cp_async_bulk_tensor_global_shared_cta(
+                            o_desc_ptr,
+                            smem_chunk,
+                            (d_coord, q_head_idx, q_row_coord, cutlass.Int32(0)),
+                        )
+                else:
                     nvvm.cp_async_bulk_tensor_global_shared_cta(
                         o_desc_ptr,
                         smem_chunk,
-                        (d_coord, q_head_idx, q_row_coord, cutlass.Int32(0)),
+                        (o_slice.coord_d + d_coord, q_head_idx, q_row_coord, o_batch),
                     )
-            else:
-                nvvm.cp_async_bulk_tensor_global_shared_cta(
-                    o_desc_ptr,
-                    smem_chunk,
-                    (o_slice.coord_d + d_coord, q_head_idx, q_row_coord, o_batch),
-                )
-            tma_store_commit()
-            if cutlass.const_expr(CFG.BPE_O == 2 and chunk == 1):
-                tma_store_wait(0)
+                tma_store_commit()
+                if cutlass.const_expr(CFG.BPE_O == 2 and chunk == 1):
+                    tma_store_wait(0)
+                    if nvvm.elect_sync():
+                        bars.mb_q_o_alias.arrive()
+
+            tma_store_wait(0)
+            if cutlass.const_expr(CFG.BPE_O != 2):
                 if nvvm.elect_sync():
                     bars.mb_q_o_alias.arrive()
-
-        tma_store_wait(0)
-        if cutlass.const_expr(CFG.BPE_O != 2):
-            if nvvm.elect_sync():
-                bars.mb_q_o_alias.arrive()
 
         bars.mb_o_empty.arrive()
 
@@ -2241,6 +2256,7 @@ def _correction_warp_group(
     o_scale_fused,
     amax_o_tensor,
     softmax_exchange,
+    o_partial_f32=None,
 ):
     nvvm.barrier_cta_sync(barrier_id=2, thread_count=32 * (CFG.CORRECTION_WARPS + 1))
     tmem_base_corr = tmem_ptr_i32.load()
@@ -2470,66 +2486,89 @@ def _correction_warp_group(
         CHUNKS_PER_BLK = O_EPI_BLK // O_CHUNK
 
         sO_base = sO[0].base
-        _amax_o_ptr = Pointer(amax_o_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
-        _amax_o_local = cutlass.Float32(0.0)
-
-        for block_idx in cutlass.range_constexpr(N_BLOCKS_EPI):
-            for sub in cutlass.range_constexpr(CHUNKS_PER_BLK):
-                chunk_idx_total = block_idx * CHUNKS_PER_BLK + sub
-                o_addr = tmem_base_epi + cutlass.Int32(LAYOUT.O_OFF + chunk_idx_total * O_CHUNK)
-                o_chunk = nvvm.tcgen05_ld(
-                    "32x32b",
-                    nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
-                    num=O_CHUNK,
-                )
-                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-                o_scaled = o_chunk * inv_sum
-                # Empty BMM2 leaves O TMEM unwritten, and NaN * 0 does not
-                # sanitize it. Padded top-left clears an empty tile once above;
-                # keep per-element selects for the remaining dynamic bounds.
-                if cutlass.const_expr(
-                    not _PADDED_TOP_LEFT_CAUSAL and (CFG.SEQ_KV_LENS_PRESENT or SPLIT_KV > 1 or (CFG.BOTTOM_RIGHT and not bottom_right_diagonal))
-                ):
-                    zero = cutlass.Float32(0.0)
-                    invalid = row_dead
-                    if cutlass.const_expr(CFG.THD_VARLEN):
-                        invalid = invalid | (~_row_valid)
-                    o_scaled = cutlass.Vector.from_elements(
-                        tuple(cutlass.Float32(arith.select(invalid.ir_value(), zero.ir_value(), o_scaled[i].ir_value())) for i in range(O_CHUNK)),
-                        cutlass.Float32,
-                    )
-                _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled), ftz=True)
-                o_out = o_scaled.to(OUT_STORAGE_DTYPE)
-
-                col_offset_const = (chunk_idx_total * O_CHUNK) % D_BLOCK_SIZE
-                block_offset_const = ((chunk_idx_total * O_CHUNK) // D_BLOCK_SIZE) * TMA_O_GRANU_ELEMS_LOCAL
-                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
-                smem_ptr = sO_base.subview(smem_offset).data_ptr()
-
-                if block_idx == 0 and sub == 0:
-                    bars.mb_o_empty.wait(epilogue_state)
-                smem_ptr.store_swizzled(o_out, alignment=64, swizzle=_O_SMEM_SWIZZLE)
-
-            fire_now = (block_idx % 2 == 1) or (CFG.TILE_O == O_EPI_BLK)
-            if cutlass.const_expr(fire_now):
+        if cutlass.const_expr(_FP32_PARTIALS):
+            # fp32 partials: accumulator straight to the workspace, no SMEM
+            # staging and no TMA.  The staged path's barrier traffic still has
+            # to happen: it consumes mb_o_empty once and publishes every
+            # mb_o_full chunk, and the store warp waits on all of them.
+            _store_fp32_partial_tile(
+                o_partial_f32,
+                tmem_base_epi,
+                LAYOUT.O_OFF,
+                inv_sum,
+                row_dead,
+                q_row_global < seqlen_q,
+                _partial_batch(batch_idx, split_idx, n_batch),
+                q_row_global,
+                row_head_idx,
+                CFG.TILE_O,
+                O_CHUNK,
+            )
+            bars.mb_o_empty.wait(epilogue_state)
+            for _chunk in cutlass.range_constexpr(N_O_CHUNKS):
                 nvvm.fence_proxy("async.shared", space="cta")
-                bars.mb_o_full[(block_idx // 2)].arrive()
+                bars.mb_o_full[_chunk].arrive()
+        else:
+            _amax_o_ptr = Pointer(amax_o_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
+            _amax_o_local = cutlass.Float32(0.0)
 
-        if cutlass.const_expr(SPLIT_KV == 1):
-            if cutlass.const_expr(CFG.MASK_FLAGS == MASK_NONE):
-                _amax_o_valid = cutlass.Float32(
-                    arith.select(
-                        _row_valid.ir_value(),
-                        _amax_o_local.ir_value(),
-                        cutlass.Float32(0.0).ir_value(),
+            for block_idx in cutlass.range_constexpr(N_BLOCKS_EPI):
+                for sub in cutlass.range_constexpr(CHUNKS_PER_BLK):
+                    chunk_idx_total = block_idx * CHUNKS_PER_BLK + sub
+                    o_addr = tmem_base_epi + cutlass.Int32(LAYOUT.O_OFF + chunk_idx_total * O_CHUNK)
+                    o_chunk = nvvm.tcgen05_ld(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                        num=O_CHUNK,
                     )
-                )
-                _amax_o_warp = cute.arch.warp_redux_sync(_amax_o_valid, kind="fmax")
-                if (tid_in_wg & cutlass.Int32(31)) == cutlass.Int32(0):
-                    nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_warp.bitcast(cutlass.Int32))
-            else:
-                if _row_valid:
-                    nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                    o_scaled = o_chunk * inv_sum
+                    # Empty BMM2 leaves O TMEM unwritten, and NaN * 0 does not
+                    # sanitize it. Padded top-left clears an empty tile once above;
+                    # keep per-element selects for the remaining dynamic bounds.
+                    if cutlass.const_expr(
+                        not _PADDED_TOP_LEFT_CAUSAL and (CFG.SEQ_KV_LENS_PRESENT or SPLIT_KV > 1 or (CFG.BOTTOM_RIGHT and not bottom_right_diagonal))
+                    ):
+                        zero = cutlass.Float32(0.0)
+                        invalid = row_dead
+                        if cutlass.const_expr(CFG.THD_VARLEN):
+                            invalid = invalid | (~_row_valid)
+                        o_scaled = cutlass.Vector.from_elements(
+                            tuple(cutlass.Float32(arith.select(invalid.ir_value(), zero.ir_value(), o_scaled[i].ir_value())) for i in range(O_CHUNK)),
+                            cutlass.Float32,
+                        )
+                    _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled), ftz=True)
+                    o_out = o_scaled.to(OUT_STORAGE_DTYPE)
+
+                    col_offset_const = (chunk_idx_total * O_CHUNK) % D_BLOCK_SIZE
+                    block_offset_const = ((chunk_idx_total * O_CHUNK) // D_BLOCK_SIZE) * TMA_O_GRANU_ELEMS_LOCAL
+                    smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
+                    smem_ptr = sO_base.subview(smem_offset).data_ptr()
+
+                    if block_idx == 0 and sub == 0:
+                        bars.mb_o_empty.wait(epilogue_state)
+                    smem_ptr.store_swizzled(o_out, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+
+                fire_now = (block_idx % 2 == 1) or (CFG.TILE_O == O_EPI_BLK)
+                if cutlass.const_expr(fire_now):
+                    nvvm.fence_proxy("async.shared", space="cta")
+                    bars.mb_o_full[(block_idx // 2)].arrive()
+
+            if cutlass.const_expr(SPLIT_KV == 1):
+                if cutlass.const_expr(CFG.MASK_FLAGS == MASK_NONE):
+                    _amax_o_valid = cutlass.Float32(
+                        arith.select(
+                            _row_valid.ir_value(),
+                            _amax_o_local.ir_value(),
+                            cutlass.Float32(0.0).ir_value(),
+                        )
+                    )
+                    _amax_o_warp = cute.arch.warp_redux_sync(_amax_o_valid, kind="fmax")
+                    if (tid_in_wg & cutlass.Int32(31)) == cutlass.Int32(0):
+                        nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_warp.bitcast(cutlass.Int32))
+                else:
+                    if _row_valid:
+                        nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
 
         epilogue_state = epilogue_state ^ cutlass.Int32(1)
 
@@ -2583,6 +2622,7 @@ def _host(
     thd_q_lens_tensor: Optional[cute.Tensor] = None,
     thd_kv_lens_tensor: Optional[cute.Tensor] = None,
     thd_lens_form: Optional[cutlass.Int32] = None,
+    o_partial_f32: Optional[cute.Tensor] = None,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
     B, QH, KH, SQ, SKV, _ = problem_size
@@ -2645,9 +2685,15 @@ def _host(
         swizzle=_tma_swz(CFG.V_SWZ_BYTES),
         l2_promotion=tmap.TensorMapL2Promotion.l2_256b,
     )
+    # Unused under fp32 partials, but it must still BUILD: fp32 is 4 bytes,
+    # so scale the box by the O element's own width to stay inside the
+    # swizzle's inner byte limit.
+    _o_box = list(vo_box_o)
+    if _FP32_PARTIALS:
+        _o_box[-1] = max(1, _o_box[-1] * CFG.BPE_O // 4)
     tma_o_desc = tmap.create_tensor_map_tiled_from_view(
         o_tensor,
-        box_dims=vo_box_o,
+        box_dims=tuple(_o_box),
         stride_order=stride_order,
         swizzle=_tma_swz(CFG.O_SWZ_BYTES),
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
@@ -2707,6 +2753,7 @@ def _host(
         amax_o_tensor,
         bottom_right_diagonal,
         seq_q_lens_tensor,
+        o_partial_f32,
     ).launch(
         grid=grid_shape,
         block=[CFG.THREADS_PER_CTA, 1, 1],
@@ -2768,7 +2815,12 @@ def compile(  # noqa: A001
     fake_q = _fake_bshd((fake_batch, sq, qh, d_qk), q_stride)
     fake_k = _fake_bshd((fake_batch, skv, kh, d_qk), k_stride)
     fake_v = _fake_bshd((fake_batch, skv, kh, d_v), v_stride)
-    fake_o = _fake_bshd((o_batch, sq, qh, d_v), o_stride, dtype=OUT_STORAGE_DTYPE, bpe=CFG.BPE_O)
+    fake_o = _fake_bshd(
+        (o_batch, sq, qh, d_v),
+        o_stride,
+        dtype=cutlass.Float32 if _FP32_PARTIALS else OUT_STORAGE_DTYPE,
+        bpe=4 if _FP32_PARTIALS else CFG.BPE_O,
+    )
     if not has_lse:
         # No Stats output: the LSE argument is None-specialized and the store
         # is compiled out entirely — no dummy buffer exists at any level.
@@ -2892,6 +2944,7 @@ def compile(  # noqa: A001
         fake_thd_q_lens,
         fake_thd_kv_lens,
         fake_thd_lens_form,
+        *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d256_mxfp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d256_mxfp8.py
@@ -145,6 +145,7 @@ SF_V_COLS_PER_NBLOCK = SF_NUM_BLOCKS_K_BMM2 * SF_REGISTERS_PER_BLOCK
 
 from cudnn.sdpa.fwd.kernels._common_blackwell import (
     make_split_helpers,
+    store_fp32_partial_tile as _store_fp32_partial_tile,
     KvLoopBounds,
     make_d256_bars,
     row_max_for_exp2,
@@ -269,6 +270,9 @@ _split_h = make_split_helpers(
     dispatch_decode_payload=_dispatch_decode_payload,
 )
 SPLIT_KV = _split_h.SPLIT_KV
+# A split writes fp32 partials, replacing the SMEM/TMA O path rather than
+# widening it; the combine performs the only cast to O's dtype.
+_FP32_PARTIALS = SPLIT_KV > 1
 MAY_BE_EMPTY = _split_h.MAY_BE_EMPTY
 _decode_initial_split = _split_h.decode_initial_split
 _decode_payload_split = _split_h.decode_payload_split
@@ -598,6 +602,7 @@ def _kernel(
     # CFG.SEQ_Q_LENS_PRESENT — the DSL specializes on None, so the flag-off
     # ABI is unchanged.
     seq_q_lens_tensor: Optional[cute.Tensor] = None,
+    o_partial_f32: Optional[cute.Tensor] = None,
 ) -> None:
 
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
@@ -843,6 +848,10 @@ def _kernel(
                 softmax_exchange=softmax_exchange,
                 mb_sf_reuse=mb_sf_reuse,
                 mb_qk_sf_reuse=mb_qk_sf_reuse,
+                # FUSED_CORR_SPLIT_P runs the correction on the WG1 warps
+                # instead of the correction warps, so this arm owns the
+                # epilogue -- and therefore the partial store -- too.
+                o_partial_f32=o_partial_f32,
             )
         else:
             _softmax_warp_group(
@@ -895,6 +904,7 @@ def _kernel(
             softmax_exchange=softmax_exchange,
             mb_sf_reuse=mb_sf_reuse,
             mb_qk_sf_reuse=mb_qk_sf_reuse,
+            o_partial_f32=o_partial_f32,
         )
 
     elif warp_idx == CFG.MMA_WARP_ID:
@@ -1377,38 +1387,47 @@ def _tmastg_warp_group(
         q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
         o_batch = _partial_batch(batch_idx, split_idx, n_batch)
 
-        if cutlass.const_expr(CFG.THD_VARLEN):
-            o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+        # fp32 partials wrote the workspace directly, so only the TMA copy is
+        # dead.  This warp must still CONSUME every mb_o_full the epilogue
+        # published and arrive on the QO_ALIAS gate, or the loader stalls.
+        if cutlass.const_expr(_FP32_PARTIALS):
+            for chunk in cutlass.range_constexpr(N_O_CHUNKS):
+                bars.mb_o_full[chunk].wait(o_full_phase)
+            if nvvm.elect_sync():
+                bars.mb_q_o_alias.arrive()
         else:
-            o_slice = tma_o(cutlass.Int32(0), head_idx, q_row_coord, o_batch)
-            o_desc_ptr = o_slice.tma_desc.get_ptr()
-        for chunk in cutlass.range_constexpr(N_O_CHUNKS):
-            bars.mb_o_full[chunk].wait(o_full_phase)
-            smem_chunk = sO[0].base.subview(chunk * sO[0].tma_subtile_stride_elems)
-            d_coord = cutlass.Int32(chunk * TMA_O_GRANU_ELEMS_HOST)
             if cutlass.const_expr(CFG.THD_VARLEN):
-                if batch_idx < n_batch:
+                o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+            else:
+                o_slice = tma_o(cutlass.Int32(0), head_idx, q_row_coord, o_batch)
+                o_desc_ptr = o_slice.tma_desc.get_ptr()
+            for chunk in cutlass.range_constexpr(N_O_CHUNKS):
+                bars.mb_o_full[chunk].wait(o_full_phase)
+                smem_chunk = sO[0].base.subview(chunk * sO[0].tma_subtile_stride_elems)
+                d_coord = cutlass.Int32(chunk * TMA_O_GRANU_ELEMS_HOST)
+                if cutlass.const_expr(CFG.THD_VARLEN):
+                    if batch_idx < n_batch:
+                        nvvm.cp_async_bulk_tensor_global_shared_cta(
+                            o_desc_ptr,
+                            smem_chunk,
+                            (d_coord, head_idx, q_row_coord, cutlass.Int32(0)),
+                        )
+                else:
                     nvvm.cp_async_bulk_tensor_global_shared_cta(
                         o_desc_ptr,
                         smem_chunk,
-                        (d_coord, head_idx, q_row_coord, cutlass.Int32(0)),
+                        (o_slice.coord_d + d_coord, head_idx, q_row_coord, o_batch),
                     )
-            else:
-                nvvm.cp_async_bulk_tensor_global_shared_cta(
-                    o_desc_ptr,
-                    smem_chunk,
-                    (o_slice.coord_d + d_coord, head_idx, q_row_coord, o_batch),
-                )
-            tma_store_commit()
-            if cutlass.const_expr(CFG.BPE_O == 2 and chunk == 1):
-                tma_store_wait(0)
+                tma_store_commit()
+                if cutlass.const_expr(CFG.BPE_O == 2 and chunk == 1):
+                    tma_store_wait(0)
+                    if nvvm.elect_sync():
+                        bars.mb_q_o_alias.arrive()
+
+            tma_store_wait(0)
+            if cutlass.const_expr(CFG.BPE_O != 2):
                 if nvvm.elect_sync():
                     bars.mb_q_o_alias.arrive()
-
-        tma_store_wait(0)
-        if cutlass.const_expr(CFG.BPE_O != 2):
-            if nvvm.elect_sync():
-                bars.mb_q_o_alias.arrive()
 
         bars.mb_o_empty.arrive()
 
@@ -2529,6 +2548,7 @@ def _correction_warp_group(
     softmax_exchange,
     mb_sf_reuse,
     mb_qk_sf_reuse,
+    o_partial_f32=None,
 ):
     if cutlass.const_expr(CFG.FUSED_CORR_SPLIT_P):
         nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
@@ -2980,84 +3000,107 @@ def _correction_warp_group(
         CHUNKS_PER_BLK = O_EPI_BLK // O_CHUNK
 
         sO_base = sO[0].base
-        _amax_o_ptr = Pointer(amax_o_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
-        _amax_o_local = cutlass.Float32(0.0)
+        if cutlass.const_expr(_FP32_PARTIALS):
+            # fp32 partials: accumulator straight to the workspace, no SMEM
+            # staging and no TMA.  The staged path's barrier traffic still has
+            # to happen: it consumes mb_o_empty once and publishes every
+            # mb_o_full chunk, and the store warp waits on all of them.
+            _store_fp32_partial_tile(
+                o_partial_f32,
+                tmem_base_epi,
+                LAYOUT.O_OFF,
+                inv_sum,
+                row_dead,
+                q_row_global < seqlen_q,
+                _partial_batch(batch_idx, split_idx, n_batch),
+                q_row_global,
+                head_idx,
+                CFG.TILE_O,
+                O_CHUNK,
+            )
+            bars.mb_o_empty.wait(epilogue_state)
+            for _chunk in cutlass.range_constexpr(N_O_CHUNKS):
+                nvvm.fence_proxy("async.shared", space="cta")
+                bars.mb_o_full[_chunk].arrive()
+        else:
+            _amax_o_ptr = Pointer(amax_o_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
+            _amax_o_local = cutlass.Float32(0.0)
 
-        for block_idx in cutlass.range_constexpr(N_BLOCKS_EPI):
-            o_chunks = None
-            if cutlass.const_expr(_E5_STYLE_SOFTMAX and CFG.MASK_FLAGS != 0):
-                o_chunks = [
-                    nvvm.tcgen05_ld(
-                        "32x32b",
-                        nvvm.make_tmem_ptr(
-                            tmem_base_epi + cutlass.Int32(LAYOUT.O_OFF + (block_idx * CHUNKS_PER_BLK + sub) * O_CHUNK),
-                            cutlass.Float32,
-                        ),
-                        num=O_CHUNK,
-                    )
-                    for sub in range(CHUNKS_PER_BLK)
-                ]
-                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-            for sub in cutlass.range_constexpr(CHUNKS_PER_BLK):
-                chunk_idx_total = block_idx * CHUNKS_PER_BLK + sub
-                o_out = cutlass.Vector.from_elements(
-                    tuple(OUT_STORAGE_DTYPE(0.0) for _ in range(O_CHUNK)),
-                    OUT_STORAGE_DTYPE,
-                )
-                if cutlass.const_expr(not _PADDED_TOP_LEFT_CAUSAL) or (bounds.right > bounds.left):
-                    if cutlass.const_expr(_E5_STYLE_SOFTMAX and CFG.MASK_FLAGS != 0):
-                        o_chunk = o_chunks[sub]
-                    else:
-                        o_addr = tmem_base_epi + cutlass.Int32(LAYOUT.O_OFF + chunk_idx_total * O_CHUNK)
-                        o_chunk = nvvm.tcgen05_ld(
+            for block_idx in cutlass.range_constexpr(N_BLOCKS_EPI):
+                o_chunks = None
+                if cutlass.const_expr(_E5_STYLE_SOFTMAX and CFG.MASK_FLAGS != 0):
+                    o_chunks = [
+                        nvvm.tcgen05_ld(
                             "32x32b",
-                            nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                            nvvm.make_tmem_ptr(
+                                tmem_base_epi + cutlass.Int32(LAYOUT.O_OFF + (block_idx * CHUNKS_PER_BLK + sub) * O_CHUNK),
+                                cutlass.Float32,
+                            ),
                             num=O_CHUNK,
                         )
-                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-                    o_scaled = o_chunk * inv_sum
-                    # Empty BMM2 leaves O TMEM unwritten, and NaN * 0 does not
-                    # sanitize it. Plain top-left/SWA and square bottom-right
-                    # always retain the diagonal, so keep this off their hot path.
-                    if cutlass.const_expr(
-                        not _PADDED_TOP_LEFT_CAUSAL and (CFG.SEQ_KV_LENS_PRESENT or SPLIT_KV > 1 or (CFG.BOTTOM_RIGHT and not bottom_right_diagonal))
-                    ):
-                        zero = cutlass.Float32(0.0)
-                        invalid = row_dead
-                        if cutlass.const_expr(CFG.THD_VARLEN):
-                            invalid = invalid | (~_row_valid)
-                        o_scaled = cutlass.Vector.from_elements(
-                            tuple(cutlass.Float32(arith.select(invalid.ir_value(), zero.ir_value(), o_scaled[i].ir_value())) for i in range(O_CHUNK)),
-                            cutlass.Float32,
-                        )
-                    _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled), ftz=True)
-                    o_out = o_scaled.to(OUT_STORAGE_DTYPE)
+                        for sub in range(CHUNKS_PER_BLK)
+                    ]
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                for sub in cutlass.range_constexpr(CHUNKS_PER_BLK):
+                    chunk_idx_total = block_idx * CHUNKS_PER_BLK + sub
+                    o_out = cutlass.Vector.from_elements(
+                        tuple(OUT_STORAGE_DTYPE(0.0) for _ in range(O_CHUNK)),
+                        OUT_STORAGE_DTYPE,
+                    )
+                    if cutlass.const_expr(not _PADDED_TOP_LEFT_CAUSAL) or (bounds.right > bounds.left):
+                        if cutlass.const_expr(_E5_STYLE_SOFTMAX and CFG.MASK_FLAGS != 0):
+                            o_chunk = o_chunks[sub]
+                        else:
+                            o_addr = tmem_base_epi + cutlass.Int32(LAYOUT.O_OFF + chunk_idx_total * O_CHUNK)
+                            o_chunk = nvvm.tcgen05_ld(
+                                "32x32b",
+                                nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                                num=O_CHUNK,
+                            )
+                            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                        o_scaled = o_chunk * inv_sum
+                        # Empty BMM2 leaves O TMEM unwritten, and NaN * 0 does not
+                        # sanitize it. Plain top-left/SWA and square bottom-right
+                        # always retain the diagonal, so keep this off their hot path.
+                        if cutlass.const_expr(
+                            not _PADDED_TOP_LEFT_CAUSAL and (CFG.SEQ_KV_LENS_PRESENT or SPLIT_KV > 1 or (CFG.BOTTOM_RIGHT and not bottom_right_diagonal))
+                        ):
+                            zero = cutlass.Float32(0.0)
+                            invalid = row_dead
+                            if cutlass.const_expr(CFG.THD_VARLEN):
+                                invalid = invalid | (~_row_valid)
+                            o_scaled = cutlass.Vector.from_elements(
+                                tuple(cutlass.Float32(arith.select(invalid.ir_value(), zero.ir_value(), o_scaled[i].ir_value())) for i in range(O_CHUNK)),
+                                cutlass.Float32,
+                            )
+                        _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled), ftz=True)
+                        o_out = o_scaled.to(OUT_STORAGE_DTYPE)
 
-                col_offset_const = (chunk_idx_total * O_CHUNK) % D_BLOCK_SIZE
-                block_offset_const = ((chunk_idx_total * O_CHUNK) // D_BLOCK_SIZE) * TMA_O_GRANU_ELEMS_LOCAL
-                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
-                smem_ptr = sO_base.subview(smem_offset).data_ptr()
+                    col_offset_const = (chunk_idx_total * O_CHUNK) % D_BLOCK_SIZE
+                    block_offset_const = ((chunk_idx_total * O_CHUNK) // D_BLOCK_SIZE) * TMA_O_GRANU_ELEMS_LOCAL
+                    smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
+                    smem_ptr = sO_base.subview(smem_offset).data_ptr()
 
-                if block_idx == 0 and sub == 0:
-                    bars.mb_o_empty.wait(epilogue_state)
-                smem_ptr.store_swizzled(o_out, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+                    if block_idx == 0 and sub == 0:
+                        bars.mb_o_empty.wait(epilogue_state)
+                    smem_ptr.store_swizzled(o_out, alignment=64, swizzle=_O_SMEM_SWIZZLE)
 
-            fire_now = (block_idx % 2 == 1) or (CFG.TILE_O == O_EPI_BLK)
-            if cutlass.const_expr(fire_now):
-                nvvm.fence_proxy("async.shared", space="cta")
-                bars.mb_o_full[(block_idx // 2)].arrive()
+                fire_now = (block_idx % 2 == 1) or (CFG.TILE_O == O_EPI_BLK)
+                if cutlass.const_expr(fire_now):
+                    nvvm.fence_proxy("async.shared", space="cta")
+                    bars.mb_o_full[(block_idx // 2)].arrive()
 
-        if cutlass.const_expr(SPLIT_KV == 1):
-            _amax_o_valid = cutlass.Float32(
-                arith.select(
-                    _row_valid.ir_value(),
-                    _amax_o_local.ir_value(),
-                    cutlass.Float32(0.0).ir_value(),
+            if cutlass.const_expr(SPLIT_KV == 1):
+                _amax_o_valid = cutlass.Float32(
+                    arith.select(
+                        _row_valid.ir_value(),
+                        _amax_o_local.ir_value(),
+                        cutlass.Float32(0.0).ir_value(),
+                    )
                 )
-            )
-            _amax_o_warp = cute.arch.warp_redux_sync(_amax_o_valid, kind="fmax")
-            if (tid_in_wg & cutlass.Int32(31)) == cutlass.Int32(0):
-                nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_warp.bitcast(cutlass.Int32))
+                _amax_o_warp = cute.arch.warp_redux_sync(_amax_o_valid, kind="fmax")
+                if (tid_in_wg & cutlass.Int32(31)) == cutlass.Int32(0):
+                    nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_warp.bitcast(cutlass.Int32))
 
         epilogue_state = epilogue_state ^ cutlass.Int32(1)
 
@@ -3108,6 +3151,7 @@ def _host(
     thd_q_lens_tensor: Optional[cute.Tensor] = None,
     thd_kv_lens_tensor: Optional[cute.Tensor] = None,
     thd_lens_form: Optional[cutlass.Int32] = None,
+    o_partial_f32: Optional[cute.Tensor] = None,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
     B, QH, KH, SQ, SKV, _ = problem_size
@@ -3180,9 +3224,15 @@ def _host(
         swizzle=_tma_swz(CFG.V_SWZ_BYTES),
         l2_promotion=input_l2_promotion,
     )
+    # Unused under fp32 partials, but it must still BUILD: fp32 is 4 bytes,
+    # so scale the box by the O element's own width to stay inside the
+    # swizzle's inner byte limit.
+    _o_box = list(vo_box_o)
+    if _FP32_PARTIALS:
+        _o_box[-1] = max(1, _o_box[-1] * CFG.BPE_O // 4)
     tma_o_desc = tmap.create_tensor_map_tiled_from_view(
         o_tensor,
-        box_dims=vo_box_o,
+        box_dims=tuple(_o_box),
         stride_order=stride_order,
         swizzle=_tma_swz(CFG.O_SWZ_BYTES),
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
@@ -3304,6 +3354,7 @@ def _host(
         amax_o_tensor,
         False,
         seq_q_lens_tensor,
+        o_partial_f32,
     ).launch(
         grid=grid_shape,
         block=[CFG.THREADS_PER_CTA, 1, 1],
@@ -3345,7 +3396,7 @@ def compile(  # noqa: A001
     fake_q = _fake(STORAGE_DTYPE, (fake_batch, sq, qh, CFG.TILE_K))
     fake_k = _fake(STORAGE_DTYPE, (fake_batch, skv, kh, CFG.TILE_K))
     fake_v = _fake(STORAGE_DTYPE, (fake_batch, skv, kh, CFG.TILE_O))
-    fake_o = _fake(OUT_STORAGE_DTYPE, (fake_batch * SPLIT_KV, sq, qh, CFG.TILE_O))
+    fake_o = _fake(cutlass.Float32 if _FP32_PARTIALS else OUT_STORAGE_DTYPE, (fake_batch * SPLIT_KV, sq, qh, CFG.TILE_O))
     fake_sf_q = _fake(cutlass.Int8, (fake_batch, qh, q_sf_tiles, SF_SMEM_SIZE_Q))
     fake_sf_k = _fake(cutlass.Int8, (fake_batch, kh, kv_sf_tiles, SF_SMEM_SIZE_K))
     fake_sf_v = _fake(cutlass.Int8, (fake_batch, kh, kv_sf_tiles, SF_SMEM_SIZE_V))
@@ -3453,6 +3504,7 @@ def compile(  # noqa: A001
         fake_thd_q_lens,
         fake_thd_kv_lens,
         fake_thd_lens_form,
+        *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d512_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d512_f16.py
@@ -348,6 +348,9 @@ _split_h = make_split_helpers(
     dispatch_decode_payload=_dispatch_decode_payload,
 )
 SPLIT_KV = _split_h.SPLIT_KV
+# A split writes fp32 partials, replacing the SMEM/TMA O path rather than
+# widening it; the combine performs the only cast to O's dtype.
+_FP32_PARTIALS = SPLIT_KV > 1
 MAY_BE_EMPTY = _split_h.MAY_BE_EMPTY
 _decode_initial_split = _split_h.decode_initial_split
 _decode_payload_split = _split_h.decode_payload_split
@@ -378,6 +381,7 @@ def _kernel(
     # CFG.SEQ_Q_LENS_PRESENT — the DSL specializes on None, so the flag-off
     # ABI is unchanged.
     seq_q_lens_tensor: Optional[cute.Tensor] = None,
+    o_partial_f32: Optional[cute.Tensor] = None,
 ) -> None:
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
     tidx, _, _ = cute.arch.thread_idx()
@@ -560,6 +564,7 @@ def _kernel(
             cta_id_x=cta_id_x,
             cross_sg_peer=cross_sg_peer,
             qh_per_kh=qh_per_kh,
+            o_partial_f32=o_partial_f32,
         )
 
     elif warp_idx == cutlass.Int32(CFG.MMA_WARP_ID):
@@ -852,6 +857,7 @@ def _compute_warp_group(
     cta_id_x,
     cross_sg_peer,
     qh_per_kh,
+    o_partial_f32=None,
 ):
     nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WG_WARPS + 1))
     tmem_base_addr = tmem_ptr_i32.load()
@@ -1190,17 +1196,24 @@ def _compute_warp_group(
 
             sO_base = sO[0].base
 
-            for b in cutlass.range_constexpr(CFG.TILE_O // O_EPI_BLOCK_SIZE):
-                b_intra = b & (O_BLOCKS_PER_SUB - 1)
-                b_sub = b // O_BLOCKS_PER_SUB
-                tmem_sub = ((b_sub & 1) << 1) | ((b_sub & 2) >> 1)
-                tmem_block = tmem_sub * O_BLOCKS_PER_SUB + b_intra
-
-                o_half = cutlass.Vector.from_elements(
-                    tuple(OUT_STORAGE_DTYPE(0.0) for _ in range(O_EPI_BLOCK_SIZE)),
-                    OUT_STORAGE_DTYPE,
-                )
-                if cutlass.const_expr(not MAY_BE_EMPTY) or (kv_right > kv_left):
+            if cutlass.const_expr(_FP32_PARTIALS):
+                # fp32 partials: same TMEM walk as the staged path -- including its
+                # sub-block permutation -- but the accumulator goes straight to the
+                # workspace instead of being cast into sO and TMA-stored.  The
+                # per-chunk publishes still happen: the store warp waits on them.
+                _op32 = cutlass.make_array_view(o_partial_f32)
+                # d512 is an ENVELOPE flavor too: a graph with d_v < CFG.TILE_O
+                # gets a slab that narrow, so the store bounds itself on the
+                # tensor extent rather than the tile width (the staged TMA path
+                # clipped it).  See _common_sm100.store_fp32_partial_tile.
+                _d_v32 = cutlass.const_expr(o_partial_f32.shape[3])
+                _o_b32 = _partial_batch(batch_idx, split_idx, n_batch)
+                _valid32 = q_row_global < seqlen_q
+                for b in cutlass.range_constexpr(CFG.TILE_O // O_EPI_BLOCK_SIZE):
+                    b_intra = b & (O_BLOCKS_PER_SUB - 1)
+                    b_sub = b // O_BLOCKS_PER_SUB
+                    tmem_sub = ((b_sub & 1) << 1) | ((b_sub & 2) >> 1)
+                    tmem_block = tmem_sub * O_BLOCKS_PER_SUB + b_intra
                     o_addr = tmem_O_base + cutlass.Int32(tmem_block * O_EPI_BLOCK_SIZE)
                     o_fp32 = nvvm.tcgen05_ld(
                         "32x32b",
@@ -1209,23 +1222,56 @@ def _compute_warp_group(
                     )
                     nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                     o_scaled = o_fp32 * beta
-                    o_half = o_scaled.to(OUT_STORAGE_DTYPE)
+                    if _valid32:
+                        _row_out = _op32[_o_b32, q_row_global, row_head_idx, :]
+                        for _j in cutlass.range_constexpr(O_EPI_BLOCK_SIZE):
+                            # NaN * 0.0 is NaN: an empty mainloop never wrote O TMEM, so the
+                            # beta-zeroed scale does not sanitize a dead row on its own.
+                            if cutlass.const_expr(b * O_EPI_BLOCK_SIZE + _j < _d_v32):
+                                _row_out[cutlass.Int32(b * O_EPI_BLOCK_SIZE + _j)] = cutlass.Float32(
+                                    arith.select(row_dead.ir_value(), cutlass.Float32(0.0).ir_value(), o_scaled[_j].ir_value())
+                                )
+                    if ((b + 1) * O_EPI_BLOCK_SIZE) % O_CHUNK_ELEMS == 0:
+                        chunk = (b * O_EPI_BLOCK_SIZE) // O_CHUNK_ELEMS
+                        nvvm.fence_proxy("async.shared", space="cta")
+                        bars.mb_tma_o_full[chunk].arrive()
+            else:
+                for b in cutlass.range_constexpr(CFG.TILE_O // O_EPI_BLOCK_SIZE):
+                    b_intra = b & (O_BLOCKS_PER_SUB - 1)
+                    b_sub = b // O_BLOCKS_PER_SUB
+                    tmem_sub = ((b_sub & 1) << 1) | ((b_sub & 2) >> 1)
+                    tmem_block = tmem_sub * O_BLOCKS_PER_SUB + b_intra
 
-                col_offset_const = (b * O_EPI_BLOCK_SIZE) % O_D_BLOCK
-                block_idx_const = (b * O_EPI_BLOCK_SIZE) // O_D_BLOCK
-                block_offset_const = block_idx_const * O_TMA_GRANU_ELEMS
-                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(O_D_BLOCK)
-                smem_ptr = sO_base.subview(smem_offset).data_ptr()
-                smem_ptr.store_swizzled(
-                    o_half,
-                    alignment=64,
-                    swizzle=_O_EPI_SWIZZLE,
-                )
+                    o_half = cutlass.Vector.from_elements(
+                        tuple(OUT_STORAGE_DTYPE(0.0) for _ in range(O_EPI_BLOCK_SIZE)),
+                        OUT_STORAGE_DTYPE,
+                    )
+                    if cutlass.const_expr(not MAY_BE_EMPTY) or (kv_right > kv_left):
+                        o_addr = tmem_O_base + cutlass.Int32(tmem_block * O_EPI_BLOCK_SIZE)
+                        o_fp32 = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                            num=O_EPI_BLOCK_SIZE,
+                        )
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                        o_scaled = o_fp32 * beta
+                        o_half = o_scaled.to(OUT_STORAGE_DTYPE)
 
-                if ((b + 1) * O_EPI_BLOCK_SIZE) % O_CHUNK_ELEMS == 0:
-                    chunk = (b * O_EPI_BLOCK_SIZE) // O_CHUNK_ELEMS
-                    nvvm.fence_proxy("async.shared", space="cta")
-                    bars.mb_tma_o_full[chunk].arrive()
+                    col_offset_const = (b * O_EPI_BLOCK_SIZE) % O_D_BLOCK
+                    block_idx_const = (b * O_EPI_BLOCK_SIZE) // O_D_BLOCK
+                    block_offset_const = block_idx_const * O_TMA_GRANU_ELEMS
+                    smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(O_D_BLOCK)
+                    smem_ptr = sO_base.subview(smem_offset).data_ptr()
+                    smem_ptr.store_swizzled(
+                        o_half,
+                        alignment=64,
+                        swizzle=_O_EPI_SWIZZLE,
+                    )
+
+                    if ((b + 1) * O_EPI_BLOCK_SIZE) % O_CHUNK_ELEMS == 0:
+                        chunk = (b * O_EPI_BLOCK_SIZE) // O_CHUNK_ELEMS
+                        nvvm.fence_proxy("async.shared", space="cta")
+                        bars.mb_tma_o_full[chunk].arrive()
 
             if cutlass.const_expr(lse_tensor is None):
                 pass  # has_lse=False: the Stats store is compiled out
@@ -1884,25 +1930,29 @@ def _tmastg_warp_group(
             for chunk in cutlass.range_constexpr(N_O_CHUNKS):
                 bars.mb_tma_o_full[chunk].wait(o_full_state.phase)
 
-            q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
-            q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
-            # KV split: partials stack split-major on the workspace BATCH axis.
-            o_batch = _partial_batch(batch_idx, split_idx, n_batch)
-            if cutlass.const_expr(CFG.THD_VARLEN):
-                # DEAD unit (batch == n_batch, envelope grid — issue #552): no O
-                # rows exist and descriptor slot n_batch is never built, so skip
-                # the store; the barrier protocol below still runs.
-                if batch_idx < n_batch:
-                    o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
-                    o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), q_head_idx, q_row_coord, cutlass.Int32(0))
-                    tma_store_tile(sO[0], o_slice)
-            else:
-                tma_store_tile(
-                    sO[0],
-                    tma_o(cutlass.Int32(0), q_head_idx, q_row_coord, o_batch),
-                )
-            tma_store_commit()
-            tma_store_wait(0)
+            # fp32 partials wrote the workspace directly, so only the TMA copy is
+            # dead.  The chunk waits above, the empty arrive and the phase
+            # advance below all still run.
+            if cutlass.const_expr(not _FP32_PARTIALS):
+                q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
+                q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+                # KV split: partials stack split-major on the workspace BATCH axis.
+                o_batch = _partial_batch(batch_idx, split_idx, n_batch)
+                if cutlass.const_expr(CFG.THD_VARLEN):
+                    # DEAD unit (batch == n_batch, envelope grid — issue #552): no O
+                    # rows exist and descriptor slot n_batch is never built, so skip
+                    # the store; the barrier protocol below still runs.
+                    if batch_idx < n_batch:
+                        o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                        o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), q_head_idx, q_row_coord, cutlass.Int32(0))
+                        tma_store_tile(sO[0], o_slice)
+                else:
+                    tma_store_tile(
+                        sO[0],
+                        tma_o(cutlass.Int32(0), q_head_idx, q_row_coord, o_batch),
+                    )
+                tma_store_commit()
+                tma_store_wait(0)
 
             bars.mb_tma_o_empty.arrive()
             nvvm.bar_warp_sync(cute.arch.FULL_MASK)
@@ -1953,6 +2003,7 @@ def _host(
     thd_q_lens_tensor: Optional[cute.Tensor] = None,
     thd_kv_lens_tensor: Optional[cute.Tensor] = None,
     thd_lens_form: Optional[cutlass.Int32] = None,
+    o_partial_f32: Optional[cute.Tensor] = None,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
     B, QH, KH, SQ, SKV, _ = problem_size
@@ -1995,9 +2046,12 @@ def _host(
         swizzle=_tma_swz(CFG.V_SWZ_BYTES),
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
     )
+    _o_box = list(vo_box_o)
+    if _FP32_PARTIALS:
+        _o_box[-1] = max(1, _o_box[-1] * CFG.BPE_O // 4)
     tma_o_desc = tmap.create_tensor_map_tiled_from_view(
         o_tensor,
-        box_dims=vo_box_o,
+        box_dims=tuple(_o_box),
         stride_order=stride_order,
         swizzle=_tma_swz(CFG.O_SWZ_BYTES),
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
@@ -2053,6 +2107,7 @@ def _host(
         cutlass.Int32(QH // KH),
         scale_softmax_log2,
         seq_q_lens_tensor,
+        o_partial_f32,
     ).launch(
         grid=grid_shape,
         block=[CFG.THREADS_PER_CTA, 1, 1],
@@ -2130,7 +2185,9 @@ def compile(  # noqa: A001
     fake_q = _fake_bshd((_fake_batch, sq, qh, d_qk), q_stride)
     fake_k = _fake_bshd((_fake_batch, skv, kh, d_qk), k_stride)
     fake_v = _fake_bshd((_fake_batch, skv, kh, d_v), v_stride)
-    fake_o = _fake_bshd((_o_batch, sq, qh, d_v), o_stride, dtype=OUT_STORAGE_DTYPE, bpe=CFG.BPE_O)
+    fake_o = _fake_bshd(
+        (_o_batch, sq, qh, d_v), o_stride, dtype=cutlass.Float32 if _FP32_PARTIALS else OUT_STORAGE_DTYPE, bpe=4 if _FP32_PARTIALS else CFG.BPE_O
+    )
     if not has_lse:
         # No Stats output: the LSE argument is None-specialized and the store
         # is compiled out entirely — no dummy buffer exists at any level.
@@ -2246,6 +2303,7 @@ def compile(  # noqa: A001
         fake_thd_q_lens,
         fake_thd_kv_lens,
         fake_thd_lens_form,
+        *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d512_fp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d512_fp8.py
@@ -446,6 +446,9 @@ _split_h = make_split_helpers(
     dispatch_decode_payload=_dispatch_decode_payload,
 )
 SPLIT_KV = _split_h.SPLIT_KV
+# A split writes fp32 partials, replacing the SMEM/TMA O path rather than
+# widening it; the combine performs the only cast to O's dtype.
+_FP32_PARTIALS = SPLIT_KV > 1
 MAY_BE_EMPTY = _split_h.MAY_BE_EMPTY
 _decode_initial_split = _split_h.decode_initial_split
 _decode_payload_split = _split_h.decode_payload_split
@@ -487,6 +490,7 @@ def _kernel(
     # CFG.SEQ_Q_LENS_PRESENT — the DSL specializes on None, so the flag-off
     # ABI is unchanged.
     seq_q_lens_tensor: Optional[cute.Tensor] = None,
+    o_partial_f32: Optional[cute.Tensor] = None,
 ) -> None:
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
     tidx, _, _ = cute.arch.thread_idx()
@@ -693,6 +697,7 @@ def _kernel(
             cta_id_x=cta_id_x,
             cross_sg_peer=cross_sg_peer,
             qh_per_kh=qh_per_kh,
+            o_partial_f32=o_partial_f32,
         )
 
     elif warp_idx == cutlass.Int32(CFG.MMA_WARP_ID):
@@ -970,6 +975,7 @@ def _compute_warp_group(
     cta_id_x,
     cross_sg_peer,
     qh_per_kh,
+    o_partial_f32=None,
 ):
     nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WG_WARPS + 1))
     tmem_base_addr = tmem_ptr_i32.load()
@@ -1326,17 +1332,24 @@ def _compute_warp_group(
 
             sO_base = sO[0].base
 
-            for b in cutlass.range_constexpr(CFG.TILE_O // O_EPI_BLOCK_SIZE):
-                b_intra = b & (O_BLOCKS_PER_SUB - 1)
-                b_sub = b // O_BLOCKS_PER_SUB
-                tmem_sub = ((b_sub & 1) << 1) | ((b_sub & 2) >> 1)
-                tmem_block = tmem_sub * O_BLOCKS_PER_SUB + b_intra
-
-                o_half = cutlass.Vector.from_elements(
-                    tuple(OUT_STORAGE_DTYPE(0.0) for _ in range(O_EPI_BLOCK_SIZE)),
-                    OUT_STORAGE_DTYPE,
-                )
-                if cutlass.const_expr(not MAY_BE_EMPTY) or (kv_right > kv_left):
+            if cutlass.const_expr(_FP32_PARTIALS):
+                # fp32 partials: same TMEM walk as the staged path -- including its
+                # sub-block permutation -- but the accumulator goes straight to the
+                # workspace instead of being cast into sO and TMA-stored.  The
+                # per-chunk publishes still happen: the store warp waits on them.
+                _op32 = cutlass.make_array_view(o_partial_f32)
+                # d512 is an ENVELOPE flavor too: a graph with d_v < CFG.TILE_O
+                # gets a slab that narrow, so the store bounds itself on the
+                # tensor extent rather than the tile width (the staged TMA path
+                # clipped it).  See _common_sm100.store_fp32_partial_tile.
+                _d_v32 = cutlass.const_expr(o_partial_f32.shape[3])
+                _o_b32 = _partial_batch(batch_idx, split_idx, n_batch)
+                _valid32 = q_row_global < seqlen_q
+                for b in cutlass.range_constexpr(CFG.TILE_O // O_EPI_BLOCK_SIZE):
+                    b_intra = b & (O_BLOCKS_PER_SUB - 1)
+                    b_sub = b // O_BLOCKS_PER_SUB
+                    tmem_sub = ((b_sub & 1) << 1) | ((b_sub & 2) >> 1)
+                    tmem_block = tmem_sub * O_BLOCKS_PER_SUB + b_intra
                     o_addr = tmem_O_base + cutlass.Int32(tmem_block * O_EPI_BLOCK_SIZE)
                     o_fp32 = nvvm.tcgen05_ld(
                         "32x32b",
@@ -1345,33 +1358,66 @@ def _compute_warp_group(
                     )
                     nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                     o_scaled = o_fp32 * beta
-                    # amax over |o_scaled| via a ternary tree (see
-                    # _abs_max_tree): a running `acc = max(acc, |e|)` would
-                    # build a TILE_O-deep dependency chain through the
-                    # epilogue's critical path.  No per-element dead-row select
-                    # is needed -- a fully-masked row still has its O TMEM
-                    # written by the MMA (P is zero, so O accumulates zero), and
-                    # the only path leaving O TMEM unwritten is the empty
-                    # mainloop, which the MAY_BE_EMPTY guard above skips.  One
-                    # select on the row's scalar result covers it.
-                    _amax_o_local = cute.math.max(_amax_o_local, _abs_max_tree(o_scaled, O_EPI_BLOCK_SIZE), ftz=True)
-                    o_half = o_scaled.to(OUT_STORAGE_DTYPE)
+                    if _valid32:
+                        _row_out = _op32[_o_b32, q_row_global, row_head_idx, :]
+                        for _j in cutlass.range_constexpr(O_EPI_BLOCK_SIZE):
+                            # NaN * 0.0 is NaN: an empty mainloop never wrote O TMEM, so the
+                            # beta-zeroed scale does not sanitize a dead row on its own.
+                            if cutlass.const_expr(b * O_EPI_BLOCK_SIZE + _j < _d_v32):
+                                _row_out[cutlass.Int32(b * O_EPI_BLOCK_SIZE + _j)] = cutlass.Float32(
+                                    arith.select(row_dead.ir_value(), cutlass.Float32(0.0).ir_value(), o_scaled[_j].ir_value())
+                                )
+                    if ((b + 1) * O_EPI_BLOCK_SIZE) % O_CHUNK_ELEMS == 0:
+                        chunk = (b * O_EPI_BLOCK_SIZE) // O_CHUNK_ELEMS
+                        nvvm.fence_proxy("async.shared", space="cta")
+                        bars.mb_tma_o_full[chunk].arrive()
+            else:
+                for b in cutlass.range_constexpr(CFG.TILE_O // O_EPI_BLOCK_SIZE):
+                    b_intra = b & (O_BLOCKS_PER_SUB - 1)
+                    b_sub = b // O_BLOCKS_PER_SUB
+                    tmem_sub = ((b_sub & 1) << 1) | ((b_sub & 2) >> 1)
+                    tmem_block = tmem_sub * O_BLOCKS_PER_SUB + b_intra
 
-                col_offset_const = (b * O_EPI_BLOCK_SIZE) % O_D_BLOCK
-                block_idx_const = (b * O_EPI_BLOCK_SIZE) // O_D_BLOCK
-                block_offset_const = block_idx_const * O_TMA_GRANU_ELEMS
-                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(O_D_BLOCK)
-                smem_ptr = sO_base.subview(smem_offset).data_ptr()
-                smem_ptr.store_swizzled(
-                    o_half,
-                    alignment=64,
-                    swizzle=_O_EPI_SWIZZLE,
-                )
+                    o_half = cutlass.Vector.from_elements(
+                        tuple(OUT_STORAGE_DTYPE(0.0) for _ in range(O_EPI_BLOCK_SIZE)),
+                        OUT_STORAGE_DTYPE,
+                    )
+                    if cutlass.const_expr(not MAY_BE_EMPTY) or (kv_right > kv_left):
+                        o_addr = tmem_O_base + cutlass.Int32(tmem_block * O_EPI_BLOCK_SIZE)
+                        o_fp32 = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                            num=O_EPI_BLOCK_SIZE,
+                        )
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                        o_scaled = o_fp32 * beta
+                        # amax over |o_scaled| via a ternary tree (see
+                        # _abs_max_tree): a running `acc = max(acc, |e|)` would
+                        # build a TILE_O-deep dependency chain through the
+                        # epilogue's critical path.  No per-element dead-row select
+                        # is needed -- a fully-masked row still has its O TMEM
+                        # written by the MMA (P is zero, so O accumulates zero), and
+                        # the only path leaving O TMEM unwritten is the empty
+                        # mainloop, which the MAY_BE_EMPTY guard above skips.  One
+                        # select on the row's scalar result covers it.
+                        _amax_o_local = cute.math.max(_amax_o_local, _abs_max_tree(o_scaled, O_EPI_BLOCK_SIZE), ftz=True)
+                        o_half = o_scaled.to(OUT_STORAGE_DTYPE)
 
-                if ((b + 1) * O_EPI_BLOCK_SIZE) % O_CHUNK_ELEMS == 0:
-                    chunk = (b * O_EPI_BLOCK_SIZE) // O_CHUNK_ELEMS
-                    nvvm.fence_proxy("async.shared", space="cta")
-                    bars.mb_tma_o_full[chunk].arrive()
+                    col_offset_const = (b * O_EPI_BLOCK_SIZE) % O_D_BLOCK
+                    block_idx_const = (b * O_EPI_BLOCK_SIZE) // O_D_BLOCK
+                    block_offset_const = block_idx_const * O_TMA_GRANU_ELEMS
+                    smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(O_D_BLOCK)
+                    smem_ptr = sO_base.subview(smem_offset).data_ptr()
+                    smem_ptr.store_swizzled(
+                        o_half,
+                        alignment=64,
+                        swizzle=_O_EPI_SWIZZLE,
+                    )
+
+                    if ((b + 1) * O_EPI_BLOCK_SIZE) % O_CHUNK_ELEMS == 0:
+                        chunk = (b * O_EPI_BLOCK_SIZE) // O_CHUNK_ELEMS
+                        nvvm.fence_proxy("async.shared", space="cta")
+                        bars.mb_tma_o_full[chunk].arrive()
 
             # Row validity — the same predicate that gates the LSE store below,
             # hoisted so the amax reduction can share it.  THD: sequence-local
@@ -2083,25 +2129,27 @@ def _tmastg_warp_group(
             for chunk in cutlass.range_constexpr(N_O_CHUNKS):
                 bars.mb_tma_o_full[chunk].wait(o_full_state.phase)
 
-            q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
-            q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
-            # KV split: partials stack split-major on the workspace BATCH axis.
-            o_batch = _partial_batch(batch_idx, split_idx, n_batch)
-            if cutlass.const_expr(CFG.THD_VARLEN):
-                # DEAD unit (batch == n_batch, envelope grid — issue #552): no O
-                # rows exist and descriptor slot n_batch is never built, so skip
-                # the store; the barrier protocol below still runs.
-                if batch_idx < n_batch:
-                    o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
-                    o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), q_head_idx, q_row_coord, cutlass.Int32(0))
-                    tma_store_tile(sO[0], o_slice)
-            else:
-                tma_store_tile(
-                    sO[0],
-                    tma_o(cutlass.Int32(0), q_head_idx, q_row_coord, o_batch),
-                )
-            tma_store_commit()
-            tma_store_wait(0)
+            # fp32 partials wrote the workspace directly; only the TMA copy is dead.
+            if cutlass.const_expr(not _FP32_PARTIALS):
+                q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
+                q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+                # KV split: partials stack split-major on the workspace BATCH axis.
+                o_batch = _partial_batch(batch_idx, split_idx, n_batch)
+                if cutlass.const_expr(CFG.THD_VARLEN):
+                    # DEAD unit (batch == n_batch, envelope grid — issue #552): no O
+                    # rows exist and descriptor slot n_batch is never built, so skip
+                    # the store; the barrier protocol below still runs.
+                    if batch_idx < n_batch:
+                        o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                        o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), q_head_idx, q_row_coord, cutlass.Int32(0))
+                        tma_store_tile(sO[0], o_slice)
+                else:
+                    tma_store_tile(
+                        sO[0],
+                        tma_o(cutlass.Int32(0), q_head_idx, q_row_coord, o_batch),
+                    )
+                tma_store_commit()
+                tma_store_wait(0)
 
             bars.mb_tma_o_empty.arrive()
             nvvm.bar_warp_sync(cute.arch.FULL_MASK)
@@ -2163,6 +2211,7 @@ def _host(
     # engine row does not declare dense_seq_q_trim today, so the flag is always
     # 0 here and the parameter folds out.
     seq_q_lens_tensor: Optional[cute.Tensor] = None,
+    o_partial_f32: Optional[cute.Tensor] = None,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
     B, QH, KH, SQ, SKV, _ = problem_size
@@ -2205,9 +2254,12 @@ def _host(
         swizzle=_tma_swz(CFG.V_SWZ_BYTES),
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
     )
+    _o_box = list(vo_box_o)
+    if _FP32_PARTIALS:
+        _o_box[-1] = max(1, _o_box[-1] * CFG.BPE_O // 4)
     tma_o_desc = tmap.create_tensor_map_tiled_from_view(
         o_tensor,
-        box_dims=vo_box_o,
+        box_dims=tuple(_o_box),
         stride_order=stride_order,
         swizzle=_tma_swz(CFG.O_SWZ_BYTES),
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
@@ -2275,6 +2327,7 @@ def _host(
         scale_o_t,
         amax_o_tensor,
         seq_q_lens_tensor,
+        o_partial_f32,
     ).launch(
         grid=grid_shape,
         block=[CFG.THREADS_PER_CTA, 1, 1],
@@ -2352,7 +2405,9 @@ def compile(  # noqa: A001
     fake_q = _fake_bshd((_fake_batch, sq, qh, d_qk), q_stride)
     fake_k = _fake_bshd((_fake_batch, skv, kh, d_qk), k_stride)
     fake_v = _fake_bshd((_fake_batch, skv, kh, d_v), v_stride)
-    fake_o = _fake_bshd((_o_batch, sq, qh, d_v), o_stride, dtype=OUT_STORAGE_DTYPE, bpe=CFG.BPE_O)
+    fake_o = _fake_bshd(
+        (_o_batch, sq, qh, d_v), o_stride, dtype=cutlass.Float32 if _FP32_PARTIALS else OUT_STORAGE_DTYPE, bpe=4 if _FP32_PARTIALS else CFG.BPE_O
+    )
     if not has_lse:
         # No Stats output: the LSE argument is None-specialized and the store
         # is compiled out entirely — no dummy buffer exists at any level.
@@ -2485,6 +2540,7 @@ def compile(  # noqa: A001
         fake_thd_kv_lens,
         fake_thd_lens_form,
         fake_seq_q_lens,
+        *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm100/split_combine.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/split_combine.py
@@ -31,6 +31,19 @@ THREADS = 128
 
 NEG_INF = float("-inf")
 
+# The FP8 entries are reachable only as the OUTPUT type, where this pass
+# performs the single cast.  "f32" is a PARTIAL-only type: the split epilogue can
+# write its fp32 accumulator straight to global (no SMEM staging), so the
+# reduction reads exactly what the mainloop produced with no intermediate
+# rounding.
+_ELEM = {
+    "f32": cutlass.Float32,
+    "f16": cutlass.Float16,
+    "bf16": cutlass.BFloat16,
+    "e4m3": cutlass.Float8E4M3FN,
+    "e5m2": cutlass.Float8E5M2,
+}
+
 
 @cute.kernel
 def _combine_kernel(
@@ -44,6 +57,11 @@ def _combine_kernel(
     # splits).  The FP8 kernels therefore skip their in-kernel amax write when
     # SPLIT_KV > 1 and leave it to this pass.  None-specialized off otherwise.
     amax_o: Optional[cute.Tensor],
+    # 1-element fp32 output scale, present only when O is stored quantized.
+    # The split kernels leave it out of their epilogue and write UNSCALED
+    # partials; this pass applies it at the single cast, so the FP8 rounding
+    # happens once, on the recombined value.
+    scale_o: Optional[cute.Tensor],
     n_batch: cutlass.Int32,
     n_splits: cutlass.Int32,
     d_v: cutlass.Int32,
@@ -95,6 +113,9 @@ def _combine_kernel(
     # -inf / 0.)
     neg_inf = cutlass.Float32(NEG_INF)
     amax_local = cutlass.Float32(0.0)
+    q_scale = cutlass.Float32(1.0)
+    if cutlass.const_expr(scale_o is not None):
+        q_scale = cutlass.Float32(cutlass.make_array_view(scale_o)[0])
     for d0 in cutlass.range(tidx, d_v, THREADS, unroll=1):
         acc = cutlass.Float32(0.0)
         for s in cutlass.range(0, n_splits, 1, unroll=1):
@@ -106,11 +127,13 @@ def _combine_kernel(
                 acc = acc + w * cutlass.Float32(o_row[d0])
         out_row = oo[batch, q_row, head, :]
         o_val = acc * inv_den
-        out_row[d0] = o_val.to(o_out.element_type)
         if cutlass.const_expr(amax_o is not None):
-            # amax over the fp32 PRE-CAST value, matching what the single-pass
-            # epilogue reports.
+            # Measured before scale_o, so this is already the pre-quant amax and
+            # needs no post-hoc divide (the single-pass epilogue's does).
             amax_local = cute.math.max(amax_local, cute.math.max(o_val, -o_val))
+        if cutlass.const_expr(scale_o is not None):
+            o_val = o_val * q_scale
+        out_row[d0] = o_val.to(o_out.element_type)
 
     # One atomic per lane.  The value is non-negative, so its fp32 bit pattern
     # orders the same as the float and an integer atomicMax is exact -- the same
@@ -138,6 +161,7 @@ def _host(
     o_out: cute.Tensor,
     lse_out: Optional[cute.Tensor],
     amax_o: Optional[cute.Tensor],
+    scale_o: Optional[cute.Tensor],
     problem_size: Tuple[int, int, int, int],
     n_splits: cutlass.Int32,
     stream: _cuda_driver.CUstream = None,
@@ -149,6 +173,7 @@ def _host(
         o_out,
         lse_out,
         amax_o,
+        scale_o,
         cutlass.Int32(B),
         n_splits,
         cutlass.Int32(D),
@@ -170,6 +195,8 @@ def compile(  # noqa: A001
     has_lse: bool = False,
     lse_stride: Optional[tuple[int, int, int]] = None,
     has_amax: bool = False,
+    dtype_partial: Optional[str] = None,
+    has_scale_o: bool = False,
 ) -> Callable:
     """Compile the combine pass for one concrete (B, H, S_q, d_v, splits) shape.
 
@@ -181,10 +208,17 @@ def compile(  # noqa: A001
     same for the FP8-family amax of the recombined O.  ``lse_stride`` describes
     the caller-visible LSE output; the per-split LSE input workspace remains
     compact regardless of that final layout.
-    """
-    elem = {"f16": cutlass.Float16, "bf16": cutlass.BFloat16}[dtype_o]
 
-    fake_o_partial = cute.runtime.make_fake_compact_tensor(elem, (splits * b, sq, h, d_v), stride_order=(3, 2, 1, 0), assumed_align=16)
+    ``dtype_partial`` names the workspace element type, which is never narrower
+    than ``dtype_o``: the split kernels write "f32" where they can store their
+    accumulator registers straight to global and half otherwise, and this pass
+    performs the only cast down to ``dtype_o``, applying ``scale_o``
+    (``has_scale_o``) at that single point.  It defaults to ``dtype_o``.
+    """
+    elem = _ELEM[dtype_o]
+    elem_partial = _ELEM[dtype_partial or dtype_o]
+
+    fake_o_partial = cute.runtime.make_fake_compact_tensor(elem_partial, (splits * b, sq, h, d_v), stride_order=(3, 2, 1, 0), assumed_align=16)
     fake_lse_partial = cute.runtime.make_fake_compact_tensor(cutlass.Float32, (splits * b, h, sq), stride_order=(2, 1, 0), assumed_align=16)
     fake_o_out = cute.runtime.make_fake_compact_tensor(elem, (b, sq, h, d_v), stride_order=(3, 2, 1, 0), assumed_align=16)
     fake_lse_out = (
@@ -197,6 +231,7 @@ def compile(  # noqa: A001
         else None
     )
     fake_amax_o = cute.runtime.make_fake_compact_tensor(cutlass.Float32, (1,), stride_order=(0,), assumed_align=4) if has_amax else None
+    fake_scale_o = cute.runtime.make_fake_compact_tensor(cutlass.Float32, (1,), stride_order=(0,), assumed_align=4) if has_scale_o else None
 
     return cute.compile(
         _host,
@@ -205,6 +240,7 @@ def compile(  # noqa: A001
         fake_o_out,
         fake_lse_out,
         fake_amax_o,
+        fake_scale_o,
         (b, h, sq, d_v),
         cutlass.Int32(0),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d128_fp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d128_fp8.py
@@ -216,6 +216,7 @@ else:
 
 from cudnn.sdpa.fwd.kernels._common_blackwell import (
     make_split_helpers,
+    store_fp32_partial_tile as _store_fp32_partial_tile,
     Bars,
     KvLoopBounds,
     make_classic_bars,
@@ -303,6 +304,9 @@ _split_h = make_split_helpers(
     dispatch_decode_payload=_dispatch_decode_payload,
 )
 SPLIT_KV = _split_h.SPLIT_KV
+# A split writes fp32 partials, replacing the SMEM/TMA O path rather than
+# widening it; the combine performs the only cast to O's dtype.
+_FP32_PARTIALS = SPLIT_KV > 1
 MAY_BE_EMPTY = _split_h.MAY_BE_EMPTY
 _decode_initial_split = _split_h.decode_initial_split
 _decode_payload_split = _split_h.decode_payload_split
@@ -463,6 +467,7 @@ def _kernel(
     descale_v_t: cute.Tensor,
     scale_o_t: cute.Tensor,
     amax_o_tensor: cute.Tensor,
+    o_partial_f32: Optional[cute.Tensor] = None,
 ) -> None:
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
     tidx, _, _ = cute.arch.thread_idx()
@@ -686,6 +691,7 @@ def _kernel(
             o_scale_fused=o_scale_fused,
             amax_o_tensor=amax_o_tensor,
             qh_per_kh=qh_per_kh,
+            o_partial_f32=o_partial_f32,
         )
 
     # cga2 non-leader runs quiet body (alloc+dealloc only); cga1 folds to full path.
@@ -1097,29 +1103,33 @@ def _tmastg_warp_group(
 
         for qs in cutlass.range_constexpr(CFG.TILES_Q):
             bars.mb_o_full[qs].wait(o_full_phase)
+            # fp32 partials wrote the workspace directly, so nothing is staged
+            # to copy.  Skip ONLY the store: the arrive below and any QO_ALIAS
+            # handshake after it must still run, or this warp laps the loader
+            # and the parity waits deadlock.
+            if cutlass.const_expr(not _FP32_PARTIALS):
+                # O TMA params follow O's swizzle, not V's (V and O swizzles may differ).
+                if cutlass.const_expr(CFG.THD_VARLEN):
+                    # THD: store each Q slab through this batch's pre-built descriptor
+                    # (base at the sequence's packed row, seq extent = S_q_b → a box
+                    # past S_q_b is OOB-clipped).  q_row coord is sequence-local; the
+                    # batch coord collapses to 0.  Both slabs share one descriptor.
+                    # DEAD unit (batch == n_batch, over-launched envelope grid —
+                    # issue #552): no O rows exist and descriptor slot n_batch is
+                    # never built, so skip the store; the barrier protocol below
+                    # still runs.
+                    if batch_idx < n_batch:
+                        o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                        o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), cutlass.Int32(0))
+                        tma_store_tile(sO[qs], o_slice)
+                else:
+                    tma_store_tile(
+                        sO[qs],
+                        tma_o(cutlass.Int32(0), q_head_idx, q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE), o_batch),
+                    )
 
-            # O TMA params follow O's swizzle, not V's (V and O swizzles may differ).
-            if cutlass.const_expr(CFG.THD_VARLEN):
-                # THD: store each Q slab through this batch's pre-built descriptor
-                # (base at the sequence's packed row, seq extent = S_q_b → a box
-                # past S_q_b is OOB-clipped).  q_row coord is sequence-local; the
-                # batch coord collapses to 0.  Both slabs share one descriptor.
-                # DEAD unit (batch == n_batch, over-launched envelope grid —
-                # issue #552): no O rows exist and descriptor slot n_batch is
-                # never built, so skip the store; the barrier protocol below
-                # still runs.
-                if batch_idx < n_batch:
-                    o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
-                    o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), cutlass.Int32(0))
-                    tma_store_tile(sO[qs], o_slice)
-            else:
-                tma_store_tile(
-                    sO[qs],
-                    tma_o(cutlass.Int32(0), q_head_idx, q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE), o_batch),
-                )
-
-            tma_store_commit()
-            tma_store_wait(0)
+                tma_store_commit()
+                tma_store_wait(0)
 
             bars.mb_o_empty[qs].arrive()
 
@@ -1982,6 +1992,7 @@ def _correction_warp_group(
     o_scale_fused,
     amax_o_tensor,
     qh_per_kh,
+    o_partial_f32=None,
 ):
     """Correction warp group: 4 warps × 32 lanes = 128, one lane per O row.
 
@@ -2149,6 +2160,10 @@ def _correction_warp_group(
             bars.mb_stats_read[qs].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
 
             inv_sum = cutlass.Float32(0.0)  # pre-declare for DSL if-staging
+            # Same reason: row_dead is only bound under some mask/sink configs, but
+            # the fp32-partial store reads it unconditionally.  False here means
+            # 'not dead'; the branches below override it where it is meaningful.
+            row_dead = cutlass.Float32(0.0) > cutlass.Float32(1.0)
             lse_val = cutlass.Float32(0.0)  # pre-declare; computed in both branches
             q_row_global = (
                 q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE) + cutlass.Int32(qs * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
@@ -2222,109 +2237,128 @@ def _correction_warp_group(
 
             sO_sub_base = sO[qs].base
 
-            if cutlass.const_expr(CFG.DTYPE_O <= 1):
-                # FP8 output (DTYPE_O ∈ {0,1}): hand-rolled 16:4 fp8 pack +
-                # STS.128 — forces F2FP outputs into a register quad so STS.128
-                # needs no PRMT to gather them (vs the DSL store_swizzled which
-                # folds the swizzle XOR via byte-level PRMT).  Bit-identical to
-                # the DTYPE_O == DTYPE_QKV path.
-                _SWZ_BYTES_C = CFG.O_SWZ_BYTES
-                _SWZ_SHIFT_C = 3 - _O_SWZ_B
-                _SWZ_MASK_C = (1 << _O_SWZ_B) - 1
-                _SUBTILE_BYTES_C = CFG.TILE_M * _SWZ_BYTES_C
-
-                row_base_bytes = tid_in_wg * cutlass.Int32(_SWZ_BYTES_C)
-                row_xor_field = ((tid_in_wg >> cutlass.Int32(_SWZ_SHIFT_C)) & cutlass.Int32(_SWZ_MASK_C)) << cutlass.Int32(4)
-
-                for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
-                    o_addr = tmem_base_epi + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
-                    o_chunk = nvvm.tcgen05_ld(
-                        "32x32b",
-                        nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
-                        num=O_CHUNK,
-                    )
-                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-                    o_scaled = o_chunk * inv_sum
-                    # Dead-row sanitize: an empty mainloop never writes O TMEM,
-                    # so o_chunk is garbage (possibly NaN) and `* inv_sum(=0)`
-                    # cannot zero it — select 0 explicitly (keeps amax_o clean).
-                    _zero_f = cutlass.Float32(0.0)
-                    o_elems = [cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled[i].ir_value())) for i in range(O_CHUNK)]
-
-                    for _i in cutlass.range_constexpr(O_CHUNK):
-                        _e = o_elems[_i]
-                        _amax_o_local = cute.math.max(_amax_o_local, cute.math.max(_e, -_e))
-
-                    # Plain range (not range_constexpr) — extraction at Python trace time.
-                    o_packed_v = fp32_to_fp8_pack(
-                        [o_elems[i] for i in range(16)],
-                        dtype=OUT_STORAGE_DTYPE,
-                    )
-
-                    col_elems = chunk_idx * O_CHUNK
-                    block_idx = col_elems // D_BLOCK_SIZE
-                    col_in_block_bytes = (col_elems % D_BLOCK_SIZE) * CFG.BPE_O
-                    block_off_bytes = block_idx * _SUBTILE_BYTES_C
-
-                    swizzled_in_row = row_xor_field ^ cutlass.Int32(col_in_block_bytes)
-                    addr_off_bytes = cutlass.Int32(block_off_bytes) + row_base_bytes + swizzled_in_row
-
-                    # Re-type pointer to Int32 so 4-i32 store maps to one st.shared.v4.b32.
-                    fp8_ptr = sO_sub_base.subview(addr_off_bytes).data_ptr()
-                    i32_ptr = Pointer(fp8_ptr, dtype=cutlass.Int32)
-                    if chunk_idx == 0:
-                        bars.mb_o_empty[qs].wait(o_empty_phase)
-                    i32_ptr.store(o_packed_v, alignment=16)
+            if cutlass.const_expr(_FP32_PARTIALS):
+                # fp32 partials: the accumulator goes straight to the workspace,
+                # bypassing the SMEM O tile and its TMA store.
+                _store_fp32_partial_tile(
+                    o_partial_f32,
+                    tmem_base_epi,
+                    tmem_O_off,
+                    inv_sum,
+                    row_dead,
+                    _row_valid,
+                    _partial_batch(batch_idx, split_idx, n_batch),
+                    q_row_global,
+                    row_head_idx,
+                    CFG.TILE_O,
+                    O_CHUNK,
+                )
+                bars.mb_o_empty[qs].wait(o_empty_phase)
             else:
-                # BF16 / FP16 output (DTYPE_O ∈ {2,3}): the 16:4 fp8 pack does
-                # not apply — cast fp32 → OUT_STORAGE_DTYPE and swizzled-store,
-                # matching the BPE_O-sized TMA-O box.  Mirrors the dsv4 d512 fp8
-                # generic epilogue (prefill_sdpa_d512_fp8.py).
-                O_EPI_BLOCK_SIZE = 64 // CFG.BPE_O  # 32 elems (half-out)
-                O_D_BLOCK = CFG.O_SWZ_BYTES // CFG.BPE_O  # TMA chunk elems
-                O_TMA_GRANU_ELEMS = CFG.TILE_M * O_D_BLOCK
-                for b in cutlass.range_constexpr(CFG.TILE_O // O_EPI_BLOCK_SIZE):
-                    o_addr = tmem_base_epi + cutlass.Int32(tmem_O_off + b * O_EPI_BLOCK_SIZE)
-                    o_chunk = nvvm.tcgen05_ld(
-                        "32x32b",
-                        nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
-                        num=O_EPI_BLOCK_SIZE,
-                    )
-                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-                    o_scaled_h = o_chunk * inv_sum
-                    # Dead-row sanitize — see the fp8-pack path above.
-                    _zero_f = cutlass.Float32(0.0)
-                    o_scaled_h = cutlass.Vector.from_elements(
-                        tuple(
-                            cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled_h[i].ir_value())) for i in range(O_EPI_BLOCK_SIZE)
-                        ),
-                        cutlass.Float32,
-                    )
-                    for _i in cutlass.range_constexpr(O_EPI_BLOCK_SIZE):
-                        _e = o_scaled_h[_i]
-                        _amax_o_local = cute.math.max(_amax_o_local, cute.math.max(_e, -_e))
-                    o_half = o_scaled_h.to(OUT_STORAGE_DTYPE)
+                if cutlass.const_expr(CFG.DTYPE_O <= 1):
+                    # FP8 output (DTYPE_O ∈ {0,1}): hand-rolled 16:4 fp8 pack +
+                    # STS.128 — forces F2FP outputs into a register quad so STS.128
+                    # needs no PRMT to gather them (vs the DSL store_swizzled which
+                    # folds the swizzle XOR via byte-level PRMT).  Bit-identical to
+                    # the DTYPE_O == DTYPE_QKV path.
+                    _SWZ_BYTES_C = CFG.O_SWZ_BYTES
+                    _SWZ_SHIFT_C = 3 - _O_SWZ_B
+                    _SWZ_MASK_C = (1 << _O_SWZ_B) - 1
+                    _SUBTILE_BYTES_C = CFG.TILE_M * _SWZ_BYTES_C
 
-                    col_offset_const = (b * O_EPI_BLOCK_SIZE) % O_D_BLOCK
-                    block_idx_const = (b * O_EPI_BLOCK_SIZE) // O_D_BLOCK
-                    block_offset_const = block_idx_const * O_TMA_GRANU_ELEMS
-                    smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(O_D_BLOCK)
-                    smem_ptr = sO_sub_base.subview(smem_offset).data_ptr()
-                    if b == 0:
-                        bars.mb_o_empty[qs].wait(o_empty_phase)
-                    smem_ptr.store_swizzled(o_half, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+                    row_base_bytes = tid_in_wg * cutlass.Int32(_SWZ_BYTES_C)
+                    row_xor_field = ((tid_in_wg >> cutlass.Int32(_SWZ_SHIFT_C)) & cutlass.Int32(_SWZ_MASK_C)) << cutlass.Int32(4)
 
-            # Under KV split this epilogue sees only its OWN partial, and the
-            # recombined O is a convex combination of the partials -- so a max
-            # over partials over-reports the output amax (~2.9x at 8 splits).
-            # sm100/split_combine computes it over the recombined O instead;
-            # this write has to stay out of the way, since atomicMax only grows.
-            if cutlass.const_expr(SPLIT_KV == 1):
-                if _row_valid:
-                    nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
+                    for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                        o_addr = tmem_base_epi + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
+                        o_chunk = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                            num=O_CHUNK,
+                        )
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                        o_scaled = o_chunk * inv_sum
+                        # Dead-row sanitize: an empty mainloop never writes O TMEM,
+                        # so o_chunk is garbage (possibly NaN) and `* inv_sum(=0)`
+                        # cannot zero it — select 0 explicitly (keeps amax_o clean).
+                        _zero_f = cutlass.Float32(0.0)
+                        o_elems = [cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled[i].ir_value())) for i in range(O_CHUNK)]
 
-            # fence_proxy needed before TMA reads SMEM written by stores above.
-            nvvm.fence_proxy("async.shared", space="cta")
+                        for _i in cutlass.range_constexpr(O_CHUNK):
+                            _e = o_elems[_i]
+                            _amax_o_local = cute.math.max(_amax_o_local, cute.math.max(_e, -_e))
+
+                        # Plain range (not range_constexpr) — extraction at Python trace time.
+                        o_packed_v = fp32_to_fp8_pack(
+                            [o_elems[i] for i in range(16)],
+                            dtype=OUT_STORAGE_DTYPE,
+                        )
+
+                        col_elems = chunk_idx * O_CHUNK
+                        block_idx = col_elems // D_BLOCK_SIZE
+                        col_in_block_bytes = (col_elems % D_BLOCK_SIZE) * CFG.BPE_O
+                        block_off_bytes = block_idx * _SUBTILE_BYTES_C
+
+                        swizzled_in_row = row_xor_field ^ cutlass.Int32(col_in_block_bytes)
+                        addr_off_bytes = cutlass.Int32(block_off_bytes) + row_base_bytes + swizzled_in_row
+
+                        # Re-type pointer to Int32 so 4-i32 store maps to one st.shared.v4.b32.
+                        fp8_ptr = sO_sub_base.subview(addr_off_bytes).data_ptr()
+                        i32_ptr = Pointer(fp8_ptr, dtype=cutlass.Int32)
+                        if chunk_idx == 0:
+                            bars.mb_o_empty[qs].wait(o_empty_phase)
+                        i32_ptr.store(o_packed_v, alignment=16)
+                else:
+                    # BF16 / FP16 output (DTYPE_O ∈ {2,3}): the 16:4 fp8 pack does
+                    # not apply — cast fp32 → OUT_STORAGE_DTYPE and swizzled-store,
+                    # matching the BPE_O-sized TMA-O box.  Mirrors the dsv4 d512 fp8
+                    # generic epilogue (prefill_sdpa_d512_fp8.py).
+                    O_EPI_BLOCK_SIZE = 64 // CFG.BPE_O  # 32 elems (half-out)
+                    O_D_BLOCK = CFG.O_SWZ_BYTES // CFG.BPE_O  # TMA chunk elems
+                    O_TMA_GRANU_ELEMS = CFG.TILE_M * O_D_BLOCK
+                    for b in cutlass.range_constexpr(CFG.TILE_O // O_EPI_BLOCK_SIZE):
+                        o_addr = tmem_base_epi + cutlass.Int32(tmem_O_off + b * O_EPI_BLOCK_SIZE)
+                        o_chunk = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                            num=O_EPI_BLOCK_SIZE,
+                        )
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                        o_scaled_h = o_chunk * inv_sum
+                        # Dead-row sanitize — see the fp8-pack path above.
+                        _zero_f = cutlass.Float32(0.0)
+                        o_scaled_h = cutlass.Vector.from_elements(
+                            tuple(
+                                cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled_h[i].ir_value()))
+                                for i in range(O_EPI_BLOCK_SIZE)
+                            ),
+                            cutlass.Float32,
+                        )
+                        for _i in cutlass.range_constexpr(O_EPI_BLOCK_SIZE):
+                            _e = o_scaled_h[_i]
+                            _amax_o_local = cute.math.max(_amax_o_local, cute.math.max(_e, -_e))
+                        o_half = o_scaled_h.to(OUT_STORAGE_DTYPE)
+
+                        col_offset_const = (b * O_EPI_BLOCK_SIZE) % O_D_BLOCK
+                        block_idx_const = (b * O_EPI_BLOCK_SIZE) // O_D_BLOCK
+                        block_offset_const = block_idx_const * O_TMA_GRANU_ELEMS
+                        smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(O_D_BLOCK)
+                        smem_ptr = sO_sub_base.subview(smem_offset).data_ptr()
+                        if b == 0:
+                            bars.mb_o_empty[qs].wait(o_empty_phase)
+                        smem_ptr.store_swizzled(o_half, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+
+                # Under KV split this epilogue sees only its OWN partial, and the
+                # recombined O is a convex combination of the partials -- so a max
+                # over partials over-reports the output amax (~2.9x at 8 splits).
+                # sm100/split_combine computes it over the recombined O instead;
+                # this write has to stay out of the way, since atomicMax only grows.
+                if cutlass.const_expr(SPLIT_KV == 1):
+                    if _row_valid:
+                        nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
+
+                # fence_proxy needed before TMA reads SMEM written by stores above.
+                nvvm.fence_proxy("async.shared", space="cta")
 
             bars.mb_o_full[qs].arrive()
 
@@ -2395,6 +2429,7 @@ def _host(
     thd_q_lens_tensor: Optional[cute.Tensor] = None,
     thd_kv_lens_tensor: Optional[cute.Tensor] = None,
     thd_lens_form: Optional[cutlass.Int32] = None,
+    o_partial_f32: Optional[cute.Tensor] = None,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
     B, QH, KH, SQ, SKV, _ = problem_size
@@ -2441,9 +2476,16 @@ def _host(
         swizzle=_tma_swz(CFG.V_SWZ_BYTES),
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
     )
+    # Unused under fp32 partials, but it must still BUILD: an fp32 element
+    # doubles the box's inner byte width past what the O swizzle allows.
+    _o_box = list(vo_box_o)
+    if _FP32_PARTIALS:
+        # fp32 is 4 bytes; scale the box by the O element's own width so
+        # the inner dimension stays inside the swizzle's byte limit.
+        _o_box[-1] = max(1, _o_box[-1] * CFG.BPE_O // 4)
     tma_o_desc = tmap.create_tensor_map_tiled_from_view(
         o_tensor,
-        box_dims=vo_box_o,
+        box_dims=tuple(_o_box),
         stride_order=stride_order,
         swizzle=_tma_swz(CFG.O_SWZ_BYTES),
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
@@ -2523,6 +2565,7 @@ def _host(
         descale_v_t,
         scale_o_t,
         amax_o_tensor,
+        o_partial_f32,
     ).launch(
         grid=grid_shape,
         block=[CFG.THREADS_PER_CTA, 1, 1],
@@ -2609,7 +2652,7 @@ def compile(  # noqa: A001
         assumed_align=16,
     )
     fake_o = cute.runtime.make_fake_compact_tensor(
-        OUT_STORAGE_DTYPE,
+        cutlass.Float32 if _FP32_PARTIALS else OUT_STORAGE_DTYPE,
         (_o_batch, sq, qh, d_v),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
@@ -2736,6 +2779,7 @@ def compile(  # noqa: A001
         fake_thd_q_lens,
         fake_thd_kv_lens,
         fake_thd_lens_form,
+        *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
     )

--- a/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
+++ b/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
@@ -478,3 +478,88 @@ def test_fp8_envelope_mismatch_rules():
     # ...and straddling the floor declines on BOTH rows, identically.
     assert "no kernel-flavor envelope" in engines.mismatch(sm107, _fp8_facts(device_cc=(10, 7), d_qk=512, d_v=256))
     assert "no kernel-flavor envelope" in engines.mismatch(sm100, _fp8_facts(d_qk=512, d_v=256))
+
+
+# --- KV split on Rubin -------------------------------------------------------
+
+
+def test_sm107_split_is_wired_only_for_per_tensor_fp8_d128():
+    """config_sm107 permits the split for the ONE Rubin kernel that wires
+    make_split_helpers, and refuses it for every other flavor.
+
+    A blanket refusal contradicted the engine row, which advertises
+    ``split_d_shapes={(128, 128)}`` on the Rubin FP8 row: a long-KV Rubin graph
+    could be handed an automatically proposed split plan and then fail at
+    compile. The gate follows the ROW, not merely whether a body wires
+    SplitHelpers -- d192xd128 FP8 does, but is neither advertised nor carries an
+    o_partial_f32 slot, so it must still decline."""
+    from cudnn.sdpa.fwd import config_sm107 as cfg
+
+    def tp(**kw):
+        return cfg.TemplateParams(split_kv=4, **kw)
+
+    # The wired cell builds.
+    cfg.make_cfg_d128(tp(dtype_qkv=_E4M3, dtype_o=_BF16_OUT))
+
+    # Every other Rubin cell still refuses -- same entry point for the half
+    # d128 and d192 kernels, so the gate cannot key on the flavor string alone.
+    unwired = [
+        ("d128 half", cfg.make_cfg_d128, dict(dtype_qkv=_BF16_OUT, dtype_o=_BF16_OUT)),
+        ("d128 mxfp8", cfg.make_cfg_d128_mxfp8, dict(dtype_qkv=_E4M3, dtype_o=_BF16_OUT)),
+        ("d192", cfg.make_cfg_d192, dict(dtype_qkv=_BF16_OUT, dtype_o=_BF16_OUT)),
+        ("d256", cfg.make_cfg_d256, dict(dtype_qkv=_E4M3, dtype_o=_BF16_OUT)),
+        ("d512", cfg.make_cfg_d512, dict(dtype_qkv=_E4M3, dtype_o=_BF16_OUT)),
+    ]
+    for name, make, params in unwired:
+        with pytest.raises(ValueError, match="split_kv > 1 is not wired"):
+            make(tp(**params))
+        assert make(cfg.TemplateParams(**params)) is not None, f"{name}: unsplit must still build"
+
+
+def test_sm107_split_matches_unsplit_on_rubin():
+    """End-to-end split numerics on cc10.7 silicon.
+
+    The one executing test in this otherwise device-independent module: the
+    SM107 kernel's split path -- and the fp32 partial store it now takes
+    unconditionally -- has no other hardware coverage, since the split-KV suite
+    is marked pre-Rubin."""
+    import math
+
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (10, 7):
+        pytest.skip("cc10.7 (Rubin) part required")
+
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm100
+
+    b, h_q, s_q, s_kv, d, dev = 1, 8, 512, 8192, 128, "cuda"
+    torch.manual_seed(0)
+
+    def run(split):
+        def mk(*sh):
+            return (torch.randn(*sh, device=dev) * 0.5).to(torch.float8_e4m3fn)
+
+        torch.manual_seed(0)
+        q, k, v = mk(b, h_q, s_q, d), mk(b, 1, s_kv, d), mk(b, 1, s_kv, d)
+        o = torch.zeros(b, h_q, s_q, d, device=dev, dtype=torch.float16)
+        one = torch.ones(1, dtype=torch.float32, device=dev)
+        api = SdpaFwdDslSm100(
+            sample_q=q, sample_k=k, sample_v=v, sample_o=o, dtype_o=torch.float16, split_kv=split, pertensor_fp8=True, scale_softmax=1.0 / math.sqrt(d)
+        )
+        assert api.check_support()
+        api.compile()
+        wsb = api.scratch_workspace_bytes()
+        ws = torch.empty(wsb, dtype=torch.uint8, device=dev) if wsb else None
+        api.execute(q_tensor=q, k_tensor=k, v_tensor=v, o_tensor=o, workspace=ws, descale_q=one, descale_k=one, descale_v=one, scale_o=one)
+        torch.cuda.synchronize()
+        return api, o.float().clone(), (q, k, v)
+
+    _, base, _ = run(1)
+    for split in (2, 4, 8):
+        api, got, (q, k, v) = run(split)
+        assert api._fp32_partial_split(), "the Rubin split must take the fp32-partial path"
+        assert not torch.isnan(got).any(), f"split={split}: NaN"
+        qf = q.double()
+        kf, vf = (t.double().repeat_interleave(h_q, dim=1) for t in (k, v))
+        ref = torch.softmax(qf @ kf.transpose(-1, -2) / math.sqrt(d), dim=-1) @ vf
+        assert (got.double() - ref).abs().max().item() <= 5e-2, f"split={split}: off the oracle"
+        assert (got - base).abs().max().item() <= 5e-2, f"split={split}: diverges from unsplit"

--- a/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm100.py
@@ -21,6 +21,12 @@ import torch
 
 from frost_test_utils import requires_pre_rubin_blackwell, requires_dsl
 
+# Pre-Rubin Blackwell only. Most of this module drives the SM100 kernel modules
+# directly (_kernel_module loads prefill_*_sm100.py), which cc10.7 never runs --
+# the adapter routes every Rubin family to an SM107 sibling. Rubin's own split
+# coverage therefore lives in test_sdpa_fp8_sm107.py, next to the one SM107
+# kernel that wires SplitHelpers; the cc10.7 branches in the FP8 helpers below
+# are what would run if this mark were ever narrowed per test.
 pytestmark = [requires_pre_rubin_blackwell, requires_dsl]
 
 D = 128
@@ -54,6 +60,37 @@ def _ref_sdpa(q, k, v, scale, is_causal, kh):
     return torch.matmul(p, vb).permute(0, 2, 1, 3)
 
 
+def _partial_o_dtype(splits, o_dtype):
+    """The dtype the compiled kernel WRITES its O argument in.
+
+    Under a split the epilogue stores its fp32 accumulator registers straight to
+    the partial workspace; unsplit it TMA-stores the staged SMEM tile in O's own
+    dtype.  These tests drive the compiled kernel directly, so they have to hand
+    it the buffer the template's ABI expects rather than the caller-facing one.
+    """
+    return torch.float32 if splits > 1 else o_dtype
+
+
+def _partial_kwargs(splits, o_p):
+    """The extra ``o_partial_f32`` argument a split-compiled kernel carries.
+
+    Keyword, not positional: the slot is LAST in the kernel signature precisely
+    so the THD tensors ahead of it do not shift when it is absent.
+    """
+    return {"o_partial_f32": o_p} if splits > 1 else {}
+
+
+def _partial_tag(splits, o_dtype):
+    """The matching ``dtype_partial`` for ``sm100/split_combine.compile``.
+
+    Compiling the combine for the wrong width reinterprets the workspace and
+    yields garbage rather than an error, so it has to track _partial_o_dtype.
+    """
+    if splits > 1:
+        return "f32"
+    return "f16" if o_dtype == torch.float16 else "bf16"
+
+
 def _kernel_module(splits, dtype_qkv, causal, cta_mma=2, pack_gqa=False, qh_per_kh=1):
     from cudnn.frost.template_loader import load_template
     from cudnn.sdpa.fwd import api_dsl
@@ -83,7 +120,7 @@ def _run(splits, B, H, KH, SQ, SKV, dtype, causal, cta_mma=2, pack_gqa=False):
     mod = _kernel_module(splits, 3 if dtype == torch.float16 else 2, causal, cta_mma=cta_mma, pack_gqa=pack_gqa, qh_per_kh=H // KH)
     fn = mod.compile(b=B, qh=H, kh=KH, sq=SQ, skv=SKV, d_qk=D, d_v=D, has_lse=True)
 
-    o_p = torch.zeros(splits * B, SQ, H, D, device=dev, dtype=dtype)
+    o_p = torch.zeros(splits * B, SQ, H, D, device=dev, dtype=_partial_o_dtype(splits, dtype))
     lse_p = torch.zeros(splits * B, H, SQ, device=dev, dtype=torch.float32)
     stream = cuda_driver.CUstream(torch.cuda.current_stream().cuda_stream)
     fn(
@@ -99,6 +136,7 @@ def _run(splits, B, H, KH, SQ, SKV, dtype, causal, cta_mma=2, pack_gqa=False):
         cutlass.Float32(scale * math.log2(math.e)),
         cutlass.Int32(0),
         None,
+        **_partial_kwargs(splits, o_p),
         stream=stream,
     )
     if splits == 1:
@@ -107,8 +145,10 @@ def _run(splits, B, H, KH, SQ, SKV, dtype, causal, cta_mma=2, pack_gqa=False):
 
     o_out = torch.zeros(B, SQ, H, D, device=dev, dtype=dtype)
     lse_out = torch.zeros(B, H, SQ, device=dev, dtype=torch.float32)
-    cfn = comb.compile(b=B, h=H, sq=SQ, d_v=D, splits=splits, dtype_o="f16" if dtype == torch.float16 else "bf16", has_lse=True)
-    cfn(o_p, lse_p, o_out, lse_out, None, (B, H, SQ, D), cutlass.Int32(splits), stream=stream)
+    cfn = comb.compile(
+        b=B, h=H, sq=SQ, d_v=D, splits=splits, dtype_o="f16" if dtype == torch.float16 else "bf16", has_lse=True, dtype_partial=_partial_tag(splits, dtype)
+    )
+    cfn(o_p, lse_p, o_out, lse_out, None, None, (B, H, SQ, D), cutlass.Int32(splits), stream=stream)
     torch.cuda.synchronize()
     assert not torch.isnan(o_out).any(), "NaN in combined O"
     return o_out.float(), (q, k, v, scale)
@@ -413,7 +453,7 @@ def test_empty_splits_every_flavor(flavor):
     mod = load_template(path, TemplateParams(dtype_qkv=3, split_kv=S), tag=f"empty_{flavor}_{S}")
     fn = mod.compile(b=B, qh=H, kh=H, sq=SQ, skv=SKV, d_qk=d_qk, d_v=d_v, has_lse=True)
 
-    o_p = torch.zeros(S * B, SQ, H, d_v, device=dev, dtype=torch.float16)
+    o_p = torch.zeros(S * B, SQ, H, d_v, device=dev, dtype=_partial_o_dtype(S, torch.float16))
     lse_p = torch.zeros(S * B, H, SQ, device=dev, dtype=torch.float32)
     stream = cuda_driver.CUstream(torch.cuda.current_stream().cuda_stream)
     fn(
@@ -429,11 +469,12 @@ def test_empty_splits_every_flavor(flavor):
         cutlass.Float32(scale * _math.log2(_math.e)),
         cutlass.Int32(0),
         None,
+        **_partial_kwargs(S, o_p),
         stream=stream,
     )
     o_out = torch.zeros(B, SQ, H, d_v, device=dev, dtype=torch.float16)
-    cfn = comb.compile(b=B, h=H, sq=SQ, d_v=d_v, splits=S, dtype_o="f16", has_lse=False)
-    cfn(o_p, lse_p, o_out, None, None, (B, H, SQ, d_v), cutlass.Int32(S), stream=stream)
+    cfn = comb.compile(b=B, h=H, sq=SQ, d_v=d_v, splits=S, dtype_o="f16", has_lse=False, dtype_partial=_partial_tag(S, torch.float16))
+    cfn(o_p, lse_p, o_out, None, None, None, (B, H, SQ, d_v), cutlass.Int32(S), stream=stream)
     torch.cuda.synchronize()
 
     assert not torch.isnan(o_out).any(), f"{flavor}: NaN from an empty split"
@@ -522,7 +563,7 @@ def _fp8_family_split(kfile, dtype_qkv, splits, cta_mma, mx, *, d_qk=128, d_v=12
         compile_kwargs.update(d_qk=d_qk, d_v=d_v)
     fn = mod.compile(**compile_kwargs)
     stream = cuda_driver.CUstream(torch.cuda.current_stream().cuda_stream)
-    o_p = torch.zeros(splits * B, SQ, H, d_v, device=dev, dtype=torch.float16)
+    o_p = torch.zeros(splits * B, SQ, H, d_v, device=dev, dtype=_partial_o_dtype(splits, torch.float16))
     lse_p = torch.zeros(splits * B, H, SQ, device=dev, dtype=torch.float32)
     amax_o = torch.zeros(1, dtype=torch.float32, device=dev)
     zH = torch.zeros(H, dtype=torch.float32, device=dev)
@@ -532,14 +573,40 @@ def _fp8_family_split(kfile, dtype_qkv, splits, cta_mma, mx, *, d_qk=128, d_v=12
 
     if not mx:
         fp8_dtype = torch.float8_e5m2 if dtype_qkv == DTYPE_E5M2 else torch.float8_e4m3fn
-        mk = lambda *sh: (torch.randn(*sh, device=dev) * 0.5).to(fp8_dtype)
+
+        def mk(*sh):
+            return (torch.randn(*sh, device=dev) * 0.5).to(fp8_dtype)
+
         q, k, v = mk(B, SQ, H, d_qk), mk(B, SKV, H, d_qk), mk(B, SKV, H, d_v)
+
         # The FP8 entry takes four 1-element fp32 DEVICE scale tensors
         # (descale_q/k/v, scale_o) — the scales fold in-kernel — and no Amax_S.
-        one = lambda: torch.ones(1, dtype=torch.float32, device=dev)
+        def one():
+            return torch.ones(1, dtype=torch.float32, device=dev)
+
         # o_desc dummy + n_thd_units=0: THD-only ABI slots (dense fold), like the f16 call above.
         o_desc = torch.zeros(1, dtype=torch.int64, device=dev)
-        fn(q, k, v, o_p, lse_p, zH, zB, o_desc, ps, log2e, cutlass.Float32(1.0), cutlass.Int32(0), one(), one(), one(), one(), amax_o, stream=stream)
+        fn(
+            q,
+            k,
+            v,
+            o_p,
+            lse_p,
+            zH,
+            zB,
+            o_desc,
+            ps,
+            log2e,
+            cutlass.Float32(1.0),
+            cutlass.Int32(0),
+            one(),
+            one(),
+            one(),
+            one(),
+            amax_o,
+            **_partial_kwargs(splits, o_p),
+            stream=stream,
+        )
         qf, kf, vf = (t.float().permute(0, 2, 1, 3) for t in (q, k, v))
     else:
         from sdpa.mxfp8_quant import quantize_to_mxfp8
@@ -568,7 +635,7 @@ def _fp8_family_split(kfile, dtype_qkv, splits, cta_mma, mx, *, d_qk=128, d_v=12
         v8 = v8.reshape(B, H, SKV, d_v).permute(0, 2, 1, 3).contiguous()
         # o_desc dummy + n_thd_units=0: THD-only ABI slots (dense fold), like the f16 call above.
         o_desc = torch.zeros(1, dtype=torch.int64, device=dev)
-        fn(q8, k8, v8, o_p, sfq, sfk, sfv, lse_p, amax_o, zH, zB, o_desc, ps, log2e, cutlass.Int32(0), stream=stream)
+        fn(q8, k8, v8, o_p, sfq, sfk, sfv, lse_p, amax_o, zH, zB, o_desc, ps, log2e, cutlass.Int32(0), **_partial_kwargs(splits, o_p), stream=stream)
 
     scores = torch.matmul(qf, kf.transpose(-1, -2)) * scale
     if causal:
@@ -582,8 +649,8 @@ def _fp8_family_split(kfile, dtype_qkv, splits, cta_mma, mx, *, d_qk=128, d_v=12
     o_out = torch.zeros(B, SQ, H, d_v, device=dev, dtype=torch.float16)
     # has_amax: at splits > 1 the per-split epilogues skip their amax write, so
     # the combine is what reports it -- over the RECOMBINED O.
-    cfn = comb.compile(b=B, h=H, sq=SQ, d_v=d_v, splits=splits, dtype_o="f16", has_lse=False, has_amax=True)
-    cfn(o_p, lse_p, o_out, None, amax_o, (B, H, SQ, d_v), cutlass.Int32(splits), stream=stream)
+    cfn = comb.compile(b=B, h=H, sq=SQ, d_v=d_v, splits=splits, dtype_o="f16", has_lse=False, has_amax=True, dtype_partial=_partial_tag(splits, torch.float16))
+    cfn(o_p, lse_p, o_out, None, amax_o, None, (B, H, SQ, d_v), cutlass.Int32(splits), stream=stream)
     torch.cuda.synchronize()
     assert not torch.isnan(o_out).any(), "NaN in combined fp8-family O"
     return o_out.float(), ref, amax_o
@@ -714,7 +781,7 @@ def test_combine_lse_matches_reference(splits):
 
     mod = _kernel_module(splits, 3, causal=False)
     fn = mod.compile(b=B, qh=H, kh=H, sq=SQ, skv=SKV, d_qk=D, d_v=D, has_lse=True)
-    o_p = torch.zeros(splits * B, SQ, H, D, device=dev, dtype=torch.float16)
+    o_p = torch.zeros(splits * B, SQ, H, D, device=dev, dtype=_partial_o_dtype(splits, torch.float16))
     lse_p = torch.zeros(splits * B, H, SQ, device=dev, dtype=torch.float32)
     stream = cuda_driver.CUstream(torch.cuda.current_stream().cuda_stream)
     fn(
@@ -730,6 +797,7 @@ def test_combine_lse_matches_reference(splits):
         cutlass.Float32(scale * math.log2(math.e)),
         cutlass.Int32(0),
         None,
+        **_partial_kwargs(splits, o_p),
         stream=stream,
     )
 
@@ -743,8 +811,8 @@ def test_combine_lse_matches_reference(splits):
     else:
         o_out = torch.zeros(B, SQ, H, D, device=dev, dtype=torch.float16)
         lse_out = torch.zeros(B, H, SQ, device=dev, dtype=torch.float32)
-        cfn = comb.compile(b=B, h=H, sq=SQ, d_v=D, splits=splits, dtype_o="f16", has_lse=True)
-        cfn(o_p, lse_p, o_out, lse_out, None, (B, H, SQ, D), cutlass.Int32(splits), stream=stream)
+        cfn = comb.compile(b=B, h=H, sq=SQ, d_v=D, splits=splits, dtype_o="f16", has_lse=True, dtype_partial=_partial_tag(splits, torch.float16))
+        cfn(o_p, lse_p, o_out, lse_out, None, None, (B, H, SQ, D), cutlass.Int32(splits), stream=stream)
         torch.cuda.synchronize()
         got_lse = lse_out
     assert not torch.isnan(got_lse).any(), "NaN in recombined LSE"
@@ -784,7 +852,7 @@ def test_even_splits_every_flavor_batched(flavor, dtype):
     params = TemplateParams(dtype_qkv=3 if dtype == torch.float16 else 2, split_kv=S)
     mod = load_template(path, params, tag=f"even_{flavor}_{dtype}_{S}")
     fn = mod.compile(b=B, qh=H, kh=H, sq=SQ, skv=SKV, d_qk=d_qk, d_v=d_v, has_lse=True)
-    o_p = torch.zeros(S * B, SQ, H, d_v, device=dev, dtype=dtype)
+    o_p = torch.zeros(S * B, SQ, H, d_v, device=dev, dtype=_partial_o_dtype(S, dtype))
     lse_p = torch.zeros(S * B, H, SQ, device=dev, dtype=torch.float32)
     stream = cuda_driver.CUstream(torch.cuda.current_stream().cuda_stream)
     fn(
@@ -800,11 +868,14 @@ def test_even_splits_every_flavor_batched(flavor, dtype):
         cutlass.Float32(scale * math.log2(math.e)),
         cutlass.Int32(0),
         None,
+        **_partial_kwargs(S, o_p),
         stream=stream,
     )
     o_out = torch.zeros(B, SQ, H, d_v, device=dev, dtype=dtype)
-    cfn = comb.compile(b=B, h=H, sq=SQ, d_v=d_v, splits=S, dtype_o="f16" if dtype == torch.float16 else "bf16", has_lse=False)
-    cfn(o_p, lse_p, o_out, None, None, (B, H, SQ, d_v), cutlass.Int32(S), stream=stream)
+    cfn = comb.compile(
+        b=B, h=H, sq=SQ, d_v=d_v, splits=S, dtype_o="f16" if dtype == torch.float16 else "bf16", has_lse=False, dtype_partial=_partial_tag(S, dtype)
+    )
+    cfn(o_p, lse_p, o_out, None, None, None, (B, H, SQ, d_v), cutlass.Int32(S), stream=stream)
     torch.cuda.synchronize()
     assert not torch.isnan(o_out).any(), f"{flavor}: NaN"
     ref = _ref_sdpa(q, k, v, scale, is_causal=False, kh=H)
@@ -844,7 +915,7 @@ def _run_masked(kfile, d_qk, d_v, splits, *, B, H, KH, SQ, SKV, tp_kwargs, seq_k
     mod = load_template(path, params, tag=f"mask_{kfile[:16]}_{splits}_{cta_mma}_{sorted(tp_kwargs.items())}")
     fn = mod.compile(b=B, qh=H, kh=KH, sq=SQ, skv=SKV, d_qk=d_qk, d_v=d_v, has_lse=True)
 
-    o_p = torch.zeros(splits * B, SQ, H, d_v, device=dev, dtype=dtype)
+    o_p = torch.zeros(splits * B, SQ, H, d_v, device=dev, dtype=_partial_o_dtype(splits, dtype))
     lse_p = torch.zeros(splits * B, H, SQ, device=dev, dtype=torch.float32)
     skv_t = seq_kv_lens if seq_kv_lens is not None else torch.zeros(B, dtype=torch.int32, device=dev)
     stream = cuda_driver.CUstream(torch.cuda.current_stream().cuda_stream)
@@ -861,14 +932,17 @@ def _run_masked(kfile, d_qk, d_v, splits, *, B, H, KH, SQ, SKV, tp_kwargs, seq_k
         cutlass.Float32(scale * math.log2(math.e)),
         cutlass.Int32(0),
         seq_q_lens,
+        **_partial_kwargs(splits, o_p),
         stream=stream,
     )
     if splits == 1:
         torch.cuda.synchronize()
         return o_p.float(), q, k, v, scale
     o_out = torch.zeros(B, SQ, H, d_v, device=dev, dtype=dtype)
-    cfn = comb.compile(b=B, h=H, sq=SQ, d_v=d_v, splits=splits, dtype_o="f16" if dtype == torch.float16 else "bf16", has_lse=False)
-    cfn(o_p, lse_p, o_out, None, None, (B, H, SQ, d_v), cutlass.Int32(splits), stream=stream)
+    cfn = comb.compile(
+        b=B, h=H, sq=SQ, d_v=d_v, splits=splits, dtype_o="f16" if dtype == torch.float16 else "bf16", has_lse=False, dtype_partial=_partial_tag(splits, dtype)
+    )
+    cfn(o_p, lse_p, o_out, None, None, None, (B, H, SQ, d_v), cutlass.Int32(splits), stream=stream)
     torch.cuda.synchronize()
     assert not torch.isnan(o_out).any(), "NaN under mask+split"
     return o_out.float(), q, k, v, scale
@@ -1123,8 +1197,14 @@ def _api_fp8_case(
     causal=False,
     pack_gqa=False,
     b=1,
+    out_dtype=torch.float16,
+    scale_o=1.0,
 ):
-    """FP8 / MXFP8 through the adapter; returns (split, O, O_unsplit, amax)."""
+    """FP8 / MXFP8 through the adapter; returns (split, O, O_unsplit, amax).
+
+    ``out_dtype`` may be a QUANTIZED type: the split kernels then write fp32
+    partials and the combine performs the single cast down to it.  Both the
+    split and unsplit runs use it, so the returned pair stays comparable."""
     from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm100
     from cudnn.sdpa.fwd.config_sm100 import cga_tile_m
 
@@ -1158,10 +1238,10 @@ def _api_fp8_case(
             q, k, v = mk(b, h_q, s_q, d_qk), mk(b, h_kv, s_kv, d_qk), mk(b, h_kv, s_kv, d_v)
             q_ref, k_ref, v_ref = q.float(), k.float(), v.float()
             one = torch.ones(1, dtype=torch.float32, device=dev)
-            extra = dict(descale_q=one, descale_k=one, descale_v=one, scale_o=one)
+            extra = dict(descale_q=one, descale_k=one, descale_v=one, scale_o=one * scale_o)
             kw = dict(pertensor_fp8=True)
 
-        o = torch.zeros(b, h_q, s_q, d_v, device=dev, dtype=torch.float16)  # HALF out
+        o = torch.zeros(b, h_q, s_q, d_v, device=dev, dtype=out_dtype)
         amax = torch.zeros(1, dtype=torch.float32, device=dev)
         split_cga = 1 if d_qk == 256 or (mx and d_qk == 512) else 2
         split_knob = (
@@ -1181,7 +1261,7 @@ def _api_fp8_case(
             sample_k=k,
             sample_v=v,
             sample_o=o,
-            dtype_o=torch.float16,
+            dtype_o=out_dtype,
             split_kv=split_knob,
             is_causal=causal,
             pack_gqa=pack_gqa,
@@ -1198,13 +1278,22 @@ def _api_fp8_case(
 
     _, o_one, _, _ = build(True)
     split, o_split, amax, ref_inputs = build(False)
-    if d_qk in (256, 512):
-        q_ref, k_ref, v_ref = (t.permute(0, 2, 1, 3) for t in ref_inputs)
-        reference = _ref_sdpa(q_ref, k_ref, v_ref, 1.0 / math.sqrt(d_qk), causal, h_kv).permute(0, 2, 1, 3)
-        atol = 8e-2 if fp8_dtype == torch.float8_e5m2 else 5e-2
-        for name, output in (("split", o_split), ("unsplit", o_one)):
-            diff = (output - reference).abs().max().item()
-            assert diff <= atol, f"D{d_qk} {name} max|O-ref|={diff:.4f} > {atol:.4f}"
+    # Check BOTH executions against an independent fp32 oracle, not just each
+    # other: they share the inputs, the scales and the whole attention setup, so
+    # a defect in that shared part moves them together and a split-vs-unsplit
+    # comparison alone would pass. Only the final cast differs by construction
+    # (split_combine for the split, the kernel epilogue otherwise).
+    q_ref, k_ref, v_ref = (t.permute(0, 2, 1, 3) for t in ref_inputs)
+    reference = _ref_sdpa(q_ref, k_ref, v_ref, 1.0 / math.sqrt(d_qk), causal, h_kv).permute(0, 2, 1, 3)
+    reference = reference * scale_o
+    atol = 8e-2 if fp8_dtype == torch.float8_e5m2 else 5e-2
+    if out_dtype in _FP8_OUT:
+        # A quantized O lands on its own lattice, so the oracle has to allow the
+        # rounding step the store itself introduces.
+        atol = max(atol, 3.0 * (reference - reference.to(out_dtype).float()).abs().max().item())
+    for name, output in (("split", o_split), ("unsplit", o_one)):
+        diff = (output - reference).abs().max().item()
+        assert diff <= atol, f"D{d_qk} {name} max|O-ref|={diff:.4f} > {atol:.4f}"
     return split, o_split, o_one, amax
 
 
@@ -1323,3 +1412,291 @@ def test_api_fp8_amax_describes_the_recombined_output(mx, d):
     true_amax = got.abs().max().item()
     assert amax >= true_amax * 0.99, f"amax {amax} under-reports |O| {true_amax}"
     assert amax <= true_amax * 1.01, f"amax {amax} over-reports |O| {true_amax} — taken over partials?"
+
+
+# --- a QUANTIZED O under a split -------------------------------------------
+#
+# The split kernels write half partials whatever the O dtype, and the combine
+# performs the ONLY cast down to it. That is what makes an FP8 O safe to split:
+# the reduction runs wider than the output, so the quantization happens once,
+# on the recombined value, rather than once per split and again on the sum.
+
+_FP8_OUT = [torch.float8_e4m3fn, torch.float8_e5m2]
+_FP8_OUT_IDS = ["e4m3_out", "e5m2_out"]
+
+
+@pytest.mark.L0
+def test_api_splits_a_quantized_output_mxfp8():
+    """MXFP8 takes the same route with no scalar scale: its O scaling lives in
+    the SF tensors, so the combine casts unscaled -- exactly what the
+    single-pass epilogue does."""
+    split, got, unsplit, _ = _api_fp8_case(8, 1, 512, 16384, mx=True, out_dtype=torch.float8_e4m3fn)
+    assert split > 1
+    step = (unsplit.abs().max() * torch.finfo(torch.float8_e4m3fn).eps).item()
+    assert (got - unsplit).abs().max().item() <= 4 * step + 2e-2
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("out_dtype", _FP8_OUT, ids=_FP8_OUT_IDS)
+def test_api_splits_a_quantized_output(out_dtype):
+    """A split with an FP8 O matches the unsplit kernel to its own grid.
+
+    The tolerance is the OUTPUT type's quantization step, not a half-precision
+    one: both runs land on the same e4m3/e5m2 lattice, so anything beyond a
+    step apart means the split changed the value before it was cast."""
+    split, got, unsplit, _ = _api_fp8_case(8, 1, 512, 16384, mx=False, out_dtype=out_dtype)
+    assert split > 1
+    step = (unsplit.abs().max() * torch.finfo(out_dtype).eps).item()
+    assert (got - unsplit).abs().max().item() <= 4 * step + 5e-3
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("out_dtype", _FP8_OUT, ids=_FP8_OUT_IDS)
+def test_quantized_split_reduces_in_half_not_in_the_output_type(out_dtype):
+    """The partial slabs are sized by the PARTIAL dtype, not the O dtype.
+
+    Sizing them from O would carve one byte per element for an FP8 output and
+    hand the kernel a workspace half as big as the half-precision partials it
+    writes -- a silent overrun that the numerics above would not localize."""
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm100
+
+    if torch.cuda.get_device_capability() not in ((10, 0), (10, 3), (10, 7)):
+        pytest.skip("per-tensor FP8 prefill requires cc10.0 / cc10.3 / cc10.7")
+    b, h, s_q, s_kv, d, dev = 1, 8, 512, 16384, 128, "cuda"
+
+    def mk(*sh):
+        return (torch.randn(*sh, device=dev) * 0.5).to(torch.float8_e4m3fn)
+
+    q, k, v = mk(b, h, s_q, d), mk(b, 1, s_kv, d), mk(b, 1, s_kv, d)
+
+    def carved(o_dtype):
+        o = torch.zeros(b, h, s_q, d, device=dev, dtype=o_dtype)
+        api = SdpaFwdDslSm100(sample_q=q, sample_k=k, sample_v=v, sample_o=o, dtype_o=o_dtype, split_kv=4, pertensor_fp8=True)
+        assert api.check_support()
+        return api.scratch_workspace_bytes()
+
+    assert carved(out_dtype) == carved(torch.float16) > 0
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("scale", [0.5, 2.0])
+def test_quantized_split_applies_scale_o_once(scale):
+    """scale_o moves from the kernel epilogue to the combine's cast.
+
+    Left in the epilogue it would scale the partials and the combine would
+    then cast an already-scaled value -- or, worse, apply it a second time.
+    Scaling the output by s must scale the STORED O by s while leaving amax,
+    which describes the PRE-quantization output, untouched."""
+    _, one, _, amax_one = _api_fp8_case(8, 1, 512, 16384, mx=False, out_dtype=torch.float8_e4m3fn)
+    _, scaled, _, amax_scaled = _api_fp8_case(8, 1, 512, 16384, mx=False, out_dtype=torch.float8_e4m3fn, scale_o=scale)
+    want = one * scale
+    rel = (scaled - want).abs().max().item() / max(want.abs().max().item(), 1e-6)
+    assert rel <= 0.15, f"stored O is not scale_o x the unscaled O (rel {rel:.3f})"
+    assert abs(amax_scaled - amax_one) <= 0.03, "amax must describe the PRE-quant output, so scale_o cannot move it"
+
+
+@pytest.mark.L0
+def test_quantized_split_amax_describes_the_recombined_output():
+    """amax reports the PRE-quantization recombined O, not the stored one.
+
+    So it cannot be compared to |stored O| directly: the cast rounds the peak
+    onto the FP8 lattice and the two differ by up to half a step. Rounding is
+    monotone, though, so max(quantize(O)) == quantize(max(O)) exactly -- which
+    pins BOTH that amax is the pre-quant value and that the stored O is the
+    quantization of it. A max taken over partials would over-report by far
+    more than one step and fail this."""
+    split, got, _unsplit, amax = _api_fp8_case(8, 1, 512, 16384, mx=False, out_dtype=torch.float8_e4m3fn)
+    assert split > 1
+    quantized_amax = torch.tensor(amax, device=got.device).to(torch.float8_e4m3fn).float().item()
+    assert got.abs().max().item() == quantized_amax, f"|O| {got.abs().max().item()} is not amax {amax} cast to e4m3 ({quantized_amax})"
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("mx", [False, True], ids=["fp8", "mxfp8"])
+@pytest.mark.parametrize("out_dtype", _FP8_OUT, ids=_FP8_OUT_IDS)
+def test_api_d256_splits_a_quantized_output(mx, out_dtype):
+    """D256 is a split flavor too, and its FP8 family runs the predecode
+    scheduler rather than the persistent loop the d128 tests exercise.
+
+    Same contract as d128: the partials stay WIDER than O and the combine
+    performs the only cast, so a split must land on the same FP8 lattice as the
+    unsplit kernel. Covering it here keeps the quantized-O path from being
+    d128-only."""
+    split, got, unsplit, _ = _api_fp8_case(8, 1, 512, 8192, mx=mx, d_qk=256, d_v=256, out_dtype=out_dtype)
+    assert split > 1
+    step = (unsplit.abs().max() * torch.finfo(out_dtype).eps).item()
+    assert (got - unsplit).abs().max().item() <= 4 * step + 2e-2
+
+
+@pytest.mark.L0
+def test_api_d256_quantized_split_reduces_in_half():
+    """The d256 partials are sized by the PARTIAL dtype as well -- sizing them
+    from an FP8 O would carve half the bytes the kernel writes."""
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm100
+
+    if torch.cuda.get_device_capability() not in ((10, 0), (10, 3)):
+        pytest.skip("D256 per-tensor FP8 prefill requires cc10.0 / cc10.3")
+    b, h, s_q, s_kv, d, dev = 1, 8, 512, 8192, 256, "cuda"
+
+    def mk(*sh):
+        return (torch.randn(*sh, device=dev) * 0.5).to(torch.float8_e4m3fn)
+
+    q, k, v = mk(b, h, s_q, d), mk(b, 1, s_kv, d), mk(b, 1, s_kv, d)
+
+    def carved(o_dtype):
+        o = torch.zeros(b, h, s_q, d, device=dev, dtype=o_dtype)
+        api = SdpaFwdDslSm100(sample_q=q, sample_k=k, sample_v=v, sample_o=o, dtype_o=o_dtype, split_kv=4, pertensor_fp8=True)
+        assert api.check_support()
+        return api.scratch_workspace_bytes()
+
+    assert carved(torch.float8_e4m3fn) == carved(torch.float16) > 0
+
+
+# --- fp32 split partials ----------------------------------------------------
+#
+# The unsplit epilogue casts its fp32 accumulator into the SMEM O tile and
+# TMA-stores that. Under a split it stores the accumulator straight to the
+# workspace instead, which is what lets the partial be fp32 without the staged
+# tile growing to match. Not a mode: every SM100 split does this.
+
+
+def _fp32_partials_api(split, out_dtype=torch.float16, b=1, h_q=8, s_q=512, s_kv=8192, d=128):
+    """Build (and run) the d128 per-tensor FP8 adapter at the given split."""
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm100
+
+    if torch.cuda.get_device_capability() not in ((10, 0), (10, 3), (10, 7)):
+        pytest.skip("per-tensor FP8 d128 prefill requires cc10.0 / cc10.3 / cc10.7")
+    dev = "cuda"
+    torch.manual_seed(0)
+
+    def mk(*sh):
+        return (torch.randn(*sh, device=dev) * 0.5).to(torch.float8_e4m3fn)
+
+    q, k, v = mk(b, h_q, s_q, d), mk(b, 1, s_kv, d), mk(b, 1, s_kv, d)
+    o = torch.zeros(b, h_q, s_q, d, device=dev, dtype=out_dtype)
+    amax = torch.zeros(1, dtype=torch.float32, device=dev)
+    one = torch.ones(1, dtype=torch.float32, device=dev)
+    api = SdpaFwdDslSm100(
+        sample_q=q,
+        sample_k=k,
+        sample_v=v,
+        sample_o=o,
+        dtype_o=out_dtype,
+        split_kv=split,
+        pertensor_fp8=True,
+        scale_softmax=1.0 / math.sqrt(d),
+    )
+    assert api.check_support()
+    api.compile()
+    wsb = api.scratch_workspace_bytes()
+    ws = torch.empty(wsb, dtype=torch.uint8, device=dev) if wsb else None
+    api.execute(q_tensor=q, k_tensor=k, v_tensor=v, o_tensor=o, amax_o=amax, workspace=ws, descale_q=one, descale_k=one, descale_v=one, scale_o=one)
+    torch.cuda.synchronize()
+
+    qf = q.double()
+    kf, vf = (t.double().repeat_interleave(h_q, dim=1) for t in (k, v))
+    ref = torch.softmax(qf @ kf.transpose(-1, -2) / math.sqrt(d), dim=-1) @ vf
+    return api, o.float().clone(), ref, wsb
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("split", [2, 4, 8], ids=lambda s: f"split{s}")
+def test_fp32_partials_match_an_independent_reference(split):
+    """The direct-to-global epilogue must produce the same answer as the staged
+    one -- it is a different STORE path for the same values, so any divergence
+    is an addressing or dead-row bug, not a rounding difference."""
+    api, got, ref, _ = _fp32_partials_api(split)
+    assert api._fp32_partial_split(), "SM100 split did not take the fp32-partial path"
+    assert (got.double() - ref).abs().max().item() <= 5e-2
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("split", [2, 4], ids=lambda s: f"split{s}")
+def test_split_workspace_is_sized_for_fp32_partials(split):
+    """The reservation has to agree with the 4 bytes per element the epilogue
+    actually stores.
+
+    Sizing it for a half partial would not fail loudly: the stores would simply
+    run past the end of the O slab, over the LSE slab that follows it and then
+    over whatever the caller placed after the workspace."""
+    b, h_q, s_q, d = 1, 8, 512, 128
+    _api, _got, _ref, wsb = _fp32_partials_api(split, b=b, h_q=h_q, s_q=s_q, d=d)
+    o_bytes = split * b * s_q * h_q * d * 4
+    lse_bytes = split * b * h_q * s_q * 4
+    assert wsb >= o_bytes + lse_bytes, f"workspace {wsb} cannot hold fp32 partials ({o_bytes} O + {lse_bytes} LSE)"
+    # Alignment padding only -- a much larger reservation means the sizing and
+    # the store disagree in the other direction.
+    assert wsb < o_bytes + lse_bytes + 4096, f"workspace {wsb} is oversized for {o_bytes + lse_bytes} of partials"
+
+
+@pytest.mark.L0
+def test_fp32_partials_compile_the_combine_for_f32():
+    """The combine has to READ f32; compiling it for f16 would reinterpret the
+    workspace and produce garbage rather than fail."""
+    from cudnn.sdpa.fwd.kernels.sm100 import split_combine as comb
+
+    seen = []
+    orig = comb.compile
+    try:
+        comb.compile = lambda **kw: (seen.append(kw), orig(**kw))[1]
+        _fp32_partials_api(4)
+    finally:
+        comb.compile = orig
+    assert seen, "the combine was never compiled"
+    assert seen[0]["dtype_partial"] == "f32", f"combine partial dtype is {seen[0]['dtype_partial']!r}"
+
+
+@pytest.mark.L0
+def test_fp32_partials_fold_off_without_a_split():
+    """split_kv == 1 has no partials at all, so the direct-to-global store must
+    fold away and leave the single-pass SMEM/TMA epilogue byte-identical."""
+    api, _got, _ref, wsb = _fp32_partials_api(1)
+    assert not api._fp32_partial_split()
+    assert wsb == 0
+
+
+# --- narrow head dims under a split -----------------------------------------
+#
+# The flavors are ENVELOPES: d_v=64 runs on the d128 tile. The epilogue then
+# holds TILE_O=128 columns while the partial slab is only d_v wide, so a store
+# that walks the TILE has to be clipped to the TENSOR. Every other case in this
+# file sits exactly on an envelope boundary (d_v == TILE_O), which is the one
+# shape that cannot expose the difference.
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("split", [1, 4], ids=lambda s: f"split{s}")
+@pytest.mark.parametrize("d", [64, 96], ids=lambda d: f"d{d}")
+def test_split_does_not_overrun_a_narrow_head_dim(split, d):
+    """A d_v narrower than its flavor's tile must not write past the row.
+
+    The staged TMA store clipped the surplus columns for free; the direct fp32
+    partial store does not, and an unclipped one corrupts the NEXT head's row --
+    which stays inside the allocation, so it surfaces as wrong numbers rather
+    than as a fault. Measured before the clip: d_v=64 at split 4 was 0.156 off
+    the oracle, against 0.00005 for the same shape unsplit.
+    """
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm100
+
+    b, h_q, s_q, s_kv, dev = 1, 8, 512, 4096, "cuda"
+    torch.manual_seed(0)
+    q = torch.randn(b, h_q, s_q, d, device=dev, dtype=torch.float16)
+    k = torch.randn(b, 1, s_kv, d, device=dev, dtype=torch.float16)
+    v = torch.randn(b, 1, s_kv, d, device=dev, dtype=torch.float16)
+    o = torch.zeros(b, h_q, s_q, d, device=dev, dtype=torch.float16)
+
+    api = SdpaFwdDslSm100(sample_q=q, sample_k=k, sample_v=v, sample_o=o, split_kv=split, scale_softmax=1.0 / math.sqrt(d))
+    assert api.check_support()
+    api.compile()
+    wsb = api.scratch_workspace_bytes()
+    # Poison tail: an overrun on the LAST row lands past the reservation.
+    guard = 1 << 20
+    ws_full = torch.full((wsb + guard,), 0xA5, dtype=torch.uint8, device=dev)
+    api.execute(q_tensor=q, k_tensor=k, v_tensor=v, o_tensor=o, workspace=ws_full[:wsb] if wsb else None)
+    torch.cuda.synchronize()
+
+    qf = q.double()
+    kf, vf = (t.double().repeat_interleave(h_q, dim=1) for t in (k, v))
+    ref = torch.softmax(qf @ kf.transpose(-1, -2) / math.sqrt(d), dim=-1) @ vf
+    assert (ws_full[wsb:] == 0xA5).all().item(), "the partial store wrote past the workspace reservation"
+    assert (o.double() - ref).abs().max().item() <= 5e-3

--- a/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm120.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm120.py
@@ -187,3 +187,130 @@ def test_sm120_causal_split_requires_the_natural_scheduler():
         pytest.skip("this part is small enough that the causal shape already fills it")
     assert result.split == result.expected_split > 1, "the causal arm must actually exercise the split"
     assert (result.output - result.reference).abs().max().item() <= 2e-2
+
+
+# --- FP8, including a QUANTIZED O ------------------------------------------
+#
+# The SM120 FP8 adapter shares the split plumbing with SM100: under a split the
+# kernel writes half partials and the combine performs the only cast down to
+# the O dtype, applying scale_o there. Nothing above exercises the FP8 arm.
+
+
+def _sm120_fp8_case(h_q, h_kv, s_q, s_kv, *, out_dtype, split_kv, scale_o=1.0):
+    """FP8 through the SM120 adapter; returns (split, O, amax)."""
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm120
+
+    if torch.cuda.get_device_capability()[0] != 12:
+        pytest.skip("SM120 part required")
+    b, d, dev = 1, 128, "cuda"
+    torch.manual_seed(0)
+
+    def mk(*sh):
+        return (torch.randn(*sh, device=dev) * 0.5).to(torch.float8_e4m3fn)
+
+    q, k, v = mk(b, h_q, s_q, d), mk(b, h_kv, s_kv, d), mk(b, h_kv, s_kv, d)
+    o = torch.zeros(b, h_q, s_q, d, device=dev, dtype=out_dtype)
+    amax = torch.zeros(1, dtype=torch.float32, device=dev)
+
+    def one():
+        return torch.ones(1, dtype=torch.float32, device=dev)
+
+    kw = dict(pertensor_fp8=True, dtype_o=out_dtype)
+    if split_kv > 1:
+        kw.update(split_kv=split_kv, sched_policy=0)
+    api = SdpaFwdDslSm120(sample_q=q, sample_k=k, sample_v=v, sample_o=o, **kw)
+    assert api.check_support()
+    ws_bytes = api.scratch_workspace_bytes()
+    api.compile()
+    ws = torch.empty(ws_bytes, dtype=torch.uint8, device=dev) if ws_bytes else None
+    api.execute(
+        q_tensor=q,
+        k_tensor=k,
+        v_tensor=v,
+        o_tensor=o,
+        amax_o=amax,
+        workspace=ws,
+        descale_q=one(),
+        descale_k=one(),
+        descale_v=one(),
+        scale_o=one() * scale_o,
+    )
+    torch.cuda.synchronize()
+
+    # Independent fp32 oracle. Comparing a split run against an unsplit one only
+    # proves they agree -- they share the inputs, the scales and the attention
+    # math, so a defect there moves both. descale_* are 1.0, so the dequantized
+    # inputs are just the fp8 values.
+    qf, kf, vf = q.float(), k.float(), v.float()
+    if h_q != h_kv:
+        rep = h_q // h_kv
+        kf, vf = kf.repeat_interleave(rep, dim=1), vf.repeat_interleave(rep, dim=1)
+    reference = (torch.softmax(qf @ kf.transpose(-1, -2) / math.sqrt(d), dim=-1) @ vf) * scale_o
+    atol = 5e-2
+    if out_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+        # A quantized O lands on its own lattice; allow the store's own step.
+        atol = max(atol, 3.0 * (reference - reference.to(out_dtype).float()).abs().max().item())
+    diff = (o.float() - reference).abs().max().item()
+    assert diff <= atol, f"SM120 split={api.split_kv} max|O-ref|={diff:.4f} > {atol:.4f}"
+    return api.split_kv, o.float().clone(), amax.item(), ws_bytes
+
+
+@pytest.mark.parametrize("out_dtype", [torch.float16, torch.float8_e4m3fn, torch.float8_e5m2], ids=["f16_out", "e4m3_out", "e5m2_out"])
+def test_sm120_fp8_split_matches_unsplit(out_dtype):
+    """A split must not move the result, quantized O included."""
+    _, unsplit, amax_one, _ = _sm120_fp8_case(8, 1, 128, 8192, out_dtype=out_dtype, split_kv=1)
+    split, got, amax_split, ws = _sm120_fp8_case(8, 1, 128, 8192, out_dtype=out_dtype, split_kv=4)
+    assert split == 4 and ws > 0
+    step = (unsplit.abs().max() * torch.finfo(out_dtype).eps).item()
+    assert (got - unsplit).abs().max().item() <= 4 * step + 5e-3
+    assert abs(amax_split - amax_one) <= 0.03, "amax must describe the recombined output at either split"
+
+
+def test_sm120_quantized_split_reduces_in_half():
+    """Partials are sized by the PARTIAL dtype, so an FP8 O carves the same
+    workspace as a half one -- sizing from O would under-allocate by half."""
+    _, _, _, ws_fp8 = _sm120_fp8_case(8, 1, 128, 8192, out_dtype=torch.float8_e4m3fn, split_kv=4)
+    _, _, _, ws_half = _sm120_fp8_case(8, 1, 128, 8192, out_dtype=torch.float16, split_kv=4)
+    assert ws_fp8 == ws_half > 0
+
+
+@pytest.mark.parametrize("scale", [0.5, 2.0])
+def test_sm120_quantized_split_applies_scale_o_once(scale):
+    """scale_o is applied at the combine's cast, not in the split epilogue."""
+    _, one, amax_one, _ = _sm120_fp8_case(8, 1, 128, 8192, out_dtype=torch.float8_e4m3fn, split_kv=4)
+    _, scaled, amax_scaled, _ = _sm120_fp8_case(8, 1, 128, 8192, out_dtype=torch.float8_e4m3fn, split_kv=4, scale_o=scale)
+    want = one * scale
+    rel = (scaled - want).abs().max().item() / max(want.abs().max().item(), 1e-6)
+    assert rel <= 0.15, f"stored O is not scale_o x the unscaled O (rel {rel:.3f})"
+    assert abs(amax_scaled - amax_one) <= 0.03, "amax describes the PRE-quant output, so scale_o cannot move it"
+
+
+def test_sm120_split_keeps_half_partials():
+    """SM120 partials stay half: sO aliases sKV here, so there is no room to
+    widen the O tile the way the SM100 kernels do, and these producers are
+    compiled without the fp32 partial-tensor slot.
+
+    The predicate that selects fp32 lives on the shared base, so if it ever
+    stops excluding this arch the adapter would hand an SM120 kernel an
+    argument it cannot take -- an ABI mismatch at launch, not a wrong number."""
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm120
+
+    if torch.cuda.get_device_capability()[0] != 12:
+        pytest.skip("SM120 part required")
+    b, h, s_q, s_kv, d, dev = 1, 8, 128, 8192, 128, "cuda"
+    torch.manual_seed(0)
+    q = torch.randn(b, h, s_q, d, device=dev, dtype=torch.float16)
+    k = torch.randn(b, 1, s_kv, d, device=dev, dtype=torch.float16)
+    v = torch.randn(b, 1, s_kv, d, device=dev, dtype=torch.float16)
+    o = torch.zeros_like(q)
+    api = SdpaFwdDslSm120(
+        sample_q=q,
+        sample_k=k,
+        sample_v=v,
+        sample_o=o,
+        split_kv=4,
+        sched_policy=0,
+    )
+    assert api.check_support()
+    assert not api._fp32_partial_split()
+    assert api._partial_dtype_tag() == "f16"

--- a/test/python/sdpa/frost/test_split_kv_heuristic.py
+++ b/test/python/sdpa/frost/test_split_kv_heuristic.py
@@ -185,16 +185,20 @@ def test_exactly_balanced_launch_never_splits():
 _FIT_S_Q = 512
 
 # (base_ctas, chosen split) pinned against a per-split sweep on B300 (148 SMs,
-# d128, 512 KV tiles, S_q=512, bf16, mask-free), re-measured for the two-kernel
-# cost model. A change that moves any of these is a policy change and needs its
-# own measurement.
+# d128, 512 KV tiles, S_q=512, bf16, mask-free). A change that moves any of
+# these is a policy change and needs its own measurement.
 #
-# The model matches the measured optimum on 8 of 12; mean regret 1.009, worst
-# 1.035. The misses (88, 100, 150, 160) all sit within ~10% of a FULL machine,
-# where the measured curve is nearly flat -- e.g. base=88 spans 2.264..2.512 ms
-# across every split -- so the ranking there is worth little and the model
-# prefers the cheap answer. Regret, not exact agreement, is the bar.
-_B300_FIT = [(8, 16), (16, 8), (32, 4), (64, 2), (88, 1), (100, 1), (120, 1), (128, 1), (150, 2), (160, 2), (200, 2), (296, 1)]
+# Re-swept end-to-end (split kernel + combine) once SM100 splits started writing
+# fp32 partials, which changed BOTH kernels: the epilogue stopped staging O
+# through SMEM and TMA, and the combine reads wider partials. The measured
+# optimum moved at 88 (1 -> 4), 150 (2 -> 4) and 160 (2 -> 4), so these entries
+# and _SPLIT_KV_COMBINE_COST were refitted together.
+#
+# The model now matches the measured optimum on 11 of 12; mean regret 1.0001,
+# worst 1.0007. The one miss is base=100, where split 1 and split 4 measure
+# 0.6701 vs 0.6706 ms -- a 0.07% tie the ranking cannot meaningfully resolve.
+# Regret, not exact agreement, is the bar.
+_B300_FIT = [(8, 16), (16, 8), (32, 4), (64, 2), (88, 4), (100, 4), (120, 1), (128, 1), (150, 4), (160, 4), (200, 2), (296, 1)]
 
 
 @pytest.mark.parametrize("base_ctas,expected", _B300_FIT, ids=[f"{b}ctas" for b, _ in _B300_FIT])
@@ -378,3 +382,147 @@ def test_decode_rows_barely_pay_for_the_combine():
     prefill = choose_split_kv(q_tiles=1, heads_q=8, batch=1, kv_tiles=512, sm_count=B200_SMS, ctas_per_tile=2, combine_rows=8 * 4096)
     assert decode > 1
     assert decode >= prefill
+
+
+# --- a quantized O is a legal split target ---------------------------------
+#
+# The split kernels write HALF partials whatever the O dtype and the combine
+# performs the only cast down to it, so nothing about an FP8 output makes the
+# reduction narrower. Both the eligibility gate and the candidate generator
+# used to decline it; these pin that they no longer do.
+
+
+def _fp8_caps():
+    from cudnn.sdpa.fwd.engines import ENGINE_SPECS
+
+    return next(sp for sp in ENGINE_SPECS if sp.name == "sdpa_fwd_prefill_sm100_fp8").capabilities
+
+
+def _fp8_facts(dtype_o, *, mx=False):
+    import cudnn
+    from cudnn.sdpa import graph_analyzer as ga
+
+    return ga.SdpaGraphFacts(
+        b=1,
+        h_q=8,
+        h_kv=1,
+        s_q=512,
+        s_kv=16384,
+        d_qk=128,
+        d_v=128,
+        dtype=cudnn.data_type.FP8_E4M3,
+        dtype_o=dtype_o,
+        is_fp8=not mx,
+        is_mxfp8=mx,
+        device_sm_count=B200_SMS,
+        device_cc=(10, 0),
+    )
+
+
+@pytest.mark.parametrize("out_name", ["FP8_E4M3", "FP8_E5M2", "HALF", "BFLOAT16"])
+@pytest.mark.parametrize("mx", [False, True], ids=["fp8", "mxfp8"])
+def test_quantized_output_does_not_block_a_split(out_name, mx):
+    """mismatch() must not decline split_kv on the O dtype alone."""
+    import cudnn
+
+    why = mismatch(_fp8_caps(), _fp8_facts(getattr(cudnn.data_type, out_name), mx=mx), SdpaFwdKnobs(split_kv=4)) or ""
+    assert "split_kv" not in why, f"quantized O declined the split: {why}"
+
+
+@pytest.mark.parametrize("out_name", ["FP8_E4M3", "FP8_E5M2"])
+def test_quantized_output_still_gets_split_candidates(out_name):
+    """And the generator must actually PROPOSE one — passing the eligibility
+    gate is not enough if the candidate list is still hard-coded to [1]."""
+    import cudnn
+
+    from cudnn.sdpa.fwd.heuristics import _split_points
+
+    points = _split_points(_fp8_caps(), _fp8_facts(getattr(cudnn.data_type, out_name)), 128, 128, 2)
+    assert points[0] > 1, f"a decode-shaped FP8-out graph got no split: {points}"
+    assert points[-1] == 1, "no-split must remain reachable behind the chosen split"
+
+
+def test_quantized_and_half_outputs_choose_the_same_split():
+    """The O dtype is not a performance input: partials are half either way, so
+    the chooser must land on the same split for an FP8 and a bf16 output."""
+    import cudnn
+
+    from cudnn.sdpa.fwd.heuristics import _split_points
+
+    caps = _fp8_caps()
+    fp8 = _split_points(caps, _fp8_facts(cudnn.data_type.FP8_E4M3), 128, 128, 2)
+    half = _split_points(caps, _fp8_facts(cudnn.data_type.BFLOAT16), 128, 128, 2)
+    assert fp8 == half, f"O dtype moved the split choice: {fp8} vs {half}"
+
+
+def test_every_combine_call_site_matches_the_compiled_arity():
+    """The combine is invoked POSITIONALLY, so adding a parameter to its host
+    silently breaks every call site that was not updated with it.
+
+    The failure is a TypeError raised only when a split actually runs, so a
+    missed site hides until some shape happens to split -- and the arms that
+    never split (dense half, THD) look fine either way. Compare the sites
+    against the signature instead of waiting for a shape to find them."""
+    import ast
+    import inspect
+
+    from cudnn.sdpa.fwd import api_dsl
+    from cudnn.sdpa.fwd.kernels.sm100 import split_combine
+
+    # _host's parameters, minus the trailing `stream` keyword.
+    params = [p for p in inspect.signature(split_combine._host).parameters if p != "stream"]
+    expected = len(params)
+
+    tree = ast.parse(inspect.getsource(api_dsl))
+    sites = [n for n in ast.walk(tree) if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute) and n.func.attr == "_combine_kernel"]
+    assert sites, "no combine call sites found — did the attribute get renamed?"
+    bad = [(n.lineno, len(n.args)) for n in sites if len(n.args) != expected]
+    assert not bad, f"combine call sites passing != {expected} positional args ({params}): {bad}"
+
+
+def test_every_split_capable_sm100_kernel_has_the_slot():
+    """A split-capable SM100 kernel either carries the o_partial_f32 slot, or the
+    adapter must know it does not.
+
+    _fp32_partial_split() is unconditional for SM100, so a kernel that wires
+    make_split_helpers WITHOUT the slot gets handed an argument it never
+    declares -- a launch-time arity error on whatever shape happens to split.
+    That is exactly how sm100/prefill_d512_mxfp8 arrived: split-capable from the
+    day it landed, written against the staged epilogue. Scanning the directory
+    means the NEXT such kernel fails here instead of in production.
+
+    A kernel without the slot is fine, provided _SLOTLESS_FLAVORS records it and
+    the predicate excludes that flavor.
+    """
+    import pathlib
+
+    from cudnn.sdpa.fwd import api_dsl
+
+    # (mxfp8, d_shape) pairs the adapter deliberately keeps on half partials.
+    _SLOTLESS_FLAVORS = {"prefill_d512_mxfp8.py"}
+
+    kdir = pathlib.Path(api_dsl.__file__).parent / "kernels" / "sm100"
+    assert kdir.is_dir(), f"kernel directory moved: {kdir}"
+
+    offenders = []
+    for f in sorted(kdir.glob("prefill_*.py")):
+        src = f.read_text()
+        if "make_split_helpers" not in src:
+            continue  # not split-capable, nothing to carry
+        if "o_partial_f32" in src:
+            continue  # wired
+        if f.name in _SLOTLESS_FLAVORS:
+            continue  # known, and excluded by _fp32_partial_split
+        offenders.append(f.name)
+
+    assert not offenders, (
+        f"split-capable SM100 kernels with no o_partial_f32 slot: {offenders}. "
+        "Either port the fp32 partial store into them, or exclude their flavor in "
+        "api_dsl.SdpaFwdDsl._fp32_partial_split and list them in _SLOTLESS_FLAVORS."
+    )
+
+    # ...and the recorded exceptions must still be real, or this guard rots.
+    for name in _SLOTLESS_FLAVORS:
+        src = (kdir / name).read_text()
+        assert "make_split_helpers" in src, f"{name}: no longer split-capable; drop it from _SLOTLESS_FLAVORS"
+        assert "o_partial_f32" not in src, f"{name}: now carries the slot; drop it from _SLOTLESS_FLAVORS and let the predicate return True"


### PR DESCRIPTION
The split path required a bf16/fp16 O because the combine reduced partials in the output type. Keep the partials in half precision regardless of the O dtype and let the combine perform the only cast down to it, so the reduction stays wider than the output and the FP8 rounding happens once, on the recombined value.

The per-tensor scale_o moves with that cast: the split kernels write unscaled partials and the combine applies it at the store, which also makes the amax it reports the pre-quantization value with no post-hoc divide. Block-scaled MXFP8 carries its scaling in the SF tensors and casts unscaled, as its single-pass epilogue does.

Drops the corresponding gates in the standalone adapters, the engine eligibility check and the split candidate generator.

## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches (see [root AGENTS.md § Reviewing a PR](https://github.com/NVIDIA/cudnn-frontend/blob/develop/AGENTS.md#reviewing-a-pr-human-or-agent)) and my changes comply, or I explain the exception below.
- [x] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

<!-- What changed? Keep the scope concise. -->

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled split-KV execution for FP8 and MXFP8 outputs on supported SM100 and SM120 workloads.
  * Added optional FP32 intermediate buffers for supported split workloads, including D128, D192/D128, D256, and D512 configurations.
  * Output scaling is applied once, with accurate pre-quantization maximum-value reporting.
  * Workspace sizing reflects the selected intermediate precision.

* **Tests**
  * Added coverage for quantized split-KV accuracy, scaling, workspace sizing, FP32 intermediates, and configuration selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->