### PR TITLE
test(sdpa): align the SM100 fp8 d512 envelope test with the exact-shape d256 floor

### DIFF
--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -1776,13 +1776,18 @@ def test_fp8_d512_head_dim_envelope(d_qk, d_v, mask):
 @pytest.mark.L0
 @_skip_d512_on_rubin
 def test_fp8_d512_envelope_floor_declines_straddling_shapes():
-    """D256 serves its own envelope; shapes straddling the D512 floor decline."""
+    """The D512 flavor serves the (256, 512] band on both head dims; shapes
+    straddling its floor decline.  Below it the D256 flavor is exact-shape only
+    (its padded envelope is non-deterministic, see
+    test_fp8_large_flavors_serve_exact_shapes_only), so a shape such as
+    (160, 160) -- too wide for D192/128, not the D256 shape -- is declined too.
+    """
     from cudnn.sdpa.fwd.api_dsl import _fp8_envelope_covers, _sm100_fp8_shapes
 
     shapes = _sm100_fp8_shapes(pertensor=True, device_cc=(10, 0))
-    for d_qk, d_v in [(160, 160), (256, 256), (384, 448), (464, 368), (272, 272), (512, 512)]:
+    for d_qk, d_v in [(256, 256), (384, 448), (464, 368), (272, 272), (512, 512)]:
         assert _fp8_envelope_covers(d_qk, d_v, shapes), (d_qk, d_v)
-    for d_qk, d_v in [(272, 256), (384, 128), (512, 256)]:
+    for d_qk, d_v in [(160, 160), (272, 256), (384, 128), (512, 256)]:
         assert not _fp8_envelope_covers(d_qk, d_v, shapes), (d_qk, d_v)
 
 


### PR DESCRIPTION
## What

One test file. `test_fp8_d512_envelope_floor_declines_straddling_shapes` still expected `(160, 160)` to be served through the SM100 per-tensor FP8 d256 envelope. PR #869 made that flavor exact-shape only (its padded envelope is non-deterministic; see `test_fp8_large_flavors_serve_exact_shapes_only`, which asserts `(160, 160)` is declined). Both cannot hold. `(160, 160)` is too wide for the 192/128 flavor, is not the d256 shape, and sits below the d512 floor, so the row declines it. This moves it to the declined list and says why in the docstring.

## Why now

The `frost-sdpa:cutlass-rel:sm100` lane fails on this test for every PR (seen on #948's pipeline 66841536), and it fails locally on a cc 10.0 device against develop. It has been latent since #869 merged; my mistake for not reconciling the two tests then.

## Verification

Blackwell (cc 10.0), develop + this change: the four fp8 floor/exact-shape tests in the file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated SDPA FP8 coverage expectations for head dimensions in the `(256, 512]` range.
  - Clarified that the D256 configuration supports only exact shapes below the D512 boundary.
  - Updated the `(160, 160)` case to expect rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->