### PR TITLE
build(python): make CuTeDSL a required dependency, floor 4.6.2, require Python >=3.10

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,8 @@ The C++ build uses `-Werror` (`/WX` on MSVC) with `-Wall -Wextra -Wpedantic` —
 Python (editable; compiles the pybind11 extension via CMake):
 
 ```bash
-pip install -e .              # core graph API only
-pip install -e ".[cutedsl]"   # + OSS CuTeDSL kernels (nvidia-cutlass-dsl, cuda-python, tvm-ffi; framework-neutral)
+pip install -e .              # graph API + the OSS CuTeDSL kernels (nvidia-cutlass-dsl, cuda-python, tvm-ffi; framework-neutral)
+                              # ".[cutedsl]" still resolves -- it is now an empty back-compat alias for the line above
 pip install -e ".[cutile]"    # + the cuTile linear-attention engines (cuda-tile; needs a system tileiras)
 pip install --group torch      # + torch for the CuTeDSL APIs (torch, torch-c-dlpack-ext)
 pip install --group jax        # + jax for the CuTeDSL APIs (jax >= 0.5; XLA entry points via cutlass.jax)
@@ -66,7 +66,7 @@ cd test/python
 pytest                        # default is -m L0 (smoke level) per pytest.ini
 pytest -m L1                  # deeper levels: L0..L4
 pytest test_conv_fprop.py     # one file (still filtered by -m L0 — pass -m "L0 or L1" to widen)
-pytest fe_api/                # OSS kernel tests; require ".[cutedsl]" + `--group torch` (and `--group jax` for the *_jax tests) + SM90/SM100 GPU
+pytest fe_api/                # OSS kernel tests; require `--group torch` (and `--group jax` for the *_jax tests) + SM90/SM100 GPU
 ```
 
 Read [test/AGENTS.md](test/AGENTS.md) before touching tests — `test/python/conftest.py` has import-order and env-var requirements that are easy to break.
@@ -84,7 +84,7 @@ First invocation builds the hook environments and can take >5 minutes; later run
 
 - `include/` is header-only: no `.cpp` files, no new required dependencies. Vendored third-party code lives in `include/cudnn_frontend/thirdparty/`.
 - Every new frontend-only Python API needs: `APIBase` subclass + wrapper, lazy export in `python/cudnn/__init__.py`, docs under `docs/fe-oss-apis/`, and pytest coverage under `test/python/fe_api/`. Full recipe: [python/cudnn/AGENTS.md](python/cudnn/AGENTS.md) and the `cutedsl-kernel-integration` skill.
-- Frontend-only OSS APIs are experimental; keep the `[cutedsl]` optional-dependency boundary intact (no eager `torch`/`cutlass` imports at `cudnn` import time).
+- Frontend-only OSS APIs are experimental; keep the lazy-import boundary intact (no eager `torch`/`cutlass` imports at `cudnn` import time). CuTeDSL is a required dependency now, but a tensor framework is not, and `import cudnn` still has to stay cheap.
 - Version lives in three places that must stay in sync: `CMakeLists.txt` (`project(... VERSION ...)`), `include/cudnn_frontend_version.h`, `python/cudnn/__init__.py` (`__version__`).
 - Runtime debugging: set `CUDNN_FRONTEND_LOG_INFO=1` and `CUDNN_FRONTEND_LOG_FILE=stderr` for FE logs; backend logs via `CUDNN_LOGLEVEL_DBG=3 CUDNN_LOGDEST_DBG=stderr`.
 - Public-API signatures evolve **append-only**: new parameters go at the end (with defaults), never inserted mid-signature — positional callers across C++, pybind, and Python wrappers break silently otherwise (review on PR #266).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Directory-specific guides: [include/cudnn_frontend/AGENTS.md](include/cudnn_fron
 - NVIDIA GPU required for essentially all tests and samples (SDPA/OSS kernels need Hopper SM90 or Blackwell SM100+).
 - CUDA toolkit (`nvcc`), cuDNN **9.x** backend (headers + libs), CMake ≥ 3.23, a C++17 compiler.
 - If cuDNN or CUDA are not in default system locations, set `CUDNN_PATH` and `CUDAToolkit_ROOT` (both honored by CMake and `setup.py`).
-- Python ≥ 3.9. `cudnn.backend_version()` gates many features at runtime (integer, e.g. 9.12.0 → `91200`); tests skip on older backends.
+- Python ≥ 3.10. `cudnn.backend_version()` gates many features at runtime (integer, e.g. 9.12.0 → `91200`); tests skip on older backends.
 
 ## Build
 
@@ -44,7 +44,7 @@ Python (editable; compiles the pybind11 extension via CMake):
 
 ```bash
 pip install -e .              # graph API + the OSS CuTeDSL kernels (nvidia-cutlass-dsl, cuda-python, tvm-ffi; framework-neutral)
-                              # ".[cutedsl]" still resolves -- it is now an empty back-compat alias for the line above
+                              # ".[cutedsl]" still resolves -- it now holds only cuda-python, which the DSL pulls in anyway
 pip install -e ".[cutile]"    # + the cuTile linear-attention engines (cuda-tile; needs a system tileiras)
 pip install --group torch      # + torch for the CuTeDSL APIs (torch, torch-c-dlpack-ext)
 pip install --group jax        # + jax for the CuTeDSL APIs (jax >= 0.5; XLA entry points via cutlass.jax)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ cd cudnn-frontend
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j $(nproc)
 
-# Python package (editable). Add ".[cutedsl]" to work on the OSS CuTeDSL kernels.
+# Python package (editable). The OSS CuTeDSL kernel dependencies come with it.
 pip install -e .
 ```
 
@@ -29,7 +29,7 @@ See [AGENTS.md](AGENTS.md) for the full repo map, all build options, and per-dir
 cd test/python && pytest          # Python; defaults to the L0 smoke level
 ```
 
-Python tests need `pip install -e ".[cutedsl]"` plus `pytest pytest-xdist looseversion`, and a GPU. Details and conventions: [test/AGENTS.md](test/AGENTS.md).
+Python tests need `pip install -e .` plus `pytest pytest-xdist looseversion`, and a GPU. Details and conventions: [test/AGENTS.md](test/AGENTS.md).
 
 ## Code formatting
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ pip install nvidia-cudnn-frontend
 ```
 
 **Requirements:**
-*   Python 3.9+
+*   Python 3.10+
 *   NVIDIA driver and CUDA Toolkit
 *   NVIDIA cuDNN (minimum 8.5.0)
 

--- a/benchmark/cutedsl_fusion_kernels/README.md
+++ b/benchmark/cutedsl_fusion_kernels/README.md
@@ -45,7 +45,7 @@ docker run -it --gpus=all --workdir /workspace \
 Then, inside the container:
 
 ```bash
-PIP_CONSTRAINT="" pip install nvidia-cudnn-frontend[cutedsl] transformer-engine
+PIP_CONSTRAINT="" pip install nvidia-cudnn-frontend transformer-engine
 
 python cutedsl_fusion_benchmarks.py
 ```

--- a/benchmark/dsa/README.md
+++ b/benchmark/dsa/README.md
@@ -31,8 +31,9 @@ FLOPs = 2 * S_q * H * topk * (3 * d_qk + 2 * d_v)
 
 - Hopper (SM90) or Blackwell (SM100) GPU
 - PyTorch with CUDA support
-- `pip install nvidia-cudnn-frontend[cutedsl]` (or a development install of
-  this repository's `python/` package with the `cutedsl` extra)
+- `pip install nvidia-cudnn-frontend` (or a development install of
+  this repository's `python/` package) -- the CuTe DSL dependencies are
+  required dependencies and come with either
 
 ## How to run
 

--- a/benchmark/flex_attention/README.md
+++ b/benchmark/flex_attention/README.md
@@ -14,7 +14,7 @@ mask patterns.
 From a source checkout:
 
 ```bash
-pip install -e ".[cutedsl]"
+pip install -e .
 pip install --group torch
 ```
 

--- a/docs/fe-oss-apis/attention/flex_attention.md
+++ b/docs/fe-oss-apis/attention/flex_attention.md
@@ -40,16 +40,16 @@ autograd.
 
 - SM90, SM100, or SM103 NVIDIA GPU
 - CUDA-enabled PyTorch
-- the cuDNN Frontend `cutedsl` optional dependencies
+- cuDNN Frontend (its CuTeDSL dependencies are required and install with it)
 
 From a source checkout:
 
 ```bash
-pip install -e ".[cutedsl]"
+pip install -e .
 pip install --group torch
 ```
 
-For a published package, install `nvidia-cudnn-frontend[cutedsl]` and a
+For a published package, install `nvidia-cudnn-frontend` and a
 compatible CUDA-enabled PyTorch separately.
 
 ## Fixed-length BSHD API

--- a/docs/fe-oss-apis/attention/hstu.md
+++ b/docs/fe-oss-apis/attention/hstu.md
@@ -43,10 +43,10 @@ guide](../../../LICENSING.md) and [third-party notices](../../../THIRD_PARTY_LIC
 
 ## Installation
 
-Install cuDNN Frontend with its CuTe DSL optional dependencies:
+Install cuDNN Frontend; its CuTe DSL dependencies are required and come with it:
 
 ```bash
-pip install nvidia-cudnn-frontend[cutedsl]
+pip install nvidia-cudnn-frontend
 ```
 
 The implementation is available from `cudnn.hstu_attention` and through the

--- a/docs/fe-oss-apis/attention/sdpa_bwd_sm120.md
+++ b/docs/fe-oss-apis/attention/sdpa_bwd_sm120.md
@@ -27,8 +27,8 @@ dBias convert kernels, the GQA `reduce`, `dsink`) in
 
 ## Requirements
 
-The `cutedsl` optional dependency (`nvidia-cutlass-dsl` + `apache-tvm-ffi`)
-and an SM120 or SM121 device.
+The CuTeDSL runtime (`nvidia-cutlass-dsl` + `apache-tvm-ffi`), which ships as a
+required dependency of the package, and an SM120 or SM121 device.
 
 ## API Usage
 

--- a/docs/fe-oss-apis/bsa.md
+++ b/docs/fe-oss-apis/bsa.md
@@ -27,17 +27,16 @@ BSA is implemented with Python CuTe DSL/JIT kernels.
 
 ## Installation
 
-Install the CuTe DSL optional dependencies:
+The CuTe DSL runtime is a required dependency, so the base install is enough:
 
 ```bash
-pip install nvidia-cudnn-frontend[cutedsl]
+pip install nvidia-cudnn-frontend
 ```
 
-The package-wide `nvidia-cutlass-dsl[cu13]>=4.5.0` dependency floor applies to
-BSA. The FP16/BF16 APIs continue to work with supported CuTe DSL 4.5 releases.
-The Sage FP8 API below performs an additional runtime check and requires
-`nvidia-cutlass-dsl>=4.6.1`; this narrower requirement does not change the
-package dependency floor or make importing `cudnn` require CuTe DSL 4.6.1.
+The package-wide `nvidia-cutlass-dsl[cu13]>=4.6.2` dependency floor applies to
+BSA. The Sage FP8 API below performs an additional runtime check and requires
+`nvidia-cutlass-dsl>=4.6.1`, which the package floor already satisfies; the
+check stays in place for environments that force an older DSL.
 
 ## Forward
 

--- a/docs/fe-oss-apis/csa.md
+++ b/docs/fe-oss-apis/csa.md
@@ -155,7 +155,7 @@ that need a fully deterministic backward must use an eager implementation.
 ## Installation
 
 ```bash
-pip install nvidia-cudnn-frontend[cutedsl]
+pip install nvidia-cudnn-frontend
 ```
 
 ## API Usage

--- a/docs/fe-oss-apis/dsa.md
+++ b/docs/fe-oss-apis/dsa.md
@@ -63,7 +63,7 @@ Training-score loss path:
 ## Installation
 
 ```bash
-pip install nvidia-cudnn-frontend[cutedsl]
+pip install nvidia-cudnn-frontend
 ```
 
 ---

--- a/docs/fe-oss-apis/fla.md
+++ b/docs/fe-oss-apis/fla.md
@@ -112,11 +112,11 @@ version-gated to the validated release:
 
 ```bash
 pip install flash-linear-attention==0.5.2
-pip install "nvidia-cudnn-frontend[cutedsl]"
+pip install nvidia-cudnn-frontend
 ```
 
-The `cutedsl` extra supplies the optional CUTLASS DSL and CUDA Python
-dependencies required by the native `gated_mlp` and `short_conv` targets. To
+The base install supplies the CUTLASS DSL and CUDA Python dependencies
+required by the native `gated_mlp` and `short_conv` targets. To
 require the native `short_conv` route instead of its typed fallback, also
 ensure CUTLASS DSL 4.7 or newer is installed using the package variant that
 matches the CUDA Toolkit:

--- a/docs/fe-oss-apis/gemm_fusions/gemm_proj_rope_mxfp8.md
+++ b/docs/fe-oss-apis/gemm_fusions/gemm_proj_rope_mxfp8.md
@@ -180,10 +180,10 @@ The compiled-kernel lifecycle (`check_support`/`compile`/`execute`) lives in the
 
 ## Installation
 
-Requires the optional CuTeDSL dependencies:
+Requires the CuTeDSL dependencies, which ship with the package:
 
 ```bash
-pip install nvidia-cudnn-frontend[cutedsl]
+pip install nvidia-cudnn-frontend
 ```
 
 ## Usage examples

--- a/docs/fe-oss-apis/gemm_fusions/grouped_gemm.md
+++ b/docs/fe-oss-apis/gemm_fusions/grouped_gemm.md
@@ -1,10 +1,10 @@
 # Grouped GEMM (SM100 BF16)
 
 **This is an experimental API and subject to change.** It requires an NVIDIA
-SM100-or-newer GPU and the optional CuTe DSL dependencies:
+SM100-or-newer GPU. The CuTe DSL dependencies ship with the package:
 
 ```bash
-pip install nvidia-cudnn-frontend[cutedsl]
+pip install nvidia-cudnn-frontend
 ```
 
 `GroupedGemmSm100` and `grouped_gemm_wrapper_sm100` implement the neutral,

--- a/docs/fe-oss-apis/gemm_fusions/grouped_gemm_wgrad.md
+++ b/docs/fe-oss-apis/gemm_fusions/grouped_gemm_wgrad.md
@@ -5,10 +5,10 @@ SM100+ APIs for grouped MoE weight gradients. The same public surface dispatches
 BF16 inputs to the BF16 kernel and preserves the legacy FP4/FP8 block-scaled
 backend.
 
-Install the optional CuTe DSL dependencies before importing either API:
+The CuTe DSL dependencies both APIs need ship with the package:
 
 ```bash
-pip install nvidia-cudnn-frontend[cutedsl]
+pip install nvidia-cudnn-frontend
 ```
 
 ## JAX support

--- a/docs/fe-oss-apis/nsa.md
+++ b/docs/fe-oss-apis/nsa.md
@@ -43,10 +43,11 @@ Each component can be used independently or combined for the full NSA pipeline.
 
 ## Installation
 
-Install the cuDNN Frontend package with the CuteDSL optional dependencies:
+Install the cuDNN Frontend package; the CuTe DSL runtime it JITs through is a
+required dependency and comes with it:
 
 ```bash
-pip install nvidia-cudnn-frontend[cutedsl]
+pip install nvidia-cudnn-frontend
 ```
 
 ---

--- a/docs/fe-oss-apis/overview.md
+++ b/docs/fe-oss-apis/overview.md
@@ -42,12 +42,13 @@ This folder documents the Python FE APIs implemented under `python/cudnn`. For d
 
 ## Installation and setup
 
-All Frontend OSS APIs come installed with the `nvidia-cudnn-frontend` package. However, each API may require additional optional dependencies defined in the `pyproject.toml` file. For instance, GEMM + Amax, GEMM + SwiGLU, and the grouped GEMM APIs require the `cutedsl` optional dependency, which can be installed via:
+All Frontend OSS APIs come installed with the `nvidia-cudnn-frontend` package, and so does the CuTeDSL runtime they JIT through — `nvidia-cutlass-dsl[cu13]>=4.6.2`, `cuda-python`, and `apache-tvm-ffi` are required dependencies:
 ```bash
-pip install nvidia-cudnn-frontend[cutedsl]
+pip install nvidia-cudnn-frontend
 ```
+(`pip install nvidia-cudnn-frontend[cutedsl]` still works; the `cutedsl` extra is now an empty back-compat alias. A few APIs still want extras of their own — the cuTile linear-attention engines need `[cutile]`.)
 
-The `cutedsl` extra is framework-neutral (nvidia-cutlass-dsl, cuda-python, apache-tvm-ffi). Install your tensor framework separately — from a checkout, the PEP 735 dependency groups pin the right companion packages:
+Those required dependencies are framework-neutral. Install your tensor framework separately — from a checkout, the PEP 735 dependency groups pin the right companion packages:
 ```bash
 pip install --group torch   # torch + torch-c-dlpack-ext
 pip install --group jax     # jax >= 0.5 (XLA entry points via cutlass.jax, shipped with nvidia-cutlass-dsl)

--- a/docs/fe-oss-apis/overview.md
+++ b/docs/fe-oss-apis/overview.md
@@ -42,11 +42,11 @@ This folder documents the Python FE APIs implemented under `python/cudnn`. For d
 
 ## Installation and setup
 
-All Frontend OSS APIs come installed with the `nvidia-cudnn-frontend` package, and so does the CuTeDSL runtime they JIT through — `nvidia-cutlass-dsl[cu13]>=4.6.2`, `cuda-python`, and `apache-tvm-ffi` are required dependencies:
+All Frontend OSS APIs come installed with the `nvidia-cudnn-frontend` package, and so does the CuTeDSL runtime they JIT through — `nvidia-cutlass-dsl[cu13]>=4.6.2` and `apache-tvm-ffi` are required dependencies (and the DSL pulls `cuda-python` in transitively):
 ```bash
 pip install nvidia-cudnn-frontend
 ```
-(`pip install nvidia-cudnn-frontend[cutedsl]` still works; the `cutedsl` extra is now an empty back-compat alias. A few APIs still want extras of their own — the cuTile linear-attention engines need `[cutile]`.)
+(`pip install nvidia-cudnn-frontend[cutedsl]` still works; the `cutedsl` extra now names only `cuda-python`. A few APIs still want extras of their own — the cuTile linear-attention engines need `[cutile]`.)
 
 Those required dependencies are framework-neutral. Install your tensor framework separately — from a checkout, the PEP 735 dependency groups pin the right companion packages:
 ```bash

--- a/docs/operations/Attention.md
+++ b/docs/operations/Attention.md
@@ -793,7 +793,7 @@ o, lse = cudnn.sdpa_torch(q, k, v, is_causal=True, cu_seqlens_q=cu, cu_seqlens_k
 
 #### Requirements
 
-- `nvidia-cudnn-frontend[cutedsl]`, cuDNN backend ≥ 9.6 (THD token-major
+- `nvidia-cudnn-frontend`, cuDNN backend ≥ 9.6 (THD token-major
   stats), sm80+.
 
 Tests: [test/python/sdpa/test_torch_ops.py](https://github.com/NVIDIA/cudnn-frontend/blob/main/test/python/sdpa/test_torch_ops.py).

--- a/docs/python_graph_and_execution_backends.md
+++ b/docs/python_graph_and_execution_backends.md
@@ -433,9 +433,10 @@ only to decline is why `closed_under` existed.
   imports neither torch nor cutlass.
 - A missing or too-old DSL is a DECLINE at `check_support()`, probed without
   executing the module (`importlib.util.find_spec`, `importlib.metadata`).
-  `CUTEDSL_MIN_VERSION` in `frost/buffers.py` is the floor; `pyproject`'s extra
-  deliberately does NOT pin it, since that would make cudnn-frontend
-  incompatible with anything holding the DSL back.
+  `CUTEDSL_MIN_VERSION` in `frost/buffers.py` is the floor these engines want;
+  `pyproject`'s required dependency deliberately sits below it (`>=4.6.2`),
+  since pinning that high would make cudnn-frontend incompatible with anything
+  holding the DSL back.
 - `test/python/test_import_boundaries.py` holds all of this, in a fresh
   interpreter, measuring the delta against an empty one.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "nvidia-cudnn-frontend"
 dynamic = ["version"]
 description = "NVIDIA cuDNN Frontend — Python and C++ Graph API with SOTA attention (SDPA / Flash Attention), MoE grouped GEMM fusions, and FP8/MXFP8 kernels for Hopper and Blackwell GPUs."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "Apache-2.0 AND MIT"}
 keywords = [
     "cudnn",
@@ -56,16 +56,11 @@ dependencies = [
     # vLLM and friends carry their own constraints. The engines check the version
     # at support time and decline when it is too old, so an older DSL costs those
     # engines and nothing else. The 4.6.2 floor is the oldest DSL this package is
-    # tested against.
+    # tested against, and it is also what sets `requires-python` above: every
+    # nvidia-cutlass-dsl release is `Requires-Python >=3.10`.
     # Framework-neutral core only: the CuTeDSL APIs are type-erased, so torch (like
     # jax) is opt-in via the [dependency-groups] below (`pip install --group torch`).
-    # Marker: every nvidia-cutlass-dsl release is `Requires-Python >=3.10`, and this
-    # package still declares `requires-python = ">=3.9"`. Without the marker a 3.9
-    # install stops resolving entirely instead of just losing the JIT engines, which
-    # decline at check_support when the DSL is absent -- the same trade-off the
-    # `cutile` extra below already makes for cuda-tile.
-    "nvidia-cutlass-dsl[cu13]>=4.6.2; python_version >= '3.10'",
-    "cuda-python",
+    "nvidia-cutlass-dsl[cu13]>=4.6.2",
     "apache-tvm-ffi>=0.1.11",
 ]
 
@@ -78,11 +73,18 @@ dependencies = [
 "Release Notes" = "https://github.com/NVIDIA/cudnn-frontend/releases"
 
 [project.optional-dependencies]
-# Back-compat alias, intentionally empty: the CuTeDSL stack moved to the required
-# [project] dependencies above, so `pip install nvidia-cudnn-frontend[cutedsl]`
-# now resolves to the same thing as a plain install. Kept so the extra keeps
-# resolving instead of warning for everyone still spelling it out.
-cutedsl = []
+cutedsl = [
+    # nvidia-cutlass-dsl and apache-tvm-ffi moved to the required [project]
+    # dependencies above; this extra is what is left of the old CuTeDSL group.
+    # Naming cuda-python here is belt-and-braces rather than load-bearing: the
+    # required nvidia-cutlass-dsl pulls nvidia-cutlass-dsl-libs-base, which itself
+    # requires cuda-python>=12.8, so a plain `pip install nvidia-cudnn-frontend`
+    # already has it. Keeping it spelled out pins the dependency to this package
+    # instead of to a transitive detail of the DSL's packaging, and keeps
+    # `pip install nvidia-cudnn-frontend[cutedsl]` resolving for everyone who
+    # still writes it that way.
+    "cuda-python",
+]
 cutile = [
     # The cuTile linear-attention engines. Base cuda-tile only -- its [tileiras]
     # extra pins cuda-toolkit>=13.2,<13.4, and that upper bound would cap the
@@ -91,7 +93,7 @@ cutile = [
     # already leaves GPU wheels to the user. Engines that cannot import the
     # runtime decline in check_support, so a missing compiler costs those
     # engines and nothing else.
-    "cuda-tile>=1.4; python_version >= '3.10'",
+    "cuda-tile>=1.4",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,19 +47,6 @@ classifiers = [
 ]
 
 dependencies = [
-    # The CuTeDSL stack is a required dependency: the OSS kernel engines (FROST
-    # SDPA, GEMM fusions, sparse/linear attention) are Python kernels that JIT
-    # through CuTeDSL, and they are a headline part of the package rather than an
-    # add-on. Still NOT pinned to the floor those engines want (4.7.0, see
-    # CUTEDSL_MIN_VERSION in cudnn/frost/buffers.py): pinning that high here would
-    # make this package uninstallable next to anything holding the DSL back --
-    # vLLM and friends carry their own constraints. The engines check the version
-    # at support time and decline when it is too old, so an older DSL costs those
-    # engines and nothing else. The 4.6.2 floor is the oldest DSL this package is
-    # tested against, and it is also what sets `requires-python` above: every
-    # nvidia-cutlass-dsl release is `Requires-Python >=3.10`.
-    # Framework-neutral core only: the CuTeDSL APIs are type-erased, so torch (like
-    # jax) is opt-in via the [dependency-groups] below (`pip install --group torch`).
     "nvidia-cutlass-dsl[cu13]>=4.6.2",
     "apache-tvm-ffi>=0.1.11",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,29 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
+dependencies = [
+    # The CuTeDSL stack is a required dependency: the OSS kernel engines (FROST
+    # SDPA, GEMM fusions, sparse/linear attention) are Python kernels that JIT
+    # through CuTeDSL, and they are a headline part of the package rather than an
+    # add-on. Still NOT pinned to the floor those engines want (4.7.0, see
+    # CUTEDSL_MIN_VERSION in cudnn/frost/buffers.py): pinning that high here would
+    # make this package uninstallable next to anything holding the DSL back --
+    # vLLM and friends carry their own constraints. The engines check the version
+    # at support time and decline when it is too old, so an older DSL costs those
+    # engines and nothing else. The 4.6.2 floor is the oldest DSL this package is
+    # tested against.
+    # Framework-neutral core only: the CuTeDSL APIs are type-erased, so torch (like
+    # jax) is opt-in via the [dependency-groups] below (`pip install --group torch`).
+    # Marker: every nvidia-cutlass-dsl release is `Requires-Python >=3.10`, and this
+    # package still declares `requires-python = ">=3.9"`. Without the marker a 3.9
+    # install stops resolving entirely instead of just losing the JIT engines, which
+    # decline at check_support when the DSL is absent -- the same trade-off the
+    # `cutile` extra below already makes for cuda-tile.
+    "nvidia-cutlass-dsl[cu13]>=4.6.2; python_version >= '3.10'",
+    "cuda-python",
+    "apache-tvm-ffi>=0.1.11",
+]
+
 [project.urls]
 "Homepage" = "https://github.com/NVIDIA/cudnn-frontend"
 "Documentation" = "https://docs.nvidia.com/deeplearning/cudnn/frontend/latest/"
@@ -55,19 +78,11 @@ classifiers = [
 "Release Notes" = "https://github.com/NVIDIA/cudnn-frontend/releases"
 
 [project.optional-dependencies]
-cutedsl = [
-    # NOT pinned to the floor the FROST engines need (4.7.0): pinning it here
-    # would make this package incompatible with anything holding the DSL at an
-    # older version -- quack-kernels pins ==4.6.0, and vLLM and friends carry
-    # their own constraints. The engines check the version at support time and
-    # decline when it is too old, so an older DSL costs those engines and
-    # nothing else. See CUTEDSL_MIN_VERSION in cudnn/frost/buffers.py.
-    # Framework-neutral core only: the CuTeDSL APIs are type-erased, so torch (like
-    # jax) is opt-in via the [dependency-groups] below (`pip install --group torch`).
-    "nvidia-cutlass-dsl[cu13]>=4.5.0",
-    "cuda-python",
-    "apache-tvm-ffi>=0.1.11",
-]
+# Back-compat alias, intentionally empty: the CuTeDSL stack moved to the required
+# [project] dependencies above, so `pip install nvidia-cudnn-frontend[cutedsl]`
+# now resolves to the same thing as a plain install. Kept so the extra keeps
+# resolving instead of warning for everyone still spelling it out.
+cutedsl = []
 cutile = [
     # The cuTile linear-attention engines. Base cuda-tile only -- its [tileiras]
     # extra pins cuda-toolkit>=13.2,<13.4, and that upper bound would cap the

--- a/python/cudnn/AGENTS.md
+++ b/python/cudnn/AGENTS.md
@@ -6,7 +6,7 @@ The `cudnn` Python package: pybind11-backed graph API plus pure-Python **fronten
 
 - `import cudnn` must work **without** torch/cutlass/cuda-python installed. Everything that needs them is exported lazily via `_LAZY_OPTIONAL_IMPORTS` in `__init__.py` — a module-level `__getattr__` imports the submodule on first attribute access and re-raises failures as `ImportError` pointing at `pip install nvidia-cudnn-frontend[cutedsl]`.
 - Never add an eager `import torch` / `import cutlass` to `__init__.py` or anything it imports transitively. `api_base.py` itself imports them at top level, which is why kernel classes must only be reachable through the lazy table.
-- Reuse the existing `[cutedsl]` extra (`pyproject.toml` optional-dependencies) unless a kernel truly needs a new package.
+- Reuse the existing required CuTeDSL dependencies (`pyproject.toml` `[project] dependencies`) unless a kernel truly needs a new package. The `[cutedsl]` extra is now an empty back-compat alias — do not add to it.
 
 ## Hard rules
 

--- a/python/cudnn/AGENTS.md
+++ b/python/cudnn/AGENTS.md
@@ -6,7 +6,7 @@ The `cudnn` Python package: pybind11-backed graph API plus pure-Python **fronten
 
 - `import cudnn` must work **without** torch/cutlass/cuda-python installed. Everything that needs them is exported lazily via `_LAZY_OPTIONAL_IMPORTS` in `__init__.py` — a module-level `__getattr__` imports the submodule on first attribute access and re-raises failures as `ImportError` pointing at `pip install nvidia-cudnn-frontend[cutedsl]`.
 - Never add an eager `import torch` / `import cutlass` to `__init__.py` or anything it imports transitively. `api_base.py` itself imports them at top level, which is why kernel classes must only be reachable through the lazy table.
-- Reuse the existing required CuTeDSL dependencies (`pyproject.toml` `[project] dependencies`) unless a kernel truly needs a new package. The `[cutedsl]` extra is now an empty back-compat alias — do not add to it.
+- Reuse the existing required CuTeDSL dependencies (`pyproject.toml` `[project] dependencies`) unless a kernel truly needs a new package. The `[cutedsl]` extra now holds only `cuda-python`.
 
 ## Hard rules
 

--- a/python/cudnn/block_sparse_attention/_interface.py
+++ b/python/cudnn/block_sparse_attention/_interface.py
@@ -106,10 +106,10 @@ def _cutlass_dsl_version() -> tuple[int, int, int]:
 
 
 def _require_sage_fp8_cutedsl() -> None:
-    """Gate the new Sage FP8 kernels while preserving the package's 4.5 floor."""
+    """Gate the Sage FP8 kernels for environments that force a DSL below the package floor."""
     if _cutlass_dsl_version() < (4, 6, 1):
         raise RuntimeError(
-            "Sage FP8 block-sparse attention requires nvidia-cutlass-dsl>=4.6.1; " "the BF16/FP16 BSA paths remain available with the package minimum of 4.5.0"
+            "Sage FP8 block-sparse attention requires nvidia-cutlass-dsl>=4.6.1; " "the BF16/FP16 BSA paths remain available on older DSL builds"
         )
 
 

--- a/python/cudnn/csa/compressor/compressor_sm100_r128.py
+++ b/python/cudnn/csa/compressor/compressor_sm100_r128.py
@@ -130,7 +130,7 @@ _L2E_LO = 1.925963033500011e-08  # fp32(log2(e) - _L2E_HI); residual ~4e-16
 
 
 # ``cute.math.exp2``'s ``approx``/``ftz`` keywords are newer than the
-# ``nvidia-cutlass-dsl>=4.5.0`` floor this project's dependency spec resolves to, so the
+# ``nvidia-cutlass-dsl>=4.6.2`` floor this project's dependency spec resolves to, so the
 # same instruction is requested through ``fastmath=True``, which both versions accept.
 # Both spellings lower to ``ex2.approx.ftz.f32`` -- the form the tolerance contract is
 # calibrated on: on 4.6.1 the 16-kernel ``reg_probe_csa_compressor_r128.py`` PTX is

--- a/python/cudnn/native_sparse_attention/sparse_attention.md
+++ b/python/cudnn/native_sparse_attention/sparse_attention.md
@@ -28,9 +28,9 @@ python/cudnn/native_sparse_attention/
 
 ## Installation
 
-Install the optional cudnn dependences required for NSA:
+The dependencies NSA needs are required dependencies of the package:
 ```bash
-pip install nvidia-cudnn-frontend[cutedsl]
+pip install nvidia-cudnn-frontend
 ```
 
 ## Usage

--- a/skills/cutedsl-kernel-integration/SKILL.md
+++ b/skills/cutedsl-kernel-integration/SKILL.md
@@ -26,7 +26,7 @@ Use this skill to add or update a CuTeDSL frontend-only API in cuDNN Frontend. T
 2. Implement the class API by extending `APIBase`; keep constructor descriptors, `check_support()`, `compile()`, and `execute()` consistent with the closest template.
 3. Add a high-level wrapper that allocates outputs, caches/reuses compiled kernels where the template does, and returns a `TupleDict`.
 4. Export the public class and wrapper through the operation/family `__init__.py` files and `_LAZY_OPTIONAL_IMPORTS` in `python/cudnn/__init__.py`.
-5. Reuse the existing CuTeDSL dependencies in `[project] dependencies` unless the new kernel truly needs an additional package. The `cutedsl` extra is now an empty back-compat alias -- do not add to it.
+5. Reuse the existing CuTeDSL dependencies in `[project] dependencies` unless the new kernel truly needs an additional package. The `cutedsl` extra now holds only `cuda-python`.
 6. Add FE OSS documentation and update the relevant overview or operation index links.
 7. Add tests under `test/python/fe_api/`, including support validation and numerical/reference coverage when executable.
 8. For grouped/discrete/MoE/SDPA kernels, preserve the source helper and scheduler topology; shared helper modules should be internal package files, not public `cudnn` exports.

--- a/skills/cutedsl-kernel-integration/SKILL.md
+++ b/skills/cutedsl-kernel-integration/SKILL.md
@@ -26,7 +26,7 @@ Use this skill to add or update a CuTeDSL frontend-only API in cuDNN Frontend. T
 2. Implement the class API by extending `APIBase`; keep constructor descriptors, `check_support()`, `compile()`, and `execute()` consistent with the closest template.
 3. Add a high-level wrapper that allocates outputs, caches/reuses compiled kernels where the template does, and returns a `TupleDict`.
 4. Export the public class and wrapper through the operation/family `__init__.py` files and `_LAZY_OPTIONAL_IMPORTS` in `python/cudnn/__init__.py`.
-5. Reuse the existing `cutedsl` optional dependency unless the new kernel truly needs an additional package.
+5. Reuse the existing CuTeDSL dependencies in `[project] dependencies` unless the new kernel truly needs an additional package. The `cutedsl` extra is now an empty back-compat alias -- do not add to it.
 6. Add FE OSS documentation and update the relevant overview or operation index links.
 7. Add tests under `test/python/fe_api/`, including support validation and numerical/reference coverage when executable.
 8. For grouped/discrete/MoE/SDPA kernels, preserve the source helper and scheduler topology; shared helper modules should be internal package files, not public `cudnn` exports.

--- a/skills/cutedsl-kernel-integration/references/integration-pattern.md
+++ b/skills/cutedsl-kernel-integration/references/integration-pattern.md
@@ -162,7 +162,7 @@ For family modules such as `gemm.cutedsl.grouped`, `gemm.cutedsl.discrete_groupe
 
 ## Dependencies
 
-`pyproject.toml` already lists the CuTeDSL stack (`nvidia-cutlass-dsl[cu13]>=4.6.2`, `cuda-python`, `apache-tvm-ffi`) under `[project] dependencies`, so it is always installed. Reuse it by default; `[project.optional-dependencies].cutedsl` is an empty back-compat alias.
+`pyproject.toml` already lists the CuTeDSL stack (`nvidia-cutlass-dsl[cu13]>=4.6.2`, `apache-tvm-ffi`) under `[project] dependencies`, so it is always installed, and the DSL pulls `cuda-python` in transitively. Reuse it by default; `[project.optional-dependencies].cutedsl` names only `cuda-python`.
 
 Only change dependencies when the new kernel requires a package not already covered by `cutedsl`. If adding one, document why it is needed and keep the dependency scoped to the optional extra.
 

--- a/skills/cutedsl-kernel-integration/references/integration-pattern.md
+++ b/skills/cutedsl-kernel-integration/references/integration-pattern.md
@@ -162,7 +162,7 @@ For family modules such as `gemm.cutedsl.grouped`, `gemm.cutedsl.discrete_groupe
 
 ## Dependencies
 
-`pyproject.toml` already defines `[project.optional-dependencies].cutedsl` for CuTeDSL integrations. Reuse it by default.
+`pyproject.toml` already lists the CuTeDSL stack (`nvidia-cutlass-dsl[cu13]>=4.6.2`, `cuda-python`, `apache-tvm-ffi`) under `[project] dependencies`, so it is always installed. Reuse it by default; `[project.optional-dependencies].cutedsl` is an empty back-compat alias.
 
 Only change dependencies when the new kernel requires a package not already covered by `cutedsl`. If adding one, document why it is needed and keep the dependency scoped to the optional extra.
 

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -20,7 +20,7 @@ pytest test_conv_fprop.py    # one file — note the default -m L0 filter still 
 pytest fe_api/gemm/          # OSS kernel tests
 ```
 
-**Read pytest's own summary line; do not post-process the output.** `... | grep -c "passed"` counts a collection error as a pass, and `cmd | tail` reports *tail's* exit status, so a failed build or a failed suite behind a pipe looks like success. Both have produced confidently wrong "all green" reports here. Requirements: `pip install -e ".[cutedsl]"` plus `pytest pytest-xdist looseversion`. `fe_api/` additionally requires an SM90/SM100-class GPU; tests skip (or should skip) on unsupported arch/dtype/backend-version combos rather than fail.
+**Read pytest's own summary line; do not post-process the output.** `... | grep -c "passed"` counts a collection error as a pass, and `cmd | tail` reports *tail's* exit status, so a failed build or a failed suite behind a pipe looks like success. Both have produced confidently wrong "all green" reports here. Requirements: `pip install -e .` plus `pytest pytest-xdist looseversion`. `fe_api/` additionally requires an SM90/SM100-class GPU; tests skip (or should skip) on unsupported arch/dtype/backend-version combos rather than fail.
 
 ### conftest.py landmines — read before editing
 


### PR DESCRIPTION
## What

Moves the CuTeDSL runtime out of the `cutedsl` optional-dependency group and into the required `[project] dependencies`, raises the DSL floor from `>=4.5.0` to `>=4.6.2`, and raises `requires-python` to `>=3.10`.

The OSS kernel engines (FROST SDPA, GEMM fusions, sparse/linear attention) are Python kernels that JIT through CuTeDSL. They are a headline part of this package rather than an add-on, so the runtime they need should install by default.

```diff
-requires-python = ">=3.9"
+requires-python = ">=3.10"

+dependencies = [
+    "nvidia-cutlass-dsl[cu13]>=4.6.2",
+    "apache-tvm-ffi>=0.1.11",
+]

 [project.optional-dependencies]
-cutedsl = [
-    "nvidia-cutlass-dsl[cu13]>=4.5.0",
-    "cuda-python",
-    "apache-tvm-ffi>=0.1.11",
-]
+cutedsl = [
+    "cuda-python",
+]
```

Resulting wheel metadata:

```
Requires-Python: >=3.10
Requires-Dist: nvidia-cutlass-dsl[cu13]>=4.6.2
Requires-Dist: apache-tvm-ffi>=0.1.11
Requires-Dist: cuda-python; extra == "cutedsl"
Requires-Dist: cuda-tile>=1.4; extra == "cutile"
```

## Notes for review

**Python 3.9 is dropped.** `requires-python` was `>=3.9` while the classifiers already only listed 3.10–3.14, and every `nvidia-cutlass-dsl` release is `Requires-Python >=3.10` — so with the DSL required, 3.9 could not have resolved anyway. Raising the floor makes that explicit instead of encoding it in a marker. It also makes the `python_version >= '3.10'` marker on `cuda-tile` redundant, so that is removed too. `README.md` and `AGENTS.md` now state Python ≥ 3.10.

**`cuda-python` stays in the `cutedsl` extra rather than moving up.** It arrives either way: the required `nvidia-cutlass-dsl` pulls `nvidia-cutlass-dsl-libs-base`, which itself declares `cuda-python>=12.8`, so a plain `pip install nvidia-cudnn-frontend` still has it. Naming it in the extra pins it to this package instead of to a transitive detail of the DSL's own packaging, and keeps `pip install nvidia-cudnn-frontend[cutedsl]` resolving for everyone who still writes it that way.

**`CUTEDSL_MIN_VERSION` is unchanged at `(4, 7, 0)`.** The packaging floor deliberately sits below the version the FROST engines want, for the same reason as before: pinning the hard floor at 4.7 would make cudnn-frontend uninstallable next to anything holding the DSL back. The engines version-check at support time and decline, so an older DSL costs those engines and nothing else.

**One compatibility call worth flagging:** the previous comment justified the low floor partly by "quack-kernels pins `==4.6.0`". A 4.6.2 floor now hard-conflicts with that pin, and since the dependency is required rather than opt-in, the conflict can no longer be sidestepped by skipping the extra. Flagging in case quack co-installation matters to anyone.

**The lazy-import boundary is untouched.** `import cudnn` must still not eagerly import torch or cutlass; torch and jax remain opt-in via the PEP 735 dependency groups. `python/cudnn/__init__.py`'s `_OPTIONAL_DEPENDENCY_INSTALL_HINT` is left as-is, so `test/python/test_import_boundaries.py` — which hard-asserts that hint string — is unaffected.

## Docs

Install snippets across `docs/fe-oss-apis/`, `AGENTS.md`, `CONTRIBUTING.md`, and the benchmark READMEs drop the now-redundant extra, and the stale "package floor is 4.5.0" / "optional dependency" claims are corrected (`bsa.md`, `csa/compressor/compressor_sm100_r128.py`, `block_sparse_attention/_interface.py`, `python_graph_and_execution_backends.md`).

## Verification

- Generated the wheel `METADATA` via the PEP 517 `prepare_metadata_for_build_wheel` hook and confirmed the two required packages appear as unconditional `Requires-Dist` with no `extra ==` guard, and that `cuda-python` appears only under `extra == "cutedsl"` (output quoted above).
- Parsed every requirement with `packaging.Requirement` and asserted name / specifier / extras, that no marker remains on either the DSL or `cuda-tile`, that `requires-python == ">=3.10"`, and that no 3.9 classifier survives.
- Confirmed on PyPI that `nvidia-cutlass-dsl` 4.6.2 is published, that every release carries `Requires-Python >=3.10`, and that `nvidia-cutlass-dsl-libs-base` 4.6.2 declares `cuda-python>=12.8` — which is what makes demoting `cuda-python` safe.
- `black --line-length 160` clean on the touched Python files; pre-commit (black, SPDX) passed.

Not run: the Python test suite, which needs a compiled extension and a GPU. CI should cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Python 3.10 or newer is now required; Python 3.9 is no longer supported.

* **Installation**
  * The standard installation now includes CuTeDSL and related kernel dependencies.
  * Existing installation instructions have been updated to use the base package rather than the optional CuTeDSL extra.
  * The CuTeDSL extra remains available as a compatibility alias for `cuda-python`.

* **Documentation**
  * Updated setup, testing, benchmark, and integration guidance to reflect the revised dependencies and requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->