### PR TITLE
test(dsrelu): allow FP8 dprob reassociation drift on Rubin

### DIFF
--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
@@ -1176,12 +1176,19 @@ def test_grouped_gemm_dsrelu_deterministic_dprob_discrete(request, ab_dtype, c_d
 
     baseline = run(deterministic=False)
     deterministic = run(deterministic=True)
+    # The FP8 kernels may reassociate the same fp32 dprob sum differently on
+    # Rubin (the observed delta is below 5e-4).  This remains far below the
+    # tens-of-percent signal from a dropped or duplicated partial.  Keep the
+    # tighter default for the FP4 kernel, which does not show that drift.
+    dprob_tol = 1e-3 if ab_dtype == torch.float8_e4m3fn else 1e-4
     _assert_dprob_deterministic(
         (inputs, cfg),
         baseline,
         deterministic,
         lambda: run(deterministic=True),
         ref_inputs=_dense_ref_inputs_from_discrete(inputs),
+        dprob_rtol=dprob_tol,
+        dprob_atol=dprob_tol,
     )
 
 


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches and my changes comply.
- [x] I added GitHub labels: `cat-ci`, `area:frost`, `orig-nv-eng`, and `mod-cutedsl`.

## Affected area

CI or test infrastructure; CuTeDSL grouped GEMM dSReLU tests.

## Summary

Use the existing 1e-3 dprob reassociation tolerance for the FP8 discrete deterministic-vs-default comparison. Keep FP4 at the original 1e-4 tolerance.

## Why

On SM107, nightly job 429105299 and a later independent run both produced the same isolated failure in `fp8-k-major`: 1 of 1024 dprob elements differed, with absolute error 0.000244140625 and relative error 0.0004138216. This assertion compares two legal FP32 reduction orders over the same terms; it is not the mathematical reference check.

The test already uses 1e-3 for the same dprob reassociation invariant at larger N. That remains orders of magnitude below the tens-of-percent change expected from the missing/double partial bugs this check is designed to catch.

The other two guarantees remain unchanged:

- repeated deterministic launches must be bitwise identical;
- the complete deterministic output set must pass the mathematical reference check.

## Related issues

Related to cuDNN Frontend nightly pipeline 66621707, job 429105299.

## API and compatibility impact

None. Test-only tolerance change; no kernel, dispatch, or performance behavior changes.

## Testing

- B200 focused `fp4-k-major` and `fp8-k-major` deterministic discrete cases — 2 passed, including bitwise relaunch and final reference checks.
- `pre-commit run --files test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py` — passed.

No SM107 GPU is available locally. The required final validation is the focused `fp8-k-major` case and the `oss:cutlass-4.8:sm107` lane that exposed the architecture-specific reassociation delta.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated FP8 dSReLU validation to allow small floating-point tolerance differences.
  - Retained stricter validation thresholds for FP4 configurations.
  - Deterministic behavior and reference-input handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->