### PR TITLE
sdpa: fix d256 fp8/mxfp8 SM100 kernels importing the renamed thd_helpers module

### DIFF
--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_fp8_sm100.py
@@ -149,7 +149,7 @@ _thd_tma_offsets = _sdpa_h.thd_tma_offsets
 HEADS_PER_TILE = CFG.QH_PER_KH if CFG.PACK_GQA else 1
 TOKENS_PER_TILE = CFG.TILE_M // HEADS_PER_TILE
 
-from cudnn.sdpa.fwd.kernels.thd_sm100 import (
+from cudnn.sdpa.fwd.kernels.thd_helpers import (
     build_thd_meta_o_kv_descs_kernel as _build_thd_meta_o_kv_descs_kernel,
     thd_decode_unit,
     TENSOR_MAP_QWORDS,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_mxfp8_sm100.py
@@ -197,7 +197,7 @@ _resolve_seqlen_q = _sdpa_h.resolve_seqlen_q
 _thd_tma_offsets = _sdpa_h.thd_tma_offsets
 _thd_sf_tile_bases = _sdpa_h.thd_sf_tile_bases
 
-from cudnn.sdpa.fwd.kernels.thd_sm100 import (
+from cudnn.sdpa.fwd.kernels.thd_helpers import (
     build_thd_meta_o_kv_descs_kernel as _build_thd_meta_o_kv_descs_kernel,
     thd_decode_unit,
     TENSOR_MAP_QWORDS,


### PR DESCRIPTION
## Summary
- #884 renamed `python/cudnn/sdpa/fwd/kernels/thd_sm100.py` → `thd_helpers.py` and updated every caller.
- #860 (SM100 d256 fp8/mxfp8 kernels) landed in parallel and still imports `cudnn.sdpa.fwd.kernels.thd_sm100`.
- Result on `develop`: every d256 fp8/mxfp8 SM100 test fails at template load with `ModuleNotFoundError` — 78 failures in the `frost-sdpa:cutlass-rel:sm100` lane (e.g. internal job 424611712 on the #887 mirror pipeline, which merges with develop).

This is a two-line import fix in `prefill_d256_fp8_sm100.py` and `prefill_d256_mxfp8_sm100.py`. `thd_helpers.py` is a pure rename plus additions, so `build_thd_meta_o_kv_descs_kernel`, `thd_decode_unit`, and `TENSOR_MAP_QWORDS` are unchanged.

## Test plan
- [x] Local B200 (cuDNN 9.26.0.33): `test_sdpa_fwd_fp8_sm100.py::test_fp8_d256_output_dtypes` + `test_sdpa_fwd_split_kv_sm100.py::test_api_splits_the_fp8_family` — 12 passed (previously `ModuleNotFoundError`).
- [x] `git grep thd_sm100` is empty after this change.
- [x] black `--line-length 160` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal helper references for select FP8 and MXFP8 prefill operations without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->