### PR TITLE
Msalasoo/conv fixed python coverage

### DIFF
--- a/test/python/test_conv_fixed.py
+++ b/test/python/test_conv_fixed.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import random
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+import torch
+
+import test_conv_fuzzer as conv_fuzzer
+from sdpa.helpers import create_sparse_int_tensor
+
+
+@dataclass(frozen=True)
+class FixedConvCase:
+    config: conv_fuzzer.ConvConfig
+    rtol: float = 1e-2
+    atol: float = 1e-2
+    accumulate_output: bool = False
+
+
+@pytest.fixture
+def num_diffs(request):
+    return request.config.getoption("--diffs")
+
+
+def _fixed_conv_case(
+    *,
+    spatial_dims: int,
+    batch: int,
+    in_channels: int,
+    out_channels: int,
+    input_spatial,
+    filter_spatial,
+    padding,
+    stride,
+    dilation,
+    conv_type: conv_fuzzer.ConvType,
+    dtype: torch.dtype,
+    epilogue: conv_fuzzer.EpilogueType = conv_fuzzer.EpilogueType.NONE,
+    rtol: float = 1e-2,
+    atol: float = 1e-2,
+    accumulate_output: bool = False,
+    rng_seed: int,
+) -> FixedConvCase:
+    config = conv_fuzzer.ConvConfig(
+        spatial_dims=spatial_dims,
+        batch=batch,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        groups=1,
+        input_spatial=input_spatial,
+        filter_spatial=filter_spatial,
+        padding=padding,
+        stride=stride,
+        dilation=dilation,
+        conv_type=conv_type,
+        x_dtype=dtype,
+        w_dtype=dtype,
+        y_dtype=dtype,
+        epilogue=epilogue,
+        rng_seed=rng_seed,
+    )
+    return FixedConvCase(config=config, rtol=rtol, atol=atol, accumulate_output=accumulate_output)
+
+
+FIXED_CONV_CASES_L0 = tuple(
+    pytest.param(
+        _fixed_conv_case(
+            spatial_dims=2,
+            batch=2,
+            in_channels=8,
+            out_channels=8,
+            input_spatial=(15, 20),
+            filter_spatial=(3, 3),
+            padding=(1, 1),
+            stride=(1, 1),
+            dilation=(1, 1),
+            conv_type=conv_type,
+            dtype=torch.float32,
+            accumulate_output=True,
+            rng_seed=100 + int(conv_type),
+        ),
+        id=f"conv2d_{conv_fuzzer.conv_type_name(conv_type)}_accum_f32",
+    )
+    for conv_type in (conv_fuzzer.ConvType.FPROP, conv_fuzzer.ConvType.DGRAD, conv_fuzzer.ConvType.WGRAD)
+) + (
+    pytest.param(
+        _fixed_conv_case(
+            spatial_dims=2,
+            batch=5,
+            in_channels=32,
+            out_channels=32,
+            input_spatial=(32, 32),
+            filter_spatial=(3, 3),
+            padding=(1, 1),
+            stride=(1, 1),
+            dilation=(1, 1),
+            conv_type=conv_fuzzer.ConvType.FPROP,
+            dtype=torch.float16,
+            epilogue=conv_fuzzer.EpilogueType.BIAS,
+            rtol=2.5e-3,
+            atol=2.5e-3,
+            rng_seed=103,
+        ),
+        id="conv2d_bias_f16",
+    ),
+)
+
+
+FIXED_CONV_CASES_L1 = tuple(
+    pytest.param(
+        _fixed_conv_case(
+            spatial_dims=3,
+            batch=2,
+            in_channels=8,
+            out_channels=8,
+            input_spatial=(15, 20, 25),
+            filter_spatial=(3, 3, 3),
+            padding=(1, 1, 1),
+            stride=(1, 1, 1),
+            dilation=(1, 1, 1),
+            conv_type=conv_type,
+            dtype=torch.float32,
+            accumulate_output=True,
+            rng_seed=104 + int(conv_type),
+        ),
+        id=f"conv3d_{conv_fuzzer.conv_type_name(conv_type)}_accum_f32",
+    )
+    for conv_type in (conv_fuzzer.ConvType.FPROP, conv_fuzzer.ConvType.DGRAD, conv_fuzzer.ConvType.WGRAD)
+) + tuple(
+    pytest.param(
+        _fixed_conv_case(
+            spatial_dims=3,
+            batch=batch,
+            in_channels=3,
+            out_channels=out_channels,
+            input_spatial=(32, 32, 32),
+            filter_spatial=(3, 3, 3),
+            padding=(3, 0, 0),
+            stride=(7, 1, 1),
+            dilation=(1, 1, 1),
+            conv_type=conv_fuzzer.ConvType.FPROP,
+            dtype=torch.float16,
+            rtol=2.5e-3,
+            atol=2.5e-3,
+            rng_seed=107 + batch_index * 3 + channel_index,
+        ),
+        id=f"conv3d_n{batch}_k{out_channels}_f16",
+    )
+    for batch_index, batch in enumerate((4, 24, 31))
+    for channel_index, out_channels in enumerate((32, 24, 9))
+)
+
+
+def _create_prior_output(conv_case: FixedConvCase, X: torch.Tensor, W: torch.Tensor, Y: torch.Tensor) -> Optional[torch.Tensor]:
+    """Create an independently seeded initial value for output accumulation."""
+    if not conv_case.accumulate_output:
+        return None
+
+    config = conv_case.config
+    if config.conv_type == conv_fuzzer.ConvType.FPROP:
+        destination = Y
+    elif config.conv_type == conv_fuzzer.ConvType.DGRAD:
+        destination = X
+    else:
+        destination = W
+
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(config.rng_seed + 10_000)
+    memory_format = torch.channels_last if config.spatial_dims == 2 else torch.channels_last_3d
+    return create_sparse_int_tensor(destination.size(), destination.dtype, generator, memory_format=memory_format)
+
+
+def _run_fixed_conv_test(conv_case: FixedConvCase, cudnn_handle, num_diffs: int) -> None:
+    config = conv_case.config
+    X = W = Y = bias = prior_output = reference = None
+    try:
+        X, W, Y, bias = conv_fuzzer.create_tensors(config, random.Random(config.rng_seed))
+        prior_output = _create_prior_output(conv_case, X, W, Y)
+
+        execution_succeeded, execution_message = conv_fuzzer.run_cudnn_conv(config, X, W, Y, bias, cudnn_handle, prior_output=prior_output)
+        if not execution_succeeded:
+            pytest.fail(execution_message)
+
+        reference = conv_fuzzer.compute_reference(config, X, W, Y, bias, prior_output=prior_output)
+        if config.conv_type == conv_fuzzer.ConvType.FPROP:
+            actual_output, output_dtype, output_name = Y, config.y_dtype, "Y"
+        elif config.conv_type == conv_fuzzer.ConvType.DGRAD:
+            actual_output, output_dtype, output_name = X, config.x_dtype, "dX"
+        else:
+            actual_output, output_dtype, output_name = W, config.w_dtype, "dW"
+
+        comparison_passed, comparison_message = conv_fuzzer.compare_results(
+            actual_output,
+            reference,
+            output_dtype,
+            num_diffs,
+            rtol=conv_case.rtol,
+            atol=conv_case.atol,
+        )
+        assert comparison_passed, f"{output_name} numerical mismatch: {comparison_message}"
+    finally:
+        del X, W, Y, bias, prior_output, reference
+        torch.cuda.empty_cache()
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("conv_case", FIXED_CONV_CASES_L0)
+def test_conv_fixed_L0(conv_case: FixedConvCase, cudnn_handle, num_diffs):
+    _run_fixed_conv_test(conv_case, cudnn_handle, num_diffs)
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize("conv_case", FIXED_CONV_CASES_L1)
+def test_conv_fixed_L1(conv_case: FixedConvCase, cudnn_handle, num_diffs):
+    _run_fixed_conv_test(conv_case, cudnn_handle, num_diffs)

--- a/test/python/test_conv_fuzzer.py
+++ b/test/python/test_conv_fuzzer.py
@@ -623,7 +623,8 @@ def create_tensors(config: ConvConfig, rng: random.Random):
 
 
 def compute_reference(config: ConvConfig, X: torch.Tensor, W: torch.Tensor,
-                      Y: torch.Tensor, bias: Optional[torch.Tensor]) -> torch.Tensor:
+                      Y: torch.Tensor, bias: Optional[torch.Tensor],
+                      prior_output: Optional[torch.Tensor] = None) -> torch.Tensor:
     """
     Compute reference result using PyTorch.
 
@@ -631,6 +632,8 @@ def compute_reference(config: ConvConfig, X: torch.Tensor, W: torch.Tensor,
       FPROP: compute Y = conv(X, W) + bias + relu
       DGRAD: compute dX from dY(=Y) and W
       WGRAD: compute dW from X and dY(=Y)
+
+    If prior_output is provided, it is added before the FPROP epilogue or to the computed dX/dW.
 
     Returns the tensor that should match the cuDNN output:
       FPROP -> Y_ref (to compare with Y)
@@ -663,6 +666,9 @@ def compute_reference(config: ConvConfig, X: torch.Tensor, W: torch.Tensor,
                         dilation=config.dilation,
                         groups=config.groups
                     )
+
+                if prior_output is not None:
+                    ref = ref + prior_output.to(compute_dtype)
 
                 # Apply epilogue
                 if bias is not None and config.epilogue in [EpilogueType.BIAS, EpilogueType.BIAS_RELU]:
@@ -708,6 +714,9 @@ def compute_reference(config: ConvConfig, X: torch.Tensor, W: torch.Tensor,
                 dummy_Y.backward(dY_f)
                 dX_ref = dummy_X.grad.clone()
 
+                if prior_output is not None:
+                    dX_ref = dX_ref + prior_output.to(compute_dtype)
+
                 return dX_ref.to(config.x_dtype)
             finally:
                 del dY_f, W_f, dummy_X
@@ -748,6 +757,9 @@ def compute_reference(config: ConvConfig, X: torch.Tensor, W: torch.Tensor,
                 dummy_Y.backward(dY_f)
                 dW_ref = dummy_W.grad.clone()
 
+                if prior_output is not None:
+                    dW_ref = dW_ref + prior_output.to(compute_dtype)
+
                 return dW_ref.to(config.w_dtype)
             finally:
                 del X_f, dY_f, dummy_W
@@ -756,7 +768,8 @@ def compute_reference(config: ConvConfig, X: torch.Tensor, W: torch.Tensor,
 
 
 def run_cudnn_conv(config: ConvConfig, X: torch.Tensor, W: torch.Tensor, Y: torch.Tensor,
-                   bias: Optional[torch.Tensor], cudnn_handle) -> Tuple[bool, str]:
+                   bias: Optional[torch.Tensor], cudnn_handle,
+                   prior_output: Optional[torch.Tensor] = None) -> Tuple[bool, str]:
     """
     Run convolution using cuDNN and return success status and message.
 
@@ -764,6 +777,8 @@ def run_cudnn_conv(config: ConvConfig, X: torch.Tensor, W: torch.Tensor, Y: torc
       FPROP: inputs=X,W, output=Y     (compute Y)
       DGRAD: inputs=Y(dY),W, output=X (compute dX into X)
       WGRAD: inputs=X,Y(dY), output=W (compute dW into W)
+
+    If prior_output is provided, it is added before the FPROP epilogue or to the computed dX/dW.
     """
     try:
         stream = torch.cuda.current_stream().cuda_stream
@@ -805,6 +820,15 @@ def run_cudnn_conv(config: ConvConfig, X: torch.Tensor, W: torch.Tensor, Y: torc
                 dilation=list(config.dilation),
             )
 
+            if prior_output is not None:
+                prior_output_tensor = graph.tensor(
+                    name="prior_Y",
+                    dim=list(prior_output.size()),
+                    stride=list(prior_output.stride()),
+                    data_type=convert_to_cudnn_type(config.y_dtype),
+                )
+                conv_output = graph.add(a=conv_output, b=prior_output_tensor, name="accumulate_Y")
+
             # Apply epilogue
             if config.epilogue in [EpilogueType.BIAS, EpilogueType.BIAS_RELU]:
                 B_tensor = graph.tensor(
@@ -822,6 +846,8 @@ def run_cudnn_conv(config: ConvConfig, X: torch.Tensor, W: torch.Tensor, Y: torc
             exec_dict = {X_tensor: X, W_tensor: W, conv_output: Y}
             if config.epilogue in [EpilogueType.BIAS, EpilogueType.BIAS_RELU]:
                 exec_dict[B_tensor] = bias
+            if prior_output is not None:
+                exec_dict[prior_output_tensor] = prior_output
 
         elif config.conv_type == ConvType.DGRAD:
             # DGRAD: dX = conv_dgrad(dY, W)
@@ -843,10 +869,23 @@ def run_cudnn_conv(config: ConvConfig, X: torch.Tensor, W: torch.Tensor, Y: torc
                 dilation=list(config.dilation),
             )
             # Must set output dimensions explicitly for dgrad (cuDNN can't infer them)
+            conv_output.set_dim(list(X.size())).set_stride(list(X.stride()))
+
+            if prior_output is not None:
+                prior_output_tensor = graph.tensor(
+                    name="prior_dX",
+                    dim=list(prior_output.size()),
+                    stride=list(prior_output.stride()),
+                    data_type=convert_to_cudnn_type(config.x_dtype),
+                )
+                conv_output = graph.add(a=conv_output, b=prior_output_tensor, name="accumulate_dX")
+
             conv_output.set_output(True).set_dim(list(X.size())).set_stride(list(X.stride()))
 
             # Execution dict: Y(dY),W are inputs, X(dX) is output
             exec_dict = {dY_tensor: Y, W_tensor: W, conv_output: X}
+            if prior_output is not None:
+                exec_dict[prior_output_tensor] = prior_output
 
         else:  # WGRAD
             # WGRAD: dW = conv_wgrad(X, dY)
@@ -867,10 +906,23 @@ def run_cudnn_conv(config: ConvConfig, X: torch.Tensor, W: torch.Tensor, Y: torc
                 stride=list(config.stride),
                 dilation=list(config.dilation),
             )
+            conv_output.set_dim(list(W.size())).set_stride(list(W.stride()))
+
+            if prior_output is not None:
+                prior_output_tensor = graph.tensor(
+                    name="prior_dW",
+                    dim=list(prior_output.size()),
+                    stride=list(prior_output.stride()),
+                    data_type=convert_to_cudnn_type(config.w_dtype),
+                )
+                conv_output = graph.add(a=conv_output, b=prior_output_tensor, name="accumulate_dW")
+
             conv_output.set_output(True).set_dim(list(W.size())).set_stride(list(W.stride()))
 
             # Execution dict: X,Y(dY) are inputs, W(dW) is output
             exec_dict = {X_tensor: X, dY_tensor: Y, conv_output: W}
+            if prior_output is not None:
+                exec_dict[prior_output_tensor] = prior_output
 
         # Validate and build
         graph.validate()
@@ -901,13 +953,11 @@ def run_cudnn_conv(config: ConvConfig, X: torch.Tensor, W: torch.Tensor, Y: torc
 
 
 def compare_results(actual: torch.Tensor, ref: torch.Tensor, _dtype: torch.dtype,
-                    num_diffs: int = 10) -> Tuple[bool, str]:
-    """Compare cuDNN result with reference."""
-    # Base tolerances - TF32/FP16/BF16 all have similar effective precision
-    # cuDNN uses TF32 for FP32 tensor core ops
-    # _dtype kept for potential future per-dtype tolerance tuning
-    rtol, atol = 1e-2, 1e-2
+                    num_diffs: int = 10, rtol: float = 1e-2, atol: float = 1e-2) -> Tuple[bool, str]:
+    """Compare cuDNN result with reference using caller-provided tolerances.
 
+    The defaults preserve existing fuzzer behavior. _dtype is reserved for future per-dtype tuning.
+    """
     passed, _, msg = compare_tensors(actual, ref, rtol=rtol, atol=atol, num_diffs=num_diffs)
     return passed, msg
 


### PR DESCRIPTION
# Add deterministic fixed convolution coverage

## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches (see [root AGENTS.md § Reviewing a PR](https://github.com/NVIDIA/cudnn-frontend/blob/develop/AGENTS.md#reviewing-a-pr-human-or-agent)) and my changes comply, or I explain the exception below.
- [ ] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

CI or test infrastructure

## Summary

Add 16 deterministic frontend Python convolution cases in `test_conv_fixed.py`:

- Four L0 cases covering 2D FP32 fprop, dgrad, and wgrad with output accumulation, plus FP16 ConvBias.
- Twelve L1 cases covering 3D FP32 fprop, dgrad, and wgrad with output accumulation, plus nine FP16 Conv3D configurations.

The fixed suite reuses the existing convolution fuzzer's tensor creation, graph construction, PyTorch references, and numerical comparison helpers. The helper defaults and randomized fuzzer behavior remain unchanged.

## Why

The randomized convolution fuzzer provides broad exploration, but its generated configurations can change between runs. This fixed suite adds stable, reproducible coverage for representative 2D and 3D forward and gradient paths, ConvBias, and convolution-plus-add accumulation. Fixed cases run exactly once and report unsupported graphs or numerical mismatches as failures instead of regenerating another configuration.

PyTorch's cuDNN backend is disabled while computing the references, so the frontend result is not compared against another cuDNN execution.

## Related issues

None.

## API and compatibility impact

None. This is test-only coverage. The existing fuzzer helpers gain optional prior-output and tolerance arguments whose defaults preserve all current callers.

The high-level convolution graph API uses fixed convolution-node alpha and beta values, so the accumulated cases represent the prior output with a pointwise add after convolution.

## Testing

Validated with cuDNN Frontend 1.29.0:

```text
python -m pytest test/python/test_conv_fixed.py \
  -o "addopts=" -m "L0 or L1" --tb=short --no-header -rfEsX
```

| GPU | Result | Runtime |
|---|---:|---:|
| NVIDIA L40S | 16 passed | 9.82s |
| NVIDIA H100 | 16 passed | 8.82s |
| NVIDIA B100 (SM100) | 16 passed | 8.18s |

```text
python -m pytest test/python/test_conv_fuzzer.py \
  -o "addopts=" -m L0 \
  --seed 12345 --tb=short --no-header -rfEsX
```

H100 result: `1040 passed, 1 skipped` in `37.77s`. The skip is the expected repro placeholder when no `--repro` argument is supplied.

```text
python -m pytest test/python/test_conv_fuzzer.py \
  -o "addopts=" -m L1 \
  --seed 12345 --tb=short --no-header -rfEsX
```

H100 result: `1056 passed` in `35.53s`.

Collection confirms four L0 and twelve L1 fixed cases. Focused `pre-commit` checks and `git diff --check` pass for both changed Python files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added fixed-case convolution coverage for 2D and 3D forward, data-gradient, and weight-gradient operations.
  - Expanded convolution validation to cover accumulated prior outputs and configurable numerical tolerances.
  - Added comparisons between cuDNN results and reference calculations across multiple parameter sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->