### PR TITLE
fix-ci-by-adding-protection

### DIFF
--- a/test/python/fe_api/gemm/test_gemm_proj_rope_mxfp8.py
+++ b/test/python/fe_api/gemm/test_gemm_proj_rope_mxfp8.py
@@ -5,7 +5,10 @@ import torch
 
 import pytest
 
-from test_utils import torch_fork_set_rng
+from test_utils import require_cutedsl_version, torch_fork_set_rng
+
+require_cutedsl_version("4.7.0")
+
 from fe_api.gemm.test_gemm_proj_rope_mxfp8_utils import with_gemm_proj_rope_mxfp8_params
 
 

--- a/test/python/fe_api/gemm/test_gemm_srelu.py
+++ b/test/python/fe_api/gemm/test_gemm_srelu.py
@@ -5,7 +5,9 @@ import pytest
 import torch
 
 import cudnn
-from test_utils import torch_fork_set_rng
+from test_utils import require_cutedsl_version, torch_fork_set_rng
+
+require_cutedsl_version("4.7.0")
 
 from fe_api.gemm.test_gemm_srelu_utils import (
     allocate_gemm_srelu_outputs,

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu.py
@@ -11,7 +11,10 @@ and discrete weight modes, with SwiGLU and GeGLU activations.
 import torch
 import pytest
 import cudnn
-from test_utils import torch_fork_set_rng
+from test_utils import require_cutedsl_version, torch_fork_set_rng
+
+require_cutedsl_version("4.7.0")
+
 from fe_api.test_fe_api_utils import DYNAMIC_SHAPES_M_VALUES, reencode_sf_tensor_as_ue5m3
 from fe_api.grouped_gemm.test_grouped_gemm_wgrad_utils import _skip_unless_e5m3_supported
 from fe_api.grouped_gemm.test_grouped_gemm_swiglu_utils import (

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_hadamard.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_hadamard.py
@@ -8,7 +8,10 @@ from typing import Dict
 import pytest
 import torch
 
-from test_utils import torch_fork_set_rng
+from test_utils import require_cutedsl_version, torch_fork_set_rng
+
+require_cutedsl_version("4.7.0")
+
 from fe_api.grouped_gemm.test_discrete_grouped_gemm_swiglu_utils import allocate_discrete_input_tensors
 from fe_api.test_fe_api_utils import DYNAMIC_SHAPES_M_VALUES, compute_reference_amax
 from fe_api.grouped_gemm.test_grouped_gemm_swiglu_utils import allocate_grouped_gemm_input_tensors, grouped_gemm_swiglu_init

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_hadamard_quant.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_hadamard_quant.py
@@ -8,9 +8,12 @@ from typing import Dict, Optional
 import pytest
 import torch
 
+from test_utils import require_cutedsl_version, torch_fork_set_rng
+
+require_cutedsl_version("4.7.0")
+
 from cudnn.gemm.cutedsl.grouped.glu_hadamard_quant.rht_utils import HADAMARD_SIZE
 from test_low_precision_matmul import float4_e2m1fn_x2_to_float32
-from test_utils import torch_fork_set_rng
 from fe_api.grouped_gemm.test_discrete_grouped_gemm_swiglu_utils import allocate_discrete_input_tensors
 from fe_api.grouped_gemm.test_grouped_gemm_swiglu_utils import allocate_grouped_gemm_input_tensors, grouped_gemm_swiglu_init
 from fe_api.grouped_gemm.test_grouped_gemm_wgrad_utils import _skip_unless_e5m3_supported

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_quant.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_quant.py
@@ -11,7 +11,10 @@ Used for FC2 (forward down-projection) and dFC1 (backward FC1 GEMMs).
 
 import torch
 import pytest
-from test_utils import torch_fork_set_rng
+from test_utils import require_cutedsl_version, torch_fork_set_rng
+
+require_cutedsl_version("4.7.0")
+
 from fe_api.test_fe_api_utils import DYNAMIC_SHAPES_M_VALUES
 from fe_api.grouped_gemm.test_grouped_gemm_swiglu_utils import (
     allocate_grouped_gemm_input_tensors,

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_srelu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_srelu.py
@@ -12,7 +12,10 @@ Reference: continugous_blockscaled_grouped_gemm_srelu_quant_fusion.py
 
 import torch
 import pytest
-from test_utils import torch_fork_set_rng
+from test_utils import require_cutedsl_version, torch_fork_set_rng
+
+require_cutedsl_version("4.7.0")
+
 from fe_api.grouped_gemm.test_grouped_gemm_srelu_utils import (
     grouped_gemm_srelu_init,
     with_grouped_gemm_srelu_params_fp4,

--- a/test/python/fe_api/test_grouped_gemm_bf16.py
+++ b/test/python/fe_api/test_grouped_gemm_bf16.py
@@ -8,6 +8,10 @@ from __future__ import annotations
 import pytest
 import torch
 
+from test_utils import require_cutedsl_version
+
+require_cutedsl_version("4.7.0")
+
 from test_grouped_gemm_bf16_utils import (
     assert_grouped_gemm_close,
     grouped_gemm_bf16_reference,

--- a/test/python/fe_api/test_grouped_gemm_wrapper_memo.py
+++ b/test/python/fe_api/test_grouped_gemm_wrapper_memo.py
@@ -16,6 +16,10 @@ from __future__ import annotations
 import pytest
 import torch
 
+from test_utils import require_cutedsl_version
+
+require_cutedsl_version("4.7.0")
+
 
 @pytest.fixture(autouse=True)
 def require_sm100():

--- a/test/python/fe_api/test_rubin_kernel_dispatch.py
+++ b/test/python/fe_api/test_rubin_kernel_dispatch.py
@@ -17,7 +17,10 @@ from unittest import mock
 
 import pytest
 
+from test_utils import require_cutedsl_version
+
 pytest.importorskip("cutlass")
+require_cutedsl_version("4.7.0")
 
 RUBIN_DISPATCH_CASES = [
     pytest.param(

--- a/test/python/test_utils.py
+++ b/test/python/test_utils.py
@@ -5,6 +5,55 @@ import os
 import torch
 import functools
 
+
+def require_cutedsl_version(minimum: str) -> None:
+    """Skip the current test module when the public CuTe DSL is too old.
+
+    Internal RC wheels use an unrelated 0.x version scheme, so presence is
+    sufficient for them, matching the runtime support checks in
+    ``cudnn.frost.buffers``.
+    """
+    import importlib.metadata
+    import importlib.util
+
+    import pytest
+
+    try:
+        installed = importlib.util.find_spec("cutlass") is not None
+    except (ImportError, ValueError):
+        installed = False
+    if not installed:
+        pytest.skip("CuTe DSL is not installed", allow_module_level=True)
+
+    try:
+        installed_version = importlib.metadata.version("nvidia-cutlass-dsl")
+    except importlib.metadata.PackageNotFoundError:
+        # Internal builds are distributed as nvidia-cutlass-dsl-internal and
+        # cannot be compared with the public wheel's version numbering.
+        try:
+            importlib.metadata.version("nvidia-cutlass-dsl-internal")
+        except importlib.metadata.PackageNotFoundError:
+            return
+        return
+
+    def release_tuple(value: str):
+        try:
+            parts = [int(component) for component in value.split("+", 1)[0].split(".")[:3]]
+        except ValueError:
+            return None
+        return tuple((parts + [0, 0, 0])[:3])
+
+    installed_release = release_tuple(installed_version)
+    minimum_release = release_tuple(minimum)
+    if installed_release is None or minimum_release is None:
+        return
+    if installed_release < minimum_release:
+        pytest.skip(
+            f"requires nvidia-cutlass-dsl >= {minimum}; found {installed_version}",
+            allow_module_level=True,
+        )
+
+
 # Repeats for bitwise-determinism checks. A reduction-order race is timing-dependent, so a
 # single repeat proves little; overridable for bisecting a flaky one.
 DETERMINISM_REPEATS = int(os.environ.get("DETERMINISM_REPEATS", "8"))


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches (see [root AGENTS.md § Reviewing a PR](https://github.com/NVIDIA/cudnn-frontend/blob/develop/AGENTS.md#reviewing-a-pr-human-or-agent)) and my changes comply, or I explain the exception below.
- [x] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

Fix CI failure by skip tests on unsupported cutedsl version 

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added version-aware test gating for CuTe DSL-dependent tests.
  - Tests now require CuTe DSL 4.7.0 or later and are skipped when the required version is unavailable.
  - Internal builds and incomplete version metadata continue to run without version comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->