### PR TITLE
Model-specific-api-moe-swiglu

### DIFF
--- a/python/cudnn/gemm/__init__.py
+++ b/python/cudnn/gemm/__init__.py
@@ -21,6 +21,7 @@ _LAZY_EXPORTS = {
     "moe_grouped_matmul": ("cudnn.gemm.ops", "moe_grouped_matmul"),
     "situ_mlp": ("cudnn.gemm.ops", "situ_mlp"),
     "swiglu_mlp": ("cudnn.gemm.ops", "swiglu_mlp"),
+    "swiglu_moe": ("cudnn.gemm.ops", "swiglu_moe"),
 }
 
 

--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -4054,11 +4054,17 @@ class CompiledMoeGemm:
         ):
             if len(t.shape) != rank:
                 raise ValueError(f"MoE {name} must be rank-{rank}; got shape {tuple(t.shape)}")
-        for role, slots in (("token", a_slots), ("weight", b_slots)):
+        for role, slots, major in (
+            ("token", a_slots, chain.matmul.a_major),
+            ("weight", b_slots, chain.matmul.b_major),
+        ):
+            unit_dim = -1 if major == "k" else -2
             for t in slots:
-                if len(t.shape) != 3 or t.stride(-1) != 1:
+                if len(t.shape) != 3 or t.stride(unit_dim) != 1:
                     raise ValueError(
-                        f"multi-GEMM MoE {role} must be rank-3 with contiguous " f"innermost dim; got shape {tuple(t.shape)} stride {tuple(t.stride())}"
+                        f"multi-GEMM MoE {role} must be rank-3 and contiguous "
+                        f"along its {major}-major dimension; got shape "
+                        f"{tuple(t.shape)} stride {tuple(t.stride())}"
                     )
         if _moe_dense_layout_bad(out):
             raise ValueError("multi-GEMM MoE output requires contiguous innermost dim")

--- a/python/cudnn/gemm/ops/__init__.py
+++ b/python/cudnn/gemm/ops/__init__.py
@@ -13,6 +13,7 @@ _LAZY_EXPORTS = {
     # Both semantic entry points share the existing implementation module.
     "situ_mlp": ("cudnn.gemm.ops.swiglu_mlp", "situ_mlp"),
     "swiglu_mlp": ("cudnn.gemm.ops.swiglu_mlp", "swiglu_mlp"),
+    "swiglu_moe": ("cudnn.gemm.ops.swiglu_moe", "swiglu_moe"),
 }
 
 

--- a/python/cudnn/gemm/ops/swiglu_mlp.py
+++ b/python/cudnn/gemm/ops/swiglu_mlp.py
@@ -40,11 +40,11 @@ For ``swiglu_mlp`` only, by default,
 kernel that never materialises ``dh`` to HBM (set
 ``CUDNN_GEMM_SWIGLU_FROST_BWD=0`` for the separate nvjet GEMM + one-kernel
 pointwise, which it falls back to anyway if FROST cannot serve a
-shape/arch/thread). The dense large-M path uses the B200-tuned 2-CTA
-M128/N256/K128, cluster2x1, CLC strategy; its bare GEMM is at nvjet parity and
-the fused epilogue turns the avoided ``dh`` round-trip into a net win. A balanced
-B200 run at M=8192, H=5120, I=17408 measured 1.077x backward and 1.109x full
-fwd+bwd versus eager torch (the exact ratio is workload/runtime dependent).
+shape/arch/thread). On the first call for a shape, the dense path autotunes the
+M128/N128 and M128/N256 variants (cluster2x1, 2-CTA for M > 128) on the actual
+inputs and caches the winner; set ``CUDNN_GEMM_SWIGLU_FROST_AUTOTUNE=0`` to use
+the static N256-for-I>=256 policy instead. The fused epilogue avoids the ``dh``
+HBM round-trip in either case.
 Numerically matches torch to bf16 noise on the output and all four gradients.
 
 At the public call boundary the op snapshots GradMode and each input's
@@ -377,6 +377,9 @@ _FROST_DSWIGLU_CACHE = {}
 # the pointwise path if FROST explicitly declines a shape, architecture, layout,
 # or optional dependency.
 _FROST_BWD = os.environ.get("CUDNN_GEMM_SWIGLU_FROST_BWD", "1") != "0"
+_FROST_BWD_AUTOTUNE = os.environ.get("CUDNN_GEMM_SWIGLU_FROST_AUTOTUNE", "1") != "0"
+_FROST_AUTOTUNE_ITERS = 10
+_FROST_AUTOTUNE_REPEATS = 3
 _FROST_DECLINE_ERRORS = (NotImplementedError, cudnn.cudnnGraphNotSupportedError, ImportError)
 
 
@@ -400,10 +403,11 @@ def _frost_dswiglu(
     FROST takes the natural down weight directly (an N-major / I-contiguous B -- no
     transpose copy; the downstream ``dg.t()`` wgrad operand is likewise a free strided
     view) and keeps ``dh`` on-chip (no HBM round-trip). This is the DEFAULT backward
-    stage. The large-M path deliberately pins the B200-tuned
-    M128/N256/Kbytes128, cluster2x1, 2CTAMMA, CLC strategy. The previous geometry-
-    only sweep fixed 1CTAMMA/cluster1x1 and therefore did not cover this execution-
-    strategy win. Small M retains the 1CTAMMA/cluster1x1 strategy. Not a transpose
+    stage. The first call for each shape autotunes M128/N128 and M128/N256 using
+    CUDA events around the actual inputs, then caches the winner. Both candidates
+    use cluster2x1, 2CTAMMA for M > 128; small M retains 1CTAMMA/cluster1x1.
+    Autotuning can be disabled with ``CUDNN_GEMM_SWIGLU_FROST_AUTOTUNE=0``, which
+    retains the static N256-for-I>=256 policy. Not a transpose
     problem (dense bf16 needs none; ``dg.t()`` is a free view) and not a host-
     overhead one (host is ~1% of these compute-bound GEMMs, and #612 already cut
     it). SiTU is deliberately unsupported here: this FROST graph contains
@@ -463,19 +467,31 @@ def _frost_dswiglu(
         from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
         from cudnn.gemm.frost.tile_config import CATALOG
 
-        stream = torch.cuda.current_stream(device).cuda_stream
-        key = (M, H, interm, dout2.dtype, device.index)
+        torch_stream = torch.cuda.current_stream(device)
+        stream = torch_stream.cuda_stream
+        capability = torch.cuda.get_device_capability(device)
+        key = (M, H, interm, dout2.dtype, device.index, capability)
+        dgate = torch.empty(1, M, interm, device=device, dtype=dout2.dtype)
+        dup = torch.empty(1, M, interm, device=device, dtype=dout2.dtype)
+
+        def launch(entry):
+            compiled, bd, out_by, aux_by = entry
+            compiled(
+                {
+                    bd.a_operands[0]: dout2.unsqueeze(0),
+                    bd.b_operands[0]: Wd.unsqueeze(0),  # natural [1,H,I], N-major — no transpose
+                    out_by["dup"]: dup,
+                    out_by["dgate"]: dgate,
+                    aux_by["gate_pre"]: gate.unsqueeze(0),
+                    aux_by["up_pre"]: up.unsqueeze(0),
+                },
+                stream=stream,
+            )
+
         e = _FROST_DSWIGLU_CACHE.get(key)
         if e is None:
-            tn = 256 if interm >= 256 else 128
             cta_group = 2 if M > 128 else 1
             cluster_m = 2 if cta_group == 2 else 1
-            cfg = next(
-                c
-                for c in CATALOG
-                if (c.pipeline, c.cta_tile_m, c.cta_tile_n, c.cta_tile_k_bytes, c.cga_size_m, c.cga_size_n, c.cta_group)
-                == ("sm100", 128, tn, 128, cluster_m, 1, cta_group)
-            )
             g = cudnn.pygraph(io_data_type=_BF16, intermediate_data_type=_FP32, compute_data_type=_FP32)
             DY = g.tensor(name="dy", dim=[1, M, H], stride=[M * H, H, 1])
             # Natural down weight [H,I] as an N-major (I-contiguous) B -- FROST takes
@@ -486,26 +502,49 @@ def _frost_dswiglu(
             dh = g.matmul(A=DY, B=WD, name="dgrad")
             g.mul(a=dh, b=g.swish(input=G), name="dup").set_output(True).set_data_type(_BF16)
             g.mul(a=g.swish_backward(loss=dh, input=G), b=U, name="dgate").set_output(True).set_data_type(_BF16)
-            compiled = jit_from_cudnn_graph(g, config=cfg)
-            bd = compiled.binding
-            out_by = {o.get_name().split("::")[0]: o for o in bd.outputs}
-            aux_by = {a.get_name(): a for a in bd.aux}
-            e = (compiled, bd, out_by, aux_by)
+
+            if _FROST_BWD_AUTOTUNE and interm >= 256:
+                tile_ns = (128, 256)
+            else:
+                tile_ns = (256 if interm >= 256 else 128,)
+            entries = []
+            for tn in tile_ns:
+                cfg = next(
+                    c
+                    for c in CATALOG
+                    if (c.pipeline, c.cta_tile_m, c.cta_tile_n, c.cta_tile_k_bytes, c.cga_size_m, c.cga_size_n, c.cta_group)
+                    == ("sm100", 128, tn, 128, cluster_m, 1, cta_group)
+                )
+                compiled = jit_from_cudnn_graph(g, config=cfg)
+                bd = compiled.binding
+                out_by = {o.get_name().split("::")[0]: o for o in bd.outputs}
+                aux_by = {a.get_name(): a for a in bd.aux}
+                entries.append((compiled, bd, out_by, aux_by))
+
+            if len(entries) == 1:
+                e = entries[0]
+            else:
+                # Warm both candidates before timing. Events and launches share
+                # torch_stream, so the measured interval excludes JIT and host work.
+                for entry in entries:
+                    launch(entry)
+                torch_stream.synchronize()
+                samples = [[] for _ in entries]
+                start = torch.cuda.Event(enable_timing=True)
+                stop = torch.cuda.Event(enable_timing=True)
+                for repeat in range(_FROST_AUTOTUNE_REPEATS):
+                    order = range(len(entries)) if repeat % 2 == 0 else reversed(range(len(entries)))
+                    for index in order:
+                        start.record(torch_stream)
+                        for _ in range(_FROST_AUTOTUNE_ITERS):
+                            launch(entries[index])
+                        stop.record(torch_stream)
+                        stop.synchronize()
+                        samples[index].append(start.elapsed_time(stop) / _FROST_AUTOTUNE_ITERS)
+                medians = [sorted(values)[len(values) // 2] for values in samples]
+                e = entries[min(range(len(entries)), key=medians.__getitem__)]
             _FROST_DSWIGLU_CACHE[key] = e
-        compiled, bd, out_by, aux_by = e
-        dgate = torch.empty(1, M, interm, device=device, dtype=dout2.dtype)
-        dup = torch.empty(1, M, interm, device=device, dtype=dout2.dtype)
-        compiled(
-            {
-                bd.a_operands[0]: dout2.unsqueeze(0),
-                bd.b_operands[0]: Wd.unsqueeze(0),  # natural [1,H,I], N-major — no transpose
-                out_by["dup"]: dup,
-                out_by["dgate"]: dgate,
-                aux_by["gate_pre"]: gate.unsqueeze(0),
-                aux_by["up_pre"]: up.unsqueeze(0),
-            },
-            stream=stream,
-        )
+        launch(e)
     return dgate.squeeze(0), dup.squeeze(0)
 
 

--- a/python/cudnn/gemm/ops/swiglu_moe.py
+++ b/python/cudnn/gemm/ops/swiglu_moe.py
@@ -23,7 +23,10 @@ _FP32 = cudnn.data_type.FLOAT
 _FC1_CACHE = {}
 _MM_CACHE = {}
 _DSWIGLU_CACHE = {}
+_WGRAD_CACHE = {}
 _FROST_WORKSPACES = {}
+_CUDNN_HANDLES = {}
+_CUDNN_WORKSPACES = {}
 
 
 def _device_key(tensor: torch.Tensor) -> tuple:
@@ -55,14 +58,14 @@ def _frost_workspace(plan, tensor):
 def _frost_fc1(routed_x, Wg, Wu, offsets):
     """Fused ``gate/up grouped GEMMs + SwiGLU``; also materialize BF16 taps."""
     _, S, H = routed_x.shape
-    E, I, _ = Wg.shape
-    key = ("fc1", S, H, I, E, routed_x.dtype, *_device_key(routed_x))
+    E, interm, _ = Wg.shape
+    key = ("fc1", S, H, interm, E, routed_x.dtype, *_device_key(routed_x))
     plan = _FC1_CACHE.get(key)
     if plan is None:
         graph = cudnn.pygraph(io_data_type=_BF16, intermediate_data_type=_FP32, compute_data_type=_FP32)
         X = graph.tensor(name="x", dim=[1, S, H], stride=[S * H, H, 1], data_type=_BF16)
-        WG = graph.tensor(name="Wg", dim=[E, H, I], stride=[H * I, 1, H], data_type=_BF16)
-        WU = graph.tensor(name="Wu", dim=[E, H, I], stride=[H * I, 1, H], data_type=_BF16)
+        WG = graph.tensor(name="Wg", dim=[E, H, interm], stride=[H * interm, 1, H], data_type=_BF16)
+        WU = graph.tensor(name="Wu", dim=[E, H, interm], stride=[H * interm, 1, H], data_type=_BF16)
         FTO = graph.tensor(name="first_token_offset", dim=[E, 1, 1], stride=[1, 1, 1], data_type=cudnn.data_type.INT32)
         gate_raw = graph.moe_grouped_matmul(X, WG, FTO, mode=cudnn.moe_grouped_matmul_mode.NONE, compute_data_type=_FP32, name="gate")
         up_raw = graph.moe_grouped_matmul(X, WU, FTO, mode=cudnn.moe_grouped_matmul_mode.NONE, compute_data_type=_FP32, name="up")
@@ -80,7 +83,7 @@ def _frost_fc1(routed_x, Wg, Wu, offsets):
 
     binding = plan.binding
     outputs = _output_map(binding)
-    gate = torch.empty(1, S, I, dtype=routed_x.dtype, device=routed_x.device)
+    gate = torch.empty(1, S, interm, dtype=routed_x.dtype, device=routed_x.device)
     up = torch.empty_like(gate)
     h = torch.empty_like(gate)
     buffers = {"gate_tap": gate, "up_tap": up, "h": h}
@@ -146,18 +149,18 @@ def _frost_mm(token, weight, offsets):
 def _frost_dswiglu(dout, Wd, gate, up, offsets):
     """Fuse the grouped down dgrad with both SwiGLU derivatives."""
     _, S, H = dout.shape
-    E, weight_h, I = Wd.shape
+    E, weight_h, interm = Wd.shape
     if weight_h != H:
         raise ValueError(f"internal grouped dSwiGLU H mismatch: dout H={H}, Wd H={weight_h}")
-    key = ("dswiglu", S, H, I, E, dout.dtype, *_device_key(dout))
+    key = ("dswiglu", S, H, interm, E, dout.dtype, *_device_key(dout))
     plan = _DSWIGLU_CACHE.get(key)
     if plan is None:
         graph = cudnn.pygraph(io_data_type=_BF16, intermediate_data_type=_FP32, compute_data_type=_FP32)
         DY = graph.tensor(name="dout", dim=[1, S, H], stride=[S * H, H, 1], data_type=_BF16)
-        WD = graph.tensor(name="Wd", dim=[E, H, I], stride=[H * I, I, 1], data_type=_BF16)
+        WD = graph.tensor(name="Wd", dim=[E, H, interm], stride=[H * interm, interm, 1], data_type=_BF16)
         FTO = graph.tensor(name="first_token_offset", dim=[E, 1, 1], stride=[1, 1, 1], data_type=cudnn.data_type.INT32)
-        G = graph.tensor(name="gate", dim=[1, S, I], stride=[S * I, I, 1], data_type=_BF16)
-        U = graph.tensor(name="up", dim=[1, S, I], stride=[S * I, I, 1], data_type=_BF16)
+        G = graph.tensor(name="gate", dim=[1, S, interm], stride=[S * interm, interm, 1], data_type=_BF16)
+        U = graph.tensor(name="up", dim=[1, S, interm], stride=[S * interm, interm, 1], data_type=_BF16)
         dh = graph.moe_grouped_matmul(DY, WD, FTO, mode=cudnn.moe_grouped_matmul_mode.NONE, compute_data_type=_FP32, name="dh")
         dup = graph.mul(a=dh, b=graph.swish(input=G), name="dup")
         dgate = graph.mul(a=graph.swish_backward(loss=dh, input=G), b=U, name="dgate")
@@ -169,7 +172,7 @@ def _frost_dswiglu(dout, Wd, gate, up, offsets):
     binding = plan.binding
     outputs = _output_map(binding)
     aux = {tensor.get_name(): tensor for tensor in binding.aux}
-    dgate = torch.empty(1, S, I, dtype=dout.dtype, device=dout.device)
+    dgate = torch.empty(1, S, interm, dtype=dout.dtype, device=dout.device)
     dup = torch.empty_like(dgate)
     buffers = {"dgate": dgate, "dup": dup}
     workspace, stream = _frost_workspace(plan, dout)
@@ -189,44 +192,53 @@ def _frost_dswiglu(dout, Wd, gate, up, offsets):
     return dgate, dup
 
 
+def _cudnn_handle(tensor):
+    device = tensor.device
+    handle = _CUDNN_HANDLES.get(device.index)
+    if handle is None:
+        handle = cudnn.create_handle()
+        _CUDNN_HANDLES[device.index] = handle
+    cudnn.set_stream(handle=handle, stream=torch.cuda.current_stream(device).cuda_stream)
+    return handle
+
+
 def _moe_wgrad(doutput, token, offsets):
-    """cuTeDSL grouped wgrad, padding each routed expert to its 256-row contract."""
+    """Native cuDNN grouped wgrad with arbitrary expert token counts."""
     _, S, N = doutput.shape
     _, token_s, K = token.shape
     E = offsets.numel()
     if token_s != S:
         raise ValueError(f"internal grouped wgrad token mismatch: {S} and {token_s}")
-    starts = [int(value) for value in offsets.tolist()]
-    if not starts or starts[0] != 0 or any(a > b for a, b in zip(starts, starts[1:])) or starts[-1] > S:
-        raise ValueError("cudnn.gemm.swiglu_moe: offsets must start at 0 and be non-decreasing within S")
-    ends = starts[1:] + [S]
-    padded_sizes = [((end - begin + 255) // 256) * 256 for begin, end in zip(starts, ends)]
-    total = sum(padded_sizes)
-    doutput_pad = torch.zeros(N, total, dtype=doutput.dtype, device=doutput.device)
-    token_pad = torch.zeros(total, K, dtype=token.dtype, device=token.device)
-    padded_ends = []
-    dst = 0
-    for begin, end, padded in zip(starts, ends, padded_sizes):
-        rows = end - begin
-        if rows:
-            doutput_pad[:, dst : dst + rows].copy_(doutput[0, begin:end].transpose(0, 1))
-            token_pad[dst : dst + rows].copy_(token[0, begin:end])
-        dst += padded
-        padded_ends.append(dst)
-    padded_offsets = torch.tensor(padded_ends, dtype=torch.int32, device=token.device)
+    key = (S, N, K, E, doutput.dtype, *_device_key(doutput))
+    cached = _WGRAD_CACHE.get(key)
+    handle = _cudnn_handle(doutput)
+    if cached is None:
+        graph = cudnn.pygraph(intermediate_data_type=_FP32, compute_data_type=_FP32, handle=handle)
+        DY = graph.tensor(name="doutput", dim=[1, S, N], stride=[S * N, N, 1], data_type=_BF16)
+        X = graph.tensor(name="token", dim=[1, S, K], stride=[S * K, K, 1], data_type=_BF16)
+        FTO = graph.tensor(name="first_token_offset", dim=[E, 1, 1], stride=[1, 1, 1], data_type=cudnn.data_type.INT32)
+        DW = graph.moe_grouped_matmul_bwd(DY, X, FTO, compute_data_type=_FP32, name="wgrad")
+        # Logical [E,K,N], column-major inner dimensions.  Its physical storage
+        # is a contiguous [E,N,K] tensor, exactly the public weight layout.
+        DW.set_output(True).set_data_type(_BF16)
+        graph.validate()
+        graph.build_operation_graph()
+        graph.create_execution_plans([cudnn.heur_mode.A])
+        graph.check_support()
+        graph.build_plans()
+        cached = (graph, DY, X, FTO, DW, graph.get_workspace_size())
+        _WGRAD_CACHE[key] = cached
 
-    from cudnn.gemm.cutedsl.grouped.wgrad.api import grouped_gemm_wgrad_wrapper_sm100
-
-    result = grouped_gemm_wgrad_wrapper_sm100(
-        doutput_pad,
-        token_pad,
-        None,
-        None,
-        padded_offsets,
-        wgrad_dtype=torch.bfloat16,
-        current_stream=torch.cuda.current_stream(token.device).cuda_stream,
-    )
-    return result["wgrad_tensor"]
+    graph, DY, X, FTO, DW, workspace_size = cached
+    output = torch.empty(E, N, K, dtype=doutput.dtype, device=doutput.device)
+    stream = torch.cuda.current_stream(doutput.device).cuda_stream
+    workspace_key = (id(graph), doutput.device.index, stream)
+    workspace = _CUDNN_WORKSPACES.get(workspace_key)
+    if workspace is None:
+        workspace = torch.empty(workspace_size, dtype=torch.uint8, device=doutput.device)
+        _CUDNN_WORKSPACES[workspace_key] = workspace
+    graph.execute({DY: doutput, X: token, FTO: offsets, DW: output}, workspace, handle=handle)
+    return output
 
 
 class _SwiGLUMoE(torch.autograd.Function):
@@ -240,6 +252,7 @@ class _SwiGLUMoE(torch.autograd.Function):
         return output
 
     @staticmethod
+    @torch.autograd.function.once_differentiable
     def backward(ctx, dout):
         routed_x, Wg, Wu, Wd, offsets, h, gate, up = ctx.saved_tensors
         need_x, need_wg, need_wu, need_wd, _ = ctx.needs_input_grad
@@ -268,8 +281,13 @@ def swiglu_moe(routed_x, Wg, Wu, Wd, first_token_offset):
         Wg, Wu: Contiguous expert gate/up weights ``[E,I,H]`` in BF16.
         Wd: Contiguous expert down weights ``[E,H,I]`` in BF16.
         first_token_offset: Contiguous INT32 starts ``[E]`` (``[E,1,1]`` is
-            also accepted). Tokens remain in routed order; routing and combine
-            probabilities are intentionally outside this operation.
+            also accepted). The first value must be 0; all values must be in
+            ``[0, S]`` and monotonically nondecreasing. The last expert ends at
+            ``S``, so the final value is its start and need not equal ``S``.
+            Tokens remain in routed order; routing and combine probabilities
+            are intentionally outside this operation. These value invariants
+            are a device-data contract and are not host-validated on the hot
+            path.
 
     Returns:
         BF16 tensor ``[1,S,H]``, differentiable with respect to the tokens and
@@ -291,16 +309,16 @@ def swiglu_moe(routed_x, Wg, Wu, Wd, first_token_offset):
         )
     if any(tensor.device != routed_x.device for _, tensor in tensors[1:]) or first_token_offset.device != routed_x.device:
         raise ValueError(f"{prefix}: inputs and first_token_offset must be on the same CUDA device")
-    E, I, H = Wg.shape
-    if Wu.shape != Wg.shape or Wd.shape != (E, H, I) or routed_x.shape[2] != H:
+    E, interm, H = Wg.shape
+    if Wu.shape != Wg.shape or Wd.shape != (E, H, interm) or routed_x.shape[2] != H:
         raise ValueError(
-            f"{prefix}: expected x[1,S,{H}], Wg/Wu[{E},{I},{H}], Wd[{E},{H},{I}]; "
+            f"{prefix}: expected x[1,S,{H}], Wg/Wu[{E},{interm},{H}], Wd[{E},{H},{interm}]; "
             f"got x{tuple(routed_x.shape)}, Wg{tuple(Wg.shape)}, Wu{tuple(Wu.shape)}, Wd{tuple(Wd.shape)}"
         )
     if first_token_offset.dtype != torch.int32 or first_token_offset.numel() != E or not first_token_offset.is_contiguous():
         raise ValueError(f"{prefix}: first_token_offset must be contiguous int32 with E={E} elements")
-    if H % 8 or I % 8 or routed_x.shape[1] == 0:
-        raise ValueError(f"{prefix}: S must be nonzero and H/I multiples of 8; got S={routed_x.shape[1]}, H={H}, I={I}")
+    if H % 8 or interm % 8 or routed_x.shape[1] == 0:
+        raise ValueError(f"{prefix}: S must be nonzero and H/I multiples of 8; " f"got S={routed_x.shape[1]}, H={H}, I={interm}")
     capability = torch.cuda.get_device_capability(routed_x.device)
     if not ((10, 0) <= capability < (12, 0)):
         raise RuntimeError(f"{prefix}: FROST MoE requires SM100-SM119, got SM{capability[0]}{capability[1]}")

--- a/python/cudnn/gemm/ops/swiglu_moe.py
+++ b/python/cudnn/gemm/ops/swiglu_moe.py
@@ -1,0 +1,313 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pre-routed BF16 SwiGLU Mixture-of-Experts operation.
+
+The caller owns routing.  Tokens are already grouped by expert and
+``first_token_offset[e]`` is the first row belonging to expert ``e``; the last
+expert ends at ``routed_x.shape[1]``.  One fused FROST kernel computes the two
+FC1 grouped GEMMs and SwiGLU, then a grouped GEMM computes the down projection.
+The custom autograd function supplies gradients for the tokens and all three
+expert weights.
+"""
+
+from __future__ import annotations
+
+import torch
+
+import cudnn
+
+_BF16 = cudnn.data_type.BFLOAT16
+_FP32 = cudnn.data_type.FLOAT
+
+_FC1_CACHE = {}
+_MM_CACHE = {}
+_DSWIGLU_CACHE = {}
+_FROST_WORKSPACES = {}
+
+
+def _device_key(tensor: torch.Tensor) -> tuple:
+    device = tensor.device
+    return device.index, torch.cuda.get_device_capability(device)
+
+
+def _frost_plan(graph):
+    from cudnn.gemm.frost.graph_analyzer import build_gemm_plan
+
+    return build_gemm_plan(graph)
+
+
+def _output_map(binding) -> dict[str, object]:
+    return {tensor.get_name().split("::")[0]: tensor for tensor in binding.outputs}
+
+
+def _frost_workspace(plan, tensor):
+    """Per-plan/per-stream torch-owned MoE descriptor workspace."""
+    stream = torch.cuda.current_stream(tensor.device).cuda_stream
+    key = (id(plan), tensor.device.index, stream)
+    workspace = _FROST_WORKSPACES.get(key)
+    if workspace is None:
+        workspace = torch.empty(plan.workspace_bytes, dtype=torch.uint8, device=tensor.device)
+        _FROST_WORKSPACES[key] = workspace
+    return workspace, stream
+
+
+def _frost_fc1(routed_x, Wg, Wu, offsets):
+    """Fused ``gate/up grouped GEMMs + SwiGLU``; also materialize BF16 taps."""
+    _, S, H = routed_x.shape
+    E, I, _ = Wg.shape
+    key = ("fc1", S, H, I, E, routed_x.dtype, *_device_key(routed_x))
+    plan = _FC1_CACHE.get(key)
+    if plan is None:
+        graph = cudnn.pygraph(io_data_type=_BF16, intermediate_data_type=_FP32, compute_data_type=_FP32)
+        X = graph.tensor(name="x", dim=[1, S, H], stride=[S * H, H, 1], data_type=_BF16)
+        WG = graph.tensor(name="Wg", dim=[E, H, I], stride=[H * I, 1, H], data_type=_BF16)
+        WU = graph.tensor(name="Wu", dim=[E, H, I], stride=[H * I, 1, H], data_type=_BF16)
+        FTO = graph.tensor(name="first_token_offset", dim=[E, 1, 1], stride=[1, 1, 1], data_type=cudnn.data_type.INT32)
+        gate_raw = graph.moe_grouped_matmul(X, WG, FTO, mode=cudnn.moe_grouped_matmul_mode.NONE, compute_data_type=_FP32, name="gate")
+        up_raw = graph.moe_grouped_matmul(X, WU, FTO, mode=cudnn.moe_grouped_matmul_mode.NONE, compute_data_type=_FP32, name="up")
+        # Match BF16 nn.Linear semantics before evaluating SiLU in FP32.
+        gate_raw.set_data_type(_BF16)
+        up_raw.set_data_type(_BF16)
+        gate = graph.identity(input=gate_raw, name="gate_tap")
+        up = graph.identity(input=up_raw, name="up_tap")
+        gate.set_output(True).set_data_type(_BF16)
+        up.set_output(True).set_data_type(_BF16)
+        h = graph.mul(a=graph.swish(input=gate, name="silu"), b=up, name="h")
+        h.set_output(True).set_data_type(_BF16)
+        plan = _frost_plan(graph)
+        _FC1_CACHE[key] = plan
+
+    binding = plan.binding
+    outputs = _output_map(binding)
+    gate = torch.empty(1, S, I, dtype=routed_x.dtype, device=routed_x.device)
+    up = torch.empty_like(gate)
+    h = torch.empty_like(gate)
+    buffers = {"gate_tap": gate, "up_tap": up, "h": h}
+    workspace, stream = _frost_workspace(plan, routed_x)
+    plan(
+        {
+            binding.a_operands[0]: routed_x,
+            binding.b_operands[0]: Wg,
+            binding.b_operands[1]: Wu,
+            binding.first_token_offset: offsets,
+            **{tensor: buffers[name] for name, tensor in outputs.items()},
+        },
+        workspace=workspace,
+        stream=stream,
+    )
+    return h, gate, up
+
+
+def _frost_mm(token, weight, offsets):
+    """One grouped GEMM; runtime weight follows FROST's physical ``[E,N,K]`` contract."""
+    _, S, K = token.shape
+    E, N, weight_k = weight.shape
+    if weight_k != K:
+        raise ValueError(f"internal grouped GEMM K mismatch: token K={K}, weight K={weight_k}")
+    key = (
+        "mm",
+        S,
+        K,
+        N,
+        E,
+        tuple(weight.stride()),
+        token.dtype,
+        *_device_key(token),
+    )
+    plan = _MM_CACHE.get(key)
+    if plan is None:
+        graph = cudnn.pygraph(io_data_type=_BF16, intermediate_data_type=_FP32, compute_data_type=_FP32)
+        A = graph.tensor(name="token", dim=[1, S, K], stride=[S * K, K, 1], data_type=_BF16)
+        logical_weight = weight.transpose(1, 2)
+        B = graph.tensor(name="weight", dim=[E, K, N], stride=list(logical_weight.stride()), data_type=_BF16)
+        FTO = graph.tensor(name="first_token_offset", dim=[E, 1, 1], stride=[1, 1, 1], data_type=cudnn.data_type.INT32)
+        Y = graph.moe_grouped_matmul(A, B, FTO, mode=cudnn.moe_grouped_matmul_mode.NONE, compute_data_type=_FP32, name="out")
+        Y.set_output(True).set_data_type(_BF16)
+        plan = _frost_plan(graph)
+        _MM_CACHE[key] = plan
+
+    binding = plan.binding
+    output = torch.empty(1, S, N, dtype=token.dtype, device=token.device)
+    workspace, stream = _frost_workspace(plan, token)
+    plan(
+        {
+            binding.a_operands[0]: token,
+            binding.b_operands[0]: weight,
+            binding.first_token_offset: offsets,
+            binding.outputs[0]: output,
+        },
+        workspace=workspace,
+        stream=stream,
+    )
+    return output
+
+
+def _frost_dswiglu(dout, Wd, gate, up, offsets):
+    """Fuse the grouped down dgrad with both SwiGLU derivatives."""
+    _, S, H = dout.shape
+    E, weight_h, I = Wd.shape
+    if weight_h != H:
+        raise ValueError(f"internal grouped dSwiGLU H mismatch: dout H={H}, Wd H={weight_h}")
+    key = ("dswiglu", S, H, I, E, dout.dtype, *_device_key(dout))
+    plan = _DSWIGLU_CACHE.get(key)
+    if plan is None:
+        graph = cudnn.pygraph(io_data_type=_BF16, intermediate_data_type=_FP32, compute_data_type=_FP32)
+        DY = graph.tensor(name="dout", dim=[1, S, H], stride=[S * H, H, 1], data_type=_BF16)
+        WD = graph.tensor(name="Wd", dim=[E, H, I], stride=[H * I, I, 1], data_type=_BF16)
+        FTO = graph.tensor(name="first_token_offset", dim=[E, 1, 1], stride=[1, 1, 1], data_type=cudnn.data_type.INT32)
+        G = graph.tensor(name="gate", dim=[1, S, I], stride=[S * I, I, 1], data_type=_BF16)
+        U = graph.tensor(name="up", dim=[1, S, I], stride=[S * I, I, 1], data_type=_BF16)
+        dh = graph.moe_grouped_matmul(DY, WD, FTO, mode=cudnn.moe_grouped_matmul_mode.NONE, compute_data_type=_FP32, name="dh")
+        dup = graph.mul(a=dh, b=graph.swish(input=G), name="dup")
+        dgate = graph.mul(a=graph.swish_backward(loss=dh, input=G), b=U, name="dgate")
+        dup.set_output(True).set_data_type(_BF16)
+        dgate.set_output(True).set_data_type(_BF16)
+        plan = _frost_plan(graph)
+        _DSWIGLU_CACHE[key] = plan
+
+    binding = plan.binding
+    outputs = _output_map(binding)
+    aux = {tensor.get_name(): tensor for tensor in binding.aux}
+    dgate = torch.empty(1, S, I, dtype=dout.dtype, device=dout.device)
+    dup = torch.empty_like(dgate)
+    buffers = {"dgate": dgate, "dup": dup}
+    workspace, stream = _frost_workspace(plan, dout)
+    plan(
+        {
+            binding.a_operands[0]: dout,
+            # Physical [E,N=I,K=H], as a zero-copy N-major view of [E,H,I].
+            binding.b_operands[0]: Wd.transpose(1, 2),
+            binding.first_token_offset: offsets,
+            aux["gate"]: gate,
+            aux["up"]: up,
+            **{tensor: buffers[name] for name, tensor in outputs.items()},
+        },
+        workspace=workspace,
+        stream=stream,
+    )
+    return dgate, dup
+
+
+def _moe_wgrad(doutput, token, offsets):
+    """cuTeDSL grouped wgrad, padding each routed expert to its 256-row contract."""
+    _, S, N = doutput.shape
+    _, token_s, K = token.shape
+    E = offsets.numel()
+    if token_s != S:
+        raise ValueError(f"internal grouped wgrad token mismatch: {S} and {token_s}")
+    starts = [int(value) for value in offsets.tolist()]
+    if not starts or starts[0] != 0 or any(a > b for a, b in zip(starts, starts[1:])) or starts[-1] > S:
+        raise ValueError("cudnn.gemm.swiglu_moe: offsets must start at 0 and be non-decreasing within S")
+    ends = starts[1:] + [S]
+    padded_sizes = [((end - begin + 255) // 256) * 256 for begin, end in zip(starts, ends)]
+    total = sum(padded_sizes)
+    doutput_pad = torch.zeros(N, total, dtype=doutput.dtype, device=doutput.device)
+    token_pad = torch.zeros(total, K, dtype=token.dtype, device=token.device)
+    padded_ends = []
+    dst = 0
+    for begin, end, padded in zip(starts, ends, padded_sizes):
+        rows = end - begin
+        if rows:
+            doutput_pad[:, dst : dst + rows].copy_(doutput[0, begin:end].transpose(0, 1))
+            token_pad[dst : dst + rows].copy_(token[0, begin:end])
+        dst += padded
+        padded_ends.append(dst)
+    padded_offsets = torch.tensor(padded_ends, dtype=torch.int32, device=token.device)
+
+    from cudnn.gemm.cutedsl.grouped.wgrad.api import grouped_gemm_wgrad_wrapper_sm100
+
+    result = grouped_gemm_wgrad_wrapper_sm100(
+        doutput_pad,
+        token_pad,
+        None,
+        None,
+        padded_offsets,
+        wgrad_dtype=torch.bfloat16,
+        current_stream=torch.cuda.current_stream(token.device).cuda_stream,
+    )
+    return result["wgrad_tensor"]
+
+
+class _SwiGLUMoE(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, routed_x, Wg, Wu, Wd, first_token_offset):
+        with torch.cuda.device(routed_x.device):
+            h, gate, up = _frost_fc1(routed_x, Wg, Wu, first_token_offset)
+            # Wd already has FROST's physical [E,N=H,K=I] runtime layout.
+            output = _frost_mm(h, Wd, first_token_offset)
+        ctx.save_for_backward(routed_x, Wg, Wu, Wd, first_token_offset, h, gate, up)
+        return output
+
+    @staticmethod
+    def backward(ctx, dout):
+        routed_x, Wg, Wu, Wd, offsets, h, gate, up = ctx.saved_tensors
+        need_x, need_wg, need_wu, need_wd, _ = ctx.needs_input_grad
+        with torch.cuda.device(dout.device):
+            dgate = dup = None
+            if need_x or need_wg or need_wu:
+                dgate, dup = _frost_dswiglu(dout.contiguous(), Wd, gate, up, offsets)
+            dx = None
+            if need_x:
+                dx = _frost_mm(dgate, Wg.transpose(1, 2), offsets) + _frost_mm(dup, Wu.transpose(1, 2), offsets)
+            dWg = _moe_wgrad(dgate, routed_x, offsets) if need_wg else None
+            dWu = _moe_wgrad(dup, routed_x, offsets) if need_wu else None
+            dWd = _moe_wgrad(dout.contiguous(), h, offsets) if need_wd else None
+        return dx, dWg, dWu, dWd, None
+
+
+def swiglu_moe(routed_x, Wg, Wu, Wd, first_token_offset):
+    """Pre-routed BF16 MoE layer.
+
+    For expert ``e`` and rows ``b:e`` selected by ``first_token_offset``:
+
+    ``out = (silu(x @ Wg[e].T) * (x @ Wu[e].T)) @ Wd[e].T``.
+
+    Args:
+        routed_x: Expert-grouped tokens ``[1,S,H]`` in row-major BF16.
+        Wg, Wu: Contiguous expert gate/up weights ``[E,I,H]`` in BF16.
+        Wd: Contiguous expert down weights ``[E,H,I]`` in BF16.
+        first_token_offset: Contiguous INT32 starts ``[E]`` (``[E,1,1]`` is
+            also accepted). Tokens remain in routed order; routing and combine
+            probabilities are intentionally outside this operation.
+
+    Returns:
+        BF16 tensor ``[1,S,H]``, differentiable with respect to the tokens and
+        all three expert weights.
+    """
+    prefix = "cudnn.gemm.swiglu_moe"
+    tensors = (("routed_x", routed_x), ("Wg", Wg), ("Wu", Wu), ("Wd", Wd))
+    for name, tensor in tensors:
+        if tensor.dtype != torch.bfloat16:
+            raise TypeError(f"{prefix}: {name} must be bfloat16, got {tensor.dtype}")
+        if tensor.device.type != "cuda":
+            raise ValueError(f"{prefix}: {name} must be a CUDA tensor, got {tensor.device}")
+        if not tensor.is_contiguous():
+            raise ValueError(f"{prefix}: {name} must be contiguous, got stride {tuple(tensor.stride())}")
+    if routed_x.dim() != 3 or routed_x.shape[0] != 1 or Wg.dim() != 3 or Wu.dim() != 3 or Wd.dim() != 3:
+        raise ValueError(
+            f"{prefix}: expected routed_x[1,S,H], Wg/Wu[E,I,H], Wd[E,H,I]; "
+            f"got {tuple(routed_x.shape)}, {tuple(Wg.shape)}, {tuple(Wu.shape)}, {tuple(Wd.shape)}"
+        )
+    if any(tensor.device != routed_x.device for _, tensor in tensors[1:]) or first_token_offset.device != routed_x.device:
+        raise ValueError(f"{prefix}: inputs and first_token_offset must be on the same CUDA device")
+    E, I, H = Wg.shape
+    if Wu.shape != Wg.shape or Wd.shape != (E, H, I) or routed_x.shape[2] != H:
+        raise ValueError(
+            f"{prefix}: expected x[1,S,{H}], Wg/Wu[{E},{I},{H}], Wd[{E},{H},{I}]; "
+            f"got x{tuple(routed_x.shape)}, Wg{tuple(Wg.shape)}, Wu{tuple(Wu.shape)}, Wd{tuple(Wd.shape)}"
+        )
+    if first_token_offset.dtype != torch.int32 or first_token_offset.numel() != E or not first_token_offset.is_contiguous():
+        raise ValueError(f"{prefix}: first_token_offset must be contiguous int32 with E={E} elements")
+    if H % 8 or I % 8 or routed_x.shape[1] == 0:
+        raise ValueError(f"{prefix}: S must be nonzero and H/I multiples of 8; got S={routed_x.shape[1]}, H={H}, I={I}")
+    capability = torch.cuda.get_device_capability(routed_x.device)
+    if not ((10, 0) <= capability < (12, 0)):
+        raise RuntimeError(f"{prefix}: FROST MoE requires SM100-SM119, got SM{capability[0]}{capability[1]}")
+    # The graph declares cuDNN's [E,1,1] descriptor, while FROST's runtime
+    # contract consumes the same storage as a rank-1 offsets vector.
+    offsets = first_token_offset.reshape(E)
+    return _SwiGLUMoE.apply(routed_x, Wg, Wu, Wd, offsets)
+
+
+__all__ = ["swiglu_moe"]

--- a/test/python/gemm/test_swiglu_moe.py
+++ b/test/python/gemm/test_swiglu_moe.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public pre-routed SwiGLU MoE operation tests."""
+
+import pytest
+import torch
+
+from cudnn.gemm import swiglu_moe
+
+
+def _cc():
+    major, minor = torch.cuda.get_device_capability()
+    return major * 10 + minor
+
+
+def _relative_l2(actual, expected):
+    return (actual.float() - expected.float()).norm() / expected.float().norm().clamp_min(1e-9)
+
+
+def _reference(x, Wg, Wu, Wd, starts):
+    S = x.shape[1]
+    output = torch.empty_like(x)
+    for expert, begin in enumerate(starts):
+        end = starts[expert + 1] if expert + 1 < len(starts) else S
+        if begin == end:
+            continue
+        token = x[:, begin:end]
+        gate = token @ Wg[expert].transpose(0, 1)
+        up = token @ Wu[expert].transpose(0, 1)
+        h = (torch.nn.functional.silu(gate.float()) * up.float()).to(torch.bfloat16)
+        output[:, begin:end] = h @ Wd[expert].transpose(0, 1)
+    return output
+
+
+@pytest.mark.L0
+def test_swiglu_moe_is_public():
+    import cudnn.gemm as gemm
+    import cudnn.gemm.ops as ops
+
+    assert gemm.swiglu_moe is swiglu_moe
+    assert ops.swiglu_moe is swiglu_moe
+
+
+@pytest.mark.L0
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() and 100 <= _cc() < 120),
+    reason="FROST SwiGLU MoE requires SM100-SM119",
+)
+def test_swiglu_moe_forward_and_all_gradients_with_empty_expert():
+    E, H, I = 4, 128, 256
+    group_sizes = [64, 0, 96, 32]
+    starts, total = [], 0
+    for size in group_sizes:
+        starts.append(total)
+        total += size
+
+    torch.manual_seed(7)
+    base = (
+        torch.randn(1, total, H, device="cuda", dtype=torch.bfloat16) * 0.2,
+        torch.randn(E, I, H, device="cuda", dtype=torch.bfloat16) * 0.02,
+        torch.randn(E, I, H, device="cuda", dtype=torch.bfloat16) * 0.02,
+        torch.randn(E, H, I, device="cuda", dtype=torch.bfloat16) * 0.02,
+    )
+    actual_inputs = tuple(t.detach().clone().requires_grad_(True) for t in base)
+    reference_inputs = tuple(t.detach().clone().requires_grad_(True) for t in base)
+    offsets = torch.tensor(starts, device="cuda", dtype=torch.int32)
+
+    actual = swiglu_moe(*actual_inputs, offsets)
+    expected = _reference(*reference_inputs, starts)
+    dout = torch.randn_like(actual)
+    actual.backward(dout)
+    expected.backward(dout)
+
+    assert _relative_l2(actual, expected) < 1e-2
+    for name, got, ref in zip(("dx", "dWg", "dWu", "dWd"), actual_inputs, reference_inputs):
+        error = _relative_l2(got.grad, ref.grad)
+        assert error < 1e-2, f"{name} relative L2 error {error.item():.3e}"
+
+
+@pytest.mark.L0
+def test_swiglu_moe_validates_public_layout():
+    x = torch.empty(1, 8, 16, dtype=torch.bfloat16)
+    Wg = torch.empty(2, 32, 16, dtype=torch.bfloat16)
+    Wu = torch.empty_like(Wg)
+    Wd = torch.empty(2, 16, 32, dtype=torch.bfloat16)
+    offsets = torch.tensor([0, 4], dtype=torch.int32)
+    with pytest.raises(ValueError, match="must be a CUDA tensor"):
+        swiglu_moe(x, Wg, Wu, Wd, offsets)


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches (see [root AGENTS.md § Reviewing a PR](https://github.com/NVIDIA/cudnn-frontend/blob/develop/AGENTS.md#reviewing-a-pr-human-or-agent)) and my changes comply, or I explain the exception below.
- [x] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

Add moe-swiglu model specific api
Enable autotuning in model specific apis

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a pre-routed SwiGLU Mixture-of-Experts operation for supported CUDA BF16 workloads, including forward computation and gradients.
  - Exposed the operation through the GEMM package’s public API.
  - Added runtime autotuning for SwiGLU backward operations, with cached results and an option to disable autotuning.
  - Added support for arbitrary expert token counts.

- **Bug Fixes**
  - Improved tensor contiguity validation and error details, including relevant shapes and strides.

- **Tests**
  - Added coverage for API access, outputs, gradients, empty expert groups, and CPU input validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->