### PR TITLE
Fix D192 BF16 short-sequence performance regression

### DIFF
--- a/python/cudnn/sdpa/fwd/config_sm100.py
+++ b/python/cudnn/sdpa/fwd/config_sm100.py
@@ -90,9 +90,11 @@ class TemplateParams:
     # Compile-time LPT head/batch grouping. Keep 1 unless the selected kernel
     # and concrete graph shape opt into a divisor of B*Hq.
     lpt_head_group: int = 1
-    # Dense FP8 kernels may specialize scheduler selection/decoding to the
-    # graph's compile-time number of query tiles. Zero keeps runtime derivation.
+    # D192 FP8 kernels may specialize grouped-LPT decoding to the graph's
+    # compile-time number of query tiles. Zero keeps runtime derivation.
     lpt_q_tiles: int = 0
+    # Selects the public-source schedule used by the short D192 BF16 LPT path.
+    d192_short_bf16_lpt: bool = False
     # Optional L2 working-set budget for SCHED_LPT_L2. Zero keeps the flavor's
     # default budget.
     lpt_l2_size_mib: int = 0
@@ -1095,6 +1097,28 @@ def _validate_cfg_d192(cfg: CfgD192) -> None:
             raise ValueError(msg)
 
 
+def d192_short_bf16_lpt_region(params: TemplateParams, *, s_q: int, s_kv: int) -> bool:
+    """Whether the measured short-sequence D192 BF16 LPT path applies."""
+
+    q_rows_per_cluster = cga_tile_m(192, params.cta_mma)
+    return (
+        params.dtype_qkv == DTYPE_BF16
+        and params.split_kv == 1
+        and not params.thd_varlen
+        and not params.seq_q_lens_present
+        and not params.seq_kv_lens_present
+        and not params.pack_gqa
+        and params.qh_per_kh == 1
+        and params.cta_mma == 2
+        and not params.has_sink
+        and params.window_left is None
+        and params.window_right == 0
+        and not params.bottom_right
+        and s_q == s_kv
+        and q_rows_per_cluster <= s_q <= 7 * q_rows_per_cluster
+    )
+
+
 def d192_square_br_as_tl(params: TemplateParams, *, s_q: int, s_kv: int) -> bool:
     """Whether a D192 bottom-right mask is exactly top-left causal."""
 
@@ -1157,6 +1181,7 @@ def derive_d192_internal_params(
     groups = batch_size * h_q // pack_gqa_ratio
     lpt_head_group = 8 if fp8 and not params.thd_varlen and groups % 8 == 0 else 1
     q_rows_per_cluster = cga_tile_m(192, params.cta_mma)
+    bf16_short_square_lpt = params.sched_policy == SCHED_LPT and d192_short_bf16_lpt_region(params, s_q=s_q, s_kv=s_kv)
     lpt_q_tiles = (s_q * pack_gqa_ratio + q_rows_per_cluster - 1) // q_rows_per_cluster if fp8 and not params.thd_varlen else 0
 
     lpt_l2_size_mib = 0
@@ -1174,6 +1199,7 @@ def derive_d192_internal_params(
         params,
         lpt_head_group=lpt_head_group,
         lpt_q_tiles=lpt_q_tiles,
+        d192_short_bf16_lpt=bf16_short_square_lpt,
         lpt_l2_size_mib=lpt_l2_size_mib,
     )
 

--- a/python/cudnn/sdpa/fwd/heuristics.py
+++ b/python/cudnn/sdpa/fwd/heuristics.py
@@ -58,6 +58,7 @@ from cudnn.frost.tile_dsl.constants import (
 from cudnn.sdpa.fwd.config_sm100 import (
     TemplateParams as Sm100TemplateParams,
     cga_tile_m,
+    d192_short_bf16_lpt_region,
     d192_square_br_as_tl,
     d256_square_br_as_tl,
     pack_gqa_supported,
@@ -387,6 +388,11 @@ def select_d192_auto_knobs(
     window_left = params.window_left
     window_right = params.window_right
     top_left = not params.bottom_right or d192_square_br_as_tl(params, s_q=s_q, s_kv=s_kv)
+    # Plain LPT has lower scheduling overhead through seven square Q work
+    # units. At eight, the winner becomes grid-dependent, so keep LPT_L2.
+    # FALLBACK deliberately supplies NATURAL; only replace a balancing policy
+    # selected by the ordinary heuristic or standalone auto path.
+    bf16_short_dense_causal_lpt = params.sched_policy != SCHED_NATURAL and d192_short_bf16_lpt_region(params, s_q=s_q, s_kv=s_kv)
 
     mx_dense_mid_causal_cga1 = (
         mxfp8
@@ -397,7 +403,12 @@ def select_d192_auto_knobs(
         and 4096 < s_kv <= 8192
         and (params.dtype_qkv == DTYPE_E5M2 or s_q >= 4096)
     )
-    sched_policy = SCHED_NATURAL if mx_dense_mid_causal_cga1 else params.sched_policy
+    if bf16_short_dense_causal_lpt:
+        sched_policy = SCHED_LPT
+    elif mx_dense_mid_causal_cga1:
+        sched_policy = SCHED_NATURAL
+    else:
+        sched_policy = params.sched_policy
 
     pt_cga1 = (
         pertensor
@@ -473,10 +484,12 @@ def _sm100_params_from_facts(facts, *, split_kv: int, sched_policy: int) -> Sm10
         window_left=facts.window_left,
         window_right=(facts.right_bound if facts.right_band_widening else 0 if facts.causal else None),
         bottom_right=facts.bottom_right,
+        has_sink=facts.has_sink,
         seq_kv_lens_present=facts.padded,
         seq_q_lens_present=facts.seq_q_trim,
         sched_policy=sched_policy,
         thd_varlen=facts.thd,
+        qh_per_kh=facts.h_q // facts.h_kv,
         split_kv=split_kv,
     )
 

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm100.py
@@ -81,6 +81,7 @@ from cudnn.frost.tile_dsl.scheduler import (
     scheduler_warp_loop,
     scheduler_warp_loop_persistent,
     read_tile_id_arrive,
+    SCHED_LPT,
     SCHED_NATURAL,
 )
 from cudnn.frost.tile_dsl.pointwise import (
@@ -106,7 +107,10 @@ from cudnn.frost.tile_dsl.mask import (
 from cudnn.block_sparse_attention.csrc.utils.kernel_utils import ex2_emulation_2
 
 _PADDED_CAUSAL = CFG.MASK_FLAGS == (MASK_CAUSAL | MASK_PADDED) and CFG.WINDOW_RIGHT == 0
-_DENSE_CAUSAL_PUBLIC_EXP2_MIX = not CFG.THD_VARLEN and CFG.MASK_FLAGS == MASK_CAUSAL and CFG.WINDOW_RIGHT == 0 and not CFG.BOTTOM_RIGHT and not CFG.HAS_SINK
+_SHORT_BF16_LPT = CFG.DTYPE_QKV == 2 and CFG.SCHEDULER_POLICY == SCHED_LPT and PARAMS.d192_short_bf16_lpt
+_DENSE_CAUSAL_PUBLIC_EXP2_MIX = (
+    not CFG.THD_VARLEN and CFG.MASK_FLAGS == MASK_CAUSAL and CFG.WINDOW_RIGHT == 0 and not CFG.BOTTOM_RIGHT and not CFG.HAS_SINK and not _SHORT_BF16_LPT
+)
 _REUSE_BMM2_ISSUE_ELECTION = CFG.THD_VARLEN or _DENSE_CAUSAL_PUBLIC_EXP2_MIX
 
 

--- a/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
@@ -290,6 +290,25 @@ def test_dsl_sm100_d192_d128(dtype, is_causal):
     torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
 
 
+@pytest.mark.L1
+@torch_fork_set_rng(seed=17)
+def test_dsl_sm100_d192_d128_short_bf16_lpt():
+    """The short BF16 LPT specialization preserves both output and LSE."""
+    _require_dsl()
+    b, h, s = 2, 8, 2048
+    d_qk, d_v = 192, 128
+    dtype = torch.bfloat16
+    scale = 1.0 / math.sqrt(d_qk)
+    q = _bhsd(b, h, s, d_qk, dtype)
+    k = _bhsd(b, h, s, d_qk, dtype)
+    v = _bhsd(b, h, s, d_v, dtype)
+
+    o, stats = _run_dsl_graph(q, k, v, scale=scale, dtype=dtype, sdpa_kwargs=dict(use_causal_mask=True), return_stats=True)
+    o_ref, stats_ref = _ref_sdpa_full(q, k, v, scale=scale, is_causal=True, return_stats=True)
+    torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
+    torch.testing.assert_close(stats.squeeze(-1), stats_ref, atol=5e-2, rtol=3e-2)
+
+
 @pytest.mark.L0
 @pytest.mark.parametrize("d", _FLAVORS, ids=_FLAVOR_IDS)
 @pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)

--- a/test/python/sdpa/frost/test_sdpa_fwd_heuristics.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_heuristics.py
@@ -14,15 +14,18 @@ from the caller workspace, recombines correctly (O and Stats), and its
 """
 
 import math
+from dataclasses import replace
 
 import pytest
 import torch
 
 import cudnn
 from cudnn.engines.base import PlanConfig
+from cudnn.frost.tile_dsl.constants import DTYPE_BF16, DTYPE_FP16, SCHED_LPT, SCHED_LPT_L2, SCHED_NATURAL
+from cudnn.sdpa.fwd.config_sm100 import TemplateParams, derive_d192_internal_params
 from cudnn.sdpa.fwd import engines
 from cudnn.engines.heuristics import _assemble
-from cudnn.sdpa.fwd.heuristics import _MAX_SETS_PER_ENGINE, recommend
+from cudnn.sdpa.fwd.heuristics import _MAX_SETS_PER_ENGINE, recommend, select_d192_auto_knobs
 from cudnn.sdpa.graph_analyzer import SdpaGraphFacts
 
 _F16 = "sdpa_fwd_prefill_sm100"
@@ -74,6 +77,65 @@ def test_recommend_primary_reproduces_the_derived_scheduler():
     dense_f16 = [p for p in dense if p.engine_id == 20500]
     assert dense_f16[0].knobs.sched_policy == 0  # SCHED_NATURAL
     assert all(p.knobs.sched_policy == 0 for p in dense_f16), "mask-free graphs gain nothing from LPT runners"
+
+
+@pytest.mark.L0
+def test_d192_bf16_short_causal_scheduler_is_scoped():
+    params = TemplateParams(
+        dtype_qkv=DTYPE_BF16,
+        dtype_o=DTYPE_BF16,
+        window_right=0,
+        sched_policy=SCHED_LPT_L2,
+        cta_mma=2,
+    )
+
+    for seq in (512, 2048, 3584):
+        assert select_d192_auto_knobs(params, pertensor=False, s_q=seq, s_kv=seq)[0] == SCHED_LPT
+    assert select_d192_auto_knobs(replace(params, sched_policy=SCHED_NATURAL), pertensor=False, s_q=2048, s_kv=2048)[0] == SCHED_NATURAL
+
+    unchanged = (
+        (params, 4096, 4096),
+        (params, 2048, 4096),
+        (replace(params, dtype_qkv=DTYPE_FP16, dtype_o=DTYPE_FP16), 2048, 2048),
+        (replace(params, has_sink=True), 2048, 2048),
+        (replace(params, qh_per_kh=8), 2048, 2048),
+        (replace(params, cta_mma=1), 2048, 2048),
+        (replace(params, window_right=None), 2048, 2048),
+        (replace(params, bottom_right=True), 2048, 2048),
+        (replace(params, window_left=1024), 2048, 2048),
+        (replace(params, thd_varlen=True), 2048, 2048),
+        (replace(params, seq_kv_lens_present=True), 2048, 2048),
+        (replace(params, seq_q_lens_present=True), 2048, 2048),
+    )
+    for other, s_q, s_kv in unchanged:
+        assert select_d192_auto_knobs(other, pertensor=False, s_q=s_q, s_kv=s_kv)[0] == SCHED_LPT_L2
+    assert select_d192_auto_knobs(replace(params, split_kv=2), pertensor=False, s_q=2048, s_kv=2048)[0] == SCHED_NATURAL
+
+    graph_cases = (
+        ({}, SCHED_LPT),
+        ({"has_sink": True}, SCHED_LPT_L2),
+        ({"h_q": 128, "h_kv": 16}, SCHED_LPT_L2),
+    )
+    for overrides, expected in graph_cases:
+        facts_kwargs = dict(
+            s_q=2048,
+            s_kv=2048,
+            h_q=128,
+            h_kv=128,
+            d_qk=192,
+            d_v=128,
+            dtype=cudnn.data_type.BFLOAT16,
+            dtype_o=cudnn.data_type.BFLOAT16,
+        )
+        facts_kwargs.update(overrides)
+        facts = _facts(**facts_kwargs)
+        plans = [p for p in recommend("A", facts, _OFFERED) if p.engine_id == 20500]
+        assert plans[0].knobs.sched_policy == expected
+
+    short_lpt = derive_d192_internal_params(replace(params, sched_policy=SCHED_LPT), pertensor=False, batch_size=2, h_q=128, s_q=2048, s_kv=2048)
+    long_lpt = derive_d192_internal_params(replace(params, sched_policy=SCHED_LPT), pertensor=False, batch_size=2, h_q=128, s_q=4096, s_kv=4096)
+    assert short_lpt.d192_short_bf16_lpt and short_lpt.lpt_q_tiles == 0
+    assert not long_lpt.d192_short_bf16_lpt and long_lpt.lpt_q_tiles == 0
 
 
 @pytest.mark.L0
@@ -267,9 +329,24 @@ def test_assemble_strips_mode_dedups_and_our_proposals_lead():
 
 @pytest.mark.L0
 def test_fallback_kind_is_least_demanding():
-    for p in recommend("FALLBACK", _facts(), _OFFERED):
-        assert p.knobs.split_kv == 1
-        assert p.knobs.sched_policy == 0  # SCHED_NATURAL
+    facts = (
+        _facts(),
+        _facts(
+            b=2,
+            h_q=8,
+            h_kv=8,
+            s_q=2048,
+            s_kv=2048,
+            d_qk=192,
+            d_v=128,
+            dtype=cudnn.data_type.BFLOAT16,
+            dtype_o=cudnn.data_type.BFLOAT16,
+        ),
+    )
+    for case in facts:
+        for p in recommend("FALLBACK", case, _OFFERED):
+            assert p.knobs.split_kv == 1
+            assert p.knobs.sched_policy == 0  # SCHED_NATURAL
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches and the changes comply.
- [x] I added the required category, area, and origin labels.

## Affected area

FE OSS kernels or CuTeDSL; benchmarks or performance.

## Summary

Fix the SM100 D192/D128 BF16 short-sequence performance regression by selecting the measured D192 scheduler and matching source schedule for square top-left causal sequences from 512 through 3584 tokens.

## Why

The D192 half kernel previously used plain LPT. After scheduler selection moved to the generic heuristic, short BF16 sequences selected LPT-L2. The public-source exp2/descriptor/election schedule used by the long-sequence path also costs additional time when paired with plain LPT at these short lengths. Earlier validation focused on 8K and did not expose the short-sequence crossover.

This change:

- selects LPT as the D192-specific primary only in the measured short BF16 region;
- selects the matching existing source schedule through a private codegen flag;
- preserves explicit user knobs, the LPT-L2 and NATURAL runner configurations, and NATURAL fallback behavior;
- leaves FP16, FP8, MXFP8, no-mask, bottom-right, GQA, sink, SWA, THD/runtime-length, CTA1, and split-KV paths unchanged.

The remaining 2K gap to a historical build is about 2.4-3.0%. That build used internal compiler controls which cannot be used in public source; this PR recovers the public-source regression without restoring them. Later public-source tuning has already recovered essentially all of the corresponding 8K gap.

Paired measurements used a local SM100 GPU at fixed 847 MHz SM / 4000 MHz memory clocks, with 10 warmups and 40 measured iterations per side. Lower is better.

| BF16 top-left, Sq=Skv=2048 | Upstream | PR | Change |
|---|---:|---:|---:|
| Kimi K2.6, B2 H64 | 0.341 ms | 0.323 ms | -5.28% |
| Kimi K3, B2 H96 | 0.485 ms | 0.474 ms | -2.27% |
| DeepSeek V3, B2 H128 | 0.660 ms | 0.620 ms | -6.06% |

The non-target regression sweep covered 87 BF16/per-tensor-FP8/MXFP8 model cells across 2K/4K/8K/16K/32K and top-left/no-mask. Median change was 0.000%; the largest slowdown was 0.321% (1 microsecond). A supplementary 30-cell FP16 sweep also had a 0.000% median; its only initial outlier disappeared in four crossed-order repeats.

## Related issues

None.

## API and compatibility impact

No API or engine-capability change. Explicit scheduler/CGA choices remain authoritative.

## Testing

```bash
cd test/python
python3 -m pytest -q sdpa/frost/test_sdpa_fwd_heuristics.py
python3 -m pytest -q -m "L0 or L1" \
  sdpa/frost/test_sdpa_fwd_dsl_sm100.py::test_dsl_sm100_d192_d128 \
  sdpa/frost/test_sdpa_fwd_dsl_sm100.py::test_dsl_sm100_d192_d128_short_bf16_lpt
```

- Heuristic suite: `24 passed`.
- D192 FP16/BF16 dense/causal plus the exact 2K BF16 O/LSE reference case: `5 passed`.
- Representative 2K path: Compute Sanitizer synccheck and memcheck both reported `0 errors`.
- Pre-commit hooks passed on all changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved scheduling for short, dense BF16 attention workloads on supported hardware.
  * Added specialized handling for D192/D128 causal attention configurations.

* **Bug Fixes**
  * Corrected execution-path selection for qualifying BF16 causal workloads while preserving existing behavior for other configurations.

* **Tests**
  * Added regression coverage comparing outputs and statistics with FP32 references.
  * Expanded scheduler-selection tests across sequence lengths and configuration variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->