### PR TITLE
test(hstu): order block-sparse inputs before cross-stream build

### DIFF
--- a/test/python/fe_api/hstu_attention/test_hstu_block_sparse.py
+++ b/test/python/fe_api/hstu_attention/test_hstu_block_sparse.py
@@ -275,8 +275,10 @@ def test_q2k_builder_rebuilds_mutated_func_on_current_stream():
         "block_size": (256, 128),
     }
     stream = torch.cuda.Stream()
+    producer_stream = torch.cuda.current_stream()
 
     with torch.cuda.stream(stream):
+        stream.wait_stream(producer_stream)
         full_metadata = build_hstu_q2k_block_sparse(
             func,
             cu_q,
@@ -407,8 +409,10 @@ def test_k2q_builder_rebuilds_mutated_func_on_current_stream():
         "block_size": (128, 128),
     }
     stream = torch.cuda.Stream()
+    producer_stream = torch.cuda.current_stream()
 
     with torch.cuda.stream(stream):
+        stream.wait_stream(producer_stream)
         full_metadata = build_hstu_k2q_block_sparse(
             func,
             cu_q,


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches and my changes comply.
- [x] I added GitHub labels: `cat-ci`, `area:frost`, `orig-nv-eng`, and `mod-cutedsl`.

## Affected area

CI or test infrastructure; HSTU CuTeDSL tests.

## Summary

Make the two HSTU block-sparse rebuild tests establish a CUDA dependency from their input-producing default stream to the non-default stream used by the builder.

## Why

`cu_q`, `cu_k`, and `func` are initialized asynchronously on the current stream. The tests then immediately consume them on a newly created stream without an event or wait. Nightly job 429105268 observed small q2k/k2q metadata mismatches during the first pre-mutation comparison, which is consistent with that undefined cross-stream ordering.

The builder already honors its caller's current stream. The test must order its own producers, matching the paired-builder test in the same file. A device-wide synchronize would hide ordering bugs and unnecessarily serialize unrelated work, so this uses `stream.wait_stream(producer_stream)` instead.

## Related issues

Related to cuDNN Frontend nightly pipeline 66621707, job 429105268. PR #927 renames this test path and should carry these two waits when it rebases.

## API and compatibility impact

None. Test-only synchronization; no product code or performance path changes.

## Testing

On B200 with the edited worktree sources:

- q2k and k2q focused pytest cases — 2 passed.
- Both cases invoked for 20 hot-cache iterations each — all 40 invocations passed.
- q2k/k2q CUDA-graph replay plus paired-builder stream and graph tests — 4 passed.
- `pre-commit run --files test/python/fe_api/hstu_attention/test_hstu_block_sparse.py` — passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization in attention stream-mutation tests to ensure worker operations wait for producer work to complete before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->