### PR TITLE
frost: Rule 7 follow-through — SM80 SDPA DSL-version gates, prerelease-aware floor, lazy-import message, #921 doc fixes

### DIFF
--- a/benchmark/dsa/README.md
+++ b/benchmark/dsa/README.md
@@ -72,7 +72,7 @@ FLOPs = 2 * S_q * H * topk * (3 * d_qk + 2 * d_v)
 - PyTorch with CUDA support
 - `pip install nvidia-cudnn-frontend` (or a development install of
   this repository's `python/` package) -- the CuTe DSL dependencies are
-  required dependencies and come with either
+  required dependencies and come with either installation method
 
 ### How to run
 
@@ -117,7 +117,9 @@ Generated on an NVIDIA B200 with the default
 sweep settings (`nheads=64`, `d_qk = d_v = 512`, bf16, attention sink and
 `topk_length` enabled, `warmup=10`, `repeat=50`), using `torch 2.12.1`,
 `nvidia-cutlass-dsl 4.5.2`, and `nvidia-cudnn-frontend` built from this
-repository.
+repository. That DSL release predates the package's current `>=4.6.2` floor;
+the numbers are a historical measurement and have not been re-run on a
+supported DSL.
 
 | seqlen_q | seqlen_kv | topk | BWD ms | BWD TFLOPS |
 |---------:|----------:|-----:|-------:|-----------:|

--- a/benchmark/flex_attention/README.md
+++ b/benchmark/flex_attention/README.md
@@ -9,7 +9,7 @@ mask patterns.
 
 - NVIDIA Hopper SM90, Blackwell SM100, or Blackwell SM103 GPU
 - CUDA-enabled PyTorch
-- the cuDNN Frontend `cutedsl` optional dependencies
+- cuDNN Frontend (its CuTeDSL dependencies are required and install with it)
 
 From a source checkout:
 

--- a/docs/fe-oss-apis/fla.md
+++ b/docs/fe-oss-apis/fla.md
@@ -65,7 +65,7 @@ unsupported-kernel declines fall back, while unexpected native binding,
 allocation, and launch failures propagate.
 
 The current native kernel requires CUTLASS DSL 4.7 or newer. If only the
-package-wide `cutedsl>=4.5` minimum is present and the native import is
+package-wide `nvidia-cutlass-dsl>=4.6.2` floor is present and the native import is
 unavailable, the adapter catches that typed `ImportError` and executes FLA's
 original path. Hardware correctness coverage is SM80, SM89, SM90, and SM100;
 the native kernel is additionally runtime-validated on SM103 and SM120.

--- a/python/cudnn/AGENTS.md
+++ b/python/cudnn/AGENTS.md
@@ -4,7 +4,7 @@ The `cudnn` Python package: pybind11-backed graph API plus pure-Python **fronten
 
 ## Import-time rules (the most common way to break this package)
 
-- `import cudnn` must work **without** torch/cutlass/cuda-python installed. Everything that needs them is exported lazily via `_LAZY_OPTIONAL_IMPORTS` in `__init__.py` — a module-level `__getattr__` imports the submodule on first attribute access and re-raises failures as `ImportError` pointing at `pip install nvidia-cudnn-frontend[cutedsl]`.
+- `import cudnn` must work **without** torch/cutlass/cuda-python installed. Everything that needs them is exported lazily via `_LAZY_OPTIONAL_IMPORTS` in `__init__.py` — a module-level `__getattr__` imports the submodule on first attribute access and re-raises failures as `ImportError` that names the missing framework module (torch, jax, cuda-python) alongside the base `pip install nvidia-cudnn-frontend` hint — or, for a CuTe DSL below `CUTEDSL_MIN_VERSION`, points at the DSL upgrade (Rule 7).
 - Never add an eager `import torch` / `import cutlass` to `__init__.py` or anything it imports transitively. `api_base.py` itself imports them at top level, which is why kernel classes must only be reachable through the lazy table.
 - Reuse the existing required CuTeDSL dependencies (`pyproject.toml` `[project] dependencies`) unless a kernel truly needs a new package. The `[cutedsl]` extra now holds only `cuda-python`.
 

--- a/python/cudnn/__init__.py
+++ b/python/cudnn/__init__.py
@@ -395,9 +395,41 @@ def _load_optional_symbol(name: str) -> Any:
     return value
 
 
+# `cuda` (cuda-python) is deliberately NOT here: it is a separate dependency the
+# `[cutedsl]` extra installs, so a missing `cuda` wants that install, not a DSL upgrade.
+_DSL_STACK_MODULES = ("cutlass", "tvm_ffi", "nvidia_cutlass_dsl", "cudnn")
+
+
+def _missing_non_dsl_module(error: BaseException):
+    """Name of the missing module when the failure is a ModuleNotFoundError outside
+    the CuTe DSL stack, else None.
+
+    Walks the exception chain; the first ModuleNotFoundError decides. ``cudnn``
+    counts as the DSL stack because a kernel package failing to import on an old
+    DSL surfaces as a missing cudnn.* submodule.
+    """
+    seen = set()
+    while error is not None and id(error) not in seen:
+        seen.add(id(error))
+        if isinstance(error, ModuleNotFoundError):
+            name = error.name or ""
+            top = name.split(".", 1)[0]
+            return name if top and top not in _DSL_STACK_MODULES else None
+        error = error.__cause__ or error.__context__
+    return None
+
+
 def _optional_dependency_message(name: str, error: Exception) -> str:
     # A DSL that is installed but below the floor must not be reported as a
-    # missing dependency: "pip install [cutedsl]" would change nothing.
+    # missing dependency: "pip install [cutedsl]" would change nothing. The
+    # converse holds too: a failure that is plainly NOT the DSL's -- a missing
+    # third-party module such as torch -- must not be blamed on the DSL version
+    # just because an old DSL happens to be installed.
+    missing = _missing_non_dsl_module(error)
+    if missing is not None:
+        # Name the module: the install hint alone does not fetch a missing framework
+        # (torch, jax) and only fetches cuda-python via the extra.
+        return f"{name} requires the {missing!r} module, which is not installed. {_OPTIONAL_DEPENDENCY_INSTALL_HINT}: {error}"
     try:
         from .frost.buffers import cutedsl_requirement_error
 

--- a/python/cudnn/frost/buffers.py
+++ b/python/cudnn/frost/buffers.py
@@ -18,6 +18,7 @@ no tensor-library dependency on the execute path.
 from __future__ import annotations
 
 import ctypes
+import re as _re
 import struct
 
 from cudnn import _pybind_module
@@ -456,6 +457,8 @@ def fill_word_strided_async(ptr: int, shape, strides, elem_bytes: int, word: int
 # version, so the check belongs where an engine can still decline.
 CUTEDSL_MIN_VERSION = (4, 7, 0)
 
+_RELEASE_INT = _re.compile(r"^(\d+)")  # leading integer of one version component ("2rc1" -> 2)
+
 _DSL_STATE = None
 
 
@@ -506,11 +509,23 @@ def cutedsl_too_old(version):
     dist, ver = version
     if dist != "nvidia-cutlass-dsl":
         return False
-    try:
-        parts = tuple(int(x) for x in ver.split("+", 1)[0].split(".")[:3])
-    except ValueError:
+    # PEP 440 public versions: keep the leading integer of each release component
+    # so a prerelease of X ("4.6.2a0", "4.6.2rc1") compares as X -- below the
+    # floor it is too old, at/above it is not. Local labels ("+...") are dropped,
+    # and a dotted post/dev segment ("4.6.post1", "4.6.2.dev0") ends the release
+    # segment: what precedes it is the version being compared.
+    parts = []
+    for component in ver.split("+", 1)[0].split(".")[:3]:
+        m = _RELEASE_INT.match(component)
+        if m is None:
+            break
+        parts.append(int(m.group(1)))
+    if not parts:
         return False
-    return len(parts) == 3 and parts < CUTEDSL_MIN_VERSION
+    # A short public version ("4.6") means the omitted components are zero
+    # ("4.6.0"), so it compares against the floor instead of slipping past it.
+    parts += [0] * (3 - len(parts))
+    return tuple(parts) < CUTEDSL_MIN_VERSION
 
 
 def cutedsl_requirement_error(what):

--- a/python/cudnn/sdpa/bwd/api_dsl.py
+++ b/python/cudnn/sdpa/bwd/api_dsl.py
@@ -1896,6 +1896,14 @@ def sdpa_bwd_wrapper_sm80(
     drops KV tiles, an undersized ``max_s_q`` indexes the relay counter out
     of bounds.
     """
+    # Rule 7 (python/cudnn/AGENTS.md): this entry reaches the kernel module on its
+    # own, so decline by DSL version here instead of surfacing the DSL's own
+    # TypeError/ModuleNotFoundError from the template load.
+    from cudnn.frost.buffers import cutedsl_requirement_error
+
+    _too_old = cutedsl_requirement_error("sdpa_bwd_wrapper_sm80")
+    if _too_old is not None:
+        raise NotImplementedError(_too_old)
     # THD / varlen: q/k/v/o/dO are PACKED [1, T, H, D] (BSHD) + cu_seqlens;
     # lse is packed [1, H, T_q].  Dedicated path that skips the dense BHSD
     # transpose + dense grad alloc (mirrors the forward THD branch).

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -4496,6 +4496,14 @@ def sdpa_fwd_wrapper_sm80(
     token extents.  ALiBi, block_mask and the score-stat side outputs are not
     supported (use the graph API, which routes them to the cuDNN backend).
     """
+    # Rule 7 (python/cudnn/AGENTS.md): this entry reaches the kernel module on its
+    # own, so decline by DSL version here instead of surfacing the DSL's own
+    # TypeError/ModuleNotFoundError from the template load.
+    from cudnn.frost.buffers import cutedsl_requirement_error
+
+    _too_old = cutedsl_requirement_error("sdpa_fwd_wrapper_sm80")
+    if _too_old is not None:
+        raise NotImplementedError(_too_old)
     if q_tensor.ndim != 4 or v_tensor.ndim != 4:
         raise ValueError(f"Q and V must be rank-4 BHSD; got Q={q_tensor.ndim}D V={v_tensor.ndim}D")
     if scale_output not in (None, 1.0):

--- a/test/python/fe_api/sdpa/test_sdpa_bwd_sm80.py
+++ b/test/python/fe_api/sdpa/test_sdpa_bwd_sm80.py
@@ -23,22 +23,19 @@ def _is_sm80() -> bool:
     return (major, minor) == (8, 0)
 
 
-def _dsl_available() -> bool:
-    # The kernels need the CuTe DSL *with* cutlass.experimental (cutlass-dsl
-    # >= 4.7). The package imports lazily (PEP 562), so a missing/old DSL
-    # only surfaces at kernel-load time — probe it here so the suite SKIPS
-    # instead of erroring mid-test.
-    try:
-        import cutlass.experimental  # noqa: F401
-    except ImportError:
-        return False
-    return True
+def _has_supported_cutedsl() -> bool:
+    """Rule 7 (python/cudnn/AGENTS.md): skip below CUTEDSL_MIN_VERSION instead of
+    failing inside the DSL when the kernel module loads."""
+    from cudnn.frost.buffers import cutedsl_state, cutedsl_too_old
+
+    installed, version = cutedsl_state()
+    return bool(installed) and not cutedsl_too_old(version)
 
 
-pytestmark = pytest.mark.skipif(
-    not (_is_sm80() and _dsl_available()),
-    reason="SM80 SDPA API requires an SM80 (A100) device and nvidia-cutlass-dsl >= 4.7.",
-)
+pytestmark = [
+    pytest.mark.skipif(not _is_sm80(), reason="SM80 SDPA API requires an SM80 (A100) device"),
+    pytest.mark.skipif(not _has_supported_cutedsl(), reason="requires nvidia-cutlass-dsl at or above cudnn.frost.buffers.CUTEDSL_MIN_VERSION"),
+]
 
 
 def _bshd_randn(b, h, s, d, **kw):

--- a/test/python/fe_api/sdpa/test_sdpa_fwd_sm80.py
+++ b/test/python/fe_api/sdpa/test_sdpa_fwd_sm80.py
@@ -22,22 +22,19 @@ def _is_sm80() -> bool:
     return (major, minor) == (8, 0)
 
 
-def _dsl_available() -> bool:
-    # The kernels need the CuTe DSL *with* cutlass.experimental (cutlass-dsl
-    # >= 4.7). The package imports lazily (PEP 562), so a missing/old DSL
-    # only surfaces at kernel-load time — probe it here so the suite SKIPS
-    # instead of erroring mid-test.
-    try:
-        import cutlass.experimental  # noqa: F401
-    except ImportError:
-        return False
-    return True
+def _has_supported_cutedsl() -> bool:
+    """Rule 7 (python/cudnn/AGENTS.md): skip below CUTEDSL_MIN_VERSION instead of
+    failing inside the DSL when the kernel module loads."""
+    from cudnn.frost.buffers import cutedsl_state, cutedsl_too_old
+
+    installed, version = cutedsl_state()
+    return bool(installed) and not cutedsl_too_old(version)
 
 
-pytestmark = pytest.mark.skipif(
-    not (_is_sm80() and _dsl_available()),
-    reason="SM80 SDPA API requires an SM80 (A100) device and nvidia-cutlass-dsl >= 4.7.",
-)
+pytestmark = [
+    pytest.mark.skipif(not _is_sm80(), reason="SM80 SDPA API requires an SM80 (A100) device"),
+    pytest.mark.skipif(not _has_supported_cutedsl(), reason="requires nvidia-cutlass-dsl at or above cudnn.frost.buffers.CUTEDSL_MIN_VERSION"),
+]
 
 
 def _bshd_randn(b, h, s, d, **kw):

--- a/test/python/fe_api/sdpa/test_sdpa_sm80_cutedsl_gate.py
+++ b/test/python/fe_api/sdpa/test_sdpa_sm80_cutedsl_gate.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The SM80 SDPA wrappers decline a too-old CuTe DSL by version (AGENTS.md Rule 7).
+
+Host-only: the wrapper entry is an independent caller-facing path to the kernel
+modules (no engine check_support in front of it), so it must raise an error
+that names the installed version *before* importing a kernel module, where a
+4.5.x wheel would otherwise fail with the DSL's own TypeError.
+"""
+
+import pytest
+import torch
+
+from cudnn.frost import buffers
+
+pytestmark = pytest.mark.L0
+
+
+@pytest.fixture
+def old_dsl(monkeypatch):
+    monkeypatch.setattr(buffers, "_DSL_STATE", (True, ("nvidia-cutlass-dsl", "4.6.2")))
+
+
+def test_bwd_wrapper_declines_by_version(old_dsl):
+    from cudnn.sdpa.bwd.api_dsl import sdpa_bwd_wrapper_sm80
+
+    t = torch.zeros(1, 1, 8, 16, dtype=torch.float16)
+    with pytest.raises(NotImplementedError, match=r"found 4\.6\.2"):
+        sdpa_bwd_wrapper_sm80(q_tensor=t, k_tensor=t, v_tensor=t, o_tensor=t, do_tensor=t, lse_tensor=torch.zeros(1, 1, 8, 1))
+
+
+def test_fwd_wrapper_declines_by_version(old_dsl):
+    from cudnn.sdpa.fwd.api_dsl import sdpa_fwd_wrapper_sm80
+
+    t = torch.zeros(1, 1, 8, 16, dtype=torch.float16)
+    with pytest.raises(NotImplementedError, match=r"found 4\.6\.2"):
+        sdpa_fwd_wrapper_sm80(t, t, t)

--- a/test/python/sdpa/frost/test_sdpa_sm80_frontend_integration.py
+++ b/test/python/sdpa/frost/test_sdpa_sm80_frontend_integration.py
@@ -35,6 +35,18 @@ def _is_sm80() -> bool:
 
 _SM80 = pytest.mark.skipif(not _is_sm80(), reason="needs an SM80 (A100) GPU")
 
+
+def _has_supported_cutedsl() -> bool:
+    """Rule 7 (python/cudnn/AGENTS.md): skip below CUTEDSL_MIN_VERSION instead of
+    failing inside the DSL when the kernel module loads."""
+    from cudnn.frost.buffers import cutedsl_state, cutedsl_too_old
+
+    installed, version = cutedsl_state()
+    return bool(installed) and not cutedsl_too_old(version)
+
+
+pytestmark = pytest.mark.skipif(not _has_supported_cutedsl(), reason="requires nvidia-cutlass-dsl at or above cudnn.frost.buffers.CUTEDSL_MIN_VERSION")
+
 B, H, S, D = 2, 4, 512, 128
 _HALF = cudnn.data_type.HALF
 _SCALE = 1.0 / math.sqrt(D)

--- a/test/python/sdpa/frost/test_sdpa_sm80_stream_respect.py
+++ b/test/python/sdpa/frost/test_sdpa_sm80_stream_respect.py
@@ -26,17 +26,19 @@ def _is_sm80() -> bool:
     return torch.cuda.is_available() and torch.cuda.get_device_capability(torch.cuda.current_device()) == (8, 0)
 
 
-def _dsl_available() -> bool:
-    try:
-        import cutlass  # noqa: F401
-    except ImportError:
-        return False
-    return True
+def _has_supported_cutedsl() -> bool:
+    """Rule 7 (python/cudnn/AGENTS.md): skip below CUTEDSL_MIN_VERSION instead of
+    failing inside the DSL when the kernel module loads."""
+    from cudnn.frost.buffers import cutedsl_state, cutedsl_too_old
+
+    installed, version = cutedsl_state()
+    return bool(installed) and not cutedsl_too_old(version)
 
 
 pytestmark = [
     pytest.mark.L0,
-    pytest.mark.skipif(not (_is_sm80() and _dsl_available()), reason="needs an SM80 (A100) GPU with cutlass"),
+    pytest.mark.skipif(not _is_sm80(), reason="needs an SM80 (A100) GPU"),
+    pytest.mark.skipif(not _has_supported_cutedsl(), reason="requires nvidia-cutlass-dsl at or above cudnn.frost.buffers.CUTEDSL_MIN_VERSION"),
 ]
 
 _B, _H, _S, _D = 2, 8, 256, 128

--- a/test/python/test_cutedsl_version_gate.py
+++ b/test/python/test_cutedsl_version_gate.py
@@ -75,5 +75,53 @@ def test_decode_update_route_declines_by_version_before_importing_the_kernel(dsl
     conv_state = torch.zeros(2, 8, 3, dtype=torch.bfloat16)
     weight = torch.zeros(8, 4, dtype=torch.bfloat16)
 
-    with pytest.raises(NotImplementedError, match="found 4.6.2"):
+    with pytest.raises(NotImplementedError, match=r"found 4\.6\.2"):
         update._validated_native_update(x, conv_state, weight, None, "silu", None, None)
+
+
+@pytest.mark.parametrize(
+    "version,too_old",
+    [
+        ("4.6.2a0", True),
+        ("4.6.2rc1", True),
+        ("4.6.9b1", True),
+        ("4.7.0a0", False),
+        ("4.7.0rc1", False),
+        ("4.7.0a0+20260727", False),
+        ("4.5.1", True),
+        ("4.7.0", False),
+        ("4.6", True),
+        ("4", True),
+        ("4.7", False),
+        ("5", False),
+        ("4.6.post1", True),
+        ("4.6.2.post1", True),
+        ("4.6.2.dev0", True),
+        ("4.7.0.post1", False),
+    ],
+)
+def test_prerelease_versions_compare_by_release_number(version, too_old):
+    """A public prerelease of X compares as X against the floor (Rule 7): 4.6.2rc1 is
+    too old, 4.7.0a0 is not. Before, any letter in a component made the check
+    return False and an unsupported DSL walked through every gate."""
+    assert buffers.cutedsl_too_old(("nvidia-cutlass-dsl", version)) is too_old
+
+
+def test_missing_third_party_module_is_not_blamed_on_the_dsl(dsl_state):
+    """With an old DSL installed, a lazy import that fails because torch is missing
+    must report the optional-dependency hint, not a DSL upgrade."""
+    dsl_state(True, ("nvidia-cutlass-dsl", "4.6.2"))
+    missing_torch = ModuleNotFoundError("No module named 'torch'", name="torch")
+    message = cudnn._optional_dependency_message("sdpa_torch", missing_torch)
+    assert "requires nvidia-cutlass-dsl" not in message
+    assert "pip install nvidia-cudnn-frontend[cutedsl]" in message
+    assert "'torch' module" in message  # the hint alone would not fetch torch, so name it
+    # cuda-python is a separate dependency (the [cutedsl] extra), not the DSL stack:
+    missing_cuda = ModuleNotFoundError("No module named 'cuda.bindings'", name="cuda.bindings")
+    cuda_message = cudnn._optional_dependency_message("sdpa_torch", missing_cuda)
+    assert "requires nvidia-cutlass-dsl" not in cuda_message and "cuda.bindings" in cuda_message
+    # ...while a DSL-stack failure on the same old DSL still names the version
+    dsl_failure = TypeError("set_name_prefix() got an unexpected keyword argument 'remove_cutlass_symbol'")
+    assert "found 4.6.2" in cudnn._optional_dependency_message("GemmSreluSm100", dsl_failure)
+    missing_cutlass = ModuleNotFoundError("No module named 'cutlass.experimental'", name="cutlass.experimental")
+    assert "found 4.6.2" in cudnn._optional_dependency_message("GemmSreluSm100", missing_cutlass)


### PR DESCRIPTION
Follow-through on **Rule 7** (`python/cudnn/AGENTS.md`, introduced by #917): gate the CuTe DSL version at runtime, decline with an error that names the version, and have tests skip below the floor instead of failing. Three independent commits; each can be dropped on its own.

## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches and my changes comply.
- [x] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*`.

## Affected area

- Python frontend: `cudnn/frost/buffers.py` (DSL floor check), `cudnn/__init__.py` (lazy-import error message)
- FE OSS kernels: SM80 SDPA wrapper entry points (`sdpa/fwd/api_dsl.py`, `sdpa/bwd/api_dsl.py`)
- Tests and docs

## Why

After #921 the package installs any `nvidia-cutlass-dsl >= 4.6.2`, while the FROST-derived kernels need `CUTEDSL_MIN_VERSION = 4.7.0`. Rule 7 therefore requires every path that reaches a kernel module to check the installed DSL first. Two gaps remained after #917, and two of #917's own CodeRabbit findings merged unaddressed.

## What changes

**1. SM80 SDPA paths gate the DSL version** (commit 1)
- `sdpa_fwd_wrapper_sm80` / `sdpa_bwd_wrapper_sm80` are caller-facing entries with no engine `check_support` in front of them. On a too-old DSL they failed inside the template load with the DSL's own `TypeError` (`set_name_prefix` kwargs). They now decline first via `cutedsl_requirement_error(...)` → `NotImplementedError` naming the installed version, mirroring #917's `_validated_native_update`. The engine path was already gated in `engines.mismatch()`.
- The four SM80 test files skip below the floor with the Rule 7 `skipif` idiom on `cutedsl_state()` / `cutedsl_too_old()`. This replaces the `import cutlass.experimental` proxy probe in the two `fe_api/sdpa` files (which the `oss:` CI lanes run), adds the version check the stream-respect test lacked (it probed `import cutlass` only), and gates the SM80 frontend-integration file, which had no DSL check. Device skips stay separate markers.
- New host-only `test_sdpa_sm80_cutedsl_gate.py` pins both wrapper declines.

**2. The floor check itself, two fixes left open on #917** (commit 2)
- `cutedsl_too_old()` gave up on any version component containing a letter, so a public prerelease below the floor (`4.6.2a0`, `4.6.2rc1`) read as *not* too old and walked through every Rule 7 gate, including the ones above. Each release component now compares by its leading integer: a prerelease of X compares as X (`4.6.2rc1` too old, `4.7.0a0` not). Internal builds and unparsable strings still count as not too old, as before.
- `_optional_dependency_message()` blamed the DSL version for *every* lazy-import failure whenever an old DSL was installed, so a missing `torch` was reported as "requires nvidia-cutlass-dsl >= 4.7.0". A `ModuleNotFoundError` for a module outside the DSL stack now keeps the optional-dependency hint; DSL-stack failures on an old DSL still name the version.
- RUF043: raw string for the regex in the existing gate test.

**3. Doc corrections left open on #921** (commit 3, unrelated to SM80, kept separate)
Stale `4.5` floors in `docs/fe-oss-apis/fla.md` and `bsa.md`, the truncated sentence in `benchmark/dsa/README.md`, and the two remaining `[cutedsl]`-extra hints (`benchmark/flex_attention/README.md`, the import-error line in `python/cudnn/AGENTS.md`).

## Behaviour and compatibility

- At or above 4.7.0 nothing changes: the gates are transparent, and the tests run as before.
- Below the floor: SM80 wrapper callers get `NotImplementedError` naming the version instead of a DSL-internal `TypeError`; the affected test files skip instead of failing; prerelease wheels below the floor are now caught by every Rule 7 gate.
- No public API change.

## Testing

- Host-only (no GPU): gate tests (ours + #917's, incl. the new prerelease and misclassification regressions) + `test_import_boundaries.py`: 27 passed.
- A100, local DSL 4.7.0a0: the four SM80 files at L0, 34 passed (gates transparent at/above the floor).
- Simulated 4.5.1 (`buffers._DSL_STATE` patched): all four modules' DSL `skipif` markers armed, imports clean.

## Commits (review in order)

1. `sdpa(sm80)`: gate the CuTe DSL version at the wrapper entry and in the tests
2. `frost`: prerelease-aware DSL floor; do not blame the DSL for a missing third-party module
3. `docs`: finish #921's CodeRabbit nits

Rule 7 note for the guide (not changed here): the FROST wrapper entry points are a fourth caller-facing gate location alongside route checks, `check_support`, and the family lazy import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility checks for SM80 forward and backward operations.
  - Unsupported or missing CuTe DSL versions now produce clear version-related errors instead of lower-level loading errors.
  - Version detection now correctly handles prereleases, abbreviated versions, and local version suffixes.
  - Optional dependency errors more clearly distinguish missing frameworks from unsupported DSL installations.

- **Documentation**
  - Updated benchmark and API documentation with current CuTe DSL requirements and forward/backward usage guidance.

- **Tests**
  - Expanded coverage for version gates, SM80 compatibility, and additional attention dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->