### PR TITLE
test_mhas_v2 refs: torch.matmul instead of torch.einsum (SM107 CI worker crashes in cuBLAS)

### DIFF
--- a/test/python/sdpa/fp16_ref.py
+++ b/test/python/sdpa/fp16_ref.py
@@ -93,17 +93,42 @@ def _grouped(x, h_kv):
     return x.view(b, h_kv, h_q // h_kv, s, d)
 
 
+# The three contractions below are written with torch.matmul on the grouped 5-D views rather
+# than torch.einsum. Same fp32 math, but einsum lowers "bhgqd,bhkd->bhgqk" to one bmm with the
+# GQA group folded into M (M = g*s_q up to ~10^5, N = the 128-wide KV block); on aarch64 VR200
+# (SM107) that cublasSgemmStridedBatched shape crashes or hangs under multi-process GPU
+# sharing (xdist -n 8), while the matmul form keeps the group as a batch dimension and does
+# not. See /home/scratch.vagarwalla_gpu/sm107_cublas_concurrency_repro.
+
+
+def _mm(a, b):
+    # matmul, except that a contraction of length 1 (a 1-column KV block in P @ V, or s_q = 1 in
+    # dS^T @ Q / P^T @ dO) is a plain broadcast product. torch nightlies (2.14.0.dev, torch._native)
+    # reroute aten::bmm with K = 1 to a Triton outer-product kernel, and Triton's ptxas has no
+    # sm_107a target (PTXASError / process abort on Rubin). The product is exact either way.
+    if a.shape[-1] == 1:
+        return a * b
+    return torch.matmul(a, b)
+
+
 def _qk(q, k_block, h_k):
     # q: (b, h_q, s_q, d), k_block: (b, h_k, n, d) -> (b, h_q, s_q, n) without expanding K.
     b, h_q, s_q, _ = q.shape
-    s = torch.einsum("bhgqd,bhkd->bhgqk", _grouped(q, h_k), k_block)
+    s = _mm(_grouped(q, h_k), k_block.transpose(-1, -2).unsqueeze(2))  # (b, h_k, g, s_q, n)
     return s.reshape(b, h_q, s_q, -1)
 
 
 def _pv(p, v_block, h_v):
+    # p: (b, h_q, s_q, n), v_block: (b, h_v, n, d) -> (b, h_q, s_q, d) without expanding V.
     b, h_q, s_q, _ = p.shape
-    o = torch.einsum("bhgqk,bhkd->bhgqd", _grouped(p, h_v), v_block)
+    o = _mm(_grouped(p, h_v), v_block.unsqueeze(2))  # (b, h_v, g, s_q, d)
     return o.reshape(b, h_q, s_q, -1)
+
+
+def _kv_reduce(x, y, h_kv):
+    # x: (b, h_q, s_q, n), y: (b, h_q, s_q, d) -> (b, h_kv, n, d): x^T @ y per head, summed over
+    # the GQA group ("bhgqk,bhgqd->bhkd"). Used for dK (x = dS, y = Q) and dV (x = P, y = dO).
+    return _mm(_grouped(x, h_kv).transpose(-1, -2), _grouped(y, h_kv)).sum(2)
 
 
 def _score_blocks(q, k, attn_scale, mask):
@@ -261,15 +286,13 @@ def compute_ref_backward(
     dV = torch.zeros((b, h_v, s_kv, d_v), dtype=torch.float32, device=device)
     dBias = torch.zeros((1, h_q, s_q, s_kv), dtype=torch.float32, device=device) if bias is not None else None
 
-    q_g_k = _grouped(q, h_k)
-    dO_g_v = _grouped(dO, h_v)
 
     # Pass 2: P = exp(S - lse) per block; all-masked rows give exp(-inf - -inf) -> nan -> 0.
     for start, end, s_block in _score_blocks(q, k, attn_scale, mask):
         p = torch.exp(s_block - lse).nan_to_num()
 
         # dP = dO @ V^T, then apply dropout mask
-        dP = torch.einsum("bhgqd,bhkd->bhgqk", dO_g_v, v[:, :, start:end, :]).reshape(b, h_q, s_q, end - start)
+        dP = _qk(dO, v[:, :, start:end, :], h_v)
         if dropout_prob != 0.0:
             drop = dropout_mask[:, :, :, start:end]
             dP = (dP * drop) / (1 - dropout_prob)
@@ -289,8 +312,8 @@ def compute_ref_backward(
         # dQ += dS @ K_block
         dQ = dQ + _pv(dS, k[:, :, start:end, :], h_k)
         # dK_block = dS^T @ Q, dV_block = P_dropped^T @ dO (both reduce over the GQA group directly)
-        dK[:, :, start:end, :] = torch.einsum("bhgqk,bhgqd->bhkd", _grouped(dS, h_k), q_g_k)
-        dV[:, :, start:end, :] = torch.einsum("bhgqk,bhgqd->bhkd", _grouped(p_dropped, h_v), dO_g_v)
+        dK[:, :, start:end, :] = _kv_reduce(dS, q, h_k)
+        dV[:, :, start:end, :] = _kv_reduce(p_dropped, dO, h_v)
 
     # dSink_token: gradient for sink token
     dSink_token = None

--- a/test/python/sdpa/fp8_ref.py
+++ b/test/python/sdpa/fp8_ref.py
@@ -5,7 +5,7 @@ import math
 import torch
 
 from .helpers import get_fp8_scale_factor, get_fp8_descale_factor
-from .fp16_ref import _ScoreMask, _score_blocks, _pv, _grouped, _init_softmax_state, _prepare
+from .fp16_ref import _ScoreMask, _score_blocks, _qk, _pv, _kv_reduce, _init_softmax_state, _prepare
 
 # fmt: off
 
@@ -115,12 +115,10 @@ def compute_ref_backward(q, k, v, o, dO, attn_scale,
 
     D = (o.float() * dO.transpose(1, 2)).sum(dim=-1, keepdim=True).transpose(1, 2) * o_descale * dO_descale
 
-    dO_g_v = _grouped(dO, h_v)
-    q_g_k = _grouped(q, h_k)
 
     def dP_block(start, end):
         # dO (FP8) @ V (FP8) -> dP (FP32)
-        dP = torch.einsum("bhgqd,bhkd->bhgqk", dO_g_v, v[:, :, start:end, :]).reshape(b, h_q, s_q, end - start)
+        dP = _qk(dO, v[:, :, start:end, :], h_v)
         return dP * dO_descale * v_descale
 
     # dP is quantized with one global scale, so its amax needs a pass of its own.
@@ -141,7 +139,7 @@ def compute_ref_backward(q, k, v, o, dO, attn_scale,
 
         # P (FP32) -> P (FP8); P (FP8) @ dO (FP8) -> dV (FP32)
         p_quant = (p * s_scale).to(torch_itype).float()
-        dV[:, :, start:end, :] = torch.einsum("bhgqk,bhgqd->bhkd", _grouped(p_quant, h_v), dO_g_v) * s_descale * dO_descale
+        dV[:, :, start:end, :] = _kv_reduce(p_quant, dO, h_v) * s_descale * dO_descale
 
         dS = p * (dP_block(start, end) - D) * attn_scale
         # dS (FP32) -> dS (FP8)
@@ -149,7 +147,7 @@ def compute_ref_backward(q, k, v, o, dO, attn_scale,
 
         # dS (FP8) @ K (FP8) -> dQ (FP32); dS^T (FP8) @ Q (FP8) -> dK (FP32)
         dQ = dQ + _pv(dS_quant, k[:, :, start:end, :], h_k) * k_descale * dP_descale
-        dK[:, :, start:end, :] = torch.einsum("bhgqk,bhgqd->bhkd", _grouped(dS_quant, h_k), q_g_k) * q_descale * dP_descale
+        dK[:, :, start:end, :] = _kv_reduce(dS_quant, q, h_k) * q_descale * dP_descale
 
     # Compute dSink_token if sink_token was provided
     # Formula: dSink = -exp(sink - logsumexp) * D summed over batch and sequence

--- a/test/python/sdpa/mxfp8_ref.py
+++ b/test/python/sdpa/mxfp8_ref.py
@@ -4,7 +4,7 @@
 import math
 import torch
 
-from .fp16_ref import _ScoreMask, _score_blocks, _pv, _grouped, _init_softmax_state
+from .fp16_ref import _ScoreMask, _score_blocks, _qk, _pv, _kv_reduce, _init_softmax_state
 
 # fmt: off
 
@@ -141,9 +141,6 @@ def compute_ref_backward(q_fp8, q_t_fp8, k_fp8, k_t_fp8, v_fp8, o_f16, dO_f16, d
     dQ = torch.zeros((b, h_q, s_q, d_qk), dtype=torch.float32, device=device)
     dK = torch.zeros((b, h_k, s_kv, d_qk), dtype=torch.float32, device=device)
     dV = torch.zeros((b, h_v, s_kv, d_vo), dtype=torch.float32, device=device)
-    dO_g_v = _grouped(dO_dq, h_v)
-    dO_t_g_v = _grouped(dO_t_dq, h_v)
-    q_t_g_k = _grouped(q_t_dq, h_k)
 
     for start, end, s_raw in _score_blocks(q_dq, k_dq, None, mask):
         n = end - start
@@ -168,7 +165,7 @@ def compute_ref_backward(q_fp8, q_t_fp8, k_fp8, k_t_fp8, v_fp8, o_f16, dO_f16, d
         p_fp8 = (p * 256.0).to(torch_itype).float() * (1.0 / 256.0)
 
         # dO @ V -> dP
-        dP = torch.einsum("bhgqd,bhkd->bhgqk", dO_g_v, v_dq[:, :, start:end, :]).reshape(b, h_q, s_q, n)
+        dP = _qk(dO_dq, v_dq[:, :, start:end, :], h_v)
 
         # dS = P * (dP - D) * attn_scale
         dS = p * (dP - D) * attn_scale
@@ -182,10 +179,10 @@ def compute_ref_backward(q_fp8, q_t_fp8, k_fp8, k_t_fp8, v_fp8, o_f16, dO_f16, d
         dS_fp32 = _dequant(dS_fp8, sf_dS_ref)
         dS_fp32_t = _dequant(dS_fp8_t, sf_dS_t_ref)
 
-        # P @ dO -> dV; dS @ K -> dQ; dS^T @ Q -> dK (GQA reduction folded into the einsum)
-        dV[:, :, start:end, :] = torch.einsum("bhgqk,bhgqd->bhkd", _grouped(p_fp8, h_v), dO_t_g_v)
+        # P @ dO -> dV; dS @ K -> dQ; dS^T @ Q -> dK (GQA reduction inside _kv_reduce)
+        dV[:, :, start:end, :] = _kv_reduce(p_fp8, dO_t_dq, h_v)
         dQ = dQ + _pv(dS_fp32, k_t_dq[:, :, start:end, :], h_k)
-        dK[:, :, start:end, :] = torch.einsum("bhgqk,bhgqd->bhkd", _grouped(dS_fp32_t, h_k), q_t_g_k)
+        dK[:, :, start:end, :] = _kv_reduce(dS_fp32_t, q_t_dq, h_k)
 
     # Compute dSink_token if sink_token was provided
     # Formula: dSink = -exp(sink - logsumexp) * D summed over batch and sequence


### PR DESCRIPTION
Replaces the three `torch.einsum` contractions in the `test_mhas_v2` SDPA references (`fp16_ref.py`, `fp8_ref.py`, `mxfp8_ref.py`) with `torch.matmul` on the same grouped 5-D views. Same fp32 math; only the cuBLAS call shape changes.

### Why
`test_mhas_v2.py -n 8` on the SM107 CI (aarch64 VR200, `dl/dgx/pytorch:rubin-py3-devel`: torch 2.14.0a0 nvinternal, CUDA 13.5, cuBLAS 13.8.0.1023, driver 615.62.07) loses xdist workers to `CUBLAS_STATUS_EXECUTION_FAILED` in `cublasSgemmStridedBatched` / `unspecified launch failure`, or hangs with the GPU at 100 %, inside the **PyTorch reference** (e.g. gitlab job 430534451, after the stream fix in #947). A cuDNN-free reproducer that only runs the reference einsums shows the same thing:

| workload on one VR200 GPU, 8 processes | result |
|---|---|
| reference `einsum`s (`"bhgqd,bhkd->bhgqk"` etc.) | 4 of 4 runs hit: 5 crashes + 1 hang across 32 workers |
| same products via `torch.matmul` on the 5-D views | 0 of 3 runs |
| einsum, 1 or 2 processes, or `CUDA_LAUNCH_BLOCKING=1` | clean |

The difference is the GEMM layout: einsum folds the GQA group into M (one bmm with M = g·s_q up to ~10^5, N = the 128-wide KV block, batch = b·h_k); matmul keeps the group as a batch dimension (M = s_q). Only the einsum shape faults on that platform. B200 and x86-hosted Rubin are clean either way. The cuBLAS/driver issue is being reported separately with the standalone reproducer; this PR just removes our exposure so the CI can stay at 8 workers.

### Change
- `fp16_ref.py`: `_qk` / `_pv` rewritten with `torch.matmul`; new `_kv_reduce(x, y, h_kv)` = x^T @ y per head summed over the GQA group (the old `"bhgqk,bhgqd->bhkd"`), used for dK and dV. Comment at the definitions records the reason.
- `_mm(a, b)`: `torch.matmul`, except a contraction of length 1 (a 1-column KV block in P·V, or s_q = 1 in dSᵀ·Q / Pᵀ·dO) is computed as the broadcast product `a * b`. Found on x86 Rubin with the torch 2.14.0.dev nightly: its experimental `torch._native` layer reroutes `aten::bmm` with K = 1 to a Triton outer-product kernel, and Triton's bundled ptxas has no `sm_107a` target (`PTXASError`, and in some cases a process abort that takes the xdist worker down). einsum never hit that path; the plain matmul form did in 32 cases (`*_sq1_*`, random shapes with s_kv ≡ 1 mod 128). The product is exact either way.
- `fp8_ref.py`, `mxfp8_ref.py`: the dP / dK / dV einsums call `_qk` / `_kv_reduce`; the now-unused pre-grouped views are gone.
- Helper parity vs the old einsums (fp32, several GQA shapes): Q·Kᵀ and P·V bit-identical; dK/dV differ only by fp32 summation order (≤ 2e-6 relative).

### Verification (`test_mhas_v2.py -n 8`, cudnn 9.26 release build)
| GPU | result |
|---|---|
| B200 | **3243 passed / 0 failed** |
| x86 Rubin (cc 10.7) | **3243 passed / 0 failed** |

No test tolerances or expected values change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated FP16, FP8, and MXFP8 attention reference calculations to use revised grouped contraction paths.
  * Improved coverage of grouped-query and multi-query attention backward calculations, including gradient computations.
  * Avoided affected contraction paths for single-column operations in FP16 reference testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->