### PR TITLE
fix(dsa): handle infinite sinks deterministically

### DIFF
--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100_deterministic.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100_deterministic.py
@@ -169,7 +169,13 @@ class FlashAttentionDSABackwardSm100Deterministic(FlashAttentionDSABackwardSm100
         sink_log2 = attn_sink[head_idx, (0, batch_idx)] * log2_e
         acc = Float32(0.0)
         while q_idx < problem_shape[0]:
-            p_sink = cute.math.exp2(sink_log2 + scaled_lse[head_idx, (q_idx, batch_idx)])
+            p_sink = Float32(0.0)
+            if sink_log2 == Float32(float("inf")):
+                p_sink = Float32(1.0)
+            elif sink_log2 == Float32(float("-inf")):
+                p_sink = Float32(0.0)
+            else:
+                p_sink = cute.math.exp2(sink_log2 + scaled_lse[head_idx, (q_idx, batch_idx)])
             acc += p_sink * sum_OdO[head_idx, (q_idx, batch_idx)]
             q_idx += self.dSink_num_threads
         acc = cute.arch.warp_reduction_sum(acc, threads_in_group=self.dSink_num_threads)

--- a/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
@@ -903,8 +903,9 @@ def test_DSA_sparse_attention_backward_sm100_masks_invalid_topk_rows(invalid_val
 
 @pytest.mark.L0
 @torch_fork_set_rng(seed=677)
+@pytest.mark.parametrize("deterministic", [False, True], ids=["ordinary", "deterministic"])
 @pytest.mark.parametrize("sink_value,empty_row", [(-math.inf, True), (math.inf, False)], ids=["empty-no-mass", "positive-infinite-sink"])
-def test_DSA_sparse_attention_backward_sm100_handles_infinite_sink_limits(sink_value, empty_row):
+def test_DSA_sparse_attention_backward_sm100_handles_infinite_sink_limits(sink_value, empty_row, deterministic):
     """Sink/LSE infinities must use their limiting probabilities without inf-inf."""
     _require_sm100()
     try:
@@ -937,6 +938,7 @@ def test_DSA_sparse_attention_backward_sm100_handles_infinite_sink_limits(sink_v
         topk_idxs,
         softmax_scale=192**-0.5,
         topk_length=topk_length,
+        deterministic=deterministic,
     )
 
     assert torch.equal(result["dq"], torch.zeros_like(result["dq"]))


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` files for the directories touched by this PR; the change is confined to a CuTeDSL kernel and its existing regression test.
- [ ] I added the required GitHub labels. This draft has not been submitted yet.

## Affected area

FE OSS kernels or CuTeDSL — DeepSeek Sparse Attention backward on SM100.

## Summary

Handle infinite attention-sink logits explicitly in the deterministic SM100 DSA backward `dSink` reduction:

- use the limiting sink probability `1` for a `+Inf` sink;
- use the limiting sink probability `0` for a `-Inf` sink;
- preserve the existing `exp2(sink_log2 + scaled_lse)` calculation for every finite sink.

The existing infinite-sink regression test now covers both ordinary and deterministic execution.

## Why

The preprocessing step represents the inverse softmax denominator as `scaled_lse = -Inf` when the attention sink is `+Inf`. The deterministic `dSink` reducer previously evaluated:

```text
exp2(+Inf + -Inf)
```

which produced `NaN` for every `dSink` element. The ordinary reducer already handled the two infinite limits explicitly. Applying the same limits to the deterministic reducer avoids the indeterminate expression while preserving the finite-input path and its fixed reduction order.

The implementation intentionally uses the same explicit `+Inf` / `-Inf` / `else` split as the ordinary reducer. This keeps NaN propagation unchanged and avoids relying on ordered-versus-unordered lowering of a floating-point `!=` comparison.

Before the fix, the new regression matrix produced three passing cases and one failure:

```text
FAILED positive-infinite-sink-deterministic
1 failed, 3 passed
```

After the fix, all four ordinary/deterministic × negative/positive-infinite-sink cases pass.

## Related issues

None.

## API and compatibility impact

None.

- No public API, workspace, dtype, layout, dispatch, or supported-shape changes.
- Finite-input behavior and deterministic reduction order are unchanged.
- The only behavioral change is that deterministic `dSink` now returns the defined limiting result instead of `NaN` for infinite sink logits.

## Testing

Tested on an NVIDIA GB200 GPU (SM100), with kernel compilation caches disabled for the targeted runs.

- RED verification against the unfixed `origin/develop` implementation:
  - `positive-infinite-sink-deterministic` failed with all-NaN `dSink`.
  - The other three cases passed.
- Infinite-sink regression matrix after the fix: `4 passed`.
- DSA backward L0 suite: `46 passed, 5 skipped, 26 deselected`.
- Deterministic H64/D576 checks:
  - 1,000-repeat bitwise reproducibility test passed.
  - 128-CTA wave-boundary test passed.
- Compute Sanitizer on the deterministic `+Inf` path:
  - memcheck: `0 errors`.
  - initcheck: `0 errors`.
  - racecheck: `0 hazards (0 errors, 0 warnings)`.
- `pre-commit run --files` for both changed files: passed.

The reported Python deprecation and CUDA-context initialization messages are framework warnings, not Compute Sanitizer findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected sparse attention backward calculations when sink logits are positive or negative infinity.
  - Preserved existing behavior for finite sink values.
  - Ensured consistent results in both ordinary and deterministic execution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->