### PR TITLE
Add HSTU LMSD CuTe DSL forward and backward kernels

### DIFF
--- a/docs/fe-oss-apis/hstu/hstu_lmsd.md
+++ b/docs/fe-oss-apis/hstu/hstu_lmsd.md
@@ -1,0 +1,207 @@
+# HSTU LayerNorm-Multiply-SiLU-Dropout (LMSD)
+
+**This is an experimental API and subject to change.**
+
+## Overview
+
+HSTU LMSD is a fused training operation used by Hierarchical Sequential
+Transduction Unit (HSTU) models. For each row of `x`, it computes LayerNorm,
+applies the learned affine transform, multiplies the result by an optional
+`SiLU(u)`, and optionally applies inverted dropout. With
+
+$$
+\hat{x} = (x - \mathrm{mean}(x))\mathrm{rstd}(x),
+\qquad
+\ell = \hat{x} \odot \mathrm{weight} + \mathrm{bias},
+\qquad
+a = \begin{cases}\mathrm{SiLU}(u), & \text{when activation is enabled} \\ u, & \text{otherwise}.\end{cases}
+$$
+
+the mandatory result is `dropout(ell * a)`. The output optionally prepends
+`dropout(a)` and `dropout(x)` according to `concat_u` and `concat_x`:
+
+$$
+y = \left[
+    \mathrm{dropout}(a)\ \text{if the activated-u segment is enabled},
+    \mathrm{dropout}(x)\ \text{if the x segment is enabled},
+    \mathrm{dropout}(\ell \odot a)
+\right].
+$$
+
+When `dropout_ratio > 0`, the independent decisions are packed into one
+`int8` mask per input element: bit 0 corresponds to the mandatory LMSD result,
+bit 1 to the optional x segment, and bit 2 to the optional activated-u segment.
+A set bit means that the element is kept. Disabled auxiliary segments leave
+their bits clear. With `dropout_ratio=0`, Philox and mask traffic are compiled
+out and forward returns `mask_tensor=None`. Forward also returns the row-wise
+mean and reciprocal standard deviation needed by the explicit backward
+operation.
+
+This API does not register an autograd operator. Call
+`hstu_lmsd_backward` explicitly with the tensors saved by
+`hstu_lmsd_forward` and the matching four forward configuration parameters.
+
+## Installation
+
+Install cuDNN Frontend with the CuTe DSL optional dependencies and a supported
+PyTorch installation:
+
+```bash
+pip install nvidia-cudnn-frontend[cutedsl]
+pip install torch torch-c-dlpack-ext
+```
+
+From a source checkout, the PyTorch dependencies can instead be installed with
+`pip install --group torch`.
+
+The forward and backward functions are available through lazy top-level
+exports:
+
+```python
+from cudnn import hstu_lmsd_backward, hstu_lmsd_forward
+```
+
+## Supported configurations
+
+| Property | Support |
+| --- | --- |
+| GPU architecture | SM10x |
+| Input dtype | BF16 |
+| Rows (`N`) | Positive, with `N * D <= 2^31` |
+| Hidden dimension (`D`) | BF16 dimensions divisible by 8 in `8 <= D < 1024` |
+| `eps` | Positive and finite |
+| `dropout_ratio` | Finite and remains in `[0, 1)` after FP32 conversion |
+| `apply_u_silu` | Apply SiLU to u when true; use u directly when false |
+| `concat_u`, `concat_x` | Independently materialize the two auxiliary output segments |
+| `compute_dweight` | Backward may compile out dWeight and its workspace |
+
+All tensors must be CUDA tensors on the same device and have 16-byte-aligned
+storage. Output tensors and backward workspaces must not overlap inputs or one
+another.
+
+### Tensor shapes and layouts
+
+| Tensor | Shape | Dtype | Layout |
+| --- | --- | --- | --- |
+| `x`, `u` | `(N, D)` | BF16 | inner stride 1; each input independently supports a padded row stride |
+| `weight`, `bias` | `(D,)` | BF16 | contiguous |
+| `y`, `dy` | `(N, SD)` | BF16 | `S = 1 + concat_u + concat_x`; `y` is contiguous; `dy` may have a padded row stride |
+| `mean`, `rstd` | `(N,)` | FP32 | contiguous |
+| `mask` | `(N, D)` or `None` | `int8` | contiguous when dropout is enabled; `None` otherwise |
+| `dx`, `du` | `(N, D)` | BF16 | contiguous |
+| `dweight`, `dbias` | `(D,)` | BF16 | contiguous; dWeight may be `None` when disabled |
+
+For BF16 matrices with a padded row stride, each row must remain 16-byte
+aligned. A cached compiled implementation accepts any runtime `N` in the
+supported range. The `x`, `u`, and `dy` row strides are runtime values and do
+not participate in the compile-cache key; `D`, dtypes, devices, and feature
+flags remain plan-time configuration.
+
+The launch grid adapts to the runtime row count without changing the compiled
+plan. Forward caps its persistent row blocks by the device SM count. Backward
+uses at most one persistent tile per input row and caps large inputs at the
+device SM count times 64 persistent CTAs per SM. The compiled vector width,
+CTA shape, and backward row width are selected from `D`; they are not tied to
+one model shape.
+
+## Functions
+
+The allocating functions cache compiled API objects for repeated calls with
+the same tensor layout and configuration. The cache key excludes `N`, so one
+compiled kernel is reused across supported row counts:
+
+```python
+import torch
+
+from cudnn import hstu_lmsd_backward, hstu_lmsd_forward
+
+n, d = 257, 128
+x_storage = torch.randn((n, 3 * d), device="cuda", dtype=torch.bfloat16)
+x = x_storage[:, :d]
+u_storage = torch.randn((n, 4 * d), device="cuda", dtype=torch.bfloat16)
+u = u_storage[:, :d]
+weight = torch.randn((d,), device="cuda", dtype=torch.bfloat16)
+bias = torch.randn((d,), device="cuda", dtype=torch.bfloat16)
+
+saved = hstu_lmsd_forward(
+    x,
+    u,
+    weight,
+    bias,
+    eps=1e-6,
+    dropout_ratio=0.1,
+    seed=17,
+)
+y = saved["y_tensor"]
+
+dy = torch.randn_like(y)
+grads = hstu_lmsd_backward(
+    dy,
+    x,
+    u,
+    weight,
+    bias,
+    saved["mean_tensor"],
+    saved["rstd_tensor"],
+    saved["mask_tensor"],
+    dropout_ratio=0.1,
+    apply_u_silu=True,
+    concat_u=True,
+    concat_x=True,
+)
+dx = grads["dx_tensor"]
+du = grads["du_tensor"]
+dweight = grads["dweight_tensor"]
+dbias = grads["dbias_tensor"]
+```
+
+`hstu_lmsd_forward` returns a `TupleDict` in the order `y_tensor`,
+`mean_tensor`, `rstd_tensor`, and `mask_tensor`. `hstu_lmsd_backward` returns
+`dx_tensor`, `du_tensor`, `dweight_tensor`, and `dbias_tensor`. The backward
+function accepts optional caller-owned gradient output tensors. Pass
+`compute_dweight=False` for a non-trainable weight; the returned
+`dweight_tensor` is then `None`, and neither its FP32 workspace nor its
+reduction work is created.
+
+Forward and backward must use the same `dropout_ratio`, `apply_u_silu`,
+`concat_u`, `concat_x`, saved statistics, and optional packed mask. Pass all
+four configuration values explicitly to `hstu_lmsd_backward`; output tensors
+do not carry hidden Python metadata. The `seed` is a signed 64-bit integer.
+Pass `stream=` to enqueue wrapper allocation and execution on a specific
+`torch.cuda.Stream` or CUDA stream handle; `None` uses the current PyTorch CUDA
+stream.
+
+For example, this returns only the mandatory `LN(x) * u` segment, performs no
+dropout work, and skips dWeight:
+
+```python
+saved = hstu_lmsd_forward(
+    x,
+    u,
+    weight,
+    bias,
+    dropout_ratio=0.0,
+    apply_u_silu=False,
+    concat_u=False,
+    concat_x=False,
+)
+grads = hstu_lmsd_backward(
+    torch.randn_like(saved["y_tensor"]),
+    x,
+    u,
+    weight,
+    bias,
+    saved["mean_tensor"],
+    saved["rstd_tensor"],
+    saved["mask_tensor"],  # None for this configuration
+    dropout_ratio=0.0,
+    apply_u_silu=False,
+    concat_u=False,
+    concat_x=False,
+    compute_dweight=False,
+)
+assert grads["dweight_tensor"] is None
+```
+
+See the focused tests in [`test/python/fe_api/hstu/hstu_lmsd/`](../../../test/python/fe_api/hstu/hstu_lmsd/)
+for complete function calls.

--- a/docs/fe-oss-apis/overview.md
+++ b/docs/fe-oss-apis/overview.md
@@ -35,6 +35,7 @@ This folder documents the Python FE APIs implemented under `python/cudnn`. For d
 - [DeepSeek Sparse Attention (DSA)](dsa.md)
 - [Flex Attention](attention/flex_attention.md)
 - [HSTU Attention (Blackwell SM100/SM103)](hstu/hstu_attention.md)
+- [HSTU LayerNorm-Multiply-SiLU-Dropout (LMSD)](hstu/hstu_lmsd.md)
 - [Native Sparse Attention (NSA)](nsa.md)
 - [CSA Fused Compressor](csa.md)
 - [RMSNorm + RHT + Amax](rmsnorm_rht_amax.md)

--- a/python/cudnn/__init__.py
+++ b/python/cudnn/__init__.py
@@ -363,6 +363,8 @@ _LAZY_OPTIONAL_IMPORTS = {
     "grouped_gemm_dsrelu_wrapper_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_dsrelu_wrapper_sm100"),
     "hstu_attention_forward": (".hstu.hstu_attention", "hstu_attention_forward"),
     "hstu_attention_backward": (".hstu.hstu_attention", "hstu_attention_backward"),
+    "hstu_lmsd_forward": (".hstu.hstu_lmsd", "hstu_lmsd_forward"),
+    "hstu_lmsd_backward": (".hstu.hstu_lmsd", "hstu_lmsd_backward"),
     "GroupedGemmQuantSm100": (".gemm.cutedsl.grouped", "GroupedGemmQuantSm100"),
     "grouped_gemm_quant_wrapper_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_quant_wrapper_sm100"),
     "GroupedGemmGluSm100": (".gemm.cutedsl.grouped", "GroupedGemmGluSm100"),

--- a/python/cudnn/hstu/hstu_lmsd/__init__.py
+++ b/python/cudnn/hstu/hstu_lmsd/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Experimental functions for HSTU LayerNorm-Multiply-SiLU-Dropout."""
+
+from .ops import hstu_lmsd_backward, hstu_lmsd_forward
+
+__all__ = [
+    "hstu_lmsd_forward",
+    "hstu_lmsd_backward",
+]

--- a/python/cudnn/hstu/hstu_lmsd/_kernels/__init__.py
+++ b/python/cudnn/hstu/hstu_lmsd/_kernels/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/python/cudnn/hstu/hstu_lmsd/_kernels/_common.py
+++ b/python/cudnn/hstu/hstu_lmsd/_kernels/_common.py
@@ -64,6 +64,8 @@ def domain_offset_i64(
     ip=None,
 ) -> cute.Tensor:
     """Rebase a tensor with a 64-bit byte offset, preserving its layout."""
+    # Materializing the row base pointer separately gives ptxas better uniform-register
+    # allocation than cute.domain_offset for LMSD row views and produces faster code.
     flat_coord_i64 = tuple(cutlass.Int64(c) for c in cute.flatten(coord))
     flat_stride = cute.flatten_to_tuple(tensor.stride)
     assert len(flat_coord_i64) == len(flat_stride)

--- a/python/cudnn/hstu/hstu_lmsd/_kernels/_common.py
+++ b/python/cudnn/hstu/hstu_lmsd/_kernels/_common.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared constants and device helpers for the HSTU LMSD kernels."""
+
+import math
+import struct
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cutlass_dsl import dsl_user_op
+
+ALIGNMENT_BYTES = 16
+LOG2E = 1.4426950408889634
+HIDDEN_SIZE_GRANULARITY = 8
+MAX_HIDDEN_SIZE_EXCLUSIVE = 1024
+MAX_FLAT_ELEMENTS = 1 << 31
+
+_DROPOUT_KEEP_LMSD_BIT = 1 << 0
+_DROPOUT_KEEP_X_BIT = 1 << 1
+_DROPOUT_KEEP_U_BIT = 1 << 2
+
+
+def is_supported_hidden_size(hidden_size: int) -> bool:
+    return 0 < hidden_size < MAX_HIDDEN_SIZE_EXCLUSIVE and hidden_size % HIDDEN_SIZE_GRANULARITY == 0
+
+
+def round_to_float32(value: float) -> float:
+    """Round a host scalar exactly as a CuTe DSL Float32 argument."""
+    return struct.unpack("f", struct.pack("f", value))[0]
+
+
+def normalize_dropout_ratio(dropout_ratio: float) -> float:
+    """Validate and normalize a dropout ratio to its kernel representation."""
+    raw_dropout_ratio = float(dropout_ratio)
+    if not math.isfinite(raw_dropout_ratio) or not 0.0 <= raw_dropout_ratio < 1.0:
+        raise ValueError(f"dropout_ratio must be finite and in [0, 1), got {raw_dropout_ratio}")
+    normalized_dropout_ratio = round_to_float32(raw_dropout_ratio)
+    if not 0.0 <= normalized_dropout_ratio < 1.0:
+        raise ValueError("dropout_ratio must remain in [0, 1) after float32 conversion, " f"got {raw_dropout_ratio} -> {normalized_dropout_ratio}")
+    return normalized_dropout_ratio
+
+
+def keep_threshold32(dropout_ratio: float) -> int:
+    """Return the first uint32 Philox sample kept by the dropout comparison."""
+    dropout_ratio_f32 = normalize_dropout_ratio(dropout_ratio)
+    scale = round_to_float32(2.0**-32)
+    low, high = 0, 1 << 32
+    while low < high:
+        midpoint = (low + high) // 2
+        if round_to_float32(round_to_float32(midpoint) * scale) > dropout_ratio_f32:
+            high = midpoint
+        else:
+            low = midpoint + 1
+    return low
+
+
+@dsl_user_op
+def domain_offset_i64(
+    coord: cute.Coord,
+    tensor: cute.Tensor,
+    *,
+    loc=None,
+    ip=None,
+) -> cute.Tensor:
+    """Rebase a tensor with a 64-bit byte offset, preserving its layout."""
+    flat_coord_i64 = tuple(cutlass.Int64(c) for c in cute.flatten(coord))
+    flat_stride = cute.flatten_to_tuple(tensor.stride)
+    assert len(flat_coord_i64) == len(flat_stride)
+    element_offset = sum(c * s for c, s in zip(flat_coord_i64, flat_stride))
+    assert isinstance(tensor.iterator, cute.Pointer)
+    new_ptr = cute.make_ptr(
+        tensor.element_type,
+        tensor.iterator.toint() + element_offset * tensor.element_type.width // 8,
+        tensor.memspace,
+        assumed_align=tensor.iterator.max_alignment,
+    )
+    return cute.make_tensor(new_ptr, tensor.layout)

--- a/python/cudnn/hstu/hstu_lmsd/_kernels/_config.py
+++ b/python/cudnn/hstu/hstu_lmsd/_kernels/_config.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Launch configuration for the HSTU LMSD kernels."""
+
+from dataclasses import dataclass
+
+WARP_SIZE = 32
+
+
+@dataclass(frozen=True)
+class HSTULMSDFwdConfig:
+    vector_size: int = 4
+    threads_per_row: int = WARP_SIZE
+    rows_per_cta: int = 4
+    grid_ctas_per_sm: int = 192
+    min_blocks_per_mp: int = 8
+
+    @classmethod
+    def from_hidden_size(cls, hidden_size: int) -> "HSTULMSDFwdConfig":
+        if hidden_size >= 960:
+            return cls(vector_size=8, rows_per_cta=4, grid_ctas_per_sm=192, min_blocks_per_mp=6)
+        return cls()
+
+    def launch_grid(self, num_rows: int, multiprocessor_count: int) -> int:
+        row_blocks = (num_rows + self.rows_per_cta - 1) // self.rows_per_cta
+        return min(row_blocks, multiprocessor_count * self.grid_ctas_per_sm)
+
+
+@dataclass(frozen=True)
+class HSTULMSDBwdConfig:
+    vector_size: int
+    threads_per_row: int
+    rows_per_cta: int = 1
+    grid_ctas_per_sm: int = 64
+    min_blocks_per_mp: int = 12
+
+    @classmethod
+    def from_hidden_size(cls, hidden_size: int) -> "HSTULMSDBwdConfig":
+        if hidden_size <= 256:
+            return cls(vector_size=8, threads_per_row=WARP_SIZE)
+        if hidden_size <= 512:
+            return cls(vector_size=8, threads_per_row=2 * WARP_SIZE)
+        return cls(vector_size=8, threads_per_row=4 * WARP_SIZE, min_blocks_per_mp=8)
+
+    def workspace_rows(self, multiprocessor_count: int) -> int:
+        return multiprocessor_count * self.grid_ctas_per_sm
+
+    def launch_grid(self, num_rows: int, multiprocessor_count: int) -> int:
+        return min(num_rows, self.workspace_rows(multiprocessor_count))
+
+
+@dataclass(frozen=True)
+class HSTULMSDGradReduceConfig:
+    threads: int = 256
+    columns_per_cta: int = 4
+    prefetch_batch: int = 16
+
+    @property
+    def warps(self) -> int:
+        return self.threads // WARP_SIZE
+
+    @property
+    def rows_per_warp(self) -> int:
+        return WARP_SIZE // self.columns_per_cta
+
+    @property
+    def rows_per_cta(self) -> int:
+        return self.threads // self.columns_per_cta

--- a/python/cudnn/hstu/hstu_lmsd/_kernels/hstu_lmsd_bwd.py
+++ b/python/cudnn/hstu/hstu_lmsd/_kernels/hstu_lmsd_bwd.py
@@ -1,0 +1,462 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""CuTe DSL implementation of HSTU LMSD backward.
+
+The optional activated-U and X segments of ``dy`` precede the mandatory LMSD
+segment. Dropout, SiLU, and dWeight work are compile-time specializations.
+
+The persistent grid-stride main kernel emits per-CTA dW/dB partials. The
+companion ``HSTULMSDGradReduce`` kernel reduces those partials to the
+public gradients without depending on Triton.
+"""
+
+from cuda.bindings import driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.cute.math as _cm
+from cutlass import const_expr
+
+from ._common import (
+    _DROPOUT_KEEP_LMSD_BIT,
+    _DROPOUT_KEEP_U_BIT,
+    _DROPOUT_KEEP_X_BIT,
+    LOG2E,
+    domain_offset_i64,
+    is_supported_hidden_size,
+)
+from ._config import HSTULMSDBwdConfig, HSTULMSDGradReduceConfig, WARP_SIZE
+
+
+class HSTULMSDBackward:
+    """Compile-time configuration and device code for LMSD backward.
+
+    The JIT-callable object owns launch policy and its ``kernel`` method owns
+    device-side work. Tensor names use the same scope convention: ``m`` for
+    whole tensors, ``g`` for tiled global-memory views, ``t`` for per-thread
+    partitions, ``r`` for register fragments, and ``s`` for shared memory.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        *,
+        apply_u_silu: bool = True,
+        concat_u: bool = True,
+        concat_x: bool = True,
+        has_dropout: bool = True,
+        compute_dweight: bool = True,
+        config: HSTULMSDBwdConfig | None = None,
+    ):
+        if not is_supported_hidden_size(hidden_size):
+            raise ValueError(f"unsupported HSTU LMSD hidden size: {hidden_size}")
+        self.config = HSTULMSDBwdConfig.from_hidden_size(hidden_size) if config is None else config
+        self.hidden_size = hidden_size
+        self.min_blocks_per_mp = self.config.min_blocks_per_mp
+        self.rows_per_cta = self.config.rows_per_cta
+        assert self.rows_per_cta == 1, "this kernel requires one row per CTA"
+        self.threads_per_row = self.config.threads_per_row
+        self.vector_size = self.config.vector_size
+        self.warps_per_row = self.threads_per_row // WARP_SIZE
+        self.apply_u_silu = apply_u_silu
+        self.concat_u = concat_u
+        self.concat_x = concat_x
+        self.has_dropout = has_dropout
+        self.compute_dweight = compute_dweight
+
+    @cute.kernel
+    def kernel(
+        self,
+        gDYSilu: cute.Tensor,
+        gDYX: cute.Tensor,
+        gDYLmsd: cute.Tensor,
+        gX: cute.Tensor,
+        gU: cute.Tensor,
+        gW: cute.Tensor,
+        gB: cute.Tensor,
+        gMask: cute.Tensor,
+        gDX: cute.Tensor,
+        gDU: cute.Tensor,
+        gMean: cute.Tensor,
+        gRstd: cute.Tensor,
+        gDW: cute.Tensor,
+        gDB: cute.Tensor,
+        drop: cutlass.Float32,
+        thr_layout: cute.Layout,
+        val_layout: cute.Layout,
+        num_column_tiles: cutlass.Constexpr,
+        ncols: cutlass.Int32,
+        nblk: cutlass.Int32,
+        grid: cutlass.Int32,
+    ):
+        thread_idx, _, _ = cute.arch.thread_idx()
+        block_idx, _, _ = cute.arch.block_idx()
+        thread_in_row = thread_idx % self.threads_per_row
+        warp_in_row = thread_in_row // WARP_SIZE
+        reduction_smem = cute.make_tensor(
+            cute.arch.alloc_smem(cutlass.Float32, self.rows_per_cta * self.warps_per_row * 2),
+            cute.make_layout(self.rows_per_cta * self.warps_per_row * 2),
+        )
+
+        # Phase 1: establish copy and row-reduction resources. The wide X/U/dY
+        # row streams have no useful L1 reuse. Bypass L1 while
+        # retaining L2; keep the compact byte mask on the default cache policy.
+        wide_load_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyG2ROp(),
+            gX.element_type,
+            num_bits_per_copy=self.vector_size * 16,
+            load_cache_mode=cute.nvgpu.LoadCacheMode.GLOBAL,
+            l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.EVICT_NORMAL,
+            l2_prefetch_size=cute.nvgpu.L2PrefetchSize.NONE,
+        )
+        mask_copy_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), gMask.element_type) if const_expr(self.has_dropout) else None
+        tensor_copy_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), gX.element_type)
+        fp32_copy_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), gDB.element_type)
+        thread_copy = cute.make_tiled_copy_tv(tensor_copy_atom, thr_layout, val_layout).get_slice(thread_idx)
+        mask_thread_copy = cute.make_tiled_copy_tv(mask_copy_atom, thr_layout, val_layout).get_slice(thread_idx) if const_expr(self.has_dropout) else None
+        fp32_thread_copy = cute.make_tiled_copy_tv(fp32_copy_atom, thr_layout, val_layout).get_slice(thread_idx)
+
+        scale = cutlass.Float32(1.0) / (cutlass.Float32(1.0) - drop) if const_expr(self.has_dropout) else cutlass.Float32(1.0)
+        inv_d = cutlass.Float32(1.0) / ncols.to(cutlass.Float32)
+
+        # Phase 2: retain W/B and parameter-gradient accumulators across the
+        # persistent row loop.
+        rW_tiles, rB_tiles = [], []
+        for j in cutlass.range_constexpr(num_column_tiles):
+            for src, dst in ((gW, rW_tiles), (gB, rB_tiles)):
+                t = thread_copy.partition_S(src[((None, None), (0, j))])
+                f = cute.make_fragment_like(t)
+                vector_index = j * self.threads_per_row + thread_in_row
+                if const_expr(self.hidden_size % (self.threads_per_row * self.vector_size) == 0) or vector_index < self.hidden_size // self.vector_size:
+                    cute.copy(wide_load_atom, t, f)
+                dst.append(f)
+        rDW_accum = cute.make_rmem_tensor(num_column_tiles * self.vector_size, cutlass.Float32) if const_expr(self.compute_dweight) else None
+        rDB_accum = cute.make_rmem_tensor(num_column_tiles * self.vector_size, cutlass.Float32)
+        for e in cutlass.range_constexpr(num_column_tiles * self.vector_size):
+            if const_expr(self.compute_dweight):
+                rDW_accum[e] = cutlass.Float32(0.0)
+            rDB_accum[e] = cutlass.Float32(0.0)
+
+        tXgMask_rows = []
+        for j in cutlass.range_constexpr(num_column_tiles):
+            all_rows = ((None, None), (None, j))
+            if const_expr(self.has_dropout):
+                tXgMask_rows.append(mask_thread_copy.partition_S(gMask[all_rows]))
+
+        # Phase 3: process rows assigned to this persistent CTA.
+        for row_block in cutlass.range(block_idx, nblk, grid):
+            row = row_block
+            row_coord = ((0, 0), (row_block, 0))
+            gDYSilu_row = domain_offset_i64(row_coord, gDYSilu) if const_expr(self.concat_u) else None
+            gDYX_row = domain_offset_i64(row_coord, gDYX) if const_expr(self.concat_x) else None
+            gDYLmsd_row = domain_offset_i64(row_coord, gDYLmsd)
+            gX_row = domain_offset_i64(row_coord, gX)
+            gU_row = domain_offset_i64(row_coord, gU)
+            mean = gMean[row]
+            rstd = gRstd[row]
+            norm_bias = -mean * rstd
+            sum_xhat_wdy = cutlass.Float32(0.0)
+            sum_wdy = cutlass.Float32(0.0)
+            rXhat_tiles, rWdy_tiles, rDirectDX_tiles = [], [], []
+            for j in cutlass.range_constexpr(num_column_tiles):
+                rXhat = cute.make_rmem_tensor(self.vector_size, cutlass.Float32)
+                rWdy = cute.make_rmem_tensor(self.vector_size, cutlass.Float32)
+                rDirectDX = cute.make_rmem_tensor(self.vector_size, cutlass.Float32)
+                vector_index = j * self.threads_per_row + thread_in_row
+                if const_expr(self.hidden_size % (self.threads_per_row * self.vector_size) == 0) or vector_index < self.hidden_size // self.vector_size:
+                    tile_coord = ((None, None), (row_block, j))
+                    row_tile_coord = ((None, None), (0, j))
+                    tXgX = thread_copy.partition_S(gX_row[row_tile_coord])
+                    tXgU = thread_copy.partition_S(gU_row[row_tile_coord])
+                    tXgDYSilu = thread_copy.partition_S(gDYSilu_row[row_tile_coord]) if const_expr(self.concat_u) else None
+                    tXgDYX = thread_copy.partition_S(gDYX_row[row_tile_coord]) if const_expr(self.concat_x) else None
+                    tXgDYLmsd = thread_copy.partition_S(gDYLmsd_row[row_tile_coord])
+                    tXgMask = tXgMask_rows[j][None, None, None, row_block] if const_expr(self.has_dropout) else None
+
+                    rX = cute.make_fragment_like(tXgX)
+                    rU = cute.make_fragment_like(tXgU)
+                    rDYSilu = cute.make_fragment_like(tXgDYSilu) if const_expr(self.concat_u) else None
+                    rDYX = cute.make_fragment_like(tXgDYX) if const_expr(self.concat_x) else None
+                    rDYLmsd = cute.make_fragment_like(tXgDYLmsd)
+                    rMask = cute.make_fragment_like(tXgMask) if const_expr(self.has_dropout) else None
+                    cute.copy(wide_load_atom, tXgX, rX)
+                    cute.copy(wide_load_atom, tXgU, rU)
+                    if const_expr(self.concat_u):
+                        cute.copy(wide_load_atom, tXgDYSilu, rDYSilu)
+                    if const_expr(self.concat_x):
+                        cute.copy(wide_load_atom, tXgDYX, rDYX)
+                    cute.copy(wide_load_atom, tXgDYLmsd, rDYLmsd)
+                    if const_expr(self.has_dropout):
+                        cute.copy(mask_copy_atom, tXgMask, rMask)
+
+                    tXgDU = thread_copy.partition_D(gDU[tile_coord])
+                    rDU = cute.make_fragment_like(tXgDU)
+                    for e in cutlass.range_constexpr(self.vector_size):
+                        xf = rX[e].to(cutlass.Float32)
+                        uf = rU[e].to(cutlass.Float32)
+                        zero = cutlass.Float32(0.0)
+                        direct_du = zero
+                        direct_dx = zero
+                        if const_expr(self.has_dropout):
+                            mb = rMask[e].to(cutlass.Int32)
+                            if const_expr(self.concat_u):
+                                direct_du = rDYSilu[e].to(cutlass.Float32) * scale if (mb & _DROPOUT_KEEP_U_BIT) != 0 else zero
+                            if const_expr(self.concat_x):
+                                direct_dx = rDYX[e].to(cutlass.Float32) * scale if (mb & _DROPOUT_KEEP_X_BIT) != 0 else zero
+                            grad_lmsd = rDYLmsd[e].to(cutlass.Float32) * scale if (mb & _DROPOUT_KEEP_LMSD_BIT) != 0 else zero
+                        else:
+                            if const_expr(self.concat_u):
+                                direct_du = rDYSilu[e].to(cutlass.Float32)
+                            if const_expr(self.concat_x):
+                                direct_dx = rDYX[e].to(cutlass.Float32)
+                            grad_lmsd = rDYLmsd[e].to(cutlass.Float32)
+
+                        xh = _cm.fma(xf, rstd, norm_bias)
+                        ln = _cm.fma(xh, rW_tiles[j][e].to(cutlass.Float32), rB_tiles[j][e].to(cutlass.Float32))
+                        if const_expr(self.apply_u_silu):
+                            den = cutlass.Float32(1.0) + cute.arch.exp2(-uf * cutlass.Float32(LOG2E))
+                            sig = cute.arch.rcp_approx(den)
+                            activated_u = uf * sig
+                            dactivated_u = _cm.fma(activated_u, cutlass.Float32(1.0) - sig, sig)
+                        else:
+                            activated_u = uf
+                            dactivated_u = cutlass.Float32(1.0)
+
+                        du_from_lmsd = grad_lmsd * ln * dactivated_u
+                        grad_layer_norm = grad_lmsd * activated_u
+                        rDU[e] = (du_from_lmsd + direct_du * dactivated_u).to(gX.element_type)
+
+                        wd = rW_tiles[j][e].to(cutlass.Float32) * grad_layer_norm
+                        xh_e = xh
+                        sum_xhat_wdy = sum_xhat_wdy + xh_e * wd
+                        sum_wdy = sum_wdy + wd
+                        if const_expr(self.compute_dweight):
+                            rDW_accum[j * self.vector_size + e] = rDW_accum[j * self.vector_size + e] + grad_layer_norm * xh_e
+                        rDB_accum[j * self.vector_size + e] = rDB_accum[j * self.vector_size + e] + grad_layer_norm
+                        rXhat[e] = xh_e
+                        rWdy[e] = wd
+                        rDirectDX[e] = direct_dx
+
+                    cute.copy(tensor_copy_atom, rDU, tXgDU)
+                rXhat_tiles.append(rXhat)
+                rWdy_tiles.append(rWdy)
+                rDirectDX_tiles.append(rDirectDX)
+
+            # Reduce the two LayerNorm gradient statistics across both warps.
+            for off in cutlass.range_constexpr(5):
+                sum_xhat_wdy = sum_xhat_wdy + cute.arch.shuffle_sync_bfly(sum_xhat_wdy, 1 << off)
+                sum_wdy = sum_wdy + cute.arch.shuffle_sync_bfly(sum_wdy, 1 << off)
+            if thread_in_row % WARP_SIZE == 0:
+                reduction_smem[warp_in_row * 2 + 0] = sum_xhat_wdy
+                reduction_smem[warp_in_row * 2 + 1] = sum_wdy
+            cute.arch.sync_threads()
+            sum_xhat_wdy = cutlass.Float32(0.0)
+            sum_wdy = cutlass.Float32(0.0)
+            for source_warp in cutlass.range_constexpr(self.warps_per_row):
+                sum_xhat_wdy = sum_xhat_wdy + reduction_smem[source_warp * 2]
+                sum_wdy = sum_wdy + reduction_smem[source_warp * 2 + 1]
+            cute.arch.sync_threads()
+            sum_xhat_wdy = sum_xhat_wdy * inv_d
+            sum_wdy = sum_wdy * inv_d
+
+            # Complete dX once the row statistics are available.
+            for j in cutlass.range_constexpr(num_column_tiles):
+                vector_index = j * self.threads_per_row + thread_in_row
+                if const_expr(self.hidden_size % (self.threads_per_row * self.vector_size) == 0) or vector_index < self.hidden_size // self.vector_size:
+                    tile_coord = ((None, None), (row_block, j))
+                    tXgDX = thread_copy.partition_D(gDX[tile_coord])
+                    rDX = cute.make_fragment_like(tXgDX)
+                    for e in cutlass.range_constexpr(self.vector_size):
+                        rDX[e] = (rDirectDX_tiles[j][e] + (rWdy_tiles[j][e] - (rXhat_tiles[j][e] * sum_xhat_wdy + sum_wdy)) * rstd).to(gX.element_type)
+                    cute.copy(tensor_copy_atom, rDX, tXgDX)
+
+        # Phase 4: write this CTA's dW/dB partials for the companion reduction.
+        for j in cutlass.range_constexpr(num_column_tiles):
+            vector_index = j * self.threads_per_row + thread_in_row
+            if const_expr(self.hidden_size % (self.threads_per_row * self.vector_size) == 0) or vector_index < self.hidden_size // self.vector_size:
+                tile_coord = ((None, None), (block_idx, j))
+                tXgDW = fp32_thread_copy.partition_S(gDW[tile_coord]) if const_expr(self.compute_dweight) else None
+                tXgDB = fp32_thread_copy.partition_S(gDB[tile_coord])
+                rDW = cute.make_fragment_like(tXgDW) if const_expr(self.compute_dweight) else None
+                rDB = cute.make_fragment_like(tXgDB)
+                for e in cutlass.range_constexpr(self.vector_size):
+                    if const_expr(self.compute_dweight):
+                        rDW[e] = rDW_accum[j * self.vector_size + e]
+                    rDB[e] = rDB_accum[j * self.vector_size + e]
+                if const_expr(self.compute_dweight):
+                    cute.copy(fp32_copy_atom, rDW, tXgDW)
+                cute.copy(fp32_copy_atom, rDB, tXgDB)
+
+    @cute.jit
+    def __call__(
+        self,
+        mDYSilu: cute.Tensor,
+        mDYX: cute.Tensor,
+        mDYLmsd: cute.Tensor,
+        mX: cute.Tensor,
+        mU: cute.Tensor,
+        mW: cute.Tensor,
+        mB: cute.Tensor,
+        mMask: cute.Tensor,
+        mDX: cute.Tensor,
+        mDU: cute.Tensor,
+        mMean: cute.Tensor,
+        mRstd: cute.Tensor,
+        mDW: cute.Tensor,
+        mDB: cute.Tensor,
+        drop: cutlass.Float32,
+        ncols: cutlass.Int32,
+        nblk: cutlass.Int32,
+        grid: cutlass.Int32,
+        stream: cuda.CUstream,
+    ):
+        thr_layout = cute.make_ordered_layout((self.rows_per_cta, self.threads_per_row), order=(1, 0))
+        val_layout = cute.make_ordered_layout((1, self.vector_size), order=(1, 0))
+        tiler, _ = cute.make_layout_tv(thr_layout, val_layout)
+        tile = lambda tensor: cute.zipped_divide(tensor, tiler)
+        gX = tile(mX)
+        param_layout = cute.make_layout((1, cute.size(mW)), stride=(0, 1))
+        mW2 = cute.make_tensor(mW.iterator, param_layout)
+        mB2 = cute.make_tensor(mB.iterator, param_layout)
+        self.kernel(
+            tile(mDYSilu) if const_expr(self.concat_u) else None,
+            tile(mDYX) if const_expr(self.concat_x) else None,
+            tile(mDYLmsd),
+            gX,
+            tile(mU),
+            tile(mW2),
+            tile(mB2),
+            tile(mMask) if const_expr(self.has_dropout) else None,
+            tile(mDX),
+            tile(mDU),
+            mMean,
+            mRstd,
+            tile(mDW) if const_expr(self.compute_dweight) else None,
+            tile(mDB),
+            drop,
+            thr_layout,
+            val_layout,
+            cute.size(gX, mode=[1, 1]),
+            ncols,
+            nblk,
+            grid,
+        ).launch(
+            grid=(grid, 1, 1),
+            block=(cute.size(thr_layout), 1, 1),
+            smem=self.rows_per_cta * self.warps_per_row * 2 * 4,
+            min_blocks_per_mp=self.min_blocks_per_mp,
+            stream=stream,
+        )
+
+
+class HSTULMSDGradReduce:
+    """Reduce persistent-CTA dW/dB partials to the public gradients."""
+
+    def __init__(self, compute_dweight: bool = True, config: HSTULMSDGradReduceConfig | None = None):
+        self.config = HSTULMSDGradReduceConfig() if config is None else config
+        self.threads = self.config.threads
+        self.columns_per_cta = self.config.columns_per_cta
+        self.warps = self.config.warps
+        self.rows_per_warp = self.config.rows_per_warp
+        self.rows_per_cta = self.config.rows_per_cta
+        self.prefetch_batch = self.config.prefetch_batch
+        self.compute_dweight = compute_dweight
+
+    @cute.kernel
+    def kernel(
+        self,
+        mDW: cute.Tensor,
+        mDB: cute.Tensor,
+        mFinalDW: cute.Tensor,
+        mFinalDB: cute.Tensor,
+        nrows: cutlass.Int32,
+        ncols: cutlass.Int32,
+    ):
+        thread_idx, _, _ = cute.arch.thread_idx()
+        block_idx, _, _ = cute.arch.block_idx()
+        lane = thread_idx % WARP_SIZE
+        warp = thread_idx // WARP_SIZE
+        column_in_cta = lane % self.columns_per_cta
+        row_in_warp = lane // self.columns_per_cta
+        column = block_idx * self.columns_per_cta + column_in_cta
+        row = warp * self.rows_per_warp + row_in_warp
+
+        dw = cutlass.Float32(0.0)
+        db = cutlass.Float32(0.0)
+        rDW = cute.make_rmem_tensor(self.prefetch_batch, cutlass.Float32) if const_expr(self.compute_dweight) else None
+        rDB = cute.make_rmem_tensor(self.prefetch_batch, cutlass.Float32)
+        for row_base in cutlass.range(
+            row,
+            nrows,
+            self.rows_per_cta * self.prefetch_batch,
+            unroll=1,
+        ):
+            # Expose independent global loads before consuming them, then add
+            # in the original row, row+64, ... order. This retains bitwise
+            # results while hiding the dependent workspace-read latency.
+            for item in cutlass.range_constexpr(self.prefetch_batch):
+                if const_expr(self.compute_dweight):
+                    rDW[item] = cutlass.Float32(0.0)
+                rDB[item] = cutlass.Float32(0.0)
+                partial_row = row_base + item * self.rows_per_cta
+                if partial_row < nrows and column < ncols:
+                    if const_expr(self.compute_dweight):
+                        rDW[item] = mDW[(partial_row, column)]
+                    rDB[item] = mDB[(partial_row, column)]
+            for item in cutlass.range_constexpr(self.prefetch_batch):
+                if const_expr(self.compute_dweight):
+                    dw = dw + rDW[item]
+                db = db + rDB[item]
+
+        # Lanes 0/4/.../28 own one column. These XOR distances reduce the
+        # eight row positions while keeping the four columns independent.
+        for offset in cutlass.range_constexpr(self.rows_per_warp.bit_length() - 1):
+            delta = self.columns_per_cta << offset
+            if const_expr(self.compute_dweight):
+                dw = dw + cute.arch.shuffle_sync_bfly(dw, delta)
+            db = db + cute.arch.shuffle_sync_bfly(db, delta)
+
+        partials = cute.make_tensor(
+            cute.arch.alloc_smem(
+                cutlass.Float32,
+                self.warps * self.columns_per_cta * 2,
+            ),
+            cute.make_layout((self.warps, self.columns_per_cta, 2)),
+        )
+        if row_in_warp == 0:
+            if const_expr(self.compute_dweight):
+                partials[(warp, column_in_cta, 0)] = dw
+            partials[(warp, column_in_cta, 1)] = db
+        cute.arch.sync_threads()
+
+        if thread_idx < self.columns_per_cta:
+            final_dw = cutlass.Float32(0.0)
+            final_db = cutlass.Float32(0.0)
+            for source_warp in cutlass.range_constexpr(self.warps):
+                if const_expr(self.compute_dweight):
+                    final_dw = final_dw + partials[(source_warp, thread_idx, 0)]
+                final_db = final_db + partials[(source_warp, thread_idx, 1)]
+            output_column = block_idx * self.columns_per_cta + thread_idx
+            if output_column < ncols:
+                if const_expr(self.compute_dweight):
+                    mFinalDW[output_column] = final_dw.to(mFinalDW.element_type)
+                mFinalDB[output_column] = final_db.to(mFinalDB.element_type)
+
+    @cute.jit
+    def __call__(
+        self,
+        mDW: cute.Tensor,
+        mDB: cute.Tensor,
+        mFinalDW: cute.Tensor,
+        mFinalDB: cute.Tensor,
+        nrows: cutlass.Int32,
+        ncols: cutlass.Int32,
+        stream: cuda.CUstream,
+    ):
+        grid = (cute.size(mFinalDB) + self.columns_per_cta - 1) // self.columns_per_cta
+        self.kernel(mDW, mDB, mFinalDW, mFinalDB, nrows, ncols).launch(
+            grid=(grid, 1, 1),
+            block=(self.threads, 1, 1),
+            smem=self.warps * self.columns_per_cta * 2 * 4,
+            stream=stream,
+        )

--- a/python/cudnn/hstu/hstu_lmsd/_kernels/hstu_lmsd_fwd.py
+++ b/python/cudnn/hstu/hstu_lmsd/_kernels/hstu_lmsd_fwd.py
@@ -1,0 +1,336 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""CuTe DSL implementation of HSTU LMSD forward.
+
+The output contains optional activated-U and X segments followed by the
+mandatory LMSD segment. With all options enabled, it is laid out as:
+
+* segment 0: dropout(SiLU(u))
+* segment 1: dropout(x)
+* segment 2: dropout(LayerNorm(x) * SiLU(u))
+
+When dropout is enabled, one int8 mask stores the active keep decisions in
+bits 2, 1, and 0, respectively.
+"""
+
+from cuda.bindings import driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.cute.math as _cm
+from cutlass import const_expr
+
+from ._common import (
+    _DROPOUT_KEEP_LMSD_BIT,
+    _DROPOUT_KEEP_U_BIT,
+    _DROPOUT_KEEP_X_BIT,
+    LOG2E,
+    domain_offset_i64,
+    is_supported_hidden_size,
+)
+from ._config import HSTULMSDFwdConfig
+
+_PHILOX_M0, _PHILOX_M1 = 0xD2511F53, 0xCD9E8D57
+_PHILOX_W0, _PHILOX_W1 = 0x9E3779B9, 0xBB67AE85
+_PHILOX_MASK32 = 0xFFFFFFFF
+_PHILOX_ROUNDS = 10
+
+
+class HSTULMSDForward:
+    """Compile-time configuration and device code for LMSD forward.
+
+    Four warps process four independent rows per CTA.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        *,
+        apply_u_silu: bool = True,
+        concat_u: bool = True,
+        concat_x: bool = True,
+        has_dropout: bool = True,
+        config: HSTULMSDFwdConfig | None = None,
+    ):
+        if not is_supported_hidden_size(hidden_size):
+            raise ValueError(f"unsupported HSTU LMSD hidden size: {hidden_size}")
+        self.config = HSTULMSDFwdConfig.from_hidden_size(hidden_size) if config is None else config
+        self.hidden_size = hidden_size
+        self.threads_per_row = self.config.threads_per_row
+        self.rows_per_cta = self.config.rows_per_cta
+        self.vector_size = self.config.vector_size
+        self.min_blocks_per_mp = self.config.min_blocks_per_mp
+        self.apply_u_silu = apply_u_silu
+        self.concat_u = concat_u
+        self.concat_x = concat_x
+        self.has_dropout = has_dropout
+
+    @cute.jit
+    def _generate_dropout_mask(
+        self,
+        rMask: cute.Tensor,
+        row: cutlass.Int32,
+        philox_block: cutlass.Uint32,
+        key0: cutlass.Uint32,
+        key1: cutlass.Uint32,
+        thresh: cutlass.Uint32,
+    ):
+        for element in cutlass.range_constexpr(self.vector_size):
+            rMask[element] = cutlass.Int8(0)
+        philox_groups = self.vector_size // 4
+        for mask_plane in cutlass.range_constexpr(3):
+            plane_enabled = mask_plane == 0 or (mask_plane == 1 and self.concat_x) or (mask_plane == 2 and self.concat_u)
+            if const_expr(plane_enabled):
+                for group in cutlass.range_constexpr(philox_groups):
+                    counter0 = cutlass.Uint32(row)
+                    counter1 = philox_block * cutlass.Uint32(philox_groups) + cutlass.Uint32(group)
+                    counter2 = cutlass.Uint32(mask_plane)
+                    counter3 = cutlass.Uint32(0)
+                    round_key0, round_key1 = key0, key1
+                    multiplier0 = cutlass.Uint32(_PHILOX_M0)
+                    multiplier1 = cutlass.Uint32(_PHILOX_M1)
+                    for _round in cutlass.range_constexpr(_PHILOX_ROUNDS):
+                        product0 = cute.arch.mul_wide(multiplier0, counter0)
+                        product1 = cute.arch.mul_wide(multiplier1, counter2)
+                        high0 = (product0 >> cutlass.Uint64(32)).to(cutlass.Uint32)
+                        low0 = (product0 & cutlass.Uint64(_PHILOX_MASK32)).to(cutlass.Uint32)
+                        high1 = (product1 >> cutlass.Uint64(32)).to(cutlass.Uint32)
+                        low1 = (product1 & cutlass.Uint64(_PHILOX_MASK32)).to(cutlass.Uint32)
+                        counter0 = high1 ^ counter1 ^ round_key0
+                        counter1 = low1
+                        counter2 = high0 ^ counter3 ^ round_key1
+                        counter3 = low0
+                        round_key0 = round_key0 + cutlass.Uint32(_PHILOX_W0)
+                        round_key1 = round_key1 + cutlass.Uint32(_PHILOX_W1)
+                    words = (counter0, counter1, counter2, counter3)
+                    for word_index in cutlass.range_constexpr(4):
+                        element = group * 4 + word_index
+                        bit = cutlass.Int8(1 << mask_plane) if words[word_index] >= thresh else cutlass.Int8(0)
+                        rMask[element] = rMask[element] | bit
+
+    @cute.kernel
+    def kernel(
+        self,
+        gX: cute.Tensor,
+        gU: cute.Tensor,
+        gW: cute.Tensor,
+        gB: cute.Tensor,
+        gSiluOut: cute.Tensor,
+        gXOut: cute.Tensor,
+        gLmsdOut: cute.Tensor,
+        gMask: cute.Tensor,
+        gMean: cute.Tensor,
+        gRstd: cute.Tensor,
+        eps: cutlass.Float32,
+        drop: cutlass.Float32,
+        thresh: cutlass.Uint32,
+        thr_layout: cute.Layout,
+        val_layout: cute.Layout,
+        num_column_tiles: cutlass.Constexpr,
+        seed: cutlass.Int64,
+        nrows: cutlass.Int32,
+        ncols: cutlass.Int32,
+        num_row_blocks: cutlass.Int32,
+        num_iterations: cutlass.Int32,
+        grid_size: cutlass.Int32,
+    ):
+        thread_idx, _, _ = cute.arch.thread_idx()
+        block_idx, _, _ = cute.arch.block_idx()
+        lane = thread_idx % self.threads_per_row
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+
+        tensor_copy_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), gX.element_type)
+        mask_copy_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), gMask.element_type) if const_expr(self.has_dropout) else None
+        thread_copy = cute.make_tiled_copy_tv(tensor_copy_atom, thr_layout, val_layout).get_slice(lane)
+        mask_thread_copy = cute.make_tiled_copy_tv(mask_copy_atom, thr_layout, val_layout).get_slice(lane) if const_expr(self.has_dropout) else None
+
+        inv_d = cutlass.Float32(1.0) / ncols.to(cutlass.Float32)
+        scale = cutlass.Float32(1.0) / (cutlass.Float32(1.0) - drop) if const_expr(self.has_dropout) else cutlass.Float32(1.0)
+        if const_expr(self.has_dropout):
+            key0 = cutlass.Uint32(seed & _PHILOX_MASK32)
+            key1 = cutlass.Uint32((seed >> 32) & _PHILOX_MASK32)
+
+        # Runtime loop bounds preserve one compiled binary across all supported
+        # row counts while retaining the persistent grid-stride schedule.
+        for iteration in cutlass.range(num_iterations):
+            row_block = block_idx + iteration * grid_size
+            if row_block < num_row_blocks:
+                row = row_block * self.rows_per_cta + warp_idx
+                if row < nrows:
+                    row_coord = ((0, 0), (row, 0))
+                    gX_row = domain_offset_i64(row_coord, gX)
+                    sum_x = cutlass.Float32(0.0)
+                    sum_sq_x = cutlass.Float32(0.0)
+                    for column_tile in cutlass.range_constexpr(num_column_tiles):
+                        row_tile_coord = ((None, None), (0, column_tile))
+                        tXgReduction = thread_copy.partition_S(gX_row[row_tile_coord])
+                        rXReduction = cute.make_fragment_like(tXgReduction)
+                        if const_expr(self.hidden_size % (self.threads_per_row * self.vector_size) == 0):
+                            cute.copy(tensor_copy_atom, tXgReduction, rXReduction)
+                        else:
+                            for element in cutlass.range_constexpr(self.vector_size):
+                                rXReduction[element] = cutlass.BFloat16(0.0)
+                            vector_index = column_tile * self.threads_per_row + lane
+                            if vector_index < self.hidden_size // self.vector_size:
+                                cute.copy(tensor_copy_atom, tXgReduction, rXReduction)
+                        for element in cutlass.range_constexpr(self.vector_size):
+                            value = rXReduction[element].to(cutlass.Float32)
+                            sum_x = sum_x + value
+                            sum_sq_x = sum_sq_x + value * value
+
+                    for offset in cutlass.range_constexpr(self.threads_per_row.bit_length() - 1):
+                        sum_x = sum_x + cute.arch.shuffle_sync_bfly(sum_x, 1 << offset)
+                        sum_sq_x = sum_sq_x + cute.arch.shuffle_sync_bfly(sum_sq_x, 1 << offset)
+
+                    mean = sum_x * inv_d
+                    variance = cute.arch.fmax(sum_sq_x * inv_d - mean * mean, cutlass.Float32(0.0))
+                    rstd = cutlass.Float32(1.0) / _cm.sqrt(variance + eps)
+
+                    # Optional auxiliary segments and the mandatory LMSD segment
+                    # are views into one compact output allocation.
+                    gSiluOut_row = domain_offset_i64(row_coord, gSiluOut) if const_expr(self.concat_u) else None
+                    gXOut_row = domain_offset_i64(row_coord, gXOut) if const_expr(self.concat_x) else None
+                    gLmsdOut_row = domain_offset_i64(row_coord, gLmsdOut)
+                    gU_row = domain_offset_i64(row_coord, gU)
+
+                    for column_tile in cutlass.range_constexpr(num_column_tiles):
+                        vector_index = column_tile * self.threads_per_row + lane
+                        if const_expr(self.hidden_size % (self.threads_per_row * self.vector_size) == 0) or vector_index < self.hidden_size // self.vector_size:
+                            global_coord = ((None, None), (row, column_tile))
+                            local_coord = ((None, None), (0, column_tile))
+                            tXgSiluOut = thread_copy.partition_S(gSiluOut_row[local_coord]) if const_expr(self.concat_u) else None
+                            tXgXOut = thread_copy.partition_S(gXOut_row[local_coord]) if const_expr(self.concat_x) else None
+                            tXgLmsdOut = thread_copy.partition_S(gLmsdOut_row[local_coord])
+                            tXgMask = mask_thread_copy.partition_S(gMask[global_coord]) if const_expr(self.has_dropout) else None
+                            rSiluOut = cute.make_fragment_like(tXgSiluOut) if const_expr(self.concat_u) else None
+                            rXOut = cute.make_fragment_like(tXgXOut) if const_expr(self.concat_x) else None
+                            rLmsdOut = cute.make_fragment_like(tXgLmsdOut)
+                            rMask = cute.make_fragment_like(tXgMask) if const_expr(self.has_dropout) else None
+
+                            # Reload X only after the reduction fragment is dead,
+                            # limiting the register live range in the output pass.
+                            tXgX = thread_copy.partition_S(gX_row[local_coord])
+                            tXgU = thread_copy.partition_S(gU_row[local_coord])
+                            rX = cute.make_fragment_like(tXgX)
+                            rU = cute.make_fragment_like(tXgU)
+                            cute.copy(tensor_copy_atom, tXgX, rX)
+                            cute.copy(tensor_copy_atom, tXgU, rU)
+
+                            if const_expr(self.has_dropout):
+                                philox_block = cutlass.Uint32(column_tile * self.threads_per_row) + cutlass.Uint32(lane)
+                                self._generate_dropout_mask(rMask, row, philox_block, key0, key1, thresh)
+
+                            # W/B do not participate in Philox. Loading them here
+                            # shortens their live range through the integer loop.
+                            parameter_coord = ((None, None), (0, column_tile))
+                            tXgW = thread_copy.partition_S(gW[parameter_coord])
+                            tXgB = thread_copy.partition_S(gB[parameter_coord])
+                            rW = cute.make_fragment_like(tXgW)
+                            rB = cute.make_fragment_like(tXgB)
+                            cute.copy(tensor_copy_atom, tXgW, rW)
+                            cute.copy(tensor_copy_atom, tXgB, rB)
+
+                            zero = cutlass.Float32(0.0)
+                            for element in cutlass.range_constexpr(self.vector_size):
+                                x_value = rX[element].to(cutlass.Float32)
+                                u_value = rU[element].to(cutlass.Float32)
+                                weight = rW[element].to(cutlass.Float32)
+                                bias = rB[element].to(cutlass.Float32)
+                                layer_norm = (x_value - mean) * rstd * weight + bias
+                                if const_expr(self.apply_u_silu):
+                                    denominator = cutlass.Float32(1.0) + cute.arch.exp2(-u_value * cutlass.Float32(LOG2E))
+                                    activated_u = _cm.div(u_value, denominator, approx=True)
+                                else:
+                                    activated_u = u_value
+                                if const_expr(self.has_dropout):
+                                    mask_bits = rMask[element].to(cutlass.Int32)
+                                    dropped_u = activated_u * scale if (mask_bits & _DROPOUT_KEEP_U_BIT) != 0 else zero
+                                    dropped_x = x_value * scale if (mask_bits & _DROPOUT_KEEP_X_BIT) != 0 else zero
+                                    dropped_lmsd = layer_norm * activated_u * scale if (mask_bits & _DROPOUT_KEEP_LMSD_BIT) != 0 else zero
+                                else:
+                                    dropped_u = activated_u
+                                    dropped_x = x_value
+                                    dropped_lmsd = layer_norm * activated_u
+                                if const_expr(self.concat_u):
+                                    rSiluOut[element] = dropped_u.to(gX.element_type)
+                                if const_expr(self.concat_x):
+                                    rXOut[element] = dropped_x.to(gX.element_type)
+                                rLmsdOut[element] = dropped_lmsd.to(gX.element_type)
+
+                            if const_expr(self.concat_x):
+                                cute.copy(tensor_copy_atom, rXOut, tXgXOut)
+                            if const_expr(self.concat_u):
+                                cute.copy(tensor_copy_atom, rSiluOut, tXgSiluOut)
+                            cute.copy(tensor_copy_atom, rLmsdOut, tXgLmsdOut)
+                            if const_expr(self.has_dropout):
+                                cute.copy(mask_copy_atom, rMask, tXgMask)
+
+                    if lane == 0:
+                        gMean[row] = mean
+                        gRstd[row] = rstd
+
+    @cute.jit
+    def __call__(
+        self,
+        mX: cute.Tensor,
+        mU: cute.Tensor,
+        mW: cute.Tensor,
+        mB: cute.Tensor,
+        mSiluOut: cute.Tensor,
+        mXOut: cute.Tensor,
+        mLmsdOut: cute.Tensor,
+        mMask: cute.Tensor,
+        mMean: cute.Tensor,
+        mRstd: cute.Tensor,
+        seed: cutlass.Int64,
+        nrows: cutlass.Int32,
+        ncols: cutlass.Int32,
+        eps: cutlass.Float32,
+        drop: cutlass.Float32,
+        thresh: cutlass.Uint32,
+        num_row_blocks: cutlass.Int32,
+        num_iterations: cutlass.Int32,
+        grid_size: cutlass.Int32,
+        stream: cuda.CUstream,
+    ):
+        thr_layout = cute.make_ordered_layout((1, self.threads_per_row), order=(1, 0))
+        val_layout = cute.make_ordered_layout((1, self.vector_size), order=(1, 0))
+        tiler, _ = cute.make_layout_tv(thr_layout, val_layout)
+        tile = lambda tensor: cute.zipped_divide(tensor, tiler)
+
+        gX = tile(mX)
+        gSiluOut = tile(mSiluOut) if const_expr(self.concat_u) else None
+        param_layout = cute.make_layout((1, cute.size(mW)), stride=(0, 1))
+        mW2 = cute.make_tensor(mW.iterator, param_layout)
+        mB2 = cute.make_tensor(mB.iterator, param_layout)
+
+        self.kernel(
+            gX,
+            tile(mU),
+            tile(mW2),
+            tile(mB2),
+            gSiluOut,
+            tile(mXOut) if const_expr(self.concat_x) else None,
+            tile(mLmsdOut),
+            tile(mMask) if const_expr(self.has_dropout) else None,
+            mMean,
+            mRstd,
+            eps,
+            drop,
+            thresh,
+            thr_layout,
+            val_layout,
+            (self.hidden_size + self.threads_per_row * self.vector_size - 1) // (self.threads_per_row * self.vector_size),
+            seed,
+            nrows,
+            ncols,
+            num_row_blocks,
+            num_iterations,
+            grid_size,
+        ).launch(
+            grid=(grid_size, 1, 1),
+            block=(self.rows_per_cta * self.threads_per_row, 1, 1),
+            smem=0,
+            min_blocks_per_mp=self.min_blocks_per_mp,
+            stream=stream,
+        )

--- a/python/cudnn/hstu/hstu_lmsd/_runtime.py
+++ b/python/cudnn/hstu/hstu_lmsd/_runtime.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared runtime helpers for the HSTU LMSD APIs and wrappers."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+from cuda.bindings import driver as cuda
+import torch
+
+
+def tensor_signature(tensor: torch.Tensor, *, dynamic_rows: bool = False) -> tuple:
+    """Return the stride-independent plan-time tensor contract."""
+    shape = tuple(tensor.shape)
+    if dynamic_rows:
+        shape = (None, *shape[1:])
+    return shape, tensor.dtype, tensor.device
+
+
+def as_torch_stream(stream, device: torch.device) -> torch.cuda.Stream:
+    """Return a PyTorch stream view for a torch stream or CUDA stream handle."""
+    if isinstance(stream, torch.cuda.Stream):
+        if stream.device != device:
+            raise ValueError(f"stream must be on {device}, got {stream.device}")
+        return stream
+    if int(stream) == 0:
+        return torch.cuda.default_stream(device)
+    return torch.cuda.ExternalStream(int(stream), device=device)
+
+
+def allocation_context(stream, device: torch.device):
+    """Allocate on the launch stream when the caller supplies one."""
+    if stream is None:
+        return nullcontext()
+    return torch.cuda.stream(as_torch_stream(stream, device))
+
+
+def stream_handle(
+    stream: cuda.CUstream | torch.cuda.Stream | None,
+    device: torch.device,
+) -> cuda.CUstream:
+    """Normalize an optional stream to the CUDA handle expected by CuTe DSL."""
+    if stream is None:
+        return cuda.CUstream(torch.cuda.current_stream(device).cuda_stream)
+    if isinstance(stream, torch.cuda.Stream):
+        as_torch_stream(stream, device)
+        return cuda.CUstream(stream.cuda_stream)
+    return stream
+
+
+def record_streams(tensors, stream, device: torch.device) -> None:
+    """Keep tensor storage alive on an explicitly selected launch stream."""
+    if stream is None:
+        return
+    torch_stream = as_torch_stream(stream, device)
+    for tensor in tensors:
+        tensor.record_stream(torch_stream)

--- a/python/cudnn/hstu/hstu_lmsd/api.py
+++ b/python/cudnn/hstu/hstu_lmsd/api.py
@@ -1,0 +1,742 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal compile/execute implementations for the HSTU LMSD functions."""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+from cuda.bindings import driver as cuda
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.runtime import make_fake_stream
+import torch
+
+from cudnn.api_base import APIBase, TensorDesc
+
+from ._runtime import record_streams, stream_handle
+from ._kernels._common import (
+    ALIGNMENT_BYTES,
+    HIDDEN_SIZE_GRANULARITY,
+    MAX_FLAT_ELEMENTS,
+    MAX_HIDDEN_SIZE_EXCLUSIVE,
+    is_supported_hidden_size,
+    keep_threshold32,
+    normalize_dropout_ratio,
+)
+from ._kernels._config import HSTULMSDBwdConfig, HSTULMSDFwdConfig, HSTULMSDGradReduceConfig
+from ._kernels.hstu_lmsd_fwd import HSTULMSDForward
+from ._kernels.hstu_lmsd_bwd import HSTULMSDBackward, HSTULMSDGradReduce
+
+
+def _require_cuda_tensor(tensor: torch.Tensor, name: str) -> None:
+    if not tensor.is_cuda:
+        raise ValueError(f"{name} must be a CUDA tensor")
+    if tensor.data_ptr() % ALIGNMENT_BYTES != 0:
+        raise ValueError(f"{name} storage must be {ALIGNMENT_BYTES}-byte aligned")
+
+
+def _require_same_device_desc(reference: TensorDesc, tensors) -> None:
+    if reference.device.type != "cuda":
+        raise ValueError(f"{reference.name} must be on a CUDA device, got {reference.device}")
+    for name, desc in tensors:
+        if desc.device.type != "cuda":
+            raise ValueError(f"{name} must be on a CUDA device, got {desc.device}")
+        if desc.device != reference.device:
+            raise ValueError(f"{name} must be on {reference.device}, got {desc.device}")
+
+
+def _require_matrix_layout(
+    tensor: torch.Tensor | TensorDesc,
+    name: str,
+    *,
+    row_stride: Optional[int] = None,
+) -> None:
+    shape = tuple(tensor.shape)
+    stride_attr = tensor.stride
+    stride = tuple(stride_attr() if callable(stride_attr) else stride_attr)
+    if tensor.ndim != 2:
+        raise ValueError(f"{name} must be rank 2, got shape {shape}")
+    if stride[1] != 1:
+        raise ValueError(f"{name} must have a unit innermost stride")
+    if row_stride is not None and stride[0] != row_stride:
+        raise ValueError(f"{name} row stride must be {row_stride}, got {stride[0]}")
+    if stride[0] < shape[1]:
+        raise ValueError(f"{name} rows must not overlap")
+    if tensor.dtype == torch.bfloat16 and stride[0] % 8 != 0:
+        raise ValueError(f"{name} row starts must remain 16-byte aligned")
+
+
+def _require_vector(desc: TensorDesc, name: str, length: int) -> None:
+    if desc.shape != (length,) or desc.stride != (1,):
+        raise ValueError(f"{name} must be contiguous with shape ({length},), got " f"shape {tuple(desc.shape)} and stride {tuple(desc.stride)}")
+
+
+def _check_runtime_tensor(
+    tensor: torch.Tensor,
+    desc: TensorDesc,
+    name: str,
+    *,
+    num_rows: Optional[int] = None,
+    dynamic_row_stride: bool = False,
+) -> None:
+    expected_shape = tuple(desc.shape) if num_rows is None else (num_rows, *desc.shape[1:])
+    stride_mismatch = not dynamic_row_stride and tuple(tensor.stride()) != tuple(desc.stride)
+    if expected_shape != tuple(tensor.shape) or stride_mismatch or tensor.dtype != desc.dtype or tensor.device != desc.device:
+        raise ValueError(f"{name} specification changed after compilation")
+    if dynamic_row_stride:
+        _require_matrix_layout(tensor, name)
+    _require_cuda_tensor(tensor, name)
+
+
+def _storage_span(tensor: torch.Tensor) -> tuple[int, int]:
+    start = tensor.data_ptr()
+    offset = sum((int(size) - 1) * int(stride) for size, stride in zip(tensor.shape, tensor.stride()) if size > 0)
+    return start, start + (offset + 1) * tensor.element_size()
+
+
+def _require_disjoint(writes, reads) -> None:
+    all_tensors = tuple(reads) + tuple(writes)
+    for write_name, write_tensor in writes:
+        write_begin, write_end = _storage_span(write_tensor)
+        for other_name, other_tensor in all_tensors:
+            if write_name == other_name and write_tensor is other_tensor:
+                continue
+            if write_tensor.device != other_tensor.device:
+                continue
+            other_begin, other_end = _storage_span(other_tensor)
+            if write_begin < other_end and other_begin < write_end:
+                raise ValueError(f"{write_name} storage must not overlap {other_name} storage")
+
+
+class _HSTULMSDBase(APIBase):
+    """Validation and dynamic fake-tensor helpers shared by forward/backward."""
+
+    def _init_common(
+        self,
+        *,
+        sample_x: torch.Tensor | TensorDesc,
+        sample_u: torch.Tensor | TensorDesc,
+        sample_weight: torch.Tensor | TensorDesc,
+        sample_bias: torch.Tensor | TensorDesc,
+        dropout_ratio: float,
+    ) -> None:
+        super().__init__()
+        self._warn_experimental_api()
+        self.x_desc = self._make_tensor_desc(sample_x, name="x")
+        self.u_desc = self._make_tensor_desc(sample_u, name="u")
+        self.weight_desc = self._make_tensor_desc(sample_weight, name="weight")
+        self.bias_desc = self._make_tensor_desc(sample_bias, name="bias")
+        self.dropout_ratio = float(dropout_ratio)
+        if self.x_desc.ndim != 2:
+            raise ValueError("x must be rank 2")
+        self.num_rows = int(self.x_desc.shape[0])
+        self.hidden_size = int(self.x_desc.shape[1])
+
+    def _check_common(self) -> None:
+        x = self.x_desc
+        u = self.u_desc
+        weight = self.weight_desc
+        bias = self.bias_desc
+        _require_same_device_desc(
+            x,
+            (("u", u), ("weight", weight), ("bias", bias)),
+        )
+        if x.dtype != torch.bfloat16:
+            raise ValueError(f"x must have dtype torch.bfloat16, got {x.dtype}")
+        if u.dtype != x.dtype or weight.dtype != x.dtype or bias.dtype != x.dtype:
+            raise ValueError("x, u, weight, and bias must have the same dtype")
+        if x.shape != u.shape:
+            raise ValueError(f"u must have shape {tuple(x.shape)}, got {tuple(u.shape)}")
+        if not is_supported_hidden_size(self.hidden_size):
+            raise ValueError(
+                f"HSTU LMSD supports D divisible by {HIDDEN_SIZE_GRANULARITY} in "
+                f"[{HIDDEN_SIZE_GRANULARITY}, {MAX_HIDDEN_SIZE_EXCLUSIVE}), got D={self.hidden_size}"
+            )
+        self.max_num_rows = MAX_FLAT_ELEMENTS // self.hidden_size
+        if not 1 <= self.num_rows <= self.max_num_rows:
+            raise ValueError(f"x row count must be in [1, {self.max_num_rows}] for D={self.hidden_size}, got {self.num_rows}")
+        _require_matrix_layout(x, "x")
+        _require_matrix_layout(u, "u")
+        _require_vector(weight, "weight", self.hidden_size)
+        _require_vector(bias, "bias", self.hidden_size)
+        self.dropout_ratio = normalize_dropout_ratio(self.dropout_ratio)
+        major, minor = torch.cuda.get_device_capability(x.device)
+        if major != 10:
+            raise RuntimeError(f"HSTU LMSD requires an SM10x GPU; found SM{major}{minor}")
+
+    def _check_runtime_common(
+        self,
+        x: torch.Tensor,
+        u: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor,
+    ) -> int:
+        if x.ndim != 2 or x.shape[0] <= 0:
+            raise ValueError(f"x must be rank 2 with at least one row, got shape {tuple(x.shape)}")
+        num_rows = int(x.shape[0])
+        if num_rows > self.max_num_rows:
+            raise ValueError(f"x row count must be in [1, {self.max_num_rows}] for D={self.hidden_size}, got {num_rows}")
+        for tensor, desc, name, dynamic_rows, dynamic_row_stride in (
+            (x, self.x_desc, "x", True, True),
+            (u, self.u_desc, "u", True, True),
+            (weight, self.weight_desc, "weight", False, False),
+            (bias, self.bias_desc, "bias", False, False),
+        ):
+            _check_runtime_tensor(
+                tensor,
+                desc,
+                name,
+                num_rows=num_rows if dynamic_rows else None,
+                dynamic_row_stride=dynamic_row_stride,
+            )
+        return num_rows
+
+    def _fake_matrix(self, desc, rows, *, dynamic_row_stride: bool = False) -> cute.Tensor:
+        stride = (cute.sym_int64(divisibility=8), 1) if dynamic_row_stride else desc.stride
+        return self._make_fake_cute_tensor(
+            dtype=desc.dtype,
+            shape=(rows, desc.shape[1]),
+            stride=stride,
+            assumed_align=ALIGNMENT_BYTES,
+        )
+
+    def _fake_vector(self, desc, length=None) -> cute.Tensor:
+        return self._make_fake_cute_tensor(
+            dtype=desc.dtype,
+            shape=(desc.shape[0] if length is None else length,),
+            stride=desc.stride,
+            assumed_align=ALIGNMENT_BYTES,
+        )
+
+
+class HSTULMSDFwd(_HSTULMSDBase):
+    """Explicit compile/execute API for HSTU LMSD forward on SM10x."""
+
+    def __init__(
+        self,
+        sample_x: torch.Tensor | TensorDesc,
+        sample_u: torch.Tensor | TensorDesc,
+        sample_weight: torch.Tensor | TensorDesc,
+        sample_bias: torch.Tensor | TensorDesc,
+        sample_y: torch.Tensor | TensorDesc,
+        sample_mean: torch.Tensor | TensorDesc,
+        sample_rstd: torch.Tensor | TensorDesc,
+        sample_mask: torch.Tensor | TensorDesc | None,
+        eps: float = 1e-6,
+        dropout_ratio: float = 0.1,
+        apply_u_silu: bool = True,
+        concat_u: bool = True,
+        concat_x: bool = True,
+    ) -> None:
+        self._init_common(
+            sample_x=sample_x,
+            sample_u=sample_u,
+            sample_weight=sample_weight,
+            sample_bias=sample_bias,
+            dropout_ratio=dropout_ratio,
+        )
+        self.y_desc = self._make_tensor_desc(sample_y, name="y")
+        self.mean_desc = self._make_tensor_desc(sample_mean, name="mean")
+        self.rstd_desc = self._make_tensor_desc(sample_rstd, name="rstd")
+        self.mask_desc = self._make_tensor_desc(sample_mask, name="mask") if sample_mask is not None else None
+        self.eps = float(eps)
+        self.apply_u_silu = bool(apply_u_silu)
+        self.concat_u = bool(concat_u)
+        self.concat_x = bool(concat_x)
+        self.output_segments = 1 + int(self.concat_u) + int(self.concat_x)
+        self._kernel_config = HSTULMSDFwdConfig.from_hidden_size(self.hidden_size)
+
+    def check_support(self) -> bool:
+        if self._is_supported:
+            return True
+        self._check_common()
+        self.has_dropout = self.dropout_ratio > 0.0
+        self._threshold = keep_threshold32(self.dropout_ratio) if self.has_dropout else 0
+        n, d = self.num_rows, self.hidden_size
+        y = self.y_desc
+        mean = self.mean_desc
+        rstd = self.rstd_desc
+        mask = self.mask_desc
+        _require_same_device_desc(
+            self.x_desc,
+            (("y", y), ("mean", mean), ("rstd", rstd)) + ((("mask", mask),) if mask is not None else ()),
+        )
+        output_width = self.output_segments * d
+        if y.shape != (n, output_width) or y.dtype != self.x_desc.dtype:
+            raise ValueError(f"y must have shape ({n}, {output_width}) and dtype {self.x_desc.dtype}")
+        _require_matrix_layout(y, "y", row_stride=output_width)
+        for tensor, name in ((mean, "mean"), (rstd, "rstd")):
+            _require_vector(tensor, name, n)
+            if tensor.dtype != torch.float32:
+                raise ValueError(f"{name} must have dtype torch.float32")
+        if self.has_dropout:
+            if mask is None:
+                raise ValueError("mask must be provided when dropout_ratio is nonzero")
+            if mask.shape != (n, d) or mask.dtype != torch.int8:
+                raise ValueError(f"mask must have shape ({n}, {d}) and dtype torch.int8")
+            _require_matrix_layout(mask, "mask", row_stride=d)
+        elif mask is not None:
+            raise ValueError("mask must be None when dropout_ratio is zero")
+        if not math.isfinite(self.eps) or self.eps <= 0.0:
+            raise ValueError(f"eps must be positive and finite, got {self.eps}")
+        self._multiprocessor_count = torch.cuda.get_device_properties(self.x_desc.device).multi_processor_count
+        self._is_supported = True
+        return True
+
+    def compile(self) -> None:
+        self._ensure_support_checked()
+        if self._compiled_kernel is not None:
+            return
+        rows = cute.sym_int()
+        fake_x = self._fake_matrix(self.x_desc, rows, dynamic_row_stride=True)
+        fake_u = self._fake_matrix(self.u_desc, rows, dynamic_row_stride=True)
+        fake_weight = self._fake_vector(self.weight_desc)
+        fake_bias = self._fake_vector(self.bias_desc)
+        fake_output_segment = self._make_fake_cute_tensor(
+            dtype=self.y_desc.dtype,
+            shape=(rows, self.hidden_size),
+            stride=self.y_desc.stride,
+            assumed_align=ALIGNMENT_BYTES,
+        )
+        # Every materialized segment has the same plan-time tensor contract.
+        fake_silu_output = fake_output_segment
+        fake_x_output = fake_output_segment
+        fake_lmsd_output = fake_output_segment
+        fake_mask = self._fake_matrix(self.mask_desc, rows) if self.has_dropout else fake_x
+        fake_mean = self._fake_vector(self.mean_desc, rows)
+        fake_rstd = self._fake_vector(self.rstd_desc, rows)
+        fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
+        self._compiled_kernel = cute.compile(
+            HSTULMSDForward(
+                self.hidden_size,
+                apply_u_silu=self.apply_u_silu,
+                concat_u=self.concat_u,
+                concat_x=self.concat_x,
+                has_dropout=self.has_dropout,
+                config=self._kernel_config,
+            ),
+            fake_x,
+            fake_u,
+            fake_weight,
+            fake_bias,
+            fake_silu_output,
+            fake_x_output,
+            fake_lmsd_output,
+            fake_mask,
+            fake_mean,
+            fake_rstd,
+            cutlass.Int64(0),
+            cutlass.Int32(1),
+            cutlass.Int32(self.hidden_size),
+            cutlass.Float32(self.eps),
+            cutlass.Float32(self.dropout_ratio),
+            cutlass.Uint32(self._threshold),
+            cutlass.Int32(1),
+            cutlass.Int32(1),
+            cutlass.Int32(1),
+            fake_stream,
+            options="--enable-tvm-ffi",
+        )
+
+    def execute(
+        self,
+        x_tensor: torch.Tensor,
+        u_tensor: torch.Tensor,
+        weight_tensor: torch.Tensor,
+        bias_tensor: torch.Tensor,
+        y_tensor: torch.Tensor,
+        mean_tensor: torch.Tensor,
+        rstd_tensor: torch.Tensor,
+        mask_tensor: Optional[torch.Tensor],
+        seed: int,
+        current_stream: Optional[cuda.CUstream | torch.cuda.Stream] = None,
+    ) -> None:
+        if self._compiled_kernel is None:
+            raise RuntimeError("HSTULMSDFwd kernel is not compiled")
+        n = self._check_runtime_common(x_tensor, u_tensor, weight_tensor, bias_tensor)
+        for tensor, desc, name in (
+            (y_tensor, self.y_desc, "y"),
+            (mean_tensor, self.mean_desc, "mean"),
+            (rstd_tensor, self.rstd_desc, "rstd"),
+        ):
+            _check_runtime_tensor(tensor, desc, name, num_rows=n)
+        if self.has_dropout:
+            if mask_tensor is None:
+                raise ValueError("mask_tensor is required by the compiled dropout configuration")
+            _check_runtime_tensor(mask_tensor, self.mask_desc, "mask", num_rows=n)
+        elif mask_tensor is not None:
+            raise ValueError("mask_tensor must be None for the compiled no-dropout configuration")
+        if not -(1 << 63) <= int(seed) < (1 << 63):
+            raise ValueError("seed must fit in a signed 64-bit integer")
+        writes = (("y", y_tensor), ("mean", mean_tensor), ("rstd", rstd_tensor))
+        if mask_tensor is not None:
+            writes += (("mask", mask_tensor),)
+        _require_disjoint(
+            writes,
+            (("x", x_tensor), ("u", u_tensor), ("weight", weight_tensor), ("bias", bias_tensor)),
+        )
+        stream = stream_handle(current_stream, x_tensor.device)
+        d = self.hidden_size
+        num_row_blocks = (n + self._kernel_config.rows_per_cta - 1) // self._kernel_config.rows_per_cta
+        grid_size = self._kernel_config.launch_grid(n, self._multiprocessor_count)
+        num_iterations = (num_row_blocks + grid_size - 1) // grid_size
+        segment = 0
+        silu_output = y_tensor[:, segment * d : (segment + 1) * d] if self.concat_u else None
+        segment += int(self.concat_u)
+        x_output = y_tensor[:, segment * d : (segment + 1) * d] if self.concat_x else None
+        segment += int(self.concat_x)
+        lmsd_output = y_tensor[:, segment * d : (segment + 1) * d]
+        self._compiled_kernel(
+            x_tensor,
+            u_tensor,
+            weight_tensor,
+            bias_tensor,
+            silu_output if silu_output is not None else lmsd_output,
+            x_output if x_output is not None else lmsd_output,
+            lmsd_output,
+            mask_tensor if mask_tensor is not None else x_tensor,
+            mean_tensor,
+            rstd_tensor,
+            cutlass.Int64(seed),
+            cutlass.Int32(n),
+            cutlass.Int32(d),
+            cutlass.Float32(self.eps),
+            cutlass.Float32(self.dropout_ratio),
+            cutlass.Uint32(self._threshold),
+            cutlass.Int32(num_row_blocks),
+            cutlass.Int32(num_iterations),
+            cutlass.Int32(grid_size),
+            stream,
+        )
+        record_streams(
+            tuple(t for t in (x_tensor, u_tensor, weight_tensor, bias_tensor, y_tensor, mean_tensor, rstd_tensor, mask_tensor) if t is not None),
+            current_stream,
+            x_tensor.device,
+        )
+
+
+class HSTULMSDBwd(_HSTULMSDBase):
+    """Explicit LMSD backward without forward-output recomputation."""
+
+    def __init__(
+        self,
+        sample_dy: torch.Tensor | TensorDesc,
+        sample_x: torch.Tensor | TensorDesc,
+        sample_u: torch.Tensor | TensorDesc,
+        sample_weight: torch.Tensor | TensorDesc,
+        sample_bias: torch.Tensor | TensorDesc,
+        sample_mean: torch.Tensor | TensorDesc,
+        sample_rstd: torch.Tensor | TensorDesc,
+        sample_mask: torch.Tensor | TensorDesc | None,
+        sample_dx: torch.Tensor | TensorDesc,
+        sample_du: torch.Tensor | TensorDesc,
+        sample_dweight: torch.Tensor | TensorDesc | None,
+        sample_dbias: torch.Tensor | TensorDesc,
+        sample_dweight_workspace: torch.Tensor | TensorDesc | None,
+        sample_dbias_workspace: torch.Tensor | TensorDesc,
+        dropout_ratio: float = 0.1,
+        apply_u_silu: bool = True,
+        concat_u: bool = True,
+        concat_x: bool = True,
+        compute_dweight: bool = True,
+    ) -> None:
+        self._init_common(
+            sample_x=sample_x,
+            sample_u=sample_u,
+            sample_weight=sample_weight,
+            sample_bias=sample_bias,
+            dropout_ratio=dropout_ratio,
+        )
+        samples = {
+            "dy": sample_dy,
+            "mean": sample_mean,
+            "rstd": sample_rstd,
+            "dx": sample_dx,
+            "du": sample_du,
+            "dbias": sample_dbias,
+            "dbias_workspace": sample_dbias_workspace,
+        }
+        for name, tensor in samples.items():
+            setattr(self, f"{name}_desc", self._make_tensor_desc(tensor, name=name))
+        self.mask_desc = self._make_tensor_desc(sample_mask, name="mask") if sample_mask is not None else None
+        self.dweight_desc = self._make_tensor_desc(sample_dweight, name="dweight") if sample_dweight is not None else None
+        self.dweight_workspace_desc = (
+            self._make_tensor_desc(sample_dweight_workspace, name="dweight_workspace") if sample_dweight_workspace is not None else None
+        )
+        self.apply_u_silu = bool(apply_u_silu)
+        self.concat_u = bool(concat_u)
+        self.concat_x = bool(concat_x)
+        self.compute_dweight = bool(compute_dweight)
+        self.output_segments = 1 + int(self.concat_u) + int(self.concat_x)
+        self._kernel_config = HSTULMSDBwdConfig.from_hidden_size(self.hidden_size)
+        self._reduce_config = HSTULMSDGradReduceConfig()
+
+    def check_support(self) -> bool:
+        if self._is_supported:
+            return True
+        self._check_common()
+        self._multiprocessor_count = torch.cuda.get_device_properties(self.x_desc.device).multi_processor_count
+        self._workspace_rows = self._kernel_config.workspace_rows(self._multiprocessor_count)
+        self.has_dropout = self.dropout_ratio > 0.0
+        n, d = self.num_rows, self.hidden_size
+        x = self.x_desc
+        tensors = [
+            ("dy", self.dy_desc),
+            ("mean", self.mean_desc),
+            ("rstd", self.rstd_desc),
+            ("dx", self.dx_desc),
+            ("du", self.du_desc),
+            ("dbias", self.dbias_desc),
+            ("dbias_workspace", self.dbias_workspace_desc),
+        ]
+        if self.mask_desc is not None:
+            tensors.append(("mask", self.mask_desc))
+        if self.dweight_desc is not None:
+            tensors.append(("dweight", self.dweight_desc))
+        if self.dweight_workspace_desc is not None:
+            tensors.append(("dweight_workspace", self.dweight_workspace_desc))
+        _require_same_device_desc(x, tensors)
+        output_width = self.output_segments * d
+        if self.dy_desc.shape != (n, output_width) or self.dy_desc.dtype != x.dtype:
+            raise ValueError(f"dy must have shape ({n}, {output_width}) and dtype {x.dtype}")
+        _require_matrix_layout(self.dy_desc, "dy")
+        for desc, name in ((self.mean_desc, "mean"), (self.rstd_desc, "rstd")):
+            _require_vector(desc, name, n)
+            if desc.dtype != torch.float32:
+                raise ValueError(f"{name} must have dtype torch.float32")
+        if self.has_dropout:
+            if self.mask_desc is None:
+                raise ValueError("mask must be provided when dropout_ratio is nonzero")
+            if self.mask_desc.shape != (n, d) or self.mask_desc.dtype != torch.int8:
+                raise ValueError(f"mask must have shape ({n}, {d}) and dtype torch.int8")
+            _require_matrix_layout(self.mask_desc, "mask", row_stride=d)
+        elif self.mask_desc is not None:
+            raise ValueError("mask must be None when dropout_ratio is zero")
+        for desc, name in ((self.dx_desc, "dx"), (self.du_desc, "du")):
+            if desc.shape != (n, d) or desc.dtype != x.dtype:
+                raise ValueError(f"{name} must have shape ({n}, {d}) and dtype {x.dtype}")
+            _require_matrix_layout(desc, name, row_stride=d)
+        if self.compute_dweight:
+            if self.dweight_desc is None or self.dweight_workspace_desc is None:
+                raise ValueError("dweight and dweight_workspace are required when compute_dweight is True")
+            _require_vector(self.dweight_desc, "dweight", d)
+            if self.dweight_desc.dtype != x.dtype:
+                raise ValueError(f"dweight must have dtype {x.dtype}")
+        elif self.dweight_desc is not None or self.dweight_workspace_desc is not None:
+            raise ValueError("dweight and dweight_workspace must be None when compute_dweight is False")
+        _require_vector(self.dbias_desc, "dbias", d)
+        if self.dbias_desc.dtype != x.dtype:
+            raise ValueError(f"dbias must have dtype {x.dtype}")
+        workspaces = [(self.dbias_workspace_desc, "dbias_workspace")]
+        if self.compute_dweight:
+            workspaces.append((self.dweight_workspace_desc, "dweight_workspace"))
+        for desc, name in workspaces:
+            if desc.shape != (self._workspace_rows, d) or desc.dtype != torch.float32:
+                raise ValueError(f"{name} must have shape ({self._workspace_rows}, {d}) and dtype torch.float32")
+            _require_matrix_layout(desc, name, row_stride=d)
+        self._is_supported = True
+        return True
+
+    def compile(self) -> None:
+        self._ensure_support_checked()
+        if self._compiled_kernel is not None:
+            return
+        d = self.hidden_size
+        fake_weight = self._fake_vector(self.weight_desc)
+        fake_bias = self._fake_vector(self.bias_desc)
+        fake_dbp = self._make_fake_cute_tensor_from_desc(self.dbias_workspace_desc, assumed_align=ALIGNMENT_BYTES)
+        fake_db = self._make_fake_cute_tensor_from_desc(self.dbias_desc, assumed_align=ALIGNMENT_BYTES)
+        fake_dwp = self._make_fake_cute_tensor_from_desc(self.dweight_workspace_desc, assumed_align=ALIGNMENT_BYTES) if self.compute_dweight else fake_dbp
+        fake_dw = self._make_fake_cute_tensor_from_desc(self.dweight_desc, assumed_align=ALIGNMENT_BYTES) if self.compute_dweight else fake_db
+        fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
+
+        # Compile the row count symbolically so one plan serves every supported N.
+        rows = cute.sym_int()
+        fake_dy_segment = self._make_fake_cute_tensor(
+            dtype=self.dy_desc.dtype,
+            shape=(rows, d),
+            stride=(cute.sym_int64(divisibility=8), 1),
+            assumed_align=ALIGNMENT_BYTES,
+        )
+        # Every materialized dY segment has the same plan-time tensor contract.
+        fake_dy_silu = fake_dy_segment
+        fake_dy_x = fake_dy_segment
+        fake_dy_lmsd = fake_dy_segment
+        fake_x = self._fake_matrix(self.x_desc, rows, dynamic_row_stride=True)
+        fake_u = self._fake_matrix(self.u_desc, rows, dynamic_row_stride=True)
+        fake_mask = self._fake_matrix(self.mask_desc, rows) if self.has_dropout else fake_x
+        fake_dx = self._fake_matrix(self.dx_desc, rows)
+        fake_du = self._fake_matrix(self.du_desc, rows)
+        fake_mean = self._fake_vector(self.mean_desc, rows)
+        fake_rstd = self._fake_vector(self.rstd_desc, rows)
+        main = cute.compile(
+            HSTULMSDBackward(
+                d,
+                apply_u_silu=self.apply_u_silu,
+                concat_u=self.concat_u,
+                concat_x=self.concat_x,
+                has_dropout=self.has_dropout,
+                compute_dweight=self.compute_dweight,
+                config=self._kernel_config,
+            ),
+            fake_dy_silu,
+            fake_dy_x,
+            fake_dy_lmsd,
+            fake_x,
+            fake_u,
+            fake_weight,
+            fake_bias,
+            fake_mask,
+            fake_dx,
+            fake_du,
+            fake_mean,
+            fake_rstd,
+            fake_dwp,
+            fake_dbp,
+            cutlass.Float32(self.dropout_ratio),
+            cutlass.Int32(d),
+            cutlass.Int32(1),
+            cutlass.Int32(self._workspace_rows),
+            fake_stream,
+            options="--enable-tvm-ffi",
+        )
+
+        reduce = cute.compile(
+            HSTULMSDGradReduce(self.compute_dweight, config=self._reduce_config),
+            fake_dwp,
+            fake_dbp,
+            fake_dw,
+            fake_db,
+            cutlass.Int32(self._workspace_rows),
+            cutlass.Int32(d),
+            fake_stream,
+            options="--enable-tvm-ffi",
+        )
+        self._compiled_kernel = (main, reduce)
+
+    def execute(
+        self,
+        dy_tensor: torch.Tensor,
+        x_tensor: torch.Tensor,
+        u_tensor: torch.Tensor,
+        weight_tensor: torch.Tensor,
+        bias_tensor: torch.Tensor,
+        mean_tensor: torch.Tensor,
+        rstd_tensor: torch.Tensor,
+        mask_tensor: Optional[torch.Tensor],
+        dx_tensor: torch.Tensor,
+        du_tensor: torch.Tensor,
+        dweight_tensor: Optional[torch.Tensor],
+        dbias_tensor: torch.Tensor,
+        dweight_workspace: Optional[torch.Tensor],
+        dbias_workspace: torch.Tensor,
+        current_stream: Optional[cuda.CUstream | torch.cuda.Stream] = None,
+    ) -> None:
+        if self._compiled_kernel is None:
+            raise RuntimeError("HSTULMSDBwd kernels are not compiled")
+        n = self._check_runtime_common(x_tensor, u_tensor, weight_tensor, bias_tensor)
+        runtime = [
+            (dy_tensor, self.dy_desc, "dy", True, True),
+            (mean_tensor, self.mean_desc, "mean", True, False),
+            (rstd_tensor, self.rstd_desc, "rstd", True, False),
+            (dx_tensor, self.dx_desc, "dx", True, False),
+            (du_tensor, self.du_desc, "du", True, False),
+            (dbias_tensor, self.dbias_desc, "dbias", False, False),
+            (dbias_workspace, self.dbias_workspace_desc, "dbias_workspace", False, False),
+        ]
+        if self.has_dropout:
+            if mask_tensor is None:
+                raise ValueError("mask_tensor is required by the compiled dropout configuration")
+            runtime.append((mask_tensor, self.mask_desc, "mask", True, False))
+        elif mask_tensor is not None:
+            raise ValueError("mask_tensor must be None for the compiled no-dropout configuration")
+        if self.compute_dweight:
+            if dweight_tensor is None or dweight_workspace is None:
+                raise ValueError("dweight_tensor and dweight_workspace are required by the compiled configuration")
+            runtime.extend(
+                (
+                    (dweight_tensor, self.dweight_desc, "dweight", False, False),
+                    (dweight_workspace, self.dweight_workspace_desc, "dweight_workspace", False, False),
+                )
+            )
+        elif dweight_tensor is not None or dweight_workspace is not None:
+            raise ValueError("dweight_tensor and dweight_workspace must be None when compute_dweight is False")
+        for tensor, desc, name, dynamic_rows, dynamic_row_stride in runtime:
+            _check_runtime_tensor(
+                tensor,
+                desc,
+                name,
+                num_rows=n if dynamic_rows else None,
+                dynamic_row_stride=dynamic_row_stride,
+            )
+        writes = [
+            ("dx", dx_tensor),
+            ("du", du_tensor),
+            ("dbias", dbias_tensor),
+            ("dbias_workspace", dbias_workspace),
+        ]
+        if self.compute_dweight:
+            writes.extend((("dweight", dweight_tensor), ("dweight_workspace", dweight_workspace)))
+        reads = [
+            ("dy", dy_tensor),
+            ("x", x_tensor),
+            ("u", u_tensor),
+            ("weight", weight_tensor),
+            ("bias", bias_tensor),
+            ("mean", mean_tensor),
+            ("rstd", rstd_tensor),
+        ]
+        if self.has_dropout:
+            reads.append(("mask", mask_tensor))
+        _require_disjoint(
+            writes,
+            reads,
+        )
+        stream = stream_handle(current_stream, x_tensor.device)
+        main, reduce = self._compiled_kernel
+        d = self.hidden_size
+        segment = 0
+        dy_silu = dy_tensor[:, segment * d : (segment + 1) * d] if self.concat_u else None
+        segment += int(self.concat_u)
+        dy_x = dy_tensor[:, segment * d : (segment + 1) * d] if self.concat_x else None
+        segment += int(self.concat_x)
+        dy_lmsd = dy_tensor[:, segment * d : (segment + 1) * d]
+        grid_size = self._kernel_config.launch_grid(n, self._multiprocessor_count)
+        main(
+            dy_silu if dy_silu is not None else dy_lmsd,
+            dy_x if dy_x is not None else dy_lmsd,
+            dy_lmsd,
+            x_tensor,
+            u_tensor,
+            weight_tensor,
+            bias_tensor,
+            mask_tensor if mask_tensor is not None else x_tensor,
+            dx_tensor,
+            du_tensor,
+            mean_tensor,
+            rstd_tensor,
+            dweight_workspace if dweight_workspace is not None else dbias_workspace,
+            dbias_workspace,
+            cutlass.Float32(self.dropout_ratio),
+            cutlass.Int32(d),
+            cutlass.Int32(n),
+            cutlass.Int32(grid_size),
+            stream,
+        )
+        reduce(
+            dweight_workspace if dweight_workspace is not None else dbias_workspace,
+            dbias_workspace,
+            dweight_tensor if dweight_tensor is not None else dbias_tensor,
+            dbias_tensor,
+            cutlass.Int32(grid_size),
+            cutlass.Int32(d),
+            stream,
+        )
+        record_streams(
+            tuple(tensor for tensor, _, _, _, _ in runtime) + (x_tensor, u_tensor, weight_tensor, bias_tensor),
+            current_stream,
+            x_tensor.device,
+        )

--- a/python/cudnn/hstu/hstu_lmsd/ops.py
+++ b/python/cudnn/hstu/hstu_lmsd/ops.py
@@ -1,0 +1,269 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Allocation-and-dispatch helpers for the explicit HSTU LMSD operation."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import Optional
+
+from cuda.bindings import driver as cuda
+import torch
+
+from cudnn.api_base import TupleDict
+
+from ._runtime import allocation_context, tensor_signature
+from .api import HSTULMSDBwd, HSTULMSDFwd
+from ._kernels._common import normalize_dropout_ratio
+from ._kernels._config import HSTULMSDBwdConfig
+
+_CACHE_CAPACITY = 128
+_FWD_CACHE: OrderedDict = OrderedDict()
+_BWD_CACHE: OrderedDict = OrderedDict()
+
+
+def _cache_get(cache: OrderedDict, key):
+    value = cache.get(key)
+    if value is not None:
+        cache.move_to_end(key)
+    return value
+
+
+def _cache_put(cache: OrderedDict, key, value) -> None:
+    cache[key] = value
+    cache.move_to_end(key)
+    if len(cache) > _CACHE_CAPACITY:
+        cache.popitem(last=False)
+
+
+def _tensor_signature_or_none(tensor: Optional[torch.Tensor], *, dynamic_rows: bool = False):
+    return None if tensor is None else tensor_signature(tensor, dynamic_rows=dynamic_rows)
+
+
+def hstu_lmsd_forward(
+    x_tensor: torch.Tensor,
+    u_tensor: torch.Tensor,
+    weight_tensor: torch.Tensor,
+    bias_tensor: torch.Tensor,
+    eps: float = 1e-6,
+    dropout_ratio: float = 0.1,
+    seed: int = 0,
+    stream: Optional[cuda.CUstream | torch.cuda.Stream] = None,
+    apply_u_silu: bool = True,
+    concat_u: bool = True,
+    concat_x: bool = True,
+) -> TupleDict:
+    """Run explicit LMSD forward and return all backward-save tensors.
+
+    This is an operation API, not an autograd registration. The mandatory LMSD
+    segment follows the optional activated-u and x segments. With dropout, the
+    returned mask packs their keep decisions into bits 0, 2, and 1,
+    respectively; without dropout, mask_tensor is None.
+    """
+    if x_tensor.ndim != 2:
+        raise ValueError("x_tensor must be rank 2")
+    dropout_ratio = normalize_dropout_ratio(dropout_ratio)
+    apply_u_silu = bool(apply_u_silu)
+    concat_u = bool(concat_u)
+    concat_x = bool(concat_x)
+    has_dropout = dropout_ratio > 0.0
+    n, d = x_tensor.shape
+    output_segments = 1 + int(concat_u) + int(concat_x)
+    with torch.cuda.device(x_tensor.device), allocation_context(stream, x_tensor.device):
+        y_tensor = torch.empty((n, output_segments * d), dtype=x_tensor.dtype, device=x_tensor.device)
+        mean_tensor = torch.empty((n,), dtype=torch.float32, device=x_tensor.device)
+        rstd_tensor = torch.empty((n,), dtype=torch.float32, device=x_tensor.device)
+        mask_tensor = torch.empty((n, d), dtype=torch.int8, device=x_tensor.device) if has_dropout else None
+
+    key = (
+        tensor_signature(x_tensor, dynamic_rows=True),
+        tensor_signature(u_tensor, dynamic_rows=True),
+        tensor_signature(weight_tensor),
+        tensor_signature(bias_tensor),
+        tensor_signature(y_tensor, dynamic_rows=True),
+        tensor_signature(mean_tensor, dynamic_rows=True),
+        tensor_signature(rstd_tensor, dynamic_rows=True),
+        _tensor_signature_or_none(mask_tensor, dynamic_rows=True),
+        float(eps),
+        float(dropout_ratio),
+        apply_u_silu,
+        concat_u,
+        concat_x,
+    )
+    api = _cache_get(_FWD_CACHE, key)
+    if api is None:
+        with torch.cuda.device(x_tensor.device):
+            api = HSTULMSDFwd(
+                sample_x=x_tensor,
+                sample_u=u_tensor,
+                sample_weight=weight_tensor,
+                sample_bias=bias_tensor,
+                sample_y=y_tensor,
+                sample_mean=mean_tensor,
+                sample_rstd=rstd_tensor,
+                sample_mask=mask_tensor,
+                eps=eps,
+                dropout_ratio=dropout_ratio,
+                apply_u_silu=apply_u_silu,
+                concat_u=concat_u,
+                concat_x=concat_x,
+            )
+            api.check_support()
+            api.compile()
+        _cache_put(_FWD_CACHE, key, api)
+    api.execute(
+        x_tensor=x_tensor,
+        u_tensor=u_tensor,
+        weight_tensor=weight_tensor,
+        bias_tensor=bias_tensor,
+        y_tensor=y_tensor,
+        mean_tensor=mean_tensor,
+        rstd_tensor=rstd_tensor,
+        mask_tensor=mask_tensor,
+        seed=seed,
+        current_stream=stream,
+    )
+    return TupleDict(
+        y_tensor=y_tensor,
+        mean_tensor=mean_tensor,
+        rstd_tensor=rstd_tensor,
+        mask_tensor=mask_tensor,
+    )
+
+
+def hstu_lmsd_backward(
+    dy_tensor: torch.Tensor,
+    x_tensor: torch.Tensor,
+    u_tensor: torch.Tensor,
+    weight_tensor: torch.Tensor,
+    bias_tensor: torch.Tensor,
+    mean_tensor: torch.Tensor,
+    rstd_tensor: torch.Tensor,
+    mask_tensor: Optional[torch.Tensor],
+    dropout_ratio: Optional[float] = None,
+    stream: Optional[cuda.CUstream | torch.cuda.Stream] = None,
+    dx_tensor: Optional[torch.Tensor] = None,
+    du_tensor: Optional[torch.Tensor] = None,
+    dweight_tensor: Optional[torch.Tensor] = None,
+    dbias_tensor: Optional[torch.Tensor] = None,
+    apply_u_silu: Optional[bool] = None,
+    concat_u: Optional[bool] = None,
+    concat_x: Optional[bool] = None,
+    compute_dweight: bool = True,
+) -> TupleDict:
+    """Run explicit LMSD backward without recomputing the forward output.
+
+    ``dropout_ratio``, ``apply_u_silu``, ``concat_u``, and ``concat_x`` must
+    all be provided and must match the forward configuration. Missing enabled
+    gradient outputs are allocated here. Set
+    ``compute_dweight=False`` for a non-trainable weight.
+    """
+    if x_tensor.ndim != 2:
+        raise ValueError("x_tensor must be rank 2")
+    n, d = x_tensor.shape
+    missing_config = [
+        name
+        for name, value in (
+            ("dropout_ratio", dropout_ratio),
+            ("apply_u_silu", apply_u_silu),
+            ("concat_u", concat_u),
+            ("concat_x", concat_x),
+        )
+        if value is None
+    ]
+    if missing_config:
+        raise ValueError(f"hstu_lmsd_backward requires explicit forward configuration: {', '.join(missing_config)}")
+    dropout_ratio = normalize_dropout_ratio(dropout_ratio)
+    apply_u_silu = bool(apply_u_silu)
+    concat_u = bool(concat_u)
+    concat_x = bool(concat_x)
+    compute_dweight = bool(compute_dweight)
+    kernel_config = HSTULMSDBwdConfig.from_hidden_size(d)
+    multiprocessor_count = torch.cuda.get_device_properties(x_tensor.device).multi_processor_count
+    workspace_rows = kernel_config.workspace_rows(multiprocessor_count)
+    if not compute_dweight and dweight_tensor is not None:
+        raise ValueError("dweight_tensor must be None when compute_dweight is False")
+    with torch.cuda.device(x_tensor.device), allocation_context(stream, x_tensor.device):
+        if dx_tensor is None:
+            dx_tensor = torch.empty((n, d), dtype=x_tensor.dtype, device=x_tensor.device)
+        if du_tensor is None:
+            du_tensor = torch.empty((n, d), dtype=x_tensor.dtype, device=x_tensor.device)
+        if compute_dweight and dweight_tensor is None:
+            dweight_tensor = torch.empty((d,), dtype=weight_tensor.dtype, device=x_tensor.device)
+        if dbias_tensor is None:
+            dbias_tensor = torch.empty((d,), dtype=bias_tensor.dtype, device=x_tensor.device)
+        dweight_workspace = torch.empty((workspace_rows, d), dtype=torch.float32, device=x_tensor.device) if compute_dweight else None
+        dbias_workspace = torch.empty((workspace_rows, d), dtype=torch.float32, device=x_tensor.device)
+
+    key = (
+        tensor_signature(dy_tensor, dynamic_rows=True),
+        tensor_signature(x_tensor, dynamic_rows=True),
+        tensor_signature(u_tensor, dynamic_rows=True),
+        tensor_signature(weight_tensor),
+        tensor_signature(bias_tensor),
+        tensor_signature(mean_tensor, dynamic_rows=True),
+        tensor_signature(rstd_tensor, dynamic_rows=True),
+        _tensor_signature_or_none(mask_tensor, dynamic_rows=True),
+        tensor_signature(dx_tensor, dynamic_rows=True),
+        tensor_signature(du_tensor, dynamic_rows=True),
+        _tensor_signature_or_none(dweight_tensor),
+        tensor_signature(dbias_tensor),
+        _tensor_signature_or_none(dweight_workspace),
+        tensor_signature(dbias_workspace),
+        float(dropout_ratio),
+        apply_u_silu,
+        concat_u,
+        concat_x,
+        compute_dweight,
+    )
+    api = _cache_get(_BWD_CACHE, key)
+    if api is None:
+        with torch.cuda.device(x_tensor.device):
+            api = HSTULMSDBwd(
+                sample_dy=dy_tensor,
+                sample_x=x_tensor,
+                sample_u=u_tensor,
+                sample_weight=weight_tensor,
+                sample_bias=bias_tensor,
+                sample_mean=mean_tensor,
+                sample_rstd=rstd_tensor,
+                sample_mask=mask_tensor,
+                sample_dx=dx_tensor,
+                sample_du=du_tensor,
+                sample_dweight=dweight_tensor,
+                sample_dbias=dbias_tensor,
+                sample_dweight_workspace=dweight_workspace,
+                sample_dbias_workspace=dbias_workspace,
+                dropout_ratio=dropout_ratio,
+                apply_u_silu=apply_u_silu,
+                concat_u=concat_u,
+                concat_x=concat_x,
+                compute_dweight=compute_dweight,
+            )
+            api.check_support()
+            api.compile()
+        _cache_put(_BWD_CACHE, key, api)
+    api.execute(
+        dy_tensor=dy_tensor,
+        x_tensor=x_tensor,
+        u_tensor=u_tensor,
+        weight_tensor=weight_tensor,
+        bias_tensor=bias_tensor,
+        mean_tensor=mean_tensor,
+        rstd_tensor=rstd_tensor,
+        mask_tensor=mask_tensor,
+        dx_tensor=dx_tensor,
+        du_tensor=du_tensor,
+        dweight_tensor=dweight_tensor,
+        dbias_tensor=dbias_tensor,
+        dweight_workspace=dweight_workspace,
+        dbias_workspace=dbias_workspace,
+        current_stream=stream,
+    )
+    return TupleDict(
+        dx_tensor=dx_tensor,
+        du_tensor=du_tensor,
+        dweight_tensor=dweight_tensor,
+        dbias_tensor=dbias_tensor,
+    )

--- a/test/python/fe_api/hstu/hstu_lmsd/reference.py
+++ b/test/python/fe_api/hstu/hstu_lmsd/reference.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unfused PyTorch reference operations for HSTU LMSD tests."""
+
+import torch
+import torch.nn.functional as F
+
+
+def layer_norm_stats(x, eps):
+    x_float = x.float()
+    mean = x_float.mean(dim=1)
+    variance = (x_float.square().mean(dim=1) - mean.square()).clamp_min(0.0)
+    return mean, torch.rsqrt(variance + eps)
+
+
+def hstu_lmsd_forward_reference(
+    x,
+    u,
+    weight,
+    bias,
+    mask,
+    dropout_ratio,
+    eps,
+    *,
+    apply_u_silu=True,
+    concat_u=True,
+    concat_x=True,
+):
+    x_float = x.float()
+    u_float = u.float()
+    mean, rstd = layer_norm_stats(x, eps)
+    normalized = (x_float - mean[:, None]) * rstd[:, None]
+    layer_norm = normalized * weight.float() + bias.float()
+    activated_u = F.silu(u_float) if apply_u_silu else u_float
+
+    outputs = []
+    if concat_u:
+        outputs.append((activated_u, 4))
+    if concat_x:
+        outputs.append((x_float, 2))
+    outputs.append((layer_norm * activated_u, 1))
+
+    if mask is not None:
+        mask_int = mask.to(torch.int32)
+        scale = 1.0 / (1.0 - dropout_ratio)
+        zero = torch.zeros((), device=x.device)
+        outputs = [(torch.where((mask_int & bit) != 0, value * scale, zero), bit) for value, bit in outputs]
+
+    return torch.cat([value for value, _ in outputs], dim=1), mean, rstd
+
+
+def hstu_lmsd_backward_reference(
+    dy,
+    x,
+    u,
+    weight,
+    bias,
+    mask,
+    dropout_ratio,
+    eps,
+    *,
+    apply_u_silu=True,
+    concat_u=True,
+    concat_x=True,
+    compute_dweight=True,
+):
+    d = x.shape[1]
+    x_float = x.float()
+    u_float = u.float()
+    weight_float = weight.float()
+    bias_float = bias.float()
+    dy_parts = [part.float() for part in dy.split(d, dim=1)]
+    part = 0
+    dy_u = dy_parts[part] if concat_u else torch.zeros_like(x_float)
+    part += int(concat_u)
+    dy_x = dy_parts[part] if concat_x else torch.zeros_like(x_float)
+    part += int(concat_x)
+    dy_lmsd = dy_parts[part]
+
+    if mask is not None:
+        mask_int = mask.to(torch.int32)
+        scale = 1.0 / (1.0 - dropout_ratio)
+        zero = torch.zeros((), device=x.device)
+        direct_du = torch.where((mask_int & 4) != 0, dy_u * scale, zero)
+        direct_dx = torch.where((mask_int & 2) != 0, dy_x * scale, zero)
+        fused_dy = torch.where((mask_int & 1) != 0, dy_lmsd * scale, zero)
+    else:
+        direct_du = dy_u
+        direct_dx = dy_x
+        fused_dy = dy_lmsd
+
+    mean, rstd = layer_norm_stats(x, eps)
+    x_hat = (x_float - mean[:, None]) * rstd[:, None]
+    layer_norm = x_hat * weight_float + bias_float
+    if apply_u_silu:
+        sigmoid = torch.sigmoid(u_float)
+        activated_u = u_float * sigmoid
+        activated_u_grad = sigmoid + activated_u * (1.0 - sigmoid)
+    else:
+        activated_u = u_float
+        activated_u_grad = torch.ones_like(u_float)
+
+    layer_norm_grad = fused_dy * activated_u
+    dweight = torch.sum(layer_norm_grad * x_hat, dim=0) if compute_dweight else None
+    dbias = torch.sum(layer_norm_grad, dim=0)
+    weighted_grad = layer_norm_grad * weight_float
+    mean_weighted_grad = torch.mean(weighted_grad, dim=1, keepdim=True)
+    mean_x_hat_weighted_grad = torch.mean(x_hat * weighted_grad, dim=1, keepdim=True)
+    dx = direct_dx + (weighted_grad - mean_weighted_grad - x_hat * mean_x_hat_weighted_grad) * rstd[:, None]
+    du = (fused_dy * layer_norm + direct_du) * activated_u_grad
+    return dx, du, dweight, dbias

--- a/test/python/fe_api/hstu/hstu_lmsd/test_fuzzer.py
+++ b/test/python/fe_api/hstu/hstu_lmsd/test_fuzzer.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shape and dropout fuzz coverage for HSTU LMSD forward."""
+
+import pytest
+import torch
+
+try:
+    import cutlass  # noqa: F401
+except (ImportError, OSError) as exc:
+    pytest.skip(f"CuTe DSL is unavailable: {exc}", allow_module_level=True)
+
+from cudnn.hstu.hstu_lmsd import hstu_lmsd_forward
+from cudnn.hstu.hstu_lmsd._kernels._common import keep_threshold32
+from reference import hstu_lmsd_forward_reference
+
+pytestmark = [
+    pytest.mark.gpu_exclusive,
+    pytest.mark.xdist_group(name="gpu_exclusive"),
+]
+
+_IS_SM10X = torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10
+
+_MASK32 = (1 << 32) - 1
+_PHILOX_M0, _PHILOX_M1 = 0xD2511F53, 0xCD9E8D57
+_PHILOX_W0, _PHILOX_W1 = 0x9E3779B9, 0xBB67AE85
+
+
+def _philox4x32(counter0, counter1, counter2, counter3, key0, key1):
+    for _ in range(10):
+        product0 = _PHILOX_M0 * counter0
+        product1 = _PHILOX_M1 * counter2
+        counter0, counter1, counter2, counter3 = (
+            ((product1 >> 32) ^ counter1 ^ key0) & _MASK32,
+            product1 & _MASK32,
+            ((product0 >> 32) ^ counter3 ^ key1) & _MASK32,
+            product0 & _MASK32,
+        )
+        key0 = (key0 + _PHILOX_W0) & _MASK32
+        key1 = (key1 + _PHILOX_W1) & _MASK32
+    return counter0, counter1, counter2, counter3
+
+
+def _reference_mask(n, d, dropout_ratio, seed):
+    expected = [[0] * d for _ in range(n)]
+    threshold = keep_threshold32(dropout_ratio)
+    key0 = seed & _MASK32
+    key1 = (seed >> 32) & _MASK32
+    threads_per_row = 32
+    vector_size = 8
+    philox_groups = vector_size // 4
+    num_vectors = d // vector_size
+    num_column_tiles = (num_vectors + threads_per_row - 1) // threads_per_row
+    for row in range(n):
+        for column_tile in range(num_column_tiles):
+            for lane in range(threads_per_row):
+                philox_block = column_tile * threads_per_row + lane
+                if philox_block >= num_vectors:
+                    continue
+                for mask_plane in range(3):
+                    for group in range(philox_groups):
+                        words = _philox4x32(row, philox_block * philox_groups + group, mask_plane, 0, key0, key1)
+                        for word_index, word in enumerate(words):
+                            column = column_tile * threads_per_row * vector_size + lane * vector_size + group * 4 + word_index
+                            if word >= threshold:
+                                expected[row][column] |= 1 << mask_plane
+    return torch.tensor(expected, dtype=torch.int8)
+
+
+@pytest.mark.L1
+@pytest.mark.skipif(not _IS_SM10X, reason="HSTU LMSD requires SM10x")
+@pytest.mark.parametrize(
+    "n,dropout_ratio,seed",
+    ((1, 0.0, 0), (37, 0.1, 7), (1025, 0.35, 2**40 + 9)),
+)
+def test_forward_matches_mask_reconstruction(n, dropout_ratio, seed):
+    torch.manual_seed(11 + n)
+    d = 512
+    x = torch.randn((n, d), device="cuda", dtype=torch.bfloat16)
+    u_storage = torch.randn((n, 4 * d), device="cuda", dtype=torch.bfloat16)
+    u = u_storage[:, :d]
+    weight = torch.randn((d,), device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn((d,), device="cuda", dtype=torch.bfloat16)
+
+    eps = 1e-6
+    result = hstu_lmsd_forward(
+        x,
+        u,
+        weight,
+        bias,
+        eps=eps,
+        dropout_ratio=dropout_ratio,
+        seed=seed,
+    )
+    y, mean, rstd, mask = result
+    mask_i32 = mask.to(torch.int32) if mask is not None else None
+    if mask_i32 is not None:
+        assert torch.count_nonzero(mask_i32 & ~0x7) == 0
+
+    expected_y, expected_mean, expected_rstd = hstu_lmsd_forward_reference(x, u, weight, bias, mask, dropout_ratio, eps)
+    torch.testing.assert_close(mean, expected_mean, rtol=2e-4, atol=2e-4)
+    torch.testing.assert_close(rstd, expected_rstd, rtol=2e-4, atol=2e-4)
+    torch.testing.assert_close(y.float(), expected_y, rtol=1.5e-2, atol=1.5e-2)
+
+
+@pytest.mark.L1
+@pytest.mark.skipif(not _IS_SM10X, reason="HSTU LMSD requires SM10x")
+@pytest.mark.parametrize(
+    "d,n,dropout_ratio,seed",
+    ((8, 1, 0.0, 0), (24, 3, 0.1, 1), (264, 5, 0.37, 2**32 + 17), (1016, 2, 0.1, 23)),
+)
+def test_forward_mask_matches_philox_reference(d, n, dropout_ratio, seed):
+    torch.manual_seed(29 + n)
+    x = torch.randn((n, d), device="cuda", dtype=torch.bfloat16)
+    u_storage = torch.randn((n, 4 * d), device="cuda", dtype=torch.bfloat16)
+    u = u_storage[:, :d]
+    weight = torch.randn((d,), device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn((d,), device="cuda", dtype=torch.bfloat16)
+
+    result = hstu_lmsd_forward(x, u, weight, bias, dropout_ratio=dropout_ratio, seed=seed)
+    torch.cuda.synchronize()
+    if dropout_ratio == 0.0:
+        assert result["mask_tensor"] is None
+    else:
+        assert torch.equal(result["mask_tensor"].cpu(), _reference_mask(n, d, dropout_ratio, seed))

--- a/test/python/fe_api/hstu/hstu_lmsd/test_integration.py
+++ b/test/python/fe_api/hstu/hstu_lmsd/test_integration.py
@@ -1,0 +1,406 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Forward-to-backward integration coverage for HSTU LMSD."""
+
+from dataclasses import replace
+
+import pytest
+import torch
+
+try:
+    import cutlass  # noqa: F401
+except (ImportError, OSError) as exc:
+    pytest.skip(f"CuTe DSL is unavailable: {exc}", allow_module_level=True)
+
+import cudnn.hstu.hstu_lmsd.ops as _ops
+from cudnn.hstu.hstu_lmsd import hstu_lmsd_backward, hstu_lmsd_forward
+from reference import hstu_lmsd_backward_reference, hstu_lmsd_forward_reference, layer_norm_stats
+
+pytestmark = [
+    pytest.mark.gpu_exclusive,
+    pytest.mark.xdist_group(name="gpu_exclusive"),
+]
+
+_IS_SM10X = torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10
+
+
+@pytest.mark.L0
+def test_backward_requires_explicit_forward_configuration():
+    x = torch.empty((1, 8), dtype=torch.bfloat16)
+    u = torch.empty_like(x)
+    weight = torch.empty((8,), dtype=torch.bfloat16)
+    bias = torch.empty_like(weight)
+    mean = torch.empty((1,), dtype=torch.float32)
+    rstd = torch.empty_like(mean)
+    mask = torch.empty_like(x, dtype=torch.int8)
+    dy = torch.empty((1, 24), dtype=torch.bfloat16)
+
+    for missing in ("dropout_ratio", "apply_u_silu", "concat_u", "concat_x"):
+        config = {
+            "dropout_ratio": 0.1,
+            "apply_u_silu": True,
+            "concat_u": True,
+            "concat_x": True,
+        }
+        del config[missing]
+        with pytest.raises(ValueError, match=f"explicit forward configuration:.*{missing}"):
+            hstu_lmsd_backward(dy, x, u, weight, bias, mean, rstd, mask, **config)
+
+
+@pytest.mark.L0
+@pytest.mark.skipif(not _IS_SM10X, reason="HSTU LMSD requires SM10x")
+@pytest.mark.parametrize("d", (8, 24, 128, 264, 512, 1016))
+def test_forward_outputs_feed_explicit_backward(d):
+    torch.manual_seed(2026)
+    n, p, eps = 513, 0.1, 1e-6
+    x_storage = torch.randn((n, 3 * d), device="cuda", dtype=torch.bfloat16)
+    x = x_storage[:, :d]
+    u_storage = torch.randn((n, 4 * d), device="cuda", dtype=torch.bfloat16)
+    u = u_storage[:, :d]
+    weight = torch.randn((d,), device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn((d,), device="cuda", dtype=torch.bfloat16)
+    dy = torch.randn((n, 3 * d), device="cuda", dtype=torch.bfloat16)
+
+    forward = hstu_lmsd_forward(x, u, weight, bias, eps=eps, dropout_ratio=p, seed=29)
+    y, mean, rstd, mask = forward
+    expected_mean, expected_rstd = layer_norm_stats(x, eps)
+    torch.testing.assert_close(mean, expected_mean, rtol=2e-4, atol=2e-4)
+    torch.testing.assert_close(rstd, expected_rstd, rtol=2e-4, atol=2e-4)
+    actual = hstu_lmsd_backward(
+        dy,
+        x,
+        u,
+        weight,
+        bias,
+        mean.clone(),
+        rstd.clone(),
+        mask.clone(),
+        dropout_ratio=p,
+        apply_u_silu=True,
+        concat_u=True,
+        concat_x=True,
+    )
+    expected = hstu_lmsd_backward_reference(dy, x, u, weight, bias, mask, p, eps)
+    tolerances = (
+        (2.5e-2, 2.5e-2),
+        (2.5e-2, 2.5e-2),
+        (3.5e-2, 5.0e-1),
+        (3.5e-2, 5.0e-1),
+    )
+    for got, ref, (rtol, atol) in zip(actual, expected, tolerances):
+        torch.testing.assert_close(got.float(), ref, rtol=rtol, atol=atol)
+
+
+@pytest.mark.L1
+@pytest.mark.skipif(not _IS_SM10X, reason="HSTU LMSD requires SM10x")
+@pytest.mark.parametrize(
+    "d,p,apply_u_silu,concat_u,concat_x,compute_dweight",
+    (
+        (8, 0.0, False, False, False, False),
+        (256, 0.2, True, True, False, False),
+        (1016, 0.2, False, False, True, True),
+    ),
+)
+def test_optional_forward_backward_configurations(d, p, apply_u_silu, concat_u, concat_x, compute_dweight):
+    torch.manual_seed(4701)
+    n, eps = 129, 1e-6
+    x = torch.randn((n, d), device="cuda", dtype=torch.bfloat16)
+    u = torch.randn_like(x)
+    weight = torch.randn((d,), device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn((d,), device="cuda", dtype=torch.bfloat16)
+
+    forward = hstu_lmsd_forward(
+        x,
+        u,
+        weight,
+        bias,
+        eps=eps,
+        dropout_ratio=p,
+        seed=71,
+        apply_u_silu=apply_u_silu,
+        concat_u=concat_u,
+        concat_x=concat_x,
+    )
+    y, mean, rstd, mask = forward
+    assert y.shape == (n, (1 + int(concat_u) + int(concat_x)) * d)
+    assert (mask is not None) == (p > 0.0)
+
+    expected_y, expected_mean, expected_rstd = hstu_lmsd_forward_reference(
+        x,
+        u,
+        weight,
+        bias,
+        mask,
+        p,
+        eps,
+        apply_u_silu=apply_u_silu,
+        concat_u=concat_u,
+        concat_x=concat_x,
+    )
+    torch.testing.assert_close(y.float(), expected_y, rtol=1.5e-2, atol=1.5e-2)
+    torch.testing.assert_close(mean, expected_mean, rtol=2e-4, atol=2e-4)
+    torch.testing.assert_close(rstd, expected_rstd, rtol=2e-4, atol=2e-4)
+
+    dy = torch.randn_like(y)
+    actual = hstu_lmsd_backward(
+        dy,
+        x,
+        u,
+        weight,
+        bias,
+        mean,
+        rstd,
+        mask,
+        dropout_ratio=p,
+        apply_u_silu=apply_u_silu,
+        concat_u=concat_u,
+        concat_x=concat_x,
+        compute_dweight=compute_dweight,
+    )
+    expected = hstu_lmsd_backward_reference(
+        dy,
+        x,
+        u,
+        weight,
+        bias,
+        mask,
+        p,
+        eps,
+        apply_u_silu=apply_u_silu,
+        concat_u=concat_u,
+        concat_x=concat_x,
+        compute_dweight=compute_dweight,
+    )
+    assert (actual["dweight_tensor"] is not None) == compute_dweight
+    tolerances = ((2.5e-2, 2.5e-2), (2.5e-2, 2.5e-2), (3.5e-2, 5.0e-1), (3.5e-2, 5.0e-1))
+    for got, ref, (rtol, atol) in zip(actual, expected, tolerances):
+        if ref is None:
+            assert got is None
+        else:
+            torch.testing.assert_close(got.float(), ref, rtol=rtol, atol=atol)
+
+
+@pytest.mark.L1
+@pytest.mark.skipif(not _IS_SM10X, reason="HSTU LMSD requires SM10x")
+def test_wrappers_reuse_compiled_binaries_across_dynamic_n_and_row_strides(monkeypatch):
+    """Runtime N and padded row strides must rebind one compile per direction."""
+    original_fwd_compile = _ops.HSTULMSDFwd.compile
+    original_bwd_compile = _ops.HSTULMSDBwd.compile
+    compile_calls = {"forward": 0, "backward": 0}
+
+    def counted_fwd_compile(self):
+        compile_calls["forward"] += 1
+        return original_fwd_compile(self)
+
+    def counted_bwd_compile(self):
+        compile_calls["backward"] += 1
+        return original_bwd_compile(self)
+
+    monkeypatch.setattr(_ops.HSTULMSDFwd, "compile", counted_fwd_compile)
+    monkeypatch.setattr(_ops.HSTULMSDBwd, "compile", counted_bwd_compile)
+    _ops._FWD_CACHE.clear()
+    _ops._BWD_CACHE.clear()
+
+    first_fwd_api = first_bwd_api = None
+    first_fwd_binary = first_bwd_binary = None
+    try:
+        cases = (
+            (37, 512, 2048, 1536),
+            (513, 1536, 2560, 2048),
+        )
+        for case, (n, x_row_stride, u_row_stride, dy_row_stride) in enumerate(cases):
+            torch.manual_seed(3100 + n)
+            d, p, eps = 512, 0.1, 1e-6
+            x_storage = torch.randn((n, x_row_stride), device="cuda", dtype=torch.bfloat16)
+            x = x_storage[:, :d]
+            u_storage = torch.randn((n, u_row_stride), device="cuda", dtype=torch.bfloat16)
+            u = u_storage[:, :d]
+            weight = torch.randn((d,), device="cuda", dtype=torch.bfloat16)
+            bias = torch.randn((d,), device="cuda", dtype=torch.bfloat16)
+
+            forward = hstu_lmsd_forward(
+                x,
+                u,
+                weight,
+                bias,
+                eps=eps,
+                dropout_ratio=p,
+                seed=91 + case,
+            )
+            y, mean, rstd, mask = forward
+            assert y.shape == (n, 3 * d)
+            assert mean.shape == rstd.shape == (n,)
+            assert mask.shape == (n, d)
+
+            expected_mean, expected_rstd = layer_norm_stats(x, eps)
+            torch.testing.assert_close(mean, expected_mean, rtol=2e-4, atol=2e-4)
+            torch.testing.assert_close(rstd, expected_rstd, rtol=2e-4, atol=2e-4)
+            mask_i32 = mask.to(torch.int32)
+            assert torch.count_nonzero(mask_i32 & ~0x7) == 0
+            scale = 1.0 / (1.0 - p)
+            zero = torch.zeros((), device=x.device)
+            xf = x.float()
+            expected_mean = xf.mean(dim=1)
+            expected_var = (xf.square().mean(dim=1) - expected_mean.square()).clamp_min(0.0)
+            expected_rstd = torch.rsqrt(expected_var + 1e-6)
+            torch.testing.assert_close(mean, expected_mean, rtol=1e-4, atol=1e-4)
+            torch.testing.assert_close(rstd, expected_rstd, rtol=1e-4, atol=1e-4)
+            silu = torch.nn.functional.silu(u.float())
+            ln = (xf - expected_mean[:, None]) * expected_rstd[:, None]
+            ln = ln * weight.float() + bias.float()
+            expected_y = torch.cat(
+                (
+                    torch.where((mask_i32 & 4) != 0, silu * scale, zero),
+                    torch.where((mask_i32 & 2) != 0, xf * scale, zero),
+                    torch.where((mask_i32 & 1) != 0, ln * silu * scale, zero),
+                ),
+                dim=1,
+            )
+            torch.testing.assert_close(y.float(), expected_y, rtol=1.5e-2, atol=1.5e-2)
+
+            dy_storage = torch.randn((n, dy_row_stride), device="cuda", dtype=torch.bfloat16)
+            dy = dy_storage[:, : 3 * d]
+            actual = hstu_lmsd_backward(
+                dy,
+                x,
+                u,
+                weight,
+                bias,
+                mean,
+                rstd,
+                mask,
+                dropout_ratio=p,
+                apply_u_silu=True,
+                concat_u=True,
+                concat_x=True,
+            )
+            expected = hstu_lmsd_backward_reference(dy, x, u, weight, bias, mask, p, eps)
+            assert actual["dx_tensor"].shape == (n, d)
+            assert actual["du_tensor"].shape == (n, d)
+            assert actual["dweight_tensor"].shape == (d,)
+            assert actual["dbias_tensor"].shape == (d,)
+            tolerances = (
+                (2.5e-2, 2.5e-2),
+                (2.5e-2, 2.5e-2),
+                (3.5e-2, 5.0e-1),
+                (3.5e-2, 5.0e-1),
+            )
+            for got, ref, (rtol, atol) in zip(actual, expected, tolerances):
+                torch.testing.assert_close(got.float(), ref, rtol=rtol, atol=atol)
+
+            assert len(_ops._FWD_CACHE) == 1
+            assert len(_ops._BWD_CACHE) == 1
+            fwd_api = next(iter(_ops._FWD_CACHE.values()))
+            bwd_api = next(iter(_ops._BWD_CACHE.values()))
+            if case == 0:
+                first_fwd_api = fwd_api
+                first_bwd_api = bwd_api
+                first_fwd_binary = fwd_api._compiled_kernel
+                first_bwd_binary = bwd_api._compiled_kernel
+            else:
+                assert fwd_api is first_fwd_api
+                assert bwd_api is first_bwd_api
+                assert fwd_api._compiled_kernel is first_fwd_binary
+                assert bwd_api._compiled_kernel is first_bwd_binary
+                assert tuple(fwd_api.x_desc.stride) != tuple(x.stride())
+                assert tuple(fwd_api.u_desc.stride) != tuple(u.stride())
+                assert tuple(bwd_api.dy_desc.stride) != tuple(dy.stride())
+
+        assert compile_calls == {"forward": 1, "backward": 1}
+    finally:
+        _ops._FWD_CACHE.clear()
+        _ops._BWD_CACHE.clear()
+
+
+@pytest.mark.L1
+@pytest.mark.skipif(not _IS_SM10X, reason="HSTU LMSD requires SM10x")
+def test_forward_persistent_loop_matches_default_grid():
+    """A one-block grid exercises repeated persistent-loop iterations."""
+    _ops._FWD_CACHE.clear()
+    try:
+        torch.manual_seed(812)
+        n, d = 37, 512
+        x = torch.randn((n, d), device="cuda", dtype=torch.bfloat16)
+        u_storage = torch.randn((n, 4 * d), device="cuda", dtype=torch.bfloat16)
+        u = u_storage[:, :d]
+        weight = torch.randn((d,), device="cuda", dtype=torch.bfloat16)
+        bias = torch.randn((d,), device="cuda", dtype=torch.bfloat16)
+
+        expected = hstu_lmsd_forward(x, u, weight, bias, dropout_ratio=0.1, seed=43)
+        api = next(iter(_ops._FWD_CACHE.values()))
+        api._multiprocessor_count = 1
+        api._kernel_config = replace(api._kernel_config, grid_ctas_per_sm=1)
+        actual = hstu_lmsd_forward(x, u, weight, bias, dropout_ratio=0.1, seed=43)
+        torch.cuda.synchronize()
+
+        assert len(_ops._FWD_CACHE) == 1
+        for expected_tensor, actual_tensor in zip(expected, actual):
+            assert torch.equal(expected_tensor, actual_tensor)
+    finally:
+        _ops._FWD_CACHE.clear()
+
+
+@pytest.mark.L1
+@pytest.mark.skipif(not _IS_SM10X, reason="HSTU LMSD requires SM10x")
+def test_wrappers_use_tensor_device_and_custom_stream():
+    """Compile and launch on the tensor device even when another device is current."""
+    if torch.cuda.device_count() < 2:
+        pytest.skip("requires two visible CUDA devices")
+
+    original_device = torch.cuda.current_device()
+    target_device = (original_device + 1) % torch.cuda.device_count()
+    if torch.cuda.get_device_capability(target_device)[0] != 10:
+        pytest.skip("target device is not SM10x")
+
+    _ops._FWD_CACHE.clear()
+    _ops._BWD_CACHE.clear()
+    try:
+        with torch.cuda.device(target_device):
+            torch.manual_seed(909)
+            n, d = 37, 512
+            x = torch.randn((n, d), device=target_device, dtype=torch.bfloat16)
+            u_storage = torch.randn((n, 4 * d), device=target_device, dtype=torch.bfloat16)
+            u = u_storage[:, :d]
+            weight = torch.randn((d,), device=target_device, dtype=torch.bfloat16)
+            bias = torch.randn((d,), device=target_device, dtype=torch.bfloat16)
+            dy = torch.randn((n, 3 * d), device=target_device, dtype=torch.bfloat16)
+            stream = torch.cuda.Stream(device=target_device)
+            torch.cuda.synchronize(target_device)
+
+        with torch.cuda.device(original_device):
+            forward = hstu_lmsd_forward(
+                x,
+                u,
+                weight,
+                bias,
+                eps=1e-6,
+                dropout_ratio=0.1,
+                seed=17,
+                stream=stream,
+            )
+            y, mean, rstd, mask = forward
+            backward = hstu_lmsd_backward(
+                dy,
+                x,
+                u,
+                weight,
+                bias,
+                mean,
+                rstd,
+                mask,
+                dropout_ratio=0.1,
+                apply_u_silu=True,
+                concat_u=True,
+                concat_x=True,
+                stream=stream,
+            )
+            assert torch.cuda.current_device() == original_device
+
+        stream.synchronize()
+        for tensor in (*forward, *backward):
+            assert tensor.device.index == target_device
+            assert torch.isfinite(tensor).all()
+    finally:
+        _ops._FWD_CACHE.clear()
+        _ops._BWD_CACHE.clear()

--- a/test/python/fe_api/hstu/hstu_lmsd/test_usage.py
+++ b/test/python/fe_api/hstu/hstu_lmsd/test_usage.py
@@ -1,0 +1,296 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimal public-API usage tests for HSTU LMSD."""
+
+import itertools
+
+import cudnn
+import pytest
+import torch
+
+try:
+    import cutlass  # noqa: F401
+except (ImportError, OSError) as exc:
+    pytest.skip(f"CuTe DSL is unavailable: {exc}", allow_module_level=True)
+
+from cudnn.api_base import TensorDesc
+from cudnn.hstu import hstu_lmsd
+from cudnn.hstu.hstu_lmsd import hstu_lmsd_backward, hstu_lmsd_forward
+from cudnn.hstu.hstu_lmsd.api import HSTULMSDBwd, HSTULMSDFwd
+from cudnn.hstu.hstu_lmsd._kernels._config import HSTULMSDBwdConfig, HSTULMSDFwdConfig
+
+pytestmark = [
+    pytest.mark.gpu_exclusive,
+    pytest.mark.xdist_group(name="gpu_exclusive"),
+]
+
+_IS_SM10X = torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10
+
+
+@pytest.mark.L0
+def test_public_exports_are_function_only():
+    assert hstu_lmsd.__all__ == ["hstu_lmsd_forward", "hstu_lmsd_backward"]
+    assert not hasattr(hstu_lmsd, "HSTULMSDFwd")
+    assert not hasattr(hstu_lmsd, "HSTULMSDBwd")
+    assert not hasattr(cudnn, "HSTULMSDFwd")
+    assert not hasattr(cudnn, "HSTULMSDBwd")
+
+
+def _inputs(n: int = 257, d: int = 512):
+    torch.manual_seed(123)
+    x = torch.randn((n, d), device="cuda", dtype=torch.bfloat16)
+    u_storage = torch.randn((n, 4 * d), device="cuda", dtype=torch.bfloat16)
+    u = u_storage[:, :d]
+    weight = torch.randn((d,), device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn((d,), device="cuda", dtype=torch.bfloat16)
+    return x, u, weight, bias
+
+
+def _desc(shape, dtype, *, stride=None, name=""):
+    """Build a storage-free descriptor with the same metadata as a CUDA tensor."""
+    shape = tuple(shape)
+    if stride is None:
+        running = 1
+        reversed_stride = []
+        for extent in reversed(shape):
+            reversed_stride.append(running)
+            running *= extent
+        stride = tuple(reversed(reversed_stride))
+    else:
+        stride = tuple(stride)
+    stride_order = tuple(dim for dim, _ in sorted(enumerate(stride), key=lambda item: (item[1], shape[item[0]])))
+    return TensorDesc(
+        dtype=dtype,
+        shape=shape,
+        stride=stride,
+        stride_order=stride_order,
+        device=torch.device("cuda", torch.cuda.current_device()),
+        name=name,
+    )
+
+
+def _metadata_only_apis(
+    *,
+    n=37,
+    d=512,
+    dtype=torch.bfloat16,
+    x_stride=None,
+    u_stride=None,
+    dropout_ratio=0.1,
+    apply_u_silu=True,
+    concat_u=True,
+    concat_x=True,
+    compute_dweight=True,
+):
+    """Construct both APIs exclusively from TensorDesc metadata."""
+    x = _desc((n, d), dtype, stride=x_stride, name="x")
+    u = _desc((n, d), dtype, stride=(4 * d, 1) if u_stride is None else u_stride, name="u")
+    weight = _desc((d,), dtype, name="weight")
+    bias = _desc((d,), dtype, name="bias")
+
+    output_width = (1 + int(concat_u) + int(concat_x)) * d
+    mask = _desc((n, d), torch.int8, name="mask") if dropout_ratio > 0.0 else None
+    dweight = _desc((d,), dtype, name="dweight") if compute_dweight else None
+    kernel_config = HSTULMSDBwdConfig.from_hidden_size(d)
+    multiprocessor_count = torch.cuda.get_device_properties(x.device).multi_processor_count
+    workspace_rows = kernel_config.workspace_rows(multiprocessor_count)
+    dweight_workspace = _desc((workspace_rows, d), torch.float32, name="dweight_workspace") if compute_dweight else None
+
+    fwd = HSTULMSDFwd(
+        sample_x=x,
+        sample_u=u,
+        sample_weight=weight,
+        sample_bias=bias,
+        sample_y=_desc((n, output_width), dtype, name="y"),
+        sample_mean=_desc((n,), torch.float32, name="mean"),
+        sample_rstd=_desc((n,), torch.float32, name="rstd"),
+        sample_mask=mask,
+        eps=1e-6,
+        dropout_ratio=dropout_ratio,
+        apply_u_silu=apply_u_silu,
+        concat_u=concat_u,
+        concat_x=concat_x,
+    )
+    bwd = HSTULMSDBwd(
+        sample_dy=_desc((n, output_width), dtype, name="dy"),
+        sample_x=x,
+        sample_u=u,
+        sample_weight=weight,
+        sample_bias=bias,
+        sample_mean=_desc((n,), torch.float32, name="mean"),
+        sample_rstd=_desc((n,), torch.float32, name="rstd"),
+        sample_mask=mask,
+        sample_dx=_desc((n, d), dtype, name="dx"),
+        sample_du=_desc((n, d), dtype, name="du"),
+        sample_dweight=dweight,
+        sample_dbias=_desc((d,), dtype, name="dbias"),
+        sample_dweight_workspace=dweight_workspace,
+        sample_dbias_workspace=_desc((workspace_rows, d), torch.float32, name="dbias_workspace"),
+        dropout_ratio=dropout_ratio,
+        apply_u_silu=apply_u_silu,
+        concat_u=concat_u,
+        concat_x=concat_x,
+        compute_dweight=compute_dweight,
+    )
+    return fwd, bwd
+
+
+def test_launch_grids_follow_runtime_row_count():
+    fwd = HSTULMSDFwdConfig.from_hidden_size(512)
+    fwd_wide = HSTULMSDFwdConfig.from_hidden_size(960)
+    bwd_small = HSTULMSDBwdConfig.from_hidden_size(128)
+    bwd_large = HSTULMSDBwdConfig.from_hidden_size(512)
+    bwd_wide = HSTULMSDBwdConfig.from_hidden_size(768)
+
+    assert fwd.launch_grid(1, 148) == 1
+    assert fwd.launch_grid(1_000_000, 148) == 148 * fwd.grid_ctas_per_sm
+    assert (fwd.vector_size, fwd.rows_per_cta, fwd.min_blocks_per_mp) == (4, 4, 8)
+    assert (fwd_wide.vector_size, fwd_wide.rows_per_cta, fwd_wide.min_blocks_per_mp) == (8, 4, 6)
+    assert bwd_small.launch_grid(513, 148) == 513
+    assert bwd_large.workspace_rows(32) == 32 * bwd_large.grid_ctas_per_sm
+    assert bwd_large.workspace_rows(148) == 148 * bwd_large.grid_ctas_per_sm
+    assert bwd_large.launch_grid(1_000_000, 148) == 148 * bwd_large.grid_ctas_per_sm
+    assert (bwd_small.threads_per_row, bwd_large.threads_per_row, bwd_wide.threads_per_row) == (32, 64, 128)
+
+
+@pytest.mark.L0
+@pytest.mark.skipif(not _IS_SM10X, reason="HSTU LMSD requires SM10x")
+def test_metadata_only_check_support_accepts_forward_and_backward():
+    """Plan-time support checks need tensor metadata, not allocated GPU storage."""
+    for d in range(8, 1024, 8):
+        for api in _metadata_only_apis(d=d, x_stride=(3 * d, 1)):
+            assert api.check_support() is True
+
+
+@pytest.mark.L0
+@pytest.mark.skipif(not _IS_SM10X, reason="HSTU LMSD requires SM10x")
+def test_metadata_only_check_support_accepts_optional_configurations():
+    for dropout_ratio in (0.0, 0.2):
+        for apply_u_silu, concat_u, concat_x, compute_dweight in itertools.product((False, True), repeat=4):
+            options = {
+                "dropout_ratio": dropout_ratio,
+                "apply_u_silu": apply_u_silu,
+                "concat_u": concat_u,
+                "concat_x": concat_x,
+                "compute_dweight": compute_dweight,
+            }
+            for api in _metadata_only_apis(d=128, **options):
+                assert api.check_support() is True
+
+
+@pytest.mark.L0
+@pytest.mark.skipif(not _IS_SM10X, reason="HSTU LMSD requires SM10x")
+@pytest.mark.parametrize("d", (0, 7, 10, 1024))
+def test_metadata_only_check_support_rejects_invalid_hidden_dimensions(d):
+    for api in _metadata_only_apis(d=d):
+        with pytest.raises(ValueError, match="supports D divisible by"):
+            api.check_support()
+
+
+@pytest.mark.L0
+@pytest.mark.skipif(not _IS_SM10X, reason="HSTU LMSD requires SM10x")
+@pytest.mark.parametrize("api_index", (0, 1), ids=("forward", "backward"))
+@pytest.mark.parametrize(
+    "overrides,match",
+    (
+        ({"d": 1024}, "supports D divisible by"),
+        ({"dtype": torch.float16}, "x must have dtype torch.bfloat16"),
+        ({"x_stride": (1024, 2)}, "x must have a unit innermost stride"),
+        ({"x_stride": (504, 1)}, "x rows must not overlap"),
+        ({"n": 4_194_305}, "x row count must be in"),
+    ),
+    ids=("hidden-size", "dtype", "inner-stride", "overlapping-rows", "row-count"),
+)
+def test_metadata_only_check_support_rejects_invalid_contracts(api_index, overrides, match):
+    """Unsupported descriptors must fail during check_support()."""
+    api = _metadata_only_apis(**overrides)[api_index]
+    with pytest.raises(ValueError, match=match):
+        api.check_support()
+
+
+@pytest.mark.L0
+@pytest.mark.skipif(not _IS_SM10X, reason="HSTU LMSD requires SM10x")
+@pytest.mark.parametrize("api_index", (0, 1), ids=("forward", "backward"))
+@pytest.mark.parametrize(
+    "dropout_ratio,match",
+    (
+        (-0.1, "finite and in"),
+        (1.0, "finite and in"),
+        (float("inf"), "finite and in"),
+        (float("nan"), "finite and in"),
+        (0.99999999, "after float32 conversion"),
+    ),
+    ids=("negative", "one", "infinity", "nan", "rounds-to-one-f32"),
+)
+def test_metadata_only_check_support_rejects_invalid_dropout(api_index, dropout_ratio, match):
+    api = _metadata_only_apis(dropout_ratio=dropout_ratio)[api_index]
+    with pytest.raises(ValueError, match=match):
+        api.check_support()
+
+
+@pytest.mark.L0
+@pytest.mark.skipif(not _IS_SM10X, reason="HSTU LMSD requires SM10x")
+def test_metadata_only_check_support_normalizes_dropout_to_float32():
+    dropout_ratio = 0.99999994
+    expected = torch.tensor(dropout_ratio, dtype=torch.float32).item()
+    fwd, bwd = _metadata_only_apis(dropout_ratio=dropout_ratio)
+    for api in (fwd, bwd):
+        assert api.check_support() is True
+        assert api.dropout_ratio == expected
+    assert 0 <= fwd._threshold < (1 << 32)
+
+
+@pytest.mark.L0
+@pytest.mark.skipif(not _IS_SM10X, reason="HSTU LMSD requires SM10x")
+def test_forward_wrapper_rejects_dropout_that_rounds_to_one():
+    x, u, weight, bias = _inputs(n=1)
+    with pytest.raises(ValueError, match="after float32 conversion"):
+        hstu_lmsd_forward(x, u, weight, bias, dropout_ratio=0.99999999)
+
+
+@pytest.mark.L0
+@pytest.mark.skipif(not _IS_SM10X, reason="HSTU LMSD requires SM10x")
+@pytest.mark.parametrize("d", (128, 512))
+def test_explicit_forward_backward_usage(d):
+    x, u, weight, bias = _inputs(d=d)
+    forward = hstu_lmsd_forward(
+        x,
+        u,
+        weight,
+        bias,
+        eps=1e-6,
+        dropout_ratio=0.1,
+        seed=17,
+    )
+    y, mean, rstd, mask = forward
+    assert y.shape == (x.shape[0], 3 * x.shape[1])
+    assert mean.shape == rstd.shape == (x.shape[0],)
+    assert mask.shape == x.shape
+    assert y.dtype == x.dtype
+    assert mean.dtype == rstd.dtype == torch.float32
+    assert mask.dtype == torch.int8
+
+    dy = torch.randn_like(y)
+    backward = hstu_lmsd_backward(
+        dy,
+        x,
+        u,
+        weight,
+        bias,
+        mean,
+        rstd,
+        mask,
+        dropout_ratio=0.1,
+        apply_u_silu=True,
+        concat_u=True,
+        concat_x=True,
+    )
+    dx, du, dweight, dbias = backward
+    assert dx.shape == du.shape == x.shape
+    assert dweight.shape == dbias.shape == weight.shape
+    assert dx.dtype == du.dtype == dweight.dtype == dbias.dtype == x.dtype
+    assert torch.isfinite(dx).all()
+    assert torch.isfinite(du).all()
+    assert torch.isfinite(dweight).all()
+    assert torch.isfinite(dbias).all()


### PR DESCRIPTION
## Scope

- Add BF16 HSTU LayerNorm-Multiply-SiLU-Dropout forward and backward CuTe DSL kernels for hidden dimensions below 1024 that are divisible by 8.
- Add allocating frontend operation wrappers with runtime row-count and row-stride reuse; changing the X, U, or dY row stride does not trigger recompilation.
- Support independently strided X and U inputs, optional SiLU, dropout, concatenated U/X outputs, and optional dWeight computation.
- Select launch and vector configuration from the hidden dimension and runtime device SM count.
- Add unfused PyTorch references, integration/fuzzer/API-contract coverage, and FE OSS documentation.

Co-authored-by: [zhaorunchu@gmail.com](mailto:zhaorunchu@gmail.com) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental HSTU LayerNorm-Multiply-SiLU-Dropout APIs for GPU forward and backward operations.
  * Supports optional SiLU activation, concatenated outputs, dropout masks, dynamic row sizes, custom streams, and parameter gradients.
  * Added forward and backward operation exports through the Python package.
* **Documentation**
  * Added API documentation, usage examples, supported configurations, installation guidance, and runtime behavior details.
* **Tests**
  * Added GPU validation covering correctness, dropout masks, configurations, dynamic shapes, streams, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->