### PR TITLE
test_mhas_v2: mismatch budget for fp8 SDPA gradient compares (rounding-boundary flips)

### DIFF
--- a/test/python/sdpa/fp8.py
+++ b/test/python/sdpa/fp8.py
@@ -308,7 +308,9 @@ def assert_close_fp8_grad(actual, expected, atol, rtol, tag, budget=1e-5):
     actual = actual.detach().float()
     expected = expected.detach().float()
     diff = (actual - expected).abs()
-    bad = (diff > atol + rtol * expected.abs()) | ~torch.isfinite(actual)
+    # NaN compares false against the tolerance, so non-finite values on either side are flagged explicitly.
+    nonfinite = ~torch.isfinite(actual) | ~torch.isfinite(expected)
+    bad = (diff > atol + rtol * expected.abs()) | nonfinite
     n_bad = int(bad.sum().item())
     if n_bad == 0:
         return
@@ -318,8 +320,8 @@ def assert_close_fp8_grad(actual, expected, atol, rtol, tag, budget=1e-5):
         f"%%%% '{tag}': {n_bad:,} of {actual.numel():,} elements outside atol={atol} rtol={rtol} (budget {allowed}); "
         f"first at {idx}: actual={actual[idx].item():+.5f} expected={expected[idx].item():+.5f}; max |diff|={diff.max().item():.4f}"
     )
-    if n_bad > allowed or not bool(torch.isfinite(actual).all()):
-        torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+    if n_bad > allowed or bool(nonfinite.any()):
+        torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol, equal_nan=False)
 
 
 def create_paged_container_and_block_table(tensor, block_size):
@@ -345,6 +347,7 @@ def create_paged_container_and_block_table(tensor, block_size):
     return (container, block_table)
 
 def exec_sdpa_fp8(cfg, request, cudnn_handle):
+    """Build, run and validate one fp8 SDPA forward (and backward when cfg.is_train) against fp8_ref."""
     if request.config.option.dryrun:
         pytest.skip("dryrun")
     perf = request.config.getoption("--perf")

--- a/test/python/sdpa/fp8.py
+++ b/test/python/sdpa/fp8.py
@@ -292,6 +292,36 @@ def generate_graph_bwd(cudnn_itype, cudnn_otype, b, h_q, h_k, h_v, s_qo, s_kv, d
 
     return graph_bwd
 
+def assert_close_fp8_grad(actual, expected, atol, rtol, tag, budget=1e-5):
+    """assert_close for fp8 SDPA gradients with a small mismatch budget.
+
+    The kernel and the reference each quantize P (with s_scale) and dS (with dP_scale) to fp8
+    independently, from fp32 values that differ by ~1e-6 relative (exp2/FMA vs torch.exp). When
+    such a value lands on an e4m3 rounding midpoint (seen: P*s_scale = 25.00008 between 24 and
+    26; dS*dP_scale = 15.0 / -13.0), the two sides round to different fp8 codes and every
+    gradient element fed by that value moves by one e4m3 step * |dO| (or |K|, |Q|): 0.09-0.26 for
+    the suite's data, more than atol + rtol*|ref| for near-cancelling elements. That is not a
+    kernel defect and it hits a handful of elements out of 10^6-10^7 (up to one row of d), so a
+    budget of 1e-5 of the elements (at least 1) is tolerated. NaN/Inf are never budgeted, and a
+    real bug (a tile, >= 128*d elements) is orders of magnitude above the budget.
+    """
+    actual = actual.detach().float()
+    expected = expected.detach().float()
+    diff = (actual - expected).abs()
+    bad = (diff > atol + rtol * expected.abs()) | ~torch.isfinite(actual)
+    n_bad = int(bad.sum().item())
+    if n_bad == 0:
+        return
+    allowed = max(1, int(actual.numel() * budget))
+    idx = tuple(bad.nonzero()[0].tolist())
+    print(
+        f"%%%% '{tag}': {n_bad:,} of {actual.numel():,} elements outside atol={atol} rtol={rtol} (budget {allowed}); "
+        f"first at {idx}: actual={actual[idx].item():+.5f} expected={expected[idx].item():+.5f}; max |diff|={diff.max().item():.4f}"
+    )
+    if n_bad > allowed or not bool(torch.isfinite(actual).all()):
+        torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+
+
 def create_paged_container_and_block_table(tensor, block_size):
     B, H, S, D = tensor.shape
     blocks_per_batch = math.ceil(S / block_size)
@@ -318,6 +348,13 @@ def exec_sdpa_fp8(cfg, request, cudnn_handle):
     if request.config.option.dryrun:
         pytest.skip("dryrun")
     perf = request.config.getoption("--perf")
+
+    # The conftest binds the handle to its own torch.cuda.Stream(); every tensor below
+    # (inputs, page tables, the NaN-prefilled outputs) is produced on torch's current
+    # stream. Run the graphs on that same stream, like fp16.py does, or the two are
+    # unordered: under GPU contention (xdist -n 8, CI) the prefill lands after cuDNN's
+    # memset/kernel -> NaN dSink/O, and a page table can be read before it is written.
+    cudnn.set_stream(handle=cudnn_handle, stream=torch.cuda.current_stream().cuda_stream)
 
     cudnn_version = LooseVersion(cudnn.backend_version_string())
     if cudnn_version < "9.14.0":
@@ -707,9 +744,9 @@ def exec_sdpa_fp8(cfg, request, cudnn_handle):
 
             # E5M2 is less precise than E4M3, so its P quantization needs one wider step.
             atol, rtol = (0.125 if torch_itype == torch.float8_e5m2 else 0.08), 0.2
-            torch.testing.assert_close(dQ_out, dQ_ref_float, atol=atol, rtol=rtol)
-            torch.testing.assert_close(dK_out, dK_ref_float, atol=atol, rtol=rtol)
-            torch.testing.assert_close(dV_out, dV_ref_float, atol=atol, rtol=rtol)
+            assert_close_fp8_grad(dQ_out, dQ_ref_float, atol, rtol, tag="dQ")
+            assert_close_fp8_grad(dK_out, dK_ref_float, atol, rtol, tag="dK")
+            assert_close_fp8_grad(dV_out, dV_ref_float, atol, rtol, tag="dV")
 
             if with_sink_token:
                 torch.testing.assert_close(dSink_token_gpu, dSink_token_ref, atol=0.02, rtol=0.2)


### PR DESCRIPTION
Two test-side fixes for the fp8 SDPA cases in `test_mhas_v2` that fail only under `pytest -n 8` / CI (cudnn `test_mhas.sh` moved to 8 workers in cudnn MR !4410; its GB100 and SM107 jobs showed these).

### 1. Stream race: NaN `dSink` / NaN `O` / paged-attention crashes
`conftest.py` binds the cuDNN handle to its own `torch.cuda.Stream()`, while `exec_sdpa_fp8` builds every tensor — inputs, page tables, the NaN-prefilled outputs — on torch's current stream and never orders the two. Under GPU contention the prefill lands *after* cuDNN's memset/kernel (dSink and O stay NaN), and a paged kernel can read a page table before it is written (SM107 CI: `CUDA error: unspecified launch failure`, xdist worker crashes).

Evidence: the fp8 bwd suite fails 8–23 cases at `-n 2` / `-n 8`, zero at `-n 0` or with `CUDA_LAUNCH_BLOCKING=1`; disabling cuDNN's kernel cache changes nothing. `fp16.py` already binds the handle to `torch.cuda.current_stream()` and never showed this; `mxfp8.py` is covered by its `torch.cuda.synchronize()` before each execute. Fix: same binding at the top of `exec_sdpa_fp8`.

### 2. Sparse gradient mismatches: fp8 rounding-midpoint flips
1–113 elements of 10^6–10^7 off by 0.09–0.26 vs atol 0.08 in dQ/dK/dV (B200 `fp8_bwd_L0[test341]`, Rubin `[test98/230]`, GB100 `[test65/98/220/370]`). Kernel and reference quantize P (with `s_scale`) and dS (with `dP_scale`) to fp8 independently from fp32 values that differ by ~1e-6 (exp2/FMA vs `torch.exp`). When one sits on an e4m3 rounding midpoint they round apart and every element fed by it moves by one e4m3 step × |dO| (or |K|, |Q|). Measured at the failing elements: `P*s_scale = 25.00008` (24 vs 26 → 2/32 × dO 2.0 = the observed 0.125), `dS*dP_scale = 15.0 / -13.0` (two flips, ±0.0625 each = 0.125). Not a kernel defect — two correct fp8 implementations legitimately disagree at midpoints. Fix: `assert_close_fp8_grad` — same atol/rtol, but a budget of 1e-5 of the elements (≥ 1) may miss; NaN/Inf are never budgeted; mismatches are printed. A real bug (a tile, ≥ 128·d elements) is orders of magnitude above the budget.

### Verification (`test_mhas_v2.py -n 8`, cudnn dev @ MR !4405 merged, Release build)
| GPU | before | after |
|---|---|---|
| B200 (148 SMs) | 1 failed / 3242 passed (test341) — plus 23–28 failures when the fp8 suites run under `-n 8` in isolation | **3243 passed / 0 failed** |
| Rubin (208 SMs) | 2 failed / 3241 passed (test98, test230) | **3243 passed / 0 failed** |

Both changes are confined to `test/python/sdpa/fp8.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved FP8 gradient validation to allow minor numerical differences while still detecting excessive mismatches and non-finite results.
  - Improved CUDA stream handling during cuDNN execution for more consistent test behavior.
  - Updated backward-pass comparisons to use the enhanced gradient validation, improving reliability when checking FP8 training results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->