### PR TITLE
 Reduce instruction number for tanh soft clamp srelu/dsrelu grouped GEMM epilogues

### DIFF
--- a/python/cudnn/gemm/cutedsl/grouped/dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
@@ -77,8 +77,8 @@ from ..moe_sched_extension import (
     ContiguousAndConsistentGroupedGemmSchedExtension,
 )
 from ..moe_kernel_helpers import (
-    fmin,
     fmax,
+    tanh_clamp_unit,
     atomic_add_float32,
     atomic_max_float32,
     compute_stages,
@@ -2134,6 +2134,19 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
                 real_prob, _ = epi_ext.get_gmem_tensor("prob", prob, padded_offsets, epi_work_tile_info)
                 mProb = real_prob[mPosition, 0, 0]
 
+                if cutlass.const_expr(self.epilogue_type == EpilogueType.DSRELU.value and self.tanh_clamp_scale is not None):
+                    # Soft-clamp constants, once per tile. The clamped epilogue below is written in
+                    # t = tanh(relu(C)/s) alone, so s enters the per-element math only through these:
+                    #   d_srelu = t^2 * s^2 * w         = t^2 * clamp_k_srelu
+                    #   dprob  += t^2 * s^2 * g         = (t^2 g) * clamp_s2
+                    #   dgrad   = g * (t - t^3) * (2sw) = g * (t - t^3) * clamp_k_dgrad
+                    # clamp_k_srelu must be the same expression as prob_scale in the forward kernel
+                    # (regen must reproduce the forward bit for bit when C is stored in fp32).
+                    clamp_s_rcp = cutlass.Float32(1.0 / self.tanh_clamp_scale)
+                    clamp_s2 = cutlass.Float32(self.tanh_clamp_scale * self.tanh_clamp_scale)
+                    clamp_k_srelu = cutlass.Float32(mProb) * clamp_s2
+                    clamp_k_dgrad = cutlass.Float32(mProb) * cutlass.Float32(2.0 * self.tanh_clamp_scale)
+
                 # Accumulator for dprob: summed over N subtiles, written once per tile
                 dProbVal = cutlass.Float32(0.0)
 
@@ -2216,97 +2229,102 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
                         # Here acc_vec is the upstream gradient from the following GEMM,
                         # and c_vec is the saved forward SReLU input.
                         c_forward = c_vec.load()
-                        c_relu = cute.where(c_forward > 0, c_forward, cute.full_like(c_forward, 0))
-                        tRelu = cute.make_rmem_tensor(acc_vec.shape, self.acc_dtype)
-                        tRelu.store(c_relu)
-
                         if cutlass.const_expr(self.tanh_clamp_scale is not None):
-                            # Soft-clamped dSReLU: t = tanh(relu(C)/s), c = s*t. Overwrite
-                            # tRelu in place with c -- every consumer below treats it as an
-                            # opaque value and none re-derives relu, so the dprob and d_srelu
-                            # paths stay correct unchanged. (1-t^2) is stashed in tCompute,
-                            # which is dead until the dgrad write below.
-                            #
-                            # t is capped at 1: mathematically t is in [0, 1], but it comes
-                            # from tanh.approx.f32, whose range this kernel does not assume --
-                            # a t above 1 would flip the gradient's sign, by a margin that
-                            # sits far inside the fp8 tolerance of every test here.
-                            one = cutlass.Float32(1.0)
-                            s = cutlass.Float32(self.tanh_clamp_scale)
-                            s_rcp = cutlass.Float32(1.0 / self.tanh_clamp_scale)
-                            if cutlass.const_expr(self.vectorized_f32):
-                                for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
-                                    t0 = fmin(cute.math.tanh(tRelu[i] * s_rcp, fastmath=True), one)
-                                    t1 = fmin(cute.math.tanh(tRelu[i + 1] * s_rcp, fastmath=True), one)
-                                    # (1-t)*(1+t) rather than 1-t*t: free, better conditioned
-                                    # as t -> 1 in the saturated tail.
-                                    tCompute[i], tCompute[i + 1] = cute.arch.mul_packed_f32x2(
-                                        (one - t0, one - t1),
-                                        (one + t0, one + t1),
-                                        rnd="rn",
-                                        ftz=False,
-                                    )
-                                    tRelu[i], tRelu[i + 1] = cute.arch.mul_packed_f32x2(
-                                        (t0, t1),
-                                        (s, s),
-                                        rnd="rn",
-                                        ftz=False,
-                                    )
-                            else:
-                                for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
-                                    t = fmin(cute.math.tanh(tRelu[i] * s_rcp, fastmath=True), one)
-                                    tCompute[i] = (one - t) * (one + t)
-                                    tRelu[i] = t * s
-
-                        if cutlass.const_expr(self.use_dsrelu_reuse):
-                            tRelu2 = self.compute_relu2(tTR_rAcc, tRelu)
+                            # t = tanh(relu(C)/s)
+                            # d_srelu = t^2 * s^2 * w         = t^2 * clamp_k_srelu
+                            # dprob  += t^2 * s^2 * g         = (t^2 g) * clamp_s2
+                            # dgrad   = g * (t - t^3) * (2sw) = g * (t - t^3) * clamp_k_dgrad
+                            # relu and the t <= 1 cap are one saturating multiply inside
+                            # tanh_clamp_unit (see moe_kernel_helpers)
+                            tCompute.store(c_forward)
+                            if cutlass.const_expr(self.generate_d_srelu):
+                                tComputeSrelu = cute.make_rmem_tensor(acc_vec.shape, self.acc_dtype)
                             if cutlass.const_expr(dprob is not None):
-                                dprob_partial = self.compute_dprob_from_relu2(
-                                    tTR_rAcc,
-                                    acc_vec,
-                                    tRelu2,
-                                )
-                            if cutlass.const_expr(self.generate_d_srelu):
-                                tComputeSrelu = self.scale_srelu_from_relu2(
-                                    tTR_rAcc,
-                                    tRelu2,
-                                    mProb,
-                                )
-                        else:
-                            if cutlass.const_expr(self.generate_d_srelu):
-                                tComputeSrelu = self.compute_srelu(tRelu, mProb)
-                        probx2 = 2 * mProb
-                        if cutlass.const_expr(self.tanh_clamp_scale is not None):
-                            # dgrad = g * 2*c*(1-t^2) * w. (1-t^2) is stashed in tCompute from
-                            # the overwrite above; read both lanes into temporaries before this
-                            # store, since it aliases the same tensor it reads.
+                                dprob_acc = cutlass.Float32(0.0)
                             if cutlass.const_expr(self.vectorized_f32):
                                 for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
-                                    one_minus_t2_0 = tCompute[i]
-                                    one_minus_t2_1 = tCompute[i + 1]
-                                    tCompute[i], tCompute[i + 1] = cute.arch.mul_packed_f32x2(
-                                        (tRelu[i], tRelu[i + 1]),
+                                    u0, u1 = cute.arch.mul_packed_f32x2(
+                                        (tCompute[i], tCompute[i + 1]),
+                                        (clamp_s_rcp, clamp_s_rcp),
+                                        rnd="rn",
+                                        ftz=False,
+                                    )
+                                    t0 = tanh_clamp_unit(u0)
+                                    t1 = tanh_clamp_unit(u1)
+                                    t2_0, t2_1 = cute.arch.mul_packed_f32x2(
+                                        (t0, t1),
+                                        (t0, t1),
+                                        rnd="rn",
+                                        ftz=False,
+                                    )
+                                    if cutlass.const_expr(dprob is not None):
+                                        p0, p1 = cute.arch.mul_packed_f32x2(
+                                            (t2_0, t2_1),
+                                            (acc_vec[i], acc_vec[i + 1]),
+                                            rnd="rn",
+                                            ftz=False,
+                                        )
+                                        dprob_acc += p0 + p1
+                                    if cutlass.const_expr(self.generate_d_srelu):
+                                        tComputeSrelu[i], tComputeSrelu[i + 1] = cute.arch.mul_packed_f32x2(
+                                            (t2_0, t2_1),
+                                            (clamp_k_srelu, clamp_k_srelu),
+                                            rnd="rn",
+                                            ftz=False,
+                                        )
+                                    v0, v1 = cute.arch.fma_packed_f32x2(
+                                        (-t2_0, -t2_1),
+                                        (t0, t1),
+                                        (t0, t1),
+                                        rnd="rn",
+                                        ftz=False,
+                                    )
+                                    gk0, gk1 = cute.arch.mul_packed_f32x2(
                                         (acc_vec[i], acc_vec[i + 1]),
+                                        (clamp_k_dgrad, clamp_k_dgrad),
                                         rnd="rn",
                                         ftz=False,
                                     )
                                     tCompute[i], tCompute[i + 1] = cute.arch.mul_packed_f32x2(
-                                        (tCompute[i], tCompute[i + 1]),
-                                        (cutlass.Float32(probx2), cutlass.Float32(probx2)),
-                                        rnd="rn",
-                                        ftz=False,
-                                    )
-                                    tCompute[i], tCompute[i + 1] = cute.arch.mul_packed_f32x2(
-                                        (tCompute[i], tCompute[i + 1]),
-                                        (one_minus_t2_0, one_minus_t2_1),
+                                        (gk0, gk1),
+                                        (v0, v1),
                                         rnd="rn",
                                         ftz=False,
                                     )
                             else:
                                 for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
-                                    one_minus_t2 = tCompute[i]
-                                    tCompute[i] = tRelu[i] * acc_vec[i] * cutlass.Float32(probx2) * one_minus_t2
+                                    t = tanh_clamp_unit(tCompute[i] * clamp_s_rcp)
+                                    t2 = t * t
+                                    if cutlass.const_expr(dprob is not None):
+                                        dprob_acc += t2 * acc_vec[i]
+                                    if cutlass.const_expr(self.generate_d_srelu):
+                                        tComputeSrelu[i] = t2 * clamp_k_srelu
+                                    tCompute[i] = acc_vec[i] * clamp_k_dgrad * (t - t2 * t)
+                            if cutlass.const_expr(dprob is not None):
+                                dprob_partial = dprob_acc * clamp_s2
                         else:
+                            c_relu = cute.where(c_forward > 0, c_forward, cute.full_like(c_forward, 0))
+                            tRelu = cute.make_rmem_tensor(acc_vec.shape, self.acc_dtype)
+                            tRelu.store(c_relu)
+
+                            if cutlass.const_expr(self.use_dsrelu_reuse):
+                                tRelu2 = self.compute_relu2(tTR_rAcc, tRelu)
+                                if cutlass.const_expr(dprob is not None):
+                                    dprob_partial = self.compute_dprob_from_relu2(
+                                        tTR_rAcc,
+                                        acc_vec,
+                                        tRelu2,
+                                    )
+                                if cutlass.const_expr(self.generate_d_srelu):
+                                    tComputeSrelu = self.scale_srelu_from_relu2(
+                                        tTR_rAcc,
+                                        tRelu2,
+                                        mProb,
+                                    )
+                            else:
+                                if cutlass.const_expr(self.generate_d_srelu):
+                                    tComputeSrelu = self.compute_srelu(tRelu, mProb)
+                            probx2 = 2 * mProb
                             if cutlass.const_expr(self.vectorized_f32):
                                 for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
                                     tCompute[i], tCompute[i + 1] = cute.arch.mul_packed_f32x2(
@@ -2325,27 +2343,27 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
                                 for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
                                     tCompute[i] = tRelu[i] * acc_vec[i] * cutlass.Float32(probx2)
 
-                        # Accumulate dprob: dprob[m] += sum_n(relu(C)^2 * upstream_grad)
-                        if cutlass.const_expr(dprob is not None and not self.use_dsrelu_reuse):
-                            tDprob = cute.make_rmem_tensor(acc_vec.shape, self.acc_dtype)
-                            if cutlass.const_expr(self.vectorized_f32):
-                                for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
-                                    tDprob[i], tDprob[i + 1] = cute.arch.mul_packed_f32x2(
-                                        (tRelu[i], tRelu[i + 1]),
-                                        (tRelu[i], tRelu[i + 1]),
-                                        rnd="rn",
-                                        ftz=False,
-                                    )
-                                    tDprob[i], tDprob[i + 1] = cute.arch.mul_packed_f32x2(
-                                        (tDprob[i], tDprob[i + 1]),
-                                        (acc_vec[i], acc_vec[i + 1]),
-                                        rnd="rn",
-                                        ftz=False,
-                                    )
-                            else:
-                                for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
-                                    tDprob[i] = tRelu[i] * tRelu[i] * acc_vec[i]
-                            dprob_partial = tDprob.load().reduce(cute.ReductionOp.ADD, cutlass.Float32(0.0), 0)
+                            # Accumulate dprob: dprob[m] += sum_n(relu(C)^2 * upstream_grad)
+                            if cutlass.const_expr(dprob is not None and not self.use_dsrelu_reuse):
+                                tDprob = cute.make_rmem_tensor(acc_vec.shape, self.acc_dtype)
+                                if cutlass.const_expr(self.vectorized_f32):
+                                    for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
+                                        tDprob[i], tDprob[i + 1] = cute.arch.mul_packed_f32x2(
+                                            (tRelu[i], tRelu[i + 1]),
+                                            (tRelu[i], tRelu[i + 1]),
+                                            rnd="rn",
+                                            ftz=False,
+                                        )
+                                        tDprob[i], tDprob[i + 1] = cute.arch.mul_packed_f32x2(
+                                            (tDprob[i], tDprob[i + 1]),
+                                            (acc_vec[i], acc_vec[i + 1]),
+                                            rnd="rn",
+                                            ftz=False,
+                                        )
+                                else:
+                                    for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
+                                        tDprob[i] = tRelu[i] * tRelu[i] * acc_vec[i]
+                                dprob_partial = tDprob.load().reduce(cute.ReductionOp.ADD, cutlass.Float32(0.0), 0)
 
                         # Single home for both producers above -- their guards are mutually
                         # exclusive on use_dsrelu_reuse, so exactly one has run.

--- a/python/cudnn/gemm/cutedsl/grouped/moe_kernel_helpers.py
+++ b/python/cudnn/gemm/cutedsl/grouped/moe_kernel_helpers.py
@@ -138,6 +138,32 @@ def fmax(a: Union[float, Float32], b: Union[float, Float32], *, nan=True, loc=No
     )
 
 
+def tanh_clamp_unit(u: Float32, *, loc=None, ip=None) -> Float32:
+    """``t = sat(tanh(u))`` for ``u = x/s``: the soft-clamp unit of the srelu/dsrelu epilogues.
+
+    One MUFU.TANH plus one FMUL.SAT (``mul.rn.sat.f32`` by 1.0 clamps to [0, 1]; NaN -> +0).
+    The saturate does two jobs. It is the relu: tanh is monotone with tanh(0) = 0, so u < 0
+    lands on t = 0, and NaN lands on 0 exactly like ``where(NaN > 0, NaN, 0)`` did. And it is
+    the defensive t <= 1 cap the backward needs for t - t^3 >= 0, since tanh.approx.f32's
+    range is not assumed.
+
+    Both kernels must go through this one function: with C stored in fp32 the backward's
+    d_srelu regen has to reproduce the forward bit for bit.
+    """
+    t = cute.math.tanh(u, fastmath=True)
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(t).ir_value(loc=loc, ip=ip)],
+            "mul.rn.sat.f32 $0, $1, 0f3F800000;",
+            "=f,f",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
 def fmin_bf16x2(
     a0: BFloat16,
     a1: BFloat16,

--- a/python/cudnn/gemm/cutedsl/grouped/srelu/moe_blockscaled_grouped_gemm_srelu_quant.py
+++ b/python/cudnn/gemm/cutedsl/grouped/srelu/moe_blockscaled_grouped_gemm_srelu_quant.py
@@ -47,8 +47,8 @@ from ..moe_sched_extension import (
     ContiguousAndConsistentGroupedGemmSchedExtension,
 )
 from ..moe_kernel_helpers import (
-    fmin,
     fmax,
+    tanh_clamp_unit,
     atomic_max_float32,
     compute_stages,
     compute_grid,
@@ -1894,6 +1894,18 @@ class BlockScaledMoEGroupedGemmQuantKernel:
                 real_prob, _ = epi_ext.get_gmem_tensor("prob", prob, padded_offsets, epi_work_tile_info)
                 mProb = real_prob[mPosition, 0, 0]
 
+                # Per-row scale applied to the activation below the subtile loop.
+                # Plain srelu: prob.
+                # Soft-clamped srelu: the activation is t^2 * (s^2 prob) with t = tanh(relu(x)/s),
+                # so s^2 is folded in here once per tile. This expression must match clamp_k_srelu
+                # in the dsrelu kernel.
+                if cutlass.const_expr(self.epilogue_type == EpilogueType.SRELU.value and self.tanh_clamp_scale is not None):
+                    clamp_s_rcp = cutlass.Float32(1.0 / self.tanh_clamp_scale)
+                    clamp_s2 = cutlass.Float32(self.tanh_clamp_scale * self.tanh_clamp_scale)
+                    prob_scale = cutlass.Float32(mProb) * clamp_s2
+                else:
+                    prob_scale = mProb
+
                 # C1 fix: phase-based acc stage indexing for overlapping_accum
                 if cutlass.const_expr(self.overlapping_accum):
                     acc_stage_index = acc_consumer_state.phase
@@ -1973,37 +1985,36 @@ class BlockScaledMoEGroupedGemmQuantKernel:
                     acc_vec = tTR_rAcc.load()
 
                     if cutlass.const_expr(self.epilogue_type == EpilogueType.SRELU.value):
-                        acc_relu = cute.where(acc_vec > 0, acc_vec, cute.full_like(acc_vec, 0))
                         if cutlass.const_expr(self.tanh_clamp_scale is not None):
-                            # Soft-clamped squared ReLU: c = s * tanh(relu(x) / s); out = c**2.
-                            # Plain squared ReLU is the s -> infinity limit. t is capped at 1:
-                            # tanh.approx.f32's range is not assumed (the backward kernel needs
-                            # 1 - t**2 >= 0); the cap makes c <= s structural.
-                            one = cutlass.Float32(1.0)
-                            s = cutlass.Float32(self.tanh_clamp_scale)
-                            s_rcp = cutlass.Float32(1.0 / self.tanh_clamp_scale)
+                            # Soft-clamped squared ReLU: out = (s * tanh(relu(x)/s))^2 * w,
+                            # computed as t^2 * prob_scale where t = tanh(relu(x)/s), and
+                            # prob_scale = s^2 * w was folded once per tile.
+                            # tanh_clamp_unit is relu, tanh and the defensive t <= 1 cap in
+                            # two instructions (negative x -> t = 0, NaN -> 0).
+                            # The dsrelu kernel's d_srelu regen uses this same expression;
+                            # keep them identical.
                             if cutlass.const_expr(self.vectorized_f32):
                                 for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
-                                    t0 = fmin(cute.math.tanh(acc_relu[i] * s_rcp, fastmath=True), one)
-                                    t1 = fmin(cute.math.tanh(acc_relu[i + 1] * s_rcp, fastmath=True), one)
-                                    c0, c1 = cute.arch.mul_packed_f32x2(
-                                        (t0, t1),
-                                        (s, s),
+                                    u0, u1 = cute.arch.mul_packed_f32x2(
+                                        (acc_vec[i], acc_vec[i + 1]),
+                                        (clamp_s_rcp, clamp_s_rcp),
                                         rnd="rn",
                                         ftz=False,
                                     )
+                                    t0 = tanh_clamp_unit(u0)
+                                    t1 = tanh_clamp_unit(u1)
                                     tTR_rAcc[i], tTR_rAcc[i + 1] = cute.arch.mul_packed_f32x2(
-                                        (c0, c1),
-                                        (c0, c1),
+                                        (t0, t1),
+                                        (t0, t1),
                                         rnd="rn",
                                         ftz=False,
                                     )
                             else:
                                 for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
-                                    t = fmin(cute.math.tanh(acc_relu[i] * s_rcp, fastmath=True), one)
-                                    c = t * s
-                                    tTR_rAcc[i] = c * c
+                                    t = tanh_clamp_unit(acc_vec[i] * clamp_s_rcp)
+                                    tTR_rAcc[i] = t * t
                         else:
+                            acc_relu = cute.where(acc_vec > 0, acc_vec, cute.full_like(acc_vec, 0))
                             for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
                                 tTR_rAcc[i], tTR_rAcc[i + 1] = cute.arch.mul_packed_f32x2(
                                     (acc_relu[i], acc_relu[i + 1]),
@@ -2018,13 +2029,13 @@ class BlockScaledMoEGroupedGemmQuantKernel:
                         for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
                             tCompute[i], tCompute[i + 1] = cute.arch.mul_packed_f32x2(
                                 (acc_vec[i], acc_vec[i + 1]),
-                                (mProb, mProb),
+                                (prob_scale, prob_scale),
                                 rnd="rn",
                                 ftz=False,
                             )
                     else:
                         for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
-                            tCompute[i] = acc_vec[i] * mProb
+                            tCompute[i] = acc_vec[i] * prob_scale
 
                     if cutlass.const_expr(self.generate_amax):
                         thread_tile_amax = amax_reduction_per_thread(tCompute, thread_tile_amax)


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches (see [root AGENTS.md § Reviewing a PR](https://github.com/NVIDIA/cudnn-frontend/blob/develop/AGENTS.md#reviewing-a-pr-human-or-agent)) and my changes comply, or I explain the exception below.
- [x] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

FE OSS kernels or CuTeDSL; Benchmarks or performance.

## Summary

Follow-up to the `tanh_clamp_scale` epilogues (#79418e29). The clamped backward cost +12-14% over
the unclamped kernel at k=3072 while the clamped forward cost ~+3.5%. Nsight Compute shows the
dSReLU epilogue is the backward's critical path (one latency-bound epilogue warp per scheduler,
MUFU at 4%, registers/occupancy unchanged), so each of the 8 instructions the clamp added per
element was wall time.

Both clamped branches are rewritten in `t = tanh(relu(x)/s)`:

* `s` folded into per-tile scalars (`s^2*w`, `2*s*w`, `s^2`); no per-element multiply by `s`
* relu and the `t <= 1` cap fused into one saturating multiply (`tanh_clamp_unit`, new helper)
* backward: `t^2` computed once and shared by dgrad, dprob and the d_srelu regen; `t - t^3` is one
  FFMA; the whole branch is a single per-element pass
* forward and backward use the same `tanh_clamp_unit`, so the regen stays bit-identical to the
  forward when C is stored in fp32

Unclamped path unchanged; `tanh_clamp_scale=None` stays bit-identical (existing tests).

## Why

Extra instructions per element: backward 8.0 -> 2.2, forward 4.5 -> 2.5. Kernel time over the
unclamped kernel, GB300 (sm_103), n=8192/16384, k=3072, MXFP8, same node back to back:

| | before | after |
|---|---|---|
| backward, dynamic scheduler (TE default) | +13.4% to +13.7% | +2.1% to +2.4% |
| backward, static scheduler | +12.4% to +12.6% | +3.6% to +3.8% |
| forward | +2.0% to +3.9% | +1.1% to +3.7% |

Numerics on identical inputs, old vs new kernels: unclamped outputs bitwise identical (forward and
backward, deterministic dprob). Clamped, s=16: forward D, d_srelu and dprob bitwise identical;
d_row/d_col differ in ~3e-7 of fp8 codes (rounding sequence of the dgrad expression). Clamped
backward compiles to 255 registers/thread (unclamped 230), no spills.

## Related issues

Follow-up to the tanh_clamp_scale change (79418e29).

## API and compatibility impact

None. No API change; `tanh_clamp_scale=None` output is bit-identical to before; clamped outputs
differ from the previous clamped kernel only by fp32 rounding order.

## Testing

GB300 (sm_103), cuDNN FE test suite unmodified, from `test/python`:

```
pytest fe_api/grouped_gemm/test_grouped_gemm_srelu.py    # 81 passed, 80 skipped
pytest fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py   # 121 passed, 80 skipped
```

Includes the clamped cases (two scales x fp8/fp4 x vector_f32 x reuse x deterministic), the
`None`-vs-omitted bitwise tests, the saturated-gradient tests and the regen-matches-forward test.
Performance: interleaved clamped-vs-unclamped bench (101 samples x 20 launches) and Nsight Compute
instruction/cycle counts, numbers above.