### PR TITLE
ci: keep causal-conv contract tests compatible with CuTe DSL 4.6.2

### DIFF
--- a/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_backward_contract_unit.py
+++ b/test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_backward_contract_unit.py
@@ -221,6 +221,17 @@ def test_v2_cpasync_planner_is_safe_for_arbitrary_t_d_and_sm(monkeypatch):
 
 
 def test_v2_cpasync_burst_store_uses_compact_row_major_staging():
+    # This is the only test in this host-contract module that imports a kernel
+    # implementation directly.  The public dependency floor stays at 4.6.2 for
+    # downstreams such as vLLM/SGLang, while FROST's tile-DSL primitives require
+    # 4.7.0.  Keep exercising the host contracts on 4.6.2 and skip only this
+    # implementation-detail assertion there.
+    from cudnn.frost.buffers import cutedsl_state, cutedsl_too_old
+
+    installed, version = cutedsl_state()
+    if not installed or cutedsl_too_old(version):
+        pytest.skip("the v2-cpasync kernel requires nvidia-cutlass-dsl>=4.7.0")
+
     from cudnn.causal_conv1d_bulk_sm100.backward_kernel_vec2_cpasync import (
         _DX_STAGE_STRIDE,
     )


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches and my changes comply.
- [x] I added GitHub labels: `cat-ci`, `area:frost`, `orig-nv-eng`, and `mod-cutedsl`.

## Affected area

CI or test infrastructure; FE OSS kernels or CuTeDSL.

## Summary

Gate the one causal-conv backward host-contract test that directly imports the v2-cpasync kernel on FROST's CuTe DSL 4.7 floor.

The rest of the host-contract module continues to run with CuTe DSL 4.6.2.

## Why

The public optional-dependency floor must remain 4.6.2 for downstream compatibility with vLLM and SGLang. The v2-cpasync kernel implementation imports `cutlass.experimental`, which only exists at the FROST kernel floor (4.7), while this implementation-detail assertion was the only test in the module to bypass the existing runtime version gates.

This caused the 4.6.2 compatibility lanes to fail during collection with `ModuleNotFoundError: cutlass.experimental` (for example, nightly job 429105248). Skipping only the direct kernel assertion preserves both contracts: downstream imports stay compatible with 4.6.2, and the host-side tests still exercise that lane.

## Related issues

Related to cuDNN Frontend nightly pipeline 66621707, job 429105248.

## API and compatibility impact

No public API or runtime behavior change. The `nvidia-cutlass-dsl>=4.6.2` dependency floor is intentionally unchanged.

## Testing

- Exact `nvidia-cutlass-dsl==4.6.2` environment: the original full `fe_api` run was `1 failed, 217 passed, 4519 skipped`, with this direct import as the only failure; the patched focused case is now `1 skipped` with the expected 4.7 requirement and exits successfully.
- CuTe DSL 4.7.0: `python -m pytest -q test/python/fe_api/causal_conv1d_bulk/test_causal_conv1d_bulk_backward_contract_unit.py -rs` — 51 passed.
- `pre-commit run --from-ref gh/develop --to-ref HEAD` — passed.

The three compatibility lanes that exposed the failure (SM80, SM90, and SM100 shard 1) provide the final matrix validation.
