### PR TITLE
test(python): drop stale pytest_load_initial_conftests note

### DIFF
--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -219,10 +219,6 @@ def cudnn_handle():
 
 
 # =================== PyTest Hooks =====================
-# (pytest_load_initial_conftests is not called for conftest.py files -- pluggy
-# snapshots the hook impls before conftests are registered -- so the --tb=short
-# / --no-header defaults it used to set live in pytest.ini addopts instead.)
-
 
 def pytest_configure(config):
     global _xdist_controller, _stderr_fd


### PR DESCRIPTION
@coderabbitai ignore

Comment-only. Removes the note left in #639 about the deleted (never-invoked) `pytest_load_initial_conftests` hook; `pytest.ini` addopts already documents the defaults.