### PR TITLE
test(sdpa): waive zero-length sequences below cuDNN 9.25 in the random sweeps

### DIFF
--- a/test/python/sdpa/fp16.py
+++ b/test/python/sdpa/fp16.py
@@ -130,6 +130,12 @@ def validate_config(cfg):
         print("@@@@ Overall result: WAIVED, mixed-form sequence lengths require cuDNN 9.25.0 or higher.")
         pytest.skip("mixed-form sequence lengths (cumulative on one side only) require cuDNN 9.25.0 or higher")
 
+    # Same gate as test_sdpa_edge_cases.py: the random sweeps draw zero-length
+    # sequences (~10% per batch), which older engines answer with NaN rows.
+    if cudnn_version < "9.25.0" and (0 in cfg.seq_len_q or 0 in cfg.seq_len_kv):
+        print("@@@@ Overall result: WAIVED, zero sequence length SDPA requires cuDNN 9.25.0 or higher.")
+        pytest.skip("zero sequence length SDPA requires cuDNN 9.25.0 or higher")
+
 
 def allocate_tensors(cfg, rng_data_gen, perf=False):
     allocs = {}


### PR DESCRIPTION
## What

Waive configurations that contain a zero-length sequence when the backend is older
than cuDNN 9.25, in `exec_sdpa`, mirroring the gate that `test_sdpa_edge_cases.py`
already applies to its zero-seqlen cases (`zero sequence length SDPA requires
cuDNN >= 9.25.0`). Six lines; on cuDNN >= 9.25 nothing changes.

## Why

The random sweeps draw a zero-length sequence for a batch with ~10% probability
(`seq_len_q` since v1.18, `seq_len_kv` since a5ce256b). Zero-length sequences are a
9.25 feature: on cuDNN 9.22 the engine returns NaN for the query rows of a zero-KV
batch while the reference returns zeros, so every such draw fails —
`test_sdpa_random_fwd_ragged_L0` 67 / 256 and `test_sdpa_random_bwd_ragged_L0`
177 / 384 on an H200, identical before and after #910 and with the ragged stride-gap
fuzz on or off. Details and repro in #943.

## Verification

H200, frontend built from `develop`:

| cuDNN | | fwd ragged L0 | bwd ragged L0 |
|---|---|---|---|
| 9.22.0 | without this change | 67 failed / 189 passed | 177 failed / 103 passed / 104 skipped |
| 9.22.0 | with this change | 0 failed / 131 passed / 125 skipped | 0 failed / 22 passed / 362 skipped |
| 9.25.1.1 | (gate inactive) | 0 failed / 256 passed | 0 failed / 280 passed / 104 skipped |

Every config without a zero-length sequence is unaffected (131 / 131 and 22 / 22
still run and pass). `black` and the SPDX hook pass.

Refs #943.
