### PR TITLE
frost(sdpa): GQA/MQA under THD for the SM100 d512 backward, and both THD conjunction flags deleted

### DIFF
--- a/python/cudnn/sdpa/bwd/api_dsl.py
+++ b/python/cudnn/sdpa/bwd/api_dsl.py
@@ -2272,15 +2272,6 @@ class SdpaBwdDslSm100(SdpaBwdDsl):
                 bool(self._stage_in or self._stage_out),
                 f"SM100 bwd THD: {', '.join(self._stage_in + self._stage_out)} must be BSHD-physical " "(the packed path has no staging copy)",
             )
-            # Declined HERE and not only at execute: `_execute_thd` raises after
-            # the workspace carve and the do_dot launch, so a direct
-            # SdpaBwdDslSm100 caller would pay a build and an allocation before
-            # learning the plan is unserved. The graph path never reaches either
-            # (the row leaves `thd_gqa` False), which is why this is a backstop.
-            self._value_error_if(
-                self._gqa_group > 1,
-                "SM100 bwd THD: GQA is not implemented yet (the dK/dV partials need packed per-Q-head buffers)",
-            )
             self._value_error_if(
                 self._thd_lse_token_major and bool(self.thd_stats_head_stride),
                 "SM100 bwd THD: thd_stats_head_stride is head-major-only (token-major (T, H) Stats is compact)",
@@ -2323,7 +2314,11 @@ class SdpaBwdDslSm100(SdpaBwdDsl):
         if self._gqa_group > 1:
             # One dK and one dV partial per Q head, reduced to the KV heads at
             # the end. Sized on h_q, not h_kv -- that is the whole point.
-            total += 2 * ws_align(self.batch_size * self.s_k_max * self.h_q * self.head_dim_qk * self._bpe)
+            # THD packs the kv axis into ONE batch of `t_kv_cap` tokens, which is
+            # the same memory win the blocked S/dS workspace gets: B * S_kv_max
+            # tokens become the declared packed total.
+            _kv_rows = self._t_kv_cap if self.thd else self.batch_size * self.s_k_max
+            total += 2 * ws_align(_kv_rows * self.h_q * self.head_dim_qk * self._bpe)
         return total
 
     # --- compilation ---------------------------------------------------------
@@ -2875,8 +2870,21 @@ class SdpaBwdDslSm100(SdpaBwdDsl):
             # it directly), so this only re-asserts the shape `compile()` baked
             # into the artifact.
             lse = stats_tensor.reshape(t_q_cap, h) if self._thd_lse_token_major else stats_tensor.reshape(1, h, self._thd_lse_head_stride or t_q_cap)
+            # GQA: the stage-3 dK/dV GEMMs write ONE PARTIAL PER Q HEAD and a
+            # separate reduce folds the group. Writing straight to dk/dv would
+            # have a group's Q heads overwrite each other instead of summing.
+            # Packed `[1, T_kv_cap, H_q, D]` -- the same shape the dense path
+            # uses with the batch collapsed, so every downstream slice, the
+            # per-sequence descriptor bases (which take their row stride from
+            # the C tensor) and `dkv_reduce_host` (which sizes its grid from
+            # `dk.shape[0..2]`) all work unchanged.
             gqa = self._gqa_group > 1
-            self._value_error_if(gqa, "SM100 bwd THD: GQA is not implemented yet (the dK/dV partials need packed per-Q-head buffers)")
+            if gqa:
+                dk_part = carver.take(t_kv_cap * h * d, self.dtype).view(1, t_kv_cap, h, d)
+                dv_part = carver.take(t_kv_cap * h * d, self.dtype).view(1, t_kv_cap, h, d)
+                dk_tgt, dv_tgt = dk_part, dv_part
+            else:
+                dk_tgt, dv_tgt = dk, dv
 
             for c in range(h // chunk):
                 hb = c * chunk
@@ -2906,7 +2914,7 @@ class SdpaBwdDslSm100(SdpaBwdDsl):
                 mm_lo.matmul_bh(
                     s_ws.permute(3, 2, 1, 0),
                     do[:, :, hs, :].permute(3, 1, 2, 0),
-                    dv[:, :, hs, :].permute(1, 3, 2, 0),
+                    dv_tgt[:, :, hs, :].permute(1, 3, 2, 0),
                     n_head=chunk,
                     n_batch=b,
                     stream=stream,
@@ -2917,7 +2925,7 @@ class SdpaBwdDslSm100(SdpaBwdDsl):
                 mm_lo.matmul_bh(
                     ds_ws.permute(3, 2, 1, 0),
                     q[:, :, hs, :].permute(3, 1, 2, 0),
-                    dk[:, :, hs, :].permute(1, 3, 2, 0),
+                    dk_tgt[:, :, hs, :].permute(1, 3, 2, 0),
                     n_head=chunk,
                     n_batch=b,
                     stream=stream,
@@ -2925,14 +2933,52 @@ class SdpaBwdDslSm100(SdpaBwdDsl):
                     desc_words=desc3,
                     grid_m=self.s_k_max,
                 )
-                mm_hi.matmul_bh(
-                    ds_ws.permute(2, 3, 1, 0),
-                    k[:, :, hs, :].permute(3, 1, 2, 0),
-                    dq[:, :, hs, :].permute(1, 3, 2, 0),
-                    n_head=chunk,
-                    n_batch=b,
-                    stream=stream,
-                    meta=meta,
-                    desc_words=desc3,
-                    grid_m=self.s_q_max,
-                )
+                # dQ = dS.K. Under GQA the K head is shared by `group` Q heads,
+                # so the GEMM runs once per group MEMBER: taking every `group`-th
+                # Q head lines A and the output up with the KV heads exactly, and
+                # every operand stays a strided view (no expand, no copy). The
+                # per-sequence dQ descriptors follow, because they take their row
+                # stride from the C tensor and striding the HEAD axis leaves the
+                # row stride at H_q * D.
+                kv_lo, kv_n = hb // self._gqa_group, chunk // self._gqa_group
+                kvs = slice(kv_lo, kv_lo + kv_n)
+                for gi in range(self._gqa_group):
+                    a_g = ds_ws[:, gi :: self._gqa_group] if gqa else ds_ws
+                    o_g = dq[:, :, hs, :][:, :, gi :: self._gqa_group, :] if gqa else dq[:, :, hs, :]
+                    mm_hi.matmul_bh(
+                        a_g.permute(2, 3, 1, 0),
+                        k[:, :, kvs, :].permute(3, 1, 2, 0),
+                        o_g.permute(1, 3, 2, 0),
+                        n_head=kv_n,
+                        n_batch=b,
+                        stream=stream,
+                        meta=meta,
+                        desc_words=desc3,
+                        grid_m=self.s_q_max,
+                    )
+
+            if gqa:
+                # Fold the Q-head partials onto the KV heads -- the same
+                # arch-neutral reduce the dense path uses, unchanged: it is
+                # elementwise over rows and sizes its grid from the OUTPUT's
+                # (batch, seq, head), so a packed batch of 1 needs nothing
+                # special.
+                from cudnn.sdpa.bwd.kernels.bprop_chain_f16_sm120 import dkv_reduce_host
+
+                io_dt = cutlass.BFloat16 if self.dtype == torch.bfloat16 else cutlass.Float16
+                if self._reduce_fn is None:
+                    self._reduce_fn = cutlass.cute.compile(
+                        dkv_reduce_host,
+                        _t(dk_part),
+                        _t(dv_part),
+                        _t(dk),
+                        _t(dv),
+                        d,
+                        d,
+                        self._gqa_group,
+                        io_dt,
+                        False,
+                        make_fake_stream(use_tvm_ffi_env_stream=False),
+                        options="--enable-tvm-ffi",
+                    )
+                self._reduce_fn(_t(dk_part), _t(dv_part), _t(dk), _t(dv), stream)

--- a/python/cudnn/sdpa/bwd/engines.py
+++ b/python/cudnn/sdpa/bwd/engines.py
@@ -162,19 +162,20 @@ class Capabilities:
     cu_seq_len: bool = False
     # THD is a SEPARATE code path (packed views + a blocked S/dS workspace), so
     # a feature the dense path serves is not automatically served under THD.
-    # These are the conjunction verdicts; mismatch() knows the shape of each.
     #
-    # BOTH ARE TRANSITIONAL AND MEANT TO BE DELETED, not accumulated. A
-    # conjunction flag earns its place only while some row genuinely cannot
-    # serve the pair; once the last one can, the flag is vacuous (it can never
-    # fire) and the field, its branch in mismatch(), and its tests all go --
-    # rather than being left set to True forever as a widening record of
-    # everything the packed path once could not do.
-    #   thd_causal: True on sdpa_bwd_sm100, the only row that sets thd -- so it
-    #     is ALREADY vacuous and is scheduled for removal.
-    #   thd_gqa:    still False; removal lands with the GQA-under-THD work.
-    thd_causal: bool = False  # any causal-family bound (causal / SWA / band / bottom-right) under THD
-    thd_gqa: bool = False  # h_q != h_kv under THD
+    # A conjunction flag here is TRANSITIONAL AND MEANT TO BE DELETED, not
+    # accumulated: it earns its place only while some row genuinely cannot serve
+    # the pair, and once the last one can it is vacuous -- it can never fire --
+    # so the field, its branch in mismatch() and its tests all go, rather than
+    # sitting at True forever as a widening record of what the packed path once
+    # could not do.
+    #
+    # `thd_causal` and `thd_gqa` were both removed on exactly that rule, once
+    # sdpa_bwd_sm100 -- the only row that sets `thd` -- served the causal family
+    # and then GQA. NOTHING is left here: the packed path's remaining limits
+    # (`thd_declared_totals`, the BSHD requirement) are not feature
+    # conjunctions, they are properties of the path itself. Think twice before
+    # adding another.
     # True when THD REQUIRES sdpa(max_total_seq_len_q=..., max_total_seq_len_kv=...):
     # the row's workspace is sized from the packed token totals at BUILD time,
     # before any buffer exists.
@@ -307,18 +308,6 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", requested: 
             return f"graph uses {label}, which this engine does not support"
 
     if facts.thd and capabilities.thd:
-        # These are the generic MATCHER, NOT a statement about any engine: a
-        # branch fires only for a row that has not set the flag. Reading the
-        # string below as "THD cannot do causal" is the wrong conclusion --
-        # sdpa_bwd_sm100 sets thd_causal=True and serves the whole causal
-        # family (stage 2 masks per sequence, stage 3 renders untrimmed; see
-        # SdpaBwdDslSm100.compile). thd_gqa is the one still declined.
-        #
-        # Both flags are TRANSITIONAL -- see Capabilities for the removal plan.
-        if (facts.causal or facts.right_band_widening or facts.window_left is not None) and not capabilities.thd_causal:
-            return "this engine does not serve causal-family masks under THD (its row leaves thd_causal unset)"
-        if facts.h_q != facts.h_kv and not capabilities.thd_gqa:
-            return f"this engine does not serve GQA / MQA under THD (its row leaves thd_gqa unset; H_q={facts.h_q}, H_kv={facts.h_kv})"
         if capabilities.thd_declared_totals and (facts.max_total_seq_len_q is None or facts.max_total_seq_len_kv is None):
             return (
                 "THD requires sdpa_backward(max_total_seq_len_q=..., max_total_seq_len_kv=...): "
@@ -792,11 +781,14 @@ def _sm100_spec() -> EngineSpec:
     family is served: stage 2 masks from the per-sequence metadata lengths (the
     bottom-right diagonal included, as ``S_kv[b] - S_q[b]``), and stage 3 is
     rendered UNTRIMMED because its K-trim is in absolute workspace rows -- the
-    adapter zero-fills the blocked workspace instead. Its remaining conjunctions
-    are declined and each is asserted by a reject test: GQA (the dK/dV partials
-    would have to be packed per Q head), and a graph that does not declare
+    adapter zero-fills the blocked workspace instead. GQA / MQA is served too,
+    by per-Q-head dK/dV partials over the PACKED kv axis plus the shared group
+    fold -- so the packed path now matches the dense one feature for feature,
+    and both THD conjunction flags are gone. What remains is a property of the
+    path, not a feature it declines: it requires
     ``max_total_seq_len_q/kv`` (``scratch_workspace_bytes()`` is a build-time
-    function and the blocked row count comes from the packed totals).
+    function and the blocked row count comes from the packed totals) and
+    BSHD-physical io (there is no staging leg).
 
     Everything else is declined for now and each rejection is asserted by a
     test: DENSE padding masks (the kernel compiles a scalar length; THD threads
@@ -819,7 +811,6 @@ def _sm100_spec() -> EngineSpec:
             right_band_widening=True,
             gqa=True,  # per-Q-head dK/dV partials + the shared dkv_reduce group fold
             thd=True,
-            thd_causal=True,  # stage 2 masks per sequence; stage 3 drops its trim and leans on the zero-fill
             thd_declared_totals=True,  # the blocked workspace is sized at build time
             # Any dense layout: the adapter uses a BSHD-physical tensor in place
             # (a permuted view, zero copy) and stages a non-conforming one

--- a/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
+++ b/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
@@ -82,7 +82,7 @@ MMA as d=512.
 | Padding mask + stats (per-batch LSE trim) | ✅ | f16/fp8 only⁴ | f16/fp8 only⁴ | ✅ | f16/fp8 only⁴ | ❌ |
 | Dense padded-Q trim (O:=0, LSE:=−inf) | f16 only⁵ | f16 only⁵ | f16 only⁵ | ✅ | f16 only⁵ | ❌ |
 | Attention sink | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| GQA / MQA (`H_q ≠ H_kv`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ᵇ ᶠ ᵍ · dense only under THDʰ |
+| GQA / MQA (`H_q ≠ H_kv`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ᵇ ᶠ ᵍ ʰ |
 | Bias / dBias | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `use_deterministic_algorithm` | — | — | — | — | — | ❌ᵇ · ✅ᵍ |
 | Ragged `S_kv` (non-multiple of 128) | ✅⁶ | ✅⁶ | ✅⁶ | ✅⁶ | ✅⁶ | ✅ᵇ ᵉ ᵍ |
@@ -162,12 +162,17 @@ A sequence that is empty on ONE side only (`S_q[b] == 0` with `S_kv[b] > 0`, or
 the reverse) is served and returns exactly zero for that sequence: its GEMM's
 reduction axis is empty, so no MMA initialises the accumulator, and the epilogue
 stores zeros rather than TMEM residue.
-Its remaining conjunctions are declined, each with a reject test: **GQA** (the dK/dV
-partials would have to be packed per Q head), a non-BSHD-physical layout (the packed
-path has no staging copy), and a graph that does not declare
-**`max_total_seq_len_q`/`_kv`** — those are REQUIRED here, because
-`scratch_workspace_bytes()` is a build-time function and the blocked row count
-comes from the packed totals before any buffer exists.
+**GQA / MQA is served** as well: the stage-3 dK/dV GEMMs write one partial per Q
+head over the PACKED kv axis and the shared reduce folds the group onto the KV
+heads, so the packed path now matches the dense one feature for feature. With
+that, BOTH THD conjunction flags (`thd_causal`, `thd_gqa`) are **deleted** rather
+than set True — a conjunction flag is transitional by design and earns its place
+only while some row genuinely cannot serve the pair.
+What remains is a property of the path, not a feature it declines: a
+non-BSHD-physical layout (the packed path has no staging copy), and a graph that
+does not declare **`max_total_seq_len_q`/`_kv`** — those are REQUIRED here,
+because `scratch_workspace_bytes()` is a build-time function and the blocked row
+count comes from the packed totals before any buffer exists.
 ʲ Not a gap in this engine: `cu_seq_len_q/kv` is a **forward-only** graph
 attribute. `SDPA_backward_attributes` has no such input port and
 `pygraph.sdpa_backward()` no such keyword, so no backward row can claim it and
@@ -312,7 +317,6 @@ feature-free d=64 graph.
 | Backward pass entirely | SM107 |
 | Backward outside d ∈ (256, 512] (f16/bf16) or d = 256 (MXFP8) | SM100, SM103 — the two backward engines there serve exactly those bands |
 | Backward per-batch padding mask (`seq_len_q/kv`) on a DENSE graph | SM100, SM103 — a UNIFORM non-tile-multiple length is served, and the THD path carries per-sequence lengths; a per-batch mask on a dense graph is not |
-| Backward THD + GQA | SM100, SM103 |
 | Backward sink / dSink, bias / dBias | SM100, SM103 |
 | Backward deterministic, decode | SM100, SM103 — served by the MXFP8 d=256 row only |
 | MXFP8 backward: E5M2, bottom-right / band-widened / sliding-window masks, non-BSHD strides, `amax_*` outputs | SM100, SM103 |

--- a/test/python/sdpa/frost/test_sdpa_bwd_dsl_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_bwd_dsl_sm100.py
@@ -556,8 +556,12 @@ def test_capabilities_match_what_is_implemented():
     assert c.d_envelope_floor == 256, "an envelope with no floor silently claims every small head dim"
     assert c.thd, "the packed path is served (blocked S/dS workspace + per-sequence descriptors)"
     assert c.thd_declared_totals, "the blocked workspace is sized from the declared totals at BUILD time"
-    assert c.thd_causal, "the causal family is served under THD (stage 2 masks per sequence; stage 3 drops its trim)"
-    assert not c.thd_gqa, "the dK/dV partials would have to be packed per Q head"
+    for gone in ("thd_causal", "thd_gqa"):
+        assert not hasattr(c, gone), (
+            f"{gone} must stay DELETED, not re-added: every row that serves THD now serves that "
+            "feature too, so the flag can never fire. THD conjunction flags are transitional by "
+            "design -- they exist only while some row genuinely cannot serve the pair."
+        )
     assert not c.cu_seq_len, "sdpa_backward has no cu_seq_len_* port; no row can claim or test it"
     assert not c.padded, "DENSE padding masks: the kernel compiles a scalar length; THD carries its own"
     assert not c.bias and not c.dbias and not c.sink and not c.dsink

--- a/test/python/sdpa/frost/test_sdpa_bwd_thd_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_bwd_thd_sm100.py
@@ -262,7 +262,22 @@ def _plan_index(g, name=_ENGINE):
     return None
 
 
-def _thd_case(lens_q, lens_kv, h, d, dtype, cap_q=None, cap_kv=None, poison=False, seed=7, causal=False, bottom_right=False, window_left=None, window_right=None, hkv=None,):  # fmt: skip
+def _thd_case(
+    lens_q,
+    lens_kv,
+    h,
+    d,
+    dtype,
+    cap_q=None,
+    cap_kv=None,
+    poison=False,
+    seed=7,
+    causal=False,
+    bottom_right=False,
+    window_left=None,
+    window_right=None,
+    hkv=None,
+):
     """Packed Q/K/V/dO plus the forward's O and packed LSE, per sequence in fp64.
 
     ``cap_*`` over-allocates the packed buffers past the real totals; with

--- a/test/python/sdpa/frost/test_sdpa_bwd_thd_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_bwd_thd_sm100.py
@@ -262,9 +262,7 @@ def _plan_index(g, name=_ENGINE):
     return None
 
 
-def _thd_case(
-    lens_q, lens_kv, h, d, dtype, cap_q=None, cap_kv=None, poison=False, seed=7, causal=False, bottom_right=False, window_left=None, window_right=None
-):
+def _thd_case(lens_q, lens_kv, h, d, dtype, cap_q=None, cap_kv=None, poison=False, seed=7, causal=False, bottom_right=False, window_left=None, window_right=None, hkv=None,):  # fmt: skip
     """Packed Q/K/V/dO plus the forward's O and packed LSE, per sequence in fp64.
 
     ``cap_*`` over-allocates the packed buffers past the real totals; with
@@ -283,14 +281,18 @@ def _thd_case(
         cu_k.append(cu_k[-1] + c)
     g = torch.Generator(device=dev).manual_seed(seed)
 
-    def _pk(cap, live):
-        x = torch.randn(1, cap, h, d, generator=g, device=dev, dtype=dtype) * 0.3
+    # K/V carry H_kv heads under GQA; Q/dO/O always carry H_q.
+    hkv = h if hkv is None else hkv
+    grp = h // hkv
+
+    def _pk(cap, live, nh):
+        x = torch.randn(1, cap, nh, d, generator=g, device=dev, dtype=dtype) * 0.3
         if poison and cap > live:
             x[0, live:] = float("nan")
         return x
 
-    q_p, do_p = _pk(cap_q, t_q), _pk(cap_q, t_q)
-    k_p, v_p = _pk(cap_kv, t_kv), _pk(cap_kv, t_kv)
+    q_p, do_p = _pk(cap_q, t_q, h), _pk(cap_q, t_q, h)
+    k_p, v_p = _pk(cap_kv, t_kv, hkv), _pk(cap_kv, t_kv, hkv)
     o_p = torch.full_like(q_p, float("nan") if poison else 0.0)
     lse_p = torch.full((1, h, cap_q), float("nan") if poison else 0.0, device=dev, dtype=torch.float32)
     scale = 1.0 / math.sqrt(d)
@@ -300,20 +302,26 @@ def _thd_case(
         qs, ks, vs = (
             x[0, cu[i] : cu[i] + L].transpose(0, 1).double() for x, cu, L in ((q_p, cu_q, lens_q[i]), (k_p, cu_k, lens_kv[i]), (v_p, cu_k, lens_kv[i]))
         )
+        # GQA: one KV head feeds `grp` consecutive Q heads. repeat_interleave,
+        # not repeat -- the kernel's mapping is `kv_head = q_head // grp`, so
+        # heads 0..grp-1 share KV head 0. Getting this backwards still produces
+        # a plausible-looking O and would only show as a cosine miss.
+        if grp > 1:
+            ks, vs = ks.repeat_interleave(grp, dim=0), vs.repeat_interleave(grp, dim=0)
         sc = (qs @ ks.transpose(-1, -2)) * scale
         if causal:
             sc = sc + _causal_bias(lens_q[i], lens_kv[i], dev, bottom_right, window_left, window_right)
         lse_p[0, :, cu_q[i] : cu_q[i] + lens_q[i]] = torch.logsumexp(sc, dim=-1).float()
         o_p[0, cu_q[i] : cu_q[i] + lens_q[i]] = (torch.softmax(sc, dim=-1) @ vs).transpose(0, 1).to(dtype)
     return SimpleNamespace(
-        b=b, h=h, d=d, dtype=dtype, scale=scale, causal=causal, bottom_right=bottom_right, window_left=window_left, window_right=window_right,
+        b=b, h=h, hkv=hkv, d=d, dtype=dtype, scale=scale, causal=causal, bottom_right=bottom_right, window_left=window_left, window_right=window_right,
         lens_q=list(lens_q), lens_kv=list(lens_kv), cu_q=cu_q, cu_k=cu_k,
         t_q=t_q, t_kv=t_kv, cap_q=cap_q, cap_kv=cap_kv,
         q=q_p, k=k_p, v=v_p, do=do_p, o=o_p, lse=lse_p,
     )  # fmt: skip
 
 
-def _check(case, dq, dk, dv):
+def _check(case, dq, dk, dv, hkv=None):
     """Per-sequence comparison against the fp64 reference.
 
     Collected, not asserted per gradient: which of the three a sequence gets
@@ -328,10 +336,12 @@ def _check(case, dq, dk, dv):
             continue
         sl_q = slice(case.cu_q[i], case.cu_q[i] + case.lens_q[i])
         sl_k = slice(case.cu_k[i], case.cu_k[i] + case.lens_kv[i])
+        _grp = case.h // case.hkv
+        _rep = (lambda x: x.repeat_interleave(_grp, dim=0)) if _grp > 1 else (lambda x: x)
         rq, rk, rv = _ref_bwd(
             case.q[0, sl_q].transpose(0, 1),
-            case.k[0, sl_k].transpose(0, 1),
-            case.v[0, sl_k].transpose(0, 1),
+            _rep(case.k[0, sl_k].transpose(0, 1)),
+            _rep(case.v[0, sl_k].transpose(0, 1)),
             case.do[0, sl_q].transpose(0, 1),
             case.scale,
             causal=case.causal,
@@ -339,6 +349,14 @@ def _check(case, dq, dk, dv):
             window_left=case.window_left,
             window_right=case.window_right,
         )
+        if case.hkv != case.h:
+            # GQA: the reference ran with K/V BROADCAST to every Q head, so its
+            # dK/dV are per Q head. The kernel returns them already folded onto
+            # the KV heads, so sum each group before comparing -- comparing
+            # against one group member would pass for MQA and fail for GQA, and
+            # comparing unfolded would fail for both.
+            rk = rk.reshape(case.hkv, _grp, *rk.shape[1:]).sum(1)
+            rv = rv.reshape(case.hkv, _grp, *rv.shape[1:]).sum(1)
         for name, got, want in (
             ("dQ", dq[0, sl_q].transpose(0, 1), rq),
             ("dK", dk[0, sl_k].transpose(0, 1), rk),
@@ -431,7 +449,7 @@ def _build_thd_bwd_graph(case, *, stats_layout="head_major", declare_totals=True
     return g, vp, (dq_t, dk_t, dv_t)
 
 
-def _run_graph(lens_q, lens_kv, *, h=2, d=_D, dtype=torch.bfloat16, stats_layout="head_major", poison=False, pad_cap=0, **kw):
+def _run_graph(lens_q, lens_kv, *, h=2, hkv=None, d=_D, dtype=torch.bfloat16, stats_layout="head_major", poison=False, pad_cap=0, **kw):
     """Build the ragged graph, PIN the engine, execute, compare per sequence.
 
     ``use_causal_mask`` / ``use_causal_mask_bottom_right`` thread through ``kw``
@@ -452,8 +470,9 @@ def _run_graph(lens_q, lens_kv, *, h=2, d=_D, dtype=torch.bfloat16, stats_layout
         bottom_right=bool(kw.get("use_causal_mask_bottom_right")),
         window_left=kw.get("sliding_window_length"),
         window_right=kw.get("diagonal_band_right_bound"),
+        hkv=hkv,
     )
-    g, vp, (dq_t, dk_t, dv_t) = _build_thd_bwd_graph(case, stats_layout=stats_layout, **kw)
+    g, vp, (dq_t, dk_t, dv_t) = _build_thd_bwd_graph(case, stats_layout=stats_layout, hkv=hkv, **kw)
     g.validate()
     g.build_operation_graph()
     g.create_execution_plans([cudnn.heur_mode.A])
@@ -462,7 +481,11 @@ def _run_graph(lens_q, lens_kv, *, h=2, d=_D, dtype=torch.bfloat16, stats_layout
     g.select_plan(idx)
     g.check_support()
     g.build_plans()
-    dq, dk, dv = (torch.zeros_like(x) for x in (case.q, case.k, case.v))
+    # dK / dV carry H_kv heads under GQA, so they are shaped from the graph's
+    # KV head count, not from the Q tensors.
+    _kvh = h if hkv is None else hkv
+    dq = torch.zeros_like(case.q)
+    dk, dv = (torch.zeros(1, case.cap_kv, _kvh, d, device="cuda", dtype=dtype) for _ in range(2))
     vp.update({dq_t: dq, dk_t: dk, dv_t: dv})
     ws = torch.empty(max(g.get_workspace_size(), 1), device="cuda", dtype=torch.uint8)
     g.execute(vp, ws)
@@ -470,7 +493,7 @@ def _run_graph(lens_q, lens_kv, *, h=2, d=_D, dtype=torch.bfloat16, stats_layout
     for name, x in (("dQ", dq), ("dK", dk), ("dV", dv)):
         live = x[0, : case.t_q] if name == "dQ" else x[0, : case.t_kv]
         assert torch.isfinite(live).all(), f"{name} has non-finite values in the packed region"
-    _check(case, dq, dk, dv)
+    _check(case, dq, dk, dv, hkv=_kvh)
     return case, dq, dk, dv
 
 
@@ -582,6 +605,34 @@ def test_graph_thd_b1_matches_dense_shape():
     _run_graph((512,), (512,))
 
 
+@pytest.mark.parametrize("hkv", (2, 1), ids=("gqa_group2", "mqa"))
+def test_graph_thd_gqa(hkv):
+    """Packed GQA / MQA end to end.
+
+    The dK/dV partials are ONE PER Q HEAD over the packed kv axis, then folded
+    onto the KV heads. Two things this pins that a single group size would not:
+    MQA (group 4) collapses every Q head onto one KV head, and the reference
+    must SUM a group's contributions -- comparing against one member passes for
+    MQA and fails for GQA, so both sizes run.
+    """
+    _run_graph((300, 128, 200), (300, 128, 200), h=4, hkv=hkv)
+
+
+def test_graph_thd_gqa_causal():
+    """GQA together with a per-sequence causal mask -- the two THD conjunctions
+    that were declined separately, now exercised together."""
+    _run_graph((256, 100), (256, 100), h=4, hkv=2, use_causal_mask=True)
+
+
+def test_graph_thd_gqa_cross_attention_and_zero_length():
+    """GQA over unequal Q/KV totals with an empty sequence in the middle.
+
+    The dK/dV partial buffer is sized on the packed KV capacity while dQ rides
+    the Q one, so unequal totals are what would catch the two being conflated.
+    """
+    _run_graph((256, 0, 100), (180, 0, 300), h=4, hkv=2)
+
+
 # --- causal family ----------------------------------------------------------
 #
 # The per-sequence diagonal is the whole risk here.  Stage 2 masks from the
@@ -647,10 +698,12 @@ def test_graph_thd_causal_swa():
 def test_graph_thd_causal_right_band():
     """Right-band widening: the causal upper bound pushed out by an offset.
 
-    The fourth member of the single ``thd_causal`` flag -- it covers causal, SWA,
-    bottom-right AND band widening, so each is its own accept test (engine
-    contract section 9).  ``diagonal_band_right_bound`` is exclusive with
-    ``use_causal_mask``; it IS the upper bound.
+    The fourth causal-family band, and each gets its own accept test rather than
+    one test for "causal" (engine contract section 9).  That granularity is what
+    justified deleting the ``thd_causal`` conjunction flag outright: all four
+    bands are served, so nothing is left for the flag to decline.
+    ``diagonal_band_right_bound`` is exclusive with ``use_causal_mask``; it IS
+    the upper bound.
     """
     _run_graph((300, 128, 200), (300, 128, 200), diagonal_band_right_bound=64)
 
@@ -697,17 +750,24 @@ def test_graph_thd_accepts_the_plain_case():
 def test_accept_thd_causal():
     """The inverse of the reject this used to be (test/AGENTS.md: invert, do not
     delete).  Stage 2 masks from the per-sequence metadata lengths and stage 3
-    drops its absolute-row K-trim under THD, so the causal family is served."""
+    drops its absolute-row K-trim under THD, so the causal family is served.
+
+    Kept after the ``thd_causal`` flag was deleted, and now MORE load-bearing
+    than before: with no flag left to decline on, this is the only thing that
+    would catch a regression re-introducing a causal-under-THD refusal."""
     assert _thd_mismatch(use_causal_mask=True) is None
     assert _thd_mismatch(use_causal_mask_bottom_right=True) is None
     assert _thd_mismatch(use_causal_mask=True, sliding_window_length=64) is None
     assert _thd_mismatch(diagonal_band_right_bound=64) is None
 
 
-def test_reject_thd_gqa():
-    """The dK/dV partials would have to be packed per Q head."""
-    reason = _thd_mismatch(h=4, hkv=2)
-    assert reason is not None and "GQA" in reason
+def test_accept_thd_gqa():
+    """The inverse of the reject this used to be (test/AGENTS.md: invert, do not
+    delete).  The dK/dV partials are now packed per Q head over the kv axis and
+    folded by the shared reduce, so GQA and MQA are both served."""
+    assert _thd_mismatch(h=4, hkv=2) is None  # GQA, group 2
+    assert _thd_mismatch(h=4, hkv=1) is None  # MQA, group 4
+    assert _thd_mismatch(h=4, hkv=2, use_causal_mask=True) is None  # with a mask
 
 
 def test_reject_thd_without_declared_totals():


### PR DESCRIPTION
Follow-up to #898. `sdpa_bwd_sm100`'s packed (THD) path now matches its dense path
feature for feature, so the two THD conjunction flags have nothing left to decline
and are **deleted** rather than set `True`.

That is the point of the PR as much as the feature is: per review on #898, a
conjunction flag in `engines.py` is transitional by design — it earns its place only
while some row genuinely cannot serve the pair, and once the last one can it is
vacuous, so the field, its branch in `mismatch()` and its tests all go rather than
sitting at `True` forever as a widening record of what the packed path once could not do.

> "As a rule, we should be wary of increasing conjunctions in engines.py ... the
> expectation from the next PR will [be] that it can totally remove `thd_gqa`. And a
> later one can remove `thd_causal` and so on."

Both are removed here. `Capabilities` carries the rule inline, and notes that what
remains (`thd_declared_totals`, the BSHD-physical requirement) are properties of the
path, not features it declines.

## GQA / MQA under THD

The dense pattern ports almost unchanged, because three things were already generic
and only had to be pointed at packed buffers:

* the stage-3 dK/dV GEMMs write **one partial per Q head**, now packed
  `[1, T_kv_cap, H_q, D]` instead of `[B, S_kv_max, H_q, D]`;
* the per-sequence C descriptors take their row stride **from** the C tensor
  (`c_row_stride = out_stride_m_0`), so handing them the partial buffer yields the
  right `H_q * D` stride with no kernel change;
* `dkv_reduce_host` sizes its grid from the OUTPUT's `(batch, seq, head)` and is
  elementwise over rows, so a packed batch of 1 needs nothing special.

**Stage 2 needed nothing** — `kv_head_g = head_g // gqa_ratio` was already there and
simply never exercised under THD. dQ runs once per group MEMBER over strided views,
exactly as the dense path does. `scratch_workspace_bytes()` sizes the partials on
`_t_kv_cap` under THD rather than `B * S_kv_max`, the same packing win the blocked
S/dS workspace already gets.

## Tests

`test_reject_thd_gqa` is **inverted, not deleted** (per `test/AGENTS.md`) into
`test_accept_thd_gqa`, plus end-to-end coverage: `test_graph_thd_gqa[gqa_group2|mqa]`,
`test_graph_thd_gqa_causal`, `test_graph_thd_gqa_cross_attention_and_zero_length`.
The capability test now asserts **both** removed names stay absent, so re-adding
either is a test failure rather than a silent widening.

Two deliberate choices worth reviewing:

* **Both group sizes run.** MQA collapses every Q head onto one KV head, and the
  reference must SUM a group's contributions — comparing against a single member
  passes for MQA and fails for GQA, so one size would not pin it.
* **The head mapping is verified sensitive, not assumed.** The reference broadcasts
  K/V with `repeat_interleave`, matching the kernel's `kv_head = q_head // group`.
  Probing `repeat` instead drops dQ/dK to **cos 0.50** — and dV stays at 0.996, so
  dV alone would not have caught a reversed mapping.

## Verification

SM100 (cc 10.0, cuDNN 9.27, cutlass-dsl 4.8.0.dev0):
`test_sdpa_bwd_{dsl,thd,thd_setup}_sm100.py`, `test_sdpa_graph_analyzer.py`,
`test_sdpa_frontend_integration.py`, `test_dispatch.py` → **245 passed, 1 skipped**.

Rule S2: `SUPPORT_MATRIX_TRACKER.md` updated in the same commit (the GQA row, footnote
ʰ, and the retired gap row).

## Unrelated, but seen while testing

On 4.8.0.dev0 `test_sdpa_bwd_mxfp8_sm100.py::test_ragged_tails_causal_gqa` fails
intermittently with an all-NaN dK — **only when run alongside other files** (it passes
3/3 standalone, fails 2/2 in a 3-file set). That is develop's MXFP8 d256 backward from
#904, untouched by this PR, and looks like cross-test state rather than a numerics
break. Flagging it rather than folding it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added SM100 backward support for grouped-query attention (GQA) and multi-query attention (MQA) with THD layouts.
  - Supports causal, cross-attention, and zero-length sequence scenarios while producing correctly folded KV gradients.

- **Documentation**
  - Updated the support matrix to reflect GQA/MQA availability and current layout and sequence-length requirements.

- **Tests**
  - Updated coverage for THD GQA/MQA, causal combinations, cross-attention, zero-length sequences, and capability reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->