### PR TITLE
perf(sm80 bwd): conflict-free dQ staging, L2-grouped causal grid order, shared loop-bounds helpers

### DIFF
--- a/python/cudnn/frost/tile_dsl/mask.py
+++ b/python/cudnn/frost/tile_dsl/mask.py
@@ -103,6 +103,24 @@ def _div_up(a, b):
     return (a + cutlass.Int32(b - 1)) // cutlass.Int32(b)
 
 
+def swa_kv_lo_tile(anchor_row, window_left: int, tile_n: int):
+    """First KV tile a left window of ``window_left`` keeps for ``anchor_row``
+    (the q row plus the bottom-right diagonal); 0 while the window still
+    reaches kv 0.  The forward's KV-loop lower bound, and the backward's
+    deterministic dQ relay -- a kv-tile's turn on a q-tile is its rank among
+    that q-tile's visitors, which start here.
+    """
+    cond = anchor_row > cutlass.Int32(window_left)
+    delta = anchor_row - cutlass.Int32(window_left)
+    return cutlass.Int32(
+        arith.select(
+            cond.ir_value(),
+            (delta // cutlass.Int32(tile_n)).ir_value(),
+            cutlass.Int32(0).ir_value(),
+        )
+    )
+
+
 def compute_kv_loop_bounds(
     q_row_coord,
     seqlen_q,
@@ -133,17 +151,7 @@ def compute_kv_loop_bounds(
         # The whole band shifts with the diagonal: under BOTTOM_RIGHT the SWA
         # lower bound is q + (S_kv - S_q) - W, same anchor the causal upper
         # bound uses (causal_diag folds to 0 for top-left).
-        swa_base = q_row_coord + causal_diag
-        cond = swa_base > cutlass.Int32(window_left)
-        delta = swa_base - cutlass.Int32(window_left)
-        kv_lo_swa = cutlass.Int32(
-            arith.select(
-                cond.ir_value(),
-                (delta // cutlass.Int32(tile_n)).ir_value(),
-                cutlass.Int32(0).ir_value(),
-            )
-        )
-        left = cute.math.max(left, kv_lo_swa)
+        left = cute.math.max(left, swa_kv_lo_tile(q_row_coord + causal_diag, window_left, tile_n))
 
     unmasked_hi = right
     if cutlass.const_expr(mask_flags & MASK_PADDED):
@@ -183,3 +191,55 @@ def compute_kv_loop_bounds(
         unmasked_hi=unmasked_hi,
         right=right,
     )
+
+
+# The KV-major dual: a backward CTA owns one KV tile and loops over Q tiles, so
+# it needs the range of q tiles that attend its kv rows.  Causal trims from
+# BELOW (q rows above the diagonal never see this kv tile), the sliding window
+# trims from ABOVE (rows more than window_left past the tile never see it).
+# Same inputs and conventions as compute_kv_loop_bounds; the causal diagonal is
+# derived the same way, and the right-band widening may be a runtime value
+# (the backward keeps it dynamic).
+
+
+class QLoopBounds(NamedTuple):
+    lo: object  # first q tile attending the kv tile (inclusive)
+    hi: object  # one past the last; hi <= lo means the kv tile has no work
+
+
+def compute_q_loop_bounds(
+    kv_row_coord,
+    seqlen_q,
+    seq_kv_len,
+    n_q_tiles,
+    window_left: int,
+    mask_flags: int,
+    tile_q: int,
+    tile_kv: int,
+    bottom_right: bool = False,
+    window_right=0,
+) -> QLoopBounds:
+    if cutlass.const_expr(bottom_right):
+        causal_diag = seq_kv_len - seqlen_q
+    else:
+        causal_diag = cutlass.Int32(0)
+
+    lo = cutlass.Int32(0)
+    if cutlass.const_expr(mask_flags & MASK_CAUSAL):
+        # kv rows [kv_row_coord, +tile_kv) are attended by q whenever
+        # kv <= q + causal_diag + window_right: the first such q is the tile's
+        # first row minus the diagonal minus the band widening (the widening
+        # is subtracted so the straddling rows of the previous tile keep their
+        # dQ and this tile keeps their dK/dV contribution).
+        q_lo_abs = kv_row_coord - causal_diag - window_right
+        lo = cute.math.max(q_lo_abs // cutlass.Int32(tile_q), cutlass.Int32(0))
+
+    hi = n_q_tiles
+    if cutlass.const_expr(mask_flags & MASK_SWA):
+        # The window keeps kv >= q + causal_diag - window_left, so no q at or
+        # past kv_row_coord + tile_kv + window_left - causal_diag attends the tile.
+        q_hi_abs = kv_row_coord + cutlass.Int32(tile_kv + window_left) - causal_diag
+        q_hi_abs = cute.math.max(q_hi_abs, cutlass.Int32(0))
+        hi = cute.math.min(_div_up(q_hi_abs, tile_q), n_q_tiles)
+
+    return QLoopBounds(lo=lo, hi=hi)

--- a/python/cudnn/sdpa/bwd/api_dsl.py
+++ b/python/cudnn/sdpa/bwd/api_dsl.py
@@ -1180,8 +1180,23 @@ _cache_of_objects: dict = {}
 _SM80_BWD_KERNEL_FILE = "bprop_f16_sm80.py"
 # The shared tile_dsl scheduler vocabulary maps identity onto the bwd grid
 # decode (NATURAL == plain 3-D == 0, LPT == kv-major == 1).
-from cudnn.frost.tile_dsl.constants import SCHED_LPT as _BWD_SCHED_LPT  # noqa: E402
+from cudnn.frost.tile_dsl.constants import SCHED_LPT_L2 as _BWD_SCHED_LPT_L2  # noqa: E402
 from cudnn.frost.tile_dsl.constants import SCHED_NATURAL as _BWD_SCHED_NATURAL  # noqa: E402
+
+
+def _sm80_bwd_sched_policy(*, is_causal: bool, deterministic: bool) -> int:
+    """Grid order for the SM80 backward (a ``tile_dsl.constants.SCHED_*``).
+
+    Causal takes the kv-major LPT order WITHIN L2-sized head groups.  The plain
+    kv-major LPT over every head at once spreads a head's kv-tiles across the
+    whole grid, so its Q / dO / dQ tiles fall out of L2 between visits and the
+    dQ atomics turn into DRAM read-modify-writes (1.4x slower than the plain
+    3-D grid at 64x8 heads, S=4K); the plain grid in turn leaves a one-CTA-long
+    tail that costs 10-17% on small grids.  Grouping keeps both.  Non-causal
+    work is uniform per kv-tile, so the plain 3-D grid stays; the deterministic
+    relay REQUIRES the plain decode (kv_tile == blockIdx.x).
+    """
+    return _BWD_SCHED_LPT_L2 if (is_causal and not deterministic) else _BWD_SCHED_NATURAL
 
 
 def _load_sm80_bwd_module(params):
@@ -1483,10 +1498,7 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
         self._ensure_support_checked()
         from cudnn.sdpa.bwd.config_sm80 import bwd_params_for_flavor
 
-        # Scheduler resolution (the old backward()'s "auto"): kv-major LPT for
-        # causal load-balance, the plain 3-D grid otherwise; the deterministic
-        # relay REQUIRES the plain decode (kv_tile == blockIdx.x).
-        sched = _BWD_SCHED_LPT if (self.is_causal and not self.deterministic) else _BWD_SCHED_NATURAL
+        sched = _sm80_bwd_sched_policy(is_causal=self.is_causal, deterministic=self.deterministic)
         # NOTE: the generic pipeline always ran the llama-swept tile point
         # regardless of flavor (the old backward() defaults); the gptoss
         # wide-Q-tile row stays unwired pending an adapter-level perf gate.

--- a/python/cudnn/sdpa/bwd/config_sm80.py
+++ b/python/cudnn/sdpa/bwd/config_sm80.py
@@ -62,6 +62,7 @@ GPTOSS_CFG = Cfg(D_QK=64, D_V=64, TILE_KV=64, TILE_Q=128, WARPS_PER_SG=4)
 # DYNAMIC (``cute.sym_int``) there and are never part of any key (issue #604).
 # ---------------------------------------------------------------------------
 from cudnn.frost.tile_dsl.constants import SCHED_LPT as _SCHED_LPT  # noqa: E402
+from cudnn.frost.tile_dsl.constants import SCHED_LPT_L2 as _SCHED_LPT_L2  # noqa: E402
 from cudnn.frost.tile_dsl.constants import SCHED_NATURAL as _SCHED_NATURAL  # noqa: E402
 
 
@@ -102,10 +103,13 @@ class TemplateParams:
     # Packed varlen (wrapper-only today; the engine row declares thd=False).
     thd_varlen: bool = False
     # Tile-scheduler policy in the SHARED frost vocabulary
-    # (tile_dsl.constants.SCHED_*): the bwd grid interprets NATURAL as its
-    # plain kv-major grid and LPT as the kv-major LPT remap (LPT_L2 is a
-    # forward-only policy today).
+    # (tile_dsl.constants.SCHED_*): NATURAL is the plain 3-D grid, LPT the
+    # kv-major remap over every (head, batch) at once, LPT_L2 the kv-major
+    # remap within L2-sized (batch, kv_head) groups so the resident CTAs keep
+    # re-touching the same Q / dO / dQ tiles (the causal default).
     sched_policy: int = _SCHED_NATURAL
+    # L2 budget (MiB) that sizes the LPT_L2 head groups (mirrors fwd).
+    sched_l2_mib: int = 16
 
 
 def validate_bwd_params(p: TemplateParams) -> None:
@@ -125,8 +129,10 @@ def validate_bwd_params(p: TemplateParams) -> None:
         raise ValueError(f"sm80 bwd: d_v ({p.d_v}) must be a multiple of 32 (do_dot warp reduce)")
     if p.has_rope and p.d_qk > 128:
         raise ValueError("sm80 bwd: RoPE requires d_qk <= 128 (the sDQ SMEM staging exceeds the A100 budget beyond that)")
-    if p.sched_policy not in (_SCHED_NATURAL, _SCHED_LPT):
-        raise ValueError(f"sm80 bwd: sched_policy must be SCHED_NATURAL or SCHED_LPT; got {p.sched_policy}")
+    if p.sched_policy not in (_SCHED_NATURAL, _SCHED_LPT, _SCHED_LPT_L2):
+        raise ValueError(f"sm80 bwd: sched_policy must be SCHED_NATURAL, SCHED_LPT or SCHED_LPT_L2; got {p.sched_policy}")
+    if p.sched_l2_mib <= 0:
+        raise ValueError(f"sm80 bwd: sched_l2_mib must be > 0; got {p.sched_l2_mib}")
     if p.deterministic and p.sched_policy != _SCHED_NATURAL:
         raise ValueError("sm80 bwd: deterministic dQ requires SCHED_NATURAL (the kv-ordered semaphore relay)")
     if p.causal_bottom_right and not (p.is_causal or p.has_swa):

--- a/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
@@ -37,6 +37,12 @@ the tile to ``sDQ`` and then atomicAdd-ing in row-major order (consecutive lanes
 → consecutive dQ columns) drops it to 4 sectors/request → halves the dQ atomic L2
 traffic.  This is what closes the gap to cuDNN (whose dQ atomic also coalesces):
 +18 % @ B2H16S4096 (75→89 TFLOPS, ~1.0× cuDNN), +16 % @ B1H16S2048 (1.08×).
+The staging itself must be bank-conflict-free: the fragment's 8 rows per warp
+store share banks at a d_qk-word row stride (8-way conflict, about as many SMEM
+cycles per Q-iter as the MMAs take), so ``sDQ`` uses the XOR layout of
+:func:`_sdq_off` and 8 B ``v2`` pair stores (-9 % kernel time, non-causal
+B2 H64/8 S4096).  The kernel runs 8 warps/SM at the 255-register cap, so it is
+issue-bound: every non-MMA instruction in the Q-loop shows up in the runtime.
 
 **Deterministic dQ** (``TemplateParams.deterministic``): the cross-KV-tile dQ
 atomicAdd is order-non-deterministic (fp32 add is non-associative → bitwise
@@ -65,7 +71,9 @@ Named-"barrier" table (all ``nvvm.barrier_cta_sync()`` — full 256-thread CTA):
   * B1  after sg0 writes ``sP``               (sg1's dS reads it; dV's P operand is in regs)
   * B2  after sg1 writes ``sdS``/``sdSᵀ``     (dQ reads sdSᵀ; sP/sdO read done)
   * B2b after both sg stage ``sDQ``           (before the coalesced dQ atomicAdd)
-  * B3  after dQ atomicAdds                    (before next Q-iter reloads Q/dO)
+  * B3  after dQ atomicAdds                    (direct-atomic path only: before the
+                                                next Q-iter reloads Q/dO; the staged
+                                                path is already ordered by B2b + B0)
 ALL barriers are at top level (never inside a divergent ``if sg0`` arm) so the
 per-thread barrier count is identical across both sub-groups.
 
@@ -966,24 +974,25 @@ def _bprop_kernel(
             nvvm.barrier_cta_sync()
         if cutlass.const_expr(dq_smem_coalesce or has_rope):
             # COALESCED via SMEM staging (sDQ).  Stage the dq_acc C-fragment into
-            # sDQ[tile_q, d_qk] (each sg writes its d-col half).  The frag layout
-            # scatters (8 rows / warp) — cheap SMEM scatter.  Then ALL threads
-            # atomicAdd sDQ → GMEM dQ in row-major order: consecutive lanes hit
-            # consecutive dQ columns, so each warp's atomic request coalesces to
-            # 4 L2 sectors (vs 8 direct) → halves the dQ atomic L2 traffic.  Also
-            # the ONLY path that supports RoPE un-rotate (needs SMEM scratch).
+            # sDQ[tile_q, d_qk] (each sg writes its d-col half) as 8 B pairs at
+            # the bank-swizzled offsets of _sdq_off (the frag layout puts 8 rows
+            # under one warp store; unswizzled they share banks).  Then ALL
+            # threads atomicAdd sDQ → GMEM dQ in row-major order: consecutive
+            # lanes hit consecutive dQ columns, so each warp's atomic request
+            # coalesces to 4 L2 sectors (vs 8 direct) → halves the dQ atomic L2
+            # traffic.  Also the ONLY path that supports RoPE un-rotate (needs
+            # SMEM scratch).
             for mb in cutlass.range_constexpr(DQ_M_BLOCKS):
                 q_row_g = cutlass.Int32(mb * M_STRIDE) + warp_local * 16 + g_lane
                 q_row_g8 = q_row_g + 8
                 for nf in cutlass.range_constexpr(DQ_NFRAGS):
                     col = sg_d_base + cutlass.Int32(nf * 8) + cutlass.Int32(2) * p_lane
                     off = (mb * DQ_NFRAGS + nf) * 4
-                    r0 = q_row_g * cutlass.Int32(d_qk) + col
-                    r1 = q_row_g8 * cutlass.Int32(d_qk) + col
-                    Pointer(sDQ.subview(r0).data_ptr(), dtype=cutlass.Float32).store(dq_acc[off + 0])
-                    Pointer(sDQ.subview(r0 + cutlass.Int32(1)).data_ptr(), dtype=cutlass.Float32).store(dq_acc[off + 1])
-                    Pointer(sDQ.subview(r1).data_ptr(), dtype=cutlass.Float32).store(dq_acc[off + 2])
-                    Pointer(sDQ.subview(r1 + cutlass.Int32(1)).data_ptr(), dtype=cutlass.Float32).store(dq_acc[off + 3])
+                    # (col, col+1) is one 8 B pair -> a single st.shared.v2.f32.
+                    v_top = cutlass.Vector.from_elements((dq_acc[off + 0], dq_acc[off + 1]), cutlass.Float32)
+                    v_bot = cutlass.Vector.from_elements((dq_acc[off + 2], dq_acc[off + 3]), cutlass.Float32)
+                    Pointer(sDQ.subview(_sdq_off(q_row_g, col, d_qk)).data_ptr(), dtype=cutlass.Float32).store(v_top, alignment=8)
+                    Pointer(sDQ.subview(_sdq_off(q_row_g8, col, d_qk)).data_ptr(), dtype=cutlass.Float32).store(v_bot, alignment=8)
 
             nvvm.barrier_cta_sync()  # sDQ fully staged (both sg)
 
@@ -998,22 +1007,25 @@ def _bprop_kernel(
                     _cs = (q_base + qrow).to(cutlass.Int64) * cutlass.Int64(_d2 * 2) + i.to(cutlass.Int64) * cutlass.Int64(2)
                     c = rope_cs_ptr[_cs]
                     s = rope_cs_ptr[_cs + cutlass.Int64(1)]
-                    lo_off = qrow * cutlass.Int32(d_qk) + i
-                    hi_off = lo_off + cutlass.Int32(_d2)
+                    lo_off = _sdq_off(qrow, i, d_qk)
+                    hi_off = _sdq_off(qrow, i + cutlass.Int32(_d2), d_qk)
                     lo = sDQ[lo_off]
                     hi = sDQ[hi_off]
                     sDQ[lo_off] = lo * c + hi * s  # un-rotate: sin sign flipped
                     sDQ[hi_off] = hi * c - lo * s
                 nvvm.barrier_cta_sync()
 
-            # Coalesced atomicAdd: thread t owns elements {t, t+threads, …}; a
-            # warp's 32 lanes span 32 consecutive dQ cols → one coalesced request.
+            # Coalesced atomicAdd: thread t owns elements {t, t+threads, ...}; a
+            # warp's 32 lanes span 32 consecutive dQ cols -> one 4-sector request.
+            # (Keep the lanes column-consecutive: a v4 read-back with 4 atomics
+            # per thread strides the lanes 4 apart -> 16 sectors/request and the
+            # atomics run ~2x slower overall.)
             for s in cutlass.range_constexpr((tile_q * d_qk) // threads):
                 e = cutlass.Int32(s * threads) + tidx
                 row = e // cutlass.Int32(d_qk)
                 col = e % cutlass.Int32(d_qk)
                 gaddr = ((q_row_origin + q_base + row) * cutlass.Int32(H) + head) * cutlass.Int32(d_qk) + col
-                val = Pointer(sDQ.subview(e).data_ptr(), dtype=cutlass.Float32).load()
+                val = Pointer(sDQ.subview(_sdq_off(row, col, d_qk)).data_ptr(), dtype=cutlass.Float32).load()
                 # Partial last q-tile / short THD seq: skip rows q >= S_q (OOB).
                 if cutlass.const_expr(GATE_Q):
                     if (q_base + row) < q_bound:
@@ -1053,7 +1065,12 @@ def _bprop_kernel(
                 cute.arch.atomic_exch(sem_ptr, relay_turn + cutlass.Int32(1), sem="release", scope="gpu")
 
         # ---- B3: before next Q-iter overwrites the ring stage ---------------
-        nvvm.barrier_cta_sync()
+        # Direct-atomic path only.  On the staged path B2b already follows every
+        # warp's last ring-stage read (the dQ MMA precedes the staging), and the
+        # next iteration's B0 follows every warp's last sDQ read, so the next
+        # prefetch and the next staging are both ordered without a third barrier.
+        if cutlass.const_expr(not (dq_smem_coalesce or has_rope)):
+            nvvm.barrier_cta_sync()
 
         # 1-stage: reload the NEXT tile into the single slot now that every warp
         # has finished reading stage_cur (B3 barrier above).  2-stage already
@@ -1170,6 +1187,27 @@ def _bprop_kernel(
 
 
 _bprop_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
+@cute.jit
+def _sdq_off(row, col, d_qk: cutlass.Constexpr[int]):
+    """Element offset of (row, col) in the fp32 ``sDQ`` staging tile.
+
+    The dQ C-fragment store is 8 rows x 4 column-pairs (one 8 B ``v2`` store
+    each) per warp instruction.  With a row stride of d_qk fp32 -- a multiple
+    of 32 words -- every row lands in the same banks: 8-way conflict, ~2k SMEM
+    cycles per Q-iter against ~2.5k cycles of MMA.  XOR bits 3-4 of the column
+    with ``row & 3`` so each half-warp's 16 pairs cover all 32 banks (a 64-bit
+    access is serviced per half-warp).  The row-major read-back (32 consecutive
+    columns per warp) becomes a permutation of one 32-word block, so it stays
+    conflict-free too.  Requires d_qk % 32 == 0 (the XOR never leaves the
+    aligned 32-column block); other head dims keep the plain layout.
+    """
+    if cutlass.const_expr(d_qk % 32 == 0):
+        swz = (row & cutlass.Int32(3)) << 3
+        return row * cutlass.Int32(d_qk) + (col ^ swz)
+    else:
+        return row * cutlass.Int32(d_qk) + col
 
 
 @cute.jit

--- a/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
@@ -116,7 +116,7 @@ from cudnn.frost.tile_dsl.mma import load_b_smem_x4, mma_step  # noqa: E402
 from cudnn.frost.tile_dsl.pointwise import fp32_to_fp16  # noqa: E402
 from cudnn.frost.tile_dsl.swizzle import swizzle_xor_128b  # noqa: E402
 from cudnn.frost.tile_dsl.tma import load_tile_2d, cp_async_commit, cp_async_wait  # noqa: E402
-from cudnn.frost.tile_dsl.mask import MASK_NONE, MASK_PADDED, MASK_CAUSAL, MASK_SWA  # noqa: E402
+from cudnn.frost.tile_dsl.mask import MASK_NONE, MASK_PADDED, MASK_CAUSAL, MASK_SWA, compute_q_loop_bounds, swa_kv_lo_tile  # noqa: E402
 from cudnn.frost.tile_dsl.rope import rope_rotate_smem_tile  # noqa: E402
 from cudnn.frost.tile_dsl.scheduler import lpt_l2_tile_coords  # noqa: E402
 
@@ -427,42 +427,30 @@ def _bprop_kernel(
     VV_RS = cutlass.Int32(Hkv) * cutlass.Int32(d_v)  # V read row stride (H_kv heads)
     kv_base = kv_tile * cutlass.Int32(tile_kv)
 
-    # ---- Causal compute-skip: a kv-tile [kv_base, kv_base+tile_kv) is attended
-    #      only by q >= kv_base (top-left causal) or q >= kv_base - causal_diag
-    #      (bottom-right).  Start the q-loop at the first such q-tile and run a
-    #      j-counter (q_iter = q_lo_tile + j) so the double-buffer stage parity is
-    #      relative to the loop start, not the absolute q-tile.  ~2x on causal
-    #      bprop.  Non-causal → q_lo_tile=0, n_iters=n_q_tiles (byte-identical).
-    #      SKV>SQ edge: kv-tiles past SQ get q_lo_tile >= n_q_tiles → 0 iters →
-    #      dV/dK epilogue writes 0 (those kv attend no q under causal).  The
-    #      prologue's valid_rows row-gate makes the OOB prefetch a zero-size copy.
-    if cutlass.const_expr(mask_flags & MASK_CAUSAL):
-        # A kv-tile [kv_base, kv_base+tile_kv) is attended by q whenever
-        # kv <= q + causal_diag + right_bound (band widening), i.e. the first
-        # attending q is (kv_base - causal_diag) - right_bound (BR) / kv_base -
-        # right_bound (TL).  Subtract right_bound so band-right widening doesn't
-        # drop the right_bound queries that straddle the previous kv-tile (else
-        # their dQ + this tile's dK/dV lose those contributions).  right_bound==0
-        # → byte-identical to the plain-causal skip.
-        _q_lo_abs = ((kv_base - causal_diag) if cutlass.const_expr(causal_bottom_right) else kv_base) - right_bound
-        _q_lo_t = _q_lo_abs // cutlass.Int32(tile_q)
-        q_lo_tile = cutlass.Int32(arith.maxsi(_q_lo_t.ir_value(), cutlass.Int32(0).ir_value()))
-    else:
-        q_lo_tile = cutlass.Int32(0)
-    n_iters = cutlass.Int32(arith.maxsi((n_q_tiles_eff - q_lo_tile).ir_value(), cutlass.Int32(0).ir_value()))
-    # ---- SWA compute-skip (upper bound): the window keeps kv >= anchor(q) - W
-    #      (anchor = q, or q + causal_diag under bottom-right; see _mask_p), so
-    #      no q >= kv_base + tile_kv + W - diag attends this kv-tile.  Cap the
-    #      q-loop there (the forward trims kv_left the same way).  Fully-masked
-    #      tiles run 0 iters and the epilogue stores dK = dV = 0.
-    if cutlass.const_expr(mask_flags & MASK_SWA):
-        _q_hi_abs = kv_base + cutlass.Int32(tile_kv + swa_window)
-        if cutlass.const_expr(causal_bottom_right):
-            _q_hi_abs = _q_hi_abs - causal_diag
-        _q_hi_abs = cutlass.Int32(arith.maxsi(_q_hi_abs.ir_value(), cutlass.Int32(0).ir_value()))
-        _q_hi_t = (_q_hi_abs + cutlass.Int32(tile_q - 1)) // cutlass.Int32(tile_q)
-        _q_hi_t = cutlass.Int32(arith.minsi(_q_hi_t.ir_value(), n_q_tiles_eff.ir_value()))
-        n_iters = cutlass.Int32(arith.maxsi((_q_hi_t - q_lo_tile).ir_value(), cutlass.Int32(0).ir_value()))
+    # ---- Q-loop bounds (shared tile_dsl arithmetic, the KV-major dual of the
+    #      forward's compute_kv_loop_bounds): causal trims the q-loop from below
+    #      (q above the diagonal never attends this kv-tile; ~2x on causal
+    #      bprop), the sliding window trims it from above (the forward trims
+    #      kv_left the same way).  The j-counter runs from 0 (q_iter = q_lo_tile
+    #      + j) so the double-buffer stage parity is relative to the loop start.
+    #      Non-causal, no window -> [0, n_q_tiles_eff) (byte-identical).  A
+    #      kv-tile past every attending q (SKV > SQ causal edge, or a window that
+    #      ends before it) runs 0 iters and the epilogue stores dK = dV = 0.
+    #      Under THD the per-sequence lengths feed the diagonal and tile count.
+    _qb = compute_q_loop_bounds(
+        kv_base,
+        seqlen_q=s_q_b if cutlass.const_expr(THD_VARLEN) else q_bound,
+        seq_kv_len=s_kv_b if cutlass.const_expr(THD_VARLEN) else eff_skv,
+        n_q_tiles=n_q_tiles_eff,
+        window_left=swa_window,
+        mask_flags=mask_flags,
+        tile_q=tile_q,
+        tile_kv=tile_kv,
+        bottom_right=bool(causal_bottom_right),
+        window_right=right_bound,
+    )
+    q_lo_tile = _qb.lo
+    n_iters = cutlass.Int32(arith.maxsi((_qb.hi - _qb.lo).ir_value(), cutlass.Int32(0).ir_value()))
     # THD over-provisioned grid: this CTA's kv-tile may start past the packed
     # sequence's KV length (n_kv_tiles = ceil(max_skv/tile_kv) covers the longest
     # sequence).  Force 0 q-iters for such tiles → no compute, and the dV/dK
@@ -986,10 +974,11 @@ def _bprop_kernel(
         # A kv-tile's turn is its rank among the q-tile's visitors.  The visitor
         # set is contiguous in kv_tile: the causal q_lo skip removes only higher
         # kv-tiles, the window q_hi cap removes only lower ones, so it starts at
-        # kv_first = max((q_row0 + diag - W) // tile_kv, 0) (the inverse of the
-        # q_hi cap; 0 without a window) and turn = kv_tile - kv_first.  Every
-        # visitor computes the same kv_first, so acquire (== turn) and release
-        # (turn + 1) agree.  Folds out when deterministic=False.
+        # the window's first kv-tile for the q-tile's first row (the forward's
+        # KV-loop lower bound, swa_kv_lo_tile; 0 without a window) and turn =
+        # kv_tile - kv_first.  Every visitor computes the same kv_first, so
+        # acquire (== turn) and release (turn + 1) agree.  Folds out when
+        # deterministic=False.
         if cutlass.const_expr(deterministic):
             sem_idx = (batch * cutlass.Int32(H) + head) * sem_q_stride + q_iter
             sem_ptr = Pointer(cutlass.make_array_view(DQ_SEM).data_ptr() + sem_idx, dtype=cutlass.Int32)
@@ -997,9 +986,7 @@ def _bprop_kernel(
                 _q_row0 = q_iter * cutlass.Int32(tile_q)
                 if cutlass.const_expr(causal_bottom_right):
                     _q_row0 = _q_row0 + causal_diag
-                _kv_first = (_q_row0 - cutlass.Int32(swa_window)) // cutlass.Int32(tile_kv)
-                _kv_first = cutlass.Int32(arith.maxsi(_kv_first.ir_value(), cutlass.Int32(0).ir_value()))
-                relay_turn = kv_tile - _kv_first
+                relay_turn = kv_tile - swa_kv_lo_tile(_q_row0, swa_window, tile_kv)
             else:
                 relay_turn = kv_tile
             if tidx == cutlass.Int32(0):

--- a/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
@@ -118,6 +118,7 @@ from cudnn.frost.tile_dsl.swizzle import swizzle_xor_128b  # noqa: E402
 from cudnn.frost.tile_dsl.tma import load_tile_2d, cp_async_commit, cp_async_wait  # noqa: E402
 from cudnn.frost.tile_dsl.mask import MASK_NONE, MASK_PADDED, MASK_CAUSAL, MASK_SWA  # noqa: E402
 from cudnn.frost.tile_dsl.rope import rope_rotate_smem_tile  # noqa: E402
+from cudnn.frost.tile_dsl.scheduler import lpt_l2_tile_coords  # noqa: E402
 
 # Pull the default geometry from the flavor config (single source of truth).
 from cudnn.sdpa.bwd.config_sm80 import LLAMA_CFG as _LLAMA_CFG  # noqa: E402
@@ -129,14 +130,24 @@ _COPY_ELEMS = 8  # 16-byte cp.async chunk (8 fp16)
 # Scheduler policy (compile-time).  The bprop parallel axis is the KV-tile; under
 # causal the lowest kv-tile is the heaviest (most q-iters after the causal
 # skip), so an LPT schedule is KV-MAJOR (all kv=0 tiles first → the light high-kv
-# tiles land in the last wave, minimizing the makespan tail).
-SCHED_DEFAULT = 0  # 3-D grid (kv_tile, head, batch); no reorder (byte-identical)
-SCHED_LPT = 1  # 1-D kv-major grid for causal load-balance
+# tiles land in the last wave, minimizing the makespan tail).  Plain kv-major
+# over EVERY (head, batch) puts the resident CTAs on ~108 different heads, so
+# a head's Q / dO / dQ tiles leave L2 between its kv-tiles' visits and the dQ
+# atomics become DRAM read-modify-writes (1.4x slower than the 3-D grid at
+# B2 H64/8 S4K).  SCHED_LPT_L2 keeps kv-major order WITHIN an L2-sized group
+# of (batch, kv_head) — the 3-D grid's locality with LPT's tail — and is the
+# causal default; SCHED_LPT stays for small grids by explicit request.
+# The policy ids are the SHARED tile_dsl vocabulary (config_sm80 / api_dsl
+# pass those ids in), so the kernel compares against the same symbols:
+#   SCHED_DEFAULT (== SCHED_NATURAL): 3-D grid (kv_tile, head, batch); no reorder
+#   SCHED_LPT:    1-D kv-major grid over all heads (causal load-balance, no locality)
+#   SCHED_LPT_L2: 1-D kv-major grid within L2-sized head groups (causal default)
+from cudnn.frost.tile_dsl.constants import SCHED_LPT, SCHED_LPT_L2, SCHED_NATURAL  # noqa: E402
+
+SCHED_DEFAULT = SCHED_NATURAL
 
 # TemplateParams injection seam (frost.template_loader): one uniquely named
 # module per parameter set, specialized below via cutlass.const_expr folding.
-# The shared tile_dsl scheduler vocabulary maps IDENTITY onto the internal
-# grid decode (SCHED_NATURAL == SCHED_DEFAULT == 0, SCHED_LPT == 1).
 from cudnn.sdpa.bwd.config_sm80 import TemplateParams  # noqa: E402
 
 PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
@@ -237,7 +248,8 @@ def _bprop_kernel(
     has_seq_len_q: cutlass.Constexpr[bool],  # read SEQ_LEN_Q[batch] → per-batch q-pad (dense PADDED)
     THD_VARLEN: cutlass.Constexpr[bool],  # packed [1,T,H,D] + CU_Q/CU_K; per-batch S_q/S_kv
     deterministic: cutlass.Constexpr[bool],  # gate the dQ semaphore relay (folds out → byte-identical fast path)
-    sched_policy: cutlass.Constexpr[int],  # SCHED_DEFAULT / SCHED_LPT grid decode
+    sched_policy: cutlass.Constexpr[int],  # SCHED_DEFAULT / SCHED_LPT / SCHED_LPT_L2 grid decode
+    sched_l2_bytes: cutlass.Constexpr[int],  # L2 budget sizing the SCHED_LPT_L2 head groups
     n_q_tiles: cutlass.Int32,  # runtime — ceil(SQ / tile_q) (dense); THD recomputes per-batch
     softmax_scale_log2: cutlass.Float32,  # = attn_scale * log2(e)  (for P)
     attn_scale: cutlass.Float32,  # linear scale (for dS)
@@ -289,14 +301,35 @@ def _bprop_kernel(
     PARTIAL_KV = False if cutlass.const_expr(THD_VARLEN) else ((SKV % tile_kv) != 0)
 
     # Grid decode.  SCHED_DEFAULT: plain 3-D (kv_tile, head, batch).  SCHED_LPT:
-    # 1-D kv-major flat grid — bx = kv_tile*(H*B) + head*B... no: kv-major means
-    # kv_tile = bx // (H*B), so all (head,batch) of kv=0 come first (heaviest).
+    # 1-D kv-major flat grid, kv_tile = bx // (H*B), so all (head, batch) of
+    # kv=0 come first (heaviest).  SCHED_LPT_L2: the same order within L2-sized
+    # (batch, kv_head) groups, one group block after another.
     if cutlass.const_expr(sched_policy == SCHED_LPT):
         _hb = cutlass.Int32(H) * cutlass.Int32(B)
         kv_tile = bx // _hb
         _r = bx % _hb
         head = _r % cutlass.Int32(H)
         batch = _r // cutlass.Int32(H)
+    elif cutlass.const_expr(sched_policy == SCHED_LPT_L2):
+        # Block-cyclic over L2-sized (batch, kv_head) groups, kv-major within a
+        # block: the shared fwd helper decodes (row_rank, head, batch) with the
+        # row REVERSED for the forward's heavy-high-q order; the backward's heavy
+        # tiles are LOW kv (kv-tile 0 attends every q), so undo the reversal.
+        # per_group = this group's Q + dO + fp32 dQ stream over its heads_per_kv
+        # query heads -- the bytes the group's CTAs re-touch every Q-iter.
+        _nkv = cutlass.Int32((SKV + tile_kv - 1) // tile_kv)
+        _hpk = H // Hkv
+        _row, head, batch = lpt_l2_tile_coords(
+            bx,
+            cutlass.Int32(H),
+            cutlass.Int32(B),
+            _nkv,
+            _hpk,
+            cutlass.Int32(SQ),
+            _hpk * (2 * d_qk + 2 * d_v + 4 * d_qk),
+            sched_l2_bytes,
+        )
+        kv_tile = (_nkv - cutlass.Int32(1)) - _row
     else:
         kv_tile = bx
         head = by
@@ -1458,6 +1491,7 @@ def _bprop_host(
     thd_varlen: cutlass.Constexpr[bool],
     deterministic: cutlass.Constexpr[bool],
     sched_policy: cutlass.Constexpr[int],
+    sched_l2_bytes: cutlass.Constexpr[int],
     n_q_tiles: cutlass.Int32,
     softmax_scale_log2: cutlass.Float32,
     attn_scale: cutlass.Float32,
@@ -1478,7 +1512,7 @@ def _bprop_host(
     # 3-D grid only (SCHED_DEFAULT); LPT+THD is a future scheduler tweak.
     if cutlass.const_expr(thd_varlen):
         grid = (grid_kv_tiles, H, grid_batch)
-    elif cutlass.const_expr(sched_policy == SCHED_LPT):
+    elif cutlass.const_expr(sched_policy == SCHED_LPT or sched_policy == SCHED_LPT_L2):
         n_kv_tiles = (SKV + tile_kv - 1) // tile_kv
         grid = (n_kv_tiles * H * B, 1, 1)
     else:
@@ -1521,6 +1555,7 @@ def _bprop_host(
         thd_varlen,
         deterministic,
         sched_policy,
+        sched_l2_bytes,
         n_q_tiles,
         softmax_scale_log2,
         attn_scale,
@@ -1792,6 +1827,7 @@ def compile(  # noqa: A001 — the template contract's entry point
         bool(p.thd_varlen),
         bool(p.deterministic),
         int(p.sched_policy),
+        int(p.sched_l2_mib) * 1024 * 1024,
         cutlass.Int32(0),
         cutlass.Float32(0.0),
         cutlass.Float32(0.0),

--- a/test/python/fe_api/sdpa/test_sdpa_bwd_sm80.py
+++ b/test/python/fe_api/sdpa/test_sdpa_bwd_sm80.py
@@ -156,6 +156,58 @@ def test_sdpa_bwd_sm80_wrapper(dtype, d_qk, d_v, mask, gqa):
 
 
 @pytest.mark.L0
+@pytest.mark.parametrize(
+    "is_causal,deterministic,expected", [(True, False, "lpt_l2"), (True, True, "natural"), (False, False, "natural")], ids=["causal", "causal-det", "dense"]
+)
+def test_sm80_bwd_sched_policy_resolution(is_causal, deterministic, expected):
+    """Causal takes the L2-grouped kv-major order; the deterministic relay and
+    non-causal work keep the plain 3-D grid (host-only: no compile)."""
+    try:
+        from cudnn.sdpa.bwd import api_dsl as api_sm80
+        from cudnn.frost.tile_dsl.constants import SCHED_LPT_L2, SCHED_NATURAL
+    except ImportError as e:
+        pytest.skip(f"SM80 SDPA API not available: {e}")
+    want = {"lpt_l2": SCHED_LPT_L2, "natural": SCHED_NATURAL}[expected]
+    assert api_sm80._sm80_bwd_sched_policy(is_causal=is_causal, deterministic=deterministic) == want
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=0)
+def test_sm80_bwd_lpt_l2_short_last_group():
+    """LPT_L2 grid decode with a SHORT last head-group block.
+
+    per_group = S_q * (Q + dO + fp32 dQ) = 8192 * 1024 B = 8 MiB against the
+    16 MiB budget -> 2 heads per block; H=3 MHA leaves the last block with one
+    head, exercising the clamped decode.  Every (kv_tile, head) must be visited
+    exactly once for dK/dV to be right and dQ to be complete.
+    """
+    try:
+        from cudnn.sdpa.bwd import sdpa_bwd_wrapper_sm80
+        from cudnn.sdpa.fwd import sdpa_fwd_wrapper_sm80
+        from cudnn.sdpa.bwd import api_dsl as api_sm80
+    except ImportError as e:
+        pytest.skip(f"SM80 SDPA API not available: {e}")
+    b, h, s, d = 1, 3, 8192, 128
+    dtype = torch.bfloat16
+    q, k, v, do = (_bshd_randn(b, h, s, d, dtype=dtype, device="cuda") for _ in range(4))
+    scale = 1.0 / math.sqrt(d)
+    fwd = sdpa_fwd_wrapper_sm80(q_tensor=q, k_tensor=k, v_tensor=v, is_causal=True, scale_softmax=scale)
+    out = sdpa_bwd_wrapper_sm80(
+        q_tensor=q, k_tensor=k, v_tensor=v, o_tensor=fwd["o_tensor"], do_tensor=do, lse_tensor=fwd["lse_tensor"], is_causal=True, scale_softmax=scale
+    )
+    # The wrapper's cached adapter for THIS shape must be on the grouped order
+    # (the cache is module-global, so filter by the shape, not any entry).
+    from cudnn.frost.tile_dsl.constants import SCHED_LPT_L2
+
+    mine = [e for e in api_sm80._sm80_bwd_cache.values() if getattr(e, "s_q_max", None) == s and getattr(e, "h_q", None) == h]
+    assert mine and all(e._params.sched_policy == SCHED_LPT_L2 for e in mine)
+    _, dq_ref, dk_ref, dv_ref = _ref_grads(q, k, v, do, is_causal=True, window_left=-1, scale=scale)
+    torch.testing.assert_close(out["dq_tensor"].to(torch.float32), dq_ref, rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(out["dk_tensor"].to(torch.float32), dk_ref, rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(out["dv_tensor"].to(torch.float32), dv_ref, rtol=3e-2, atol=3e-2)
+
+
+@pytest.mark.L0
 @torch_fork_set_rng(seed=0)
 def test_sdpa_bwd_sm80_deterministic_repeatable():
     """deterministic=True must produce bitwise-identical dQ across runs."""

--- a/test/python/sdpa/frost/test_tile_dsl_q_loop_bounds.py
+++ b/test/python/sdpa/frost/test_tile_dsl_q_loop_bounds.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pins ``tile_dsl.mask.compute_q_loop_bounds`` / ``swa_kv_lo_tile`` (the SM80
+backward's Q-loop bounds and deterministic-relay origin) against a host replica
+of the arithmetic they replaced, over every mask family, alignment and the
+bottom-right / right-band variants.  A probe kernel evaluates the helpers for
+every kv tile; the reference is plain Python on the same inputs."""
+
+import pytest
+import torch
+
+from frost_test_utils import _dsl_installed, requires_dsl
+
+pytestmark = [pytest.mark.L0, requires_dsl]
+
+if _dsl_installed():
+    import cuda.bindings.driver as _cuda_driver
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass.base_dsl.typing import Pointer
+    from cutlass.cute.runtime import from_dlpack
+
+    from cudnn.frost.tile_dsl.mask import MASK_CAUSAL, MASK_NONE, MASK_SWA, compute_q_loop_bounds, swa_kv_lo_tile
+
+    @cute.kernel
+    def _probe_kernel(
+        out_t: cute.Tensor,
+        seqlen_q: cutlass.Int32,
+        seq_kv_len: cutlass.Int32,
+        n_q_tiles: cutlass.Int32,
+        window_right: cutlass.Int32,
+        mask_flags: cutlass.Constexpr[int],
+        window_left: cutlass.Constexpr[int],
+        tile_q: cutlass.Constexpr[int],
+        tile_kv: cutlass.Constexpr[int],
+        bottom_right: cutlass.Constexpr[bool],
+    ):
+        bx, _, _ = cute.arch.block_idx()
+        tidx, _, _ = cute.arch.thread_idx()
+        if tidx == cutlass.Int32(0):
+            kv_base = bx * cutlass.Int32(tile_kv)
+            b = compute_q_loop_bounds(kv_base, seqlen_q, seq_kv_len, n_q_tiles, window_left, mask_flags, tile_q, tile_kv, bottom_right, window_right)
+            # Relay origin for the q tile with the same index as this kv tile
+            # (any q row works; this keeps the probe one launch).
+            anchor = bx * cutlass.Int32(tile_q)
+            if cutlass.const_expr(bottom_right):
+                anchor = anchor + (seq_kv_len - seqlen_q)
+            kv_first = swa_kv_lo_tile(anchor, window_left, tile_kv)
+            base = Pointer(out_t.iterator.raw_ptr(), dtype=cutlass.Int32) + bx * cutlass.Int32(3)
+            base.store(b.lo, alignment=4)
+            (base + cutlass.Int32(1)).store(b.hi, alignment=4)
+            (base + cutlass.Int32(2)).store(kv_first, alignment=4)
+
+    _probe_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+    @cute.jit
+    def _probe_host(
+        out_t,
+        seqlen_q,
+        seq_kv_len,
+        n_q_tiles,
+        window_right,
+        n_kv,
+        mask_flags: cutlass.Constexpr[int],
+        window_left: cutlass.Constexpr[int],
+        tile_q: cutlass.Constexpr[int],
+        tile_kv: cutlass.Constexpr[int],
+        bottom_right: cutlass.Constexpr[bool],
+        stream,
+    ):
+        _probe_kernel(out_t, seqlen_q, seq_kv_len, n_q_tiles, window_right, mask_flags, window_left, tile_q, tile_kv, bottom_right).launch(
+            grid=(n_kv, 1, 1), block=(32, 1, 1), stream=stream
+        )
+
+
+def _ref_bounds(kv_base, *, s_q, s_kv, n_q_tiles, window_left, mask_flags, tile_q, tile_kv, bottom_right, window_right):
+    """The SM80 backward's original inline arithmetic (PR #866 form)."""
+    diag = (s_kv - s_q) if bottom_right else 0
+    lo = 0
+    if mask_flags & MASK_CAUSAL:
+        lo = max(((kv_base - diag) if bottom_right else kv_base) - window_right, -(10**9)) // tile_q
+        lo = max(lo, 0)
+    n_iters = max(n_q_tiles - lo, 0)
+    if mask_flags & MASK_SWA:
+        q_hi_abs = kv_base + tile_kv + window_left
+        if bottom_right:
+            q_hi_abs -= diag
+        q_hi_abs = max(q_hi_abs, 0)
+        q_hi_t = min(-(-q_hi_abs // tile_q), n_q_tiles)
+        n_iters = max(q_hi_t - lo, 0)
+    return lo, n_iters
+
+
+def _ref_kv_first(q_row0, *, window_left, tile_kv):
+    return max((q_row0 - window_left) // tile_kv, 0)
+
+
+_CASES = [
+    # (mask_flags, window_left, bottom_right, window_right, tile_q, tile_kv, s_q, s_kv)
+    (MASK_NONE, 0, False, 0, 64, 64, 512, 512),
+    (MASK_CAUSAL, 0, False, 0, 64, 64, 512, 512),
+    (MASK_CAUSAL, 0, False, 40, 64, 64, 448, 640),  # band widening, unaligned q
+    (MASK_CAUSAL, 0, True, 0, 64, 64, 512, 768),  # bottom-right, S_kv > S_q
+    (MASK_CAUSAL, 0, True, 0, 64, 64, 768, 512),  # bottom-right, S_kv < S_q (negative diagonal)
+    (MASK_CAUSAL | MASK_SWA, 128, False, 0, 64, 64, 1024, 1024),
+    (MASK_CAUSAL | MASK_SWA, 128, True, 0, 64, 64, 1024, 1536),
+    (MASK_CAUSAL | MASK_SWA, 96, True, 16, 128, 64, 1152, 1408),  # gptoss tile, odd window, band
+    (MASK_SWA, 200, False, 0, 64, 64, 704, 704),  # window without causal
+]
+
+
+@pytest.mark.parametrize("case", _CASES, ids=[f"m{c[0]}-W{c[1]}-br{int(c[2])}-R{c[3]}-tq{c[4]}-{c[6]}x{c[7]}" for c in _CASES])
+def test_q_loop_bounds_match_reference(case):
+    mask_flags, window_left, bottom_right, window_right, tile_q, tile_kv, s_q, s_kv = case
+    dev = torch.device("cuda")
+    n_kv = -(-s_kv // tile_kv)
+    n_q_tiles = -(-s_q // tile_q)
+    out = torch.full((n_kv * 3,), -7, dtype=torch.int32, device=dev)
+    stream = _cuda_driver.CUstream(torch.cuda.current_stream(dev).cuda_stream)
+    args = (
+        from_dlpack(out, assumed_align=16),
+        cutlass.Int32(s_q),
+        cutlass.Int32(s_kv),
+        cutlass.Int32(n_q_tiles),
+        cutlass.Int32(window_right),
+        cutlass.Int32(n_kv),
+        int(mask_flags),
+        int(window_left),
+        int(tile_q),
+        int(tile_kv),
+        bool(bottom_right),
+        stream,
+    )
+    # The compiled host takes only the runtime arguments; the Constexpr ones are
+    # baked in at compile time.
+    runtime = tuple(a for a in args if not isinstance(a, (int, bool)) or isinstance(a, cutlass.Int32))
+    cute.compile(_probe_host, *args)(*runtime)
+    torch.cuda.synchronize()
+    got = out.cpu().tolist()
+    for kv_tile in range(n_kv):
+        lo, n_iters = _ref_bounds(
+            kv_tile * tile_kv,
+            s_q=s_q,
+            s_kv=s_kv,
+            n_q_tiles=n_q_tiles,
+            window_left=window_left,
+            mask_flags=mask_flags,
+            tile_q=tile_q,
+            tile_kv=tile_kv,
+            bottom_right=bottom_right,
+            window_right=window_right,
+        )
+        g_lo, g_hi, g_first = got[kv_tile * 3 : kv_tile * 3 + 3]
+        assert g_lo == lo, (kv_tile, g_lo, lo)
+        assert max(g_hi - g_lo, 0) == n_iters, (kv_tile, g_hi, g_lo, n_iters)
+        q_row0 = kv_tile * tile_q + ((s_kv - s_q) if bottom_right else 0)
+        assert g_first == _ref_kv_first(q_row0, window_left=window_left, tile_kv=tile_kv), (kv_tile, g_first)


### PR DESCRIPTION
## What

Two performance fixes for the SM80 (A100) SDPA backward kernel and the shared-helper refactor of its loop bounds, as three separate commits:

1. **Bank-conflict-free dQ staging.** The dQ C-fragment is staged through SMEM (`sDQ`) so the atomics coalesce. That staging store put 8 rows per warp instruction at a `d_qk`-word row stride, so every row landed in the same banks: an 8-way conflict costing about as many SMEM cycles per Q-iteration as the MMAs take. `sDQ` now uses an XOR-swizzled column (`_sdq_off`) with 8 B pair stores; the row-major read-back stays conflict-free. The B3 barrier after the atomics is dropped on this path (B2b and the next iteration's B0 already order the ring-stage and `sDQ` reuse).
2. **Causal grid order: kv-major LPT within L2-sized head groups (`SCHED_LPT_L2`).** The kv-major LPT over every head at once put the ~108 resident CTAs on ~108 different heads, so a head's Q / dO / dQ tiles left L2 between its kv-tiles' visits and the fp32 dQ atomics became DRAM read-modify-writes. The plain 3-D grid keeps the locality but ends with a one-CTA-long tail that costs 10-17% on small grids. `SCHED_LPT_L2` (the forward's `lpt_l2_tile_coords` decode with the row un-reversed, since the backward's heavy tiles are the *low* kv tiles) keeps both. Causal non-deterministic graphs resolve to it (`_sm80_bwd_sched_policy`); deterministic and non-causal keep the plain grid; `SCHED_LPT` stays available by request. `TemplateParams.sched_l2_mib` (16) sizes the groups.
3. **Shared loop-bounds helpers.** `compute_q_loop_bounds` in `tile_dsl/mask.py` is the KV-major dual of `compute_kv_loop_bounds` (q-tile range attending one kv tile; causal trims from below, the window from above); `swa_kv_lo_tile` is the window's first kv tile for an anchor row, now shared by the forward's KV-loop lower bound and the backward's deterministic relay turn. The kernel uses both in place of its inline arithmetic. A probe-kernel test pins them against a host replica of the previous arithmetic across causal / bottom-right / right-band / window / gptoss-tile cases.

## Numbers

A100 40GB, B=2, H=64/8 (GQA), d=128, bf16, wrapper kernel time in ms (`cudnn` = native backend for reference):

| | develop | this PR | cuDNN backend |
|---|---:|---:|---:|
| causal S=4K | 23.3 | 16.5 | 13.2 |
| causal S=8K | 89.2 | 62.6 | 48.1 |
| non-causal S=4K | 33.4 | 30.0 | 23.1 |
| non-causal S=8K | 131.5 | 116.3 | 89.0 |

Engine path through the graph API (`benchmark_single_sdpa.py --sdpa_backend cudnn_oss`) matches: causal S4K 16.3 ms / 85 TFLOPS, non-causal 29.8 ms / 92 TFLOPS. Small causal grids (B1 H4..H16, S2K..8K) are within 1.5% of plain LPT. The refactor commit leaves timings unchanged.

What the ablations said, for the record: RMW contention on the atomics themselves is only ~1 ms of the 33 ms non-causal S4K; the kernel runs 8 warps/SM at the 255-register cap and is issue-bound, so instruction count in the Q-loop is what matters. A v4 read-back with four atomics per thread was 2x slower (lanes stride 4 apart → 16 L2 sectors per request), so the read-back keeps lanes column-consecutive. Deterministic mode keeps the plain grid and is now the slower path (36 vs 16 ms causal S4K).

## Tests

- `test/python/fe_api/sdpa/test_sdpa_bwd_sm80.py`: scheduler-resolution pin (host-only) and an H=3 MHA S=8K causal case whose last head-group block is short (2 heads per 16 MiB block).
- `test/python/sdpa/frost/test_tile_dsl_q_loop_bounds.py`: probe-kernel equivalence for the shared helpers (9 cases).
- Existing SM80 backward suites (wrapper, frontend integration, stream respect): 32 passed on an A100.

No capability change, so the support matrix tracker is untouched; the kernel's design docstring (staging, barrier table, scheduler) is updated with the code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added improved SM80 backward scheduling for causal workloads, with better L2 locality.
  * Expanded support for sliding-window and causal attention layouts, including bottom-right alignment and varying window bands.
  * Improved memory access patterns for backward gradient computation.

* **Bug Fixes**
  * Improved deterministic sliding-window execution and handling of short final tile groups.
  * Refined query/key-value traversal bounds for more reliable masked attention processing.

* **Tests**
  * Added coverage for scheduling policies, execution correctness, and diverse attention mask configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->