### PR TITLE
Optimize Rubin split-KV combine

### DIFF
--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -1398,6 +1398,11 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 has_lse=self.lse_desc is not None,
                 has_amax=self._fp8,
                 lse_stride=self._lse_stride,
+                # Rubin's D128 combine has thousands of row blocks at the
+                # admitted prefill shapes.  Up through split-6, one warp keeps
+                # that grid full while avoiding four copies of the row-uniform
+                # LSE/weight work.  Larger factors favor the wider block.
+                threads=32 if self._device_cc == (10, 7) and self.head_dim_v == 128 and self.split_kv <= 6 else 128,
             )
         self._logger.debug("compile completed")
 

--- a/python/cudnn/sdpa/fwd/kernels/split_combine_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/split_combine_sm100.py
@@ -10,8 +10,7 @@ A split whose range came out empty ends with total_sum == 0, which the epilogue
 turns into ``O := 0 / lse := -inf`` — the identity here, so empty splits need no
 special case.
 
-One block per (q_row, head, batch); the block's threads stride over d_v, and
-each thread walks the split axis in registers.
+One block per (q_row, head, batch); the block's threads stride over d_v.
 """
 
 from typing import Callable, Optional, Tuple
@@ -25,9 +24,8 @@ from cutlass.base_dsl.typing import Pointer
 from cutlass.experimental import primitives as nvvm
 import cuda.bindings.driver as _cuda_driver  # noqa: F401  (cute.compile pulls cuda)
 
-# One block per (q_row, head, batch); 128 lanes stride over d_v.  d_v <= 128 for
-# every flavor that uses this pass today, so the stride loop runs once.
-THREADS = 128
+WARP_SIZE = 32
+DEFAULT_THREADS = 128
 
 NEG_INF = float("-inf")
 
@@ -47,6 +45,7 @@ def _combine_kernel(
     n_batch: cutlass.Int32,
     n_splits: cutlass.Int32,
     d_v: cutlass.Int32,
+    threads: cutlass.Constexpr[int],
 ) -> None:
     tidx, _, _ = cute.arch.thread_idx()
     q_row = cute.arch.block_idx()[0]
@@ -58,12 +57,28 @@ def _combine_kernel(
     oo = cutlass.make_array_view(o_out)
 
     # --- pass 1: M = max_s lse_s, then den = sum_s exp(lse_s - M) ---
-    # Every lane redundantly walks the (very short) split axis; the values are
-    # block-uniform and hit L1, which is cheaper than staging them through SMEM.
-    m = cutlass.Float32(NEG_INF)
-    for s in cutlass.range(0, n_splits, 1, unroll=1):
-        lse_row = lp[batch + s * n_batch, head, :]
-        m = cute.math.max(m, cutlass.Float32(lse_row[q_row]))
+    # The split count is normally <= 8.  Assign one split to each lane and
+    # exchange the block-uniform LSE-derived values within the warp instead of
+    # making every lane reload and exponentiate every split.  Keep the original
+    # loop for unusually large split counts.
+    neg_inf = cutlass.Float32(NEG_INF)
+    lane = tidx & cutlass.Int32(WARP_SIZE - 1)
+    # Every lane in a warp must execute the shuffles below.  Envelope head
+    # dimensions only require a multiple of 8, so retain the scalar fallback
+    # when the final warp is partial.
+    warp_combine = (n_splits <= cutlass.Int32(WARP_SIZE)) & ((d_v & cutlass.Int32(WARP_SIZE - 1)) == cutlass.Int32(0))
+    lse_lane = neg_inf
+    m = neg_inf
+    if warp_combine:
+        if lane < n_splits:
+            lse_row = lp[batch + lane * n_batch, head, :]
+            lse_lane = cutlass.Float32(lse_row[q_row])
+        for s in cutlass.range(0, n_splits, 1, unroll=1):
+            m = cute.math.max(m, cutlass.Float32(cute.arch.shuffle_sync(lse_lane, s)))
+    else:
+        for s in cutlass.range(0, n_splits, 1, unroll=1):
+            lse_row = lp[batch + s * n_batch, head, :]
+            m = cute.math.max(m, cutlass.Float32(lse_row[q_row]))
 
     # All splits dead (every row fully masked): emit O := 0 / lse := -inf rather
     # than exp(-inf - -inf) == NaN.  m_safe only feeds the exponentials.
@@ -72,12 +87,21 @@ def _combine_kernel(
 
     # Same reasoning as pass 2: skip dead splits rather than trusting a fastmath
     # exp(-inf) to be exactly 0.
+    weight_lane = cutlass.Float32(0.0)
+    live_lane = cutlass.Int32(0)
     den = cutlass.Float32(0.0)
-    for s in cutlass.range(0, n_splits, 1, unroll=1):
-        lse_row = lp[batch + s * n_batch, head, :]
-        lse_s = cutlass.Float32(lse_row[q_row])
-        if lse_s > cutlass.Float32(NEG_INF):
-            den = den + cute.math.exp(lse_s - m_safe, fastmath=True)
+    if warp_combine:
+        if lse_lane > neg_inf:
+            weight_lane = cute.math.exp(lse_lane - m_safe, fastmath=True)
+            live_lane = cutlass.Int32(1)
+        for s in cutlass.range(0, n_splits, 1, unroll=1):
+            den = den + cutlass.Float32(cute.arch.shuffle_sync(weight_lane, s))
+    else:
+        for s in cutlass.range(0, n_splits, 1, unroll=1):
+            lse_row = lp[batch + s * n_batch, head, :]
+            lse_s = cutlass.Float32(lse_row[q_row])
+            if lse_s > neg_inf:
+                den = den + cute.math.exp(lse_s - m_safe, fastmath=True)
 
     inv_den = cutlass.Float32(1.0) / cute.math.max(den, cutlass.Float32(1e-30))
     inv_den = cutlass.Float32(arith.select(all_dead.ir_value(), cutlass.Float32(0.0).ir_value(), inv_den.ir_value()))
@@ -93,31 +117,51 @@ def _combine_kernel(
     # d512 with 5 KV tiles over 8 splits produced NaN in the recombined O
     # without this guard, even though every partial slot held a clean
     # -inf / 0.)
-    neg_inf = cutlass.Float32(NEG_INF)
     amax_local = cutlass.Float32(0.0)
-    for d0 in cutlass.range(tidx, d_v, THREADS, unroll=1):
-        acc = cutlass.Float32(0.0)
-        for s in cutlass.range(0, n_splits, 1, unroll=1):
-            lse_row = lp[batch + s * n_batch, head, :]
-            lse_s = cutlass.Float32(lse_row[q_row])
-            if lse_s > neg_inf:
-                w = cute.math.exp(lse_s - m_safe, fastmath=True)
-                o_row = op[batch + s * n_batch, q_row, head, :]
-                acc = acc + w * cutlass.Float32(o_row[d0])
-        out_row = oo[batch, q_row, head, :]
-        o_val = acc * inv_den
-        out_row[d0] = o_val.to(o_out.element_type)
-        if cutlass.const_expr(amax_o is not None):
-            # amax over the fp32 PRE-CAST value, matching what the single-pass
-            # epilogue reports.
-            amax_local = cute.math.max(amax_local, cute.math.max(o_val, -o_val))
+    if warp_combine:
+        for d0 in cutlass.range(tidx, d_v, threads, unroll=1):
+            acc = cutlass.Float32(0.0)
+            for s in cutlass.range(0, n_splits, 1, unroll=1):
+                live_s = cutlass.Int32(cute.arch.shuffle_sync(live_lane, s))
+                if live_s != cutlass.Int32(0):
+                    w = cutlass.Float32(cute.arch.shuffle_sync(weight_lane, s))
+                    o_row = op[batch + s * n_batch, q_row, head, :]
+                    acc = acc + w * cutlass.Float32(o_row[d0])
+            out_row = oo[batch, q_row, head, :]
+            o_val = acc * inv_den
+            out_row[d0] = o_val.to(o_out.element_type)
+            if cutlass.const_expr(amax_o is not None):
+                # amax over the fp32 PRE-CAST value, matching what the
+                # single-pass epilogue reports.
+                amax_local = cute.math.max(amax_local, cute.math.max(o_val, -o_val))
+    else:
+        for d0 in cutlass.range(tidx, d_v, threads, unroll=1):
+            acc = cutlass.Float32(0.0)
+            for s in cutlass.range(0, n_splits, 1, unroll=1):
+                lse_row = lp[batch + s * n_batch, head, :]
+                lse_s = cutlass.Float32(lse_row[q_row])
+                if lse_s > neg_inf:
+                    w = cute.math.exp(lse_s - m_safe, fastmath=True)
+                    o_row = op[batch + s * n_batch, q_row, head, :]
+                    acc = acc + w * cutlass.Float32(o_row[d0])
+            out_row = oo[batch, q_row, head, :]
+            o_val = acc * inv_den
+            out_row[d0] = o_val.to(o_out.element_type)
+            if cutlass.const_expr(amax_o is not None):
+                # amax over the fp32 PRE-CAST value, matching what the
+                # single-pass epilogue reports.
+                amax_local = cute.math.max(amax_local, cute.math.max(o_val, -o_val))
 
-    # One atomic per lane.  The value is non-negative, so its fp32 bit pattern
-    # orders the same as the float and an integer atomicMax is exact -- the same
-    # trick the kernels' own epilogues use.
+    # Reduce each warp before publishing its maximum.  The value is
+    # non-negative, so its fp32 bit pattern orders the same as the float and an
+    # integer atomicMax is exact -- the same trick the kernels' own epilogues
+    # use.  One atomic per warp avoids having every lane contend on the same
+    # global scalar (one atomic for a 32-thread block, four for the default).
     if cutlass.const_expr(amax_o is not None):
         _amax_ptr = Pointer(amax_o.iterator.raw_ptr(), dtype=cutlass.Int32)
-        nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_ptr, amax_local.bitcast(cutlass.Int32))
+        amax_warp = cute.arch.warp_redux_sync(amax_local, kind="fmax")
+        if (tidx & cutlass.Int32(31)) == cutlass.Int32(0):
+            nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_ptr, amax_warp.bitcast(cutlass.Int32))
 
     # --- the recombined LSE (only when the caller asked for Stats) ---
     if cutlass.const_expr(lse_out is not None):
@@ -140,6 +184,7 @@ def _host(
     amax_o: Optional[cute.Tensor],
     problem_size: Tuple[int, int, int, int],
     n_splits: cutlass.Int32,
+    threads: cutlass.Constexpr[int],
     stream: _cuda_driver.CUstream = None,
 ) -> None:
     B, H, SQ, D = problem_size
@@ -152,9 +197,10 @@ def _host(
         cutlass.Int32(B),
         n_splits,
         cutlass.Int32(D),
+        threads,
     ).launch(
         grid=(SQ, H, B),
-        block=[THREADS, 1, 1],
+        block=[threads, 1, 1],
         stream=stream,
     )
 
@@ -170,6 +216,7 @@ def compile(  # noqa: A001
     has_lse: bool = False,
     lse_stride: Optional[tuple[int, int, int]] = None,
     has_amax: bool = False,
+    threads: int = DEFAULT_THREADS,
 ) -> Callable:
     """Compile the combine pass for one concrete (B, H, S_q, d_v, splits) shape.
 
@@ -180,8 +227,12 @@ def compile(  # noqa: A001
     store is None-specialized out of the traced code.  ``has_amax`` does the
     same for the FP8-family amax of the recombined O.  ``lse_stride`` describes
     the caller-visible LSE output; the per-split LSE input workspace remains
-    compact regardless of that final layout.
+    compact regardless of that final layout.  ``threads`` is compile-time so
+    architectures with a large row grid can amortize the row-uniform reduction
+    in one warp without changing the runtime callable signature.
     """
+    if threads not in (WARP_SIZE, DEFAULT_THREADS):
+        raise ValueError(f"split combine threads must be {WARP_SIZE} or {DEFAULT_THREADS}; got {threads}")
     elem = {"f16": cutlass.Float16, "bf16": cutlass.BFloat16}[dtype_o]
 
     fake_o_partial = cute.runtime.make_fake_compact_tensor(elem, (splits * b, sq, h, d_v), stride_order=(3, 2, 1, 0), assumed_align=16)
@@ -207,6 +258,7 @@ def compile(  # noqa: A001
         fake_amax_o,
         (b, h, sq, d_v),
         cutlass.Int32(0),
+        threads,
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
     )


### PR DESCRIPTION
## Summary

- distribute split LSE loads and softmax-weight calculation across warp lanes, then broadcast the results with warp shuffles
- reduce the recombined-output amax once per warp before publishing it instead of issuing one atomic per lane
- use a 32-thread combine block for SM107 D128 at split factors 2 through 6; retain the 128-thread block for larger factors and all other architectures/head dimensions
- retain the original scalar combine for partial-warp output widths and split counts above 32

The combine owns one output row per block. On Rubin D128, the original 128-thread block made four warps independently repeat the same row-uniform LSE and weight work. The context workloads have thousands of output rows, so one warp per row preserves enough grid parallelism while removing that duplication. Split-8 measured slower with one warp, hence the split-6 cutoff.

## GR100 performance

NVIDIA Graphics Device, SM107, 208 SMs. Times are medians from 7 repeats of 50 iterations after 5 warmups. Baseline and prototype were run on the same idle GPU with identical settings.

```text
Shape                 Split  Combine baseline  Prototype  Gain     E2E baseline  Prototype  Gain
--------------------  -----  ----------------  ---------  -------  ------------  ---------  ------
Llama TP8 context       4       0.037313 ms     0.027920   25.17%    0.400018 ms   0.394310    1.43%
Llama TP4 context       2       0.065644 ms     0.028798   56.13%    0.775188 ms   0.744993    3.90%
Llama TP2 context       4       0.130337 ms     0.087505   32.86%    1.183657 ms   1.160637    1.94%
AR-DiT context          4       0.041142 ms     0.028924   29.70%    0.218333 ms   0.207395    5.01%
Llama TP8 8K x 8K       1       0.000000 ms     0.000000    0.00%    0.132817 ms   0.132844   -0.02%
```

The saturated 8K x 8K case remains unsplit, so this change does not alter its kernel path; the measured -0.02% is noise.

## Validation

- `test/python/sdpa/frost/test_sdpa_fp8_sm107.py`: 15 passed on SM107
- direct D128 split-8 combine with dead splits: passed
- direct D16 split-3 scalar fallback: passed
- adapter-level SM107 split-4 (32 threads) and split-8 (128 threads): passed
- no NaNs; output and LSE stayed within existing tolerances
- recombined amax stayed within 0.3% of the output reference
- Black, `py_compile`, and `git diff --check`: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved split-KV attention recombination performance for select Rubin hardware configurations.
  * Added optimized warp-based processing for eligible workloads, including more efficient output scaling and maximum-value reduction.
* **Compatibility**
  * Existing configurations continue using the standard 128-thread execution path.
  * Supported thread configurations are limited to validated options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->