### PR TITLE
fix(sdpa): compile backward stage 3 for the execution device

### DIFF
--- a/python/cudnn/sdpa/bwd/kernels/bprop_matmul_sm100.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_matmul_sm100.py
@@ -1882,12 +1882,21 @@ def _host(
         )
 
 
+_CODEGEN_TARGET_SMS = frozenset({100, 103, 107, 110})
+
+
 @lru_cache(maxsize=None)
 def compile(device) -> Callable:
     major, minor = compute_capability(resolve_device(device))
     sm = major * 10 + minor
-    if not 100 <= sm <= 103:
-        raise ValueError(f"SM100 SDPA bwd stage 3 requires SM100 through SM103; got SM{sm}")
+    # This is the source-level CODEGEN domain, not the engine's advertised
+    # support contract.  The complete three-stage engine remains qualified only
+    # on SM100/SM103; SM107/SM110 targets are kept available for isolated
+    # lowering and future board qualification.  In particular SM107 needs a
+    # CuTe DSL build that recognizes sm_107a (the public 4.7 wheel does not).
+    if sm not in _CODEGEN_TARGET_SMS:
+        expected = ", ".join(f"SM{x}" for x in sorted(_CODEGEN_TARGET_SMS))
+        raise ValueError(f"SM100 SDPA bwd stage 3 has codegen targets for {expected}; got SM{sm}")
     # The architecture-specific target is required for tcgen05/TMA. Resolve it
     # from this function's device cache key so B200 and B300 cannot share an
     # incompatible TVM-FFI artifact in a multi-GPU process.

--- a/python/cudnn/sdpa/bwd/kernels/bprop_matmul_sm100.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_matmul_sm100.py
@@ -46,7 +46,6 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Callable
 
-import torch
 import cutlass.experimental.primitives as nvvm
 from cudnn.gemm.frost.kernel_templates._tile_helpers import (
     epi_subtile_spans as _epi_subtile_spans,
@@ -64,6 +63,7 @@ from cutlass.cute.runtime import make_fake_stream
 from cuda.bindings import driver as _cuda
 from cutlass.cute.arch import clc as cute_clc
 
+from cudnn.frost.device import compute_capability, resolve_device
 from cudnn.frost.tile_dsl.constants import DTYPE_FP16
 from cudnn.frost.tile_dsl.thd import TENSOR_MAP_QWORDS, emit_clamped_desc, emit_seq_descs
 from cudnn.sdpa.bwd.config_sm100 import CAUSAL_K_HI, CAUSAL_K_LO, CAUSAL_K_NONE, MatmulTemplateParams, validate_matmul_params
@@ -1883,8 +1883,8 @@ def _host(
 
 
 @lru_cache(maxsize=None)
-def compile(device: torch.device) -> Callable:
-    major, minor = torch.cuda.get_device_capability(device)
+def compile(device) -> Callable:
+    major, minor = compute_capability(resolve_device(device))
     sm = major * 10 + minor
     if not 100 <= sm <= 103:
         raise ValueError(f"SM100 SDPA bwd stage 3 requires SM100 through SM103; got SM{sm}")
@@ -2043,9 +2043,9 @@ def matmul_bh(
         # Required on both paths: dense never reads them, but the compiled ABI
         # has the slots and a None would fail at the call boundary.
         raise ValueError("matmul_bh needs `meta` and `desc_words` (dense may pass any 1-D dummies)")
-    # Key the compiled artifact by the tensor's actual device.  A process may
-    # execute plans on both B200 and B300, and the TVM-FFI function is not
-    # portable between their architecture-specific targets.
+    # Use FROST's framework-neutral device facts. This is the same per-ordinal
+    # DeviceInfo cache exposed by cudnn.Handle.device, without making the kernel
+    # template depend on torch.
     fn = compile(a.device)
     # `m` sizes the GRID.  Dense: the operands' shared M.  THD: the caller
     # passes the longest sequence, because the per-sequence extents are device

--- a/python/cudnn/sdpa/bwd/kernels/bprop_matmul_sm100.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_matmul_sm100.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Callable
 
+import torch
 import cutlass.experimental.primitives as nvvm
 from cudnn.gemm.frost.kernel_templates._tile_helpers import (
     epi_subtile_spans as _epi_subtile_spans,
@@ -210,7 +211,6 @@ num_tmem_alloc_cols = 512
 tmem_alloc_exclusive = False
 acc_stages = 1  # 512 acc cols/stage
 vec_bytes_epi = int(PARAMS.vec_bytes_epi)
-frost_compile_options = "--enable-tvm-ffi --gpu-arch sm_100a"
 n_tma_outputs = 1
 moe_aligned_offsets = False
 epi_slot_widen = 1
@@ -1883,7 +1883,15 @@ def _host(
 
 
 @lru_cache(maxsize=None)
-def compile() -> Callable:
+def compile(device: torch.device) -> Callable:
+    major, minor = torch.cuda.get_device_capability(device)
+    sm = major * 10 + minor
+    if not 100 <= sm <= 103:
+        raise ValueError(f"SM100 SDPA bwd stage 3 requires SM100 through SM103; got SM{sm}")
+    # The architecture-specific target is required for tcgen05/TMA. Resolve it
+    # from this function's device cache key so B200 and B300 cannot share an
+    # incompatible TVM-FFI artifact in a multi-GPU process.
+    gpu_arch = f"sm_{major}{minor}a"
     out_vec_elems = vec_bytes_epi // (cd_dtype.width // 8)
     ab_stride_elems = 16 // (ab_dtype.width // 8)
     sym_m = cute.sym_int64()
@@ -1987,7 +1995,7 @@ def compile() -> Callable:
         fake_meta,
         fake_desc,
         stream=_fake_stream,
-        options=frost_compile_options,
+        options=f"--enable-tvm-ffi --gpu-arch {gpu_arch}",
     )
 
 
@@ -2007,7 +2015,18 @@ def _permuted(t, mn_dim: int, k_dim: int, h_dim: int, b_dim: int):
     return t.permute(mn_dim, k_dim, h_dim, b_dim)
 
 
-def matmul_bh(a, b, out, *, n_head: int, n_batch: int, stream=None, meta=None, desc_words=None, grid_m: int = None):
+def matmul_bh(
+    a,
+    b,
+    out,
+    *,
+    n_head: int,
+    n_batch: int,
+    stream=None,
+    meta=None,
+    desc_words=None,
+    grid_m: int = None,
+):
     """Run one ``(batch, head)``-batched GEMM.
 
     ``a`` / ``b`` / ``out`` are already permuted to ``(M|N, K, H, B)`` /
@@ -2024,7 +2043,10 @@ def matmul_bh(a, b, out, *, n_head: int, n_batch: int, stream=None, meta=None, d
         # Required on both paths: dense never reads them, but the compiled ABI
         # has the slots and a None would fail at the call boundary.
         raise ValueError("matmul_bh needs `meta` and `desc_words` (dense may pass any 1-D dummies)")
-    fn = compile()
+    # Key the compiled artifact by the tensor's actual device.  A process may
+    # execute plans on both B200 and B300, and the TVM-FFI function is not
+    # portable between their architecture-specific targets.
+    fn = compile(a.device)
     # `m` sizes the GRID.  Dense: the operands' shared M.  THD: the caller
     # passes the longest sequence, because the per-sequence extents are device
     # values and A's own M is the workspace's column count, not an output row

--- a/test/python/sdpa/frost/test_sdpa_bwd_dsl_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_bwd_dsl_sm100.py
@@ -42,7 +42,13 @@ def test_stage3_compile_cache_is_arch_specific(monkeypatch):
     import cudnn.sdpa.bwd.kernels.bprop_matmul_sm100 as stage3
 
     options = []
-    capabilities = {0: (10, 0), 1: (10, 3)}
+    capabilities = {
+        0: (10, 0),
+        1: (10, 3),
+        2: (10, 7),
+        3: (11, 0),
+        4: (10, 1),
+    }
 
     def fake_compile(*args, **kwargs):
         options.append(kwargs["options"])
@@ -56,9 +62,17 @@ def test_stage3_compile_cache_is_arch_specific(monkeypatch):
         assert stage3.compile(0) is b200
         b300 = stage3.compile(1)
         assert b300 is not b200
+        rubin = stage3.compile(2)
+        assert rubin is not b300
+        thor = stage3.compile(3)
+        assert thor is not rubin
+        with pytest.raises(ValueError, match="got SM101"):
+            stage3.compile(4)
         assert options == [
             "--enable-tvm-ffi --gpu-arch sm_100a",
             "--enable-tvm-ffi --gpu-arch sm_103a",
+            "--enable-tvm-ffi --gpu-arch sm_107a",
+            "--enable-tvm-ffi --gpu-arch sm_110a",
         ]
     finally:
         stage3.compile.cache_clear()

--- a/test/python/sdpa/frost/test_sdpa_bwd_dsl_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_bwd_dsl_sm100.py
@@ -42,24 +42,19 @@ def test_stage3_compile_cache_is_arch_specific(monkeypatch):
     import cudnn.sdpa.bwd.kernels.bprop_matmul_sm100 as stage3
 
     options = []
-    b200_device = torch.device("cuda:0")
-    b300_device = torch.device("cuda:1")
-    capabilities = {
-        b200_device: (10, 0),
-        b300_device: (10, 3),
-    }
+    capabilities = {0: (10, 0), 1: (10, 3)}
 
     def fake_compile(*args, **kwargs):
         options.append(kwargs["options"])
         return object()
 
-    monkeypatch.setattr(stage3.torch.cuda, "get_device_capability", capabilities.__getitem__)
+    monkeypatch.setattr(stage3, "compute_capability", capabilities.__getitem__)
     monkeypatch.setattr(stage3.cute, "compile", fake_compile)
     stage3.compile.cache_clear()
     try:
-        b200 = stage3.compile(b200_device)
-        assert stage3.compile(b200_device) is b200
-        b300 = stage3.compile(b300_device)
+        b200 = stage3.compile(0)
+        assert stage3.compile(0) is b200
+        b300 = stage3.compile(1)
         assert b300 is not b200
         assert options == [
             "--enable-tvm-ffi --gpu-arch sm_100a",

--- a/test/python/sdpa/frost/test_sdpa_bwd_dsl_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_bwd_dsl_sm100.py
@@ -38,6 +38,37 @@ _DTYPES = (torch.bfloat16, torch.float16)
 _DTYPE_IDS = ("bf16", "fp16")
 
 
+def test_stage3_compile_cache_is_arch_specific(monkeypatch):
+    import cudnn.sdpa.bwd.kernels.bprop_matmul_sm100 as stage3
+
+    options = []
+    b200_device = torch.device("cuda:0")
+    b300_device = torch.device("cuda:1")
+    capabilities = {
+        b200_device: (10, 0),
+        b300_device: (10, 3),
+    }
+
+    def fake_compile(*args, **kwargs):
+        options.append(kwargs["options"])
+        return object()
+
+    monkeypatch.setattr(stage3.torch.cuda, "get_device_capability", capabilities.__getitem__)
+    monkeypatch.setattr(stage3.cute, "compile", fake_compile)
+    stage3.compile.cache_clear()
+    try:
+        b200 = stage3.compile(b200_device)
+        assert stage3.compile(b200_device) is b200
+        b300 = stage3.compile(b300_device)
+        assert b300 is not b200
+        assert options == [
+            "--enable-tvm-ffi --gpu-arch sm_100a",
+            "--enable-tvm-ffi --gpu-arch sm_103a",
+        ]
+    finally:
+        stage3.compile.cache_clear()
+
+
 def _io_dtype(dt):
     return cudnn.data_type.HALF if dt == torch.float16 else cudnn.data_type.BFLOAT16
 


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches and my changes comply.
- [x] I added GitHub labels: `cat-bug`, `area:frost`, `area:global_attention`, `orig-nv-eng`, and `mod-cutedsl`.

## Affected area

FE OSS kernels or CuTeDSL; Python SDPA backward.

## Summary

Compile the large-head-dimension SM100-family SDPA backward stage-3 GEMMs for the device that owns their actual input tensor. Include that device in the compile cache key, so different GPU architectures cannot share an incompatible TVM-FFI artifact.

The stage-3 source-level codegen allowlist is the exact known SM100-family target set: SM100, SM103, SM107, and SM110. This does **not** widen the complete engine's advertised capability, which remains SM100-SM103 pending Rubin/Thor board qualification.

## Why

The stage-3 template unconditionally passed `--gpu-arch sm_100a`. On SM103, the template compiled successfully but aborted at invocation with `TVM FFI function is not initialized. Was this function compiled for a different architecture?`, accounting for the repeated stage-3 failures in nightly job 429105351.

Dropping the explicit target is not sufficient because these tcgen05/TMA kernels require the architecture-specific `a` target. The execution tensor's device is also more reliable than ambient current-device state in a multi-GPU process. Device normalization and capability lookup use the shared, driver-backed `cudnn.frost.device` layer—the same per-ordinal `DeviceInfo` cache exposed by first-class `cudnn.Handle.device`—so the kernel template does not need a torch dependency.

## Related issues

Related to cuDNN Frontend nightly pipeline 66621707, job 429105351.

## API and compatibility impact

No public API, kernel geometry, launch configuration, numerical behavior, or engine-admission change. B200 compiles as `sm_100a`; B300 compiles as `sm_103a`. Known future family targets `sm_107a` and `sm_110a` are accepted for isolated codegen/qualification, but AUTO still cannot route the complete three-stage engine there.

The public CuTe DSL 4.7 wheel recognizes SM100/SM103/SM110 but not `sm_107a`; SM107 qualification therefore requires a 4.8 build. This does not raise cudnn-frontend's package dependency floor: 4.6.2 remains install-compatible and FROST runtime routes continue to require 4.7+.

The steady-state execute path retains the existing cached `compile()` lookup, now keyed by device, so no additional device query occurs after the first compile per device.

## Testing

- `pre-commit run --files python/cudnn/sdpa/bwd/kernels/bprop_matmul_sm100.py test/python/sdpa/frost/test_sdpa_bwd_dsl_sm100.py` — passed.
- Architecture/cache regression test with mocked SM100/SM103/SM107/SM110 devices — passed in the CUTLASS DSL 4.8 RC container; observed distinct `sm_100a`, `sm_103a`, `sm_107a`, and `sm_110a` options and rejection of the SM101 gap.
- B200 direct-adapter THD end-to-end regression: `test_sdpa_bwd_thd_sm100.py::test_thd_single_sequence_matches_dense_shape` — passed.
- GB300/SM103 mirror job 430052006 with CUTLASS DSL 4.7.0:
  - `test_sdpa_bwd_dsl_sm100`: 42/42 passed.
  - `test_sdpa_bwd_thd_sm100`: 34/34 passed.
  - `TVM FFI function is not initialized`: 0 occurrences.
  - All 55 prior stage-3 failures disappeared; the seven remaining failures were an exact pre-existing unrelated subset, with no new-only failures.
- Target-forced representative lowering reached embedded GPU modules for stage 1/2/3, THD setup, and the GQA reducer on SM107/SM110. This is codegen evidence only; it is not board-level launch, numerical, synchronization, or performance qualification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU architecture detection for supported SM100-series devices.
  * Added compilation support for SM100, SM103, SM107, and SM110 architectures.
  * Ensured compilation uses the input tensor’s device and appropriate architecture-specific settings.
  * Preserved separate compilation caches across GPU architectures while reusing results for repeated builds on the same architecture.

* **Tests**
  * Expanded coverage for architecture-specific compilation caching and compiler settings.
  * Verified unsupported SM101 compilation is reported appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->