### PR TITLE
frost mxfp8 d=256 bwd: split the Q-head group across dK/dV clusters (GQA occupancy); write skipped causal-tail tiles

### DIFF
--- a/python/cudnn/sdpa/bwd/api_dsl_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/bwd/api_dsl_mxfp8_sm100.py
@@ -31,6 +31,14 @@ upstream; it costs ~1-2% of the backward (SF bytes are 1/32 of the payload)
 and is the first thing to remove once the kernels' SF path reads canonical
 atoms.
 
+Occupancy: the fused dK/dV kernel's grid is (KV tiles, KV heads, B) and one
+2-CTA cluster walks every Q head of its KV head, so with few KV heads (GQA /
+MQA at small batch) most SMs idle -- 2 KV heads at S=8192 is 64 clusters on
+148 SMs. The adapter therefore splits the Q-head group across clusters
+(``_dkdv_head_split``: the smallest divisor of the group that reaches about two
+waves of clusters); each slice writes a partial dK/dV and the shared
+fixed-order ``dkv_reduce`` fold sums them, so the result stays deterministic.
+
 Lives in its own module (not ``api_dsl.py``) so the MXFP8 lowering's imports
 stay out of the half-precision adapters' way; ``engines._adapter`` resolves it
 by name.
@@ -88,6 +96,7 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
         sample_sf_do,
         sample_sf_do_T,
         p_scale_log2: int = 8,
+        dkdv_head_split: Optional[int] = None,
         **kwargs,
     ) -> None:
         # Stashed raw; descs are built in _initialize_implementation, which the
@@ -106,13 +115,19 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
             sf_do_T=sample_sf_do_T,
         )
         self.p_scale_log2 = int(p_scale_log2)
+        # None = pick from the shape (see _dkdv_head_split); an int forces it.
+        self._dkdv_head_split_override = None if dkdv_head_split is None else int(dkdv_head_split)
         super().__init__(sample_q, sample_k, sample_v, sample_o, sample_do, sample_stats, sample_dq, sample_dk, sample_dv, **kwargs)
 
     # --- geometry --------------------------------------------------------------
     @staticmethod
     def _bshd_physical_ok(desc: TensorDesc) -> bool:
+        """Compact BSHD storage under a logical BHSD desc. Extent-1 dims are
+        wildcards: their stride is unobservable, and torch reports an arbitrary
+        one for e.g. the head dim of an MQA K/V tensor."""
         b, h, s, d = (int(x) for x in desc.shape)
-        return tuple(int(x) for x in desc.stride) == (s * h * d, d, h * d, 1)
+        want = (s * h * d, d, h * d, 1)
+        return all(sz == 1 or int(st) == w for sz, st, w in zip((b, h, s, d), desc.stride, want))
 
     def _sf_plan(self):
         """The eleven kernel-side SF buffers: (name, graph SF, rows, k_groups, planes, layout, plane_major).
@@ -178,7 +193,41 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
         if self.scale_softmax is None or self.scale_softmax == 0.0:
             self.scale_softmax = 1.0 / math.sqrt(self.head_dim_qk)
         self._gqa_group = self.h_q // max(self.h_kv, 1)
+        self._dkdv_split = self._dkdv_head_split()
         self._compiled = None
+
+    # dK/dV cluster count below which the Q-head group is split across clusters:
+    # two waves of 2-CTA clusters over the SMs.
+    _DKDV_TARGET_CLUSTERS_PER_SM = 2
+
+    def _dkdv_head_split(self) -> int:
+        """How many clusters share one (KV tile, KV head): the smallest divisor of
+        the GQA group that gives the fused dK/dV kernel about two waves of
+        clusters, or the whole group if none does.
+
+        The kernel's grid is (KV tiles, KV heads, B) and one cluster walks every
+        Q head of its KV head, so with few KV heads most SMs idle: 2 KV heads at
+        S=8192 is 64 clusters on 148 SMs. Each split writes a partial dK/dV
+        (one slot per Q-head slice) that a fixed-order fold sums, so the
+        result stays deterministic; the price is the partial buffers
+        (2 * split * |dK| bytes) and the fold's read of them.
+        """
+        if self._dkdv_head_split_override is not None:
+            split = self._dkdv_head_split_override
+            if split < 1 or self._gqa_group % split != 0:
+                raise ValueError(f"SM100 MXFP8 bwd: dkdv_head_split={split} must divide the GQA group {self._gqa_group}")
+            return split
+        h_r = self._gqa_group
+        kv_clusters = _cdiv(self.s_k_max, 128) * self.h_kv * self.batch_size
+        target = self._DKDV_TARGET_CLUSTERS_PER_SM * torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
+        split = 1
+        for cand in range(1, h_r + 1):
+            if h_r % cand:
+                continue
+            split = cand
+            if kv_clusters * cand >= target:
+                break
+        return split
 
     # --- capability backstop ---------------------------------------------------
     def check_support(self) -> bool:
@@ -255,6 +304,10 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
         from cudnn.sdpa.bwd.kernels.bprop_sf_repack_mxfp8_sm100 import repack_geometry
 
         total = ws_align(self._kernel_workspace_bytes())
+        if self._dkdv_split > 1:
+            # One dK and one dV partial per Q-head slice, in the gradient dtype.
+            part = self.batch_size * self.s_k_max * self.h_kv * self._dkdv_split * self.head_dim_qk * torch.tensor([], dtype=self.out_dtype).element_size()
+            total += 2 * ws_align(part)
         for _name, _src, rows, kg, l, layout, _pm in self._sf_plan():
             total += ws_align(repack_geometry(rows, kg, l, layout)[3])
         return total
@@ -271,8 +324,11 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
         hr = self._gqa_group
         q_geom = ((sq, d, hr, hk, b), (hq * d, 1, d, hr * d, sq * hq * d))
         kv_geom = ((sk, d, 1, hk, b), (hk * d, 1, d, d, sk * hk * d))
+        # dK/dV as the fused kernel sees them: h_kv * split partial slots per batch.
+        sp = self._dkdv_split
+        kv_out_geom = ((sk, d, 1, hk * sp, b), (hk * sp * d, 1, d, d, sk * hk * sp * d))
         lse_geom = ((sq, hr, hk, b), (1, sq, sq * hr, sq * hq))
-        return q_geom, kv_geom, lse_geom
+        return q_geom, kv_geom, lse_geom, kv_out_geom
 
     def _mask_types(self):
         from cudnn.sdpa.bwd.kernels import _bprop_mxfp8_masks_sm100 as masks
@@ -306,8 +362,9 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
         out_dt = cutlass.BFloat16 if self.out_dtype == torch.bfloat16 else cutlass.Float16
         b, hk, sq, sk, d = self.batch_size, self.h_kv, self.s_q_max, self.s_k_max, self.head_dim_qk
         hr = self._gqa_group
-        q_geom, kv_geom, lse_geom = self._kernel_view_geoms()
+        q_geom, kv_geom, lse_geom, kv_out_geom = self._kernel_view_geoms()
         stream = make_fake_stream()
+        sp = self._dkdv_split
 
         def fake(dt, geom):
             return make_fake_tensor(dt, geom[0], geom[1], assumed_align=16)
@@ -334,6 +391,7 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
         fq, fkv, flse = fake(E4M3, q_geom), fake(E4M3, kv_geom), fake(Float32, lse_geom)
         fo, fdq = fake(out_dt, q_geom), fake(out_dt, q_geom)
         fdkv = fake(out_dt, kv_geom)
+        fdkv_out = fake(out_dt, kv_out_geom)  # the fused kernel's dK/dV (partial slots when split > 1)
 
         def fsf(name):
             return fake_flat(E8M0, repacks[name][0].dst_bytes)
@@ -386,6 +444,7 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
             is_persistent=False,
             online_ds_scale=online,
             p_scale_log2=self.p_scale_log2,
+            h_r_split=self._dkdv_split,
         )
         dkdv_fn = cute.compile(
             dkdv_kernel,
@@ -401,8 +460,8 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
             fsf("dkdv_sf_v"),
             fsf("dkdv_sf_do"),
             fsf("dkdv_sf_dot"),
-            fdkv,  # dK
-            fdkv,  # dV
+            fdkv_out,  # dK (partial slots when split > 1)
+            fdkv_out,  # dV
             fq,  # dO (fp8)
             fq,  # dO_MN
             fo,  # dO_16bits
@@ -417,7 +476,31 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
             True,  # skip_sum_odo: reuse the dQ launch's workspace prologue
             options=_COMPILE_OPTIONS,
         )
-        self._compiled = (repacks, dq_fn, dkdv_fn, problem_shape, wr)
+        reduce_fn = None
+        if self._dkdv_split > 1:
+            # Fold the per-slice partials onto the KV heads: fixed-order fp32
+            # accumulation, one thread per 16 B output vector (shared with the
+            # half-precision GQA backward). Partials are [B, S_kv, H_kv*split, D]
+            # with the slice fastest, i.e. exactly its H_q = H_kv * group form.
+            from cudnn.sdpa.bwd.kernels.bprop_chain_f16_sm120 import dkv_reduce_host
+
+            def fake_c(dt, shape):
+                return make_fake_tensor(dt, shape, tuple(int(math.prod(shape[i + 1 :])) for i in range(len(shape))), assumed_align=16)
+
+            reduce_fn = cute.compile(
+                dkv_reduce_host,
+                fake_c(out_dt, (b, sk, hk * sp, d)),
+                fake_c(out_dt, (b, sk, hk * sp, d)),
+                fake_c(out_dt, (b, sk, hk, d)),
+                fake_c(out_dt, (b, sk, hk, d)),
+                d,
+                d,
+                sp,
+                out_dt,
+                False,
+                stream,
+            )
+        self._compiled = (repacks, dq_fn, dkdv_fn, reduce_fn, problem_shape, wr)
         return self._compiled
 
     # --- execution -------------------------------------------------------------
@@ -481,7 +564,7 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
         if scale_softmax is not None and scale_softmax != 0.0 and not math.isclose(float(scale_softmax), float(self.scale_softmax), rel_tol=1e-6):
             raise ValueError(f"SM100 MXFP8 bwd: scale_softmax {scale_softmax} differs from the plan's {self.scale_softmax}")
 
-        repacks, dq_fn, dkdv_fn, problem_shape, wr = self.compile()
+        repacks, dq_fn, dkdv_fn, reduce_fn, problem_shape, wr = self.compile()
         b, hk, sq, sk, d = self.batch_size, self.h_kv, self.s_q_max, self.s_k_max, self.head_dim_qk
         hr = self._gqa_group
         E4M3, E8M0 = cutlass.Float8E4M3FN, cutlass.Float8E8M0FNU
@@ -525,6 +608,16 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
             O, DO16 = half_view(o_tensor, sq, hk, hr), half_view(do_f16_tensor, sq, hk, hr)
             dQ = half_view(dq_tensor, sq, hk, hr)
             dK, dV = half_view(dk_tensor, sk, hk, 1), half_view(dv_tensor, sk, hk, 1)
+            sp = self._dkdv_split
+            if sp > 1:
+                # The fused kernel writes one partial per Q-head slice; the fold
+                # below sums them into the caller's dK/dV.
+                dk_part = carver.take(b * sk * hk * sp * d, self.out_dtype).view(b, sk, hk * sp, d)
+                dv_part = carver.take(b * sk * hk * sp * d, self.out_dtype).view(b, sk, hk * sp, d)
+                dK_out = from_dlpack(dk_part.view(b, sk, hk * sp, 1, d).permute(1, 4, 3, 2, 0), assumed_align=16)
+                dV_out = from_dlpack(dv_part.view(b, sk, hk * sp, 1, d).permute(1, 4, 3, 2, 0), assumed_align=16)
+            else:
+                dK_out, dV_out = dK, dV
             LSE = from_dlpack(stats_tensor.reshape(b, hk, hr, sq).permute(3, 2, 1, 0), assumed_align=16)
             WS = from_dlpack(ws_kernel, assumed_align=16)
             scale = Float32(self.scale_softmax)
@@ -569,8 +662,8 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
                 sf_bufs["dkdv_sf_v"],
                 sf_bufs["dkdv_sf_do"],
                 sf_bufs["dkdv_sf_dot"],
-                dK,
-                dV,
+                dK_out,
+                dV_out,
                 DO,
                 DO_MN,
                 DO16,
@@ -584,6 +677,14 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
                 stream,
                 True,
             )
+            if sp > 1:
+                reduce_fn(
+                    from_dlpack(dk_part, assumed_align=16),
+                    from_dlpack(dv_part, assumed_align=16),
+                    from_dlpack(dk_tensor.permute(0, 2, 1, 3).contiguous(), assumed_align=16),
+                    from_dlpack(dv_tensor.permute(0, 2, 1, 3).contiguous(), assumed_align=16),
+                    stream,
+                )
 
 
 __all__ = ["SdpaBwdDslSm100Mxfp8"]

--- a/python/cudnn/sdpa/bwd/api_dsl_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/bwd/api_dsl_mxfp8_sm100.py
@@ -35,9 +35,11 @@ Occupancy: the fused dK/dV kernel's grid is (KV tiles, KV heads, B) and one
 2-CTA cluster walks every Q head of its KV head, so with few KV heads (GQA /
 MQA at small batch) most SMs idle -- 2 KV heads at S=8192 is 64 clusters on
 148 SMs. The adapter therefore splits the Q-head group across clusters
-(``_dkdv_head_split``: the smallest divisor of the group that reaches about two
-waves of clusters); each slice writes a partial dK/dV and the shared
-fixed-order ``dkv_reduce`` fold sums them, so the result stays deterministic.
+(``_dkdv_splits``: the smallest divisor of the group that reaches about one
+cluster per SM); every slice writes a partial dK/dV and the shared fixed-order
+``dkv_reduce`` fold sums them, so the result stays deterministic. The kernel can
+also chunk each KV tile's Q-tile range (``dkdv_seq_split``), but that never
+paid off in measurement and is opt-in only.
 
 Lives in its own module (not ``api_dsl.py``) so the MXFP8 lowering's imports
 stay out of the half-precision adapters' way; ``engines._adapter`` resolves it
@@ -66,6 +68,7 @@ _COMPILE_OPTIONS = "--opt-level 2"
 
 
 def _cdiv(a: int, b: int) -> int:
+    """Ceiling division."""
     return -(-a // b)
 
 
@@ -97,10 +100,12 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
         sample_sf_do_T,
         p_scale_log2: int = 8,
         dkdv_head_split: Optional[int] = None,
+        dkdv_seq_split: Optional[int] = None,
         **kwargs,
     ) -> None:
         # Stashed raw; descs are built in _initialize_implementation, which the
         # base __init__ calls once APIBase's own state exists.
+        """Record the problem shape, dtypes, mask and tuning knobs; validate the forced dK/dV split factors."""
         self._mxfp8_samples = dict(
             q_T=sample_q_T,
             k_T=sample_k_T,
@@ -115,8 +120,9 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
             sf_do_T=sample_sf_do_T,
         )
         self.p_scale_log2 = int(p_scale_log2)
-        # None = pick from the shape (see _dkdv_head_split); an int forces it.
+        # None = pick from the shape (see _dkdv_splits); an int forces it.
         self._dkdv_head_split_override = None if dkdv_head_split is None else int(dkdv_head_split)
+        self._dkdv_seq_split_override = None if dkdv_seq_split is None else int(dkdv_seq_split)
         super().__init__(sample_q, sample_k, sample_v, sample_o, sample_do, sample_stats, sample_dq, sample_dk, sample_dv, **kwargs)
 
     # --- geometry --------------------------------------------------------------
@@ -176,6 +182,7 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
         raise ValueError(graph_sf)
 
     def _initialize_implementation(self) -> None:
+        """Check the shape/dtype/mask contract against the kernels and compute the derived tiling constants."""
         s = self._mxfp8_samples
         self.q_T_desc = self._make_tensor_desc(s["q_T"], name="q_T")
         self.k_T_desc = self._make_tensor_desc(s["k_T"], name="k_T")
@@ -193,41 +200,60 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
         if self.scale_softmax is None or self.scale_softmax == 0.0:
             self.scale_softmax = 1.0 / math.sqrt(self.head_dim_qk)
         self._gqa_group = self.h_q // max(self.h_kv, 1)
-        self._dkdv_split = self._dkdv_head_split()
+        self._dkdv_head, self._dkdv_seq = self._dkdv_splits()
+        self._dkdv_split = self._dkdv_head * self._dkdv_seq  # partial slots per KV head
         self._compiled = None
 
     # dK/dV cluster count below which the Q-head group is split across clusters:
     # two waves of 2-CTA clusters over the SMs.
-    _DKDV_TARGET_CLUSTERS_PER_SM = 2
+    _DKDV_TARGET_CLUSTERS_PER_SM = 1
 
-    def _dkdv_head_split(self) -> int:
-        """How many clusters share one (KV tile, KV head): the smallest divisor of
-        the GQA group that gives the fused dK/dV kernel about two waves of
-        clusters, or the whole group if none does.
+    def _dkdv_splits(self) -> tuple:
+        """(head split, sequence split) for the fused dK/dV kernel.
+
+        Head split: the smallest divisor of the GQA group that gives the kernel
+        about one cluster per SM (two CTAs per SM). Measured on B200, that
+        target picks the best or near-best factor from 2k to 8k; aiming for two
+        waves over-splits once the grid already covers the machine (8% slower
+        at 32/2 heads, S=8192).
+
+        Sequence split (cutting each KV tile's Q-tile range into ``seq``
+        chunks) is wired through the same partial/fold path but is never chosen
+        automatically: on every shape measured it was neutral at best (MHA,
+        S<=2k, under half a wave) and up to 30% slower otherwise -- the chunks
+        re-pay the per-cluster K/V load and pipeline setup, and the fold reads
+        ``seq`` partials. It stays available as ``dkdv_seq_split`` for
+        experiments.
 
         The kernel's grid is (KV tiles, KV heads, B) and one cluster walks every
         Q head of its KV head, so with few KV heads most SMs idle: 2 KV heads at
         S=8192 is 64 clusters on 148 SMs. Each split writes a partial dK/dV
-        (one slot per Q-head slice) that a fixed-order fold sums, so the
-        result stays deterministic; the price is the partial buffers
-        (2 * split * |dK| bytes) and the fold's read of them.
+        (one slot per slice) that a fixed-order fold sums, so the result stays
+        deterministic; the price is the partial buffers (2 * split * |dK|
+        bytes) and the fold's read of them.
         """
-        if self._dkdv_head_split_override is not None:
-            split = self._dkdv_head_split_override
-            if split < 1 or self._gqa_group % split != 0:
-                raise ValueError(f"SM100 MXFP8 bwd: dkdv_head_split={split} must divide the GQA group {self._gqa_group}")
-            return split
         h_r = self._gqa_group
         kv_clusters = _cdiv(self.s_k_max, 128) * self.h_kv * self.batch_size
         target = self._DKDV_TARGET_CLUSTERS_PER_SM * torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
-        split = 1
-        for cand in range(1, h_r + 1):
-            if h_r % cand:
-                continue
-            split = cand
-            if kv_clusters * cand >= target:
-                break
-        return split
+        head = self._dkdv_head_split_override
+        if head is not None:
+            if head < 1 or h_r % head != 0:
+                raise ValueError(f"SM100 MXFP8 bwd: dkdv_head_split={head} must divide the GQA group {self._gqa_group}")
+        else:
+            head = 1
+            for cand in range(1, h_r + 1):
+                if h_r % cand:
+                    continue
+                head = cand
+                if kv_clusters * cand >= target:
+                    break
+        seq = self._dkdv_seq_split_override
+        if seq is not None:
+            if seq < 1:
+                raise ValueError(f"SM100 MXFP8 bwd: dkdv_seq_split={seq} must be >= 1")
+        else:
+            seq = 1  # opt-in only; see the docstring
+        return head, seq
 
     # --- capability backstop ---------------------------------------------------
     def check_support(self) -> bool:
@@ -290,6 +316,7 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
 
     # --- workspace -------------------------------------------------------------
     def _kernel_workspace_bytes(self) -> int:
+        """Bytes of scratch the kernels need: dQ accumulator, fp16 dO/O views, SF repack outputs and dK/dV partials."""
         import cutlass
 
         from cudnn.sdpa.bwd.kernels._bprop_mxfp8_common_sm100 import get_workspace_size
@@ -331,6 +358,7 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
         return q_geom, kv_geom, lse_geom, kv_out_geom
 
     def _mask_types(self):
+        """Map the requested attention mask onto the kernels' (mask_type, is_causal) pair."""
         from cudnn.sdpa.bwd.kernels import _bprop_mxfp8_masks_sm100 as masks
 
         # Upstream's selection, kept verbatim: the residual mask is needed only
@@ -367,9 +395,11 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
         sp = self._dkdv_split
 
         def fake(dt, geom):
+            """Build a fake CuTe tensor with the given shape and stride order for compile."""
             return make_fake_tensor(dt, geom[0], geom[1], assumed_align=16)
 
         def fake_flat(dt, n):
+            """Build a fake flat 1-D CuTe tensor for compile."""
             return make_fake_tensor(dt, (n,), (1,), assumed_align=16)
 
         # SF repacks: one specialization per (rows, groups, planes, layout, source order).
@@ -394,6 +424,7 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
         fdkv_out = fake(out_dt, kv_out_geom)  # the fused kernel's dK/dV (partial slots when split > 1)
 
         def fsf(name):
+            """Build a fake scale-factor tensor for compile."""
             return fake_flat(E8M0, repacks[name][0].dst_bytes)
 
         dq_kernel = BlackwellFmhaBackwardDQ256(
@@ -444,7 +475,8 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
             is_persistent=False,
             online_ds_scale=online,
             p_scale_log2=self.p_scale_log2,
-            h_r_split=self._dkdv_split,
+            h_r_split=self._dkdv_head,
+            s_q_split=self._dkdv_seq,
         )
         dkdv_fn = cute.compile(
             dkdv_kernel,
@@ -485,6 +517,7 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
             from cudnn.sdpa.bwd.kernels.bprop_chain_f16_sm120 import dkv_reduce_host
 
             def fake_c(dt, shape):
+                """Build a fake contiguous CuTe tensor for compile."""
                 return make_fake_tensor(dt, shape, tuple(int(math.prod(shape[i + 1 :])) for i in range(len(shape))), assumed_align=16)
 
             reduce_fn = cute.compile(
@@ -537,6 +570,7 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
         sf_do: Optional[torch.Tensor] = None,
         sf_do_T: Optional[torch.Tensor] = None,
     ) -> None:
+        """Run the backward: SF repack, dQ kernel, dK/dV kernel and (when split) the fixed-order partial fold on ``stream``."""
         import cutlass
         from cutlass.cute.runtime import from_dlpack
         from cutlass.cute.typing import Float32
@@ -575,15 +609,18 @@ class SdpaBwdDslSm100Mxfp8(SdpaBwdDsl):
             # view. permute+contiguous is a no-op view here (check_support
             # admitted BSHD-physical only); the int8 view is the DSL's raw-byte
             # ABI for E4M3 payloads.
+            """View an fp8 tensor as the kernel's uint8 payload."""
             st = t.permute(0, 2, 1, 3).contiguous().view(torch.int8).view(b, s, h_kv_, h_r_, d).permute(1, 4, 3, 2, 0)
             ct = from_dlpack(st, assumed_align=16)
             ct.element_type = E4M3
             return ct
 
         def half_view(t, s, h_kv_, h_r_):
+            """View a tensor as the kernel's fp16/bf16 element type."""
             return from_dlpack(t.permute(0, 2, 1, 3).contiguous().view(b, s, h_kv_, h_r_, d).permute(1, 4, 3, 2, 0), assumed_align=16)
 
         def sf_bytes(t):
+            """Byte size of one scale-factor plane set."""
             flat = t.contiguous()
             if flat.dtype != torch.int8:
                 flat = flat.view(torch.int8)

--- a/python/cudnn/sdpa/bwd/kernels/bprop_dkdv_d256_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_dkdv_d256_mxfp8_sm100.py
@@ -109,6 +109,7 @@ class BlackwellFmhaBackwardDKDV256:
         is_persistent: bool = False,
         online_ds_scale: bool = True,
         p_scale_log2: int = 8,
+        h_r_split: int = 1,
     ):
         mma_tiler = self._setup_specialization(element_dtype, acc_dtype, mma_tiler)
         self._setup_mma_tilers(mma_tiler)
@@ -122,6 +123,21 @@ class BlackwellFmhaBackwardDKDV256:
         if not (0 <= int(p_scale_log2) <= 126):
             raise ValueError(f"p_scale_log2 must be in [0, 126]; got {p_scale_log2}")
         self.p_scale_log2 = int(p_scale_log2)
+        # Q-head-group split. The grid is (kv tiles, h_k, b) and one cluster
+        # walks every Q head of its KV head, so at few KV heads (GQA with 1-2
+        # KV heads, small batch) most SMs idle: 2 KV heads at S=8192 is 64
+        # clusters on 148 SMs. With h_r_split = S the grid becomes
+        # (kv tiles, h_k * S, b); cluster (h_k, s) handles Q heads
+        # [s * h_r/S, (s+1) * h_r/S) and stores its dK/dV to PARTIAL slot
+        # h_k * S + s of a [B, S_kv, h_k * S, D] buffer (the host passes that
+        # buffer as dK/dV); a fixed-order fold onto the KV heads follows
+        # (kernels/bprop_chain_f16_sm120.dkv_reduce_host). h_r must be a
+        # multiple of h_r_split; 1 = the original single-pass behaviour.
+        if int(h_r_split) < 1:
+            raise ValueError(f"h_r_split must be >= 1; got {h_r_split}")
+        if int(h_r_split) > 1 and is_persistent:
+            raise ValueError("h_r_split > 1 is not implemented for the persistent scheduler")
+        self.h_r_split = int(h_r_split)
 
     def _setup_specialization(self, element_dtype, acc_dtype, mma_tiler):
         """Normalize tile orientation and set fixed instruction/type policy."""
@@ -418,8 +434,11 @@ class BlackwellFmhaBackwardDKDV256:
         V = make_kv_head_batch_tensor(V, hb, self.varlen)
         O = make_q_head_batch_tensor(O, hb, self.varlen)
         dO_16bits = cute.make_tensor(dO_16bits.iterator, O.layout)
-        dK = make_kv_head_batch_tensor(dK, hb, self.varlen)
-        dV = make_kv_head_batch_tensor(dV, hb, self.varlen)
+        # dK/dV: with h_r_split > 1 these are the PARTIAL buffers, h_k * h_r_split
+        # slots per batch (slot = h_k * h_r_split + split); see __init__.
+        hb_out = ((h_r, h_k * self.h_r_split), b)
+        dK = make_kv_head_batch_tensor(dK, hb_out, self.varlen)
+        dV = make_kv_head_batch_tensor(dV, hb_out, self.varlen)
         dO = cute.make_tensor(dO.iterator, Q.layout)
         dOT = make_transposed_tensor(dO_MN, dO.layout)
         QT = make_transposed_tensor(Q_MN, Q.layout)
@@ -996,7 +1015,7 @@ class BlackwellFmhaBackwardDKDV256:
             )
 
         bwd_grid = cute_common.compute_grid(
-            cute.shape((k_seq_max, d, ((1, h_k), b))),
+            cute.shape((k_seq_max, d, ((1, h_k * self.h_r_split), b))),
             self.cta_tiler,
         )
         # Round up grid X to be divisible by cluster X dimension (2-CTA cluster)
@@ -1886,7 +1905,11 @@ class BlackwellFmhaBackwardDKDV256:
             #  NON-PERSISTENT MODE (original code)
             # ===================================================================
             # get the current batch problem shape
+            # bidy indexes the OUTPUT slot (h_k * h_r_split + split); the input KV
+            # head and this cluster's first Q head derive from it (see __init__).
             blk_coord = (Int32(0), bidx, Int32(0), ((Int32(0), bidy), bidz))
+            bidy_kv = bidy // self.h_r_split
+            h_r_begin = (bidy % self.h_r_split) * (problem_shape[3][0][0] // self.h_r_split)
             # problem_shape = (s_q_max, s_k_max, d: hidden dim, ((h_r: #q_head_per_kv, h_k: #kv_heads), orig_b: batch size)) mark
             problem_shape_cur_batch = problem_shape
             blk_offset = (Int32(0), Int32(0), Int32(0), ((Int32(0), Int32(0)), Int32(0)))
@@ -1927,7 +1950,16 @@ class BlackwellFmhaBackwardDKDV256:
 
             trip_end = trip_start + trip_count
 
-            trip_count = trip_count * problem_shape_cur_batch[3][0][0]
+            # Q heads walked by this cluster: h_r / h_r_split.
+            trip_count = trip_count * (problem_shape_cur_batch[3][0][0] // self.h_r_split)
+            # The dK/dV views carry h_k * h_r_split slots; the epilogues build
+            # their global tiles from the HB they are handed.
+            problem_shape_out = (
+                problem_shape_cur_batch[0],
+                problem_shape_cur_batch[1],
+                problem_shape_cur_batch[2],
+                ((problem_shape_cur_batch[3][0][0], problem_shape_cur_batch[3][0][1] * self.h_r_split), problem_shape_cur_batch[3][1]),
+            )
 
             # Cluster wait before tensor memory alloc for 2-CTA
             pipeline_init_wait(cluster_shape_mn=self.cluster_shape_mn)
@@ -2008,9 +2040,10 @@ class BlackwellFmhaBackwardDKDV256:
                             load_mma_VDO_pipeline,
                         ),
                         bidx,
-                        bidy,
+                        bidy_kv,
                         bidz,
                         problem_shape[3][0][1],  # h_k
+                        h_r_begin=h_r_begin,
                     )
 
                 # ///////////////////////////////////////////////////////////////////////////////
@@ -2117,7 +2150,7 @@ class BlackwellFmhaBackwardDKDV256:
                         self.epilogue(
                             blk_coord,
                             blk_offset,
-                            problem_shape_cur_batch,
+                            problem_shape_out,
                             dK,
                             dV,
                             tDKtDK,
@@ -2130,6 +2163,13 @@ class BlackwellFmhaBackwardDKDV256:
 
                 else:
                     cute.arch.warpgroup_reg_dealloc(self.num_regs_empty)
+            elif cluster_idx * self.tile_shape_K < problem_shape_cur_batch[1]:
+                # An in-range KV tile that no query row attends (causal with
+                # S_kv > S_q): its gradients are exactly zero, and the mainloop
+                # above is skipped, so the tile must be written here or the
+                # caller's dK/dV keep whatever was in the buffer.
+                if warp_idx >= self.compute_warp_id_0[0] and warp_idx <= self.compute_warp_id_1[-1]:
+                    self.epilogue_zero(blk_coord, blk_offset, problem_shape_out, dK, dV)
 
         # In persistent mode, sync across the 2-CTA cluster before TMEM dealloc
         # to prevent one CTA from freeing TMEM while partner CTA's MMA warp still accesses it.
@@ -2215,10 +2255,11 @@ class BlackwellFmhaBackwardDKDV256:
         blk_coord_b: Int32,
         num_h_k: Int32,  # total number of KV heads (replaces grid_dim_y)
         cumulative_trip_count: Int32 = Int32(0),  # accumulated trip_count across persistent tiles
+        h_r_begin: Int32 = Int32(0),  # first Q head of this cluster's slice (h_r_split)
     ):
         grid_dim_y = num_h_k
 
-        blk_coord_h_r = Int32(0)
+        blk_coord_h_r = h_r_begin
         blk_coord_h_q = (blk_coord_h_r, blk_coord_h_k)
         blk_coord_h_kv = (Int32(0), blk_coord_h_k)
 
@@ -3862,6 +3903,41 @@ class BlackwellFmhaBackwardDKDV256:
             iter_index += 1
             if iter_index == iter_end:
                 iter_index = iter_start
+
+    @cute.jit
+    def epilogue_zero(
+        self,
+        blk_coord: cute.Coord,
+        blk_offset: cute.Shape,
+        problem_shape: Tuple[Int32, Int32, Int32, Tuple[Tuple[Int32, Int32], Int32]],
+        dK: cute.Tensor,
+        dV: cute.Tensor,
+    ):
+        """Write zeros to this CTA's dK/dV tile (the epilogue's tile geometry) --
+        for KV tiles whose mainloop was skipped because no query row attends
+        them. Plain per-element stores from the compute warps; these tiles are
+        rare (the causal tail past S_q) so no vectorization is needed."""
+        tidx, _, _ = cute.arch.thread_idx()
+        _, K, D, HB = problem_shape
+        _, blk_coord_k, _, blk_coord_batch = blk_coord
+        mdK = cute.make_tensor(
+            dK.iterator + cute.assume(blk_offset[1] * dK.stride[0], divby=64),
+            cute.make_layout((K, self.tile_shape_dKdV_K, HB), stride=dK.stride),
+        )
+        mdV = cute.make_tensor(
+            dV.iterator + cute.assume(blk_offset[1] * dV.stride[0], divby=64),
+            cute.make_layout((K, self.tile_shape_dKdV_K, HB), stride=dV.stride),
+        )
+        rows = self.dSQ_cta_tiler[0]
+        cols = self.tile_shape_dKdV_K
+        n_threads = self.num_compute_warps * self.threads_per_warp
+        zero = Float32(0.0).to(self.element_dtype)
+        for i in cutlass.range(tidx, rows * cols, n_threads):
+            r = blk_coord_k * rows + i // cols
+            c = i % cols
+            if r < K:
+                mdK[(r, c, blk_coord_batch)] = zero
+                mdV[(r, c, blk_coord_batch)] = zero
 
     @cute.jit
     def epilogue(

--- a/python/cudnn/sdpa/bwd/kernels/bprop_dkdv_d256_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_dkdv_d256_mxfp8_sm100.py
@@ -110,7 +110,9 @@ class BlackwellFmhaBackwardDKDV256:
         online_ds_scale: bool = True,
         p_scale_log2: int = 8,
         h_r_split: int = 1,
+        s_q_split: int = 1,
     ):
+        """Fused dK/dV kernel for d=256 MXFP8 (2-CTA block-scaled MMA); see the module docstring."""
         mma_tiler = self._setup_specialization(element_dtype, acc_dtype, mma_tiler)
         self._setup_mma_tilers(mma_tiler)
         self._setup_warp_topology_and_barriers(varlen, mask_type, is_persistent, online_ds_scale)
@@ -138,6 +140,18 @@ class BlackwellFmhaBackwardDKDV256:
         if int(h_r_split) > 1 and is_persistent:
             raise ValueError("h_r_split > 1 is not implemented for the persistent scheduler")
         self.h_r_split = int(h_r_split)
+        # Q-sequence split, same mechanism along the other axis: cluster slice s
+        # walks Q tiles [c0, c1) of its KV tile's trip range, cut into s_q_split
+        # near-equal chunks (per KV tile, so causal ranges stay balanced), and
+        # stores to its own partial slot. Slots: h_k * h_r_split * s_q_split per
+        # batch, slot = (h_k * h_r_split + h_slice) * s_q_split + q_slice. A chunk
+        # that ends up empty (fewer Q tiles than slices) is written as zeros.
+        if int(s_q_split) < 1:
+            raise ValueError(f"s_q_split must be >= 1; got {s_q_split}")
+        if int(s_q_split) > 1 and is_persistent:
+            raise ValueError("s_q_split > 1 is not implemented for the persistent scheduler")
+        self.s_q_split = int(s_q_split)
+        self.n_split = self.h_r_split * self.s_q_split
 
     def _setup_specialization(self, element_dtype, acc_dtype, mma_tiler):
         """Normalize tile orientation and set fixed instruction/type policy."""
@@ -350,6 +364,7 @@ class BlackwellFmhaBackwardDKDV256:
         num_warp_groups: Int32,
         wg_idx: Int32,
     ) -> cute.Tensor:
+        """View a per-warp-group TMEM fragment for the calling warp group."""
         ret = None
         if cutlass.const_expr(cute.rank(t.layout) == 1):
             p = cute.composition(
@@ -426,6 +441,7 @@ class BlackwellFmhaBackwardDKDV256:
         stream: cuda.CUstream,
         skip_sum_odo: bool = False,
     ):
+        """JIT entry: build operand views, MMA atoms, TMA descriptors and launch the row-dot prologue and the dK/dV kernel."""
         q_seq_max, k_seq_max, d, hb = problem_shape
         h, b = hb
         h_r, h_k = h
@@ -436,7 +452,7 @@ class BlackwellFmhaBackwardDKDV256:
         dO_16bits = cute.make_tensor(dO_16bits.iterator, O.layout)
         # dK/dV: with h_r_split > 1 these are the PARTIAL buffers, h_k * h_r_split
         # slots per batch (slot = h_k * h_r_split + split); see __init__.
-        hb_out = ((h_r, h_k * self.h_r_split), b)
+        hb_out = ((h_r, h_k * self.n_split), b)
         dK = make_kv_head_batch_tensor(dK, hb_out, self.varlen)
         dV = make_kv_head_batch_tensor(dV, hb_out, self.varlen)
         dO = cute.make_tensor(dO.iterator, Q.layout)
@@ -1015,7 +1031,7 @@ class BlackwellFmhaBackwardDKDV256:
             )
 
         bwd_grid = cute_common.compute_grid(
-            cute.shape((k_seq_max, d, ((1, h_k * self.h_r_split), b))),
+            cute.shape((k_seq_max, d, ((1, h_k * self.n_split), b))),
             self.cta_tiler,
         )
         # Round up grid X to be divisible by cluster X dimension (2-CTA cluster)
@@ -1185,6 +1201,7 @@ class BlackwellFmhaBackwardDKDV256:
         cluster_layout_vmnk_sfb: cute.Layout,
         tile_sched_params: Union[utils.ClcDynamicPersistentTileSchedulerParams, None],
     ):
+        """The fused dK/dV kernel body: warp-specialized load / MMA / compute roles for one (KV tile, head slice, Q chunk)."""
         bidx, bidy, bidz = cute.arch.block_idx()
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
 
@@ -1908,8 +1925,9 @@ class BlackwellFmhaBackwardDKDV256:
             # bidy indexes the OUTPUT slot (h_k * h_r_split + split); the input KV
             # head and this cluster's first Q head derive from it (see __init__).
             blk_coord = (Int32(0), bidx, Int32(0), ((Int32(0), bidy), bidz))
-            bidy_kv = bidy // self.h_r_split
-            h_r_begin = (bidy % self.h_r_split) * (problem_shape[3][0][0] // self.h_r_split)
+            bidy_kv = bidy // self.n_split
+            h_r_begin = ((bidy % self.n_split) // self.s_q_split) * (problem_shape[3][0][0] // self.h_r_split)
+            q_slice = bidy % self.s_q_split
             # problem_shape = (s_q_max, s_k_max, d: hidden dim, ((h_r: #q_head_per_kv, h_k: #kv_heads), orig_b: batch size)) mark
             problem_shape_cur_batch = problem_shape
             blk_offset = (Int32(0), Int32(0), Int32(0), ((Int32(0), Int32(0)), Int32(0)))
@@ -1948,7 +1966,15 @@ class BlackwellFmhaBackwardDKDV256:
                 window_size_right,
             )
 
-            trip_end = trip_start + trip_count
+            # This cluster's Q-tile chunk of the KV tile's trip range (s_q_split
+            # near-equal pieces). The mask classification inside compute() is
+            # relative to the FULL range start, which travels separately.
+            trip_start_full = trip_start
+            chunk_begin = trip_start + (q_slice * trip_count) // self.s_q_split
+            chunk_end = trip_start + ((q_slice + 1) * trip_count) // self.s_q_split
+            trip_start = chunk_begin
+            trip_end = chunk_end
+            trip_count = chunk_end - chunk_begin
 
             # Q heads walked by this cluster: h_r / h_r_split.
             trip_count = trip_count * (problem_shape_cur_batch[3][0][0] // self.h_r_split)
@@ -1958,7 +1984,7 @@ class BlackwellFmhaBackwardDKDV256:
                 problem_shape_cur_batch[0],
                 problem_shape_cur_batch[1],
                 problem_shape_cur_batch[2],
-                ((problem_shape_cur_batch[3][0][0], problem_shape_cur_batch[3][0][1] * self.h_r_split), problem_shape_cur_batch[3][1]),
+                ((problem_shape_cur_batch[3][0][0], problem_shape_cur_batch[3][0][1] * self.n_split), problem_shape_cur_batch[3][1]),
             )
 
             # Cluster wait before tensor memory alloc for 2-CTA
@@ -2143,6 +2169,7 @@ class BlackwellFmhaBackwardDKDV256:
                             compute_mma_P_pipeline,
                             compute_mma_dS_pipeline,
                         ),
+                        iter_start_global=trip_start_full,
                     )
                     if warp_idx >= self.compute_warp_id_0[0] and warp_idx <= self.compute_warp_id_0[-1]:
                         mma_compute_Q_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.mma_compute_dKdV_stage)
@@ -2257,6 +2284,7 @@ class BlackwellFmhaBackwardDKDV256:
         cumulative_trip_count: Int32 = Int32(0),  # accumulated trip_count across persistent tiles
         h_r_begin: Int32 = Int32(0),  # first Q head of this cluster's slice (h_r_split)
     ):
+        """Producer warp: TMA loads of K/V once and of Q, dO, LSE, row-dot and their scale factors per Q tile and head."""
         grid_dim_y = num_h_k
 
         blk_coord_h_r = h_r_begin
@@ -2888,6 +2916,7 @@ class BlackwellFmhaBackwardDKDV256:
         sSFDO_mn: cute.Tensor,
         cumulative_trip_count: Int32 = Int32(0),  # accumulated trip_count across persistent tiles
     ):
+        """MMA warp: block-scaled tcgen05 MMAs for S = K.Q^T, dP = V.dO^T, dK += dS^T.Q and dV += P^T.dO."""
         bidx, _, _ = cute.arch.block_idx()
         iter_count_origin = iter_count
 
@@ -3535,14 +3564,20 @@ class BlackwellFmhaBackwardDKDV256:
         # (mma_compute_KQ_pipeline, mma_compute_VDO_pipeline, compute_mma_P_pipeline, compute_mma_dS_pipeline)
         pipeline_args: tuple,
         cumulative_trip_count: Int32 = Int32(0),  # accumulated trip_count across persistent tiles
+        # Start of the KV tile's FULL trip range. iter_start/iter_end may be a
+        # chunk of it (s_q_split); the masked-leading/trailing tile counts are
+        # relative to the full range, so the tile classification below uses this.
+        iter_start_global: Optional[Int32] = None,
     ):
+        """Softmax / dS / P production for one KV tile (compute warps); see the module docstring."""
         tidx, _, _ = cute.arch.thread_idx()
         Q, K, _, _ = problem_shape
         _, blk_coord_k, _, _ = blk_coord
 
         # FIXME: perhaps make it uniform register
         wg_idx_valid = (tidx % (self.num_compute_warps * self.threads_per_warp)) // 128
-        iter_start_global = iter_start
+        if cutlass.const_expr(iter_start_global is None):
+            iter_start_global = iter_start
         num_warp_groups = self.num_compute_warps // self.num_compute_0_warps
 
         tidx = tidx % 128
@@ -3954,6 +3989,7 @@ class BlackwellFmhaBackwardDKDV256:
         # (mma_compute_dQ_pipeline, mma_compute_dQ_consumer_state)
         pipeline_args: tuple,
     ):
+        """Compute warps: scale the TMEM dK/dV accumulators and store this CTA's tile to global memory."""
         tidx, _, _ = cute.arch.thread_idx()
         _, K, D, HB = problem_shape
         _, blk_coord_k, _, blk_coord_batch = blk_coord
@@ -4037,6 +4073,7 @@ class BlackwellFmhaBackwardDKDV256:
         mma_compute_Q_consumer_state.advance()
 
     def _make_and_init_load_mma_pipeline(self, load_mma_mbar_ptr, cluster_layout_vmnk, tx_count):
+        """Create and initialise one TMA-producer / MMA-consumer pipeline with the given depth."""
         return cute_common.make_tma_umma_pipeline(
             load_mma_mbar_ptr,
             self.load_mma_all_stage,
@@ -4047,17 +4084,20 @@ class BlackwellFmhaBackwardDKDV256:
         )
 
     def make_and_init_load_mma_KQ_pipeline(self, load_mma_KQ_mbar_ptr, cluster_layout_vmnk):
+        """Load -> MMA pipeline for the K and Q operand stages."""
         tx_count = self.tma_copy_Q_bytes * 2
         tx_count += self.tma_copy_sfQ_bytes * self.k_halves * 2
         tx_count += self.tma_copy_LSE_bytes
         return self._make_and_init_load_mma_pipeline(load_mma_KQ_mbar_ptr, cluster_layout_vmnk, tx_count)
 
     def make_and_init_load_mma_KQ_aux_pipeline(self, load_mma_KQ_aux_mbar_ptr, cluster_layout_vmnk):
+        """Load -> MMA pipeline for the K/Q auxiliary (scale-factor) stages."""
         tx_count = self.tma_copy_QT_bytes * 2
         tx_count += self.tma_copy_sfQ_mn_bytes * 2
         return self._make_and_init_load_mma_pipeline(load_mma_KQ_aux_mbar_ptr, cluster_layout_vmnk, tx_count)
 
     def make_and_init_load_mma_VDO_pipeline(self, load_mma_VDO_mbar_ptr, cluster_layout_vmnk):
+        """Load -> MMA pipeline for the V and dO operand stages."""
         tx_count = (self.tma_copy_dO_bytes + self.tma_copy_dOT_bytes) * 2
         tx_count += self.tma_copy_sfdO_bytes * self.k_halves * 2
         tx_count += self.tma_copy_sfdO_mn_bytes * 2
@@ -4065,6 +4105,7 @@ class BlackwellFmhaBackwardDKDV256:
         return self._make_and_init_load_mma_pipeline(load_mma_VDO_mbar_ptr, cluster_layout_vmnk, tx_count)
 
     def _make_and_init_mma_compute_pipeline(self, mbar_ptr, num_stages, cluster_layout_vmnk):
+        """Create and initialise one MMA-producer / compute-consumer TMEM pipeline."""
         return cute_common.make_umma_async_pipeline(
             mbar_ptr,
             num_stages,
@@ -4074,15 +4115,19 @@ class BlackwellFmhaBackwardDKDV256:
         )
 
     def make_and_init_mma_compute_KQ_pipeline(self, mma_compute_KQ_mbar_ptr, cluster_layout_vmnk):
+        """MMA -> compute pipeline handing off the S = K.Q^T accumulator."""
         return self._make_and_init_mma_compute_pipeline(mma_compute_KQ_mbar_ptr, self.mma_compute_KQ_stage, cluster_layout_vmnk)
 
     def make_and_init_mma_compute_VDO_pipeline(self, mma_compute_VDO_mbar_ptr, cluster_layout_vmnk):
+        """MMA -> compute pipeline handing off the dP = V.dO^T accumulator."""
         return self._make_and_init_mma_compute_pipeline(mma_compute_VDO_mbar_ptr, self.mma_compute_VDO_stage, cluster_layout_vmnk)
 
     def make_and_init_mma_compute_dK_pipeline(self, mma_compute_dK_mbar_ptr, cluster_layout_vmnk):
+        """MMA -> compute pipeline handing off the final dK/dV accumulators."""
         return cute_common.make_pipeline_umma_async(self, mma_compute_dK_mbar_ptr, self.mma_compute_dKdV_stage, cluster_layout_vmnk)
 
     def _make_and_init_compute_mma_pipeline(self, mbar_ptr, num_stages, cluster_layout_vmnk):
+        """Create and initialise one compute-producer / MMA-consumer smem pipeline."""
         return cute_common.make_async_umma_pipeline(
             mbar_ptr,
             num_stages,
@@ -4092,7 +4137,9 @@ class BlackwellFmhaBackwardDKDV256:
         )
 
     def make_and_init_compute_mma_P_pipeline(self, compute_mma_P_mbar_ptr, cluster_layout_vmnk):
+        """Compute -> MMA pipeline publishing the quantised P tile."""
         return self._make_and_init_compute_mma_pipeline(compute_mma_P_mbar_ptr, self.compute_mma_P_stage, cluster_layout_vmnk)
 
     def make_and_init_compute_mma_dS_pipeline(self, compute_mma_dS_mbar_ptr, cluster_layout_vmnk):
+        """Compute -> MMA pipeline publishing the quantised dS tile."""
         return self._make_and_init_compute_mma_pipeline(compute_mma_dS_mbar_ptr, self.compute_mma_dS_stage, cluster_layout_vmnk)

--- a/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
+++ b/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
@@ -150,7 +150,12 @@ output (the kernels write half-precision gradients and produce no amax).
 Numerics: dS is quantized in-kernel with an online per-32-block E8M0 scale;
 P with a fixed 2⁻⁸ descale (cuDNN's MXFP8 convention). Cost to know about: the
 scale-factor repack in front of the kernels (eleven launches, ~1–2 % of the
-backward) and its workspace (about one payload-equivalent of bytes).
+backward) and its workspace (about one payload-equivalent of bytes). With few
+KV heads (GQA/MQA at small batch) the fused dK/dV kernel's grid — (KV tiles,
+KV heads, B) — would leave most SMs idle, so the adapter splits the Q-head group
+across clusters (smallest divisor of the group reaching ~2 waves) and folds the
+per-slice partials with a fixed-order fp32 reduce (still deterministic); that
+costs 2·split·|dK| bytes of workspace and one extra small launch.
 
 ---
 

--- a/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
+++ b/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
@@ -153,9 +153,11 @@ scale-factor repack in front of the kernels (eleven launches, ~1–2 % of the
 backward) and its workspace (about one payload-equivalent of bytes). With few
 KV heads (GQA/MQA at small batch) the fused dK/dV kernel's grid — (KV tiles,
 KV heads, B) — would leave most SMs idle, so the adapter splits the Q-head group
-across clusters (smallest divisor of the group reaching ~2 waves) and folds the
-per-slice partials with a fixed-order fp32 reduce (still deterministic); that
-costs 2·split·|dK| bytes of workspace and one extra small launch.
+across clusters (smallest divisor of the group reaching ~1 cluster per SM); the
+per-slice partials are folded with a fixed-order fp32 reduce (still
+deterministic) at 2·split·|dK| bytes of workspace and one extra small launch.
+A Q-tile-range (sequence) split exists behind the same fold but is opt-in only:
+it did not pay off on any measured shape.
 
 ---
 

--- a/test/python/sdpa/frost/test_sdpa_bwd_mxfp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_bwd_mxfp8_sm100.py
@@ -45,6 +45,7 @@ _OUT_CUDNN = {torch.bfloat16: cudnn.data_type.BFLOAT16, torch.float16: cudnn.dat
 
 
 def _cdiv(a, b):
+    """Ceiling division."""
     return (a + b - 1) // b
 
 
@@ -182,6 +183,7 @@ def _build_graph(
 
 
 def _plan_index(g, name=_ENGINE):
+    """Index of the FROST MXFP8 bwd plan in the graph's plan list."""
     for i in range(g.get_execution_plan_count()):
         pn = g.get_plan_name_at_index(i)
         if pn == name or pn.startswith(name + "["):
@@ -347,7 +349,44 @@ def _adapter_inputs(b, hq, hkv, sq, skv, out_dt=torch.bfloat16, causal=False, se
     )
 
 
+def _adapter_shapes(b, hq, hkv, sq, skv, out_dt=torch.bfloat16, causal=False):
+    """Shape-only operands (uninitialized, no reference) for probing the adapter's
+    plan-time decisions without paying for a reference computation."""
+    d, dev = _D, "cuda"
+    fp8 = lambda h, s: _to_bshd(torch.empty(b, h, s, d, device=dev, dtype=torch.float8_e4m3fn))  # noqa: E731
+    half = lambda h, s: _to_bshd(torch.empty(b, h, s, d, device=dev, dtype=out_dt))  # noqa: E731
+    q_row, q_col = _sf_dims(b, hq, sq, d)
+    k_row, k_col = _sf_dims(b, hkv, skv, d)
+    sf = lambda dims: torch.empty(dims, device=dev, dtype=torch.int8)  # noqa: E731
+    return dict(
+        q=fp8(hq, sq),
+        q_T=fp8(hq, sq),
+        k=fp8(hkv, skv),
+        k_T=fp8(hkv, skv),
+        v=fp8(hkv, skv),
+        o=half(hq, sq),
+        dO_f16=half(hq, sq),
+        dO=fp8(hq, sq),
+        dO_T=fp8(hq, sq),
+        stats=torch.empty(b, hq, sq, 1, device=dev),
+        sf_q=sf(q_row),
+        sf_q_T=sf(q_col),
+        sf_k=sf(k_row),
+        sf_k_T=sf(k_col),
+        sf_v=sf(k_row),
+        sf_dO=sf(q_row),
+        sf_dO_T=sf(q_col),
+        dq=half(hq, sq),
+        dk=half(hkv, skv),
+        dv=half(hkv, skv),
+        ref=None,
+        scale=1.0 / math.sqrt(d),
+        causal=causal,
+    )
+
+
 def _make_adapter(inp, **kw):
+    """Construct the SdpaBwdDslSm100Mxfp8 adapter for prepared inputs, forwarding split overrides."""
     from cudnn.sdpa.bwd.api_dsl_mxfp8_sm100 import SdpaBwdDslSm100Mxfp8
 
     return SdpaBwdDslSm100Mxfp8(
@@ -378,6 +417,7 @@ def _make_adapter(inp, **kw):
 
 
 def _run_adapter(api, inp):
+    """Run the adapter directly (no graph) and return dQ/dK/dV."""
     api.check_support()
     api.compile()
     ws = torch.empty(max(api.scratch_workspace_bytes(), 1), device="cuda", dtype=torch.uint8)
@@ -422,6 +462,7 @@ def _run_adapter(api, inp):
 @pytest.mark.L0
 @pytest.mark.parametrize("out", list(_OUT), ids=list(_OUT))
 def test_dense(out):
+    """Dense (no mask) shapes across batch/head/seqlen combinations."""
     _run(out_dt=_OUT[out])
 
 
@@ -433,16 +474,19 @@ def test_default_attn_scale():
 
 @pytest.mark.L0
 def test_causal():
+    """Top-left causal mask, S_q == S_kv."""
     _run(causal=True)
 
 
 @pytest.mark.L0
 def test_gqa():
+    """Grouped-query attention with a small KV-head count."""
     _run(hq=4, hkv=2)
 
 
 @pytest.mark.L0
 def test_mqa():
+    """Multi-query attention (one KV head)."""
     _run(hq=4, hkv=1)
 
 
@@ -472,6 +516,7 @@ def test_ragged_kv_only(skv):
 
 @pytest.mark.L0
 def test_ragged_tails_causal_gqa():
+    """Causal GQA with S_q and S_kv not multiples of the tile size."""
     _run(hq=4, hkv=2, sq=129, skv=160, causal=True)
 
 
@@ -485,6 +530,7 @@ def test_causal_kv_tail():
 
 @pytest.mark.L0
 def test_q_tile_boundary_causal():
+    """Causal with S_q exactly on / one past a Q-tile boundary."""
     _run(hq=8, hkv=2, sq=257, skv=256, causal=True)
 
 
@@ -503,24 +549,34 @@ def test_deterministic_flag():
 
 @pytest.mark.L1
 def test_long_causal():
+    """Long causal sequence (L1) to exercise many KV iterations."""
     _run(b=1, hq=2, hkv=2, sq=2048, skv=2048, causal=True)
 
 
 @pytest.mark.L0
 def test_dkdv_head_split_heuristic():
     """The fused dK/dV kernel's grid is (KV tiles, KV heads, B); with few KV
-    heads the adapter splits the Q-head group across clusters so the GPU fills.
-    The split is a divisor of the group, the smallest reaching ~2 waves of
-    clusters, and 1 when there is no group (MHA) -- no partials, no fold."""
-    inp = _adapter_inputs(1, 32, 2, 2048, 2048)
-    api = _make_adapter(inp)
+    heads the adapter splits the Q-head group (a divisor of the group, the
+    smallest reaching ~1 cluster per SM). The sequence split is opt-in only, and
+    a large MHA shape needs neither -- no partials, no fold. Shape-only inputs:
+    nothing is computed."""
     sms = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
+    api = _make_adapter(_adapter_shapes(1, 32, 2, 2048, 2048))
     kv_clusters = 16 * 2  # 2048/128 tiles x 2 KV heads x B=1
-    assert 16 % api._dkdv_split == 0 and api._dkdv_split > 1
-    assert kv_clusters * api._dkdv_split >= 2 * sms or api._dkdv_split == 16
-    assert _make_adapter(_adapter_inputs(1, 2, 2, 256, 256))._dkdv_split == 1
+    assert 16 % api._dkdv_head == 0 and api._dkdv_head > 1
+    assert kv_clusters * api._dkdv_head >= sms or api._dkdv_head == 16
+    assert kv_clusters * (api._dkdv_head // 2) < sms  # the smallest such divisor
+    assert api._dkdv_seq == 1
+    # MHA, small batch, short sequence: no group to split; the sequence split is
+    # never chosen automatically.
+    api = _make_adapter(_adapter_shapes(1, 2, 2, 2048, 2048))
+    assert (api._dkdv_head, api._dkdv_seq) == (1, 1)
+    assert _make_adapter(_adapter_shapes(1, 2, 2, 2048, 2048), dkdv_seq_split=4)._dkdv_seq == 4
+    # Large MHA: the grid alone fills the machine.
+    api = _make_adapter(_adapter_shapes(4, 16, 16, 8192, 8192))
+    assert (api._dkdv_head, api._dkdv_seq) == (1, 1)
     with pytest.raises(ValueError):
-        _make_adapter(inp, dkdv_head_split=3)  # not a divisor of 16
+        _make_adapter(_adapter_shapes(1, 32, 2, 2048, 2048), dkdv_head_split=3)  # not a divisor of 16
 
 
 @pytest.mark.L0
@@ -535,6 +591,20 @@ def test_dkdv_head_split_forced(split):
         for name, a, b_ in zip(("dQ", "dK", "dV"), got, base):
             cos = torch.nn.functional.cosine_similarity(a.float().flatten(), b_.float().flatten(), dim=0).item()
             assert cos > 0.99999, f"{name} split={split} vs unsplit: cos={cos:.7f}"
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("seq_split", [2, 3, 8])
+def test_dkdv_seq_split_forced(seq_split):
+    """Q-sequence chunks per KV tile (3 does not divide the 4 Q tiles: uneven
+    chunks; 8 exceeds them: empty chunks must still write zeros), causal so
+    the per-tile ranges differ, MHA so only the sequence split is at work."""
+    inp = _adapter_inputs(1, 2, 2, 512, 384, causal=True)
+    got = _run_adapter(_make_adapter(inp, dkdv_seq_split=seq_split), inp)
+    base = _run_adapter(_make_adapter(inp, dkdv_seq_split=1), inp)
+    for name, a, b_ in zip(("dQ", "dK", "dV"), got, base):
+        cos = torch.nn.functional.cosine_similarity(a.float().flatten(), b_.float().flatten(), dim=0).item()
+        assert cos > 0.99999, f"{name} seq_split={seq_split} vs unsplit: cos={cos:.7f}"
 
 
 @pytest.mark.L0
@@ -600,6 +670,7 @@ def test_reject_other_head_dims(d):
 
 @pytest.mark.L0
 def test_reject_e5m2_payloads():
+    """e5m2 fp8 payloads are declined."""
     assert _decline_reason(fp8=cudnn.data_type.FP8_E5M2) is not None
 
 
@@ -611,21 +682,25 @@ def test_reject_gradient_dtype_mismatch():
 
 @pytest.mark.L0
 def test_reject_bottom_right_causal():
+    """Bottom-right causal is declined."""
     assert _decline_reason(use_causal_mask_bottom_right=True) is not None
 
 
 @pytest.mark.L0
 def test_reject_right_band_widening():
+    """Right-band widening masks are declined."""
     assert _decline_reason(right_bound=16) is not None
 
 
 @pytest.mark.L0
 def test_reject_sliding_window():
+    """Sliding-window masks are declined."""
     assert _decline_reason(use_causal_mask=True, left_bound=64) is not None
 
 
 @pytest.mark.L0
 def test_reject_padding_mask():
+    """Padding masks are declined."""
     assert _decline_reason(use_padding_mask=True, seq_len_dims=(1, 1, 1, 1)) is not None
 
 
@@ -638,6 +713,7 @@ def test_reject_amax_outputs():
 
 @pytest.mark.L0
 def test_reject_sink():
+    """Attention sinks are declined."""
     assert _decline_reason(with_sink=True) is not None
 
 
@@ -647,6 +723,7 @@ def test_reject_non_bshd_layout():
     BHSD-contiguous graph is declined, not staged (Hard Rule 2)."""
 
     def bhsd(sh):
+        """BHSD-strided tensor helper for the sink test."""
         b, h, s, d = sh
         return [h * s * d, s * d, d, 1]
 
@@ -655,11 +732,13 @@ def test_reject_non_bshd_layout():
 
 @pytest.mark.L0
 def test_reject_gqa_ratio_not_integer():
+    """Non-integer H_q / H_kv ratios are declined."""
     assert _decline_reason(hq=6, hkv=4) is not None
 
 
 @pytest.mark.L0
 def test_reject_foreign_tiles():
+    """Scale-factor tiles of a foreign layout are declined."""
     from cudnn.sdpa.bwd.engines import SdpaBwdKnobs
 
     assert _decline_reason(knobs=SdpaBwdKnobs(tile_m=64)) is not None
@@ -701,6 +780,7 @@ def test_capabilities_match_what_is_implemented():
 
 @pytest.mark.L0
 def test_engine_is_registered_and_opt_in():
+    """The engine is in the manifest and only used with the FROST opt-in env."""
     from cudnn.engines.manifest import MANIFEST
 
     fam = next(f for f in MANIFEST if f.name == "frost_sdpa_bwd")

--- a/test/python/sdpa/frost/test_sdpa_bwd_mxfp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_bwd_mxfp8_sm100.py
@@ -243,9 +243,11 @@ def _run(b=1, hq=2, hkv=None, sq=256, skv=256, out_dt=torch.bfloat16, causal=Fal
     g.check_support()
     g.build_plans()
     ws = torch.empty(max(g.get_workspace_size(), 1), device=dev, dtype=torch.uint8)
-    dq = _to_bshd(torch.zeros(b, hq, sq, d, device=dev, dtype=out_dt))
-    dk = _to_bshd(torch.zeros(b, hkv, skv, d, device=dev, dtype=out_dt))
-    dv = _to_bshd(torch.zeros(b, hkv, skv, d, device=dev, dtype=out_dt))
+    # NaN-poisoned outputs: a tile the kernels skip (e.g. the causal tail past
+    # S_q) must still be WRITTEN, not inherited from the buffer.
+    dq = _to_bshd(torch.full((b, hq, sq, d), float("nan"), device=dev, dtype=out_dt))
+    dk = _to_bshd(torch.full((b, hkv, skv, d), float("nan"), device=dev, dtype=out_dt))
+    dv = _to_bshd(torch.full((b, hkv, skv, d), float("nan"), device=dev, dtype=out_dt))
     pack = {
         t["q"]: Q["row"],
         t["q_T"]: Q["col"],
@@ -274,6 +276,142 @@ def _run(b=1, hq=2, hkv=None, sq=256, skv=256, out_dt=torch.bfloat16, causal=Fal
         assert not torch.isnan(got).any(), f"{name} has NaN"
         cos = torch.nn.functional.cosine_similarity(got.float().flatten(), ref.flatten(), dim=0).item()
         assert cos > tol_cos, f"{name}: cos={cos:.6f}"
+
+
+def _adapter_inputs(b, hq, hkv, sq, skv, out_dt=torch.bfloat16, causal=False, seed=0):
+    """Quantized operands + reference gradients for driving the adapter directly
+    (bypassing the graph), as a dict of BSHD-physical torch tensors."""
+    from sdpa.mxfp8_ref import compute_ref, compute_ref_backward
+
+    torch.manual_seed(seed)
+    d, dev = _D, "cuda"
+    scale = 1.0 / math.sqrt(d)
+    q, dO = torch.randn(b, hq, sq, d, device=dev), torch.randn(b, hq, sq, d, device=dev)
+    k, v = torch.randn(b, hkv, skv, d, device=dev), torch.randn(b, hkv, skv, d, device=dev)
+    Q, K, V, DO = (_quantize(x, b, h, s, d) for x, h, s in ((q, hq, sq), (k, hkv, skv), (v, hkv, skv), (dO, hq, sq)))
+    right = 0 if causal else None
+    align = cudnn.diagonal_alignment.TOP_LEFT if causal else None
+    o_ref, stats = compute_ref(
+        Q["row"], K["row"], V["col"], Q["sf_row_ref"], K["sf_row_ref"], V["sf_col_ref"], scale, output_type=out_dt, right_bound=right, diag_align=align
+    )
+    o_f16 = _to_bshd(o_ref.to(out_dt))
+    dO_f16 = _to_bshd(dO.to(out_dt))
+    dq_r, dk_r, dv_r = compute_ref_backward(
+        Q["row"],
+        Q["col"],
+        K["row"],
+        K["col"],
+        V["row"],
+        o_f16,
+        dO_f16,
+        DO["row"],
+        DO["col"],
+        scale,
+        Q["sf_row_ref"],
+        Q["sf_col_ref"],
+        K["sf_row_ref"],
+        K["sf_col_ref"],
+        V["sf_row_ref"],
+        DO["sf_row_ref"],
+        DO["sf_col_ref"],
+        torch_otype=out_dt,
+        right_bound=right,
+        diag_align=align,
+        stats=stats,
+    )[:3]
+    sf_i8 = lambda t: t.view(torch.int8)  # noqa: E731
+    return dict(
+        q=Q["row"],
+        q_T=Q["col"],
+        k=K["row"],
+        k_T=K["col"],
+        v=V["row"],
+        o=o_f16,
+        dO_f16=dO_f16,
+        dO=DO["row"],
+        dO_T=DO["col"],
+        stats=stats.contiguous(),
+        sf_q=sf_i8(Q["sf_row"]),
+        sf_q_T=sf_i8(Q["sf_col"]),
+        sf_k=sf_i8(K["sf_row"]),
+        sf_k_T=sf_i8(K["sf_col"]),
+        sf_v=sf_i8(V["sf_row"]),
+        sf_dO=sf_i8(DO["sf_row"]),
+        sf_dO_T=sf_i8(DO["sf_col"]),
+        dq=_to_bshd(torch.zeros(b, hq, sq, d, device=dev, dtype=out_dt)),
+        dk=_to_bshd(torch.zeros(b, hkv, skv, d, device=dev, dtype=out_dt)),
+        dv=_to_bshd(torch.zeros(b, hkv, skv, d, device=dev, dtype=out_dt)),
+        ref=(dq_r, dk_r, dv_r),
+        scale=scale,
+        causal=causal,
+    )
+
+
+def _make_adapter(inp, **kw):
+    from cudnn.sdpa.bwd.api_dsl_mxfp8_sm100 import SdpaBwdDslSm100Mxfp8
+
+    return SdpaBwdDslSm100Mxfp8(
+        inp["q"],
+        inp["k"],
+        inp["v"],
+        inp["o"],
+        inp["dO"],
+        inp["stats"],
+        inp["dq"],
+        inp["dk"],
+        inp["dv"],
+        sample_q_T=inp["q_T"],
+        sample_k_T=inp["k_T"],
+        sample_do_T=inp["dO_T"],
+        sample_do_f16=inp["dO_f16"],
+        sample_sf_q=inp["sf_q"],
+        sample_sf_q_T=inp["sf_q_T"],
+        sample_sf_k=inp["sf_k"],
+        sample_sf_k_T=inp["sf_k_T"],
+        sample_sf_v=inp["sf_v"],
+        sample_sf_do=inp["sf_dO"],
+        sample_sf_do_T=inp["sf_dO_T"],
+        is_causal=inp["causal"],
+        scale_softmax=inp["scale"],
+        **kw,
+    )
+
+
+def _run_adapter(api, inp):
+    api.check_support()
+    api.compile()
+    ws = torch.empty(max(api.scratch_workspace_bytes(), 1), device="cuda", dtype=torch.uint8)
+    for t in (inp["dq"], inp["dk"], inp["dv"]):
+        t.fill_(float("nan"))
+    api.execute(
+        q_tensor=inp["q"],
+        k_tensor=inp["k"],
+        v_tensor=inp["v"],
+        o_tensor=inp["o"],
+        do_tensor=inp["dO"],
+        stats_tensor=inp["stats"],
+        dq_tensor=inp["dq"],
+        dk_tensor=inp["dk"],
+        dv_tensor=inp["dv"],
+        workspace=ws,
+        q_T_tensor=inp["q_T"],
+        k_T_tensor=inp["k_T"],
+        do_T_tensor=inp["dO_T"],
+        do_f16_tensor=inp["dO_f16"],
+        sf_q=inp["sf_q"],
+        sf_q_T=inp["sf_q_T"],
+        sf_k=inp["sf_k"],
+        sf_k_T=inp["sf_k_T"],
+        sf_v=inp["sf_v"],
+        sf_do=inp["sf_dO"],
+        sf_do_T=inp["sf_dO_T"],
+    )
+    torch.cuda.synchronize()
+    for name, got, ref in zip(("dQ", "dK", "dV"), (inp["dq"], inp["dk"], inp["dv"]), inp["ref"]):
+        assert not torch.isnan(got).any(), f"{name} has NaN"
+        cos = torch.nn.functional.cosine_similarity(got.float().flatten(), ref.flatten(), dim=0).item()
+        assert cos > _TOL_COS, f"{name}: cos={cos:.6f}"
+    return tuple(t.clone() for t in (inp["dq"], inp["dk"], inp["dv"]))
 
 
 # --------------------------------------------------------------------------- #
@@ -338,6 +476,14 @@ def test_ragged_tails_causal_gqa():
 
 
 @pytest.mark.L0
+def test_causal_kv_tail():
+    """Causal with S_kv > S_q: the KV tiles past S_q are attended by no query row,
+    their gradients are zero, and the kernel must WRITE that zero (it skips the
+    mainloop for them). Outputs start NaN-poisoned, so an unwritten tile fails."""
+    _run(hq=4, hkv=2, sq=256, skv=640, causal=True)
+
+
+@pytest.mark.L0
 def test_q_tile_boundary_causal():
     _run(hq=8, hkv=2, sq=257, skv=256, causal=True)
 
@@ -358,6 +504,37 @@ def test_deterministic_flag():
 @pytest.mark.L1
 def test_long_causal():
     _run(b=1, hq=2, hkv=2, sq=2048, skv=2048, causal=True)
+
+
+@pytest.mark.L0
+def test_dkdv_head_split_heuristic():
+    """The fused dK/dV kernel's grid is (KV tiles, KV heads, B); with few KV
+    heads the adapter splits the Q-head group across clusters so the GPU fills.
+    The split is a divisor of the group, the smallest reaching ~2 waves of
+    clusters, and 1 when there is no group (MHA) -- no partials, no fold."""
+    inp = _adapter_inputs(1, 32, 2, 2048, 2048)
+    api = _make_adapter(inp)
+    sms = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
+    kv_clusters = 16 * 2  # 2048/128 tiles x 2 KV heads x B=1
+    assert 16 % api._dkdv_split == 0 and api._dkdv_split > 1
+    assert kv_clusters * api._dkdv_split >= 2 * sms or api._dkdv_split == 16
+    assert _make_adapter(_adapter_inputs(1, 2, 2, 256, 256))._dkdv_split == 1
+    with pytest.raises(ValueError):
+        _make_adapter(inp, dkdv_head_split=3)  # not a divisor of 16
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("split", [1, 2, 8])
+def test_dkdv_head_split_forced(split):
+    """Every split writes per-slice partials that a fixed-order fold sums; the
+    result must match the reference (and the unsplit kernel) for each split."""
+    inp = _adapter_inputs(1, 8, 1, 256, 384, causal=True)
+    got = _run_adapter(_make_adapter(inp, dkdv_head_split=split), inp)
+    if split > 1:
+        base = _run_adapter(_make_adapter(inp, dkdv_head_split=1), inp)
+        for name, a, b_ in zip(("dQ", "dK", "dV"), got, base):
+            cos = torch.nn.functional.cosine_similarity(a.float().flatten(), b_.float().flatten(), dim=0).item()
+            assert cos > 0.99999, f"{name} split={split} vs unsplit: cos={cos:.7f}"
 
 
 @pytest.mark.L0


### PR DESCRIPTION
## Summary

Follow-up to #904. The fused dK/dV kernel of `sdpa_bwd_sm100_mxfp8` launches one 2-CTA cluster per (KV tile, KV head, batch) and that cluster walks every Q head of its KV head. With few KV heads at small batch — the GQA shapes this engine exists for — most of the GPU idles: 2 KV heads at S=8192 is 64 clusters on 148 SMs (43%), at S=2048 it is 16 (11%). On the 32/2-head causal d=256 shape the MXFP8 backward was therefore only 1.1–1.3x the bf16 backend at 32k and *slower* than bf16 below 8k.

This PR splits the dK/dV work of one KV tile across clusters and folds the partials:

- **Kernel** (`bprop_dkdv_d256_mxfp8_sm100.py`): two new constructor parameters, `h_r_split` (Q-head group slices) and `s_q_split` (Q-tile-range chunks), both default 1 = unchanged behaviour. The grid becomes (KV tiles, KV heads × split, B); cluster `bidy` handles KV head `bidy // split`, a Q-head slice and a Q-tile chunk of that KV tile's trip range, and stores its dK/dV into partial slot `bidy` of a `[B, S_kv, H_kv·split, D]` buffer (the `dK`/`dV` operands are viewed with `h_k·split` heads). The load warp gets a Q-head start offset and a shorter trip range; the compute warps' mask classification stays relative to the full range start (`iter_start_global`), so causal/diagonal handling is unchanged. Persistent mode rejects splits > 1 (not needed here).
- **Skipped causal-tail tiles are now written.** An in-range KV tile that no query row attends (causal with S_kv > S_q) used to skip the mainloop *and* the epilogue, leaving the caller's dK/dV rows with whatever was in the buffer. A new `epilogue_zero` stores zeros for those tiles (`test_causal_kv_tail`; the test harness now NaN-poisons outputs so this class of bug fails loudly).
- **Adapter** (`api_dsl_mxfp8_sm100.py`): `_dkdv_splits()` picks the head split as the smallest divisor of the GQA group that gives about one cluster per SM (or the whole group); `dkdv_head_split=` / `dkdv_seq_split=` override it. With a split > 1 it carves two partial buffers (gradient dtype) from the workspace and folds them with the existing fixed-order fp32 `dkv_reduce` kernel (shared with the half-precision GQA backward), so `use_deterministic_algorithm` still holds. MHA (group = 1) is bit-for-bit the old path: no partials, no fold.
- **Sequence split is opt-in only.** It is wired through the same partial/fold path and tested (`test_dkdv_seq_split_forced[2|3|8]`, including more chunks than Q tiles), but on every shape measured it was neutral at best and up to 30% slower otherwise (each chunk re-pays the per-cluster K/V load and pipeline setup, and the fold reads `seq` partials), so the heuristic never selects it. Numbers below.
- Also fixes a latent strictness bug in the adapter's BSHD check: extent-1 dims (MQA K/V head dim) now wildcard their stride, as the analyzer already does.
- Tests: `test_dkdv_head_split_heuristic` (shape-only, nothing computed: chosen split on a 32/2-head shape, (1,1) for MHA, non-divisor rejected), `test_dkdv_head_split_forced[1|2|8]` and `test_dkdv_seq_split_forced[2|3|8]` (each split matches the reference and the unsplit result to cosine > 0.99999) drive the adapter directly; the existing GQA/MQA graph tests run with a split > 1 by construction of their shapes. Docstrings added to every function this diff touches (CodeRabbit's coverage check).
- Tracker + module docstring note the split and its cost (2·split·|dK| bytes of workspace, one extra small launch).

## Numbers

B200 (SM clock pinned at 847 MHz on this box, so absolute numbers are ~0.42x of a 2 GHz part; compare relatively), b=1, 32 Q / 2 KV heads, d=256, causal, backward only, `cudnn_oss`, `benchmark/attention_training`:

| S | before (#904) | after | speedup | split chosen |
|---|---|---|---|---|
| 2048 | 1.116 ms · 154 TF | 0.735 ms · 234 TF | 1.52x | 8 |
| 4096 | 2.305 ms · 298 TF | 1.819 ms · 378 TF | 1.27x | 4 |
| 8192 | 5.350 ms · 514 TF | 5.275 ms · 521 TF | 1.01x | 2 |
| 16384 | 18.06 ms · 609 TF | 17.97 ms · 612 TF | 1.01x | 1 |
| 32768 | 66.22 ms · 664 TF | 65.87 ms · 668 TF | 1.01x | 1 |

MHA regression guard (b=4, 16/16 heads, S=8192, dense; split stays 1): 18.42 ms before, 18.41 ms after.

Why "one cluster per SM" and not more — device time (dQ + dK/dV + fold, torch profiler) with forced factors, same box:

| shape (causal) | CTA waves unsplit | unsplit | head split 2 / 4 / 8 / 16 |
|---|---|---|---|
| 32/2 @2k | 0.43 | 1.028 ms | 0.723 / 0.667 / **0.655** / 0.700 |
| 32/2 @4k | 0.86 | 2.174 ms | 1.820 / 1.705 / **1.693** / – |
| 32/2 @8k | 1.73 | 5.126 ms | **5.087** / 5.523 / 5.132 / – |

Once the grid covers the machine (8k+) more slices only add fold traffic and per-cluster setup; targeting two waves (the first version of this PR) cost 8% at 8k. The sequence split on MHA shapes, where there is no head group to slice:

| shape (causal) | CTA waves unsplit | unsplit | seq split 2 / 3 / 4 / 8 |
|---|---|---|---|
| 8/8 @2k | 1.73 | **0.252 ms** | 0.288 / 0.333 / 0.347 / – |
| 8/8 @4k | 3.46 | **0.589 ms** | 0.662 / 0.752 / – / – |
| 2/2 @2k | 0.43 | 0.180 ms | **0.169** / – / 0.184 / 0.211 |
| 2/2 @8k | 1.73 | **0.512 ms** | 0.561 / – / 0.631 / 0.750 |

At S=2048 the remaining gap to the bf16 backend is the adapter's host-side launch path (~0.9 ms per execute), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved MXFP8 SDPA backward performance for grouped and multi-query attention through parallel Q-head splitting.
  * Added opt-in sequence-range splitting for dK/dV computation with deterministic partial-result reduction.
  * Added automatic head-split selection and explicit configuration for head and sequence splitting.
  * Added support for extent-one dimensions with flexible strides.

* **Bug Fixes**
  * Ensured empty or fully masked causal-attention chunks produce correctly initialized dK/dV results.

* **Documentation**
  * Updated support documentation with split behavior and workspace requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->