### PR TITLE
Fix DSA backward boundaries and relax SM100 BSA FP8 shape limits

### DIFF
--- a/docs/fe-oss-apis/bsa.md
+++ b/docs/fe-oss-apis/bsa.md
@@ -34,9 +34,9 @@ pip install nvidia-cudnn-frontend
 ```
 
 The package-wide `nvidia-cutlass-dsl[cu13]>=4.6.2` dependency floor applies to
-BSA. The Sage FP8 API below performs an additional runtime check and requires
-`nvidia-cutlass-dsl>=4.6.1`, which the package floor already satisfies; the
-check stays in place for environments that force an older DSL.
+BSA. Sage FP8 relies on functionality introduced in CuTe DSL 4.6.1, which the
+package floor already satisfies. A defensive runtime check remains for
+environments that force an older DSL.
 
 ## Forward
 
@@ -167,19 +167,19 @@ backward implementation.
 
 The architecture-specific FP8 contracts are:
 
-- SM100/SM103 requires `B=1`, `H` equal to 4 or 8, and both sequence lengths
-  to be multiples of 64. It uses fixed `block_sparse_num` with full 64-token
-  KV blocks; `q2k_block_nums` and `block_sizes` are not supported. Split-KV is
-  selected internally, and the public FP8 API does not expose `kv_splits` or
-  `use_clc`.
+- SM100/SM103 accepts any positive batch and head counts and requires both
+  sequence lengths to be multiples of 64. It uses fixed `block_sparse_num`
+  with full 64-token KV blocks; `q2k_block_nums` and `block_sizes` are not
+  supported. Split-KV is selected internally, and the public FP8 API does not
+  expose `kv_splits` or `use_clc`.
 - SM120 accepts any positive batch and head counts, non-aligned Q/KV sequence
   tails, fixed or per-query-block counts, and `block_sizes` shaped `(N_kv,)`,
   `(B, N_kv)`, or `(B, H, N_kv)`. It does not use split-KV.
 
-`block_sparse_attention_fp8_forward` requires CuTe DSL 4.6.1 or newer at call
-time. Its internal Q/K/V quantizer is also implemented in CuTe DSL and is
-loaded lazily, so importing `cudnn` still works with the package-wide CuTe DSL
-4.5 dependency floor.
+`block_sparse_attention_fp8_forward` relies on functionality introduced in
+CuTe DSL 4.6.1; package-supported installations provide CuTe DSL 4.6.2 or
+newer. Its internal Q/K/V quantizer is also implemented in CuTe DSL and is
+loaded lazily, so importing `cudnn` does not eagerly import it.
 
 ## Backward
 
@@ -223,7 +223,7 @@ therefore requires full physical KV blocks and `block_sizes=None`.
 | SM90 | 64 | FP16, BF16 | each of 64, 96, 128 | MHA, GQA, MQA |
 | SM100/SM103 | 128 | FP16, BF16 | QK=V=64, 96, or 128 | MHA, GQA, MQA |
 | SM100/SM103 | 64 (explicit) | BF16 | QK=128, V=128 | MHA |
-| SM100/SM103 | 64 | BF16 / FP8 E4M3 | QK=128, V=128 | MHA (B=1, H=4 or 8) |
+| SM100/SM103 | 64 | BF16 / FP8 E4M3 | QK=128, V=128 | MHA |
 | SM120 | 64 | FP16, BF16 | QK=128, V=128 | MHA, GQA, MQA |
 | SM120 | 64 | BF16 / FP8 E4M3 | QK=128, V=128 | MHA |
 

--- a/python/cudnn/block_sparse_attention/_fp8_quant.py
+++ b/python/cudnn/block_sparse_attention/_fp8_quant.py
@@ -407,8 +407,6 @@ def _quantize_sage_bhsd(
     if seqlen_k < 1:
         raise ValueError("Sage FP8 quantization requires positive batch, head, and sequence counts")
     is_sm120 = torch.cuda.get_device_capability(q_bhsd.device)[0] == 12
-    if not is_sm120 and (batch_size != 1 or num_heads not in (4, 8)):
-        raise ValueError("Sage FP8 v1 requires B=1, H in {4, 8}, and D=128")
     if not is_sm120 and (seqlen_q % 64 or seqlen_k % 64):
         raise ValueError("Q and K/V sequence lengths must be multiples of 64")
 

--- a/python/cudnn/block_sparse_attention/_interface.py
+++ b/python/cudnn/block_sparse_attention/_interface.py
@@ -1354,8 +1354,6 @@ def bsa_attn_fwd_blk64_cutedsl(
     assert k_bhsd.shape == (batch_size, num_head_kv, seqlen_k, head_dim)
     assert v_bhsd.shape == (batch_size, num_head_kv, seqlen_k, head_dim_v)
     if is_sage_fp8:
-        assert batch_size == 1, "SM100 FP8 requires batch size 1"
-        assert num_head in (4, 8), "SM100 FP8 supports H=4 or H=8"
         assert seqlen_q % 64 == 0 and seqlen_k % 64 == 0, "SM100 FP8 requires Sq and Sk to be multiples of 64"
         q_scale = maybe_contiguous(q_scale)
         k_scale = maybe_contiguous(k_scale)

--- a/python/cudnn/block_sparse_attention/api.py
+++ b/python/cudnn/block_sparse_attention/api.py
@@ -323,8 +323,6 @@ def block_sparse_attention_fp8_forward(
     if arch_family not in {10, 11, 12}:
         raise RuntimeError(f"Sage FP8 block sparse attention requires SM100-SM120, found SM{arch}")
     if arch_family in {10, 11}:
-        if batch != 1 or heads not in {4, 8}:
-            raise NotImplementedError("SM100/SM110 Sage FP8 requires B=1 and H in {4, 8}")
         if seqlen_q % 64 or seqlen_k % 64:
             raise NotImplementedError("SM100/SM110 Sage FP8 requires Sq and Sk to be multiples of 64")
         if q2k_block_nums is not None or block_sizes is not None:

--- a/python/cudnn/deepseek_sparse_attention/README.md
+++ b/python/cudnn/deepseek_sparse_attention/README.md
@@ -10,4 +10,4 @@
 
 ## Acknowledgements
 
-The DSA/CSA kernels were a collaborative effort, jointly developed by: Hongxiao Bai, Jiayu Sun and Jie Fang
+The DSA/CSA kernels were a collaborative effort, jointly developed by: Hongxiao Bai, Jiayu Sun, Jerry Chen, Jie Fang, Qi Zhang, Bin Chai and Yue Weng

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/_interface_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/_interface_sm90.py
@@ -64,11 +64,10 @@ def flash_attn_bwd_sm90(
         dkv: pre-allocated (total_S_kv, headdim), optional
         d_sink: pre-allocated (nheads,), optional
         topk_idxs: (total_S_q, topk_max) int32, global KV indices.
-            Compact (`topk_length` given): prefix `[0, topk_length)` is valid.
-            Non-compact (`topk_length` is None): a negative entry is padding.
-            Positive indices must be in `[0, S_kv)`; oversized `topk_length`
-            is out of contract.
-        topk_length: (total_S_q,) int32, per-query valid prefix length, optional
+            Entries outside `[0, S_kv)` are ignored in both compact and
+            non-compact modes.
+        topk_length: (total_S_q,) int32, optional per-query valid prefix
+            length, clamped to `[0, topk_max]` by the kernel.
         need_d_sink: return and compute d_sink when True
 
     Returns:

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100_h16.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100_h16.py
@@ -400,6 +400,8 @@ class FlashAttentionDSABackwardSm100H16:
         softmax_rows = self.QK_mma_tiler[1]
         LSE_smem_layout = cute.make_layout((softmax_rows, self.load_compute_LSE_stage))
         sum_OdO_smem_layout = cute.make_layout((softmax_rows, self.load_compute_sum_OdO_stage))
+        rows_per_load_pass = self.num_load_KV_warps * 4
+        valid_smem_layout = cute.make_layout((self.num_load_KV_warps, self.block_tile // rows_per_load_pass))
 
         tma_load_op = cpasync.CopyBulkTensorTileG2SOp(cta_group)
         tma_store_op = cpasync.CopyBulkTensorTileS2GOp()
@@ -462,6 +464,7 @@ class FlashAttentionDSABackwardSm100H16:
             sdS: cute.struct.Align[cute.struct.MemRange[self.element_dtype, cute.cosize(dS_smem_layout_staged)], self.non_tma_align_bytes]
             sLSE: cute.struct.Align[cute.struct.MemRange[self.acc_dtype, cute.cosize(LSE_smem_layout)], self.non_tma_align_bytes]
             sSum_OdO: cute.struct.Align[cute.struct.MemRange[self.acc_dtype, cute.cosize(sum_OdO_smem_layout)], self.non_tma_align_bytes]
+            sValid: cute.struct.Align[cute.struct.MemRange[cutlass.Uint8, cute.cosize(valid_smem_layout)], self.non_tma_align_bytes]
 
         assert (
             SharedStorage.size_in_bytes() <= _max_smem_bytes
@@ -556,6 +559,7 @@ class FlashAttentionDSABackwardSm100H16:
             dQ4_smem_layout_staged,
             LSE_smem_layout,
             sum_OdO_smem_layout,
+            valid_smem_layout,
         ).launch(
             grid=bwd_grid,
             block=[self.threads_per_cta, 1, 1],
@@ -693,13 +697,19 @@ class FlashAttentionDSABackwardSm100H16:
                     log2_e = -lse_scale
                     lse_log2 = lse_bhq * log2_e
                     sink_log2 = attn_sink_bh * log2_e
-                    lse_max_log2 = cute.arch.fmax(lse_log2, sink_log2)
-                    sum_exp2 = Float32(cute.math.exp2(lse_log2 - lse_max_log2) + cute.math.exp2(sink_log2 - lse_max_log2))
-                    lse_with_sink_log2 = lse_max_log2 + cute.math.log2(sum_exp2)
-                    scaled_lse_bhq = -lse_with_sink_log2
+                    pos_inf = Float32(float("inf"))
+                    neg_inf = Float32(float("-inf"))
 
-                    if lse_bhq == Float32(float("inf")):
-                        scaled_lse_bhq = Float32(float("-inf"))
+                    # Keep a no-mass row and every saturating denominator on
+                    # the same sentinel: inverse denominator zero. Checking
+                    # after the log2(e) multiply also catches a large finite
+                    # sink (for example 2.4e38) whose rescale overflows.
+                    scaled_lse_bhq = neg_inf
+                    if lse_log2 != pos_inf and sink_log2 != pos_inf:
+                        if lse_log2 != neg_inf or sink_log2 != neg_inf:
+                            lse_max_log2 = cute.arch.fmax(lse_log2, sink_log2)
+                            sum_exp2 = Float32(cute.math.exp2(lse_log2 - lse_max_log2) + cute.math.exp2(sink_log2 - lse_max_log2))
+                            scaled_lse_bhq = -(lse_max_log2 + cute.math.log2(sum_exp2))
 
                     sum_OdO[bidy, (idx_q + offset, bidz)] = sum_OdO_bhq
                     scaled_lse[bidy, (idx_q + offset, bidz)] = scaled_lse_bhq
@@ -722,10 +732,16 @@ class FlashAttentionDSABackwardSm100H16:
 
         log2_e = Float32(math.log2(math.e))
         sink_log2 = attn_sink[head_idx, (0, batch_idx)] * log2_e
+        pos_inf = Float32(float("inf"))
+        neg_inf = Float32(float("-inf"))
         acc = Float32(0.0)
 
         while q_idx < q_end:
-            p_sink = cute.math.exp2(sink_log2 + scaled_lse[head_idx, (q_idx, batch_idx)])
+            p_sink = Float32(0.0)
+            if sink_log2 == pos_inf:
+                p_sink = Float32(1.0)
+            elif sink_log2 != neg_inf:
+                p_sink = cute.math.exp2(sink_log2 + scaled_lse[head_idx, (q_idx, batch_idx)])
             acc += p_sink * sum_OdO[head_idx, (q_idx, batch_idx)]
             q_idx += self.dSink_num_threads
 
@@ -783,6 +799,7 @@ class FlashAttentionDSABackwardSm100H16:
         dQ4_smem_layout_staged: cute.ComposedLayout,
         LSE_smem_layout: cute.Layout,
         sum_OdO_smem_layout: cute.Layout,
+        valid_smem_layout: cute.Layout,
     ):
         token_idx, head_block_idx, batch_idx = cute.arch.block_idx()
         tidx, _, batch_idx = cute.arch.thread_idx()
@@ -794,6 +811,13 @@ class FlashAttentionDSABackwardSm100H16:
             topk = mTopkLength[token_idx]
         else:
             topk = mTopkIdxs.shape[0]
+
+        # A malformed supplied length must never widen the physical top-k
+        # tensor. Clamp before tile_count and every downstream index load.
+        if topk > Int32(mTopkIdxs.shape[0]):
+            topk = Int32(mTopkIdxs.shape[0])
+        if topk < Int32(0):
+            topk = Int32(0)
 
         # topk is CTA-uniform (one value per query token). Handle an empty
         # sparse row before initializing any async pipeline or allocating
@@ -871,6 +895,7 @@ class FlashAttentionDSABackwardSm100H16:
 
         sLSE = storage.sLSE.get_tensor(LSE_smem_layout)
         sSum_OdO = storage.sSum_OdO.get_tensor(sum_OdO_smem_layout)
+        sValid = storage.sValid.get_tensor(valid_smem_layout)
 
         sdST_ptr = cute.recast_ptr(sdS.iterator, dST_smem_layout_staged.inner)
         sdST = cute.make_tensor(sdST_ptr, dST_smem_layout_staged.outer)
@@ -1042,6 +1067,7 @@ class FlashAttentionDSABackwardSm100H16:
                 sdS_store,
                 sdQ,
                 sdQ4,
+                sValid,
                 scale_softmax,
                 tile_count,
                 (
@@ -1096,6 +1122,7 @@ class FlashAttentionDSABackwardSm100H16:
                 tile_count,
                 topk,
                 load_mma_K_pipeline,
+                sValid,
                 mTopkLength,
             )
 
@@ -1244,6 +1271,7 @@ class FlashAttentionDSABackwardSm100H16:
         self,
         mKV: cute.Tensor,
         sK_slice: cute.Tensor,
+        sValid_slice: cute.Tensor,
         topk_idx: Int32,
         tile_index: Int32,
         topk: Int32,
@@ -1263,46 +1291,35 @@ class FlashAttentionDSABackwardSm100H16:
         idx = tile_index * self.block_tile + row
         tile_sK = sK_slice[row, (None, None)]
 
-        if cutlass.const_expr(mTopkLength is not None):
-            if cutlass.const_expr(is_first):
-                if idx < topk:
-                    self._copy_kv_row(
-                        mKV,
-                        topk_idx,
-                        batch_idx,
-                        tile_sK,
-                        lane_in_subwarp,
-                        async_copy_atom,
-                        async_thr_copy,
-                    )
-                else:
-                    self._zero_kv_row(tile_sK, lane_in_subwarp)
-            else:
-                self._copy_kv_row(
-                    mKV,
-                    topk_idx,
-                    batch_idx,
-                    tile_sK,
-                    lane_in_subwarp,
-                    async_copy_atom,
-                    async_thr_copy,
-                )
+        if cutlass.const_expr(mTopkLength is not None and not is_first):
+            row_is_valid = topk_idx >= 0 and topk_idx < mKV.shape[0]
         else:
-            if idx < topk:
-                if topk_idx >= 0:
-                    self._copy_kv_row(
-                        mKV,
-                        topk_idx,
-                        batch_idx,
-                        tile_sK,
-                        lane_in_subwarp,
-                        async_copy_atom,
-                        async_thr_copy,
-                    )
-                else:
-                    self._zero_kv_row(tile_sK, lane_in_subwarp)
-            else:
-                self._zero_kv_row(tile_sK, lane_in_subwarp)
+            row_is_valid = idx < topk and topk_idx >= 0 and topk_idx < mKV.shape[0]
+
+        # All eight lanes in a subgroup own the same sparse row. Compress the
+        # four ballot groups into one nibble, then arrange even and odd loader
+        # warps in separate contiguous halves. A compute thread can consume
+        # the four loader-warps it needs with one aligned 32-bit load.
+        valid_bits = cutlass.Uint32(cute.arch.vote_ballot_sync(row_is_valid))
+        if row_is_valid:
+            self._copy_kv_row(
+                mKV,
+                topk_idx,
+                batch_idx,
+                tile_sK,
+                lane_in_subwarp,
+                async_copy_atom,
+                async_thr_copy,
+            )
+        else:
+            self._zero_kv_row(tile_sK, lane_in_subwarp)
+
+        if local_tidx == 0:
+            valid_nibble = (valid_bits & cutlass.Uint32(1)) | ((valid_bits >> 7) & cutlass.Uint32(2))
+            valid_nibble = valid_nibble | ((valid_bits >> 14) & cutlass.Uint32(4))
+            valid_nibble = valid_nibble | ((valid_bits >> 21) & cutlass.Uint32(8))
+            packed_warp_idx = local_warp_idx // 2 + (local_warp_idx % 2) * (self.num_load_KV_warps // 2)
+            sValid_slice[packed_warp_idx] = cutlass.Uint8(valid_nibble)
 
     @cute.jit
     def load_KV(
@@ -1313,6 +1330,7 @@ class FlashAttentionDSABackwardSm100H16:
         tile_count: Int32,
         topk: Int32,
         load_mma_K_pipeline,
+        sValid: cute.Tensor,
         mTopkLength: Optional[cute.Tensor],
     ):
         tidx, _, _ = cute.arch.thread_idx()
@@ -1345,6 +1363,7 @@ class FlashAttentionDSABackwardSm100H16:
             rows_per_pass = self.num_load_KV_warps * 4
             row_passes = self.block_tile // rows_per_pass
             for row_pass in cutlass.range_constexpr(row_passes):
+                sValid_slice = sValid[None, row_pass]
                 row = local_warp_idx * 4 + subgroup + row_pass * rows_per_pass
                 idx = tile_index * self.block_tile + row
                 topk_idx = Int32(-1)
@@ -1357,6 +1376,7 @@ class FlashAttentionDSABackwardSm100H16:
                     self._load_kv_rows(
                         mKV,
                         sK_slice,
+                        sValid_slice,
                         topk_idx,
                         tile_index,
                         topk,
@@ -1372,6 +1392,7 @@ class FlashAttentionDSABackwardSm100H16:
                     self._load_kv_rows(
                         mKV,
                         sK_slice,
+                        sValid_slice,
                         topk_idx,
                         tile_index,
                         topk,
@@ -1716,6 +1737,36 @@ class FlashAttentionDSABackwardSm100H16:
         load_mma_QdO_consumer_state.advance()
 
     @cute.jit
+    def _load_topk_valid_word(self, sValid: cute.Tensor, row: Int32) -> cutlass.Uint32:
+        """Load the packed validity word containing one sparse-tile row."""
+        rows_per_pass = self.num_load_KV_warps * 4
+        row_in_pass = row % rows_per_pass
+        load_warp_idx = row_in_pass // 4
+        packed_byte = (row // rows_per_pass) * self.num_load_KV_warps + load_warp_idx // 2 + (load_warp_idx % 2) * (self.num_load_KV_warps // 2)
+        sValid_words = cute.make_tensor(
+            cute.recast_ptr(sValid.iterator, dtype=cutlass.Uint32),
+            cute.make_layout((cute.size(sValid) // 4,)),
+        )
+        return sValid_words[packed_byte // 4]
+
+    @cute.jit
+    def _topk_row_is_valid(self, valid_bits: cutlass.Uint32, row: Int32) -> cutlass.Boolean:
+        """Test one row in a validity word already resident in a register."""
+        rows_per_pass = self.num_load_KV_warps * 4
+        row_in_pass = row % rows_per_pass
+        load_warp_idx = row_in_pass // 4
+        subgroup = row_in_pass % 4
+        packed_byte = load_warp_idx // 2 + (load_warp_idx % 2) * (self.num_load_KV_warps // 2)
+        bit = (packed_byte % 4) * 8 + subgroup
+        return (valid_bits & (cutlass.Uint32(1) << bit)) != 0
+
+    @cute.jit
+    def _select_valid_probability(self, probability: Float32, is_valid: cutlass.Boolean) -> Float32:
+        """Select zero for an invalid row without an inf*0 operation."""
+        zero = Float32(0.0)
+        return Float32(arith.select(is_valid.ir_value(), probability.ir_value(), zero.ir_value()))
+
+    @cute.jit
     def compute(
         self,
         tma_atom_dQ: cute.CopyAtom,
@@ -1734,6 +1785,7 @@ class FlashAttentionDSABackwardSm100H16:
         sdS_store: cute.Tensor,
         sdQ: cute.Tensor,
         sdQ4: cute.Tensor,
+        sValid: cute.Tensor,
         scale_softmax: Float32,
         tile_count: Int32,
         pipelines,
@@ -1808,6 +1860,7 @@ class FlashAttentionDSABackwardSm100H16:
             compute_mma_P_pipeline.producer_acquire(compute_mma_P_producer_state)
 
             cute.copy(tiled_t2r_S, tTR_tS, tTR_rS)
+            valid_bits = self._load_topk_valid_word(sValid, cute.get(tTR_cS[0], mode=[0]))
 
             for i in cutlass.range(0, cute.size(tTR_rS), 2, unroll_full=True):
 
@@ -1821,8 +1874,11 @@ class FlashAttentionDSABackwardSm100H16:
                     (softmax_scale_log2_e, softmax_scale_log2_e),
                     lse,
                 )
+                row_is_valid = self._topk_row_is_valid(valid_bits, cute.get(tTR_cS[i], mode=[0]))
                 tTR_rS[i] = cute.math.exp2(tTR_rS[i], fastmath=True)
                 tTR_rS[i + 1] = cute.math.exp2(tTR_rS[i + 1], fastmath=True)
+                tTR_rS[i] = self._select_valid_probability(tTR_rS[i], row_is_valid)
+                tTR_rS[i + 1] = self._select_valid_probability(tTR_rS[i + 1], row_is_valid)
 
             tTR_rS_f16 = self.quantize(tTR_rS, 1)
 
@@ -2127,10 +2183,12 @@ class FlashAttentionDSABackwardSm100H16:
                 local_row_idx = cute.get(tTR_cdKV[coord_base], mode=[1])
                 global_row_idx = tile_index * self.block_tile + local_row_idx
                 if full_tiles:
-                    rTopkIdx[i] = mTopkIdxs[global_row_idx, (token_idx, batch_idx)]
+                    topk_idx = mTopkIdxs[global_row_idx, (token_idx, batch_idx)]
+                    rTopkIdx[i] = topk_idx if topk_idx >= 0 and topk_idx < max_seqlen_kv else Int32(-1)
                 else:
                     if global_row_idx < topk:
-                        rTopkIdx[i] = mTopkIdxs[global_row_idx, (token_idx, batch_idx)]
+                        topk_idx = mTopkIdxs[global_row_idx, (token_idx, batch_idx)]
+                        rTopkIdx[i] = topk_idx if topk_idx >= 0 and topk_idx < max_seqlen_kv else Int32(-1)
                     else:
                         rTopkIdx[i] = Int32(-1)
 
@@ -2140,10 +2198,12 @@ class FlashAttentionDSABackwardSm100H16:
                 local_row_idx = cute.get(tTR_cdKV_64[coord_base], mode=[1])
                 global_row_idx = tile_index * self.block_tile + local_row_idx
                 if full_tiles:
-                    rTopkIdx_64[i] = mTopkIdxs[global_row_idx, (token_idx, batch_idx)]
+                    topk_idx = mTopkIdxs[global_row_idx, (token_idx, batch_idx)]
+                    rTopkIdx_64[i] = topk_idx if topk_idx >= 0 and topk_idx < max_seqlen_kv else Int32(-1)
                 else:
                     if global_row_idx < topk:
-                        rTopkIdx_64[i] = mTopkIdxs[global_row_idx, (token_idx, batch_idx)]
+                        topk_idx = mTopkIdxs[global_row_idx, (token_idx, batch_idx)]
+                        rTopkIdx_64[i] = topk_idx if topk_idx >= 0 and topk_idx < max_seqlen_kv else Int32(-1)
                     else:
                         rTopkIdx_64[i] = Int32(-1)
 

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100_h32.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100_h32.py
@@ -398,6 +398,7 @@ class FlashAttentionDSABackwardSm100H32(FlashAttentionDSABackwardSm100H16):
         sdS_store: cute.Tensor,
         sdQ: cute.Tensor,
         sdQ4: cute.Tensor,
+        sValid: cute.Tensor,
         scale_softmax: Float32,
         tile_count: Int32,
         pipelines,
@@ -472,8 +473,12 @@ class FlashAttentionDSABackwardSm100H32(FlashAttentionDSABackwardSm100H16):
                     (softmax_scale_log2_e, softmax_scale_log2_e),
                     lse,
                 )
+                valid_bits = self._load_topk_valid_word(sValid, cute.get(tTR_cS[i], mode=[0]))
+                row_is_valid = self._topk_row_is_valid(valid_bits, cute.get(tTR_cS[i], mode=[0]))
                 tTR_rS[i] = cute.math.exp2(tTR_rS[i], fastmath=True)
                 tTR_rS[i + 1] = cute.math.exp2(tTR_rS[i + 1], fastmath=True)
+                tTR_rS[i] = self._select_valid_probability(tTR_rS[i], row_is_valid)
+                tTR_rS[i + 1] = self._select_valid_probability(tTR_rS[i + 1], row_is_valid)
             tTR_rS_f16 = self.quantize(tTR_rS, 2)
 
             cute.copy(tiled_t2r_dP, tTR_tdP, tTR_rdP)
@@ -785,19 +790,23 @@ class FlashAttentionDSABackwardSm100H32(FlashAttentionDSABackwardSm100H16):
                     local_row_idx = cute.get(tTR_cdKV[coord_base], mode=[1])
                     global_row_idx = row_base + local_row_idx
                     if full_tiles:
-                        rTopkIdx[i] = mTopkIdxs[global_row_idx, (token_idx, batch_idx)]
+                        topk_idx = mTopkIdxs[global_row_idx, (token_idx, batch_idx)]
+                        rTopkIdx[i] = topk_idx if topk_idx >= 0 and topk_idx < max_seqlen_kv else Int32(-1)
                     else:
                         if global_row_idx < topk:
-                            rTopkIdx[i] = mTopkIdxs[global_row_idx, (token_idx, batch_idx)]
+                            topk_idx = mTopkIdxs[global_row_idx, (token_idx, batch_idx)]
+                            rTopkIdx[i] = topk_idx if topk_idx >= 0 and topk_idx < max_seqlen_kv else Int32(-1)
                         else:
                             rTopkIdx[i] = Int32(-1)
                     local_row_idx_64 = cute.get(tTR_cdKV_64[coord_base], mode=[1])
                     global_row_idx_64 = row_base + local_row_idx_64
                     if full_tiles:
-                        rTopkIdx_64[i] = mTopkIdxs[global_row_idx_64, (token_idx, batch_idx)]
+                        topk_idx = mTopkIdxs[global_row_idx_64, (token_idx, batch_idx)]
+                        rTopkIdx_64[i] = topk_idx if topk_idx >= 0 and topk_idx < max_seqlen_kv else Int32(-1)
                     else:
                         if global_row_idx_64 < topk:
-                            rTopkIdx_64[i] = mTopkIdxs[global_row_idx_64, (token_idx, batch_idx)]
+                            topk_idx = mTopkIdxs[global_row_idx_64, (token_idx, batch_idx)]
+                            rTopkIdx_64[i] = topk_idx if topk_idx >= 0 and topk_idx < max_seqlen_kv else Int32(-1)
                         else:
                             rTopkIdx_64[i] = Int32(-1)
 

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm90.py
@@ -12,6 +12,7 @@ import cutlass
 import cutlass.cute as cute
 import cutlass.utils.hopper_helpers as sm90_utils_basic
 from cutlass import Boolean, Float32, Int32, const_expr
+from cutlass._mlir.dialects import arith
 from cutlass.cute.nvgpu import cpasync, warpgroup
 from cutlass.utils import LayoutEnum
 
@@ -630,6 +631,7 @@ class FlashAttentionDSABackwardSm90:
 
         sLSE_struct = cute.struct.Align[cute.struct.MemRange[Float32, cute.round_up(self.tile_m, 64)], 128]
         sdPsum_struct = cute.struct.Align[cute.struct.MemRange[Float32, cute.round_up(self.tile_m, 64)], 128]
+        sValid_struct = cute.struct.Align[cute.struct.MemRange[cutlass.Uint8, 16], 16]
 
         @cute.struct
         class SharedStorage:
@@ -637,6 +639,7 @@ class FlashAttentionDSABackwardSm90:
             mbar_QdO: cute.struct.MemRange[cutlass.Int64, 2]
             sLSE: sLSE_struct
             sdPsum: sdPsum_struct
+            sValid: sValid_struct
             sQ: sQ_struct
             sKV: sKV_struct
             sdO: sdO_struct
@@ -888,6 +891,7 @@ class FlashAttentionDSABackwardSm90:
 
         sQ = storage.sQ.get_tensor(sQ_layout.outer, swizzle=sQ_layout.inner)
         sKV = storage.sKV.get_tensor(sKV_layout.outer, swizzle=sKV_layout.inner)
+        sValid = storage.sValid.get_tensor(cute.make_layout((4, 4)))
         sdO = storage.sdO.get_tensor(sdO_layout.outer, swizzle=sdO_layout.inner)
         sP = storage.sP.get_tensor(sPdS_layout.outer, swizzle=sPdS_layout.inner)
         sdS = storage.sdS.get_tensor(sPdS_layout.outer, swizzle=sPdS_layout.inner)
@@ -941,6 +945,7 @@ class FlashAttentionDSABackwardSm90:
                 mdQ,
                 sQ,
                 sKV,
+                sValid,
                 sV,
                 sdO,
                 sP,
@@ -990,6 +995,7 @@ class FlashAttentionDSABackwardSm90:
                 tma_atom_dQ_64,
                 mTopkLength,
                 mTopkIdxs,  # per-q length + scatter indices
+                mKV.shape[0],
                 tidx,
                 TileSchedulerCls,
             )
@@ -1009,6 +1015,7 @@ class FlashAttentionDSABackwardSm90:
         mdQ: cute.Tensor,
         sQ: cute.Tensor,
         sKV: cute.Tensor,
+        sValid: cute.Tensor,
         sV: cute.Tensor,
         sdO: cute.Tensor,
         sP: cute.Tensor,
@@ -1153,6 +1160,14 @@ class FlashAttentionDSABackwardSm90:
             else:
                 topK = self.max_topk
 
+            # Both warpgroups must derive the same bounded tile count. Apart
+            # from preventing top-k reads past the physical row, this keeps
+            # every cross-warpgroup named barrier symmetric.
+            if topK > Int32(self.max_topk):
+                topK = Int32(self.max_topk)
+            if topK < Int32(0):
+                topK = Int32(0)
+
             mKV_cur = mKV[None, None, head_idx_kv, batch_idx]
             mTopkIdxs_cur = mTopkIdxs[batch_idx, seq_idx, None]
 
@@ -1226,6 +1241,7 @@ class FlashAttentionDSABackwardSm90:
                     mKV_cur,
                     mTopkIdxs_cur,
                     sKV,
+                    sValid,
                     async_copy_atom,
                     async_thr_copy,
                     idx_in_group,
@@ -1254,6 +1270,7 @@ class FlashAttentionDSABackwardSm90:
                         mKV_cur,
                         mTopkIdxs_cur,
                         sKV,
+                        sValid,
                         async_copy_atom,
                         async_thr_copy,
                         idx_in_group,
@@ -1306,41 +1323,50 @@ class FlashAttentionDSABackwardSm90:
             tile_scheduler.advance_to_next_work()
             work_tile = tile_scheduler.get_current_work()
 
-    # cp.async one gmem row → swizzled smem
+    # cp.async one valid gmem row → swizzled smem, or zero an invalid row
     @cute.jit
     def _copy_row(
         self,
         mKV_cur: cute.Tensor,  # (s_kv, headdim) gmem
-        mTopkIdxs_cur: cute.Tensor,  # (topk,) gmem
+        token_idx: Int32,
+        row_is_valid: Boolean,
         sKV: cute.Tensor,  # (tile_n, headdim) swizzled smem
         row: Int32,  # smem row index
         idx_in_group: Int32,  # 0..7 dim dir
         copy_atom: cute.CopyAtom,
         thr_copy: cute.TiledCopy,
-        global_topk_row: Int32,  # index into topk_idxs
     ):
-        token_idx = mTopkIdxs_cur[global_topk_row]
         gKV_row = mKV_cur[token_idx, None]
         gKV_chunks = cute.flat_divide(gKV_row, (8,))
+        sKV_row = sKV[row, None]
+        sKV_row_chunks = cute.flat_divide(sKV_row, (8,))
+        pred_sKV = sKV_row_chunks[None, idx_in_group]
+        pred_tSsKV = thr_copy.partition_D(pred_sKV)
+        load_pred = cute.make_fragment_like(pred_tSsKV[(0, None), None], Boolean)
+        load_pred.fill(row_is_valid)
         for tile in cutlass.range_constexpr(self.tile_hdim // 64):
             chunk_idx = tile * 8 + idx_in_group
             g_chunk = gKV_chunks[None, chunk_idx]
-            sKV_row = sKV[row, None]
-            sKV_row_chunks = cute.flat_divide(sKV_row, (8,))
             s_chunk = sKV_row_chunks[None, chunk_idx]
             tSg = thr_copy.partition_S(g_chunk)
             tSs = thr_copy.partition_D(s_chunk)
-            cute.copy(copy_atom, tSg, tSs)
+            cute.copy(copy_atom, tSg, tSs, pred=load_pred)
 
-    # clear for OOB rows
     @cute.jit
-    def _zero_row(self, sKV: cute.Tensor, row: Int32, idx_in_group: Int32):
-        """Zero-fill one K row in smem, cooperative across 8 threads in a group."""
-        sK_row = sKV[row, None]
-        sK_chunks = cute.flat_divide(sK_row, (8,))
-        for tile in cutlass.range_constexpr(self.tile_hdim // 64):
-            chunk_idx = tile * 8 + idx_in_group
-            sK_chunks[None, chunk_idx].fill(0)
+    def _topk_row_is_valid(self, sValid: cute.Tensor, col: Int32) -> Boolean:
+        """Read one row predicate from four packed loader-warp ballots."""
+        sValid_words = cute.make_tensor(
+            cute.recast_ptr(sValid.iterator, dtype=cutlass.Uint32),
+            cute.make_layout((4,)),
+        )
+        group_idx = col % 16
+        bit = (group_idx // 4) * 8 + group_idx % 4
+        return (sValid_words[col // 16] & (cutlass.Uint32(1) << bit)) != 0
+
+    @cute.jit
+    def _select_valid_probability(self, probability: Float32, is_valid: Boolean) -> Float32:
+        zero = Float32(0.0)
+        return Float32(arith.select(is_valid.ir_value(), probability.ir_value(), zero.ir_value()))
 
     # Scatter AtomicAdd — write dKV accumulator fragment to
     # per-row interleaved fake-col layout in gmem indexed by topK_idx,
@@ -1362,6 +1388,7 @@ class FlashAttentionDSABackwardSm90:
         mdKVaccum_cur: cute.Tensor,  # (seqlen_k_rounded * hdim_rounded,) f32 gmem
         n_block: Int32,  # current n_block (KV tile index in topk)
         topK: Int32,  # per-q valid KV count (runtime)
+        max_seqlen_kv: Int32,  # logical KV row count
         thr_mma: cute.TiledMma,  # thread's MMA slice
         tidx: Int32,
     ):
@@ -1388,10 +1415,8 @@ class FlashAttentionDSABackwardSm90:
             global_topk_row = n_block * self.tile_n + local_row
             if global_topk_row < topK:
                 global_kv_row = mTopkIdxs_cur[global_topk_row]
-                should_accumulate_dkv = const_expr(True)
-                if const_expr(not self.have_topk_length):
-                    should_accumulate_dkv = global_kv_row >= 0
-                if should_accumulate_dkv:
+                row_is_valid = global_kv_row >= 0 and global_kv_row < max_seqlen_kv
+                if row_is_valid:
                     row_base = global_kv_row * self.tile_hdim + chunk_idx * self.hdim_chunk
 
                     # Each group of 4 MN-view cols maps to one N-tile.
@@ -1416,6 +1441,7 @@ class FlashAttentionDSABackwardSm90:
         mKV_cur: cute.Tensor,  # (s_kv, headdim) gmem
         mTopkIdxs_cur: cute.Tensor,  # (topk,) gmem
         sKV: cute.Tensor,  # (tile_n, headdim) swizzled smem
+        sValid: cute.Tensor,  # four packed row-validity words
         async_copy_atom: cute.CopyAtom,
         async_thr_copy: cute.TiledCopy,
         idx_in_group: Int32,
@@ -1448,36 +1474,28 @@ class FlashAttentionDSABackwardSm90:
         for r in cutlass.range_constexpr(ROWS_PER_GROUP):
             row = r * NUM_GROUPS + group_idx
             global_topk_row = n_block * self.tile_n + row
-            if row < num_valid_rows or dQ_accumulate:
-                if const_expr(self.have_topk_length):
-                    self._copy_row(
-                        mKV_cur,
-                        mTopkIdxs_cur,
-                        sKV,
-                        row,
-                        idx_in_group,
-                        async_copy_atom,
-                        async_thr_copy,
-                        global_topk_row,
-                    )
-                else:
-                    token_idx = mTopkIdxs_cur[global_topk_row]
-                    if token_idx >= 0:
-                        self._copy_row(
-                            mKV_cur,
-                            mTopkIdxs_cur,
-                            sKV,
-                            row,
-                            idx_in_group,
-                            async_copy_atom,
-                            async_thr_copy,
-                            global_topk_row,
-                        )
-                    else:
-                        self._zero_row(sKV, row, idx_in_group)
-            else:
-                # Tail padding of the peeled n_block.
-                self._zero_row(sKV, row, idx_in_group)
+            row_is_active = row < num_valid_rows or dQ_accumulate
+            token_idx = Int32(-1)
+            if row_is_active:
+                token_idx = mTopkIdxs_cur[global_topk_row]
+            row_is_valid = row_is_active and token_idx >= 0 and token_idx < mKV_cur.shape[0]
+            valid_bits = cutlass.Uint32(cute.arch.vote_ballot_sync(row_is_valid))
+            self._copy_row(
+                mKV_cur,
+                token_idx,
+                row_is_valid,
+                sKV,
+                row,
+                idx_in_group,
+                async_copy_atom,
+                async_thr_copy,
+            )
+
+            if wg_tidx % 32 == 0:
+                valid_nibble = (valid_bits & cutlass.Uint32(1)) | ((valid_bits >> 7) & cutlass.Uint32(2))
+                valid_nibble = valid_nibble | ((valid_bits >> 14) & cutlass.Uint32(4))
+                valid_nibble = valid_nibble | ((valid_bits >> 21) & cutlass.Uint32(8))
+                sValid[wg_tidx // 32, r] = cutlass.Uint8(valid_nibble)
 
         cute.arch.cp_async_commit_group()
         cute.arch.cp_async_wait_group(0)
@@ -1499,25 +1517,16 @@ class FlashAttentionDSABackwardSm90:
         #
         # Padded columns are zero-filled in sKV, so their score is 0 rather
         # than -inf. Force those lanes to probability zero.
-        # Compact: past num_valid_rows on the peeled tail n_block.
-        # Non-compact: a negative top-k index. Positive OOB indices and
-        # compact entries in [0, topK) are trusted as valid KV rows.
+        # Tail columns and every index outside the logical KV extent are
+        # invalid in both compact and non-compact modes.
         acc_S_mn = make_acc_tensor_mn_view(acc_S, transpose=self.SdP_swapAB)
         COL = const_expr(1 if not self.SdP_swapAB else 0)
         for r in cutlass.range_constexpr(cute.size(acc_S_mn, mode=[0])):
             for c in cutlass.range(cute.size(acc_S_mn, mode=[1]), unroll_full=True):
-                p = cute.math.exp2(acc_S_mn[r, c] * softmax_scale_log2 - tLSErLSE[r], fastmath=True)
                 col = tScS_mn[r, c][COL]
-                if not dQ_accumulate:
-                    p = Float32(0.0) if col >= num_valid_rows else p
-                if const_expr(not self.have_topk_length):
-                    # Peeled tile still spans tile_n columns; clamp so a
-                    # partial non-compact row is not read past its end.
-                    idx = n_block * self.tile_n + col
-                    idx = idx if idx < self.max_topk else Int32(self.max_topk - 1)
-                    if mTopkIdxs_cur[idx] < 0:
-                        p = Float32(0.0)
-                acc_S_mn[r, c] = p
+                row_is_valid = self._topk_row_is_valid(sValid, col)
+                p = cute.math.exp2(acc_S_mn[r, c] * softmax_scale_log2 - tLSErLSE[r], fastmath=True)
+                acc_S_mn[r, c] = self._select_valid_probability(p, row_is_valid)
 
         # Convert P f32 -> bf16
         tdKVrP = cvt_f16(make_acc_tensor_frgA_view(acc_S), self.dtype)
@@ -1617,6 +1626,7 @@ class FlashAttentionDSABackwardSm90:
         tma_atom_dQ_64: cute.CopyAtom,
         mTopkLength: cute.Tensor,  # (batch, seqlen_q) int32, per-q valid KV count
         mTopkIdxs: cute.Tensor,  # (batch, seqlen_q, topk_max) int32 for scatter
+        max_seqlen_kv: Int32,
         tidx: Int32,
         TileSchedulerCls: Callable,
     ):
@@ -1694,6 +1704,10 @@ class FlashAttentionDSABackwardSm90:
                 topK = mTopkLength[batch_idx, seq_idx]
             else:
                 topK = self.max_topk
+            if topK > Int32(self.max_topk):
+                topK = Int32(self.max_topk)
+            if topK < Int32(0):
+                topK = Int32(0)
             n_block_max = (topK + self.tile_n - 1) // self.tile_n
 
             # scatter AtomicAdd — flat gmem dKVaccum for per-row addressing
@@ -1764,6 +1778,7 @@ class FlashAttentionDSABackwardSm90:
                     mdKVaccum_cur,
                     n_block,
                     topK,
+                    max_seqlen_kv,
                     thr_mma_dKV,
                     tidx,
                 )
@@ -1796,6 +1811,7 @@ class FlashAttentionDSABackwardSm90:
                     mdKVaccum_cur,
                     n_block,
                     topK,
+                    max_seqlen_kv,
                     thr_mma_dKV,
                     tidx,
                 )
@@ -1828,6 +1844,7 @@ class FlashAttentionDSABackwardSm90:
                     mdKVaccum_cur,
                     n_block,
                     topK,
+                    max_seqlen_kv,
                     thr_mma_dKV,
                     tidx,
                 )
@@ -1858,6 +1875,7 @@ class FlashAttentionDSABackwardSm90:
                     mdKVaccum_cur,
                     n_block,
                     topK,
+                    max_seqlen_kv,
                     thr_mma_dKV,
                     tidx,
                 )
@@ -1882,6 +1900,7 @@ class FlashAttentionDSABackwardSm90:
                     mdKVaccum_cur,
                     n_block,
                     topK,
+                    max_seqlen_kv,
                     thr_mma_dKV,
                     tidx,
                 )
@@ -1906,6 +1925,7 @@ class FlashAttentionDSABackwardSm90:
                     mdKVaccum_cur,
                     n_block,
                     topK,
+                    max_seqlen_kv,
                     thr_mma_dKV,
                     tidx,
                 )
@@ -1930,6 +1950,7 @@ class FlashAttentionDSABackwardSm90:
                     mdKVaccum_cur,
                     n_block,
                     topK,
+                    max_seqlen_kv,
                     thr_mma_dKV,
                     tidx,
                 )
@@ -1959,6 +1980,7 @@ class FlashAttentionDSABackwardSm90:
                         mdKVaccum_cur,
                         n_block,
                         topK,
+                        max_seqlen_kv,
                         thr_mma_dKV,
                         tidx,
                     )
@@ -1969,6 +1991,7 @@ class FlashAttentionDSABackwardSm90:
                         mdKVaccum_cur,
                         n_block,
                         topK,
+                        max_seqlen_kv,
                         thr_mma_dKV,
                         tidx,
                     )
@@ -1994,6 +2017,7 @@ class FlashAttentionDSABackwardSm90:
                         mdKVaccum_cur,
                         n_block,
                         topK,
+                        max_seqlen_kv,
                         thr_mma_dKV,
                         tidx,
                     )

--- a/test/python/fe_api/bsa/test_BSA_attention_fp8.py
+++ b/test/python/fe_api/bsa/test_BSA_attention_fp8.py
@@ -38,15 +38,16 @@ def _require_sm100_fp8():
     return _import_bsa()
 
 
-def _make_block_index(heads: int, seqlen_q: int, seqlen_k: int, topk: int) -> torch.Tensor:
+def _make_block_index(batch: int, heads: int, seqlen_q: int, seqlen_k: int, topk: int) -> torch.Tensor:
     num_q_blocks = math.ceil(seqlen_q / 64)
     num_kv_blocks = math.ceil(seqlen_k / 64)
-    result = torch.empty((1, heads, num_q_blocks, topk), device="cuda", dtype=torch.int32)
+    result = torch.empty((batch, heads, num_q_blocks, topk), device="cuda", dtype=torch.int32)
     block_ids = torch.arange(num_kv_blocks, device="cuda")
-    for head in range(heads):
-        for q_block in range(num_q_blocks):
-            selected = torch.roll(block_ids, shifts=head + q_block)[:topk].sort().values
-            result[0, head, q_block] = selected.to(torch.int32)
+    for batch_idx in range(batch):
+        for head in range(heads):
+            for q_block in range(num_q_blocks):
+                selected = torch.roll(block_ids, shifts=batch_idx * 7 + head + q_block)[:topk].sort().values
+                result[batch_idx, head, q_block] = selected.to(torch.int32)
     return result
 
 
@@ -135,17 +136,18 @@ def test_bsa_fp8_interface_quantizes_before_private_launch(monkeypatch):
 
 
 @pytest.mark.L0
-def test_bsa_fp8_forward_accepts_bf16_and_returns_documented_tupledict(monkeypatch):
+@pytest.mark.parametrize(("batch", "heads"), ((1, 4), (1, 3), (2, 3)))
+def test_bsa_fp8_forward_accepts_positive_batch_and_head_counts(monkeypatch, batch, heads):
     BSA = _import_bsa()
     api = importlib.import_module("cudnn.block_sparse_attention.api")
     interface = importlib.import_module("cudnn.block_sparse_attention._interface")
     monkeypatch.setattr(api, "_device_arch", lambda tensor: 100)
 
-    shape = (1, 4, 64, 128)
+    shape = (batch, heads, 64, 128)
     q = torch.empty(shape, device="cuda", dtype=torch.bfloat16)
     k = torch.empty_like(q)
     v = torch.empty_like(q)
-    q2k = torch.zeros((1, 4, 1, 1), device="cuda", dtype=torch.int32)
+    q2k = torch.zeros((batch, heads, 1, 1), device="cuda", dtype=torch.int32)
     expected = torch.empty(shape, device="cuda", dtype=torch.bfloat16)
 
     def fake_forward(*args, **kwargs):
@@ -172,12 +174,13 @@ def test_bsa_fp8_forward_accepts_bf16_and_returns_documented_tupledict(monkeypat
 
 
 @pytest.mark.L0
+@pytest.mark.parametrize(("batch", "heads"), ((1, 4), (2, 3)))
 @torch_fork_set_rng(seed=20260709)
-def test_bsa_fp8_private_cutedsl_quantizer_matches_recipe():
+def test_bsa_fp8_private_cutedsl_quantizer_matches_recipe(batch, heads):
     _require_sm100_fp8()
     quantizer = importlib.import_module("cudnn.block_sparse_attention._fp8_quant")
 
-    batch, heads, seqlen_q, seqlen_k, head_dim = 1, 4, 128, 192, 128
+    seqlen_q, seqlen_k, head_dim = 128, 192, 128
     q = torch.randn((batch, heads, seqlen_q, head_dim), device="cuda", dtype=torch.bfloat16)
     k = torch.randn((batch, heads, seqlen_k, head_dim), device="cuda", dtype=torch.bfloat16)
     v = torch.randn_like(k)
@@ -236,7 +239,7 @@ def test_bsa_fp8_sm100_auto_split_uses_workspace_fallback(monkeypatch):
     interface = importlib.import_module("cudnn.block_sparse_attention._interface")
     monkeypatch.setattr(interface, "_get_device_arch", lambda: 100)
 
-    batch, heads, seqlen_q, seqlen_k, head_dim, topk = 1, 4, 64, 64, 128, 128
+    batch, heads, seqlen_q, seqlen_k, head_dim, topk = 2, 3, 64, 64, 128, 128
     q = torch.empty((batch, heads, seqlen_q, head_dim), device="cuda", dtype=torch.float8_e4m3fn)
     k = torch.empty((batch, heads, seqlen_k, head_dim), device="cuda", dtype=torch.float8_e4m3fn)
     v = torch.empty_like(k)
@@ -321,14 +324,15 @@ def test_bsa_fp8_split_workspace_estimate_uses_bf16_output_size():
 
 
 @pytest.mark.L0
+@pytest.mark.parametrize(("batch", "heads"), ((1, 4), (2, 3)))
 @torch_fork_set_rng(seed=2026)
-def test_bsa_fp8_sm100_bf16_forward_matches_reference():
+def test_bsa_fp8_sm100_bf16_forward_matches_reference(batch, heads):
     BSA = _require_sm100_fp8()
-    batch, heads, seqlen_q, seqlen_k, head_dim, topk = 1, 4, 128, 640, 128, 5
+    seqlen_q, seqlen_k, head_dim, topk = 128, 640, 128, 5
     q = torch.randn((batch, heads, seqlen_q, head_dim), device="cuda", dtype=torch.bfloat16) * 0.5
     k = torch.randn((batch, heads, seqlen_k, head_dim), device="cuda", dtype=torch.bfloat16) * 0.5
     v = torch.randn_like(k) * 0.5
-    q2k = _make_block_index(heads, seqlen_q, seqlen_k, topk)
+    q2k = _make_block_index(batch, heads, seqlen_q, seqlen_k, topk)
 
     block_sizes = torch.full((seqlen_k // 64,), 64, device="cuda", dtype=torch.int32)
     mask = block_sparse_mask(q2k, topk, block_sizes, seqlen_q, seqlen_k, 64)

--- a/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
@@ -1199,15 +1199,93 @@ def test_DSA_sparse_attention_backward_sm90_padded_topk_columns_contribute_zero(
 
 
 @pytest.mark.L0
-@torch_fork_set_rng(seed=437)
+@torch_fork_set_rng(seed=877)
 @pytest.mark.parametrize(
-    "sink_value",
+    "invalid_value,topk_length_value",
     [
-        pytest.param(2.4e38, id="finite-but-rescale-overflows"),
-        pytest.param(float("inf"), id="pos-inf"),
+        pytest.param(-1, None, id="noncompact-negative"),
+        pytest.param(1, None, id="noncompact-positive-oob"),
+        pytest.param(torch.iinfo(torch.int32).max, 1, id="garbage-past-length"),
+        pytest.param(-1, 64, id="compact-negative"),
+        pytest.param(1, 64, id="compact-positive-oob"),
+        pytest.param(1, 65, id="oversized-length"),
+        pytest.param(None, None, id="noncompact-mixed-two-tile"),
+        pytest.param(None, 128, id="compact-mixed-two-tile"),
     ],
 )
-def test_DSA_sparse_attention_backward_sm90_saturating_attn_sink(sink_value):
+def test_DSA_sparse_attention_backward_sm90_masks_invalid_topk_rows(invalid_value, topk_length_value):
+    """SM90 must reject invalid sparse rows before KV access, probability use, and dKV scatter."""
+    try:
+        from cudnn import DSA
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+
+    _require_sm90()
+    device = torch.device("cuda")
+    num_heads, head_dim, head_dim_v = 32, 576, 512
+    topk_width = 128 if invalid_value is None else 64
+    q = torch.full((1, num_heads, head_dim), 8.0, dtype=torch.bfloat16, device=device)
+
+    # Put readable guard rows on both sides of the logical one-row KV view.
+    # An unfixed gather can then fail numerically without poisoning the CUDA
+    # context through a wild pointer. dKV accumulation is rounded to 64 rows,
+    # so the positive guard index is safe there as well.
+    kv_storage = torch.zeros(3, head_dim, dtype=torch.bfloat16, device=device)
+    kv_storage[1].fill_(-8.0)
+    kv = kv_storage[1:2]
+
+    # Likewise retain one full guard tile behind the logical top-k view. The
+    # oversized-length case reaches only its first row in the peeled tile.
+    topk_storage = torch.full((1, 2 * topk_width), -1 if invalid_value is None else invalid_value, dtype=torch.int32, device=device)
+    topk_storage[:, 0] = 0
+    topk_idxs = topk_storage[:, :topk_width]
+    topk_length = None if topk_length_value is None else torch.full((1,), topk_length_value, dtype=torch.int32, device=device)
+
+    attn_sink = torch.full((num_heads,), -math.inf, dtype=torch.float32, device=device)
+    dout = torch.randn(1, num_heads, head_dim_v, dtype=torch.bfloat16, device=device)
+    out = kv[0, :head_dim_v].view(1, 1, head_dim_v).expand(1, num_heads, head_dim_v).contiguous()
+    lse = ((q.float() * kv[0].float()).sum(dim=-1) * (192**-0.5)).contiguous()
+    if invalid_value is None:
+        topk_idxs.zero_()
+        invalid_positions = torch.tensor([idx for idx in range(topk_width) if idx % 3 != 0], dtype=torch.int64, device=device)
+        topk_idxs[:, invalid_positions[::2]] = -1
+        topk_idxs[:, invalid_positions[1::2]] = 1
+        lse += math.log(topk_width - invalid_positions.numel())
+
+    result = DSA.sparse_attention_backward_wrapper(
+        q,
+        kv,
+        out,
+        dout,
+        lse,
+        attn_sink,
+        topk_idxs,
+        softmax_scale=192**-0.5,
+        topk_length=topk_length,
+    )
+    torch.cuda.synchronize()
+
+    expected_dkv = torch.zeros_like(kv)
+    expected_dkv[0, :head_dim_v] = dout.float().sum(dim=(0, 1)).to(torch.bfloat16)
+    assert torch.isfinite(result["dq"]).all()
+    assert torch.isfinite(result["dkv"]).all()
+    assert torch.isfinite(result["d_sink"]).all()
+    torch.testing.assert_close(result["dq"].float(), torch.zeros_like(result["dq"], dtype=torch.float32), atol=3e-5, rtol=0)
+    torch.testing.assert_close(result["dkv"], expected_dkv, atol=5e-2, rtol=1e-2)
+    assert torch.equal(result["d_sink"], torch.zeros_like(result["d_sink"]))
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=437)
+@pytest.mark.parametrize(
+    "sink_value,empty_row",
+    [
+        pytest.param(-math.inf, True, id="empty-no-mass"),
+        pytest.param(2.4e38, False, id="finite-but-rescale-overflows"),
+        pytest.param(float("inf"), False, id="pos-inf"),
+    ],
+)
+def test_DSA_sparse_attention_backward_sm90_saturating_attn_sink(sink_value, empty_row):
     """A saturating attention sink must not turn the gradients into NaN."""
     try:
         from cudnn import DSA
@@ -1223,16 +1301,20 @@ def test_DSA_sparse_attention_backward_sm90_saturating_attn_sink(sink_value):
     kv = (torch.randn(s_kv, head_dim, device=device) / 10).to(torch.bfloat16)
     attn_sink = torch.full((num_heads,), sink_value, dtype=torch.float32, device=device)
     topk_idxs = torch.stack([torch.randperm(s_kv, device=device)[:topk] for _ in range(s_q)]).to(torch.int32)
-    topk_length = torch.full((s_q,), topk, dtype=torch.int32, device=device)
-
-    out, lse = ref_sparse_attention_forward(
-        q,
-        kv,
-        attn_sink,
-        topk_idxs,
-        topk_length=topk_length,
-        softmax_scale=softmax_scale,
-    )
+    topk_length = torch.zeros(s_q, dtype=torch.int32, device=device) if empty_row else torch.full((s_q,), topk, dtype=torch.int32, device=device)
+    if empty_row:
+        topk_idxs.fill_(torch.iinfo(torch.int32).max)
+        out = torch.zeros(s_q, num_heads, 512, dtype=torch.bfloat16, device=device)
+        lse = torch.full((s_q, num_heads), -math.inf, dtype=torch.float32, device=device)
+    else:
+        out, lse = ref_sparse_attention_forward(
+            q,
+            kv,
+            attn_sink,
+            topk_idxs,
+            topk_length=topk_length,
+            softmax_scale=softmax_scale,
+        )
     dout = torch.randn_like(out)
 
     result = DSA.sparse_attention_backward_wrapper(

--- a/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
@@ -945,6 +945,147 @@ def test_DSA_sparse_attention_backward_sm100_handles_infinite_sink_limits(sink_v
 
 
 @pytest.mark.L0
+@torch_fork_set_rng(seed=785)
+@pytest.mark.parametrize(
+    "num_heads,expected_backend",
+    [
+        pytest.param(16, "h16_m128", id="h16-m128"),
+        pytest.param(32, "h32_m64", id="h32-m64"),
+    ],
+)
+def test_DSA_sparse_attention_backward_sm100_specialized_masks_invalid_topk_rows(num_heads, expected_backend):
+    """The H16/H32 kernels must mask every invalid sparse row before probability use and KV access."""
+    _require_sm100()
+
+    try:
+        from cudnn import DSA
+        from cudnn.deepseek_sparse_attention.sparse_attention_backward import _interface_sm100
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+
+    device = torch.device("cuda")
+    head_dim, head_dim_v, topk_width = 576, 512, 256
+    q = torch.full((1, num_heads, head_dim), 8.0, dtype=torch.bfloat16, device=device)
+    kv = torch.full((1, head_dim), -8.0, dtype=torch.bfloat16, device=device)
+    dout = torch.randn(1, num_heads, head_dim_v, dtype=torch.bfloat16, device=device)
+    attn_sink = torch.full((num_heads,), -math.inf, dtype=torch.float32, device=device)
+    out = kv[0, :head_dim_v].view(1, 1, head_dim_v).expand(1, num_heads, head_dim_v).contiguous()
+    one_key_lse = ((q.float() * kv[0].float()).sum(dim=-1) * (192**-0.5)).contiguous()
+
+    def run_and_check(topk_idxs, topk_length, lse):
+        result = DSA.sparse_attention_backward_wrapper(
+            q,
+            kv,
+            out,
+            dout,
+            lse,
+            attn_sink,
+            topk_idxs,
+            softmax_scale=192**-0.5,
+            topk_length=topk_length,
+        )
+        torch.cuda.synchronize()
+
+        expected_dkv = torch.zeros_like(kv)
+        expected_dkv[0, :head_dim_v] = dout.float().sum(dim=(0, 1)).to(torch.bfloat16)
+        assert torch.isfinite(result["dq"]).all()
+        assert torch.isfinite(result["dkv"]).all()
+        assert torch.isfinite(result["d_sink"]).all()
+        torch.testing.assert_close(result["dq"].float(), torch.zeros_like(result["dq"], dtype=torch.float32), atol=3e-5, rtol=0)
+        torch.testing.assert_close(result["dkv"], expected_dkv, atol=5e-2, rtol=1e-2)
+        assert torch.equal(result["d_sink"], torch.zeros_like(result["d_sink"]))
+
+    # Keep the width fixed so both has_topk_length specializations compile
+    # only once.  The cases cover padding, ignored entries past the logical
+    # length, active negative/positive OOB entries, and a malformed length
+    # larger than the physical index tensor.
+    cases = (
+        (-1, None),
+        (torch.iinfo(torch.int32).max, 1),
+        (-1, topk_width),
+        (4097, None),
+        (-1, topk_width + 1),
+    )
+    for invalid_value, topk_length_value in cases:
+        topk_idxs = torch.full((1, topk_width), invalid_value, dtype=torch.int32, device=device)
+        topk_idxs[:, 0] = 0
+        topk_length = None if topk_length_value is None else torch.full((1,), topk_length_value, dtype=torch.int32, device=device)
+        run_and_check(topk_idxs, topk_length, one_key_lse)
+
+    # Exercise every packed-mask byte/subgroup, both H16 load passes, and
+    # multiple tiles with valid rows on both sides of each invalid hole.
+    topk_idxs = torch.zeros((1, topk_width), dtype=torch.int32, device=device)
+    invalid_positions = torch.tensor(
+        [1, 2, 3, 4, 8, 12, 28, 32, 60, 63, 65, 68, 72, 92, 96, 124, 127, 129, 132, 159, 191, 193, 220, 255],
+        dtype=torch.int64,
+        device=device,
+    )
+    topk_idxs[:, invalid_positions[::2]] = -1
+    topk_idxs[:, invalid_positions[1::2]] = 4097
+    valid_count = topk_width - invalid_positions.numel()
+    repeated_key_lse = one_key_lse + math.log(valid_count)
+    run_and_check(topk_idxs, None, repeated_key_lse)
+
+    assert any(key[0] == expected_backend and key[5] == num_heads for key in _interface_sm100.flash_attn_bwd_sm100.compile_cache)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=786)
+@pytest.mark.parametrize(
+    "num_heads,expected_backend",
+    [
+        pytest.param(16, "h16_m128", id="h16-m128"),
+        pytest.param(32, "h32_m64", id="h32-m64"),
+    ],
+)
+def test_DSA_sparse_attention_backward_sm100_specialized_handles_sink_limits(num_heads, expected_backend):
+    """The H16/H32 sink path must implement empty and saturating softmax limits."""
+    _require_sm100()
+
+    try:
+        from cudnn import DSA
+        from cudnn.deepseek_sparse_attention.sparse_attention_backward import _interface_sm100
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+
+    device = torch.device("cuda")
+    head_dim, head_dim_v = 576, 512
+    q = torch.randn(1, num_heads, head_dim, dtype=torch.bfloat16, device=device)
+    kv = torch.randn(1, head_dim, dtype=torch.bfloat16, device=device)
+    out = torch.zeros(1, num_heads, head_dim_v, dtype=torch.bfloat16, device=device)
+    dout = torch.randn_like(out)
+
+    for sink_value, empty_row in ((-math.inf, True), (math.inf, False), (2.4e38, False)):
+        attn_sink = torch.full((num_heads,), sink_value, dtype=torch.float32, device=device)
+        topk_idxs = torch.full((1, 64), torch.iinfo(torch.int32).max if empty_row else -1, dtype=torch.int32, device=device)
+        topk_length = torch.zeros(1, dtype=torch.int32, device=device) if empty_row else None
+        if empty_row:
+            lse = torch.full((1, num_heads), -math.inf, dtype=torch.float32, device=device)
+        else:
+            topk_idxs[:, 0] = 0
+            lse = ((q.float() * kv[0].float()).sum(dim=-1) * (192**-0.5)).contiguous()
+
+        result = DSA.sparse_attention_backward_wrapper(
+            q,
+            kv,
+            out,
+            dout,
+            lse,
+            attn_sink,
+            topk_idxs,
+            softmax_scale=192**-0.5,
+            topk_length=topk_length,
+        )
+        torch.cuda.synchronize()
+
+        assert torch.equal(result["dq"], torch.zeros_like(result["dq"]))
+        assert torch.equal(result["dkv"], torch.zeros_like(result["dkv"]))
+        assert torch.equal(result["d_sink"], torch.zeros_like(result["d_sink"]))
+
+    assert any(key[0] == expected_backend and key[5] == num_heads for key in _interface_sm100.flash_attn_bwd_sm100.compile_cache)
+
+
+@pytest.mark.L0
 @torch_fork_set_rng(seed=678)
 def test_DSA_sparse_attention_backward_sm100_accumulates_odo_in_fp32():
     """dSink uses the saved BF16 O but must multiply O*dO in FP32."""


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes. (`pre-commit` is unavailable in the test environment; Black, `py_compile`, and `git diff --check` results are listed below.)
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches and the changes comply.
- [x] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*`.

## Affected area

FE OSS kernels or CuTeDSL

## Summary

- Extend robust sparse-row boundary handling to the dedicated SM100 H16 and H32 DSA backward kernels.
- Extend the SM90 kernel to reject negative and positive out-of-range indices in both compact and non-compact layouts, and clamp `topk_length` to the physical top-k width.
- Carry packed per-row validity masks from the KV loader into probability recomputation so invalid rows contribute zero probability and zero gradient.
- Use predicated `cp.async` in the SM90 loader to suppress invalid global reads while zero-filling their shared-memory rows.
- Recheck sparse indices before every dKV scatter and define empty-row / saturating-sink limits without NaNs.
- Add regression coverage for active invalid indices, mixed invalid holes across tiles, oversized lengths, empty rows, and saturating sinks.
- Expand SM100/SM103 Sage FP8 BSA from the conservative `B=1`, `H in {4, 8}` support boundary to any positive batch and head counts; retain D=128, MHA, and 64-token sequence alignment requirements.
- Update the package-wide CuTe DSL floor documentation and the DSA/CSA acknowledgements.

## Why

#877 fixed invalid sparse-row handling in the generic SM100 kernel, but the dedicated H16 and H32 implementations still trusted active indices and retained the unsafe sink-limit behavior. #785 fixed the original SM90 empty-row, padded-tail, and sink failures, but active negative indices in compact mode, positive out-of-range indices in either mode, and `topk_length` values wider than the physical index row could still reach KV gathers, probability recomputation, or dKV scatter.

The updated kernels use one rule throughout the pipeline: a row participates only when it is inside the bounded active prefix and its KV index is in `[0, S_kv)`. The validity decision is packed once by the loader and reused by the probability path; the scatter path independently rechecks the destination before issuing atomics.

The Sage FP8 BSA quantizer and SM100 launcher already derive grids, scales, and scheduler coordinates from runtime batch/head dimensions. The old B/H checks were conservative API gates rather than kernel requirements; B200 validation confirmed non-4/8 head counts and multi-batch execution in both ordinary and split-KV paths.

## Related issues

Related to #676.

Builds on #785 and #877.

## API and compatibility impact

There are no public function-signature changes. The accepted input domain of the public Sage FP8 BSA wrapper is expanded.

Behavior changes:

- SM100/SM103 Sage FP8 BSA now accepts any positive batch and head counts.
- Invalid sparse indices are ignored consistently in compact and non-compact layouts.
- `topk_length` is clamped to `[0, topk_idxs.shape[-1]]` in-kernel.
- Empty sparse rows and infinite or rescale-saturating sinks produce their limiting zero gradients instead of invalid memory accesses, hangs, or NaNs.

No newer CuTeDSL API is introduced and the supported architecture set is unchanged.

H100 full-wrapper performance (`BF16`, `S_q = S_kv = 4096`; negative change is faster):

| Shape | top-k | `topk_length` | Before | After | Change |
|---|---:|:---:|---:|---:|---:|
| H32, Dqk576, Dv512 | 64 | yes | 0.7952 ms | 0.7402 ms | -6.9% |
| H32, Dqk576, Dv512 | 512 | yes | 2.3438 ms | 2.3456 ms | +0.08% |
| H32, Dqk576, Dv512 | 2048 | yes | 8.0299 ms | 8.0733 ms | +0.54% |
| H32, Dqk576, Dv512 | 64 | no | 0.7942 ms | 0.7597 ms | -4.35% |
| H32, Dqk576, Dv512 | 512 | no | 2.5141 ms | 2.3088 ms | -8.17% |
| H32, Dqk576, Dv512 | 2048 | no | 9.1505 ms | 8.0165 ms | -12.39% |
| H64, Dqk512, Dv512 | 64 | yes | 1.2472 ms | 1.0958 ms | -12.14% |
| H64, Dqk512, Dv512 | 512 | yes | 2.8867 ms | 2.8823 ms | -0.15% |
| H64, Dqk512, Dv512 | 2048 | yes | 9.0662 ms | 9.1544 ms | +0.97% |
| H64, Dqk512, Dv512 | 512 | no | 2.8430 ms | 2.4628 ms | -13.37% |

Each entry is the median of nine CUDA-event samples after 30 warm-up calls; each sample contains 40-200 complete wrapper calls depending on top-k. The compact `topk=2048` regression was reproduced in reverse run order. SM100 DSA performance was not measured in this H100 run; the BSA correctness validation below was run separately on B200.

## Testing

Environment:

- NVIDIA H100 80GB HBM3 (SM90)
- CUDA 12.8 / PyTorch 2.9.1
- cuDNN backend 9.22.0
- nvidia-cutlass-dsl 4.5.2

The new SM90 positive logical-OOB regression was first run against the parent revision and failed RED with an all-NaN `dQ`.

Complete DSA backward L0 file after rebasing onto current `develop`:

```bash
cd test/python
PYTHONPATH=/code/github/cudnn-frontend/python:/code/dsl_env/lib/python3.12/site-packages \
  python -m pytest -q -m L0 fe_api/dsa/test_DSA_sparse_attention_backward.py
```

Result: `32 passed, 30 skipped, 26 deselected` in 113.28 s. SM100-only DSA cases skipped on the H100 host and are left to SM100 CI.

Sage FP8 BSA validation environment:

- NVIDIA B200 (SM100)
- CUDA 13.2 / PyTorch 2.12.0a0+5aff3928d8.nv26.05
- cuDNN backend 9.22.0
- nvidia-cutlass-dsl 4.6.2

The new arbitrary-B/H public API cases were first run against the old guards: `H=3` and `B=2, H=3` failed RED. Targeted quantizer and internal split-workspace cases also failed at their respective old guards.

```bash
cd test/python
PYTHONPATH=/code/github/cudnn-frontend/python \\
  python -m pytest -q fe_api/bsa/test_BSA_attention_fp8.py
```

Result: `26 passed` in 6.90 s on B200/SM100.

Static and formatting checks:

```bash
python -m py_compile <changed Python files>
python -m black --check --line-length 160 <changed Python files>
git diff --check upstream/develop...HEAD
```

Result: all passed; Black reported all five files unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded SM100/SM103 Sage FP8 support to accommodate positive batch sizes and head counts.
  * Added broader FP8 coverage across batch sizes and attention-head configurations.

* **Bug Fixes**
  * Improved sparse attention backward handling for invalid or out-of-range top-k indices and lengths.
  * Invalid rows are safely ignored, with appropriate zeroed outputs and gradients.
  * Improved handling of empty rows, oversized lengths, and extreme attention-sink values.
  * Added key/value bounds validation to prevent invalid memory access and accumulation.

* **Documentation**
  * Clarified handling of invalid top-k entries and lengths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->