### PR TITLE
sdpa: admit the (256, 512] FP8 head-dim band for per-tensor FP8 only, not MXFP8

### DIFF
--- a/benchmark/attention_training/benchmark_single_sdpa.py
+++ b/benchmark/attention_training/benchmark_single_sdpa.py
@@ -906,7 +906,18 @@ else:
             if args.verbose:
                 print(f"[INFO] cudnn_oss: pinned FROST engine '{eligible[0]}' for {pass_name}")
 
-        graph_fwd.validate()
+        def validate_or_skip(graph, pass_name):
+            """A frontend-level GRAPH_NOT_SUPPORTED is a support gate (shape / dtype /
+            feature the library declines up front), not a failure: report it as a
+            skip so the runner's CSV marks the case unsupported. Anything past
+            validate() (heuristics, check_support, plan build) still fails loudly,
+            since e.g. a runtime-compile error there is a library bug."""
+            try:
+                graph.validate()
+            except cudnn.cudnnGraphNotSupportedError as e:
+                exit_unsupported(f"{pass_name} graph rejected by cuDNN frontend validation: {e}")
+
+        validate_or_skip(graph_fwd, "fwd")
         graph_fwd.build_operation_graph()
         graph_fwd.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
         if args.sdpa_backend == "cudnn_oss" and run_fwd:
@@ -1146,7 +1157,7 @@ else:
                 dK_bwd.set_output(True).set_dim(dKey.size()).set_stride(dKey.stride())
                 dV_bwd.set_output(True).set_dim(dValue.size()).set_stride(dValue.stride())
 
-            graph_bwd.validate()
+            validate_or_skip(graph_bwd, "bwd")
             graph_bwd.build_operation_graph()
             graph_bwd.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
             if args.sdpa_backend == "cudnn_oss":

--- a/include/cudnn_frontend/node/sdpa_support_surface.h
+++ b/include/cudnn_frontend/node/sdpa_support_surface.h
@@ -193,11 +193,19 @@ SDPA_attributes::validate_sdpa_support_surface(const detail::Context& context,
         // (sdpa_fwd_prefill_sm100_fp8, the d512 kernel flavor), which runs the
         // band through its native d = 512 tile with TMA zero-padding. The floor
         // is the engine's: below it the flavor would pad by more than 2x, and
-        // no smaller FP8 flavor reaches above 192/128. The cuDNN backend itself
-        // has no plan for the band, so a graph that does not select that engine
-        // still fails at plan creation.
-        bool const d512_supported =
-            (d_qk > 256) && (d_qk <= 512) && (d_v > 256) && (d_v <= 512) && (d_qk % 16 == 0) && (d_v % 16 == 0);
+        // no smaller FP8 flavor reaches above 192/128.
+        //
+        // The band is PER-TENSOR FP8 only. MXFP8 (block-scaled: the descales are
+        // FP8_E8M0 scale-factor tensors) has no d512 kernel anywhere: the FROST
+        // engine declines it, and the cuDNN backend's runtime-compiled FP8
+        // engine accepts the shape at check-support time but then fails NVRTC
+        // compilation (CUDNN_STATUS_INTERNAL_ERROR_COMPILATION_FAILED) at plan
+        // build. Reject it here so the caller sees NOT_SUPPORTED up front.
+        auto const& descale_q_it   = inputs.find(SDPA_attributes::input_names::Descale_Q);
+        bool const is_block_scaled = (descale_q_it != inputs.end()) && (descale_q_it->second != nullptr) &&
+                                     (descale_q_it->second->get_data_type() == DataType_t::FP8_E8M0);
+        bool const d512_supported = !is_block_scaled && (d_qk > 256) && (d_qk <= 512) && (d_v > 256) && (d_v <= 512) &&
+                                    (d_qk % 16 == 0) && (d_v % 16 == 0);
         bool const d256_v256_supported = (detail::get_backend_version() >= 92600);
         if (prop_major >= 10) {
             RETURN_CUDNN_FRONTEND_ERROR_IF(
@@ -206,14 +214,15 @@ SDPA_attributes::validate_sdpa_support_surface(const detail::Context& context,
                 error_code_t::GRAPH_NOT_SUPPORTED,
                 "hidden_dim d_qk should be less than or equal to 128 and hidden_dim d_qk "
                 "should be multiple of 16 unless d_qk == 192 and d_v == 128 (requires cuDNN 9.19+) "
-                "or d_qk == d_v == 256 (requires cuDNN 9.26+) or both head dims are in (256, 512] and multiples of 16");
+                "or d_qk == d_v == 256 (requires cuDNN 9.26+) or, for per-tensor FP8 only (not MXFP8), both head "
+                "dims are in (256, 512] and multiples of 16");
             RETURN_CUDNN_FRONTEND_ERROR_IF(
                 ((d_v > 128) || (d_v % 16 != 0)) && !(d256_v256_supported && d_qk == 256 && d_v == 256) &&
                     !d512_supported,
                 error_code_t::GRAPH_NOT_SUPPORTED,
                 "hidden_dim d_v should be less than or equal to 128 and hidden_dim d_v should be multiple of 16 "
-                "unless d_qk == d_v == 256 (requires cuDNN 9.26+) or both head dims are in (256, 512] and multiples of "
-                "16");
+                "unless d_qk == d_v == 256 (requires cuDNN 9.26+) or, for per-tensor FP8 only (not MXFP8), both head "
+                "dims are in (256, 512] and multiples of 16");
         } else {
             RETURN_CUDNN_FRONTEND_ERROR_IF(
                 (d_qk > 256) || (d_qk % 16 != 0) || (d_v > 256) || (d_v % 16 != 0),

--- a/python/cudnn/sdpa/AGENTS.md
+++ b/python/cudnn/sdpa/AGENTS.md
@@ -57,3 +57,32 @@ head-major, never dense-padded.**
 - Reviewing: if the diff touches `fwd/engines.py`, `bwd/engines.py` or
   `cudnn/engines/manifest.py` and `python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md` is
   untouched, ask why before approving.
+
+**Rule S3 — Opening the graph-level support surface for a FROST-only shape
+admits exactly the graph forms that engine serves; never assume the backend
+will decline the rest.**
+
+- `include/cudnn_frontend/node/sdpa_support_surface.h` runs for EVERY graph,
+  including ones the plain backend serves with FROST disabled. A FROST-only
+  shape let through there does not "fail cleanly at plan creation": the
+  backend's runtime-compiled SDPA engine has no head-dim upper bound for
+  SM100/SM107 prefill (only `d % 16`), so it claims the graph at
+  check-support and dies in NVRTC —
+  `CUDNN_STATUS_INTERNAL_ERROR_COMPILATION_FAILED`, which every consumer
+  reads as a library bug, not a support gate. This is how #845's
+  `(256, 512]` fp8 band produced 16 red deepseek_v4 cases per Blackwell part
+  on the attention_training nightly: `sdpa_fp8` and `sdpa_mxfp8` share
+  `mma_core_mode = FP8_E4M3`, so the band admitted MXFP8 d512 too, which no
+  kernel anywhere serves.
+- Scope the C++ gate by the same discriminators the engine row uses
+  (per-tensor vs block-scaled = `Descale_Q` dtype `FP8_E8M0`, pass, dtype
+  family, arch), and pair it with a validate()-level test in both forms —
+  `test_fp8_d512_graph_surface_admits_per_tensor_only` is the template.
+- Detector before merging such a widening: build the newly admitted graph
+  with FROST OFF (`CUDNN_FRONTEND_ENABLE_FROST_ENGINES=0`, plain
+  `create_execution_plans([A, FALLBACK])`), print
+  `get_plan_name_at_index(i)` for every plan, and `build_plan_at_index(i)`
+  each. Any plan that builds means the backend serves the shape (say so in
+  the PR — and check it is correct); any plan that fails to build is a
+  backend NOT_SUPPORTED bug to report, and the C++ gate must stay closed
+  until it lands.

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -1819,3 +1819,71 @@ def test_fp8_d512_mxfp8_declines():
     assert (512, 512) in _sm100_fp8_shapes(pertensor=True, device_cc=(10, 0))
     assert (512, 512) not in _sm100_fp8_shapes(pertensor=False, device_cc=(10, 0))
     assert (512, 512) not in _sm100_fp8_shapes(pertensor=True, device_cc=(10, 7))
+
+
+def _d512_fp8_graph(block_scaled: bool):
+    """A d512 FP8 forward pygraph; block_scaled=True is the MXFP8 form (E8M0 scale-factor descales)."""
+    import cudnn
+
+    B, H, S, D = 2, 4, 2048, 512
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.BFLOAT16 if block_scaled else cudnn.data_type.FP8_E4M3,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    qkv = lambda n: g.tensor(name=n, dim=(B, H, S, D), stride=(H * S * D, D, H * D, 1), data_type=cudnn.data_type.FP8_E4M3)
+    q, k, v = qkv("q"), qkv("k"), qkv("v")
+    if block_scaled:
+        # Scale-factor tensor geometry follows the MXFP8 samples: 32-wide blocks, F8_128x4 reordering.
+        sf = lambda n, dim, stride: g.tensor(
+            name=n, dim=dim, stride=stride, data_type=cudnn.data_type.FP8_E8M0, reordering_type=cudnn.tensor_reordering.F8_128x4
+        )
+        d_sf = D // 32
+        s_sf = S // 32
+        o, stats, amax_o = g.sdpa_mxfp8(
+            q=q,
+            k=k,
+            v=v,
+            descale_q=sf("sf_q", (B, H, S, d_sf), (H * S * d_sf, S * d_sf, d_sf, 1)),
+            descale_k=sf("sf_k", (B, H, S, d_sf), (H * S * d_sf, S * d_sf, d_sf, 1)),
+            descale_v=sf("sf_v", (B, H, s_sf, D), (H * s_sf * D, s_sf * D, 1, s_sf)),
+            attn_scale=1.0 / math.sqrt(D),
+            generate_stats=True,
+        )
+        o.set_output(True).set_dim((B, H, S, D)).set_stride((H * S * D, D, H * D, 1)).set_data_type(cudnn.data_type.BFLOAT16)
+    else:
+        sc = lambda n: g.tensor(name=n, dim=(1, 1, 1, 1), stride=(1, 1, 1, 1), data_type=cudnn.data_type.FLOAT)
+        o, stats, _amax_s, amax_o = g.sdpa_fp8(
+            q=q,
+            k=k,
+            v=v,
+            descale_q=sc("dq"),
+            descale_k=sc("dk"),
+            descale_v=sc("dv"),
+            descale_s=sc("ds"),
+            scale_s=sc("ss"),
+            scale_o=sc("so"),
+            is_inference=False,
+            attn_scale=1.0 / math.sqrt(D),
+        )
+        o.set_output(True).set_dim((B, H, S, D)).set_stride((H * S * D, D, H * D, 1)).set_data_type(cudnn.data_type.FP8_E4M3)
+    stats.set_output(True).set_dim((B, H, S, 1)).set_stride((H * S, S, 1, 1)).set_data_type(cudnn.data_type.FLOAT)
+    amax_o.set_output(True).set_dim((1, 1, 1, 1)).set_stride((1, 1, 1, 1)).set_data_type(cudnn.data_type.FLOAT)
+    return g
+
+
+@pytest.mark.L0
+@_skip_d512_on_rubin
+def test_fp8_d512_graph_surface_admits_per_tensor_only():
+    """The graph-level support surface admits the (256, 512] head-dim band for
+    PER-TENSOR FP8 only. An MXFP8 d512 graph must be declined at validate():
+    with the band open to it, the cuDNN backend's runtime-compiled FP8 engine
+    accepts the shape at check-support and then fails NVRTC compilation
+    (CUDNN_STATUS_INTERNAL_ERROR_COMPILATION_FAILED) at plan build -- the
+    failure the attention_training nightly reported on GB200/GB300 for the
+    deepseek_v4 mxfp8 forward cases."""
+    import cudnn
+
+    _d512_fp8_graph(block_scaled=False).validate()
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match=r"per-tensor FP8 only"):
+        _d512_fp8_graph(block_scaled=True).validate()


### PR DESCRIPTION
## Problem

The attention_training nightly reports the **libcudnn backend failing with `CUDNN_STATUS_INTERNAL_ERROR_COMPILATION_FAILED` on 16 cases each on GB200, GB300 and VR200** (plus 8 of the same under the OSS runner's backend fallback). They are the `deepseek_v4` fp8/mxfp8 forward cases (d=512, 1 KV head, SWA 128): 2 models × 4 seqlens × {fp8, mxfp8} = 16.

Reproduced on B200 with develop-TOT frontend + libcudnn 9.25.1 (the public `apt install cudnn` the nightly container gets):

```
mxfp8 d=512 fwd: 1 plan: eng10_k24=1_k27=0_k38=0_k40=3_k41=2
  [0] BUILD FAILED: ... Encountered runtime kernel compilation failure
      cudnn_status: CUDNN_STATUS_INTERNAL_ERROR_COMPILATION_FAILED
```

## Root cause

Two stacked defects:

1. **Frontend (#845).** The Blackwell FP8 forward head-dim gate in `sdpa_support_surface.h` was opened to `(256, 512]` for the FROST per-tensor fp8 d512 kernel, on the assumption that "the cuDNN backend itself has no plan for the band, so a graph that does not select that engine still fails at plan creation". It does not fail cleanly: the backend's runtime-compiled unified SDPA engine has **no head-dim upper bound for SM100/SM107 prefill** (only `d % 16 == 0`; the d≤128/192/256 caps are gated on `s_q == 1 || BPROP`), so it claims the graph at check-support and NVRTC-compiles a `TILE_K = 512` kernel its fp8/mxfp8 emitters weren't designed for. Per-tensor fp8 happens to compile; mxfp8 does not. And since `sdpa_fp8` and `sdpa_mxfp8` both set `mma_core_mode = FP8_E4M3`, the widened gate admitted **MXFP8 d512** as well — which #845 itself lists as out of scope (no d512 block-scale kernel anywhere; the FROST engine row already declines it).

2. **Backend.** The engine should return `NOT_SUPPORTED` for that shape instead of failing at compile time. That is a separate backend fix (shape gate in `attentionDescriptors.cpp`), tracked outside this PR.

## Fix (frontend side)

- `sdpa_support_surface.h`: the `(256, 512]` band now requires **per-tensor** descales. MXFP8 is recognised by its `FP8_E8M0` scale-factor `Descale_Q` and is declined at `validate()` with `GRAPH_NOT_SUPPORTED` — the caller sees a support gate, not a plan-build compile failure. Per-tensor fp8 d512 is unchanged. Error messages now say "for per-tensor FP8 only (not MXFP8)".
- `benchmark_single_sdpa.py`: a frontend `GRAPH_NOT_SUPPORTED` at `validate()` now maps to the runner's unsupported exit code, so the nightly CSV marks such cases *skipped* (support gate) rather than *failed*. Errors past `validate()` (heuristics, check_support, plan build) still fail loudly — a runtime-compile error there is a library bug worth seeing.
- `test_sdpa_fwd_fp8_sm100.py::test_fp8_d512_graph_surface_admits_per_tensor_only`: builds the d512 graph in both forms; per-tensor validates, MXFP8 raises `cudnnGraphNotSupportedError`.
- `python/cudnn/sdpa/AGENTS.md`: **Rule S3** — opening the graph-level surface for a FROST-only shape admits exactly the forms that engine serves, with the runnable plan-list/build-each detector to run before merging such a widening.

## Verification (B200 cc 10.0, libcudnn 9.25.1, FE at develop TOT)

- Probe: mxfp8 d512 fwd → rejected at `validate()`; per-tensor fp8 d512 fwd → still 1 plan (`eng10…`), builds OK.
- `pytest test_sdpa_fwd_fp8_sm100.py -k "not strided_stats"` green (`test_fp8_strided_stats` is the known 9.26-only failure noted in #845).
- Harness: `benchmark_single_sdpa.py --data_type mxfp8 --head_dim 512 …` now exits `UNSUPPORTED_CONFIG` (rc 42) instead of `COMPILATION_FAILED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
