### PR TITLE
perf: fix sXfer bank conflicts in SM100 d512 SDPA backward

### DIFF
--- a/python/cudnn/sdpa/bwd/config_sm100.py
+++ b/python/cudnn/sdpa/bwd/config_sm100.py
@@ -465,6 +465,10 @@ def _validate_cfg_d512(cfg: CfgBwdD512) -> None:
             cfg.Q_SWZ_BYTES == 128 and cfg.K_SWZ_BYTES == 128 and cfg.V_SWZ_BYTES == 128 and cfg.DO_SWZ_BYTES == 128,
             "bwd d512: Q/K/V/dO swizzle must all be 128B",
         ),
+        # Not only a swizzle width: S_SWZ_BYTES alone sets the fp32 ship's
+        # 256 B per-lane row, which S_XFER_SWIZZLE's sshift is derived from.
+        # A moved S mismatches that swizzle -- bank-conflicted, not wrong.
+        (cfg.S_SWZ_BYTES == 128, f"bwd d512: S swizzle must be 128B (sets the fp32 ship's 256 B row); got {cfg.S_SWZ_BYTES}"),
         # --- caps ----------------------------------------------------------
         (
             sg0_smem <= _SM100_MAX_DYN_SMEM,

--- a/python/cudnn/sdpa/bwd/kernels/bprop_d512_f16_sm100.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_d512_f16_sm100.py
@@ -262,6 +262,11 @@ SMEM_LAYOUT_V = _SWZ_ENUM[CFG.V_SWZ_BYTES]
 SMEM_LAYOUT_S = _SWZ_ENUM[CFG.S_SWZ_BYTES]
 S_SMEM_SWIZZLE = cutlass.Swizzle(_SWZ_B[CFG.S_SWZ_BYTES], 4, 3)
 
+# fp32 ship staging is one 256 B row per lane, so a linear map is a 32-way
+# bank conflict, and no descriptor reads it, so nothing but this XOR spreads
+# its banks.  mbase + sshift == log2(row bytes); the (b, 4, 3) presets are 128 B.
+S_XFER_SWIZZLE = cutlass.Swizzle(3, 4, 4)
+
 _CORE_MATRIX_ROWS = 8
 LEADING_BYTE_OFFSET_QK = 0
 STRIDE_BYTE_OFFSET_QK = _CORE_MATRIX_ROWS * CFG.Q_SWZ_BYTES
@@ -877,13 +882,10 @@ def _compute_kv_iter(
             if cutlass.const_expr(_PADDED):
                 s_post = s_post * row_scale
 
-            # The fp32 ship, sg0 -> sg1.  This buffer is UNSWIZZLED and
-            # linear on purpose: unlike the forward's P it is never an
-            # MMA operand and never TMA'd, so a swizzled read path would
-            # buy nothing and cost a matching load.
+            # The fp32 ship, sg0 -> sg1.  sg1 reads it back through the same swizzle
+            # at the same offset; the bulk ship below copies bytes and does not care.
             bars.mb_s_xfer_empty[chunk].wait(xfer_empty_state.phase)
-            for _i in cutlass.range_constexpr(S_D_BLOCK):
-                sXfer_raw.subview(xfer_off + cutlass.Int32(_i)).store(s_post[_i])
+            sXfer_raw.subview(xfer_off).data_ptr().store_swizzled(s_post, alignment=128, swizzle=S_XFER_SWIZZLE)
 
             # The workspace store staging.  Deferred wait: the exp2 above
             # overlaps the previous TMA-STG drain.
@@ -910,9 +912,9 @@ def _compute_kv_iter(
             # dS = (attn_scale_for_dS * dS_acc - do_dot*attn_scale) * S.
             # S is read at fp32 -- rounding it to the io dtype here is
             # exactly the accuracy the Rubin reference does not lose.
-            ds_elems = tuple(
-                (reg_acc[_i] * attn_scale_for_dS - scaled_do_dot_q) * sXfer_raw.subview(xfer_off + cutlass.Int32(_i)).load() for _i in range(S_D_BLOCK)
-            )
+            # One 256 B swizzled read, the mirror of sg0's store.
+            s_ship = sXfer_raw.subview(xfer_off).data_ptr().load_swizzled(S_XFER_SWIZZLE, alignment=128, count=S_D_BLOCK)
+            ds_elems = tuple((reg_acc[_i] * attn_scale_for_dS - scaled_do_dot_q) * s_ship[_i] for _i in range(S_D_BLOCK))
             ds_post = cutlass.Vector.from_elements(ds_elems, cutlass.Float32)
 
             bars.mb_smem_empty[chunk].wait(smem_state.phase)


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches (see [root AGENTS.md § Reviewing a PR](https://github.com/NVIDIA/cudnn-frontend/blob/develop/AGENTS.md#reviewing-a-pr-human-or-agent)) and my changes comply, or I explain the exception below.
- [ ] I added the required GitHub labels. This draft has not been submitted yet.

## Affected area

FE OSS kernels / CuTeDSL, SM100 SDPA backward (d=512) performance.

## Summary

Remove the SMEM bank conflict in the FROST SM100 d=512 SDPA backward stage-2 kernel. The affected fp32 buffer, `sXfer`, transfers softmax output from sub-group 0 to sub-group 1.

Each lane holds `S_D_BLOCK = 64` fp32 values. Adjacent lanes access rows 256 B apart. Linear addressing maps all eight lanes in each 128-bit access phase to the same bank slot. Shared loads require **32.06** wavefronts per instruction against an ideal count of 4.00.

The buffer originally used linear addressing because it is neither an MMA operand nor a TMA tensor. It still needs a swizzle to distribute accesses across banks. The neighbouring `sCast` buffer already uses one.

Main changes:

-   Apply `S_XFER_SWIZZLE = cutlass.Swizzle(3, 4, 4)` to the `sXfer` store and load through `store_swizzled` / `load_swizzled`. The `sshift = 4` setting matches the 256 B lane stride and spreads each access phase across all eight bank slots. The `s128b` preset uses `sshift = 3` and leaves a 2-way conflict at this stride.

-   Preserve 16 B granules, 128-bit accesses and the SMEM footprint. The store and load use the same swizzle at matching SMEM offsets, so the bulk copy between sub-groups preserves the mapping. The backend already vectorised the original scalar loops, so shared instruction counts are unchanged.

-   Require `S_SWZ_BYTES == 128` in `_validate_cfg_d512` to keep the 256 B fp32 row stride consistent with the swizzle. This also replaces the kernel-import `KeyError` for `S_SWZ_BYTES = 256` with a configuration error.

Benchmarked on NVIDIA B200 (SM100), paired A/B in one session; full setup is listed below.

| Case | mask | develop ms | this PR ms | speedup | PR TFLOP/s |
|---|---|---:|---:|---:|---:|
| b1_h32_s4096 | dense | 3.184 | 2.767 | +15.1% | 993 |
| b1_h32_s4096 | causal | 2.454 | 2.177 | +12.7% | 631 |
| b1_h32_s8192 | dense | 12.655 | 11.232 | +12.7% | 979 |
| b1_h32_s8192 | causal | 8.186 | 7.416 | +10.4% | 741 |
| b1_h32x8_s8192, GQA 4:1 | dense | 12.832 | 11.321 | +13.3% | 971 |
| b1_h32x8_s8192, GQA 4:1 | causal | 8.426 | 7.621 | +10.6% | 721 |

Whole-chain speedup is **+12.4% geomean** across these six cases.

TFLOP/s counts useful work as `10 * B * H * S^2 * D`, with half the cells for causal masking. This covers five GEMM passes: two in stage 2 and three in stage 3.

## Profiler evidence

Nsight Compute 2026.2.1, stage-2 kernel at `b1_h32_s4096_d512_fp16_dense`, `--clock-control none`.

| Metric | develop | this PR |
|---|---:|---:|
| `derived__memory_l1_wavefronts_shared_excessive` | 234,881,024 | **0** |
| shared **LD** wavefronts/inst | **32.06** | **3.99** (ideal 4.00) |
| `smsp__sass_inst_executed_op_shared_{st,ld}.sum` | 8,388,872 / 4,211,876 | 8,388,872 / 4,211,876 |
| `smsp__average_warps_issue_stalled_short_scoreboard_per_issue_active.ratio` | 7.27 | 0.91 |

Excess shared wavefronts fall to zero without changing shared LD/ST instruction counts.

## Launch-shape invariants

Both versions use grid (64,32,1), block (256,1,1), 184 registers/thread, and 229,672 B dynamic shared memory per block. No API or workspace changes.

## Benchmark configuration

-   NVIDIA B200 (SM100), unlocked clocks, driver 580.126.09; CUDA Toolkit 12.8 (nvcc 12.8.93); PyTorch 2.13.0+cu130 (CUDA 13.0 build), nvidia-cutlass-dsl 4.7.1; FP16, d=512.
-   Baseline: develop `170c717b`. Baseline -> PR -> baseline in one session; `develop ms` averages both baseline runs.
-   CUPTI device time across the full backward chain, ~150 ms/case.

## Validation

-   Dense/THD backward suites: **76 passed** each with nvidia-cutlass-dsl 4.7.1 and 4.8.0.dev0.
-   Dense/causal/GQA spot checks: `dq/dk/dv` are **bit-identical** to develop; cosine similarity to the fp32 reference >= 0.99999.
-   Kernel-name prefix check fails on both develop and this PR with the same nine existing offenders.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fp32 score-transfer handling for supported workloads by applying consistent shared-memory data layouts during transfers.
  - Added validation to reject unsupported workspace swizzle widths and provide a clear configuration error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->