### PR TITLE
Fix conv ReLU execution plan creation test

### DIFF
--- a/test/python/test_conv_bias.py
+++ b/test/python/test_conv_bias.py
@@ -224,7 +224,7 @@ def test_conv_relu_execution_plan_creation(cudnn_handle):
                 for kernel_cfg in range(knob.min_value, knob.max_value + 1, knob.stride):
                     try:
                         graph.create_execution_plan(engine, {cudnn.knob_type.KERNEL_CFG: kernel_cfg})
-                    except RuntimeError:
+                    except (RuntimeError, cudnn.cudnnGraphNotSupportedError):
                         continue
 
     graph.check_support()


### PR DESCRIPTION
## Before submitting

- [X] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [X] I ran `pre-commit run` and committed any formatting changes.
- [X] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches (see [root AGENTS.md § Reviewing a PR](https://github.com/NVIDIA/cudnn-frontend/blob/develop/AGENTS.md#reviewing-a-pr-human-or-agent)) and my changes comply, or I explain the exception below.
- [x] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

- CI or test infrastructure

## Summary

Handle `cudnnGraphNotSupportedError` while enumerating convolution + ReLU   execution-plan kernel configurations.

## Why

Some kernel configurations are legitimately unsupported. Plan creation reports  these through `cudnnGraphNotSupportedError`, which is not a `RuntimeError`.  Consequently, an unsupported candidate escaped the existing handler and failed the entire test instead of allowing enumeration to continue.

The test now accepts either exception type used by the Frontend layers.

## Related issues

None

## API and compatibility impact

None; test-side fix.

## Testing

Tested on an NVIDIA L40S (SM89), CUDA 13.3, and cuDNN 9.24.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated execution-plan creation test handling to skip unsupported cuDNN graph configurations alongside runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->