### PR TITLE
Adding Sub-channel Scaling Grouped GEMMs

### DIFF
--- a/docs/fe-oss-apis/gemm_fusions/grouped_gemm_dswiglu_subchannel_scaled.md
+++ b/docs/fe-oss-apis/gemm_fusions/grouped_gemm_dswiglu_subchannel_scaled.md
@@ -1,0 +1,143 @@
+# Grouped GEMM + dSwiGLU (Subchannel-Scaled NVFP4)
+
+**This API is experimental and subject to change.**
+
+Second-level-scaled ("subchannel-scaled") **dSwiGLU-backward** block-scaled
+grouped GEMM for MoE workloads (the FC2 data-gradient + dGLU backward fusion).
+Inputs are NVFP4 with **two** scale levels — per-(1, 16) FP8 (e4m3) first-level
+block scale factors (SFA/SFB) plus FP32 second-level scales (SFA2/SFB2) at
+`block2_shape = (sgm, sgn, sgk)` granularity — and the fused epilogue consumes
+the forward FC1 pre-activations `c`.
+
+## Operation
+
+For each expert `e` with token rows `rows_e` (`n` = GEMM/weight width; all
+n-axis outputs cover `2n`, gate/up):
+
+```
+G[rows_e]        = alpha[e]^2 * (sum over sgk-tiles of (A @ B^T) * SFA2 * SFB2[e])
+gate, up         = clamp(split_32col_bands(C[rows_e])) * beta[e]
+sig              = sigmoid(gate);  swish = gate * sig
+dy_gate          = G * prob * up * sig * (1 + gate * (1 - sig))
+dy_up            = G * prob * swish
+D[rows_e]        = merge(dy_gate, dy_up)            # bf16, or NVFP4-quantized
+dprob[rows_e]    = rowsum(swish * up * G)            # always produced
+dbias[e]         = colsum(D[rows_e])                 # optional
+sfd2_gate/up     = per-(sgm x sgn) block max|dy| / (max(d_dtype) * max(sf_dtype))
+```
+
+`A = a_fp4 * sfa` and `B = b_fp4 * sfb` are the first-level dequantized
+operands (`value = data * sf * sf2`). In the quantized-output mode, D is
+NVFP4-encoded (`d_quant` packed e2m1 + `d_quant_sf` e4m3 row scales) with the
+per-block `sfd2` descale folded into the row scales and `norm_const` as the
+global encode scale. The default `vector_f32=True` configuration is verified
+**byte-exact** against a pure-torch/DSL reference for `d`/`d_quant`/
+`d_quant_sf`/`sfd2` (dprob and dbias are atomics-accumulated and compared with
+tight tolerances).
+
+Source provenance: ported from the `bs_ggemm_harness` `dgrad_dglu` kernel
+(`kernels/dgrad_dglu/kernel.py`), with the deinterleaved-output capability
+transplanted from `kernels/dgrad_dglu_rht_2` (`d_deinterleaved` constexpr) and
+the dGeGLU/e5m3 paths not exposed. Reference:
+`references/fc2_dgrad.py::fc2_dgrad` (dswiglu path).
+
+## Deinterleaved output layout (`d_deinterleaved=True`, default)
+
+The kernel's native storage interleaves gate/up in 32-column bands (matching
+`c`). With `d_deinterleaved=True` the n-axis outputs are stored **deinterleaved
+`[gate | up]`**: interleaved 32-column band `b` lands at deinterleaved position
+`32*(b//2) + (b%2)*n`. This applies to `d_quant` (16-byte packed-band
+granularity), `d_quant_sf` (2-byte band granularity), and `dbias` (32-column
+granularity). The fused `sfd2` output is laid out as **concatenated halves**
+`[gate blocks | up blocks]` — which makes `(d_quant, d_quant_sf, sfd2)`
+directly consumable as a downstream GEMM's two-level NVFP4 input
+(`a_data, a_scales, a_scales2` with `sgk = sgn`).
+
+`d_deinterleaved=True` requires the quantized-D output (the harness-validated
+combination); the BF16-D output is interleaved-only.
+
+## Supported configurations
+
+| Aspect | Supported |
+|---|---|
+| Architecture | SM100 (the kernel also compiles/runs as-is on sm103/sm107; no Rubin-native variant) |
+| A/B dtype | FP4 (`torch.float4_e2m1fn_x2` or `torch.uint8` as packed fp4x2), k-major |
+| First-level scales | `torch.float8_e4m3fn`, `sf_vec_size = 16` (no e8m0/e5m3) |
+| Second-level scales | `torch.float32`; `sgn % 128 == 0` (MMA tile N), `k % sgk == 0`, `valid_m % sgm == 0` |
+| C | `torch.bfloat16` `(valid_m, 2n, 1)`, n-major, gate/up interleaved in 32-col bands |
+| D | `torch.bfloat16` `(valid_m, 2n, 1)`, or `torch.float4_e2m1fn_x2` (quantized mode, + `d_quant_sf` e4m3 + `norm_const`) |
+| dprob | f32 `(valid_m, 1, 1)`, always produced, atomic-add (zero-init required) |
+| dbias | Optional `(l, 2n, 1)` bf16 (f32 = testing-only path), atomics (zero-init required) |
+| sfd2 | Fused f32 `(ceil(valid_m/sgm), 2*ceil(n/sgn), 1)`, atomic-max (zero-init required) |
+| Activation | dSwiGLU only (`glu_clamp_max/min` = ±7.0 by default; both-or-neither) |
+| MMA tiler / cluster | `(256, 128)`; cluster `(2, 1)`, `(2, 2)`, or `(2, 4)` |
+| Weight modes | Dense `(n, k, l)` tensors, or discrete per-expert pointer arrays |
+| alpha / beta | `(l,)` f32; alpha is applied **squared**; beta scales C inside dSwiGLU |
+| Alignment | `valid_m % 256 == 0`, `n % 128 == 0`, `k % 64 == 0` |
+| Frameworks | torch only |
+
+## Wrapper API
+
+```python
+import cudnn, torch
+
+result = cudnn.grouped_gemm_dswiglu_subchannel_scaled_wrapper_sm100(
+    a_tensor=a,            # (valid_m, k, 1) fp4 dY, k-major
+    sfa_tensor=sfa,        # MMA-tiled first-level scales
+    sfa2_tensor=sfa2,      # (ceil(valid_m/sgm), ceil(k/sgk), 1) f32
+    c_tensor=c,            # (valid_m, 2n, 1) bf16 pre-activations
+    padded_offsets=offs,   # (l,) int32 cumulative end offsets
+    alpha_tensor=alpha,    # (l,) f32 (applied squared)
+    beta_tensor=beta,      # (l,) f32
+    prob_tensor=prob,      # (valid_m, 1, 1) f32
+    b_tensor=b,            # (n, k, l) fp4 (dense mode)
+    sfb_tensor=sfb,
+    sfb2_tensor=sfb2,      # (ceil(n/sgn), ceil(k/sgk), l) f32
+    d_dtype=torch.float4_e2m1fn_x2,       # quantized-D mode (default: bf16)
+    norm_const_tensor=torch.tensor([0.5], dtype=torch.float32, device="cuda"),
+    dbias=True,
+    block2_shape=(1, 256, 256),
+    d_deinterleaved=True,
+)
+d_quant   = result["d_quant_tensor"]     # fp4x2, [gate | up] deinterleaved
+d_qsf     = result["d_quant_sf_tensor"]  # e4m3 MMA-tiled row scales
+dprob     = result["dprob_tensor"]
+dbias_out = result["dbias_tensor"]
+sfd2      = result["sfd2_tensor"]        # (rows, 2*nd, 1): [gate | up] halves
+```
+
+The wrapper owns the output allocations and their **zero-init contract**
+(`dprob`/`dbias`/`sfd2` are atomically accumulated every launch). Class-API
+users (`GroupedGemmDswigluSubchannelScaledSm100` + `check_support()` /
+`compile()` / `execute()`) must zero those outputs themselves before each
+`execute()`.
+
+Discrete mode replaces `b_tensor/sfb_tensor/sfb2_tensor` with 1-D `int64`
+per-expert pointer tensors (`b_ptrs/sfb_ptrs/sfb2_ptrs`) plus explicit `n` and
+`b_dtype`; per-expert SFB2 blocks must be 16-byte aligned
+(`ceil(n/sgn) * ceil(k/sgk) * 4 % 16 == 0` when `num_experts > 1`).
+
+## DSMEM sfd2 reduction
+
+With `dsmem_rowwise=True` (default) and an eligible geometry — quantized-D
+output and `sgn / 128 == cluster_n > 1` (`sgn=256` with cluster `(2, 2)`,
+`sgn=512` with `(2, 4)`) — the cross-tile rowwise sfd2 reduction runs through
+DSMEM: each N-peer CTA `red.shared::cluster`-maxes its row descales into every
+peer's smem parity slot and a per-parity `cluster_n`-arrival mbarrier replaces
+the gmem atomic + counter-spin protocol. Outputs are **byte-exact** either way
+(the identical bit-pattern u32 max; max is order-independent). Cluster shapes
+`(2, 2)`/`(2, 4)` additionally require the N work-tile count `ceil(n/128)` to
+be a `cluster_n` multiple. Non-eligible geometries keep the gmem protocol
+unchanged.
+
+## Notes
+
+- With `sgn > 128` and the quantized-D output, one sfd2 block spans multiple N
+  work tiles and the kernel runs a cross-tile arrival protocol; `execute()`
+  asserts a conservative liveness bound
+  (`(sgn/128 - 1) * min(m_cluster_tiles, n_tiles) < persistent grid clusters`)
+  and sizes the sync-counter workspace per call (grow-only).
+- `dprob` is bit-exact versus the reference only for `n <= 256` (two 128-wide
+  N tiles); larger `n` agrees to ~1e-6 (f32 atomic arrival order).
+- No JAX support (the MMA-tiled scale-factor views are not expressible as JAX
+  arrays).

--- a/docs/fe-oss-apis/gemm_fusions/grouped_gemm_dswiglu_subchannel_scaled.md
+++ b/docs/fe-oss-apis/gemm_fusions/grouped_gemm_dswiglu_subchannel_scaled.md
@@ -35,11 +35,15 @@ global encode scale. The default `vector_f32=True` configuration is verified
 `d_quant_sf`/`sfd2` (dprob and dbias are atomics-accumulated and compared with
 tight tolerances).
 
-Source provenance: ported from the `bs_ggemm_harness` `dgrad_dglu` kernel
-(`kernels/dgrad_dglu/kernel.py`), with the deinterleaved-output capability
-transplanted from `kernels/dgrad_dglu_rht_2` (`d_deinterleaved` constexpr) and
-the dGeGLU/e5m3 paths not exposed. Reference:
-`references/fc2_dgrad.py::fc2_dgrad` (dswiglu path).
+The kernel is a persistent, warp-specialized tcgen05 grouped GEMM: TMA loads the
+NVFP4 operands and first-level scales, a scale-load warp stages the second-level
+scales, the MMA warp emits one partial accumulator per `sgk` block, an
+accumulator-update warpgroup rescales and sums those partials by `SFA2 * SFB2`
+into a full-tile SMEM accumulator, and the epilogue warpgroup applies the dSwiGLU
+backward, the `dprob`/`dbias`/`sfd2` reductions and the optional NVFP4 output
+quantization. The Rubin (SM107) module implements the same computation with the
+sm107 MMA atoms, register budgets and epilogue partitioning, and additionally
+accepts E5M3 first-level scales.
 
 ## Deinterleaved output layout (`d_deinterleaved=True`, default)
 
@@ -53,16 +57,16 @@ granularity). The fused `sfd2` output is laid out as **concatenated halves**
 directly consumable as a downstream GEMM's two-level NVFP4 input
 (`a_data, a_scales, a_scales2` with `sgk = sgn`).
 
-`d_deinterleaved=True` requires the quantized-D output (the harness-validated
+`d_deinterleaved=True` requires the quantized-D output (the validated
 combination); the BF16-D output is interleaved-only.
 
 ## Supported configurations
 
 | Aspect | Supported |
 |---|---|
-| Architecture | SM100 (the kernel also compiles/runs as-is on sm103/sm107; no Rubin-native variant) |
+| Architecture | SM100+ (Blackwell); transparent Rubin (SM107) kernel dispatch |
 | A/B dtype | FP4 (`torch.float4_e2m1fn_x2` or `torch.uint8` as packed fp4x2), k-major |
-| First-level scales | `torch.float8_e4m3fn`, `sf_vec_size = 16` (no e8m0/e5m3) |
+| First-level scales | `torch.float8_e4m3fn`, `sf_vec_size = 16` (no e8m0; e5m3 reinterpretation on Rubin via `sf_fp8_dtype_override="e5m3"`) |
 | Second-level scales | `torch.float32`; `sgn % 128 == 0` (MMA tile N), `k % sgk == 0`, `valid_m % sgm == 0` |
 | C | `torch.bfloat16` `(valid_m, 2n, 1)`, n-major, gate/up interleaved in 32-col bands |
 | D | `torch.bfloat16` `(valid_m, 2n, 1)`, or `torch.float4_e2m1fn_x2` (quantized mode, + `d_quant_sf` e4m3 + `norm_const`) |
@@ -129,6 +133,21 @@ the gmem atomic + counter-spin protocol. Outputs are **byte-exact** either way
 `(2, 2)`/`(2, 4)` additionally require the N work-tile count `ceil(n/128)` to
 be a `cluster_n` multiple. Non-eligible geometries keep the gmem protocol
 unchanged.
+
+## Architecture dispatch
+
+On Rubin (SM107) devices the API transparently selects the Rubin-native kernel
+module (`moe_blockscaled_grouped_gemm_dswiglu_subchannel_scaled_rubin.py`); the
+public class and wrapper are unchanged. `sf_fp8_dtype_override="e5m3"`
+(Rubin-only, part of the compile cache key) reinterprets the FP8 first-level
+scale factors `sfa`/`sfb` as E5M3 — the tensors are still supplied as
+`torch.float8_e4m3fn` since torch has no e5m3 dtype. The output scale format
+follows the input's: with e5m3 inputs the quantized-D row scales `d_quant_sf`
+are e5m3-encoded (same `float8_e4m3fn` storage) and the `sfd2` norm becomes
+`6 * 61440` (`max(e2m1) * max(ue5m3)`) instead of `6 * 448`. The e5m3 path is
+validated byte-exact on Rubin for the bf16-D, quantized-D (dense and discrete)
+and DSMEM-sfd2 configurations (the tests re-encode the e4m3 scales as UE5M3 and
+compare against the same reference with e5m3-encoded row scales).
 
 ## Notes
 

--- a/docs/fe-oss-apis/gemm_fusions/grouped_gemm_unfused_subchannel_scaled.md
+++ b/docs/fe-oss-apis/gemm_fusions/grouped_gemm_unfused_subchannel_scaled.md
@@ -137,7 +137,9 @@ module (`moe_blockscaled_grouped_gemm_unfused_subchannel_scaled_rubin.py`); the
 public class and wrapper are unchanged. `sf_fp8_dtype_override="e5m3"`
 (Rubin-only) reinterprets the FP8 first-level scale factors as E5M3 — the scale
 tensors are still supplied as `torch.float8_e4m3fn` since torch has no e5m3
-dtype.
+dtype. The e5m3 path is validated byte-exact on Rubin for both dense and discrete
+weight modes (the tests re-encode the e4m3 scales as UE5M3 and compare against the
+same reference).
 
 ## Limitations
 

--- a/docs/fe-oss-apis/gemm_fusions/grouped_gemm_unfused_subchannel_scaled.md
+++ b/docs/fe-oss-apis/gemm_fusions/grouped_gemm_unfused_subchannel_scaled.md
@@ -26,10 +26,14 @@ SFB2 blocks cover `(sgn cols x sgk k)`. The per-token `prob` multiply is always
 fused (pass ones for a plain GEMM). The default `vector_f32=True` configuration
 is verified **byte-exact** against a pure-torch reference.
 
-Source provenance: ported from the `bs_ggemm_harness` `dgrad_quant` kernel
-(`kernels/dgrad_quant/kernel.py` / `kernel_sm107.py`), with the upstream
-quantization epilogue removed. Reference:
-`references/fc2_dgrad.py::fc2_dgrad_gemm`.
+The kernel is a persistent, warp-specialized tcgen05 grouped GEMM: TMA loads the
+NVFP4 operands and first-level scales, a scale-load warp stages the second-level
+scales, the MMA warp emits one partial accumulator per `sgk` block, an
+accumulator-update warpgroup rescales and sums those partials by `SFA2 * SFB2`
+into a full-tile SMEM accumulator, and the epilogue warpgroup applies `alpha`,
+`prob` and the optional bias before the BF16 store. The Rubin (SM107) module
+implements the same computation with the sm107 MMA atoms and additionally
+accepts E5M3 first-level scales.
 
 ## Supported configurations
 

--- a/docs/fe-oss-apis/gemm_fusions/grouped_gemm_unfused_subchannel_scaled.md
+++ b/docs/fe-oss-apis/gemm_fusions/grouped_gemm_unfused_subchannel_scaled.md
@@ -1,0 +1,148 @@
+# Grouped GEMM (Unfused, Subchannel-Scaled NVFP4)
+
+**This API is experimental and subject to change.**
+
+Second-level-scaled ("subchannel-scaled") **unfused** block-scaled grouped GEMM for
+MoE workloads. Inputs are NVFP4 with **two** scale levels — per-(1, 16) FP8 (e4m3)
+first-level block scale factors (SFA/SFB) plus FP32 second-level scales
+(SFA2/SFB2) at `block2_shape = (sgm, sgn, sgk)` granularity — and the output D is
+plain BF16 (no output quantization; this is the unfused GEMM-only counterpart of
+the fused dGLU kernels; it computes the FC2 data-gradient GEMM `dY @ W`).
+
+## Operation
+
+For each expert `e` with token rows `rows_e`:
+
+```
+G[rows_e] = sum over sgk-tiles t of:
+    (A[rows_e, t] @ B[e, :, t]^T) * SFA2[rows_e/sgm, t] * SFB2[e, :, t]
+D[rows_e]  = G[rows_e] * alpha[e] * prob[rows_e]                    (no bias)
+D[rows_e]  = G[rows_e] * alpha[e] + prob[rows_e] * bias[:, e]       (with bias)
+```
+
+where `A = a_fp4 * sfa` and `B = b_fp4 * sfb` are the first-level dequantized
+operands (`value = data * sf * sf2`). SFA2 blocks cover `(sgm rows x sgk k)`;
+SFB2 blocks cover `(sgn cols x sgk k)`. The per-token `prob` multiply is always
+fused (pass ones for a plain GEMM). The default `vector_f32=True` configuration
+is verified **byte-exact** against a pure-torch reference.
+
+Source provenance: ported from the `bs_ggemm_harness` `dgrad_quant` kernel
+(`kernels/dgrad_quant/kernel.py` / `kernel_sm107.py`), with the upstream
+quantization epilogue removed. Reference:
+`references/fc2_dgrad.py::fc2_dgrad_gemm`.
+
+## Supported configurations
+
+| Aspect | Supported |
+|---|---|
+| Architecture | SM100+ (Blackwell); transparent Rubin (SM107) kernel dispatch |
+| A/B dtype | FP4 (`torch.float4_e2m1fn_x2`, or `torch.uint8` interpreted as packed fp4x2), k-major |
+| First-level scales | `torch.float8_e4m3fn`, `sf_vec_size = 16` (e5m3 reinterpretation on Rubin via `sf_fp8_dtype_override="e5m3"`) |
+| Second-level scales | `torch.float32`, `block2_shape` e.g. `(1, 256, 256)` or `(1, 512, 512)`; `k % sgk == 0`, `valid_m % sgm == 0` |
+| D dtype | `torch.bfloat16`, n-major |
+| Accumulator | `torch.float32` |
+| MMA tiler | `(256, 128)` (default) or `(256, 256)` |
+| Cluster shape | `(2, 1)` (default) or `(2, 2)` |
+| Weight modes | Dense `(n, k, l)` tensors, or discrete per-expert pointer arrays |
+| Bias | Optional BF16 `(n, l)`, stride `(1, n)`; `d = gemm * alpha + prob * bias` |
+| prob | **Required** FP32 `(valid_m, 1, 1)` per-token multiplier |
+| Alignment | `valid_m % 256 == 0` (every expert's rows 256-padded), `n % 64 == 0` |
+| Frameworks | torch only (the MMA-tiled scale-factor views are not expressible as JAX arrays) |
+
+## Tensor layouts
+
+| Tensor | Shape | Stride | Dtype |
+|---|---|---|---|
+| `a_tensor` | `(valid_m, k, 1)` (logical) | `(k, 1, valid_m * k)` | fp4 |
+| `sfa_tensor` | `(32, 4, ceil(valid_m/128), 4, ceil(ceil(k/16)/4), 1)` | MMA-tiled | `float8_e4m3fn` |
+| `sfa2_tensor` | `(ceil(valid_m/sgm), ceil(k/sgk), 1)` | `(1, rows, rows * cols)` | `float32` |
+| `b_tensor` (dense) | `(n, k, l)` (logical) | `(k, 1, n * k)` | fp4 |
+| `sfb_tensor` (dense) | `(32, 4, ceil(n/128), 4, ceil(ceil(k/16)/4), l)` | MMA-tiled | `float8_e4m3fn` |
+| `sfb2_tensor` (dense) | `(ceil(n/sgn), ceil(k/sgk), l)` | `(1, rows, rows * cols)` | `float32` |
+| `padded_offsets` | `(l,)` cumulative END offsets after 256-padding | contiguous | `int32` |
+| `alpha_tensor` | `(l,)` | contiguous | `float32` |
+| `prob_tensor` | `(valid_m, 1, 1)` | `(1, 1, valid_m)` | `float32` |
+| `bias_tensor` | `(n, l)` | `(1, n)` | `bfloat16` |
+| `d_tensor` (out) | `(valid_m, n, 1)` | `(n, 1, valid_m * n)` | `bfloat16` |
+
+The SFA2/SFB2 tensors are **rows-contiguous** (mode-0 major). A convenient way to
+allocate them in torch:
+
+```python
+rows, cols = (valid_m + sgm - 1) // sgm, (k + sgk - 1) // sgk
+sfa2 = torch.empty((1, cols, rows), dtype=torch.float32, device="cuda").permute(2, 1, 0)
+```
+
+Discrete mode replaces `b_tensor/sfb_tensor/sfb2_tensor` with 1-D `int64` device
+tensors of per-expert base pointers (`b_ptrs/sfb_ptrs/sfb2_ptrs`) plus explicit
+`n` and `b_dtype`. Every SFB2 per-expert base must be 16-byte aligned; with
+back-to-back per-expert blocks this requires
+`ceil(n/sgn) * ceil(k/sgk) * 4 % 16 == 0` when `num_experts > 1` (enforced by
+`check_support`).
+
+## Wrapper API
+
+```python
+import cudnn
+
+result = cudnn.grouped_gemm_unfused_subchannel_scaled_wrapper_sm100(
+    a_tensor=a,            # (valid_m, k, 1) fp4, k-major
+    sfa_tensor=sfa,        # MMA-tiled first-level scales
+    sfa2_tensor=sfa2,      # (ceil(valid_m/sgm), ceil(k/sgk), 1) f32
+    padded_offsets=offs,   # (l,) int32 cumulative end offsets
+    alpha_tensor=alpha,    # (l,) f32
+    prob_tensor=prob,      # (valid_m, 1, 1) f32 -- required
+    b_tensor=b,            # (n, k, l) fp4 (dense mode)
+    sfb_tensor=sfb,
+    sfb2_tensor=sfb2,      # (ceil(n/sgn), ceil(k/sgk), l) f32
+    bias_tensor=None,      # optional (n, l) bf16
+    block2_shape=(1, 256, 256),
+    mma_tiler_mn=(256, 128),
+    cluster_shape_mn=(2, 1),
+)
+d = result["d_tensor"]     # (valid_m, n, 1) bf16
+```
+
+The wrapper allocates `d_tensor` (or writes into a preallocated one passed via
+`d_tensor=`), caches compiled kernels per configuration (dynamic in `valid_m`),
+and returns a `TupleDict` with the single output `d_tensor`.
+
+## Class API
+
+```python
+from cudnn import GroupedGemmUnfusedSubchannelScaledSm100
+
+api = GroupedGemmUnfusedSubchannelScaledSm100(
+    sample_a=a, sample_sfa=sfa, sample_sfa2=sfa2,
+    sample_padded_offsets=offs, sample_alpha=alpha, sample_prob=prob,
+    sample_d=d,
+    sample_b=b, sample_sfb=sfb, sample_sfb2=sfb2,   # dense mode
+    block2_shape=(1, 256, 256),
+)
+api.check_support()
+api.compile()
+api.execute(a_tensor=a, sfa_tensor=sfa, sfa2_tensor=sfa2,
+            padded_offsets=offs, alpha_tensor=alpha, prob_tensor=prob,
+            d_tensor=d, b_tensor=b, sfb_tensor=sfb, sfb2_tensor=sfb2)
+```
+
+Discrete mode: construct with `num_experts=l, b_shape=(n, k), b_dtype=...`
+instead of the `sample_b/sample_sfb/sample_sfb2` trio, and pass
+`b_ptrs/sfb_ptrs/sfb2_ptrs` to `execute()`.
+
+## Architecture dispatch
+
+On Rubin (SM107) devices the API transparently selects the Rubin-native kernel
+module (`moe_blockscaled_grouped_gemm_unfused_subchannel_scaled_rubin.py`); the
+public class and wrapper are unchanged. `sf_fp8_dtype_override="e5m3"`
+(Rubin-only) reinterprets the FP8 first-level scale factors as E5M3 — the scale
+tensors are still supplied as `torch.float8_e4m3fn` since torch has no e5m3
+dtype.
+
+## Limitations
+
+- `prob_tensor` is mandatory (the kernel always fuses the per-token multiply).
+- BF16 output only; no output quantization (use the fused dGLU/quant kernels for that).
+- torch tensors only (no JAX).
+- `m_aligned` must be 256 (`FIX_PAD_SIZE`); every expert's row group is 256-padded.
+- Byte-exactness versus the reference holds for the default `vector_f32=True`.

--- a/docs/fe-oss-apis/gemm_fusions/grouped_gemm_wgrad_subchannel_scaled.md
+++ b/docs/fe-oss-apis/gemm_fusions/grouped_gemm_wgrad_subchannel_scaled.md
@@ -30,9 +30,14 @@ arbitrary — they need not be powers of two). With `accumulate_on_output=True` 
 bf16 tile is TMA-reduce-added into the caller's output instead of stored. Experts
 with zero tokens produce zeros (or leave the accumulate target unchanged).
 
-Source provenance: ported from the `bs_ggemm_harness` `wgrad` kernel
-(`kernels/wgrad/kernel.py` / `kernel_sm107.py`). Reference:
-`references/wgrad.py::wgrad_gemm_2nd_level`.
+The kernel is a persistent, warp-specialized tcgen05 grouped GEMM over the ragged
+token axis: TMA loads the NVFP4 operands and first-level scales, the MMA warp emits
+one clean partial accumulator per `sgk`-token block, an accumulator-update
+warpgroup rescales each partial by the per-row `SFA2` and sums it into the running
+f32 accumulator, and the epilogue applies the optional global scales and stores
+(or reduce-adds) the BF16 tile. The Rubin (SM107) module implements the same
+computation with the sm107 MMA atoms and additionally accepts E5M3 first-level
+scales.
 
 ## Supported configurations
 

--- a/docs/fe-oss-apis/gemm_fusions/grouped_gemm_wgrad_subchannel_scaled.md
+++ b/docs/fe-oss-apis/gemm_fusions/grouped_gemm_wgrad_subchannel_scaled.md
@@ -103,6 +103,8 @@ subsequent `execute()`.
 
 - `sf_fp8_dtype_override="e5m3"` reinterprets the e4m3-typed first-level scale bytes
   as UE5M3; it is accepted only on Rubin (SM107) and takes part in the compile cache
-  key.
+  key. The e5m3 path is validated byte-exact on Rubin (the tests re-encode the e4m3
+  scales as UE5M3 and compare against the same reference) for dense/discrete output
+  and `accumulate_on_output`.
 - No JAX support (fp4 K-major operands and the hidden-contiguous SFA2 view are not
   expressible as row-major JAX arrays).

--- a/docs/fe-oss-apis/gemm_fusions/grouped_gemm_wgrad_subchannel_scaled.md
+++ b/docs/fe-oss-apis/gemm_fusions/grouped_gemm_wgrad_subchannel_scaled.md
@@ -1,0 +1,108 @@
+# Grouped GEMM + Wgrad (Subchannel-Scaled NVFP4)
+
+**This API is experimental and subject to change.**
+
+Second-level-scaled ("subchannel-scaled") **weight-gradient** (2Dx2D) block-scaled
+grouped GEMM for MoE workloads. The A operand (the transposed activation gradient)
+is NVFP4 with **two** scale levels — per-(1, 16) FP8 (e4m3) first-level block scale
+factors plus one FP32 second-level scale per `(hidden row x sgk tokens)` block
+(`sgm = 1`, the rowwise-quant producer's `sf2` grid) — and B (the activation) is
+single-level NVFP4. There is no second-level B scale. The reduction axis K is the
+**ragged per-expert token axis**; M (`hidden`) and N (`intermediate`) are fixed
+across experts.
+
+## Operation
+
+For each expert `e` with token range `[k0, k1)` split into `sgk`-token scale blocks
+`b` (ascending order):
+
+```
+dW[e] = sum_b (A[:, b] @ B[b, :]) * SFA2[:, b_idx]        # f32: dW = partial * sfa2 + dW
+dW[e] = (dW[e] * global_scale_a[e] * global_scale_b[e]).to(bf16)
+```
+
+`A = a_fp4 * sfa` and `B = b_fp4 * sfb` are the first-level dequantized operands.
+The kernel forms one clean f32 partial accumulator per `sgk` block (tensor memory),
+rescales it by the per-row SFA2 with a non-contractible `mul.rn` followed by a
+separate add, and the output is verified **byte-exact** against a pure-torch
+reference that replays those exact f32 ops in the same block order (SFA2 values are
+arbitrary — they need not be powers of two). With `accumulate_on_output=True` the
+bf16 tile is TMA-reduce-added into the caller's output instead of stored. Experts
+with zero tokens produce zeros (or leave the accumulate target unchanged).
+
+Source provenance: ported from the `bs_ggemm_harness` `wgrad` kernel
+(`kernels/wgrad/kernel.py` / `kernel_sm107.py`). Reference:
+`references/wgrad.py::wgrad_gemm_2nd_level`.
+
+## Supported configurations
+
+| Aspect | Supported |
+|---|---|
+| Architecture | SM100+ (Blackwell); transparent Rubin (SM107) kernel dispatch |
+| A/B dtype | FP4 (`torch.float4_e2m1fn_x2`, or `torch.uint8` interpreted as packed fp4x2), K(token)-major |
+| First-level scales | `torch.float8_e4m3fn`, `sf_vec_size = 16` (e5m3 reinterpretation on Rubin via `sf_fp8_dtype_override="e5m3"`) |
+| Second-level scale | `torch.float32` SFA2 `(hidden, tokens_sum / sgk)`, **hidden-contiguous** (strides `(1, hidden)`); `sgk % 256 == 0` |
+| Token counts | `tokens_sum % sgk == 0` and every expert's token count `% sgk == 0` (second-level blocks never straddle experts) |
+| dW dtype | `torch.bfloat16` |
+| Accumulator | `torch.float32` |
+| MMA tiler | `(256, 128)` (default, 2-CTA) or `(128, 128)` |
+| Cluster shape | `(1,1) (1,2) (2,1) (2,2) (1,4) (4,1) (2,4) (4,2) (4,4)`; default `(2, 1)` for the 2-CTA tiler, `(1, 1)` otherwise |
+| Output modes | Dense `(expert_cnt, hidden, intermediate)` tensor, or discrete per-expert pointer arrays |
+| Global scales | Optional `(expert_cnt,)` f32 pair, applied as `alpha = gsa[e] * gsb[e]` before the bf16 cast |
+| Alignment | `hidden % 128 == 0`, `intermediate % 128 == 0` |
+| Frameworks | torch only |
+
+## Tensor layouts
+
+| Tensor | Shape | Stride | Dtype |
+|---|---|---|---|
+| `a_tensor` | `(hidden, tokens_sum)` (logical) | `(tokens_sum, 1)` | fp4 |
+| `b_tensor` | `(tokens_sum, intermediate)` (logical) | `(1, tokens_sum)` | fp4 |
+| `sfa_tensor` | `(round_up(hidden, 128), round_up(tokens_sum/16, 4))` | assembled per-expert 128x4-atom layout (as `grouped_gemm_wgrad`) | `float8_e4m3fn` |
+| `sfb_tensor` | `(round_up(intermediate, 128), round_up(tokens_sum/16, 4))` | assembled per-expert 128x4-atom layout | `float8_e4m3fn` |
+| `sfa2_tensor` | `(hidden, tokens_sum / sgk)` | `(1, hidden)` | `float32` |
+| `offsets_tensor` | `(expert_cnt,)` cumulative END token offsets | contiguous | `int32` |
+| `wgrad_tensor` | `(expert_cnt, hidden, intermediate)` | contiguous | `bfloat16` |
+
+The first-level scale tensors use the same per-expert assembled layout as the
+existing `grouped_gemm_wgrad` API (each expert's `(mn, tokens_e / 16)` block scattered
+into 128x4 atoms, experts concatenated). The compiled kernel treats the token axis as
+dynamic: one compile serves every token distribution with the same `expert_cnt`,
+`hidden`, `intermediate` and `sgk`.
+
+## Wrapper API
+
+```python
+import cudnn, torch
+
+result = cudnn.grouped_gemm_wgrad_subchannel_scaled_wrapper_sm100(
+    a_tensor=a,            # (hidden, tokens_sum) fp4 dY^T, token-innermost
+    b_tensor=b,            # (tokens_sum, intermediate) fp4 activations, token-innermost
+    sfa_tensor=sfa,        # assembled e4m3 first-level A scales
+    sfb_tensor=sfb,        # assembled e4m3 first-level B scales
+    sfa2_tensor=sfa2,      # (hidden, tokens_sum/sgk) f32, strides (1, hidden)
+    offsets_tensor=offs,   # (expert_cnt,) int32 cumulative end offsets
+    sgk=512,
+    output_mode="dense",   # or "discrete" (+ wgrad_ptrs / wgrad_tensor)
+    global_scale_a=gsa,    # optional (expert_cnt,) f32
+    global_scale_b=gsb,
+    mma_tiler_mn=(256, 128),
+    cluster_shape_mn=(2, 1),
+)
+dw = result["wgrad_tensor"]   # (expert_cnt, hidden, intermediate) bf16
+```
+
+When `wgrad_tensor`/`wgrad_ptrs` are omitted the wrapper allocates the output
+(zero-initialized when `accumulate_on_output=True`). Class-API users
+(`GroupedGemmWgradSubchannelScaledSm100` + `check_support()` / `compile()` /
+`execute()`) pass their own output; `check_support()` validates the per-expert
+`sgk` alignment on the sample offsets, and the same contract must hold for every
+subsequent `execute()`.
+
+## Notes
+
+- `sf_fp8_dtype_override="e5m3"` reinterprets the e4m3-typed first-level scale bytes
+  as UE5M3; it is accepted only on Rubin (SM107) and takes part in the compile cache
+  key.
+- No JAX support (fp4 K-major operands and the hidden-contiguous SFA2 view are not
+  expressible as row-major JAX arrays).

--- a/docs/fe-oss-apis/overview.md
+++ b/docs/fe-oss-apis/overview.md
@@ -5,7 +5,7 @@
 The GEMM CuTeDSL APIs are type-erased and torch-lazy: torch is imported only when torch tensors are passed. JAX arrays are additionally accepted wherever the kernel's tensor layouts are expressible as row-major arrays (each API's page has a "JAX support" section with its exact contract):
 
 - **Dense fusions** (amax, swiglu, srelu, dsrelu): full JAX eager support, plus `jax.jit`-compatible XLA custom-call entry points for all four (built on `cudnn.jax.call` / CuTeDSL's native `cutlass.jax` bridge; see `gemm_amax.md` "Using JAX arrays").
-- **Grouped / discrete-grouped**: JAX eager support in discrete (pointer-array) weight modes — unfused grouped GEMM, glu/dglu (BF16), dsrelu (FP8), wgrad (BF16), and discrete-grouped swiglu/dswiglu (FP8) — plus a `jax.jit`-compatible `*_jax_sm100` entry point for each of those same families (built on `cudnn.jax.call`; each API page documents its exact jit contract). Dense weight mode, column-major bias layouts, and kernels whose scale factors are MMA-permuted tensor arguments (grouped swiglu/srelu/quant/dswiglu, unfused_subchannel_scaled, dswiglu_subchannel_scaled, glu_hadamard, block-scaled glu/dglu/wgrad backends) reject JAX with clear errors.
+- **Grouped / discrete-grouped**: JAX eager support in discrete (pointer-array) weight modes — unfused grouped GEMM, glu/dglu (BF16), dsrelu (FP8), wgrad (BF16), and discrete-grouped swiglu/dswiglu (FP8) — plus a `jax.jit`-compatible `*_jax_sm100` entry point for each of those same families (built on `cudnn.jax.call`; each API page documents its exact jit contract). Dense weight mode, column-major bias layouts, and kernels whose scale factors are MMA-permuted tensor arguments (grouped swiglu/srelu/quant/dswiglu, unfused_subchannel_scaled, dswiglu_subchannel_scaled, wgrad_subchannel_scaled, glu_hadamard, block-scaled glu/dglu/wgrad backends) reject JAX with clear errors.
 - **proj_rope_mxfp8**: JAX eager support on both input paths with `w_out_in=True` (the transposed [in, out] weight view is torch-only), plus the `jax.jit`-compatible `gemm_proj_rope_mxfp8_jax_sm100` entry point.
 
 This folder documents the Python FE APIs implemented under `python/cudnn`. For details on currently implemented operations, see:
@@ -32,6 +32,7 @@ This folder documents the Python FE APIs implemented under `python/cudnn`. For d
 - [Grouped GEMM (Unfused, Subchannel-Scaled NVFP4)](gemm_fusions/grouped_gemm_unfused_subchannel_scaled.md)
 - [Grouped GEMM + dSwiGLU (Subchannel-Scaled NVFP4)](gemm_fusions/grouped_gemm_dswiglu_subchannel_scaled.md)
 - [Grouped GEMM + Wgrad](gemm_fusions/grouped_gemm_wgrad.md)
+- [Grouped GEMM + Wgrad (Subchannel-Scaled NVFP4)](gemm_fusions/grouped_gemm_wgrad_subchannel_scaled.md)
 - [Block Sparse Attention (BSA)](bsa.md)
 - [Flex Attention](attention/flex_attention.md)
 - [HSTU Attention (Blackwell SM100/SM103)](attention/hstu.md)

--- a/docs/fe-oss-apis/overview.md
+++ b/docs/fe-oss-apis/overview.md
@@ -5,7 +5,7 @@
 The GEMM CuTeDSL APIs are type-erased and torch-lazy: torch is imported only when torch tensors are passed. JAX arrays are additionally accepted wherever the kernel's tensor layouts are expressible as row-major arrays (each API's page has a "JAX support" section with its exact contract):
 
 - **Dense fusions** (amax, swiglu, srelu, dsrelu): full JAX eager support, plus `jax.jit`-compatible XLA custom-call entry points for all four (built on `cudnn.jax.call` / CuTeDSL's native `cutlass.jax` bridge; see `gemm_amax.md` "Using JAX arrays").
-- **Grouped / discrete-grouped**: JAX eager support in discrete (pointer-array) weight modes — unfused grouped GEMM, glu/dglu (BF16), dsrelu (FP8), wgrad (BF16), and discrete-grouped swiglu/dswiglu (FP8) — plus a `jax.jit`-compatible `*_jax_sm100` entry point for each of those same families (built on `cudnn.jax.call`; each API page documents its exact jit contract). Dense weight mode, column-major bias layouts, and kernels whose scale factors are MMA-permuted tensor arguments (grouped swiglu/srelu/quant/dswiglu, glu_hadamard, block-scaled glu/dglu/wgrad backends) reject JAX with clear errors.
+- **Grouped / discrete-grouped**: JAX eager support in discrete (pointer-array) weight modes — unfused grouped GEMM, glu/dglu (BF16), dsrelu (FP8), wgrad (BF16), and discrete-grouped swiglu/dswiglu (FP8) — plus a `jax.jit`-compatible `*_jax_sm100` entry point for each of those same families (built on `cudnn.jax.call`; each API page documents its exact jit contract). Dense weight mode, column-major bias layouts, and kernels whose scale factors are MMA-permuted tensor arguments (grouped swiglu/srelu/quant/dswiglu, unfused_subchannel_scaled, glu_hadamard, block-scaled glu/dglu/wgrad backends) reject JAX with clear errors.
 - **proj_rope_mxfp8**: JAX eager support on both input paths with `w_out_in=True` (the transposed [in, out] weight view is torch-only), plus the `jax.jit`-compatible `gemm_proj_rope_mxfp8_jax_sm100` entry point.
 
 This folder documents the Python FE APIs implemented under `python/cudnn`. For details on currently implemented operations, see:
@@ -29,6 +29,7 @@ This folder documents the Python FE APIs implemented under `python/cudnn`. For d
 - [Discrete Grouped GEMM + dSwiGLU](gemm_fusions/discrete_grouped_gemm_dswiglu.md)
 - [Grouped GEMM + Quant (Legacy, Dense-only)](gemm_fusions/grouped_gemm_quant.md)
 - [Grouped GEMM + Quant (Unified)](gemm_fusions/grouped_gemm_quant_unified.md)
+- [Grouped GEMM (Unfused, Subchannel-Scaled NVFP4)](gemm_fusions/grouped_gemm_unfused_subchannel_scaled.md)
 - [Grouped GEMM + Wgrad](gemm_fusions/grouped_gemm_wgrad.md)
 - [Block Sparse Attention (BSA)](bsa.md)
 - [Flex Attention](attention/flex_attention.md)

--- a/docs/fe-oss-apis/overview.md
+++ b/docs/fe-oss-apis/overview.md
@@ -5,7 +5,7 @@
 The GEMM CuTeDSL APIs are type-erased and torch-lazy: torch is imported only when torch tensors are passed. JAX arrays are additionally accepted wherever the kernel's tensor layouts are expressible as row-major arrays (each API's page has a "JAX support" section with its exact contract):
 
 - **Dense fusions** (amax, swiglu, srelu, dsrelu): full JAX eager support, plus `jax.jit`-compatible XLA custom-call entry points for all four (built on `cudnn.jax.call` / CuTeDSL's native `cutlass.jax` bridge; see `gemm_amax.md` "Using JAX arrays").
-- **Grouped / discrete-grouped**: JAX eager support in discrete (pointer-array) weight modes — unfused grouped GEMM, glu/dglu (BF16), dsrelu (FP8), wgrad (BF16), and discrete-grouped swiglu/dswiglu (FP8) — plus a `jax.jit`-compatible `*_jax_sm100` entry point for each of those same families (built on `cudnn.jax.call`; each API page documents its exact jit contract). Dense weight mode, column-major bias layouts, and kernels whose scale factors are MMA-permuted tensor arguments (grouped swiglu/srelu/quant/dswiglu, unfused_subchannel_scaled, glu_hadamard, block-scaled glu/dglu/wgrad backends) reject JAX with clear errors.
+- **Grouped / discrete-grouped**: JAX eager support in discrete (pointer-array) weight modes — unfused grouped GEMM, glu/dglu (BF16), dsrelu (FP8), wgrad (BF16), and discrete-grouped swiglu/dswiglu (FP8) — plus a `jax.jit`-compatible `*_jax_sm100` entry point for each of those same families (built on `cudnn.jax.call`; each API page documents its exact jit contract). Dense weight mode, column-major bias layouts, and kernels whose scale factors are MMA-permuted tensor arguments (grouped swiglu/srelu/quant/dswiglu, unfused_subchannel_scaled, dswiglu_subchannel_scaled, glu_hadamard, block-scaled glu/dglu/wgrad backends) reject JAX with clear errors.
 - **proj_rope_mxfp8**: JAX eager support on both input paths with `w_out_in=True` (the transposed [in, out] weight view is torch-only), plus the `jax.jit`-compatible `gemm_proj_rope_mxfp8_jax_sm100` entry point.
 
 This folder documents the Python FE APIs implemented under `python/cudnn`. For details on currently implemented operations, see:
@@ -30,6 +30,7 @@ This folder documents the Python FE APIs implemented under `python/cudnn`. For d
 - [Grouped GEMM + Quant (Legacy, Dense-only)](gemm_fusions/grouped_gemm_quant.md)
 - [Grouped GEMM + Quant (Unified)](gemm_fusions/grouped_gemm_quant_unified.md)
 - [Grouped GEMM (Unfused, Subchannel-Scaled NVFP4)](gemm_fusions/grouped_gemm_unfused_subchannel_scaled.md)
+- [Grouped GEMM + dSwiGLU (Subchannel-Scaled NVFP4)](gemm_fusions/grouped_gemm_dswiglu_subchannel_scaled.md)
 - [Grouped GEMM + Wgrad](gemm_fusions/grouped_gemm_wgrad.md)
 - [Block Sparse Attention (BSA)](bsa.md)
 - [Flex Attention](attention/flex_attention.md)

--- a/python/cudnn/__init__.py
+++ b/python/cudnn/__init__.py
@@ -350,6 +350,8 @@ _LAZY_OPTIONAL_IMPORTS = {
     "grouped_gemm_unfused_subchannel_scaled_wrapper_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_unfused_subchannel_scaled_wrapper_sm100"),
     "GroupedGemmDswigluSubchannelScaledSm100": (".gemm.cutedsl.grouped", "GroupedGemmDswigluSubchannelScaledSm100"),
     "grouped_gemm_dswiglu_subchannel_scaled_wrapper_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_dswiglu_subchannel_scaled_wrapper_sm100"),
+    "GroupedGemmWgradSubchannelScaledSm100": (".gemm.cutedsl.grouped", "GroupedGemmWgradSubchannelScaledSm100"),
+    "grouped_gemm_wgrad_subchannel_scaled_wrapper_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_wgrad_subchannel_scaled_wrapper_sm100"),
     "grouped_gemm_jax_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_jax_sm100"),
     "grouped_gemm_glu_jax_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_glu_jax_sm100"),
     "grouped_gemm_dglu_jax_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_dglu_jax_sm100"),

--- a/python/cudnn/__init__.py
+++ b/python/cudnn/__init__.py
@@ -348,6 +348,8 @@ _LAZY_OPTIONAL_IMPORTS = {
     "grouped_gemm_wrapper_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_wrapper_sm100"),
     "GroupedGemmUnfusedSubchannelScaledSm100": (".gemm.cutedsl.grouped", "GroupedGemmUnfusedSubchannelScaledSm100"),
     "grouped_gemm_unfused_subchannel_scaled_wrapper_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_unfused_subchannel_scaled_wrapper_sm100"),
+    "GroupedGemmDswigluSubchannelScaledSm100": (".gemm.cutedsl.grouped", "GroupedGemmDswigluSubchannelScaledSm100"),
+    "grouped_gemm_dswiglu_subchannel_scaled_wrapper_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_dswiglu_subchannel_scaled_wrapper_sm100"),
     "grouped_gemm_jax_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_jax_sm100"),
     "grouped_gemm_glu_jax_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_glu_jax_sm100"),
     "grouped_gemm_dglu_jax_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_dglu_jax_sm100"),

--- a/python/cudnn/__init__.py
+++ b/python/cudnn/__init__.py
@@ -346,6 +346,8 @@ _LAZY_OPTIONAL_IMPORTS = {
     "grouped_gemm": (".gemm.cutedsl.grouped", None),
     "GroupedGemmSm100": (".gemm.cutedsl.grouped", "GroupedGemmSm100"),
     "grouped_gemm_wrapper_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_wrapper_sm100"),
+    "GroupedGemmUnfusedSubchannelScaledSm100": (".gemm.cutedsl.grouped", "GroupedGemmUnfusedSubchannelScaledSm100"),
+    "grouped_gemm_unfused_subchannel_scaled_wrapper_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_unfused_subchannel_scaled_wrapper_sm100"),
     "grouped_gemm_jax_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_jax_sm100"),
     "grouped_gemm_glu_jax_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_glu_jax_sm100"),
     "grouped_gemm_dglu_jax_sm100": (".gemm.cutedsl.grouped", "grouped_gemm_dglu_jax_sm100"),

--- a/python/cudnn/gemm/cutedsl/grouped/__init__.py
+++ b/python/cudnn/gemm/cutedsl/grouped/__init__.py
@@ -63,6 +63,10 @@ from .dswiglu_subchannel_scaled.api import (
     GroupedGemmDswigluSubchannelScaledSm100,
     grouped_gemm_dswiglu_subchannel_scaled_wrapper_sm100,
 )
+from .wgrad_subchannel_scaled.api import (
+    GroupedGemmWgradSubchannelScaledSm100,
+    grouped_gemm_wgrad_subchannel_scaled_wrapper_sm100,
+)
 
 __all__ = [
     "GroupedGemmSwigluSm100",
@@ -91,6 +95,8 @@ __all__ = [
     "grouped_gemm_unfused_subchannel_scaled_wrapper_sm100",
     "GroupedGemmDswigluSubchannelScaledSm100",
     "grouped_gemm_dswiglu_subchannel_scaled_wrapper_sm100",
+    "GroupedGemmWgradSubchannelScaledSm100",
+    "grouped_gemm_wgrad_subchannel_scaled_wrapper_sm100",
     "grouped_gemm_jax_sm100",
     "grouped_gemm_glu_jax_sm100",
     "grouped_gemm_dglu_jax_sm100",

--- a/python/cudnn/gemm/cutedsl/grouped/__init__.py
+++ b/python/cudnn/gemm/cutedsl/grouped/__init__.py
@@ -55,6 +55,10 @@ from .unfused.api import (
     GroupedGemmSm100,
     grouped_gemm_wrapper_sm100,
 )
+from .unfused_subchannel_scaled.api import (
+    GroupedGemmUnfusedSubchannelScaledSm100,
+    grouped_gemm_unfused_subchannel_scaled_wrapper_sm100,
+)
 
 __all__ = [
     "GroupedGemmSwigluSm100",
@@ -79,6 +83,8 @@ __all__ = [
     "grouped_gemm_wgrad_wrapper_sm100",
     "GroupedGemmSm100",
     "grouped_gemm_wrapper_sm100",
+    "GroupedGemmUnfusedSubchannelScaledSm100",
+    "grouped_gemm_unfused_subchannel_scaled_wrapper_sm100",
     "grouped_gemm_jax_sm100",
     "grouped_gemm_glu_jax_sm100",
     "grouped_gemm_dglu_jax_sm100",

--- a/python/cudnn/gemm/cutedsl/grouped/__init__.py
+++ b/python/cudnn/gemm/cutedsl/grouped/__init__.py
@@ -59,6 +59,10 @@ from .unfused_subchannel_scaled.api import (
     GroupedGemmUnfusedSubchannelScaledSm100,
     grouped_gemm_unfused_subchannel_scaled_wrapper_sm100,
 )
+from .dswiglu_subchannel_scaled.api import (
+    GroupedGemmDswigluSubchannelScaledSm100,
+    grouped_gemm_dswiglu_subchannel_scaled_wrapper_sm100,
+)
 
 __all__ = [
     "GroupedGemmSwigluSm100",
@@ -85,6 +89,8 @@ __all__ = [
     "grouped_gemm_wrapper_sm100",
     "GroupedGemmUnfusedSubchannelScaledSm100",
     "grouped_gemm_unfused_subchannel_scaled_wrapper_sm100",
+    "GroupedGemmDswigluSubchannelScaledSm100",
+    "grouped_gemm_dswiglu_subchannel_scaled_wrapper_sm100",
     "grouped_gemm_jax_sm100",
     "grouped_gemm_glu_jax_sm100",
     "grouped_gemm_dglu_jax_sm100",

--- a/python/cudnn/gemm/cutedsl/grouped/dswiglu_subchannel_scaled/__init__.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dswiglu_subchannel_scaled/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Subchannel-scaled dSwiGLU-backward grouped GEMM for MoE workloads."""
+
+from .api import (
+    GroupedGemmDswigluSubchannelScaledSm100,
+    grouped_gemm_dswiglu_subchannel_scaled_wrapper_sm100,
+)
+
+__all__ = [
+    "GroupedGemmDswigluSubchannelScaledSm100",
+    "grouped_gemm_dswiglu_subchannel_scaled_wrapper_sm100",
+]

--- a/python/cudnn/gemm/cutedsl/grouped/dswiglu_subchannel_scaled/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dswiglu_subchannel_scaled/api.py
@@ -1,0 +1,1373 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+API for the Subchannel-Scaled dSwiGLU Grouped GEMM Kernel (SM100)
+
+Second-level-scaled ("subchannel-scaled") dSwiGLU-backward block-scaled grouped
+GEMM for MoE workloads: NVFP4 A (upstream gradient dY) and B (FC2 weights)
+carry two scale levels -- per-(1, 16) FP8 block scale factors (SFA/SFB) plus
+FP32 second-level scales (SFA2/SFB2) at ``block2_shape = (sgm, sgn, sgk)``
+granularity. The fused epilogue consumes the forward FC1 pre-activations ``c``
+(gate/up interleaved in 32-column bands) and produces:
+
+- ``d`` -- the dSwiGLU backward output, ``2n`` wide (gate/up), either BF16 or
+  NVFP4-quantized (``d_quant`` packed e2m1 + ``d_quant_sf`` e4m3 row scales,
+  ``norm_const``-scaled);
+- ``dprob`` -- the routing-probability gradient (always produced,
+  atomic-add accumulated);
+- ``dbias`` -- optional per-expert column sums of d (atomics);
+- ``sfd2`` -- second-level output descales, per-(sgm x sgn) block max of the
+  deinterleaved ``dy_gate`` / ``dy_up`` halves (atomic-max accumulated).
+
+``d_deinterleaved=True`` (default) stores the n-axis outputs (d, its row
+scale factors, dbias) DEINTERLEAVED -- gate bands first ``[0, n)``, up bands
+second ``[n, 2n)`` -- and lays the fused ``sfd2`` out as concatenated halves,
+which is exactly a consumer GEMM's ``(rows, k/sgk)`` ``a_scales2`` grid with
+``sgk = sgn``. Only the quantized-D configuration supports the deinterleaved
+layout (the harness-validated combination).
+
+FE ``n`` convention: ``n`` is the GEMM/weight width (B is ``(n, k, l)``); the
+n-axis outputs cover ``2n``. SM100-only (the kernel also compiles and runs
+as-is on sm103/sm107 devices; there is no Rubin-native variant).
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from typing import Optional, Tuple
+
+import cutlass
+import cutlass.cute as cute
+from cuda.bindings import driver as cuda
+from cutlass.cute.runtime import from_dlpack, make_fake_stream
+
+from cudnn.api_base import APIBase, TupleDict, ceil_div, get_device_type, is_power_of_2
+from cudnn.datatypes import _convert_to_cutlass_data_type
+from cudnn.tensor_adapter import (
+    allocate_byte_workspace,
+    canonicalize_unit_dim_strides,
+    cuda_is_available,
+    default_stream,
+    detect_framework,
+    framework_dtype,
+    get_compute_capability,
+    get_data_ptr,
+    get_device,
+)
+
+from .grouped_gemm_dswiglu_subchannel_scaled import (
+    DEFAULT_CLUSTER_SHAPE,
+    DEFAULT_CTA_SHAPE,
+    BlockScaledSubChannelMoEGroupedGemmDgluDbiasKernel,
+)
+from ..moe_utils import MoEWeightMode
+from cutlass.cute.nvgpu import OperandMajorMode
+
+_JAX_SF_LAYOUT_ERROR = (
+    "the block scale-factor tensors (sfa/sfb and the d_quant_sf output) are MMA-tiled "
+    "(32, 4, m//128, 4, rest_k, l) strided views that are not expressible as JAX arrays "
+    "(a row-major JAX array of that shape has different memory); pass torch tensors"
+)
+
+
+class GroupedGemmDswigluSubchannelScaledSm100(APIBase):
+    """API for the subchannel-scaled dSwiGLU-backward grouped GEMM on SM100 GPUs.
+
+    ``D2n = dSwiGLU(alpha^2 * subchannel_scaled_gemm(A, B), beta * C, prob)``
+    with fused ``dprob``, optional ``dbias``, second-level output descales
+    ``sfd2``, and optional NVFP4 output quantization. Weight mode is
+    auto-detected from the constructor arguments:
+
+    - Dense: provide ``sample_b``, ``sample_sfb``, and ``sample_sfb2``.
+    - Discrete: provide ``num_experts``, ``b_shape``, and ``b_dtype``.
+
+    Zero-init contract: ``dprob``, ``dbias``, and ``sfd2`` are ATOMICALLY
+    accumulated by the kernel -- the caller (or the high-level wrapper, which
+    owns allocation) must pass zero-initialized tensors on every call.
+    """
+
+    def __init__(
+        self,
+        sample_a: torch.Tensor,
+        sample_sfa: torch.Tensor,
+        sample_sfa2: torch.Tensor,
+        sample_c: torch.Tensor,
+        sample_padded_offsets: torch.Tensor,
+        sample_alpha: torch.Tensor,
+        sample_beta: torch.Tensor,
+        sample_prob: torch.Tensor,
+        sample_d: torch.Tensor,
+        sample_dprob: torch.Tensor,
+        sample_sfd2: torch.Tensor,
+        sample_dbias: Optional[torch.Tensor] = None,
+        sample_d_quant_sf: Optional[torch.Tensor] = None,
+        sample_norm_const: Optional[torch.Tensor] = None,
+        # Dense mode (contiguous) -- provide these:
+        sample_b: Optional[torch.Tensor] = None,
+        sample_sfb: Optional[torch.Tensor] = None,
+        sample_sfb2: Optional[torch.Tensor] = None,
+        # Discrete mode -- provide these instead:
+        num_experts: Optional[int] = None,
+        b_shape: Optional[Tuple[int, ...]] = None,
+        b_dtype: Optional[torch.dtype] = None,
+        # Configuration
+        acc_dtype: Optional[torch.dtype] = None,
+        block2_shape: Tuple[int, int, int] = (1, 256, 256),
+        mma_tiler_mn: Tuple[int, int] = DEFAULT_CTA_SHAPE,
+        cluster_shape_mn: Optional[Tuple[int, int]] = None,
+        sf_vec_size: int = 16,
+        vector_f32: bool = True,
+        m_aligned: int = 256,
+        b_major: str = "k",
+        use_dynamic_sched: bool = False,
+        d_deinterleaved: bool = True,
+        glu_clamp_max: Optional[float] = 7.0,
+        glu_clamp_min: Optional[float] = -7.0,
+        dsmem_rowwise: bool = True,
+    ):
+        """Initialize the GroupedGemmDswigluSubchannelScaledSm100 API.
+
+        :param sample_a: Sample A tensor (valid_m, k, 1), FP4, k-major (upstream dY)
+        :param sample_sfa: Sample first-level scale factor A tensor
+            (MMA-tiled (32, 4, valid_m//128, 4, rest_k, 1) view)
+        :param sample_sfa2: Sample second-level scale factor A tensor,
+            (ceil(valid_m/sgm), ceil(k/sgk), 1) FP32, stride (1, rows, rows*cols)
+        :param sample_c: Forward FC1 pre-activations (valid_m, 2n, 1) BF16,
+            n-major, gate/up interleaved in 32-column bands
+        :param sample_padded_offsets: End offset per expert after padding, shape (expert_cnt,)
+        :param sample_alpha: Per-expert accumulator scale (expert_cnt,) f32.
+            The kernel applies alpha TWICE (alpha^2 on the GEMM accumulator).
+        :param sample_beta: Per-expert C scale (expert_cnt,) f32 (applied
+            inside dSwiGLU, after the clamps)
+        :param sample_prob: Per-token routing probability (valid_m, 1, 1) f32
+        :param sample_d: Output D. BF16 (valid_m, 2n, 1) n-major, or FP4
+            (torch.float4_e2m1fn_x2, physical (valid_m, n, 1)) -- the dtype
+            selects the quantized-output mode.
+        :param sample_dprob: dprob output (valid_m, 1, 1) f32. MUST be
+            zero-initialized (atomic-add accumulated).
+        :param sample_sfd2: Fused second-level output descales
+            (rows, 2*nd, 1) f32, rows-contiguous stride (1, rows, 2*nd*rows),
+            where rows = ceil(valid_m/sgm), nd = ceil(n/sgn). MUST be
+            zero-initialized (atomic-max accumulated). d_deinterleaved=True
+            lays it out as concatenated halves [gate | up]; False interleaves
+            gate/up per block column.
+        :param sample_dbias: Optional dbias output (expert_cnt, 2n, 1), BF16
+            or FP32 (FP32 is a testing-only plain-atomic path). MUST be
+            zero-initialized.
+        :param sample_d_quant_sf: Row scale factors of the quantized D
+            (MMA-tiled (32, 4, valid_m//128, 4, ceil(ceil(2n/16)/4), 1) e4m3
+            view). Required iff sample_d is FP4.
+        :param sample_norm_const: Global D-quant encode scale, shape (1,) f32.
+            Required iff sample_d is FP4.
+        :param sample_b: (Dense) Sample B tensor (n, k, l), FP4, k-major
+        :param sample_sfb: (Dense) Sample first-level scale factor B tensor
+        :param sample_sfb2: (Dense) Sample second-level scale factor B tensor,
+            (ceil(n/sgn), ceil(k/sgk), l) FP32, stride (1, rows, rows*cols)
+        :param num_experts: (Discrete) Number of experts
+        :param b_shape: (Discrete) Shape of a single expert B tensor, (n, k) with logical k
+        :param b_dtype: (Discrete) Data type of B tensors
+        :param acc_dtype: Accumulator data type (must be float32)
+        :param block2_shape: Second-level scale granularity (sgm, sgn, sgk).
+            sgn counts DEINTERLEAVED output columns (one sfd2 block spans sgn
+            columns of dy_gate/dy_up = 2*sgn interleaved D columns) and must be
+            a multiple of the MMA tile N (128).
+        :param mma_tiler_mn: MMA tiler shape; must be (256, 128)
+        :param cluster_shape_mn: Cluster shape; (2, 1), (2, 2), or (2, 4). cluster_n > 1 makes N-adjacent work tiles cluster peers (the rowwise-sfd2 DSMEM geometry) and requires ceil(n/128) % cluster_n == 0
+        :param sf_vec_size: First-level scale factor vector size (must be 16)
+        :param vector_f32: Use vectorized (packed) f32 arithmetic. The default
+            True is the byte-exact-verified configuration.
+        :param m_aligned: Alignment for group M dimension (must be 256)
+        :param b_major: Major dimension for B tensor (must be "k" for FP4)
+        :param use_dynamic_sched: Enable dynamic tile scheduling
+        :param d_deinterleaved: Store the n-axis outputs (d, d_quant_sf, dbias)
+            deinterleaved [gate | up] and sfd2 as concatenated halves. Only
+            supported with the quantized-D output (the harness-validated
+            combination).
+        :param glu_clamp_max: Clamp max on the raw C pre-activations (both
+            clamps must be set or both None)
+        :param glu_clamp_min: Clamp min on the raw C pre-activations
+        :param dsmem_rowwise: Allow the rowwise-sfd2 DSMEM reduction (cluster
+            red.shared::cluster max + mbarrier handoff) instead of the gmem
+            atomic + counter-spin protocol, when the geometry is eligible
+            (quantized D + sgn/128 == cluster_n > 1). Byte-exact either way.
+        """
+        framework = detect_framework(sample_a)
+        if framework == "jax":
+            raise ValueError(f"GroupedGemmDswigluSubchannelScaledSm100 does not support JAX arrays: {_JAX_SF_LAYOUT_ERROR}")
+        if framework != "torch":
+            raise ValueError(f"Unsupported tensor framework '{framework}' for GroupedGemmDswigluSubchannelScaledSm100; pass torch tensors")
+        if acc_dtype is None:
+            acc_dtype = cutlass.Float32
+        super().__init__()
+        self._framework = framework
+
+        self._warn_experimental_api()
+        self._logger.debug("Entering __init__")
+
+        # ---- Weight mode auto-detection ----
+        if sample_b is not None and num_experts is None:
+            self.weight_mode = MoEWeightMode.DENSE
+            if sample_sfb is None or sample_sfb2 is None:
+                raise ValueError("sample_sfb and sample_sfb2 are required when sample_b is provided (dense mode)")
+        elif num_experts is not None and sample_b is None:
+            self.weight_mode = MoEWeightMode.DISCRETE
+            if b_shape is None or b_dtype is None:
+                raise ValueError("b_shape and b_dtype are required in discrete mode")
+        else:
+            raise ValueError(
+                "Provide either (sample_b, sample_sfb, sample_sfb2) for dense mode " "or (num_experts, b_shape, b_dtype) for discrete mode, but not both."
+            )
+
+        self.a_desc = self._make_tensor_desc(sample_a, name="sample_a", canonical=True)
+        self.sfa_desc = self._make_tensor_desc(sample_sfa, name="sample_sfa", canonical=True)
+        self.sfa2_desc = self._make_tensor_desc(sample_sfa2, name="sample_sfa2", canonical=True)
+        self.c_desc = self._make_tensor_desc(sample_c, name="sample_c", canonical=True)
+        self.padded_offsets_desc = self._make_tensor_desc(sample_padded_offsets, name="sample_padded_offsets", canonical=True)
+        self.alpha_desc = self._make_tensor_desc(sample_alpha, name="sample_alpha", canonical=True)
+        self.beta_desc = self._make_tensor_desc(sample_beta, name="sample_beta", canonical=True)
+        self.prob_desc = self._make_tensor_desc(sample_prob, name="sample_prob", canonical=True)
+        self.dprob_desc = self._make_tensor_desc(sample_dprob, name="sample_dprob", canonical=True)
+        self.sfd2_desc = self._make_tensor_desc(sample_sfd2, name="sample_sfd2", canonical=True)
+        self.dbias_desc = self._make_tensor_desc(sample_dbias, name="sample_dbias", canonical=True)
+        self.d_quant_sf_desc = self._make_tensor_desc(sample_d_quant_sf, name="sample_d_quant_sf", canonical=True)
+        self.norm_const_desc = self._unpad_tensor_to_ndim(
+            self._make_tensor_desc(sample_norm_const, name="sample_norm_const", canonical=True),
+            1,
+            "norm_const",
+        )
+        # sfd2 view descriptors (the kernel receives the two half views of the
+        # fused buffer; their strides differ between the deint/interleaved
+        # layouts, so capture them from actual view samples).
+        nd_cols = sample_sfd2.shape[1] // 2
+        if d_deinterleaved:
+            sfd2_gate_view = sample_sfd2[:, :nd_cols, :]
+            sfd2_up_view = sample_sfd2[:, nd_cols:, :]
+        else:
+            sfd2_gate_view = sample_sfd2[:, 0::2, :]
+            sfd2_up_view = sample_sfd2[:, 1::2, :]
+        self.sfd2_gate_desc = self._make_tensor_desc(sfd2_gate_view, name="sample_sfd2[gate]", canonical=True)
+        self.sfd2_up_desc = self._make_tensor_desc(sfd2_up_view, name="sample_sfd2[up]", canonical=True)
+
+        if self.weight_mode == MoEWeightMode.DENSE:
+            self.b_desc = self._make_tensor_desc(sample_b, name="sample_b", canonical=True)
+            self.sfb_desc = self._make_tensor_desc(sample_sfb, name="sample_sfb", canonical=True)
+            self.sfb2_desc = self._make_tensor_desc(sample_sfb2, name="sample_sfb2", canonical=True)
+            self.expert_cnt = self.padded_offsets_desc.shape[0]
+        else:
+            self._value_error_if(num_experts == 0, "num_experts must be > 0")
+            self.expert_cnt = num_experts
+            self.b_shape = b_shape
+            self.b_dtype = _convert_to_cutlass_data_type(b_dtype)
+            self._value_error_if(
+                self.padded_offsets_desc.shape[0] != self.expert_cnt,
+                f"padded_offsets length ({self.padded_offsets_desc.shape[0]}) " f"must equal num_experts ({self.expert_cnt})",
+            )
+
+        self.acc_dtype = _convert_to_cutlass_data_type(acc_dtype)
+        self._value_error_if(
+            len(block2_shape) != 3,
+            f"block2_shape must be (sgm, sgn, sgk), got {block2_shape}",
+        )
+        self.block2_shape = tuple(block2_shape)
+        self.sgm, self.sgn, self.sgk = self.block2_shape
+        self.mma_tiler_mn = tuple(mma_tiler_mn)
+        self.use_2cta_instrs = self.mma_tiler_mn[0] == 256
+        if cluster_shape_mn is None:
+            self.cluster_shape_mn = DEFAULT_CLUSTER_SHAPE
+        else:
+            self.cluster_shape_mn = tuple(cluster_shape_mn)
+        self.sf_vec_size = sf_vec_size
+        self.vector_f32 = vector_f32
+        self.m_aligned = m_aligned
+        self.use_dynamic_sched = use_dynamic_sched
+        self.b_major = b_major
+        self.d_deinterleaved = d_deinterleaved
+        self.glu_clamp_max = glu_clamp_max
+        self.glu_clamp_min = glu_clamp_min
+        self.dsmem_rowwise = dsmem_rowwise
+
+        self._interpret_uint8_as_fp4x2 = True
+        # D dtype-driven quantized-output mode (glu_hadamard_quant precedent).
+        self.d_desc = self._make_tensor_desc(sample_d, name="sample_d", canonical=True)
+        self.d_quant = self._is_fp4x2(self.d_desc.dtype)
+        self._has_dbias = self.dbias_desc is not None
+        self._kernel = BlockScaledSubChannelMoEGroupedGemmDgluDbiasKernel
+
+        self.num_cluster_overlap_margin = int(os.getenv("CUDNNFE_CLUSTER_OVERLAP_MARGIN", "0"))
+        self._workspace = None
+        self._workspace_bytes = 0
+        self._gemm = None
+        self._max_active_clusters = None
+        self._logger.debug("__init__ completed")
+
+    # ---- geometry helpers ----
+
+    def _n_from_descs(self) -> int:
+        if self.weight_mode == MoEWeightMode.DENSE:
+            return self._tensor_shape(self.b_desc, name="sample_b")[0]
+        return self.b_shape[0]
+
+    @property
+    def sfd2_n_contrib(self) -> int:
+        return max(1, self.sgn // self.mma_tiler_mn[1])
+
+    def _sfd2_counter_cnt(self, valid_m: int, n: int) -> int:
+        """One u32 per (global m CTA tile, sfd2 n-block); must match the
+        kernel's _sfd2_counter_cnt formula. Zero when the arrival protocol is
+        inactive (bf16 D, or sgn <= tile N)."""
+        if not (self.d_quant and self.sfd2_n_contrib > 1):
+            return 0
+        cta_m = self.mma_tiler_mn[0] // (2 if self.use_2cta_instrs else 1)
+        cta_n = self.mma_tiler_mn[1]
+        n_tiles_f = ceil_div(n, cta_n)
+        return (valid_m // cta_m) * ceil_div(n_tiles_f, self.sfd2_n_contrib)
+
+    def check_support(self) -> bool:
+        """Check if the kernel configuration is supported.
+
+        :return: True if supported, raises exception otherwise
+        """
+        self._logger.debug("Entering check_support")
+
+        tensor_m, k, _one = self._tensor_shape(self.a_desc, name="sample_a")
+
+        if self.weight_mode == MoEWeightMode.DENSE:
+            n, _, l = self._tensor_shape(self.b_desc, name="sample_b")
+        else:
+            if len(self.b_shape) == 2:
+                n, b_k = self.b_shape
+            else:
+                n, b_k, _ = self.b_shape
+            self._value_error_if(b_k != k, f"B K dimension ({b_k}) must match A K dimension ({k})")
+            l = self.expert_cnt
+        n2 = 2 * n
+
+        # ---- shapes ----
+        self._check_tensor_shape(self.a_desc, (tensor_m, k, 1), "A")
+        if self.weight_mode == MoEWeightMode.DENSE:
+            self._check_tensor_shape(self.b_desc, (n, k, l), "B")
+        self._check_tensor_shape(self.c_desc, (tensor_m, n2, 1), "C")
+        self._check_tensor_shape(self.d_desc, (tensor_m, n2, 1), "D")
+        self._check_tensor_shape(self.prob_desc, (tensor_m, 1, 1), "prob")
+        self._check_tensor_shape(self.dprob_desc, (tensor_m, 1, 1), "dprob")
+        self._check_tensor_shape(self.dbias_desc, (l, n2, 1), "dbias")
+        self._check_tensor_shape(self.alpha_desc, (self.expert_cnt,), "alpha")
+        self._check_tensor_shape(self.beta_desc, (self.expert_cnt,), "beta")
+        self._check_tensor_shape(self.padded_offsets_desc, (self.expert_cnt,), "padded_offsets")
+
+        rest_k = ceil_div(ceil_div(k, self.sf_vec_size), 4)
+        self._check_tensor_shape(self.sfa_desc, (32, 4, ceil_div(tensor_m, 128), 4, rest_k, 1), "SFA")
+        if self.weight_mode == MoEWeightMode.DENSE:
+            self._check_tensor_shape(self.sfb_desc, (32, 4, ceil_div(n, 128), 4, rest_k, l), "SFB")
+        rest_n2 = ceil_div(ceil_div(n2, self.sf_vec_size), 4)
+        self._check_tensor_shape(self.d_quant_sf_desc, (32, 4, ceil_div(tensor_m, 128), 4, rest_n2, 1), "d_quant_sf")
+        self._check_tensor_shape(self.norm_const_desc, (1,), "norm_const")
+
+        # ---- second-level (subchannel) scale factors ----
+        self._value_error_if(
+            self.sgm < 1 or self.sgn < 1 or self.sgk < 1,
+            f"block2_shape components must be >= 1, got {self.block2_shape}",
+        )
+        self._value_error_if(
+            k % self.sgk != 0,
+            f"k ({k}) must be divisible by sgk ({self.sgk})",
+        )
+        self._value_error_if(
+            tensor_m % self.sgm != 0,
+            f"valid_m ({tensor_m}) must be divisible by sgm ({self.sgm})",
+        )
+        self._value_error_if(
+            self.sgn % self.mma_tiler_mn[1] != 0,
+            f"sgn ({self.sgn}) must be a multiple of the MMA tile N "
+            f"({self.mma_tiler_mn[1]}): one sfd2 block = sgn deinterleaved "
+            f"columns and every N work tile must sit inside one block",
+        )
+        sfa2_rows = ceil_div(tensor_m, self.sgm)
+        sf2_cols = ceil_div(k, self.sgk)
+        sfa2_shape = (sfa2_rows, sf2_cols, 1)
+        self._check_tensor_shape(self.sfa2_desc, sfa2_shape, "SFA2")
+        _ = self._check_tensor_stride(
+            self.sfa2_desc,
+            stride=[canonicalize_unit_dim_strides(sfa2_shape, (1, sfa2_rows, sfa2_rows * sf2_cols))],
+            extra_error_msg="SFA2 must be rows-contiguous",
+        )
+        sfb2_rows = ceil_div(n, self.sgn)
+        if self.weight_mode == MoEWeightMode.DENSE:
+            sfb2_shape = (sfb2_rows, sf2_cols, l)
+            self._check_tensor_shape(self.sfb2_desc, sfb2_shape, "SFB2")
+            _ = self._check_tensor_stride(
+                self.sfb2_desc,
+                stride=[canonicalize_unit_dim_strides(sfb2_shape, (1, sfb2_rows, sfb2_rows * sf2_cols))],
+                extra_error_msg="SFB2 must be rows-contiguous per expert",
+            )
+        else:
+            sfb2_block_bytes = sfb2_rows * sf2_cols * 4
+            self._value_error_if(
+                self.expert_cnt > 1 and sfb2_block_bytes % 16 != 0,
+                f"discrete SFB2 per-expert block ({sfb2_rows} x {sf2_cols} f32 = "
+                f"{sfb2_block_bytes} bytes) must be a multiple of 16 bytes when "
+                f"num_experts > 1 (per-expert bases are assumed 16B-aligned)",
+            )
+
+        # ---- sfd2 output (fused buffer + views) ----
+        sfd2_rows = ceil_div(tensor_m, self.sgm)
+        nd = ceil_div(n, self.sgn)
+        sfd2_shape = (sfd2_rows, 2 * nd, 1)
+        self._check_tensor_shape(self.sfd2_desc, sfd2_shape, "sfd2")
+        _ = self._check_tensor_stride(
+            self.sfd2_desc,
+            stride=[canonicalize_unit_dim_strides(sfd2_shape, (1, sfd2_rows, 2 * nd * sfd2_rows))],
+            extra_error_msg="sfd2 must be rows-contiguous (fused (rows, 2*nd, 1) buffer)",
+        )
+        if self.d_deinterleaved:
+            # up half base = rows*nd*4 bytes from the buffer base (16B-aligned
+            # contract of the kernel's assumed_align on the up view).
+            self._value_error_if(
+                (sfd2_rows * nd * 4) % 16 != 0,
+                f"sfd2 rows={sfd2_rows} nd={nd} breaks the up-half 16B alignment",
+            )
+        else:
+            self._value_error_if(
+                (sfd2_rows * 4) % 16 != 0,
+                f"sfd2 rows={sfd2_rows} breaks the up-view 16B alignment",
+            )
+
+        # ---- dtypes ----
+        self.ab_dtype = self._check_dtype(
+            self.a_desc,
+            dtype=[cutlass.Float4E2M1FN, cutlass.Uint8],
+            name="A/B",
+            extra_error_msg="only NVFP4 (fp4) inputs are supported",
+        )
+        if self.weight_mode == MoEWeightMode.DENSE:
+            self._check_dtype(self.b_desc, dtype=self.ab_dtype, name="B", extra_error_msg="B must have the same dtype as A")
+        else:
+            self._value_error_if(
+                self.b_dtype != self.ab_dtype,
+                f"b_dtype ({self.b_dtype}) must match A dtype ({self.ab_dtype})",
+            )
+            self._value_error_if(self.b_major != "k", f"b_major must be 'k' for fp4 ab_dtype, got {self.b_major}")
+        self.sf_dtype = self._check_dtype(
+            self.sfa_desc,
+            dtype=cutlass.Float8E4M3FN,
+            name="SFA/SFB",
+            extra_error_msg="first-level scale factors must be torch.float8_e4m3fn (the NVFP4 recipe)",
+        )
+        if self.weight_mode == MoEWeightMode.DENSE:
+            self._check_dtype(self.sfb_desc, dtype=self.sf_dtype, name="SFB")
+        self._check_dtype(self.sfa2_desc, dtype=cutlass.Float32, name="SFA2")
+        if self.weight_mode == MoEWeightMode.DENSE:
+            self._check_dtype(self.sfb2_desc, dtype=cutlass.Float32, name="SFB2")
+        self._check_dtype(self.c_desc, dtype=cutlass.BFloat16, name="C")
+        self.d_dtype = self._check_dtype(
+            self.d_desc,
+            dtype=[cutlass.BFloat16, cutlass.Float4E2M1FN],
+            name="D",
+            extra_error_msg="D must be bfloat16 (plain output) or fp4 (quantized output)",
+        )
+        self._check_dtype(self.acc_dtype, dtype=cutlass.Float32, name="Accumulator")
+        self._check_dtype(self.alpha_desc, dtype=cutlass.Float32, name="alpha")
+        self._check_dtype(self.beta_desc, dtype=cutlass.Float32, name="beta")
+        self._check_dtype(self.prob_desc, dtype=cutlass.Float32, name="prob")
+        self._check_dtype(self.dprob_desc, dtype=cutlass.Float32, name="dprob")
+        self._check_dtype(self.sfd2_desc, dtype=cutlass.Float32, name="sfd2")
+        self._check_dtype(
+            self.dbias_desc,
+            dtype=[cutlass.BFloat16, cutlass.Float32],
+            name="dbias",
+            extra_error_msg="dbias must be bfloat16 (or float32 -- a testing-only plain-atomic path)",
+        )
+        self._check_dtype(self.d_quant_sf_desc, dtype=cutlass.Float8E4M3FN, name="d_quant_sf")
+        self._check_dtype(self.norm_const_desc, dtype=cutlass.Float32, name="norm_const")
+        self._check_dtype(self.padded_offsets_desc, dtype=cutlass.Int32, name="padded_offsets")
+        self._value_error_if(
+            self.sf_vec_size != 16,
+            f"sf_vec_size must be 16 (NVFP4), got {self.sf_vec_size}",
+        )
+
+        # ---- quant-mode coupling ----
+        if self.d_quant:
+            self._value_error_if(
+                self.d_quant_sf_desc is None or self.norm_const_desc is None,
+                "quantized D output (fp4 sample_d) requires sample_d_quant_sf and sample_norm_const",
+            )
+        else:
+            self._value_error_if(
+                self.d_quant_sf_desc is not None or self.norm_const_desc is not None,
+                "sample_d_quant_sf/sample_norm_const must be omitted for the bf16 D output",
+            )
+
+        # ---- deinterleaved-layout gate ----
+        self._value_error_if(
+            self.d_deinterleaved and not self.d_quant,
+            "d_deinterleaved=True is only supported with the quantized (fp4) D "
+            "output -- the harness-validated combination; use "
+            "d_deinterleaved=False for the bf16 D output",
+        )
+
+        # ---- launch config (pinned by the kernel) ----
+        self._value_error_if(
+            self.mma_tiler_mn != (256, 128),
+            f"mma_tiler_mn must be (256, 128), got {self.mma_tiler_mn}",
+        )
+        self._value_error_if(
+            self.cluster_shape_mn not in ((2, 1), (2, 2), (2, 4)),
+            f"cluster_shape_mn must be (2, 1), (2, 2), or (2, 4), got {self.cluster_shape_mn} "
+            f"(cluster_m stays 2: wider cluster-M tiles need a per-expert-M gate that cannot "
+            f"be verified host-side on ragged inputs)",
+        )
+        if self.cluster_shape_mn[1] > 1:
+            # The scheduler decomposes over CLUSTER N tiles: the N work-tile
+            # count must be a cluster_n multiple or the last N cluster's peers
+            # would map past the edge.
+            self._value_error_if(
+                ceil_div(n, self.mma_tiler_mn[1]) % self.cluster_shape_mn[1] != 0,
+                f"with cluster_n={self.cluster_shape_mn[1]}, the N work-tile count " f"ceil({n}/{self.mma_tiler_mn[1]}) must be a cluster_n multiple",
+            )
+        self._value_error_if(
+            self.m_aligned != self._kernel.FIX_PAD_SIZE,
+            f"m_aligned must be {self._kernel.FIX_PAD_SIZE} (FIX_PAD_SIZE), got {self.m_aligned}",
+        )
+        self._value_error_if(
+            (self.glu_clamp_max is None) != (self.glu_clamp_min is None),
+            "glu_clamp_max and glu_clamp_min must both be set or both be None",
+        )
+
+        # ---- problem-shape gates ----
+        _ = self._check_tensor_stride(self.a_desc, stride=[(k, 1, tensor_m * k)], extra_error_msg="A must have k-major layout")
+        if self.weight_mode == MoEWeightMode.DENSE:
+            _ = self._check_tensor_stride(self.b_desc, stride=[(k, 1, n * k)], extra_error_msg="B must have k-major layout")
+        _ = self._check_tensor_stride(self.c_desc, stride=[(n2, 1, tensor_m * n2)], extra_error_msg="C must have n-major layout")
+        _ = self._check_tensor_stride(self.d_desc, stride=[(n2, 1, tensor_m * n2)], extra_error_msg="D must have n-major layout")
+        if self.dbias_desc is not None:
+            _ = self._check_tensor_stride(
+                self.dbias_desc,
+                stride=[canonicalize_unit_dim_strides((l, n2, 1), (n2, 1, l * n2))],
+                extra_error_msg="dbias must have contiguous columns per expert",
+            )
+        self._value_error_if(n2 % 256 != 0, f"output width 2n ({n2}) must be divisible by 256 (n % 128 == 0)")
+        self._value_error_if(k % 64 != 0, f"k ({k}) must be divisible by 64")
+        self._value_error_if(tensor_m % 256 != 0, f"valid_m must be divisible by 256, got {tensor_m}")
+        self._value_error_if(self.expert_cnt > 1024, f"expert_cnt must be <= 1024, got {self.expert_cnt}")
+
+        def check_contigous_16B_alignment(dtype, stride_order, tensor_shape):
+            is_mode0_major = stride_order == (0, 1, 2)
+            major_mode_idx = 0 if is_mode0_major else 1
+            num_major_elements = tensor_shape[major_mode_idx]
+            num_contiguous_elements = 16 * 8 // (_convert_to_cutlass_data_type(dtype, interpret_uint8_as_fp4x2=self._interpret_uint8_as_fp4x2).width)
+            return num_major_elements % num_contiguous_elements == 0
+
+        if self.weight_mode == MoEWeightMode.DENSE:
+            b_stride_order_for_check = self.b_desc.stride_order
+            b_shape_for_check = (n, k, l)
+        else:
+            b_stride_order_for_check = (1, 0, 2)
+            b_shape_for_check = (n, k, 1)
+        self._value_error_if(
+            not (
+                check_contigous_16B_alignment(self.ab_dtype, self.a_desc.stride_order, (tensor_m, k, l))
+                and check_contigous_16B_alignment(self.ab_dtype, b_stride_order_for_check, b_shape_for_check)
+                and check_contigous_16B_alignment(self.d_dtype, self.d_desc.stride_order, (tensor_m, n2, 1))
+            ),
+            "Invalid tensor alignment: tensors must be 16B aligned",
+        )
+
+        if not cuda_is_available():
+            raise RuntimeError("CUDA is not available")
+        major, minor = get_compute_capability()
+        compute_capability = major * 10 + minor
+        if compute_capability < 100:
+            raise RuntimeError(f"GroupedGemmDswigluSubchannelScaled requires SM100+ compute capability, but found SM{compute_capability}")
+
+        self._is_supported = True
+        self._logger.debug("check_support completed successfully")
+        return True
+
+    def compile(self) -> None:
+        """Compile the kernel."""
+        self._logger.debug("Entering compile")
+        self._ensure_support_checked()
+        if self._compiled_kernel is not None:
+            return
+        if self.a_desc.shape[0] == 0:
+            self._logger.debug("sample valid_m is zero, skipping kernel compilation")
+            return
+
+        n = self._n_from_descs()
+        gemm = self._kernel(
+            self.sf_vec_size,
+            self.sgm,
+            self.sgn,
+            self.sgk,
+            cutlass.Float32,
+            self.use_2cta_instrs,
+            self.mma_tiler_mn,
+            self.cluster_shape_mn,
+            self.vector_f32,
+            self.expert_cnt,
+            weight_mode=self.weight_mode,
+            use_dynamic_sched=self.use_dynamic_sched,
+            act_func="dswiglu",
+            generate_sfd2=True,
+            glu_alpha=None,
+            glu_clamp_max=self.glu_clamp_max,
+            glu_clamp_min=self.glu_clamp_min,
+            d_deinterleaved=self.d_deinterleaved,
+            deint_n=(2 * n) if self.d_deinterleaved else 0,
+            dsmem_rowwise=self.dsmem_rowwise,
+        )
+        self._gemm = gemm
+
+        hardware_info = cutlass.utils.HardwareInfo()
+        max_active_clusters = hardware_info.get_max_active_clusters(self.cluster_shape_mn[0] * self.cluster_shape_mn[1])
+        max_active_clusters -= self.num_cluster_overlap_margin
+        self._value_error_if(
+            max_active_clusters <= 0,
+            "max_active_clusters must be > 0 after applying overlap margin; reduce CUDNNFE_CLUSTER_OVERLAP_MARGIN",
+        )
+        self._max_active_clusters = max_active_clusters
+        fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
+
+        # Workspace: sized here for the sample valid_m; execute() grows it if a
+        # later call's sfd2 sync-counter count needs more bytes.
+        counter_cnt = self._sfd2_counter_cnt(self.a_desc.shape[0], n)
+        self._workspace_bytes = gemm.get_workspace_bytes(sfd2_sync_counter_cnt=counter_cnt)
+        self._workspace = allocate_byte_workspace(self._framework, self._workspace_bytes, self.a_desc.device)
+
+        if self.weight_mode == MoEWeightMode.DENSE:
+            self._compile_dense(gemm, max_active_clusters, fake_stream)
+        else:
+            self._compile_discrete(gemm, max_active_clusters, fake_stream)
+
+        self._logger.debug("Kernel compiled successfully")
+
+    def _make_dynamic_m_fakes(self, valid_m):
+        """Fake tensors for the operands whose leading extent scales with valid_m."""
+        a_cute_fake = self._make_fake_cute_compact_tensor(
+            dtype=self.a_desc.dtype,
+            shape=(valid_m, *self.a_desc.shape[1:]),
+            stride_order=self.a_desc.stride_order,
+            assumed_align=32 if self._is_fp4x2(self.ab_dtype) else 16,
+        )
+        c_cute_fake = self._make_fake_cute_compact_tensor(
+            dtype=self.c_desc.dtype,
+            shape=(valid_m, *self.c_desc.shape[1:]),
+            stride_order=self.c_desc.stride_order,
+        )
+        d_cute_fake = self._make_fake_cute_compact_tensor(
+            dtype=self.d_desc.dtype,
+            shape=(valid_m, *self.d_desc.shape[1:]),
+            stride_order=self.d_desc.stride_order,
+            assumed_align=32 if self.d_quant else 16,
+        )
+
+        tensor_m_128 = cute.sym_int()
+        stride_tensor_m_128 = cute.sym_int(divisibility=32 * 4 * 4)
+        sfa_shape = list(self.sfa_desc.shape)
+        sfa_shape[2] = tensor_m_128
+        sfa_stride = list(self.sfa_desc.stride)
+        sfa_stride[5] = stride_tensor_m_128
+        sfa_cute_fake = self._make_fake_cute_tensor(
+            dtype=self.sfa_desc.dtype,
+            shape=tuple(sfa_shape),
+            stride=tuple(sfa_stride),
+            assumed_align=16,
+        )
+
+        sfa2_rows = cute.sym_int()
+        sfa2_cute_fake = self._make_fake_cute_tensor(
+            dtype=self.sfa2_desc.dtype,
+            shape=(sfa2_rows, self.sfa2_desc.shape[1], 1),
+            stride=(1, cute.sym_int(), cute.sym_int()),
+            assumed_align=16,
+        )
+
+        prob_cute_fake = self._make_fake_cute_tensor(
+            dtype=self.prob_desc.dtype,
+            shape=(valid_m, *self.prob_desc.shape[1:]),
+            stride=self.prob_desc.stride,
+            assumed_align=16,
+        )
+        dprob_cute_fake = self._make_fake_cute_tensor(
+            dtype=self.dprob_desc.dtype,
+            shape=(valid_m, *self.dprob_desc.shape[1:]),
+            stride=self.dprob_desc.stride,
+            assumed_align=16,
+        )
+
+        # sfd2 half views: rows scale with valid_m; the column stride differs
+        # between the deint (rows) and interleaved (2*rows) layouts, so keep
+        # both strides dynamic (the layout choice is a kernel constexpr).
+        def sfd2_view_fake(desc):
+            return self._make_fake_cute_tensor(
+                dtype=desc.dtype,
+                shape=(cute.sym_int(), desc.shape[1], 1),
+                stride=(1, cute.sym_int(), cute.sym_int()),
+                assumed_align=16,
+            )
+
+        sfd2_gate_fake = sfd2_view_fake(self.sfd2_gate_desc)
+        sfd2_up_fake = sfd2_view_fake(self.sfd2_up_desc)
+
+        sfd_row_fake = None
+        if self.d_quant:
+            sfd_m_128 = cute.sym_int()
+            sfd_stride_m = cute.sym_int(divisibility=32 * 4 * 4)
+            sfd_shape = list(self.d_quant_sf_desc.shape)
+            sfd_shape[2] = sfd_m_128
+            sfd_stride = list(self.d_quant_sf_desc.stride)
+            sfd_stride[5] = sfd_stride_m
+            sfd_row_fake = self._make_fake_cute_tensor(
+                dtype=self.d_quant_sf_desc.dtype,
+                shape=tuple(sfd_shape),
+                stride=tuple(sfd_stride),
+                assumed_align=16,
+            )
+
+        return (
+            a_cute_fake,
+            c_cute_fake,
+            d_cute_fake,
+            sfa_cute_fake,
+            sfa2_cute_fake,
+            prob_cute_fake,
+            dprob_cute_fake,
+            sfd2_gate_fake,
+            sfd2_up_fake,
+            sfd_row_fake,
+        )
+
+    def _common_static_fakes(self):
+        norm_const_fake = self._make_fake_cute_tensor_from_desc(self.norm_const_desc, assumed_align=16) if self.d_quant else None
+        dbias_fake = self._make_fake_cute_tensor_from_desc(self.dbias_desc, assumed_align=16)
+        offsets_fake = self._make_fake_cute_tensor_from_desc(self.padded_offsets_desc, assumed_align=16)
+        alpha_fake = self._make_fake_cute_tensor_from_desc(self.alpha_desc, assumed_align=16)
+        beta_fake = self._make_fake_cute_tensor_from_desc(self.beta_desc, assumed_align=16)
+        return norm_const_fake, dbias_fake, offsets_fake, alpha_fake, beta_fake
+
+    def _make_tensor_api(self, _compiled_kernel, cached_n, cached_k, cached_b_stride, discrete: bool):
+        def tensor_api(
+            a_tensor,
+            b_arg,
+            sfb_arg,
+            sfb2_arg,
+            c_tensor,
+            d_tensor,
+            sfa_tensor,
+            sfa2_tensor,
+            sfd2_up_tensor,
+            sfd2_gate_tensor,
+            sfd_row_tensor,
+            norm_const_tensor,
+            padded_offsets,
+            alpha_tensor,
+            beta_tensor,
+            prob_tensor,
+            dprob_tensor,
+            dbias_tensor,
+            workspace_ptr,
+            stream,
+        ) -> None:
+            if discrete:
+                b_arg = int(get_data_ptr(b_arg))
+                sfb_arg = int(get_data_ptr(sfb_arg))
+                sfb2_arg = int(get_data_ptr(sfb2_arg))
+            _compiled_kernel(
+                a_tensor,
+                b_arg,
+                sfb_arg,
+                sfb2_arg,
+                cached_n,
+                cached_k,
+                cached_b_stride,
+                workspace_ptr,
+                c_tensor,
+                d_tensor,
+                sfa_tensor,
+                sfa2_tensor,
+                sfd2_up_tensor,
+                sfd2_gate_tensor,
+                sfd_row_tensor,
+                norm_const_tensor,
+                padded_offsets,
+                alpha_tensor,
+                beta_tensor,
+                prob_tensor,
+                dprob_tensor,
+                0.0,  # linear_offset (dgeglu-only; act_func is pinned to dswiglu)
+                dbias_tensor,
+                stream,
+            )
+
+        return tensor_api
+
+    def _compile_dense(self, gemm, max_active_clusters, fake_stream) -> None:
+        fake_workspace_ptr = cute.runtime.nullptr(dtype=cutlass.Uint8, assumed_align=128)
+        valid_m = cute.sym_int(divisibility=256)
+        a_f, c_f, d_f, sfa_f, sfa2_f, prob_f, dprob_f, sfd2_gate_f, sfd2_up_f, sfd_row_f = self._make_dynamic_m_fakes(valid_m)
+        norm_const_f, dbias_f, offsets_f, alpha_f, beta_f = self._common_static_fakes()
+        b_f = self._make_fake_cute_tensor_from_desc(self.b_desc, assumed_align=16)
+        sfb_f = self._make_fake_cute_tensor_from_desc(self.sfb_desc, assumed_align=16)
+        sfb2_f = self._make_fake_cute_tensor_from_desc(self.sfb2_desc, assumed_align=16)
+
+        _compiled_kernel = cute.compile(
+            gemm,
+            a_f,
+            b_f,
+            sfb_f,
+            sfb2_f,
+            cutlass.Int32(0),
+            cutlass.Int32(0),
+            cutlass.Int64(0),
+            OperandMajorMode.K,
+            fake_workspace_ptr,
+            c_f,
+            d_f,
+            sfa_f,
+            sfa2_f,
+            sfd2_up_f,
+            sfd2_gate_f,
+            sfd_row_f,
+            norm_const_f,
+            offsets_f,
+            alpha_f,
+            beta_f,
+            prob_f,
+            dprob_f,
+            0.0,
+            dbias_f,
+            max_active_clusters,
+            fake_stream,
+            options="--enable-tvm-ffi",
+        )
+        self._compiled_kernel = self._make_tensor_api(_compiled_kernel, cutlass.Int32(0), cutlass.Int32(0), cutlass.Int64(0), discrete=False)
+
+    def _compile_discrete(self, gemm, max_active_clusters, fake_stream) -> None:
+        if len(self.b_shape) == 2:
+            n, k = self.b_shape
+        else:
+            n, k, _ = self.b_shape
+        valid_m = cute.sym_int(divisibility=256)
+        a_f, c_f, d_f, sfa_f, sfa2_f, prob_f, dprob_f, sfd2_gate_f, sfd2_up_f, sfd_row_f = self._make_dynamic_m_fakes(valid_m)
+        norm_const_f, dbias_f, offsets_f, alpha_f, beta_f = self._common_static_fakes()
+
+        # Compile-time placeholders for the pointer-array arguments (real
+        # device bytes retyped to Int64 -- fake tensors have dummy iterators).
+        self._compile_b_ptrs = allocate_byte_workspace(self._framework, 8 * self.expert_cnt, self.a_desc.device)
+        self._compile_sfb_ptrs = allocate_byte_workspace(self._framework, 8 * self.expert_cnt, self.a_desc.device)
+        self._compile_sfb2_ptrs = allocate_byte_workspace(self._framework, 8 * self.expert_cnt, self.a_desc.device)
+
+        def _ptr_iter(buf):
+            placeholder = from_dlpack(buf, assumed_align=8)
+            placeholder.element_type = cutlass.Int64
+            return placeholder.iterator
+
+        workspace_ptr_cute = from_dlpack(self._workspace, assumed_align=128).iterator
+
+        _compiled_kernel = cute.compile(
+            gemm,
+            a_f,
+            _ptr_iter(self._compile_b_ptrs),
+            _ptr_iter(self._compile_sfb_ptrs),
+            _ptr_iter(self._compile_sfb2_ptrs),
+            cutlass.Int32(n),
+            cutlass.Int32(k),
+            cutlass.Int64(k),
+            OperandMajorMode.K,
+            workspace_ptr_cute,
+            c_f,
+            d_f,
+            sfa_f,
+            sfa2_f,
+            sfd2_up_f,
+            sfd2_gate_f,
+            sfd_row_f,
+            norm_const_f,
+            offsets_f,
+            alpha_f,
+            beta_f,
+            prob_f,
+            dprob_f,
+            0.0,
+            dbias_f,
+            max_active_clusters,
+            fake_stream,
+            options="--enable-tvm-ffi",
+        )
+        self._compiled_kernel = self._make_tensor_api(_compiled_kernel, cutlass.Int32(n), cutlass.Int32(k), cutlass.Int64(k), discrete=True)
+
+    def _ensure_workspace(self, valid_m: int, n: int):
+        """Grow-only workspace: the sfd2 sync-counter count scales with the
+        runtime valid_m, so re-size when a call needs more bytes and derive a
+        fresh iterator every call (the closure takes it as a parameter)."""
+        required = self._gemm.get_workspace_bytes(sfd2_sync_counter_cnt=self._sfd2_counter_cnt(valid_m, n))
+        if required > self._workspace_bytes:
+            self._workspace = allocate_byte_workspace(self._framework, required, self.a_desc.device)
+            self._workspace_bytes = required
+        return from_dlpack(self._workspace, assumed_align=128).iterator
+
+    def _assert_sfd2_liveness(self, valid_m: int, n: int):
+        """Liveness of the sfd2 cross-tile arrival protocol (active when the
+        quantized-D row-scale fold consumes an sfd2 block spanning multiple N
+        work tiles). Conservative ragged-safe bound: per-expert m is unknown
+        host-side, so bound the partner tile distance with the total valid_m."""
+        if self._sfd2_counter_cnt(valid_m, n) == 0:
+            return
+        # A spinning tile waits on its block partners in OTHER clusters: one
+        # block spans max(1, contrib/cluster_n) N-adjacent clusters (cluster_n
+        # N-peers share a cluster and arrive together); N-adjacent cluster
+        # linear distance is 1 when N varies fastest, m_cluster_tiles otherwise
+        # (the scheduler's short-side-first order is over CLUSTER tiles).
+        # Require the farthest partner distance < grid clusters. On the
+        # DSMEM-eligible geometries (contrib == cluster_n) block_n_clusters is
+        # 1 and the bound is vacuously true — all contributors are co-resident
+        # cluster peers.
+        cta_m = self.mma_tiler_mn[0] // (2 if self.use_2cta_instrs else 1)
+        cta_n = self.mma_tiler_mn[1]
+        n_tiles_f = ceil_div(n, cta_n)
+        n_cluster_tiles = ceil_div(n_tiles_f, self.cluster_shape_mn[1])
+        m_cluster_tiles_worst = ceil_div(valid_m, cta_m * self.cluster_shape_mn[0])
+        base_dist_worst = min(m_cluster_tiles_worst, n_cluster_tiles)
+        block_n_clusters = max(1, self.sfd2_n_contrib // self.cluster_shape_mn[1])
+        max_partner_dist = (block_n_clusters - 1) * base_dist_worst
+        self._runtime_error_if(
+            max_partner_dist >= self._max_active_clusters,
+            f"sfd2 arrival protocol could deadlock: worst-case partner cluster "
+            f"distance {max_partner_dist} (contrib={self.sfd2_n_contrib}, "
+            f"block_n_clusters={block_n_clusters}, "
+            f"m_cluster_tiles<={m_cluster_tiles_worst}, n_cluster_tiles={n_cluster_tiles}) "
+            f"must be < persistent grid clusters {self._max_active_clusters}",
+        )
+
+    def execute(
+        self,
+        a_tensor: torch.Tensor,
+        sfa_tensor: torch.Tensor,
+        sfa2_tensor: torch.Tensor,
+        c_tensor: torch.Tensor,
+        padded_offsets: torch.Tensor,
+        alpha_tensor: torch.Tensor,
+        beta_tensor: torch.Tensor,
+        prob_tensor: torch.Tensor,
+        d_tensor: torch.Tensor,
+        dprob_tensor: torch.Tensor,
+        sfd2_gate_tensor: torch.Tensor,
+        sfd2_up_tensor: torch.Tensor,
+        dbias_tensor: Optional[torch.Tensor] = None,
+        d_quant_sf_tensor: Optional[torch.Tensor] = None,
+        norm_const_tensor: Optional[torch.Tensor] = None,
+        # Dense mode:
+        b_tensor: Optional[torch.Tensor] = None,
+        sfb_tensor: Optional[torch.Tensor] = None,
+        sfb2_tensor: Optional[torch.Tensor] = None,
+        # Discrete mode:
+        b_ptrs: Optional[torch.Tensor] = None,
+        sfb_ptrs: Optional[torch.Tensor] = None,
+        sfb2_ptrs: Optional[torch.Tensor] = None,
+        current_stream: Optional[cuda.CUstream] = None,
+    ) -> None:
+        """Execute the compiled kernel.
+
+        ``dprob_tensor``, ``dbias_tensor``, and the sfd2 views MUST be
+        zero-initialized: the kernel accumulates into them with atomics.
+        ``sfd2_gate_tensor``/``sfd2_up_tensor`` are the two half views of the
+        fused sfd2 buffer (concat halves when d_deinterleaved, even/odd
+        column-strided otherwise).
+        """
+        self._logger.debug("Entering execute")
+        if current_stream is None:
+            current_stream = default_stream(detect_framework(a_tensor))
+        if a_tensor.shape[0] == 0:
+            self._logger.debug("execute: valid_m is zero, skipping kernel execution")
+            return
+        self._runtime_error_if(self._compiled_kernel is None, "Kernel not compiled; call compile() first")
+
+        if self._has_dbias:
+            self._value_error_if(dbias_tensor is None, "dbias_tensor must be provided at execute() when the API was compiled with sample_dbias")
+        else:
+            self._value_error_if(dbias_tensor is not None, "dbias_tensor must be omitted at execute() when the API was compiled without sample_dbias")
+        if self.d_quant:
+            self._value_error_if(
+                d_quant_sf_tensor is None or norm_const_tensor is None,
+                "d_quant_sf_tensor and norm_const_tensor must be provided at execute() for the quantized D output",
+            )
+        else:
+            self._value_error_if(
+                d_quant_sf_tensor is not None or norm_const_tensor is not None,
+                "d_quant_sf_tensor/norm_const_tensor must be omitted for the bf16 D output",
+            )
+
+        valid_m = a_tensor.shape[0]
+        n = self._n_from_descs()
+        self._assert_sfd2_liveness(valid_m, n)
+        workspace_ptr = self._ensure_workspace(valid_m, n)
+
+        common = dict(
+            a_tensor=a_tensor,
+            c_tensor=c_tensor,
+            d_tensor=d_tensor,
+            sfa_tensor=sfa_tensor,
+            sfa2_tensor=sfa2_tensor,
+            sfd2_up_tensor=sfd2_up_tensor,
+            sfd2_gate_tensor=sfd2_gate_tensor,
+            sfd_row_tensor=d_quant_sf_tensor,
+            norm_const_tensor=norm_const_tensor,
+            padded_offsets=padded_offsets,
+            alpha_tensor=alpha_tensor,
+            beta_tensor=beta_tensor,
+            prob_tensor=prob_tensor,
+            dprob_tensor=dprob_tensor,
+            dbias_tensor=dbias_tensor,
+            workspace_ptr=workspace_ptr,
+            stream=current_stream,
+        )
+        if self.weight_mode == MoEWeightMode.DENSE:
+            self._compiled_kernel(b_arg=b_tensor, sfb_arg=sfb_tensor, sfb2_arg=sfb2_tensor, **common)
+        else:
+            self._compiled_kernel(b_arg=b_ptrs, sfb_arg=sfb_ptrs, sfb2_arg=sfb2_ptrs, **common)
+
+        self._logger.debug("Execute completed")
+
+
+import logging
+
+_logger = logging.getLogger(__name__)
+_cache_of_GroupedGemmDswigluSubchannelScaledSm100Objects = {}
+
+
+def grouped_gemm_dswiglu_subchannel_scaled_wrapper_sm100(
+    a_tensor: torch.Tensor,
+    sfa_tensor: torch.Tensor,
+    sfa2_tensor: torch.Tensor,
+    c_tensor: torch.Tensor,
+    padded_offsets: torch.Tensor,
+    alpha_tensor: torch.Tensor,
+    beta_tensor: torch.Tensor,
+    prob_tensor: torch.Tensor,
+    b_tensor: Optional[torch.Tensor] = None,
+    sfb_tensor: Optional[torch.Tensor] = None,
+    sfb2_tensor: Optional[torch.Tensor] = None,
+    b_ptrs: Optional[torch.Tensor] = None,
+    sfb_ptrs: Optional[torch.Tensor] = None,
+    sfb2_ptrs: Optional[torch.Tensor] = None,
+    n: Optional[int] = None,
+    b_dtype: Optional[torch.dtype] = None,
+    b_major: str = "k",
+    d_dtype: Optional[torch.dtype] = None,
+    norm_const_tensor: Optional[torch.Tensor] = None,
+    dbias: bool = False,
+    dbias_dtype: Optional[torch.dtype] = None,
+    acc_dtype: Optional[torch.dtype] = None,
+    block2_shape: Tuple[int, int, int] = (1, 256, 256),
+    mma_tiler_mn: Tuple[int, int] = DEFAULT_CTA_SHAPE,
+    cluster_shape_mn: Optional[Tuple[int, int]] = None,
+    sf_vec_size: int = 16,
+    vector_f32: bool = True,
+    m_aligned: int = 256,
+    use_dynamic_sched: bool = False,
+    d_deinterleaved: bool = True,
+    glu_clamp_max: Optional[float] = 7.0,
+    glu_clamp_min: Optional[float] = -7.0,
+    dsmem_rowwise: bool = True,
+    current_stream: Optional[cuda.CUstream] = None,
+) -> TupleDict:
+    """Convenience wrapper for the subchannel-scaled dSwiGLU grouped GEMM.
+
+    Creates the API, compiles, and executes in one call; compiled kernels are
+    cached per configuration. The wrapper owns the OUTPUT allocations and their
+    zero-init contract (dprob/dbias/sfd2 are atomically accumulated).
+
+    Args:
+        a_tensor: Upstream gradient dY (valid_m, k, 1), FP4, k-major
+        sfa_tensor: First-level scale factor A (MMA-tiled view)
+        sfa2_tensor: Second-level scale factor A, (ceil(valid_m/sgm), ceil(k/sgk), 1) FP32,
+            stride (1, rows, rows * cols)
+        c_tensor: Forward FC1 pre-activations (valid_m, 2n, 1) BF16, gate/up
+            interleaved in 32-column bands
+        padded_offsets: End offset per expert after padding (l,), int32, cumulative
+        alpha_tensor: Per-expert accumulator scale (l,), f32 (applied SQUARED)
+        beta_tensor: Per-expert C scale (l,), f32
+        prob_tensor: Per-token routing probability (valid_m, 1, 1), f32
+        b_tensor: (Dense) FC2 weights (n, k, l), FP4, k-major
+        sfb_tensor: (Dense) First-level scale factor B (MMA-tiled view)
+        sfb2_tensor: (Dense) Second-level scale factor B, (ceil(n/sgn), ceil(k/sgk), l) FP32
+        b_ptrs/sfb_ptrs/sfb2_ptrs: (Discrete) 1-D int64 device tensors of
+            per-expert base pointers (SFB2 bases must be 16B-aligned)
+        n: (Discrete) B weight N dimension (the GEMM width)
+        b_dtype: (Discrete) B weight data type
+        b_major: (Discrete) B major dimension (must be "k")
+        d_dtype: Output D dtype -- torch.bfloat16 (default; plain output) or
+            torch.float4_e2m1fn_x2 (NVFP4-quantized output)
+        norm_const_tensor: (1,) f32 global D-quant encode scale; required iff
+            d_dtype is fp4
+        dbias: Also produce the per-expert dbias output
+        dbias_dtype: torch.bfloat16 (default) or torch.float32 (testing-only)
+        block2_shape: Second-level scale granularity (sgm, sgn, sgk); sgn must
+            be a multiple of 128 (the MMA tile N)
+        d_deinterleaved: Store d/d_quant_sf/dbias deinterleaved [gate | up] and
+            sfd2 as concatenated halves (default True; requires the quantized-D
+            output). In this layout the fused sfd2 output is directly a
+            consumer GEMM's a_scales2 grid with sgk = sgn.
+        (remaining config parameters mirror the class constructor)
+
+    Returns:
+        TupleDict with keys (also the unpack order):
+        - **d_tensor**: BF16 (valid_m, 2n, 1) output; None in quantized mode
+        - **d_quant_tensor**: FP4 (physical (valid_m, n, 1), logical 2n wide)
+          packed output; None in bf16 mode
+        - **d_quant_sf_tensor**: e4m3 MMA-tiled row scale factors; None in bf16 mode
+        - **dprob_tensor**: f32 (valid_m, 1, 1), always produced
+        - **dbias_tensor**: (l, 2n, 1) dbias or None
+        - **sfd2_tensor**: fused f32 (rows, 2*ceil(n/sgn), 1) second-level descales
+        - **sfd2_gate_tensor** / **sfd2_up_tensor**: live half views of sfd2_tensor
+    """
+    from cudnn.gemm.cutedsl.grouped.unfused._bf16_api import _validate_pointer_tensor
+
+    framework = detect_framework(a_tensor)
+    if framework == "jax":
+        raise ValueError(f"grouped_gemm_dswiglu_subchannel_scaled_wrapper_sm100 does not support JAX arrays: {_JAX_SF_LAYOUT_ERROR}")
+    if framework != "torch":
+        raise ValueError(f"Unsupported tensor framework '{framework}'; pass torch tensors")
+    import torch
+
+    acc_dtype = _convert_to_cutlass_data_type(acc_dtype) if acc_dtype is not None else cutlass.Float32
+    d_dtype_torch = d_dtype if d_dtype is not None else torch.bfloat16
+    dbias_dtype_torch = dbias_dtype if dbias_dtype is not None else torch.bfloat16
+    d_quant = d_dtype_torch != torch.bfloat16
+
+    is_dense = b_tensor is not None
+    is_discrete = b_ptrs is not None
+    if is_dense and is_discrete:
+        raise ValueError("Provide either (b_tensor, sfb_tensor, sfb2_tensor) or (b_ptrs, sfb_ptrs, sfb2_ptrs), not both")
+    if not is_dense and not is_discrete:
+        raise ValueError("Must provide either (b_tensor, sfb_tensor, sfb2_tensor) or (b_ptrs, sfb_ptrs, sfb2_ptrs)")
+
+    valid_m, k_physical, _ = a_tensor.shape
+    if is_dense:
+        weight_mode = MoEWeightMode.DENSE
+        if sfb_tensor is None or sfb2_tensor is None:
+            raise ValueError("sfb_tensor and sfb2_tensor are required in dense mode")
+        n_gemm, _, l = b_tensor.shape
+        num_experts = None
+        b_shape = None
+    else:
+        weight_mode = MoEWeightMode.DISCRETE
+        num_experts = _validate_pointer_tensor(b_ptrs, "b_ptrs")
+        _validate_pointer_tensor(sfb_ptrs, "sfb_ptrs", num_experts)
+        _validate_pointer_tensor(sfb2_ptrs, "sfb2_ptrs", num_experts)
+        if n is None or b_dtype is None:
+            raise ValueError("n and b_dtype are required for discrete mode")
+        b_dtype_cutlass = _convert_to_cutlass_data_type(b_dtype)
+        k_logical = k_physical * 2 if b_dtype_cutlass in (cutlass.Float4E2M1FN, cutlass.Uint8) else k_physical
+        b_shape = (n, k_logical)
+        n_gemm = n
+        l = num_experts
+
+    n2 = 2 * n_gemm
+    sgm, sgn, sgk = block2_shape
+    device = a_tensor.device
+
+    if d_quant:
+        if norm_const_tensor is None:
+            raise ValueError("norm_const_tensor is required for the quantized (fp4) D output")
+    elif norm_const_tensor is not None:
+        raise ValueError("norm_const_tensor must be omitted for the bf16 D output")
+
+    _logger.debug("grouped_gemm_dswiglu_subchannel_scaled_wrapper_sm100: Creating output tensors")
+
+    # ---- outputs ----
+    if d_quant:
+        # Physical fp4x2 (valid_m, n2/2, 1); the descriptor doubles the packed
+        # innermost dim to the logical (valid_m, n2, 1) the kernel expects.
+        d_out = torch.zeros((1, valid_m, n2 // 2), dtype=torch.uint8, device=device).view(torch.float4_e2m1fn_x2).permute(1, 2, 0)
+        d_quant_sf_out = torch.zeros(
+            (1, ceil_div(valid_m, 128), ceil_div(ceil_div(n2, 16), 4), 32, 4, 4),
+            dtype=torch.float8_e4m3fn,
+            device=device,
+        ).permute(3, 4, 1, 5, 2, 0)
+        d_bf16_out = None
+    else:
+        d_bf16_out = torch.empty_strided((valid_m, n2, 1), (n2, 1, valid_m * n2), dtype=torch.bfloat16, device=device)
+        d_quant_sf_out = None
+    d_kernel_tensor = d_out if d_quant else d_bf16_out
+
+    dprob_out = torch.zeros((valid_m, 1, 1), dtype=torch.float32, device=device)
+    dbias_out = torch.zeros((l, n2, 1), dtype=dbias_dtype_torch, device=device) if dbias else None
+
+    sfd2_rows = ceil_div(valid_m, sgm)
+    nd = ceil_div(n_gemm, sgn)
+    sfd2_buf = torch.zeros((1, 2 * nd, sfd2_rows), dtype=torch.float32, device=device).permute(2, 1, 0)
+    if d_deinterleaved:
+        sfd2_gate_view = sfd2_buf[:, :nd, :]
+        sfd2_up_view = sfd2_buf[:, nd:, :]
+    else:
+        sfd2_gate_view = sfd2_buf[:, 0::2, :]
+        sfd2_up_view = sfd2_buf[:, 1::2, :]
+
+    if valid_m == 0:
+        return TupleDict(
+            d_tensor=d_bf16_out,
+            d_quant_tensor=d_out if d_quant else None,
+            d_quant_sf_tensor=d_quant_sf_out,
+            dprob_tensor=dprob_out,
+            dbias_tensor=dbias_out,
+            sfd2_tensor=sfd2_buf,
+            sfd2_gate_tensor=sfd2_gate_view,
+            sfd2_up_tensor=sfd2_up_view,
+        )
+
+    def tensor_signature(tensor):
+        if tensor is None:
+            return None, None, None
+        return tuple(tensor.shape), tuple(tensor.stride()), tensor.dtype
+
+    def stride_order(tensor):
+        return tuple(i for i, s in sorted(enumerate(tensor.stride()), key=lambda x: x[1]))
+
+    def dynamic_m_tensor_signature(tensor, static_shape_suffix, dynamic_stride_dims=()):
+        if tensor is None:
+            return None, None, None
+        stride_signature = tuple(None if i in dynamic_stride_dims else s for i, s in enumerate(tensor.stride()))
+        return static_shape_suffix, stride_signature, tensor.dtype
+
+    device_type = get_device_type()
+    common_key_tail = (
+        tuple(padded_offsets.shape),
+        padded_offsets.dtype,
+        acc_dtype,
+        d_dtype_torch,
+        dbias,
+        dbias_dtype_torch,
+        tuple(block2_shape),
+        tuple(mma_tiler_mn),
+        cluster_shape_mn,
+        sf_vec_size,
+        vector_f32,
+        m_aligned,
+        use_dynamic_sched,
+        d_deinterleaved,
+        glu_clamp_max,
+        glu_clamp_min,
+        dsmem_rowwise,
+    )
+    dynamic_m_key = (
+        a_tensor.shape[1:],
+        stride_order(a_tensor),
+        a_tensor.dtype,
+        c_tensor.shape[1:],
+        stride_order(c_tensor),
+        *dynamic_m_tensor_signature(sfa_tensor, (sfa_tensor.shape[4], 1), dynamic_stride_dims=(5,)),
+        *dynamic_m_tensor_signature(sfa2_tensor, (sfa2_tensor.shape[1], 1), dynamic_stride_dims=(1, 2)),
+        *dynamic_m_tensor_signature(prob_tensor, (1, 1)),
+        *tensor_signature(alpha_tensor),
+        *tensor_signature(beta_tensor),
+    )
+    if is_dense:
+        cache_key = (
+            device_type,
+            weight_mode,
+            *dynamic_m_key,
+            *tensor_signature(b_tensor),
+            *tensor_signature(sfb_tensor),
+            *tensor_signature(sfb2_tensor),
+            *common_key_tail,
+        )
+    else:
+        cache_key = (
+            device_type,
+            weight_mode,
+            *dynamic_m_key,
+            b_shape,
+            b_dtype,
+            tuple(b_ptrs.shape),
+            b_ptrs.dtype,
+            *common_key_tail,
+            b_major,
+            num_experts,
+        )
+
+    if cache_key in _cache_of_GroupedGemmDswigluSubchannelScaledSm100Objects:
+        api = _cache_of_GroupedGemmDswigluSubchannelScaledSm100Objects[cache_key]
+    else:
+        _logger.debug("grouped_gemm_dswiglu_subchannel_scaled_wrapper_sm100: creating new API object")
+        common_kwargs = dict(
+            sample_a=a_tensor,
+            sample_sfa=sfa_tensor,
+            sample_sfa2=sfa2_tensor,
+            sample_c=c_tensor,
+            sample_padded_offsets=padded_offsets,
+            sample_alpha=alpha_tensor,
+            sample_beta=beta_tensor,
+            sample_prob=prob_tensor,
+            sample_d=d_kernel_tensor,
+            sample_dprob=dprob_out,
+            sample_sfd2=sfd2_buf,
+            sample_dbias=dbias_out,
+            sample_d_quant_sf=d_quant_sf_out,
+            sample_norm_const=norm_const_tensor,
+            acc_dtype=acc_dtype,
+            block2_shape=block2_shape,
+            mma_tiler_mn=mma_tiler_mn,
+            cluster_shape_mn=cluster_shape_mn,
+            sf_vec_size=sf_vec_size,
+            vector_f32=vector_f32,
+            m_aligned=m_aligned,
+            use_dynamic_sched=use_dynamic_sched,
+            d_deinterleaved=d_deinterleaved,
+            glu_clamp_max=glu_clamp_max,
+            glu_clamp_min=glu_clamp_min,
+            dsmem_rowwise=dsmem_rowwise,
+        )
+        if is_dense:
+            api = GroupedGemmDswigluSubchannelScaledSm100(
+                sample_b=b_tensor,
+                sample_sfb=sfb_tensor,
+                sample_sfb2=sfb2_tensor,
+                **common_kwargs,
+            )
+        else:
+            api = GroupedGemmDswigluSubchannelScaledSm100(
+                num_experts=num_experts,
+                b_shape=b_shape,
+                b_dtype=b_dtype,
+                b_major=b_major,
+                **common_kwargs,
+            )
+        assert api.check_support(), "Unsupported configuration"
+        api.compile()
+        _cache_of_GroupedGemmDswigluSubchannelScaledSm100Objects[cache_key] = api
+
+    exec_kwargs = dict(
+        a_tensor=a_tensor,
+        sfa_tensor=sfa_tensor,
+        sfa2_tensor=sfa2_tensor,
+        c_tensor=c_tensor,
+        padded_offsets=padded_offsets,
+        alpha_tensor=alpha_tensor,
+        beta_tensor=beta_tensor,
+        prob_tensor=prob_tensor,
+        d_tensor=d_kernel_tensor,
+        dprob_tensor=dprob_out,
+        sfd2_gate_tensor=sfd2_gate_view,
+        sfd2_up_tensor=sfd2_up_view,
+        dbias_tensor=dbias_out,
+        d_quant_sf_tensor=d_quant_sf_out,
+        norm_const_tensor=norm_const_tensor,
+        current_stream=current_stream,
+    )
+    if is_dense:
+        api.execute(b_tensor=b_tensor, sfb_tensor=sfb_tensor, sfb2_tensor=sfb2_tensor, **exec_kwargs)
+    else:
+        api.execute(b_ptrs=b_ptrs, sfb_ptrs=sfb_ptrs, sfb2_ptrs=sfb2_ptrs, **exec_kwargs)
+
+    return TupleDict(
+        d_tensor=d_bf16_out,
+        d_quant_tensor=d_out if d_quant else None,
+        d_quant_sf_tensor=d_quant_sf_out,
+        dprob_tensor=dprob_out,
+        dbias_tensor=dbias_out,
+        sfd2_tensor=sfd2_buf,
+        sfd2_gate_tensor=sfd2_gate_view,
+        sfd2_up_tensor=sfd2_up_view,
+    )

--- a/python/cudnn/gemm/cutedsl/grouped/dswiglu_subchannel_scaled/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dswiglu_subchannel_scaled/api.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 """
-API for the Subchannel-Scaled dSwiGLU Grouped GEMM Kernel (SM100)
+API for the Subchannel-Scaled dSwiGLU Grouped GEMM Kernel (SM100+)
 
 Second-level-scaled ("subchannel-scaled") dSwiGLU-backward block-scaled grouped
 GEMM for MoE workloads: NVFP4 A (upstream gradient dY) and B (FC2 weights)
@@ -27,15 +27,17 @@ which is exactly a consumer GEMM's ``(rows, k/sgk)`` ``a_scales2`` grid with
 layout (the harness-validated combination).
 
 FE ``n`` convention: ``n`` is the GEMM/weight width (B is ``(n, k, l)``); the
-n-axis outputs cover ``2n``. SM100-only (the kernel also compiles and runs
-as-is on sm103/sm107 devices; there is no Rubin-native variant).
+n-axis outputs cover ``2n``. On Rubin (SM107) devices the API transparently
+dispatches to the Rubin-native kernel module
+(``moe_blockscaled_grouped_gemm_dswiglu_subchannel_scaled_rubin.py``), which also
+accepts ``sf_fp8_dtype_override="e5m3"`` for E5M3 first-level scales.
 """
 
 from __future__ import annotations
 
 import math
 import os
-from typing import Optional, Tuple
+from typing import Literal, Optional, Tuple
 
 import cutlass
 import cutlass.cute as cute
@@ -64,6 +66,20 @@ from .grouped_gemm_dswiglu_subchannel_scaled import (
 from ..moe_utils import MoEWeightMode
 from cutlass.cute.nvgpu import OperandMajorMode
 
+
+def _get_rubin_kernel():
+    """Lazy import of the Rubin (sm107) kernel module.
+
+    It needs a cutlass-dsl build with ``cutlass.utils.rubin_helpers``, so it is
+    only imported when a Rubin device is detected (APIBase._is_rubin_kernel).
+    """
+    from .moe_blockscaled_grouped_gemm_dswiglu_subchannel_scaled_rubin import (
+        BlockScaledSubChannelMoEGroupedGemmDgluDbiasKernelSm107,
+    )
+
+    return BlockScaledSubChannelMoEGroupedGemmDgluDbiasKernelSm107
+
+
 _JAX_SF_LAYOUT_ERROR = (
     "the block scale-factor tensors (sfa/sfb and the d_quant_sf output) are MMA-tiled "
     "(32, 4, m//128, 4, rest_k, l) strided views that are not expressible as JAX arrays "
@@ -72,7 +88,7 @@ _JAX_SF_LAYOUT_ERROR = (
 
 
 class GroupedGemmDswigluSubchannelScaledSm100(APIBase):
-    """API for the subchannel-scaled dSwiGLU-backward grouped GEMM on SM100 GPUs.
+    """API for the subchannel-scaled dSwiGLU-backward grouped GEMM on SM100+ GPUs.
 
     ``D2n = dSwiGLU(alpha^2 * subchannel_scaled_gemm(A, B), beta * C, prob)``
     with fused ``dprob``, optional ``dbias``, second-level output descales
@@ -125,6 +141,7 @@ class GroupedGemmDswigluSubchannelScaledSm100(APIBase):
         glu_clamp_max: Optional[float] = 7.0,
         glu_clamp_min: Optional[float] = -7.0,
         dsmem_rowwise: bool = True,
+        sf_fp8_dtype_override: Optional[Literal["e5m3"]] = None,
     ):
         """Initialize the GroupedGemmDswigluSubchannelScaledSm100 API.
 
@@ -191,6 +208,13 @@ class GroupedGemmDswigluSubchannelScaledSm100(APIBase):
             red.shared::cluster max + mbarrier handoff) instead of the gmem
             atomic + counter-spin protocol, when the geometry is eligible
             (quantized D + sgn/128 == cluster_n > 1). Byte-exact either way.
+        :param sf_fp8_dtype_override: Reinterpret the FP8-format first-level
+            scale factors (sfa/sfb) as E5M3 instead of the E4M3 implied by their
+            storage dtype. Rubin-only; the tensors are still supplied as
+            ``torch.float8_e4m3fn`` since torch has no e5m3 dtype. With e5m3
+            inputs the quantized-D row scales (``d_quant_sf``) are e5m3-encoded
+            too (output scale format follows the input's) and the sfd2 norm
+            becomes ``6 * 61440``.
         """
         framework = detect_framework(sample_a)
         if framework == "jax":
@@ -286,13 +310,14 @@ class GroupedGemmDswigluSubchannelScaledSm100(APIBase):
         self.glu_clamp_max = glu_clamp_max
         self.glu_clamp_min = glu_clamp_min
         self.dsmem_rowwise = dsmem_rowwise
+        self.sf_fp8_dtype_override = sf_fp8_dtype_override
 
         self._interpret_uint8_as_fp4x2 = True
         # D dtype-driven quantized-output mode (glu_hadamard_quant precedent).
         self.d_desc = self._make_tensor_desc(sample_d, name="sample_d", canonical=True)
         self.d_quant = self._is_fp4x2(self.d_desc.dtype)
         self._has_dbias = self.dbias_desc is not None
-        self._kernel = BlockScaledSubChannelMoEGroupedGemmDgluDbiasKernel
+        self._kernel = _get_rubin_kernel() if self._is_rubin_kernel else BlockScaledSubChannelMoEGroupedGemmDgluDbiasKernel
 
         self.num_cluster_overlap_margin = int(os.getenv("CUDNNFE_CLUSTER_OVERLAP_MARGIN", "0"))
         self._workspace = None
@@ -342,6 +367,19 @@ class GroupedGemmDswigluSubchannelScaledSm100(APIBase):
             self._value_error_if(b_k != k, f"B K dimension ({b_k}) must match A K dimension ({k})")
             l = self.expert_cnt
         n2 = 2 * n
+
+        # e5m3 is the only override currently supported; torch has no e5m3
+        # dtype, so e5m3 scale factors arrive as e4m3 storage and the Rubin
+        # kernel reinterprets the CuTe element type.
+        self._value_error_if(
+            self.sf_fp8_dtype_override not in (None, "e5m3"),
+            f"sf_fp8_dtype_override must be None or 'e5m3', got {self.sf_fp8_dtype_override!r}",
+        )
+        if self.sf_fp8_dtype_override == "e5m3":
+            self._value_error_if(
+                not self._is_rubin_kernel,
+                f"sf_fp8_dtype_override='e5m3' requires Rubin (SM107), got device type {self._device_type!r}",
+            )
 
         # ---- shapes ----
         self._check_tensor_shape(self.a_desc, (tensor_m, k, 1), "A")
@@ -616,6 +654,11 @@ class GroupedGemmDswigluSubchannelScaledSm100(APIBase):
             d_deinterleaved=self.d_deinterleaved,
             deint_n=(2 * n) if self.d_deinterleaved else 0,
             dsmem_rowwise=self.dsmem_rowwise,
+            # Only the Rubin kernel accepts sf_fp8_dtype_override, and check_support
+            # rejects "e5m3" unless _is_rubin_kernel -- the same flag that selected
+            # self._kernel. The kernel maps the string to FloatNV8E5M3FNU itself, so
+            # that internal-only type is never named outside the Rubin module.
+            **({"sf_fp8_dtype_override": self.sf_fp8_dtype_override} if self.sf_fp8_dtype_override == "e5m3" else {}),
         )
         self._gemm = gemm
 
@@ -1071,6 +1114,7 @@ def grouped_gemm_dswiglu_subchannel_scaled_wrapper_sm100(
     glu_clamp_min: Optional[float] = -7.0,
     dsmem_rowwise: bool = True,
     current_stream: Optional[cuda.CUstream] = None,
+    sf_fp8_dtype_override: Optional[Literal["e5m3"]] = None,
 ) -> TupleDict:
     """Convenience wrapper for the subchannel-scaled dSwiGLU grouped GEMM.
 
@@ -1109,6 +1153,9 @@ def grouped_gemm_dswiglu_subchannel_scaled_wrapper_sm100(
             sfd2 as concatenated halves (default True; requires the quantized-D
             output). In this layout the fused sfd2 output is directly a
             consumer GEMM's a_scales2 grid with sgk = sgn.
+        sf_fp8_dtype_override: Reinterpret the FP8 first-level scale factors as
+            E5M3 (Rubin-only); the quantized-D row scales come out e5m3-encoded
+            as well. Part of the compile cache key.
         (remaining config parameters mirror the class constructor)
 
     Returns:
@@ -1250,6 +1297,7 @@ def grouped_gemm_dswiglu_subchannel_scaled_wrapper_sm100(
         glu_clamp_max,
         glu_clamp_min,
         dsmem_rowwise,
+        sf_fp8_dtype_override,
     )
     dynamic_m_key = (
         a_tensor.shape[1:],
@@ -1318,6 +1366,7 @@ def grouped_gemm_dswiglu_subchannel_scaled_wrapper_sm100(
             glu_clamp_max=glu_clamp_max,
             glu_clamp_min=glu_clamp_min,
             dsmem_rowwise=dsmem_rowwise,
+            sf_fp8_dtype_override=sf_fp8_dtype_override,
         )
         if is_dense:
             api = GroupedGemmDswigluSubchannelScaledSm100(

--- a/python/cudnn/gemm/cutedsl/grouped/dswiglu_subchannel_scaled/grouped_gemm_dswiglu_subchannel_scaled.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dswiglu_subchannel_scaled/grouped_gemm_dswiglu_subchannel_scaled.py
@@ -1,0 +1,5023 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Subchannel-Scaled MoE Block-Scaled Grouped GEMM Kernel with dGLU (dSwiGLU) Backward Fusion.
+
+Supports:
+    - Static / Dynamic persistent tile scheduling (MoEPersistentTileScheduler)
+    - Dense (contiguous 3-D B) / Discrete (per-expert pointer array B) weight layout
+    - FP8/FP4 output quantization with row scale factors (SFD)
+    - AMAX reduction for FP8 calibration
+    - dGLU backward activation fusion (dSwiGLU / dGeGLU)
+
+This module contains only the kernel class.
+MoE scheduler components live in moe_persistent_scheduler.py / moe_sched_extension.py / moe_utils.py.
+"""
+
+from typing import Type, Tuple, Union, Optional
+from functools import partial
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import cpasync, tcgen05
+from cutlass.cute.nvgpu import OperandMajorMode
+from cutlass.cutlass_dsl import T
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+
+from cutlass.cute.typing import Float32, Int32, AddressSpace
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import math, llvm
+from cutlass._mlir.dialects import vector, arith
+
+from ..moe_persistent_scheduler import (
+    MoEPersistentTileScheduler,
+    MoESchedulerParams,
+    MoEWorkTileInfo,
+)
+from ..moe_utils import (
+    MoEWeightMode,
+    TensormapWorkspace,
+    compute_expert_token_range,
+    store_tma_desc,
+)
+from ..moe_sched_extension import (
+    DiscreteWeightScaledGemmSchedExtension,
+    ContiguousAndConsistentGroupedGemmSchedExtension,
+)
+from ..moe_kernel_helpers import (
+    fmin,
+    fmax,
+    fmin_bf16x2,
+    fmax_bf16x2,
+    atomic_max_float32,
+    atomic_add_float32,
+    atomic_add_i32_gmem,
+    load_acquire_i32_gpu,
+    load_float32_volatile,
+    sigmoid_f32,
+    get_dtype_rcp_limits,
+    get_dtype_max,
+    get_amax_smem_size,
+    is_valid_layouts,
+    is_valid_mma_tiler_and_cluster_shape,
+    is_valid_tensor_alignment,
+    atomic_add_bf16x2,
+    nanosleep,
+    red_smem_cluster_max_f32,
+    mbarrier_arrive_cluster,
+)
+
+"""
+High-performance persistent blockscaled contiguous grouped dense GEMM (D = alpha * (SFA * A) * (SFB * B)) example for the NVIDIA Blackwell architecture
+using CUTE DSL.
+- Matrix A is MxKx1, A can be row-major("K"), ValidM is composed of valid m in different groups
+- Matrix B is NxKxL, B can be column-major("K"), L is grouped dimension
+- Matrix D is MxNx1, D can be row-major("N"), ValidM is composed of valid m in different groups
+- Matrix SFA layout is filled internally according to A shape and BlockScaledBasicChunk, which has M×ceil_div(K, sf_vec_size)×L elements respectively
+- Matrix SFB layout is filled internally according to B shape and BlockScaledBasicChunk, which has N×ceil_div(K, sf_vec_size)×L elements respectively
+
+Matrix A/D Memory Layout Diagrams:
+
+   ```
+    Group 0    Group 1   Group 2
+   -+---------+---------+---------+
+    |         |         |         |
+   K| ValidM0 | ValidM1 | ValidM2 |
+    |         |         |         |
+   -+---------+---------+---------+
+    |<-        ValidM           ->|
+   ```
+   Note: the Group(L) dimension will be flatted into M dimension, and the rest Group(L) size is 1.
+         each ValidM will be aligned to 256 or 128. The alignment is determined by the mma_tiler_mn parameter.
+         For NVFP4, 2CTA, the alignment is 256. For NVFP4, 1CTA, the alignment is 128. 
+
+This GEMM kernel supports the following features:
+    - Utilizes Tensor Memory Access (TMA) for efficient memory operations
+    - Utilizes Blackwell's tcgen05.mma for matrix multiply-accumulate (MMA) operations
+    - Implements TMA multicast with cluster to reduce L2 memory traffic
+    - Support persistent tile scheduling to better overlap memory load/store with mma between tiles
+    - Support warp specialization to avoid explicit pipelining between mainloop load and mma
+
+This GEMM works as follows:
+1. DMA warp: Load A and B matrices from global memory (GMEM) to shared memory (SMEM) using TMA operations.
+2. SCALE warp: Load scaleA and scaleB matrices from global memory (GMEM) to shared memory (SMEM) using non-TMA operations.
+2. MMA warp: 
+    - Load scale factor A/B from shared memory (SMEM) to tensor memory (TMEM) using tcgen05.cp instruction.
+    - Perform matrix multiply-accumulate (MMA) operations using tcgen05.mma instruction.
+3. EPILOGUE warp:
+    - Load completed accumulator from tensor memory (TMEM) to registers (RMEM) using tcgen05.ld.
+    - Apply alpha and update the final accumulator Final = alpha * acc
+    - Type convert Final matrix to output type.
+    - Store D matrix from registers (RMEM) to shared memory (SMEM) to global memory (GMEM) with TMA operations.
+
+SM100 tcgen05.mma.kind.block_scale instructions operate as follows:
+- Read matrix A from SMEM
+- Read matrix B from SMEM
+- Read scalefactor A from TMEM
+- Read scalefactor B from TMEM
+- Write accumulator to TMEM
+The accumulator in TMEM must then be loaded to registers before writing back to GMEM.
+
+.. code-block:: bash
+
+    python continugous_blockscaled_grouped_gemm_dglu_quant_fusion.py         \
+      --ab_dtype Float8E4M3FN --sf_dtype Float8E8M0FNU --c_dtype BFloat16    \
+      --d_dtype Float8E4M3FN --sf_vec_size 32 --mma_tiler_mn 256,256         \
+      --cluster_shape_mn 2,1 --nkl 4096,7168,8 --use_2cta_instrs             \
+      --m_aligned 256 --fixed_m 4096 --warmup_iterations 10 --iterations 30
+
+
+Constraints:
+* Supported input data types: mxf8, nvf4
+  see detailed valid dtype combinations in below Sm100BlockScaledPersistentDenseGemmKernel class documentation
+* A/B tensor must have the same data type, mixed data type is not supported (e.g., mxf8 x mxf4)
+* Mma tiler M must be 128 or 256(use_2cta_instrs)
+* Mma tiler N must be 64/128/192/256
+* Cluster shape M/N must be positive and power of 2, total cluster size <= 16
+* Cluster shape M must be multiple of 2 if Mma tiler M is 256(use_2cta_instrs)
+* The contiguous dimension of A/B/D tensors must be at least 16 bytes aligned,
+  i.e, number of elements is a multiple of 16 and 32 for Float8 and Float4, respectively.
+
+CUDA Graph Support:
+* For CUDA graph support, the A/D matrices and scale factor A can be padded to a larger size
+  (e.g., permuted_m = m*topK + num_local_experts*(FIX_PAD_SIZE-1), example: 4096*8 + 8*255 = 34808)
+* Use create_tensors() with permuted_m parameter to automatically pad:
+  - A matrix: padded to permuted_m rows (padding rows contain dummy data)
+  - D matrix: padded to permuted_m rows (output buffer for cuda_graph)
+  - Scale factor A: padded to match A matrix dimensions
+* Kernel handling of padding:
+  - Scheduler warp loads padded_offsets and calculates num_valid_tiles from padded_offsets[-1]
+  - Uses warp-parallel search (ballot + ffs) to find expert_idx for each tile
+  - Only valid tiles (tile_m_start < padded_offsets[-1]) are written to tile_info pipeline
+  - When no more valid tiles exist, outer loop exits and calls producer_tail()
+  - Consumer warps process only valid tiles from pipeline
+  - No deadlock or synchronization issues
+* Only rows within (aligned_groupm[0]+aligned_groupm[1]+...) contain valid data
+* Padding rows in D matrix will not be written by the kernel
+"""
+
+
+def _is_quant_dtype_combo(a_dtype, sf_dtype, d_dtype) -> bool:
+    """Whether the dtype triple selects the quantized-D epilogue
+    (generate_sfd). A plain module-level function so the result is a real
+    python bool even when called from traced code (the @cute.jit AST pass
+    rewrites `in`/`and` inside the kernel's __call__ into cutlass.Boolean,
+    which cannot feed SharedStorage sizing)."""
+    return (
+        a_dtype in (cutlass.Float8E5M2, cutlass.Float8E4M3FN, cutlass.Float4E2M1FN)
+        and sf_dtype in (cutlass.Float8E8M0FNU, cutlass.Float8E4M3FN)
+        and d_dtype in (cutlass.Float8E5M2, cutlass.Float8E4M3FN, cutlass.Float4E2M1FN)
+    )
+
+
+def _deinterleave_n_coord_tensor(t, mode=1, n_static=None):
+    """View a tensor carrying d's interleaved n axis at `mode` with that mode
+    split (32, 2, n/64), strides (b, (n/2)*b, 32*b): callers keep indexing in
+    INTERLEAVED d coordinates, but interleaved 32-col band bd now lands at the
+    DEINTERLEAVED position 32*(bd//2) + (bd%2)*(n/2) — gate bands fill
+    [0, n/2), up bands [n/2, n). For d it is applied to the TMA coordinate
+    tensor AFTER make_tiled_tma_atom (sfb-192 precedent): the tensormap keeps
+    its plain 3-dim box, and each (128, 32) epi box still covers one whole
+    band = 32 contiguous deinterleaved columns. Also used for the plain
+    layout-addressed tensors: dbias (n at mode 1)."""
+    n = n_static if n_static is not None else t.shape[mode]
+    b = t.stride[mode]
+    shape = list(t.shape)
+    stride = list(t.stride)
+    shape[mode] = (32, 2, n // 64)
+    # ScaledBasis strides (the TMA coordinate tensors) only accept STATIC
+    # integer scales — pass n_static (a python int) for those; the plain
+    # layout-addressed tensors work with the dynamic extent.
+    stride[mode] = (b, (n // 2) * b, 32 * b)
+    new_layout = cute.make_layout(tuple(shape), stride=tuple(stride))
+    return cute.make_tensor(t.iterator, new_layout)
+
+
+# Supported launch configs: mma tiler (256, 128) with an M-only cluster (2, 1)
+# or the 2D clusters (2, 2)/(2, 4). cluster_n > 1 makes N-adjacent work tiles
+# cluster peers — the rowwise-sfd2 DSMEM geometry (sgn/cta_n == cluster_n) —
+# and enables A/SFA multicast. Cluster M stays 2: wider cluster-M tiles need a
+# per-expert-M cluster-tile-multiple gate the FE API cannot verify host-side
+# on ragged inputs (the kernel's static can_implement still accepts the full
+# harness set (2,1)/(4,1)/(2,2)/(2,4)/(4,2) with that gate, for parity).
+VALID_CTA_SHAPES = ((256, 128),)
+VALID_CLUSTER_SHAPES = ((2, 1), (2, 2), (2, 4))
+DEFAULT_CTA_SHAPE = (256, 128)
+DEFAULT_CLUSTER_SHAPE = (2, 1)
+
+
+class BlockScaledSubChannelMoEGroupedGemmDgluDbiasKernel:
+    """Block-scaled grouped GEMM kernel with MoE tile scheduling and dGLU backward fusion.
+
+    Supports both dense and discrete weight layouts, static and dynamic
+    scheduling, and quantized output with row scale factors.
+
+    This version uses a fixed padding size (FIX_PAD_SIZE=256) that is decoupled from the kernel's tile size,
+    allowing users to pad their tensors without knowing the specific kernel implementation details.
+
+    :param sf_vec_size: Scalefactor vector size.
+    :type sf_vec_size: int
+    :param mma_tiler_mn: Shape of the Matrix Multiply-Accumulate (MMA) tile (M,N)
+    :type mma_tiler_mn: Tuple[int, int]
+    :param cluster_shape_mn: Cluster dimensions (M,N) for parallel processing
+    :type cluster_shape_mn: Tuple[int, int]
+
+    :note: In current version, A and B tensor must have the same data type
+        - i.e., Float8E4M3FN for A and Float8E5M2 for B is not supported
+
+    :note: Supported combinations of A/B data types, SF data typs and SF vector size:
+        - MXF8: A/B: Float8E5M2/Float8E4M3FN + SF: Float8E8M0FNU + sf_vec_size: 32
+        - MXF4: A/B: Float4E2M1FN + SF: Float8E8M0FNU + sf_vec_size: 32
+        - NVF4: A/B: Float4E2M1FN + SF: Float8E8M0FNU/Float8E4M3FN + sf_vec_size: 16
+
+    :note: Supported accumulator data types:
+        - Float32
+
+    :note: Supported D data types:
+        - BFloat16
+        - Float8E4M3FN/Float8E5M2
+
+    :note: Constraints:
+        - MMA tiler M must be 128 or 256 (use_2cta_instrs)
+        - MMA tiler N must be 64/128/192/256
+        - Cluster shape M must be multiple of 2 if Mma tiler M is 256
+        - Cluster shape M/N must be positive and power of 2, total cluster size <= 16
+        - Also, Cluster shape M/N must be <= 4 for scale factor multicasts due to limited size of scale factors
+        - FIX_PAD_SIZE (256) must be divisible by mma_tiler_mn[0]
+        - m_aligned parameter in create_mask() MUST equal FIX_PAD_SIZE (256)
+        - Each padded_offsets[i] will be a multiple of FIX_PAD_SIZE (guaranteed by m_aligned == FIX_PAD_SIZE)
+
+    :note: New Interface (padded_offsets):
+        Instead of tile_idx_to_expert_idx, num_non_exiting_tiles, and m_split_cumsum, users now provide:
+        - padded_offsets: shape (expert_cnt,), where padded_offsets[i] is the end position
+          of expert[i] in the padded A tensor.
+        - Expert i processes A[padded_offsets[i-1]:padded_offsets[i], :] (with padded_offsets[-1]=0)
+
+    """
+
+    # Fixed pad size for user-side padding (decoupled from kernel tile size)
+    FIX_PAD_SIZE = 256
+
+    @staticmethod
+    def is_valid_dtypes_and_scale_factor_vec_size(
+        ab_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        acc_dtype: Type[cutlass.Numeric],
+        d_dtype: Type[cutlass.Numeric],
+    ) -> bool:
+        """
+        Check if the data type / scale-factor vector-size combination is valid.
+
+        :return: True if valid, False otherwise
+        """
+        is_valid = True
+        if ab_dtype not in {
+            cutlass.Float4E2M1FN,
+        }:
+            is_valid = False
+
+        if sf_vec_size not in {16}:
+            is_valid = False
+
+        if sf_dtype not in {cutlass.Float8E8M0FNU, cutlass.Float8E4M3FN}:
+            is_valid = False
+
+        if sf_dtype in {cutlass.Float8E4M3FN} and sf_vec_size == 32:
+            is_valid = False
+        if ab_dtype in {cutlass.Float8E5M2, cutlass.Float8E4M3FN} and sf_vec_size == 16:
+            is_valid = False
+
+        if acc_dtype not in {cutlass.Float32}:
+            is_valid = False
+
+        if d_dtype not in {
+            cutlass.Float32,
+            cutlass.Float16,
+            cutlass.BFloat16,
+            cutlass.Float8E5M2,
+            cutlass.Float8E4M3FN,
+            cutlass.Float4E2M1FN,
+        }:
+            is_valid = False
+
+        if ab_dtype.width == 8 and d_dtype.width != 8:
+            is_valid = False
+
+        return is_valid
+
+    @staticmethod
+    def can_implement(
+        ab_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        acc_dtype: Type[cutlass.Numeric],
+        d_dtype: Type[cutlass.Numeric],
+        use_2cta_instrs: bool,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        m: int,
+        n: int,
+        k: int,
+        l: int,
+        a_major: str,
+        b_major: str,
+        cd_major: str,
+        m_aligned: int,
+        act_func: str,
+        weight_mode: MoEWeightMode = MoEWeightMode.DENSE,
+        sgn: int = 256,
+        sgk: int = 256,
+    ) -> bool:
+        FPS = BlockScaledSubChannelMoEGroupedGemmDgluDbiasKernel.FIX_PAD_SIZE
+        result = True
+        if m_aligned != FPS:
+            result = False
+        if not BlockScaledSubChannelMoEGroupedGemmDgluDbiasKernel.is_valid_dtypes_and_scale_factor_vec_size(
+            ab_dtype, sf_dtype, sf_vec_size, acc_dtype, d_dtype
+        ):
+            result = False
+        if not is_valid_layouts(ab_dtype, d_dtype, a_major, b_major, cd_major):
+            result = False
+        # Only supported launch configs for now: mma tiler (256, 128) with
+        # M-only clusters (2,1)/(4,1), or 2D clusters (2,2)/(2,4)/(4,2)
+        # (cluster_n > 1 makes N-adjacent work tiles cluster peers — the
+        # rowwise-sfd2 DSMEM geometry — and enables A/SFA multicast; total
+        # cluster size stays <= 8, the portable limit).
+        if tuple(mma_tiler_mn) != (256, 128) or tuple(cluster_shape_mn) not in (
+            (2, 1),
+            (4, 1),
+            (2, 2),
+            (2, 4),
+            (4, 2),
+        ):
+            result = False
+        # cluster_n > 1: the scheduler decomposes over CLUSTER N tiles, so
+        # the N work-tile count (n here is the GEMM half-width; tiles =
+        # ceil(n / cta_n), expert-uniform) must be a cluster_n multiple or
+        # the last N cluster's peers would map past the edge.
+        if cluster_shape_mn[1] > 1:
+            _n_work_tiles = -(-n // mma_tiler_mn[1])
+            if _n_work_tiles % cluster_shape_mn[1] != 0:
+                result = False
+        if not is_valid_mma_tiler_and_cluster_shape(
+            use_2cta_instrs,
+            mma_tiler_mn,
+            cluster_shape_mn,
+            m_aligned,
+            FPS,
+            allowed_cluster_tiler_m=(128, 256, 512),
+        ):
+            result = False
+        # Cluster (4,1)/(4,2) widens the cluster M tile to 512 rows sharing
+        # one multicast B load: a cluster must never straddle an expert
+        # boundary, so per-expert M must be a cluster-tile multiple.
+        _cluster_tiler_m = (cluster_shape_mn[0] // (2 if use_2cta_instrs else 1)) * mma_tiler_mn[0]
+        if (m // l) % _cluster_tiler_m != 0:
+            result = False
+        if not is_valid_tensor_alignment(m, n, k, l, ab_dtype, d_dtype, a_major, b_major, cd_major):
+            result = False
+        if not (a_major == "k"):
+            result = False
+        if act_func not in ["dswiglu", "dgeglu"]:
+            result = False
+        # SFD2 blocking (deinterleaved): one sfd2 block = sgn gate/up
+        # f-columns. The single per-thread atomic-max target / read-back and
+        # the tile_n_idx // sfd2_n_contrib block math require every N work
+        # tile to sit inside one block: sgn must be a multiple of the tile
+        # f-width.
+        if sgn % mma_tiler_mn[1] != 0:
+            result = False
+        # Discrete SFB2 per-expert base pointers are declared 16B-aligned in
+        # the sched extension (assumed_align=16). With back-to-back per-expert
+        # f32 (ceil(n/sgn), ceil(k/sgk)) blocks, every base past the first is
+        # misaligned unless the block byte size is a multiple of 16.
+        if weight_mode == MoEWeightMode.DISCRETE and l > 1:
+            sfb2_block_bytes = ((n + sgn - 1) // sgn) * ((k + sgk - 1) // sgk) * 4
+            if sfb2_block_bytes % 16 != 0:
+                result = False
+        return result
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        sgm: int,
+        sgn: int,
+        sgk: int,
+        acc_dtype: Type[cutlass.Numeric],
+        use_2cta_instrs: bool,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        vectorized_f32: bool,
+        expert_cnt: int,
+        weight_mode: MoEWeightMode = MoEWeightMode.DISCRETE,
+        use_dynamic_sched: bool = False,
+        act_func: str = "dswiglu",
+        generate_sfd2: bool = True,
+        glu_alpha: Optional[float] = None,
+        glu_clamp_max: Optional[float] = None,
+        glu_clamp_min: Optional[float] = None,
+        d_deinterleaved: bool = False,  # constexpr: True stores the n-axis
+        # outputs (D, its row SFs, dbias)
+        # DEINTERLEAVED ([gate | up]); False
+        # keeps d's interleaved band order
+        dsmem_rowwise: bool = True,  # allow the rowwise-sfd2 DSMEM reduction
+        # when the geometry is eligible
+        # (quantized D + sfd2 + sgn/cta_n ==
+        # cluster_n > 1); byte-exact vs the gmem
+        # protocol either way
+        deint_n: int = 0,  # STATIC interleaved d width (2*n); required for
+        # the TMA coordinate-tensor deinterleave rewrite
+        # (only when d_deinterleaved)
+    ):
+        """Initializes the configuration for a Blackwell blockscaled grouped GEMM dGLU kernel.
+
+        This configuration includes several key aspects:
+
+        1.  MMA Instruction Settings (tcgen05):
+            - acc_dtype: Data types for MMA accumulator.
+            - mma_tiler_mn: The (M, N) shape of the MMA instruction tiler.
+            - use_2cta_instrs: Boolean indicating if the tcgen05 MMA variant
+              with cta_group=2 should be used.
+
+        2.  Cluster Shape:
+            - cluster_shape_mn: The (ClusterM, ClusterN) shape of the CTA cluster.
+
+        3.  Expert Count:
+            - expert_cnt: Number of experts for MoE grouped GEMM.
+
+        4.  MoE Tile Scheduling:
+            - Uses MoEPersistentTileScheduler for tile iteration across experts
+            - Expert lookup is handled by the scheduler (cached O(1) fast path)
+
+        :param acc_dtype: Data type of the accumulator.
+        :type acc_dtype: type[cutlass.Numeric]
+        :param mma_tiler_mn: Tuple (M, N) shape of the MMA instruction.
+        :type mma_tiler_mn: Tuple[int, int]
+        :param use_2cta_instrs: Boolean, True to use cta_group=2 MMA variant.
+        :type use_2cta_instrs: bool
+        :param cluster_shape_mn: Tuple (ClusterM, ClusterN) shape of the cluster.
+        :type cluster_shape_mn: Tuple[int, int]
+        :param expert_cnt: Number of experts (compile-time constant).
+        :type expert_cnt: int
+
+        :raises ValueError: If FIX_PAD_SIZE is not divisible by mma_tiler_mn[0].
+        """
+        # Validate FIX_PAD_SIZE compatibility with tile size
+        mma_tile_m = mma_tiler_mn[0]
+        if self.FIX_PAD_SIZE % mma_tile_m != 0:
+            raise ValueError(
+                f"FIX_PAD_SIZE ({self.FIX_PAD_SIZE}) must be divisible by " f"mma_tiler_mn[0] ({mma_tile_m}). " f"Supported mma_tiler_mn[0] values: 128, 256."
+            )
+        if expert_cnt > 1024:
+            raise ValueError("Expert count > 1024 is not supported.")
+        if not isinstance(weight_mode, MoEWeightMode):
+            raise TypeError(f"weight_mode must be a MoEWeightMode, got {type(weight_mode)}")
+
+        self.sf_vec_size = sf_vec_size
+        self.sgm = sgm
+        self.sgn = sgn
+        self.sgk = sgk
+        # Cross-tile sfd2 sync: number of N work-tiles whose atomics feed one
+        # sfd2 block element. sgn counts DEINTERLEAVED f-columns (one block =
+        # sgn gate/up columns); each tile covers mma_tiler_n f-columns.
+        self.sfd2_n_contrib = max(1, sgn // mma_tiler_mn[1])
+        self.expert_cnt = expert_cnt
+        self.acc_dtype: Type[cutlass.Numeric] = acc_dtype
+        self.use_2cta_instrs = use_2cta_instrs
+        self.cluster_shape_mn = cluster_shape_mn
+        # K dimension is deferred in _setup_attributes
+        self.mma_tiler = (*mma_tiler_mn, 1)
+
+        self.cta_group = tcgen05.CtaGroup.TWO if use_2cta_instrs else tcgen05.CtaGroup.ONE
+
+        self.occupancy = 1
+        self.accumulator_update_warp_id = (0, 1, 2, 3)
+        self.epilog_warp_id = (4, 5, 6, 7)
+        self.mma_warp_id = 8
+        self.tma_warp_id = 9
+        self.sched_warp_id = 10
+        self.scale_warp_id = 11
+        self.threads_per_warp = 32
+
+        # Register allocation for different warp types
+        self.num_regs_uniform_warps = 24
+        self.num_regs_sched_warps = 24
+        self.num_regs_epilogue_warps = 192
+        self.num_regs_acc_update_warps = 256
+
+        self.threads_per_cta = self.threads_per_warp * len(
+            (
+                *self.accumulator_update_warp_id,
+                *self.epilog_warp_id,
+                self.mma_warp_id,
+                self.tma_warp_id,
+                self.sched_warp_id,
+                self.scale_warp_id,
+            )
+        )
+        self.threads_wo_sched = self.threads_per_warp * len(
+            (
+                *self.accumulator_update_warp_id,
+                *self.epilog_warp_id,
+                self.mma_warp_id,
+                self.tma_warp_id,
+                self.scale_warp_id,
+            )
+        )
+
+        # Set barrier for cta sync, epilogue sync and tmem ptr sync
+        self.cta_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=self.threads_per_cta,
+        )
+        self.epilog_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=32 * len(self.epilog_warp_id),
+        )
+        self.tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=3,
+            num_threads=32 * len((self.mma_warp_id, *self.accumulator_update_warp_id, *self.epilog_warp_id)),
+        )
+        self.sched_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=4,
+            num_threads=self.threads_per_warp,
+        )
+        self.num_smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        SM100_TMEM_CAPACITY_COLUMNS = 512
+        self.num_tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
+
+        self.vectorized_f32 = vectorized_f32
+        self.use_dynamic_sched = use_dynamic_sched
+
+        # Amax reduction configuration
+        self.num_epilog_warps = len(self.epilog_warp_id)
+
+        self.generate_sfd2 = generate_sfd2
+        self.weight_mode = weight_mode
+
+        self.act_func = act_func
+
+        self.glu_alpha = glu_alpha
+        self.glu_clamp_max = glu_clamp_max
+        self.glu_clamp_min = glu_clamp_min
+
+        if d_deinterleaved and deint_n <= 0:
+            raise ValueError("d_deinterleaved requires deint_n (the STATIC interleaved d " "width, 2*n) for the TMA coordinate-tensor rewrite")
+        self.d_deinterleaved = d_deinterleaved
+        self.deint_n = deint_n
+        self.dsmem_rowwise = dsmem_rowwise
+
+    def _setup_attributes(self):
+        """Set up configurations that are dependent on GEMM inputs
+
+        This method configures various attributes based on the input tensor properties
+        (data types, leading dimensions) and kernel settings:
+        - Configuring tiled MMA
+        - Computing MMA/cluster/tile shapes
+        - Computing cluster layout
+        - Computing multicast CTAs for A/B
+        - Computing epilogue subtile
+        - Setting up A/B/D stage counts in shared memory
+        - Computing A/B/D shared memory layout
+        - Computing tensor memory allocation columns
+        """
+
+        self.mma_inst_shape_mn = (
+            self.mma_tiler[0],
+            self.mma_tiler[1],
+        )
+        # (CTA_Tile_Shape_M, Round_Up(MMA_Tile_Shape_N, 128), MMA_Inst_Shape_K)
+        self.mma_inst_shape_mn_sfb = (
+            self.mma_inst_shape_mn[0] // (2 if self.use_2cta_instrs else 1),
+            cute.round_up(self.mma_inst_shape_mn[1], 128),
+        )
+
+        # Configure tiled mma
+        tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            self.mma_inst_shape_mn,
+        )
+
+        tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            cute.nvgpu.tcgen05.CtaGroup.ONE,
+            self.mma_inst_shape_mn_sfb,
+        )
+
+        # Compute mma/cluster/tile shapes
+        mma_inst_shape_k = cute.size(tiled_mma.shape_mnk, mode=[2])
+        mma_inst_tile_k = 4
+        self.mma_tiler = (
+            self.mma_tiler[0],
+            self.mma_tiler[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+
+        self.mma_tiler_sfb = (
+            self.mma_inst_shape_mn_sfb[0],
+            self.mma_inst_shape_mn_sfb[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+
+        self.cta_tile_shape_mnk = (
+            self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler[1],
+            self.mma_tiler[2],
+        )
+        self.cta_tile_shape_mnk_sfb = (
+            self.mma_tiler_sfb[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler_sfb[1],
+            self.mma_tiler_sfb[2],
+        )
+
+        self.mma_tiler_d = (
+            self.mma_inst_shape_mn[0],
+            self.mma_inst_shape_mn[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+        self.cta_tile_shape_mnk_d = (
+            self.mma_tiler_d[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler_d[1],
+            self.mma_tiler_d[2],
+        )
+        # Compute cluster layout
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma.thr_id.shape,),
+        )
+
+        self.cluster_layout_sfb_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma_sfb.thr_id.shape,),
+        )
+
+        # Compute number of multicast CTAs for A/B
+        self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+
+        # Set epilogue subtile
+        self.epi_tile = (128, 32)
+        self.epi_tile_cnt = (
+            self.cta_tile_shape_mnk_d[0] // self.epi_tile[0],
+            self.cta_tile_shape_mnk_d[1] // self.epi_tile[1],
+        )
+
+        # enable direct store D when it is NVFP4 input, BFlat16 output
+        self.store_d_directly = False
+
+        # Pipeline stages for epi_pipeline (accumulator update -> epilogue).
+        self.num_epi_stage = 1
+
+        # Setup A/B/D/Scale stage count in shared memory and ACC stage count in tensor memory
+        (
+            self.num_acc_stage,
+            self.num_ab_stage,
+            self.num_c_stage,
+            self.num_d_stage,
+            self.num_tile_stage,
+        ) = self._compute_stages(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.b_dtype,
+            self.epi_tile,
+            self.c_dtype,
+            self.c_layout,
+            self.d_dtype,
+            self.d_layout,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.num_smem_capacity,
+            self.occupancy,
+            self.store_d_directly,
+            self.generate_dbias,
+            acc_dtype=self.acc_dtype,
+            sf2_dtype=self.sf2_dtype,
+            sgm=self.sgm,
+            sgn=self.sgn,
+            sgk=self.sgk,
+            num_epi_stage=self.num_epi_stage,
+            row_dsmem=self.row_dsmem,
+        )
+
+        # Second-level scale pipeline runs in lockstep with the AB pipeline
+        self.num_scale_stage = self.num_ab_stage
+
+        # Compute A/B/D/Scale shared memory layout
+        self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.num_ab_stage,
+        )
+        self.b_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            self.mma_tiler,
+            self.b_dtype,
+            self.num_ab_stage,
+        )
+        self.sfa_smem_layout_staged = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        self.sfb_smem_layout_staged = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+
+        self.c_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.c_dtype,
+            self.c_layout,
+            self.epi_tile,
+            self.num_c_stage,
+        )
+
+        if cutlass.const_expr(not self.store_d_directly):
+            self.d_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+                self.d_dtype,
+                self.d_layout,
+                self.epi_tile,
+                self.num_d_stage,
+            )
+        else:
+            self.d_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+                self.d_dtype,
+                self.d_layout,
+                self.epi_tile,
+                1,
+            )
+
+        # Full-CTA-tile SMEM buffer for the final accumulator; the "stage" mode of the
+        # epi layout doubles as the subtile-slot index (subtile_cnt slots per epi stage).
+        # Always allocated (unlike sD, which is conditional on store_d_directly).
+        self.final_acc_subtile_cnt = (self.cta_tile_shape_mnk[0] // cute.size(self.epi_tile[0])) * (self.cta_tile_shape_mnk[1] // cute.size(self.epi_tile[1]))
+        self.final_acc_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.acc_dtype,
+            self.d_layout,
+            self.epi_tile,
+            self.final_acc_subtile_cnt * self.num_epi_stage,
+        )
+
+        # Compute second level scale factor layout
+        # Store the per-tile scale block sizes (each clamped to the CTA tile) so
+        # the device kernel builds C-shaped scale views that match the CTA tile
+        # exactly, even when sg{m,n,k} > the tile extent (e.g. sgn=512 with a
+        # 128-wide N tile spans one scale block, broadcast across the tile).
+        if self.sgm < self.cta_tile_shape_mnk[0]:
+            size_m = self.sgm
+        else:
+            size_m = self.cta_tile_shape_mnk[0]
+
+        if self.sgn < self.cta_tile_shape_mnk[1]:
+            size_n = self.sgn
+        else:
+            size_n = self.cta_tile_shape_mnk[1]
+
+        if self.sgk < self.cta_tile_shape_mnk[2]:
+            size_k = self.sgk
+        else:
+            size_k = self.mma_tiler[2]
+
+        self.scale_size_m = size_m
+        self.scale_size_n = size_n
+        self.scale_size_k = size_k
+
+        self.scale_m_per_tile = self.cta_tile_shape_mnk[0] // size_m
+        self.scale_n_per_tile = self.cta_tile_shape_mnk[1] // size_n
+        self.scale_k_per_tile = self.cta_tile_shape_mnk[2] // size_k
+
+        self.sfa2_smem_layout_staged = cute.make_layout(
+            (
+                (size_m, self.scale_m_per_tile),
+                (size_k, self.scale_k_per_tile),
+                self.num_ab_stage,
+            ),
+            stride=(
+                (0, self.scale_k_per_tile),
+                (0, 1),
+                self.scale_k_per_tile * self.scale_m_per_tile,
+            ),
+        )
+        self.sfb2_smem_layout_staged = cute.make_layout(
+            (
+                (size_n, self.scale_n_per_tile),
+                (size_k, self.scale_k_per_tile),
+                self.num_ab_stage,
+            ),
+            stride=(
+                (0, self.scale_k_per_tile),
+                (0, 1),
+                self.scale_k_per_tile * self.scale_n_per_tile,
+            ),
+        )
+
+        # Overlap and double buffer accumulator when num_acc_stage == 1 for cta_tile_n = 256 case
+        self.overlapping_accum = self.num_acc_stage == 1 and self.mma_tiler[1] == 256
+
+        # To prefetch more accumulator when overlapping_accum is enabled in epilogue
+        self.epilogue_prefetch_more = self.d_dtype.width == 8 and self.a_dtype.width == 8
+
+        # To generate dprob
+        self.generate_dprob = True
+
+        # Use ptx fp8 fp32 convert
+        self.use_fp8_ptx_cvt = False
+
+        # Compute number of TMEM columns for SFA/SFB/Accumulator
+        sf_atom_mn = 32
+        self.num_sfa_tmem_cols = (self.cta_tile_shape_mnk[0] // sf_atom_mn) * mma_inst_tile_k
+        self.num_sfb_tmem_cols = (self.cta_tile_shape_mnk_sfb[1] // sf_atom_mn) * mma_inst_tile_k
+        self.num_sf_tmem_cols = self.num_sfa_tmem_cols + self.num_sfb_tmem_cols
+        self.num_accumulator_tmem_cols = self.cta_tile_shape_mnk[1] * self.num_acc_stage
+
+        self.epi_tile_n_required = cute.size(self.epi_tile[1])
+        # Only when overlapping_accum is enabled, we need to release accumulator buffer early in epilogue
+        self.iter_acc_early_release_in_epilogue = (self.num_sf_tmem_cols + self.epi_tile_n_required - 1) // self.epi_tile_n_required - 1
+
+    def get_desc_workspace_bytes(self) -> int:
+        """Return descriptor workspace size in bytes."""
+        if self.weight_mode == MoEWeightMode.DISCRETE:
+            from ..moe_utils import DiscreteWeightTensormapConstructor
+
+            return DiscreteWeightTensormapConstructor.get_workspace_size(self.expert_cnt)
+        return 0
+
+    def get_workspace_bytes(self, sfd2_sync_counter_cnt: int = 0) -> int:
+        """Return descriptor workspace plus optional dynamic scheduler state,
+        plus optional sfd2 cross-tile arrival counters (one u32 per
+        (global m CTA tile, sfd2 n-block); the caller sizes the count — see
+        the wrapper — and it is nonzero only for quantized-D output with
+        sfd2_n_contrib > 1, i.e. sgn > mma_tiler_n)."""
+        desc_workspace_bytes = self.get_desc_workspace_bytes()
+        dynamic_sched_bytes = 4 if self.use_dynamic_sched else 0
+        return desc_workspace_bytes + dynamic_sched_bytes + 4 * sfd2_sync_counter_cnt
+
+    @cute.jit
+    def _get_sched_counter_ptr(self, workspace_ptr):
+        counter_addr = workspace_ptr.toint() + self.get_desc_workspace_bytes()
+        return cute.make_ptr(
+            cutlass.Int32,
+            counter_addr,
+            AddressSpace.gmem,
+            assumed_align=4,
+        )
+
+    @cute.jit
+    def _get_sfd2_counter_ptr(self, workspace_ptr):
+        """Base of the sfd2 arrival-counter array (after the tensormap
+        descriptors and the optional dynamic-sched counter)."""
+        counter_addr = workspace_ptr.toint() + self.get_desc_workspace_bytes() + (4 if self.use_dynamic_sched else 0)
+        return cute.make_ptr(
+            cutlass.Int32,
+            counter_addr,
+            AddressSpace.gmem,
+            assumed_align=4,
+        )
+
+    @cute.kernel
+    def sfd2_counter_zero_kernel(self, workspace_ptr, counter_cnt: Int32):
+        """Zero the sfd2 arrival counters before the main kernel (each launch
+        must start from 0: pass 2 spins until a counter reaches
+        sfd2 contributor count for its block)."""
+        bidx = cute.arch.block_idx()[0]
+        tidx = cute.arch.thread_idx()[0]
+        gdim = cute.arch.grid_dim()[0]
+        counters = cute.make_tensor(
+            self._get_sfd2_counter_ptr(workspace_ptr),
+            cute.make_layout((counter_cnt,)),
+        )
+        idx = Int32(bidx * 128 + tidx)
+        stride = Int32(gdim * 128)
+        while idx < counter_cnt:
+            counters[idx] = Int32(0)
+            idx += stride
+
+    @cute.kernel
+    def helper_kernel(
+        self,
+        ptrs_b: cute.Pointer,  # Device pointer to int64[expert_cnt] array of B addresses
+        ptrs_sfb: cute.Pointer,  # Device pointer to int64[expert_cnt] array of SFB addresses
+        n: Int32,
+        k: Int32,
+        b_stride_size: cutlass.Int64,
+        b_major_mode: cutlass.Constexpr,
+        workspace_ptr,
+        tiled_mma_arg: cute.TiledMma,
+        tiled_mma_sfb_arg: cute.TiledMma,
+        b_smem_layout_arg,
+        sfb_smem_layout_arg,
+        cluster_layout_vmnk_shape_arg: cutlass.Constexpr,
+        cluster_layout_sfb_vmnk_shape_arg: cutlass.Constexpr,
+    ):
+        """Pre-main-kernel initialization.
+
+        Launched with grid=(expert_cnt, 1, 1) for discrete mode, or
+        grid=(1, 1, 1) for dense+dynamic mode.
+
+        Discrete weight: each block builds B/SFB TMA descriptors for one expert.
+        Dynamic sched: block 0 resets the atomic tile counter to 0.
+        """
+        expert_idx = cute.arch.block_idx()[0]
+
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE):
+            b_tma_op_arg = sm100_utils.cluster_shape_to_tma_atom_B(self.cluster_shape_mn, tiled_mma_arg.thr_id)
+            sfb_tma_op_arg = sm100_utils.cluster_shape_to_tma_atom_SFB(self.cluster_shape_mn, tiled_mma_arg.thr_id)
+
+            b_ptr_tensor = cute.make_tensor(
+                cute.make_ptr(cutlass.Int64, ptrs_b.toint(), AddressSpace.gmem, assumed_align=8), cute.make_layout((self.expert_cnt,))
+            )
+            sfb_ptr_tensor = cute.make_tensor(
+                cute.make_ptr(cutlass.Int64, ptrs_sfb.toint(), AddressSpace.gmem, assumed_align=8), cute.make_layout((self.expert_cnt,))
+            )
+
+            c1 = cutlass.Int32(1)
+            c0 = cutlass.Int64(0)
+            c1_64 = 1
+            if cutlass.const_expr(b_major_mode == OperandMajorMode.K):
+                stride_n = b_stride_size
+                stride_k = c1_64
+            else:
+                stride_n = c1_64
+                stride_k = b_stride_size
+
+            b_ptr_val = b_ptr_tensor[expert_idx]
+            b_ptr = cute.make_ptr(self.b_dtype, b_ptr_val, AddressSpace.gmem)
+            b_tensor_i = cute.make_tensor(
+                b_ptr,
+                cute.make_layout((n, k, c1), stride=(stride_n, stride_k, c0)),
+            )
+            tma_atom_b, _ = cute.nvgpu.make_tiled_tma_atom_B(
+                b_tma_op_arg,
+                b_tensor_i,
+                b_smem_layout_arg,
+                self.mma_tiler,
+                tiled_mma_arg,
+                cluster_layout_vmnk_shape_arg,
+            )
+
+            workspace = TensormapWorkspace(workspace_ptr, ["b", "sfb"])
+            store_tma_desc(tma_atom_b, workspace.get_ptr("b", expert_idx))
+
+            sfb_ptr_val = sfb_ptr_tensor[expert_idx]
+            sfb_ptr = cute.make_ptr(self.sf_dtype, sfb_ptr_val, AddressSpace.gmem)
+            sfb_layout = blockscaled_utils.tile_atom_to_shape_SF((n, k, c1), self.sf_vec_size)
+            sfb_tensor_i = cute.make_tensor(sfb_ptr, sfb_layout)
+            tma_atom_sfb, _ = cute.nvgpu.make_tiled_tma_atom_B(
+                sfb_tma_op_arg,
+                sfb_tensor_i,
+                sfb_smem_layout_arg,
+                self.mma_tiler_sfb,
+                tiled_mma_sfb_arg,
+                cluster_layout_sfb_vmnk_shape_arg,
+                internal_type=cutlass.Uint64,
+            )
+            store_tma_desc(tma_atom_sfb, workspace.get_ptr("sfb", expert_idx))
+
+        if cutlass.const_expr(self.use_dynamic_sched):
+            if expert_idx == cutlass.Int32(0):
+                sched_counter = cute.make_tensor(
+                    self._get_sched_counter_ptr(workspace_ptr),
+                    cute.make_layout(1),
+                )
+                sched_counter[0] = cutlass.Int32(0)
+
+    @cute.jit
+    def __call__(
+        self,
+        a: cute.Tensor,
+        b,  # Dense: cute.Tensor (N,K,L) | Discrete: cute.Pointer to int64[]
+        sfb,  # Dense: cute.Tensor         | Discrete: cute.Pointer to int64[]
+        sfb2,  # Dense: cute.Tensor         | Discrete: cute.Pointer to int64[]
+        n: Int32,  # Ignored for dense mode
+        k: Int32,  # Ignored for dense mode
+        b_stride_size: cutlass.Int64,  # Ignored for dense mode
+        b_major_mode: cutlass.Constexpr,  # Ignored for dense mode
+        workspace_ptr,  # Descriptor workspace, plus dynamic scheduler counter when enabled
+        c: cute.Tensor,
+        d: cute.Tensor,
+        sfa: cute.Tensor,
+        sfa2: cute.Tensor,
+        sfd2_up: cute.Tensor,
+        sfd2_gate: cute.Tensor,
+        sfd_row_tensor: Optional[cute.Tensor],
+        norm_const_tensor: Optional[cute.Tensor],
+        padded_offsets: cute.Tensor,
+        alpha: cute.Tensor,
+        beta: cute.Tensor,
+        prob: cute.Tensor,
+        dprob: cute.Tensor,
+        linear_offset: Float32,
+        dbias_tensor: Optional[cute.Tensor],
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+    ):
+        """Execute the GEMM.
+
+        Dense mode: ``b`` and ``sfb`` are 3-D cute.Tensor (N, K, L).
+        Discrete mode: ``b`` and ``sfb`` are cute.Pointer to device int64[]
+        arrays of per-expert base addresses; ``n``, ``k``, ``b_stride_size``,
+        ``b_major_mode`` describe the uniform per-expert layout.
+        """
+        # Setup static attributes before smem/grid/tma computation
+        self.a_dtype: Type[cutlass.Numeric] = a.element_type
+        self.b_dtype: Type[cutlass.Numeric] = a.element_type  # B must match A dtype
+        self.c_dtype: Type[cutlass.Numeric] = c.element_type
+        self.d_dtype: Type[cutlass.Numeric] = d.element_type
+        self.sf_dtype: Type[cutlass.Numeric] = sfa.element_type
+        self.sf2_dtype: Type[cutlass.Numeric] = sfa2.element_type
+        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
+
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DENSE):
+            self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
+        else:
+            self.b_major_mode = b_major_mode
+        self.c_layout = utils.LayoutEnum.from_tensor(c)
+        self.d_layout = utils.LayoutEnum.from_tensor(d)
+
+        # dBias configuration
+        self.generate_dbias = dbias_tensor is not None
+        self.dbias_cross_warp_reduce = self.generate_dbias  # always cross-warp reduce
+
+        # Check if input data types are compatible with MMA instruction
+        if cutlass.const_expr(self.a_dtype != self.b_dtype):
+            raise TypeError(f"Type must match: {self.a_dtype} != {self.b_dtype}")
+
+        # Quantized-D mode is dtype-inferred. Derived BEFORE _setup_attributes()
+        # because the rowwise-sfd2 DSMEM eligibility below feeds smem sizing
+        # (_compute_stages).
+        # all() instead of an `and` chain: this runs inside the @cute.jit
+        # traced __call__, where the DSL AST pass rewrites `and` into a
+        # cutlass.Boolean — but these flags feed SharedStorage sizing and
+        # _compute_stages, which need plain python bools.
+        self.generate_sfd = _is_quant_dtype_combo(self.a_dtype, self.sf_dtype, self.d_dtype)
+        # ROWWISE sfd2 DSMEM: active when one block's N work-tile contributors
+        # are exactly one cluster's N-peers (sgn/cta_n == cluster_n > 1). The
+        # quantized-D row-scale fold is optional in this kernel (unlike the
+        # rht_2 source, where it is unconditionally on), so the quant + sfd2
+        # terms are AND-ed in.
+        self.row_dsmem = all(
+            (
+                self.dsmem_rowwise,
+                self.generate_sfd,
+                self.generate_sfd2,
+                self.cluster_shape_mn[1] > 1,
+                self.sfd2_n_contrib == self.cluster_shape_mn[1],
+            )
+        )
+
+        # Setup attributes that dependent on gemm inputs
+        self._setup_attributes()
+
+        # ---- SFA2 layout ----
+        sfa2_tensor = cute.make_tensor(
+            sfa2.iterator,
+            cute.make_layout(
+                (
+                    (self.sgm, sfa2.shape[0]),
+                    (self.sgk, sfa2.shape[1]),
+                    sfa2.shape[2],
+                ),
+                stride=(
+                    (0, sfa2.layout.stride[0]),
+                    (0, sfa2.layout.stride[1]),
+                    sfa2.layout.stride[2],
+                ),
+            ),
+        )
+
+        # ---- SFD2 layout ---- (None when sfd2 generation is off)
+        sfd2_up_tensor = None
+        sfd2_gate_tensor = None
+        if cutlass.const_expr(self.generate_sfd2):
+            # Inner N mode is 2*sgn: sgn counts deinterleaved f-columns, and
+            # the tensor is indexed in interleaved D-space coordinates where
+            # one block spans 2*sgn columns (sgn gate + sgn up 32-col bands).
+            sfd2_up_tensor = cute.make_tensor(
+                sfd2_up.iterator,
+                cute.make_layout(
+                    (
+                        (self.sgm, sfd2_up.shape[0]),
+                        (2 * self.sgn, sfd2_up.shape[1]),
+                        sfd2_up.shape[2],
+                    ),
+                    stride=(
+                        (0, sfd2_up.layout.stride[0]),
+                        (0, sfd2_up.layout.stride[1]),
+                        sfd2_up.layout.stride[2],
+                    ),
+                ),
+            )
+
+            sfd2_gate_tensor = cute.make_tensor(
+                sfd2_gate.iterator,
+                cute.make_layout(
+                    (
+                        (self.sgm, sfd2_gate.shape[0]),
+                        (2 * self.sgn, sfd2_gate.shape[1]),
+                        sfd2_gate.shape[2],
+                    ),
+                    stride=(
+                        (0, sfd2_gate.layout.stride[0]),
+                        (0, sfd2_gate.layout.stride[1]),
+                        sfd2_gate.layout.stride[2],
+                    ),
+                ),
+            )
+
+        c1 = cutlass.Int32(1)
+        c0 = cutlass.Int64(0)
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DENSE):
+            sfb2_ptr_typed = sfb2.iterator
+            sfb2_shape_0 = sfb2.shape[0]
+            sfb2_shape_1 = sfb2.shape[1]
+            sfb2_mode_2 = sfb2.shape[2]
+            sfb2_stride_0 = sfb2.layout.stride[0]
+            sfb2_stride_1 = sfb2.layout.stride[1]
+            sfb2_stride_2 = sfb2.layout.stride[2]
+        else:  # DISCRETE mode
+            # In discrete mode, sfb2 is a pointer to array of per-expert pointers (Int64[])
+            # Create a template tensor with correct element type (sf2_dtype) for get_gmem_tensor
+            # The pointer address is the pointer array address; get_gmem_tensor will load actual per-expert pointer
+            sfb2_ptr_typed = cute.make_ptr(
+                self.sf2_dtype,  # Correct data type so element_type is right
+                sfb2.toint(),  # Pointer array address (will be reinterpreted in get_gmem_tensor)
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            )
+            # Use computed scale values for template shape/stride
+            scale_n = cute.ceil_div(n, self.sgn)
+            scale_k = cute.ceil_div(k, self.sgk)
+            sfb2_shape_0 = scale_n
+            sfb2_shape_1 = scale_k
+            sfb2_mode_2 = c1
+            sfb2_stride_0 = c1
+            sfb2_stride_1 = scale_n
+            sfb2_stride_2 = c0
+
+        # ---- SFB2 layout ----
+        # Dense: use actual tensor shape/stride
+        # Discrete: use template shape/stride (get_gmem_tensor will load per-expert pointer)
+        sfb2_tensor = cute.make_tensor(
+            sfb2_ptr_typed,
+            cute.make_layout(
+                (
+                    (self.sgn, sfb2_shape_0),
+                    (self.sgk, sfb2_shape_1),
+                    sfb2_mode_2,
+                ),
+                stride=(
+                    (0, sfb2_stride_0),
+                    (0, sfb2_stride_1),
+                    sfb2_stride_2,
+                ),
+            ),
+        )
+
+        # ---- B / SFB setup (mode-dependent) ----
+        b_from_call_arg = b
+        sfb_from_call_arg = sfb
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DENSE):
+            sfb_layout = blockscaled_utils.tile_atom_to_shape_SF(b.shape, self.sf_vec_size)
+            sfb = cute.make_tensor(sfb.iterator, sfb_layout)
+        else:
+            c1 = cutlass.Int32(1)
+            c0 = cutlass.Int64(0)
+            c1_64 = 1
+            if cutlass.const_expr(b_major_mode == OperandMajorMode.K):
+                b_template_stride = (b_stride_size, c1_64, c0)
+            else:
+                b_template_stride = (c1_64, b_stride_size, c0)
+
+            # Creating a template layout and B tensor for a single expert
+            b_template_layout = cute.make_layout((n, k, c1), stride=b_template_stride)
+            b_ptr_typed = cute.make_ptr(self.b_dtype, b.toint(), AddressSpace.gmem, assumed_align=16)
+            b = cute.make_tensor(b_ptr_typed, b_template_layout)
+
+            sfb_ptr_typed = cute.make_ptr(self.sf_dtype, sfb.toint(), AddressSpace.gmem, assumed_align=16)
+            sfb_layout = blockscaled_utils.tile_atom_to_shape_SF((n, k, c1), self.sf_vec_size)
+            sfb = cute.make_tensor(sfb_ptr_typed, sfb_layout)
+
+        # Setup sfa tensor by filling A tensor to scale factor atom layout
+        # ((Atom_M, Rest_M),(Atom_K, Rest_K),RestL)
+        sfa_layout = blockscaled_utils.tile_atom_to_shape_SF(a.shape, self.sf_vec_size)
+        sfa = cute.make_tensor(sfa.iterator, sfa_layout)
+
+        # Dimensions of output
+        m, n_d, l = cute.shape(d)
+
+        # self.generate_sfd (the quantized-D mode) is derived above, before
+        # _setup_attributes(), so the rowwise-sfd2 DSMEM smem sizing sees it.
+
+        if cutlass.const_expr(self.d_deinterleaved and not self.generate_sfd):
+            # The deinterleaved layout is only harness-validated for the
+            # quantized-D + sfd2 configuration; check_support enforces this
+            # host-side, this is the trace-time backstop.
+            raise ValueError("d_deinterleaved requires quantized D output")
+
+        if cutlass.const_expr(dbias_tensor is not None and self.d_deinterleaved):
+            # Deinterleave dbias's n axis (mode 1). The bf16x2 atomics pair
+            # adjacent even/odd columns, which stay inside one 32-col band.
+            dbias_tensor = _deinterleave_n_coord_tensor(dbias_tensor, mode=1)
+
+        self._sfd2_sync_active = self.generate_sfd and self.generate_sfd2 and self.sfd2_n_contrib > 1
+
+        if cutlass.const_expr(self._sfd2_sync_active):
+            # One counter per (global m CTA tile, sfd2 n-block); must match
+            # the wrapper's workspace sizing and the epilogue's index math.
+            _sfd2_n_tiles_f = cute.ceil_div(n_d, 2 * self.cta_tile_shape_mnk[1])
+            _sfd2_n_j = cute.ceil_div(_sfd2_n_tiles_f, self.sfd2_n_contrib)
+            _sfd2_counter_cnt = (m // self.cta_tile_shape_mnk[0]) * _sfd2_n_j
+        else:
+            _sfd2_counter_cnt = Int32(0)
+
+        if cutlass.const_expr(self.generate_sfd):
+            output_sfd_shape = (m, n_d, l)
+            sfd_layout = blockscaled_utils.tile_atom_to_shape_SF(output_sfd_shape, self.sf_vec_size)
+            sfd_row_tensor = cute.make_tensor(sfd_row_tensor.iterator, sfd_layout)
+
+        tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            self.mma_inst_shape_mn,
+        )
+
+        tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            cute.nvgpu.tcgen05.CtaGroup.ONE,
+            self.mma_inst_shape_mn_sfb,
+        )
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+
+        # Setup TMA load for A
+        a_op = sm100_utils.cluster_shape_to_tma_atom_A(self.cluster_shape_mn, tiled_mma.thr_id)
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        tma_atom_a, tma_tensor_a = cute.nvgpu.make_tiled_tma_atom_A(
+            a_op,
+            a,
+            a_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # Setup TMA load for B
+        b_op = sm100_utils.cluster_shape_to_tma_atom_B(self.cluster_shape_mn, tiled_mma.thr_id)
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op,
+            b,
+            b_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # Setup TMA load for SFA
+        sfa_op = sm100_utils.cluster_shape_to_tma_atom_A(self.cluster_shape_mn, tiled_mma.thr_id)
+        sfa_smem_layout = cute.slice_(self.sfa_smem_layout_staged, (None, None, None, 0))
+        tma_atom_sfa, tma_tensor_sfa = cute.nvgpu.make_tiled_tma_atom_A(
+            sfa_op,
+            sfa,
+            sfa_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=cutlass.Uint16,
+        )
+
+        # Setup TMA load for SFB
+        sfb_op = sm100_utils.cluster_shape_to_tma_atom_SFB(self.cluster_shape_mn, tiled_mma.thr_id)
+        sfb_smem_layout = cute.slice_(self.sfb_smem_layout_staged, (None, None, None, 0))
+        tma_atom_sfb, tma_tensor_sfb = cute.nvgpu.make_tiled_tma_atom_B(
+            sfb_op,
+            sfb,
+            sfb_smem_layout,
+            self.mma_tiler_sfb,
+            tiled_mma_sfb,
+            self.cluster_layout_sfb_vmnk.shape,
+            internal_type=cutlass.Uint64,
+        )
+
+        if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 192):
+            x = tma_tensor_sfb.stride[0][1]
+            y = cute.ceil_div(tma_tensor_sfb.shape[0][1], 4)
+
+            new_shape = (
+                (tma_tensor_sfb.shape[0][0], ((2, 2), y)),
+                tma_tensor_sfb.shape[1],
+                tma_tensor_sfb.shape[2],
+            )
+            # Use right multiplication for ScaledBasis (3 * x instead of x * 3)
+            x_times_3 = 3 * x
+            new_stride = (
+                (tma_tensor_sfb.stride[0][0], ((x, x), x_times_3)),
+                tma_tensor_sfb.stride[1],
+                tma_tensor_sfb.stride[2],
+            )
+            tma_tensor_sfb_new_layout = cute.make_layout(new_shape, stride=new_stride)
+            tma_tensor_sfb = cute.make_tensor(tma_tensor_sfb.iterator, tma_tensor_sfb_new_layout)
+
+        a_copy_size = cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        b_copy_size = cute.size_in_bytes(self.b_dtype, b_smem_layout)
+        sfa_copy_size = cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+        sfb_copy_size = cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+        self.num_tma_load_bytes = (a_copy_size + b_copy_size + sfa_copy_size + sfb_copy_size) * atom_thr_size
+
+        # Setup TMA store for C
+        c_smem_layout = cute.slice_(self.c_smem_layout_staged, (None, None, 0))
+        self.tma_c_load_bytes = cute.size_in_bytes(self.c_dtype, c_smem_layout)
+        tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
+            c,
+            c_smem_layout,
+            self.epi_tile,
+        )
+
+        # Setup TMA store for D
+        tma_atom_d = None
+        tma_tensor_d = None
+        if cutlass.const_expr(not self.store_d_directly):
+            d_smem_layout = cute.slice_(self.d_smem_layout_staged, (None, None, 0))
+            tma_atom_d, tma_tensor_d = cpasync.make_tiled_tma_atom(
+                cpasync.CopyBulkTensorTileS2GOp(),
+                d,
+                d_smem_layout,
+                self.epi_tile,
+            )
+            if cutlass.const_expr(self.d_deinterleaved):
+                tma_tensor_d = _deinterleave_n_coord_tensor(tma_tensor_d, n_static=self.deint_n)
+        else:
+            if cutlass.const_expr(self.d_deinterleaved):
+                tma_tensor_d = _deinterleave_n_coord_tensor(d, n_static=self.deint_n)
+            else:
+                tma_tensor_d = d
+
+        # Compute grid size using MoE scheduler
+        # dGLU output has shape (m, 2*N_half, 1), but scheduling is over (m, N_half)
+        # expert_shape = (expert_cnt, N_half, K)
+        n_half = n_d // 2
+        sched_params = MoESchedulerParams(
+            scenario="2Dx3D",
+            expert_shape=(self.expert_cnt, n_half, cute.size(a.shape, mode=[1])),
+            cta_tile_shape_mnk=self.cta_tile_shape_mnk_d,
+            cluster_shape_mn=self.cluster_shape_mn,
+            use_dynamic_sched=self.use_dynamic_sched,
+        )
+        grid = MoESchedulerParams.get_grid_shape(sched_params, max_active_clusters)
+
+        self.buffer_align_bytes = 1024
+
+        # Define shared storage for kernel
+        # sD is not needed when storing D directly (and not generating SFD)
+        sD_size = 0 if (not self.generate_sfd and self.store_d_directly) else cute.cosize(self.d_smem_layout_staged.outer)
+        SchedulerStorage = MoEPersistentTileScheduler.make_storage_struct(self.num_tile_stage, self.use_dynamic_sched)
+
+        @cute.struct
+        class SharedStorage:
+            ab_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage * 2]
+            scale_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_scale_stage * 2]
+            acc_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage * 2]
+            epi_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_epi_stage * 2]
+            # DSMEM rowwise-sfd2 handoff: one cluster_n-arrival mbarrier per
+            # parity slot of sSfd2RowDsmem (every N-peer arrives after its
+            # red.shared::cluster maxes for a tile have been fenced).
+            row_dsmem_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 if self.row_dsmem else 0]
+            scheduler: SchedulerStorage
+            c_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_c_stage]
+            c_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_c_stage]
+            tmem_dealloc_mbar_ptr: cutlass.Int64
+            tmem_holding_buf: cutlass.Int32
+            # (EPI_TILE_M, EPI_TILE_N, STAGE)
+            sC: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.c_dtype,
+                    cute.cosize(self.c_smem_layout_staged.outer),
+                ],
+                self.buffer_align_bytes,
+            ]
+            sD: cute.struct.Align[
+                cute.struct.MemRange[self.d_dtype, sD_size],
+                self.buffer_align_bytes,
+            ]
+            sFinalAcc: cute.struct.Align[
+                cute.struct.MemRange[self.acc_dtype, cute.cosize(self.final_acc_smem_layout_staged.outer)],
+                self.buffer_align_bytes,
+            ]
+            # DSMEM rowwise-sfd2 reduction buffer (sgn/cta_n == cluster_n
+            # only): 2 parity slots x [cta_m gate | cta_m up] per-row block
+            # descales, max-reduced IN PLACE by every N-peer CTA via
+            # red.shared::cluster — each CTA ends up holding its 128 rows'
+            # final block descales locally (plain LDS before pass 2, no
+            # gmem counter spin / volatile read-backs).
+            sSfd2RowDsmem: cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Float32,
+                    2 * 2 * self.cta_tile_shape_mnk_d[0] if cutlass.const_expr(self.row_dsmem) else 0,
+                ],
+                16,
+            ]
+            # (MMA, MMA_M, MMA_K, STAGE)
+            sA: cute.struct.Align[
+                cute.struct.MemRange[self.a_dtype, cute.cosize(self.a_smem_layout_staged.outer)],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_N, MMA_K, STAGE)
+            sB: cute.struct.Align[
+                cute.struct.MemRange[self.b_dtype, cute.cosize(self.b_smem_layout_staged.outer)],
+                self.buffer_align_bytes,
+            ]
+            # (granularity_m, repeat_m), (granularity_k, repeat_k), num_scale_stage)
+            sSFA: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(self.sfa_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            # (granularity_n, repeat_n), (granularity_k, repeat_k), num_scale_stage)
+            sSFB: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(self.sfb_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sSFA2: cute.struct.Align[
+                cute.struct.MemRange[self.sf2_dtype, cute.cosize(self.sfa2_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sSFB2: cute.struct.Align[
+                cute.struct.MemRange[self.sf2_dtype, cute.cosize(self.sfb2_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            # dBias SMEM transpose buffer: (128, epi_tile_n*2) col-major FP32
+            sDbias: cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Float32,
+                    128 * self.epi_tile[1] * 2 if self.generate_dbias else 1,
+                ],
+                128 if self.generate_dbias else 4,
+            ]
+            # SFD row-scale store staging: one (128 rows x 128 values) SFD
+            # store event in the gmem atom layout. The T2R row-per-thread
+            # mapping scatters each thread's SF bytes at 16B stride in that
+            # layout, so direct gmem stores waste 3/4 of every sector; the
+            # block is exchanged through SMEM and written back linearly.
+            sSFDRowStage: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.sf_dtype,
+                    128 * 32 * 4 // self.sf_vec_size if cutlass.const_expr(self.generate_sfd) else 1,
+                ],
+                128 if cutlass.const_expr(self.generate_sfd) else 4,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        # Initialize per-expert B/SFB TMA descriptors in workspace
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        sfb_smem_layout = cute.slice_(self.sfb_smem_layout_staged, (None, None, None, 0))
+        _need_helper = cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE or self.use_dynamic_sched)
+        if cutlass.const_expr(_need_helper):
+            _helper_grid_x = self.expert_cnt if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else 1
+            _helper_args = (
+                b_from_call_arg if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else cute.make_ptr(cutlass.Int64, 0, AddressSpace.gmem),
+                sfb_from_call_arg if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else cute.make_ptr(cutlass.Int64, 0, AddressSpace.gmem),
+                n if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else cutlass.Int32(0),
+                k if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else cutlass.Int32(0),
+                b_stride_size if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else cutlass.Int64(0),
+                b_major_mode if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else self.b_major_mode,
+                workspace_ptr,
+                tiled_mma,
+                tiled_mma_sfb,
+                b_smem_layout,
+                sfb_smem_layout,
+                self.cluster_layout_vmnk.shape,
+                self.cluster_layout_sfb_vmnk.shape,
+            )
+            self.helper_kernel(*_helper_args).launch(
+                grid=(_helper_grid_x, 1, 1),
+                block=(1, 1, 1),
+                stream=stream,
+                min_blocks_per_mp=1,
+            )
+
+        # Zero the sfd2 arrival counters (same stream, so ordered before the
+        # main kernel; each launch must restart the arrival protocol from 0).
+        if cutlass.const_expr(self._sfd2_sync_active):
+            self.sfd2_counter_zero_kernel(workspace_ptr, _sfd2_counter_cnt).launch(
+                grid=(32, 1, 1),
+                block=(128, 1, 1),
+                stream=stream,
+                min_blocks_per_mp=1,
+            )
+
+        # Launch the main kernel
+        self.kernel(
+            tiled_mma,
+            tiled_mma_sfb,
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_sfa,
+            tma_tensor_sfa,
+            tma_atom_sfb,
+            tma_tensor_sfb,
+            sfa2_tensor,
+            sfb2_tensor,
+            sfd2_up_tensor,
+            sfd2_gate_tensor,
+            tma_atom_c,
+            tma_tensor_c,
+            tma_atom_d,
+            tma_tensor_d,
+            sfd_row_tensor,
+            norm_const_tensor,
+            padded_offsets,
+            alpha,
+            beta,
+            prob,
+            dprob,
+            linear_offset,
+            dbias_tensor,
+            workspace_ptr,
+            self.cluster_layout_vmnk,
+            self.cluster_layout_sfb_vmnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.sfa2_smem_layout_staged,
+            self.sfb2_smem_layout_staged,
+            self.c_smem_layout_staged,
+            self.d_smem_layout_staged,
+            self.final_acc_smem_layout_staged,
+            self.epi_tile,
+            sched_params,
+            epilogue_op,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            max_number_threads=[self.threads_per_cta, 1, 1],
+            smem=self.shared_storage.size_in_bytes(),
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+        return
+
+    # ------------------------------------------------------------------
+    # Internal: create extension based on weight_mode
+    # ------------------------------------------------------------------
+
+    @cute.jit
+    def _make_extension(self, workspace_ptr):
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE):
+            desc_workspace = TensormapWorkspace(workspace_ptr, ["b", "sfb"])
+            return DiscreteWeightScaledGemmSchedExtension(
+                tensormap_ctor=desc_workspace,
+                sf_vec_size=self.sf_vec_size,
+            )
+        else:
+            return ContiguousAndConsistentGroupedGemmSchedExtension(
+                sf_vec_size=self.sf_vec_size,
+            )
+
+    def mainloop_s2t_copy_and_partition(
+        self,
+        sSF: cute.Tensor,
+        tSF: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for smem to tmem load for scale factor tensor, then use it to partition smem memory (source) and tensor memory (destination).
+
+        :param sSF: The scale factor tensor in smem
+        :type sSF: cute.Tensor
+        :param tSF: The scale factor tensor in tmem
+        :type tSF: cute.Tensor
+
+        :return: A tuple containing (tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t) where:
+            - tiled_copy_s2t: The tiled copy operation for smem to tmem load for scale factor tensor(s2t)
+            - tCsSF_compact_s2t: The partitioned scale factor tensor in smem
+            - tSF_compact_s2t: The partitioned scale factor tensor in tmem
+        :rtype: Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]
+        """
+        # (MMA, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact = cute.filter_zeros(sSF)
+        # (MMA, MMA_MN, MMA_K)
+        tCtSF_compact = cute.filter_zeros(tSF)
+
+        # Make S2T CopyAtom and tiledCopy
+        copy_atom_s2t = cute.make_copy_atom(
+            tcgen05.Cp4x32x128bOp(self.cta_group),
+            self.sf_dtype,
+        )
+        tiled_copy_s2t = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSF_compact)
+        thr_copy_s2t = tiled_copy_s2t.get_slice(0)
+
+        # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact_s2t_ = thr_copy_s2t.partition_S(tCsSF_compact)
+        # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact_s2t = tcgen05.get_s2t_smem_desc_tensor(tiled_copy_s2t, tCsSF_compact_s2t_)
+        # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K)
+        tCtSF_compact_s2t = thr_copy_s2t.partition_D(tCtSF_compact)
+
+        return tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t
+
+    @cute.jit
+    def amax_reduction_per_thread(self, vec_fp32, amax_fp32) -> None:
+        vec_fp32_ssa = vec_fp32
+        abs_acc_values_ir = cutlass._mlir.dialects.math.absf(vec_fp32_ssa.ir_value())
+        abs_acc_values = type(vec_fp32_ssa)(abs_acc_values_ir, vec_fp32_ssa.shape, vec_fp32_ssa.dtype)
+        subtile_amax = abs_acc_values.reduce(cute.ReductionOp.MAX, cutlass.Float32(0.0), 0)
+        return cute.arch.fmax(amax_fp32, subtile_amax)
+
+    @cute.jit
+    def second_level_scale_row_wise_gen(self, thread_tile_amax, tgSFD2):
+        thread_gmem_ptr = tgSFD2.iterator.llvm_ptr
+        _ = atomic_max_float32(ptr=thread_gmem_ptr, value=thread_tile_amax)
+
+    @cute.jit
+    def cvt_f32x4_to_f8x4_pack_i32(self, fp32x4, fp8_type, loc=None, ip=None):
+        fp32x4 = fp32x4.load()
+        src_vec4 = fp32x4.ir_value(loc=loc, ip=ip) if hasattr(fp32x4, "ir_value") else fp32x4
+
+        src0 = Float32(vector.extract(src_vec4, [], [0])).ir_value(loc=loc, ip=ip)
+        src1 = Float32(vector.extract(src_vec4, [], [1])).ir_value(loc=loc, ip=ip)
+        src2 = Float32(vector.extract(src_vec4, [], [2])).ir_value(loc=loc, ip=ip)
+        src3 = Float32(vector.extract(src_vec4, [], [3])).ir_value(loc=loc, ip=ip)
+
+        cvt_instruction = ""
+        if cutlass.const_expr(fp8_type == cutlass.Float8E8M0FNU):
+            cvt_instruction = "cvt.rp.satfinite.ue8m0x2.f32"
+        elif cutlass.const_expr(fp8_type == cutlass.Float8E4M3FN):
+            cvt_instruction = "cvt.rn.satfinite.e4m3x2.f32"
+        else:
+            with cute.arch.elect_one():
+                cute.printf("error: unsupported fp8 element type")
+            return
+
+        asm_tmpl = (
+            "{\n"
+            "  .reg .b16 lo;\n"
+            "  .reg .b16 hi;\n"
+            f"  {cvt_instruction} lo, $2, $1;\n"
+            f"  {cvt_instruction} hi, $4, $3;\n"
+            "  mov.b32 $0, {lo, hi};\n"
+            "}"
+        )
+        packed_i32 = llvm.inline_asm(
+            T.i32(),
+            [src0, src1, src2, src3],
+            asm_tmpl,
+            "=r,f,f,f,f",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+
+        return packed_i32
+
+    @cute.jit
+    def cvt_f32x4_to_f8x4(self, fp32x4, fp8x4, loc=None, ip=None):
+        packed_i32 = self.cvt_f32x4_to_f8x4_pack_i32(fp32x4, fp8x4.element_type)
+        fp8x4_i32 = cute.recast_tensor(fp8x4, cutlass.Int32)
+        fp8x4_i32[0] = cutlass.Int32(packed_i32)
+        return
+
+    @cute.jit
+    def cvt_f32_to_f8_to_f32(self, fp32x1, fp8_type, loc=None, ip=None):
+        src_fp32 = Float32(fp32x1).ir_value(loc=loc, ip=ip)
+
+        cvt_instruction_downcast = ""
+        cvt_instruction_upcast = ""
+        # Intermediate float type used to upcast the fp8 value back to f32.
+        # ue8m0 needs bf16 (matching f32 exponent range); e4m3 must use f16
+        # since PTX has no direct e4m3->bf16 conversion (only cvt.rn.f16x2.e4m3x2).
+        upcast_vec_ty = "vector<2xbf16>"
+        if cutlass.const_expr(fp8_type == cutlass.Float8E8M0FNU):
+            cvt_instruction_downcast = "cvt.rp.satfinite.ue8m0x2.f32"
+            cvt_instruction_upcast = "cvt.rn.bf16x2.ue8m0x2"
+            upcast_vec_ty = "vector<2xbf16>"
+        elif cutlass.const_expr(fp8_type == cutlass.Float8E4M3FN):
+            cvt_instruction_downcast = "cvt.rn.satfinite.e4m3x2.f32"
+            cvt_instruction_upcast = "cvt.rn.f16x2.e4m3x2"
+            upcast_vec_ty = "vector<2xf16>"
+        else:
+            with cute.arch.elect_one():
+                cute.printf("error: unsupported fp8 element type")
+            return
+
+        asm_tmpl = "{\n" "  .reg .b16 bf_lo;\n" f"  {cvt_instruction_downcast} bf_lo, 0f00000000, $1;\n" f"  {cvt_instruction_upcast}  $0, bf_lo;\n" "}"
+        packed_i32 = llvm.inline_asm(
+            T.i32(),
+            [src_fp32],
+            asm_tmpl,
+            "=r,f",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+
+        vec_hi_ty = ir.Type.parse(upcast_vec_ty)
+        bf2_lo = llvm.bitcast(vec_hi_ty, packed_i32, loc=loc, ip=ip)
+        h0 = vector.extract(bf2_lo, [], [0], loc=loc, ip=ip)
+        dst_f32 = arith.extf(Float32.mlir_type, h0, loc=loc, ip=ip)
+
+        return dst_f32
+
+    @cute.jit
+    def quant_sfd_row(
+        self,
+        tile_idx,
+        tiled_copy_r2s,
+        src,
+        pvscale,
+        norm_const,
+        rcp_limit,
+        tRSrD,
+        sfd2_descale=None,
+    ) -> None:
+        # NOTE: `sfd2_descale` is the per-thread (per-row) second-level block
+        # descale (block_amax / (E2M1_MAX*E4M3_MAX)), read back from the sfd2
+        # gmem atomic-max reduction after pass 1 (see the pass-2 read-back in
+        # the epilogue) so it covers the FULL block even when one block spans
+        # multiple N work-tiles (sfd2_n_contrib > 1). Its reciprocal is folded
+        # into the first-level (row-wise) SFD scale below, so the e4m3 SF
+        # absorbs the per-block second-level magnitude.
+        # Get absolute max across a vector and Compute SFD
+        tCompute = cute.make_rmem_tensor(src.shape, self.acc_dtype)
+        tCompute.store(src)
+        tTR_rAcc_frg = cute.logical_divide(tCompute, cute.make_layout(self.sf_vec_size))
+        acc_frg = tTR_rAcc_frg.load()
+        abs_acc_frg_ir = cutlass._mlir.dialects.math.absf(acc_frg.ir_value())
+        abs_acc_frg = type(acc_frg)(abs_acc_frg_ir, acc_frg.shape, acc_frg.dtype)
+
+        sfd2_scale = cute.arch.rcp_approx(sfd2_descale)
+
+        for vi in cutlass.range_constexpr(abs_acc_frg.shape[1]):
+            pvscale[vi, None, tile_idx][0] = (
+                abs_acc_frg[None, vi].reduce(
+                    cute.ReductionOp.MAX,
+                    cutlass.Float32(0.0),
+                    0,  # Use 0.0 as init for abs values
+                )
+                * rcp_limit
+                * norm_const
+                * sfd2_scale
+            )
+
+        #
+        # Compute quantized output values and convert to D type
+        #
+
+        fp32_max = cutlass.Float32(3.40282346638528859812e38)
+        if cutlass.const_expr(self.vectorized_f32):
+            for vi in cutlass.range_constexpr(0, abs_acc_frg.shape[1], 2):
+                qpvscale_up_0 = self.cvt_f32_to_f8_to_f32(pvscale[vi, None, tile_idx][0], self.sf_dtype)
+                qpvscale_up_1 = self.cvt_f32_to_f8_to_f32(pvscale[vi + 1, None, tile_idx][0], self.sf_dtype)
+                acc_scale = cute.arch.mul_packed_f32x2(
+                    (
+                        cute.arch.rcp_approx(qpvscale_up_0),
+                        cute.arch.rcp_approx(qpvscale_up_1),
+                    ),
+                    (norm_const, norm_const),
+                )
+                acc_scale_min0 = fmin(acc_scale[0], fp32_max, nan=True)
+                acc_scale_min1 = fmin(acc_scale[1], fp32_max, nan=True)
+                vec0 = tTR_rAcc_frg[None, vi]
+                vec1 = tTR_rAcc_frg[None, vi + 1]
+                for ei in cutlass.range_constexpr(self.sf_vec_size):
+                    (
+                        vec0[ei],
+                        vec1[ei],
+                    ) = cute.arch.mul_packed_f32x2(
+                        (vec0[ei], vec1[ei]),
+                        (acc_scale_min0, acc_scale_min1),
+                        rnd="rn",
+                        ftz=False,
+                    )
+        else:
+            for vi in cutlass.range_constexpr(abs_acc_frg.shape[1]):
+                qpvscale_up = self.cvt_f32_to_f8_to_f32(pvscale[vi, None, tile_idx][0], self.sf_dtype)
+                acc_scale = norm_const * cute.arch.rcp_approx(qpvscale_up)
+                acc_scale = fmin(acc_scale, fp32_max, nan=True)
+                vec = tTR_rAcc_frg[None, vi]
+                for ei in cutlass.range_constexpr(self.sf_vec_size):
+                    vec[ei] = vec[ei] * acc_scale
+
+        acc_vec = tiled_copy_r2s.retile(tCompute).load()
+        if cutlass.const_expr(not self.use_fp8_ptx_cvt):
+            tRSrD.store(acc_vec.to(self.d_dtype))
+        else:
+            tRSrD_i32 = cute.recast_tensor(tRSrD, cutlass.Int32)
+            for ei in cutlass.range_constexpr(0, self.sf_vec_size, 4):
+                fp32x4 = cute.make_rmem_tensor(4, cutlass.Float32)
+                fp32x4[0] = acc_vec[ei + 0]
+                fp32x4[1] = acc_vec[ei + 1]
+                fp32x4[2] = acc_vec[ei + 2]
+                fp32x4[3] = acc_vec[ei + 3]
+                fp8x4_i32 = self.cvt_f32x4_to_f8x4_pack_i32(fp32x4, self.d_dtype)
+                tRSrD_i32[ei // 4] = cutlass.Int32(fp8x4_i32)
+
+    @cute.jit
+    def stg_256(self, ptr, vec8_f32, *, loc=None, ip=None):
+        """
+        Store 8xf32 (256b) to global memory with L1::no_allocate.
+        ptr: pointer (byte addressable)
+        vec8_f32: vector<8xf32> to store
+        """
+        dst = ptr.ir_value(loc=loc, ip=ip) if hasattr(ptr, "ir_value") else ptr
+        src = vec8_f32.ir_value(loc=loc, ip=ip) if hasattr(vec8_f32, "ir_value") else vec8_f32
+        dummy = llvm.inline_asm(
+            T.i32(),
+            [
+                dst,
+                vector.extract(src, [], [0], loc=loc, ip=ip),
+                vector.extract(src, [], [1], loc=loc, ip=ip),
+                vector.extract(src, [], [2], loc=loc, ip=ip),
+                vector.extract(src, [], [3], loc=loc, ip=ip),
+                vector.extract(src, [], [4], loc=loc, ip=ip),
+                vector.extract(src, [], [5], loc=loc, ip=ip),
+                vector.extract(src, [], [6], loc=loc, ip=ip),
+                vector.extract(src, [], [7], loc=loc, ip=ip),
+            ],
+            "st.global.L1::no_allocate.v8.f32 [$1], {$2, $3, $4, $5, $6, $7, $8, $9}; mov.u32 $0, 0;",
+            "=r,l,f,f,f,f,f,f,f,f",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+
+    @cute.jit
+    def store_global_memory_256b(self, dst: cute.Tensor, src: cute.Tensor):
+        vec_shape = cute.make_layout(8)
+        dst_f32 = cute.flatten(cute.recast_tensor(dst, cutlass.Float32))
+        src_f32 = cute.flatten(cute.recast_tensor(src, cutlass.Float32))
+        dst_vf32x8 = cute.logical_divide(dst_f32, vec_shape)
+        src_vf32x8 = cute.logical_divide(src_f32, vec_shape)
+        for ei in cutlass.range_constexpr(dst_vf32x8.shape[1]):
+            self.stg_256(dst_vf32x8[None, ei].iterator.llvm_ptr, src_vf32x8[None, ei].load())
+
+    @cute.jit
+    def dbias_reduction(
+        self,
+        d1_vec,
+        d2_vec,
+        warp_idx,
+        sDbias,
+        dbias_gmem_2d,
+        expert_idx,
+        n_base_d1,
+        n_base_d2,
+        dbias_n_total,
+    ) -> None:
+        """Merged dy1+dy2 dbias reduction via SMEM transpose."""
+        epi_n = self.epi_tile[1]
+        lane_idx = cute.arch.lane_idx()
+        warp_local = warp_idx - self.epilog_warp_id[0]
+
+        for n in cutlass.range(epi_n, unroll_full=True):
+            sDbias[(n, lane_idx, warp_local)] = d1_vec[n]
+            sDbias[(epi_n + n, lane_idx, warp_local)] = d2_vec[n]
+
+        self.epilog_sync_barrier.arrive_and_wait()
+
+        col_a = 2 * lane_idx if lane_idx < 16 else epi_n + 2 * (lane_idx - 16)
+        col_b = col_a + 1
+
+        copy_128bit_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), cutlass.Float32, num_bits_per_copy=128)
+        warp_base_ptr = sDbias.iterator + warp_local * epi_n * 2 * 32
+        swizzle_a = ((col_a >> 1) & 0x7) << 2
+        swizzle_b = ((col_b >> 1) & 0x7) << 2
+
+        sum_a = cutlass.Float32(0.0)
+        sum_b = cutlass.Float32(0.0)
+        rDst_a = cute.make_rmem_tensor(cute.make_layout((4,)), cutlass.Float32)
+        rDst_b = cute.make_rmem_tensor(cute.make_layout((4,)), cutlass.Float32)
+        for g in cutlass.range(8, unroll_full=True):
+            m_base = g * 4
+            sw_offset_a = col_a * 32 + (m_base ^ swizzle_a)
+            sSrc_a = cute.make_tensor(warp_base_ptr + sw_offset_a, cute.make_layout((4,)))
+            cute.copy_atom_call(copy_128bit_atom, sSrc_a, rDst_a)
+
+            sw_offset_b = col_b * 32 + (m_base ^ swizzle_b)
+            sSrc_b = cute.make_tensor(warp_base_ptr + sw_offset_b, cute.make_layout((4,)))
+            cute.copy_atom_call(copy_128bit_atom, sSrc_b, rDst_b)
+
+            for i in cutlass.range(4, unroll_full=True):
+                sum_a = sum_a + rDst_a[i]
+                sum_b = sum_b + rDst_b[i]
+
+        n_offset = (n_base_d1 + 2 * lane_idx) if lane_idx < 16 else (n_base_d2 + 2 * (lane_idx - 16))
+
+        if cutlass.const_expr(self.dbias_cross_warp_reduce):
+            reduce_base = sDbias.iterator
+            copy_64bit_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), cutlass.Float32, num_bits_per_copy=64)
+
+            self.epilog_sync_barrier.arrive_and_wait()
+            rSrc_partial = cute.make_rmem_tensor(cute.make_layout((2,)), cutlass.Float32)
+            rSrc_partial[0] = sum_a
+            rSrc_partial[1] = sum_b
+            sDst_partial = cute.make_tensor(reduce_base + warp_local * 64 + lane_idx * 2, cute.make_layout((2,)))
+            cute.copy_atom_call(copy_64bit_atom, rSrc_partial, sDst_partial)
+            self.epilog_sync_barrier.arrive_and_wait()
+
+            if warp_idx == self.epilog_warp_id[0]:
+                cta_sum_a = cutlass.Float32(0.0)
+                cta_sum_b = cutlass.Float32(0.0)
+                rDst_w = cute.make_rmem_tensor(cute.make_layout((2,)), cutlass.Float32)
+                for w in cutlass.range(self.num_epilog_warps):
+                    sSrc_w = cute.make_tensor(reduce_base + w * 64 + lane_idx * 2, cute.make_layout((2,)))
+                    cute.copy_atom_call(copy_64bit_atom, sSrc_w, rDst_w)
+                    cta_sum_a = cta_sum_a + rDst_w[0]
+                    cta_sum_b = cta_sum_b + rDst_w[1]
+                if n_offset < dbias_n_total:
+                    # f32 dbias accumulator (TESTING ONLY, selected by the dbias
+                    # tensor dtype): plain f32 atomics per column instead of the
+                    # packed bf16x2 reduction.
+                    if cutlass.const_expr(dbias_gmem_2d.element_type == cutlass.Float32):
+                        _ = atomic_add_float32(
+                            ptr=dbias_gmem_2d[(expert_idx, n_offset, None)].iterator.llvm_ptr,
+                            value=cta_sum_a,
+                        )
+                        _ = atomic_add_float32(
+                            ptr=dbias_gmem_2d[(expert_idx, n_offset + 1, None)].iterator.llvm_ptr,
+                            value=cta_sum_b,
+                        )
+                    else:
+                        gmem_ptr = dbias_gmem_2d[(expert_idx, n_offset, None)].iterator.llvm_ptr
+                        atomic_add_bf16x2(gmem_ptr, cta_sum_a, cta_sum_b)
+        else:
+            if n_offset < dbias_n_total:
+                if cutlass.const_expr(dbias_gmem_2d.element_type == cutlass.Float32):
+                    _ = atomic_add_float32(
+                        ptr=dbias_gmem_2d[(expert_idx, n_offset, None)].iterator.llvm_ptr,
+                        value=sum_a,
+                    )
+                    _ = atomic_add_float32(
+                        ptr=dbias_gmem_2d[(expert_idx, n_offset + 1, None)].iterator.llvm_ptr,
+                        value=sum_b,
+                    )
+                else:
+                    gmem_ptr = dbias_gmem_2d[(expert_idx, n_offset, None)].iterator.llvm_ptr
+                    atomic_add_bf16x2(gmem_ptr, sum_a, sum_b)
+
+    @cute.jit
+    def dswiglu(
+        self,
+        acc_vec: cute.Tensor,
+        ab1_vec_load: cute.Tensor,
+        ab2_vec_load: cute.Tensor,
+        mProb: cute.Tensor,
+        beta_val: Float32,
+        square_alpha: Float32,
+        dprob_swiglu: Optional[cute.Tensor] = None,
+    ):
+        # Compile-time GLU params (baked from the kernel object).
+        dglu_alpha = self.glu_alpha
+        dglu_clamp_max = self.glu_clamp_max
+        dglu_clamp_min = self.glu_clamp_min
+        LOG2_E = cutlass.Float32(1.4426950408889634)
+        if cutlass.const_expr(self.vectorized_f32):
+            ab1_vec_f32 = cute.make_rmem_tensor(ab1_vec_load.shape, cutlass.Float32)
+            ab2_vec_f32 = cute.make_rmem_tensor(ab2_vec_load.shape, cutlass.Float32)
+            for i in cutlass.range_constexpr(cute.size(ab1_vec_load)):
+                ab1_vec_f32[i] = ab1_vec_load[i].to(cutlass.Float32)
+                ab2_vec_f32[i] = ab2_vec_load[i].to(cutlass.Float32)
+            ab1_vec_load = ab1_vec_f32
+            ab2_vec_load = ab2_vec_f32
+            d1_vec = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
+            d2_vec = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
+            for i in cutlass.range(0, cute.size(acc_vec), 2, unroll_full=True):
+                # Apply scaling factors for FP8
+                (
+                    acc_vec[i + 0],
+                    acc_vec[i + 1],
+                ) = cute.arch.mul_packed_f32x2(
+                    (acc_vec[i + 0], acc_vec[i + 1]),
+                    (square_alpha, square_alpha),
+                    rnd="rn",
+                    ftz=False,
+                )
+                if cutlass.const_expr(dglu_alpha is not None and dglu_alpha != 1.0):
+                    (
+                        acc_vec[i + 0],
+                        acc_vec[i + 1],
+                    ) = cute.arch.mul_packed_f32x2(
+                        (acc_vec[i + 0], acc_vec[i + 1]),
+                        (dglu_alpha, dglu_alpha),
+                        rnd="rn",
+                        ftz=False,
+                    )
+
+                if cutlass.const_expr(dglu_clamp_max is not None and dglu_clamp_min is not None):
+                    ab1_vec_load[i + 0] = fmin(ab1_vec_load[i + 0], dglu_clamp_max)
+                    ab1_vec_load[i + 1] = fmin(ab1_vec_load[i + 1], dglu_clamp_max)
+                    ab2_vec_load[i + 0] = fmin(ab2_vec_load[i + 0], dglu_clamp_max)
+                    ab2_vec_load[i + 1] = fmin(ab2_vec_load[i + 1], dglu_clamp_max)
+                    ab2_vec_load[i + 0] = fmax(ab2_vec_load[i + 0], dglu_clamp_min)
+                    ab2_vec_load[i + 1] = fmax(ab2_vec_load[i + 1], dglu_clamp_min)
+
+                ab1_vec_acc_type = cute.arch.mul_packed_f32x2(
+                    (
+                        ab1_vec_load[i + 0].to(self.acc_dtype),
+                        ab1_vec_load[i + 1].to(self.acc_dtype),
+                    ),
+                    (beta_val, beta_val),
+                    rnd="rn",
+                    ftz=False,
+                )
+                ab2_vec_acc_type = cute.arch.mul_packed_f32x2(
+                    (
+                        ab2_vec_load[i + 0].to(self.acc_dtype),
+                        ab2_vec_load[i + 1].to(self.acc_dtype),
+                    ),
+                    (beta_val, beta_val),
+                    rnd="rn",
+                    ftz=False,
+                )
+                sig_rcp_0, sig_rcp_1 = cute.arch.mul_packed_f32x2(
+                    (ab1_vec_acc_type),
+                    (-LOG2_E, -LOG2_E),
+                    rnd="rn",
+                    ftz=False,
+                )
+                sig_rcp_0, sig_rcp_1 = cute.arch.add_packed_f32x2(
+                    (
+                        cute.math.exp2(sig_rcp_0, fastmath=True),
+                        cute.math.exp2(sig_rcp_1, fastmath=True),
+                    ),
+                    (1.0, 1.0),
+                    rnd="rn",
+                    ftz=False,
+                )
+                sig = (
+                    cute.arch.rcp_approx(sig_rcp_0),
+                    cute.arch.rcp_approx(sig_rcp_1),
+                )
+                swish = cute.arch.mul_packed_f32x2(
+                    ab1_vec_acc_type,
+                    sig,
+                    rnd="rn",
+                    ftz=False,
+                )
+                # calculate dprob
+                if cutlass.const_expr(self.generate_dprob):
+                    (
+                        dprob_swiglu[i + 0],
+                        dprob_swiglu[i + 1],
+                    ) = cute.arch.mul_packed_f32x2(
+                        (ab2_vec_acc_type[0], ab2_vec_acc_type[1]),
+                        swish,
+                    )
+                    (
+                        dprob_swiglu[i + 0],
+                        dprob_swiglu[i + 1],
+                    ) = cute.arch.mul_packed_f32x2(
+                        (dprob_swiglu[i + 0], dprob_swiglu[i + 1]),
+                        (acc_vec[i + 0], acc_vec[i + 1]),
+                    )
+                # calculate dswiglu
+                acc_vec_prob = cute.arch.mul_packed_f32x2(
+                    (acc_vec[i + 0], acc_vec[i + 1]),
+                    (mProb, mProb),
+                )
+                # calculate d2_vec
+                (
+                    d2_vec[i + 0],
+                    d2_vec[i + 1],
+                ) = cute.arch.mul_packed_f32x2(
+                    (acc_vec_prob[0], acc_vec_prob[1]),
+                    swish,
+                    rnd="rn",
+                    ftz=False,
+                )
+                # calculate d1_vec
+                (
+                    d1_vec[i + 0],
+                    d1_vec[i + 1],
+                ) = cute.arch.mul_packed_f32x2(
+                    (acc_vec_prob[0], acc_vec_prob[1]),
+                    (ab2_vec_acc_type[0], ab2_vec_acc_type[1]),
+                    rnd="rn",
+                    ftz=False,
+                )
+                (
+                    d1_vec[i + 0],
+                    d1_vec[i + 1],
+                ) = cute.arch.mul_packed_f32x2(
+                    (d1_vec[i + 0], d1_vec[i + 1]),
+                    sig,
+                    rnd="rn",
+                    ftz=False,
+                )
+                one_minus_sig = cute.arch.add_packed_f32x2(
+                    (1.0, 1.0),
+                    (-sig[0], -sig[1]),
+                    rnd="rn",
+                    ftz=False,
+                )
+                dsig = cute.arch.mul_packed_f32x2(
+                    ab1_vec_acc_type,
+                    one_minus_sig,
+                    rnd="rn",
+                    ftz=False,
+                )
+                dsig_add_1 = cute.arch.add_packed_f32x2(
+                    (dsig[0], dsig[1]),
+                    (1.0, 1.0),
+                    rnd="rn",
+                    ftz=False,
+                )
+                (
+                    d1_vec[i + 0],
+                    d1_vec[i + 1],
+                ) = cute.arch.mul_packed_f32x2(
+                    (d1_vec[i + 0], d1_vec[i + 1]),
+                    dsig_add_1,
+                    rnd="rn",
+                    ftz=False,
+                )
+            d1_vec = d1_vec.load()
+            d2_vec = d2_vec.load()
+            if cutlass.const_expr(self.generate_dprob):
+                dprob_swiglu = dprob_swiglu.load()
+            return d1_vec, d2_vec, dprob_swiglu
+        else:
+            ab1_f32 = cute.make_rmem_tensor(ab1_vec_load.shape, cutlass.Float32)
+            ab2_f32 = cute.make_rmem_tensor(ab2_vec_load.shape, cutlass.Float32)
+            for i in cutlass.range_constexpr(cute.size(ab1_vec_load)):
+                ab1_f32[i] = ab1_vec_load[i].to(cutlass.Float32)
+                ab2_f32[i] = ab2_vec_load[i].to(cutlass.Float32)
+                if cutlass.const_expr(dglu_clamp_max is not None and dglu_clamp_min is not None):
+                    ab1_f32[i] = fmin(ab1_f32[i], dglu_clamp_max)
+                    ab2_f32[i] = fmin(ab2_f32[i], dglu_clamp_max)
+                    ab2_f32[i] = fmax(ab2_f32[i], dglu_clamp_min)
+            ab1_vec_load = ab1_f32
+            ab2_vec_load = ab2_f32
+
+            acc_vec = acc_vec.load()
+            ab1_vec_load = ab1_vec_load.load()
+            ab2_vec_load = ab2_vec_load.load()
+
+            acc_vec = acc_vec * square_alpha  # apply scale for A*B
+            if cutlass.const_expr(dglu_alpha is not None and dglu_alpha != 1.0):
+                acc_vec = acc_vec * dglu_alpha
+            ab1_vec_load = ab1_vec_load * beta_val  # apply scale for C
+            ab2_vec_load = ab2_vec_load * beta_val  # apply scale for C
+
+            sig_rcp = (1 + cute.math.exp(-1 * ab1_vec_load, True)).to(self.acc_dtype)
+            res = cute.make_rmem_tensor(sig_rcp.shape, cutlass.Float32)
+            res.store(sig_rcp)
+            # let every res[?] be cute.arch.rcp_approx(res[?])
+            [res.__setitem__(i, cute.arch.rcp_approx(res[i])) for i in range(cute.size(res.shape))]
+            sig = res.load()
+            swish = ab1_vec_load * sig
+
+            # calculate dprob
+            if cutlass.const_expr(self.generate_dprob):
+                dprob_swiglu = ab2_vec_load * swish
+                dprob_swiglu = acc_vec * dprob_swiglu
+
+            # calculate dswiglu
+            d1_vec = acc_vec * mProb * ab2_vec_load * sig * (1 + ab1_vec_load * (1 - sig))
+            d2_vec = acc_vec * mProb * swish
+            return d1_vec, d2_vec, dprob_swiglu
+
+    @cute.jit
+    def dgeglu(
+        self,
+        acc_vec: cute.Tensor,
+        x1_vec_load: cute.Tensor,
+        x2_vec_load: cute.Tensor,
+        mProb: cute.Tensor,
+        linear_offset: Float32,
+        dprob_swiglu: Optional[cute.Tensor] = None,
+    ):
+        # Compile-time GLU params (baked from the kernel object).
+        dglu_alpha = self.glu_alpha
+        dglu_clamp_max = self.glu_clamp_max
+        dglu_clamp_min = self.glu_clamp_min
+        if cutlass.const_expr(dglu_clamp_max is None and dglu_clamp_min is None):
+            dglu_clamp_max = 7.0
+            dglu_clamp_min = -7.0
+        if cutlass.const_expr(dglu_alpha is None):
+            dglu_alpha = 1.702
+        LOG2_E = cutlass.Float32(1.4426950408889634)
+        x_dtype = x1_vec_load.element_type
+        geglu_max_value = x_dtype(dglu_clamp_max)
+        geglu_min_value = x_dtype(dglu_clamp_min)
+        geglu_max_value_f32 = cutlass.Float32(dglu_clamp_max)
+        geglu_min_value_f32 = cutlass.Float32(dglu_clamp_min)
+        zero_x_dtype = x_dtype(0.0)
+        fmul2 = partial(cute.arch.mul_packed_f32x2, rnd="rn", ftz=False)
+        fadd2 = partial(cute.arch.add_packed_f32x2, rnd="rn", ftz=False)
+        dglu_alpha_tuple = (dglu_alpha, dglu_alpha)
+        ones2 = (1.0, 1.0)
+        mprob2 = (mProb, mProb)
+        linear_offset2 = (linear_offset, linear_offset)
+
+        if cutlass.const_expr(self.vectorized_f32):
+            dx1_vec = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
+            dx2_vec = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
+            for i in cutlass.range(0, cute.size(acc_vec), 2, unroll_full=True):
+                acc = (acc_vec[i], acc_vec[i + 1])
+                x1_0 = x1_vec_load[i]
+                x1_1 = x1_vec_load[i + 1]
+                x2_0 = x2_vec_load[i]
+                x2_1 = x2_vec_load[i + 1]
+
+                y1_0 = 0.0
+                y1_1 = 0.0
+                y2_0 = 0.0
+                y2_1 = 0.0
+                if cutlass.const_expr(x_dtype == cutlass.BFloat16):
+                    y1_0, y1_1 = fmin_bf16x2(x1_0, x1_1, geglu_max_value, geglu_max_value)
+                    y2_0, y2_1 = fmax_bf16x2(x2_0, x2_1, geglu_min_value, geglu_min_value)
+                    y2_0, y2_1 = fmin_bf16x2(y2_0, y2_1, geglu_max_value, geglu_max_value)
+                    y1_0 = Float32(y1_0)
+                    y1_1 = Float32(y1_1)
+                    y2_0 = Float32(y2_0)
+                    y2_1 = Float32(y2_1)
+                else:
+                    y1_0 = fmin(x1_0, geglu_max_value)
+                    y1_1 = fmin(x1_1, geglu_max_value)
+                    y2_0 = fmin(x2_0, geglu_max_value)
+                    y2_1 = fmin(x2_1, geglu_max_value)
+                    y2_0 = fmax(y2_0, geglu_min_value)
+                    y2_1 = fmax(y2_1, geglu_min_value)
+                    y1_0 = Float32(y1_0)
+                    y1_1 = Float32(y1_1)
+                    y2_0 = Float32(y2_0)
+                    y2_1 = Float32(y2_1)
+
+                y1 = (y1_0, y1_1)
+                y2 = (y2_0, y2_1)
+
+                # y1 = dglu_alpha * x1
+                y1_scaled = fmul2(y1, dglu_alpha_tuple)
+
+                sigmoid_out_0 = sigmoid_f32(y1_scaled[0], fastmath=True)
+                sigmoid_out_1 = sigmoid_f32(y1_scaled[1], fastmath=True)
+
+                # g * sigmoid_out
+                acc_mul_sigmoid_out = fmul2(acc, (sigmoid_out_0, sigmoid_out_1))
+                acc_mul_sigmoid_prob = fmul2(acc_mul_sigmoid_out, mprob2)
+
+                # y1 = 1 + dglu_alpha * y1 * (1 - sigmoid_out)
+                one_minus_sigmoid_0, one_minus_sigmoid_1 = fadd2(ones2, (-sigmoid_out_0, -sigmoid_out_1))
+                y1_scaled = fadd2(
+                    fmul2(y1_scaled, (one_minus_sigmoid_0, one_minus_sigmoid_1)),
+                    ones2,
+                )
+
+                # y2 + linear_offset
+                y2_with_linear_offset_0, y2_with_linear_offset_1 = fadd2(y2, linear_offset2)
+
+                # dy1 = g * sigmoid_out * (y2 + linear_offset)
+                dy1_pre_0, dy1_pre_1 = fmul2(
+                    (y2_with_linear_offset_0, y2_with_linear_offset_1),
+                    acc_mul_sigmoid_out,
+                )
+                # dy1 = g * sigmoid_out * (y2 + linear_offset) * (1 + dglu_alpha * y1 * (1 - sigmoid_out)) * mProb
+                dy1_0, dy1_1 = fmul2((dy1_pre_0, dy1_pre_1), y1_scaled)
+                dy1_0, dy1_1 = fmul2((dy1_0, dy1_1), mprob2)
+
+                x1_filter_0 = y1_0 if x1_0 <= geglu_max_value else cutlass.Float32(0.0)
+                x1_filter_1 = y1_1 if x1_1 <= geglu_max_value else cutlass.Float32(0.0)
+
+                dx1_vec[i], dx1_vec[i + 1] = fmul2((dy1_0, dy1_1), (cutlass.Float32(x1_filter_0), cutlass.Float32(x1_filter_1)))
+
+                # dy2 = g * y1 * sigmoid_out * mProb
+                dy2_0, dy2_1 = fmul2(y1, acc_mul_sigmoid_prob)
+                x2_filter_0 = x2_0 if x2_0 <= geglu_max_value else x_dtype(0.0)
+                x2_filter_1 = x2_1 if x2_1 <= geglu_max_value else x_dtype(0.0)
+                x2_filter_0 = y2_0 if x2_filter_0 >= geglu_min_value else cutlass.Float32(0.0)
+                x2_filter_1 = y2_1 if x2_filter_1 >= geglu_min_value else cutlass.Float32(0.0)
+                dx2_vec[i], dx2_vec[i + 1] = fmul2((dy2_0, dy2_1), (cutlass.Float32(x2_filter_0), cutlass.Float32(x2_filter_1)))
+
+                if cutlass.const_expr(self.generate_dprob):
+                    prob_grad, prob_grad_1 = fmul2(
+                        (dy1_pre_0, dy1_pre_1),
+                        y1,
+                    )
+                    dprob_swiglu[i] = prob_grad
+                    dprob_swiglu[i + 1] = prob_grad_1
+            dx1_vec = dx1_vec.load()
+            dx2_vec = dx2_vec.load()
+            if cutlass.const_expr(self.generate_dprob):
+                dprob_swiglu = dprob_swiglu.load()
+            return dx1_vec, dx2_vec, dprob_swiglu
+        else:
+            element_count = cute.size(x1_vec_load)
+            acc_vec = acc_vec.load()
+            x1_vec_load = x1_vec_load.load().to(cutlass.Float32)
+            x2_vec_load = x2_vec_load.load().to(cutlass.Float32)
+            dx1_vec = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
+            dx2_vec = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
+
+            # y1 = clamp(x1, max=7.0); y2 = clamp(x2, min=-7.0, max=7.0)
+            for i in cutlass.range_constexpr(element_count):
+                # dgeglu applies alpha inside the sigmoid, not as an acc scale
+                # (matching the vectorized branch / reference).
+                fc2_dgrad = acc_vec[i]
+                g = fc2_dgrad * mProb
+                y1 = min(x1_vec_load[i], geglu_max_value_f32)
+                y2 = min(x2_vec_load[i], geglu_max_value_f32)
+                y2 = max(y2, geglu_min_value_f32)
+
+                sigmoid_out = sigmoid_f32(y1 * dglu_alpha, fastmath=True)
+
+                dy1 = g * sigmoid_out * (1 + dglu_alpha * y1 * (1 - sigmoid_out)) * (y2 + linear_offset)
+                dy2 = g * y1 * sigmoid_out
+
+                x1_filter = x1_vec_load[i] if x1_vec_load[i] <= geglu_max_value_f32 else 0.0
+                x2_filter = x2_vec_load[i] if x2_vec_load[i] <= geglu_max_value_f32 else 0.0
+                x2_filter = y2 if x2_filter >= geglu_min_value_f32 else 0.0
+
+                dx1_vec[i] = x1_filter * dy1
+                dx2_vec[i] = x2_filter * dy2
+
+                if cutlass.const_expr(self.generate_dprob):
+                    prob_grad = y1 * sigmoid_out * (y2 + linear_offset) * fc2_dgrad
+                    dprob_swiglu[i] = prob_grad
+
+            return dx1_vec.load(), dx2_vec.load(), dprob_swiglu.load()
+
+    # GPU device kernel
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tiled_mma_sfb: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        mSFA_mkl: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        mSFB_nkl: cute.Tensor,
+        sfa2_tensor: cute.Tensor,
+        sfb2_tensor,  # can be cute.Tensor or cute.Pointer
+        sfd2_up_tensor: cute.Tensor,
+        sfd2_gate_tensor: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        tma_atom_d: cute.CopyAtom,
+        mD_mnl: cute.Tensor,
+        mSFDRow_mnl: Optional[cute.Tensor],
+        norm_const_tensor: Optional[cute.Tensor],
+        padded_offsets: cute.Tensor,
+        alpha: cute.Tensor,
+        beta: cute.Tensor,
+        prob: cute.Tensor,
+        dprob: cute.Tensor,
+        linear_offset: Float32,
+        mDbias_tensor: Optional[cute.Tensor],
+        workspace_ptr,
+        cluster_layout_vmnk: cute.Layout,
+        cluster_layout_sfb_vmnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        sfa2_smem_layout_staged: cute.Layout,
+        sfb2_smem_layout_staged: cute.Layout,
+        c_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout, None],
+        d_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout, None],
+        final_acc_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout, None],
+        epi_tile: cute.Tile,
+        sched_params: MoESchedulerParams,
+        epilogue_op: cutlass.Constexpr,
+    ):
+        """
+        GPU device kernel performing the Persistent batched GEMM computation.
+        """
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = tidx // 32
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        lane_idx = cute.arch.lane_idx()
+        total_tokens = padded_offsets[self.expert_cnt - 1]
+
+        #
+        # Prefetch tma desc
+        #
+        if warp_idx == self.tma_warp_id:
+            cpasync.prefetch_descriptor(tma_atom_a)
+            cpasync.prefetch_descriptor(tma_atom_sfa)
+            if cutlass.const_expr(self.weight_mode == MoEWeightMode.DENSE):
+                cpasync.prefetch_descriptor(tma_atom_b)
+                cpasync.prefetch_descriptor(tma_atom_sfb)
+            cpasync.prefetch_descriptor(tma_atom_c)
+            if cutlass.const_expr(not self.store_d_directly):
+                cpasync.prefetch_descriptor(tma_atom_d)
+
+        use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+
+        #
+        # Setup cta/thread coordinates
+        #
+        # Coords inside cluster
+        bidx, bidy, bidz = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
+
+        block_in_cluster_coord_sfb_vmnk = cluster_layout_sfb_vmnk.get_flat_coord(cta_rank_in_cluster)
+
+        #
+        # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
+        #
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+        sched_storage = storage.scheduler
+
+        # Initialize mainloop ab_pipeline (barrier) and states
+        ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_tma_producer = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        ab_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, num_tma_producer)
+        ab_pipeline = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.ab_mbar_ptr.data_ptr(),
+            num_stages=self.num_ab_stage,
+            producer_group=ab_pipeline_producer_group,
+            consumer_group=ab_pipeline_consumer_group,
+            tx_count=self.num_tma_load_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        # Initialize acc_pipeline (barrier) and states
+        # MMA warp produces partial accumulators -> Accumulator update warp consumes
+        acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_acc_consumer_threads = len(self.accumulator_update_warp_id) * (2 if use_2cta_instrs else 1)
+        acc_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, num_acc_consumer_threads)
+        acc_pipeline = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_stage,
+            producer_group=acc_pipeline_producer_group,
+            consumer_group=acc_pipeline_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        # Initialize mainloop scale_pipeline (barrier) and states
+        scale_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * 1,
+        )
+        scale_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * len(self.epilog_warp_id),
+        )
+        scale_pipeline = pipeline.PipelineCpAsync.create(
+            barrier_storage=storage.scale_mbar_ptr.data_ptr(),
+            num_stages=self.num_scale_stage,
+            producer_group=scale_pipeline_producer_group,
+            consumer_group=scale_pipeline_consumer_group,
+            defer_sync=True,
+        )
+
+        # Initialize epi_pipeline (barrier) connecting accumulator update -> epilogue
+        epi_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, self.threads_per_warp * len(self.accumulator_update_warp_id))
+        epi_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, self.threads_per_warp * len(self.epilog_warp_id))
+        epi_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.epi_mbar_ptr.data_ptr(),
+            num_stages=self.num_epi_stage,
+            producer_group=epi_pipeline_producer_group,
+            consumer_group=epi_pipeline_consumer_group,
+        )
+
+        # Initialize mainloop scale_pipeline (barrier) and states
+        scale_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * 1,
+        )
+        scale_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * len(self.epilog_warp_id),
+        )
+        scale_pipeline = pipeline.PipelineCpAsync.create(
+            barrier_storage=storage.scale_mbar_ptr.data_ptr(),
+            num_stages=self.num_scale_stage,
+            producer_group=scale_pipeline_producer_group,
+            consumer_group=scale_pipeline_consumer_group,
+            defer_sync=True,
+        )
+
+        # Load C pipeline
+        # Threads/warps participating in tma store pipeline
+        c_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        c_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            len(self.epilog_warp_id),
+        )
+        c_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.c_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_c_stage,
+            producer_group=c_producer_group,
+            consumer_group=c_consumer_group,
+            tx_count=self.tma_c_load_bytes,
+            defer_sync=True,
+        )
+
+        # Initialize tile info pipeline (barrier) and states
+        tile_info_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * 1,
+        )
+        tile_info_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_wo_sched,
+        )
+        tile_info_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=sched_storage.tile_info_mbar.data_ptr(),
+            num_stages=self.num_tile_stage,
+            producer_group=tile_info_pipeline_producer_group,
+            consumer_group=tile_info_pipeline_consumer_group,
+        )
+
+        scheduler = MoEPersistentTileScheduler.create(
+            sched_params,
+            padded_offsets,
+            cute.arch.block_idx(),
+            cute.arch.grid_dim(),
+            counter_ptr=self._get_sched_counter_ptr(workspace_ptr),
+            sched_storage=sched_storage,
+        )
+        scheduler.internal_init()
+
+        # dBias SMEM setup
+        if cutlass.const_expr(self.generate_dbias):
+            sDbias = storage.sDbias.get_tensor(
+                cute.make_layout(
+                    (self.epi_tile[1] * 2, 32, len(self.epilog_warp_id)),
+                    stride=(32, 1, self.epi_tile[1] * 2 * 32),
+                )
+            )
+
+        # Tensor memory dealloc barrier init
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr,
+            barrier_for_retrieve=self.tmem_alloc_barrier,
+            allocator_warp_id=self.epilog_warp_id[0],
+            is_two_cta=use_2cta_instrs,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr.ptr,
+        )
+
+        # DSMEM rowwise-sfd2 reduction state (sgn/cta_n == cluster_n): the
+        # cluster_n N-peers red.shared::cluster-max their row-descale
+        # partials into EACH peer's sSfd2RowDsmem parity slot; a
+        # cluster_n-arrival mbarrier per parity replaces the gmem counter +
+        # acquire spin between pass 1 and pass 2.
+        if cutlass.const_expr(self.row_dsmem):
+            sSfd2RowDsmem = storage.sSfd2RowDsmem.get_tensor(cute.make_layout((2 * 2 * self.cta_tile_shape_mnk_d[0],)))
+            row_dsmem_mbar = storage.row_dsmem_mbar_ptr.data_ptr()
+            if warp_idx == 0:
+                with cute.arch.elect_one():
+                    cute.arch.mbarrier_init(row_dsmem_mbar + 0, self.cluster_shape_mn[1])
+                    cute.arch.mbarrier_init(row_dsmem_mbar + 1, self.cluster_shape_mn[1])
+                cute.arch.mbarrier_init_fence()
+                _rdsm_lane = cute.arch.lane_idx()
+                for _rdsm_zi in cutlass.range_constexpr(2 * 2 * self.cta_tile_shape_mnk_d[0] // 32):
+                    sSfd2RowDsmem[_rdsm_zi * 32 + _rdsm_lane] = Float32(0.0)
+                # Publish the zeroes at cluster scope: the peer's first reds
+                # into this buffer follow its cluster_wait (the relaxed
+                # arrive below carries no release — this fence does).
+                cute.arch.fence_acq_rel_cluster()
+
+        # Cluster arrive after barrier init
+        if cute.size(self.cluster_shape_mn) > 1:
+            cute.arch.cluster_arrive_relaxed()
+
+        #
+        # Setup smem tensor A/B/D/Scale
+        #
+        # (EPI_TILE_M, EPI_TILE_N, STAGE)
+        sC = storage.sC.get_tensor(c_smem_layout_staged.outer, swizzle=c_smem_layout_staged.inner)
+        sD = None
+        if cutlass.const_expr(not self.store_d_directly):
+            sD = storage.sD.get_tensor(d_smem_layout_staged.outer, swizzle=d_smem_layout_staged.inner)
+        # Full-CTA-tile final accumulator buffer (always allocated)
+        sFinalAcc = storage.sFinalAcc.get_tensor(final_acc_smem_layout_staged.outer, swizzle=final_acc_smem_layout_staged.inner)
+        # bf16 alias of the same bytes for the NVFP4 dGLU relay (see the epilogue).
+        # Built here, outside the warp-dispatch `if`: `storage` is a plain Python
+        # struct the 4.5 wheel cannot carry across a dynamic-if region boundary.
+        sFinalAccBf16 = None
+        if cutlass.const_expr(self.generate_sfd):
+            dglu_bf16_layout = sm100_utils.make_smem_layout_epi(
+                cutlass.BFloat16,
+                self.d_layout,
+                self.epi_tile,
+                self.final_acc_subtile_cnt * 2 * self.num_epi_stage,
+            )
+            sFinalAccBf16 = storage.sFinalAcc.get_tensor(
+                dglu_bf16_layout.outer,
+                swizzle=dglu_bf16_layout.inner,
+                dtype=cutlass.BFloat16,
+            )
+        # SFD row-stage SMEM tensor: same 4.5-wheel constraint as sFinalAccBf16 —
+        # derive it from `storage` out here (the epilogue's dynamic warp-dispatch
+        # `if` cannot carry the plain `storage` struct across its region boundary).
+        sSFDRowStage_flat = None
+        if cutlass.const_expr(self.generate_sfd):
+            # regPerSubtile == 4 in the epilogue SFD path.
+            _sfd_stage_size = 128 * 32 * 4 // self.sf_vec_size
+            sSFDRowStage_flat = storage.sSFDRowStage.get_tensor(cute.make_layout(_sfd_stage_size))
+        # (MMA, MMA_M, MMA_K, STAGE)
+        sA = storage.sA.get_tensor(a_smem_layout_staged.outer, swizzle=a_smem_layout_staged.inner)
+        # (MMA, MMA_N, MMA_K, STAGE)
+        sB = storage.sB.get_tensor(b_smem_layout_staged.outer, swizzle=b_smem_layout_staged.inner)
+        # (granularity_m, repeat_m), (granularity_k, repeat_k), num_scale_stage)
+        sSFA = storage.sSFA.get_tensor(sfa_smem_layout_staged)
+        # (granularity_n, repeat_n), (granularity_k, repeat_k), num_scale_stage)
+        sSFB = storage.sSFB.get_tensor(sfb_smem_layout_staged)
+        # (MMA, MMA_M, MMA_K, STAGE)
+        sSFA2 = storage.sSFA2.get_tensor(sfa2_smem_layout_staged)
+        # (MMA, MMA_N, MMA_K, STAGE)
+        sSFB2 = storage.sSFB2.get_tensor(sfb2_smem_layout_staged)
+        # (expert_idx, tile_m_idx, tile_n_idx, k_tile_cnt)
+        info_layout = cute.make_layout((4, self.num_tile_stage), stride=(1, 4))
+        sInfo = sched_storage.sInfo.get_tensor(info_layout)
+
+        #
+        # Compute multicast mask for A/B buffer full
+        #
+        a_full_mcast_mask = None
+        b_full_mcast_mask = None
+        sfa_full_mcast_mask = None
+        sfb_full_mcast_mask = None
+        if cutlass.const_expr(self.is_a_mcast or self.is_b_mcast or use_2cta_instrs):
+            a_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2)
+            b_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1)
+            sfa_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2)
+            sfb_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_sfb_vmnk, block_in_cluster_coord_sfb_vmnk, mcast_mode=1)
+
+        #
+        # Preparing LDGSTS partition for second level scale factor tensor
+        #
+        atom_scale2_copy = cute.make_copy_atom(
+            cute.nvgpu.cpasync.CopyG2SOp(),
+            self.sf2_dtype,
+            num_bits_per_copy=self.sf2_dtype.width,
+        )
+        tiled_copy_sfa2 = cute.make_tiled_copy_tv(atom_scale2_copy, cute.make_layout((32,)), cute.make_layout((1,)))
+        tiled_copy_sfb2 = cute.make_tiled_copy_tv(atom_scale2_copy, cute.make_layout((32,)), cute.make_layout((1,)))
+
+        thr_copy_sfa2 = tiled_copy_sfa2.get_slice(lane_idx)
+        thr_copy_sfb2 = tiled_copy_sfb2.get_slice(lane_idx)
+        tAsSFA2 = thr_copy_sfa2.partition_D(sSFA2)
+        tBsSFB2 = thr_copy_sfb2.partition_D(sSFB2)
+
+        #
+        # Scale viewed as C tensor
+        #
+        # N/M extents use the CTA-tile-clamped scale block size (scale_size_*),
+        # so the view spans exactly one CTA tile (size * per_tile == cta extent)
+        # regardless of whether sg{m,n} exceed the tile (e.g. sgn=512 > 128).
+        sSFA2_view_as_C_layout = cute.make_layout(
+            (
+                (self.scale_size_m, self.scale_m_per_tile),
+                self.cta_tile_shape_mnk[1],
+                self.num_scale_stage,
+            ),
+            stride=((0, 1), 0, self.scale_m_per_tile),
+        )
+        sSFB2_view_as_C_layout = cute.make_layout(
+            (
+                self.cta_tile_shape_mnk[0],
+                (self.scale_size_n, self.scale_n_per_tile),
+                self.num_scale_stage,
+            ),
+            stride=(0, (0, 1), self.scale_n_per_tile),
+        )
+        sSFA2_view_as_C = cute.make_tensor(sSFA2.iterator, sSFA2_view_as_C_layout)
+        sSFB2_view_as_C = cute.make_tensor(sSFB2.iterator, sSFB2_view_as_C_layout)
+
+        # Calculating number of k_tiles which share the same scale factor
+        k_tile_same_scale_factor = self.sgk // self.mma_tiler[2]
+        # Partition shared/tensor memory tensor for TiledMMA_A/B/D
+        # (SMEM/TMEM partitions stay global - they don't depend on per-expert tensors)
+        #
+        # (MMA, MMA_M, MMA_K, STAGE)
+        tCrA = tiled_mma.make_fragment_A(sA)
+        # (MMA, MMA_N, MMA_K, STAGE)
+        tCrB = tiled_mma.make_fragment_B(sB)
+        # (MMA, MMA_M, MMA_N)
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+        # (MMA, MMA_M, MMA_N, STAGE)
+        tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, self.num_acc_stage))
+
+        #
+        # Cluster wait before tensor memory alloc
+        #
+        if cute.size(self.cluster_shape_mn) > 1:
+            cute.arch.cluster_wait()
+        else:
+            self.cta_sync_barrier.arrive_and_wait()
+
+        if total_tokens <= 0:
+            cute.arch.nvvm.exit()
+        k_tile_cnt = cute.ceil_div(cute.size(mB_nkl, mode=[1]), self.mma_tiler[2])
+
+        #
+        # Specialized Schedule warp (MoE Persistent Tile Scheduler)
+        #
+        if warp_idx == self.sched_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_sched_warps)
+            work_tile_info = scheduler.initial_work_tile_info()
+
+            tile_info_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_tile_stage)
+
+            while work_tile_info.is_valid_tile:
+                # sInfo format: (expert_idx, tile_m_idx, tile_n_idx, k_tile_cnt)
+                tile_info_pipeline.producer_acquire(tile_info_producer_state)
+                with cute.arch.elect_one():
+                    sInfo[(0, tile_info_producer_state.index)] = work_tile_info.expert_idx
+                    sInfo[(1, tile_info_producer_state.index)] = work_tile_info.tile_m_idx
+                    sInfo[(2, tile_info_producer_state.index)] = work_tile_info.tile_n_idx
+                    sInfo[(3, tile_info_producer_state.index)] = work_tile_info.k_tile_cnt
+                cute.arch.fence_proxy("async.shared", space="cta")
+
+                self.sched_sync_barrier.arrive_and_wait()
+                tile_info_pipeline.producer_commit(tile_info_producer_state)
+                tile_info_producer_state.advance()
+
+                work_tile_info = scheduler.advance_to_next_work()
+
+            # Send invalid tile signal: expert_idx = -1
+            tile_info_pipeline.producer_acquire(tile_info_producer_state)
+            with cute.arch.elect_one():
+                sInfo[(0, tile_info_producer_state.index)] = cutlass.Int32(-1)
+                sInfo[(1, tile_info_producer_state.index)] = cutlass.Int32(0)
+                sInfo[(2, tile_info_producer_state.index)] = cutlass.Int32(0)
+                sInfo[(3, tile_info_producer_state.index)] = cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            self.sched_sync_barrier.arrive_and_wait()
+            tile_info_pipeline.producer_commit(tile_info_producer_state)
+            tile_info_producer_state.advance()
+            tile_info_pipeline.producer_tail(tile_info_producer_state)
+
+        #
+        # Specialized TMA load warp
+        #
+        if warp_idx == self.tma_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_uniform_warps)
+            ext = self._make_extension(workspace_ptr)
+
+            ab_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_ab_stage)
+
+            tile_info_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_tile_stage)
+
+            # Get the first tile info
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            while is_valid_tile:
+                work_tile_info = MoEWorkTileInfo(
+                    expert_idx=tile_info[0],
+                    tile_m_idx=tile_info[1],
+                    tile_n_idx=tile_info[2],
+                    k_tile_cnt=tile_info[3],
+                )
+                # assert(k_tile_cnt == work_tile_info.k_tile_cnt)
+                ext.update_expert_info(padded_offsets, work_tile_info.expert_idx)
+
+                # Get per-expert real tensors + TMA desc ptrs via extension
+                real_a, _ = ext.get_gmem_tensor("a", mA_mkl, padded_offsets, work_tile_info)
+                real_b, desc_ptr_b = ext.get_gmem_tensor("b", mB_nkl, padded_offsets, work_tile_info)
+                real_sfa, _ = ext.get_gmem_tensor("sfa", mSFA_mkl, padded_offsets, work_tile_info)
+                real_sfb, desc_ptr_sfb = ext.get_gmem_tensor("sfb", mSFB_nkl, padded_offsets, work_tile_info)
+
+                # local_tile on per-expert tensors
+                gA_mkl = cute.local_tile(real_a, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None))
+                gB_nkl = cute.local_tile(real_b, cute.slice_(self.mma_tiler, (0, None, None)), (None, None, None))
+                gSFA_mkl = cute.local_tile(real_sfa, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None))
+                gSFB_nkl = cute.local_tile(real_sfb, cute.slice_(self.mma_tiler_sfb, (0, None, None)), (None, None, None))
+
+                # MMA partition
+                thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+                thr_mma_sfb = tiled_mma_sfb.get_slice(mma_tile_coord_v)
+                tCgA = thr_mma.partition_A(gA_mkl)
+                tCgB = thr_mma.partition_B(gB_nkl)
+                tCgSFA = thr_mma.partition_A(gSFA_mkl)
+                tCgSFB = thr_mma_sfb.partition_B(gSFB_nkl)
+
+                # TMA partition A
+                a_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape)
+                tAsA, tAgA = cpasync.tma_partition(
+                    tma_atom_a,
+                    block_in_cluster_coord_vmnk[2],
+                    a_cta_layout,
+                    cute.group_modes(sA, 0, 3),
+                    cute.group_modes(tCgA, 0, 3),
+                )
+                # TMA partition B
+                b_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape)
+                tBsB, tBgB = cpasync.tma_partition(
+                    tma_atom_b,
+                    block_in_cluster_coord_vmnk[1],
+                    b_cta_layout,
+                    cute.group_modes(sB, 0, 3),
+                    cute.group_modes(tCgB, 0, 3),
+                )
+                # TMA partition SFA
+                sfa_cta_layout = a_cta_layout
+                tAsSFA, tAgSFA = cpasync.tma_partition(
+                    tma_atom_sfa,
+                    block_in_cluster_coord_vmnk[2],
+                    sfa_cta_layout,
+                    cute.group_modes(sSFA, 0, 3),
+                    cute.group_modes(tCgSFA, 0, 3),
+                )
+                tAsSFA = cute.filter_zeros(tAsSFA)
+                tAgSFA = cute.filter_zeros(tAgSFA)
+                # TMA partition SFB
+                sfb_cta_layout = cute.make_layout(cute.slice_(cluster_layout_sfb_vmnk, (0, None, 0, 0)).shape)
+                tBsSFB, tBgSFB = cpasync.tma_partition(
+                    tma_atom_sfb,
+                    block_in_cluster_coord_sfb_vmnk[1],
+                    sfb_cta_layout,
+                    cute.group_modes(sSFB, 0, 3),
+                    cute.group_modes(tCgSFB, 0, 3),
+                )
+                tBsSFB = cute.filter_zeros(tBsSFB)
+                tBgSFB = cute.filter_zeros(tBgSFB)
+
+                # Slice to per mma tile index (L=0 since domain already offset'd)
+                mma_tile_coord_m = work_tile_info.tile_m_idx // cute.size(tiled_mma.thr_id.shape)
+                mma_tile_coord_n = work_tile_info.tile_n_idx
+                tAgA_slice = tAgA[(None, mma_tile_coord_m, None, 0)]
+                tBgB_slice = tBgB[(None, mma_tile_coord_n, None, 0)]
+                tAgSFA_slice = tAgSFA[(None, mma_tile_coord_m, None, 0)]
+                slice_n = mma_tile_coord_n
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
+                    slice_n = mma_tile_coord_n // 2
+                tBgSFB_slice = tBgSFB[(None, slice_n, None, 0)]
+
+                # Peek (try_wait) AB buffer empty
+                peek_ab_empty_status = cutlass.Boolean(1)
+                if k_tile_cnt > 0:
+                    peek_ab_empty_status = ab_pipeline.producer_try_acquire(ab_producer_state)
+
+                #
+                # Tma load loop
+                #
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                    tAgA_k = tAgA_slice[(None, k_tile)]
+                    tBgB_k = tBgB_slice[(None, k_tile)]
+                    tAgSFA_k = tAgSFA_slice[(None, k_tile)]
+                    tBgSFB_k = tBgSFB_slice[(None, k_tile)]
+                    tAsA_pipe = tAsA[(None, ab_producer_state.index)]
+                    tBsB_pipe = tBsB[(None, ab_producer_state.index)]
+                    tAsSFA_pipe = tAsSFA[(None, ab_producer_state.index)]
+                    tBsSFB_pipe = tBsSFB[(None, ab_producer_state.index)]
+
+                    tma_bar = ab_pipeline.producer_get_barrier(ab_producer_state)
+
+                    # Conditionally wait for AB buffer empty
+                    ab_pipeline.producer_acquire(ab_producer_state, peek_ab_empty_status)
+                    ab_producer_state_next = ab_producer_state.clone()
+                    ab_producer_state_next.advance()
+                    if k_tile < k_tile_cnt - 1:
+                        peek_ab_empty_status = ab_pipeline.producer_try_acquire(ab_producer_state_next)
+
+                    # TMA load A (contiguous, global desc)
+                    cute.copy(
+                        tma_atom_a,
+                        tAgA_k,
+                        tAsA_pipe,
+                        tma_bar_ptr=tma_bar,
+                        mcast_mask=a_full_mcast_mask,
+                    )
+                    # TMA load B (discrete, per-expert desc from workspace)
+                    cute.copy(
+                        tma_atom_b,
+                        tBgB_k,
+                        tBsB_pipe,
+                        tma_bar_ptr=tma_bar,
+                        mcast_mask=b_full_mcast_mask,
+                        tma_desc_ptr=desc_ptr_b,
+                    )
+                    # TMA load SFA (contiguous, global desc)
+                    cute.copy(
+                        tma_atom_sfa,
+                        tAgSFA_k,
+                        tAsSFA_pipe,
+                        tma_bar_ptr=tma_bar,
+                        mcast_mask=sfa_full_mcast_mask,
+                    )
+                    # TMA load SFB (discrete, per-expert desc from workspace)
+                    cute.copy(
+                        tma_atom_sfb,
+                        tBgSFB_k,
+                        tBsSFB_pipe,
+                        tma_bar_ptr=tma_bar,
+                        mcast_mask=sfb_full_mcast_mask,
+                        tma_desc_ptr=desc_ptr_sfb,
+                    )
+
+                    # Peek (try_wait) AB buffer empty for next k_tile
+                    ab_producer_state = ab_producer_state_next
+
+                #
+                # Advance to next tile
+                #
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+            #
+            # Wait A/B buffer empty
+            #
+            ab_pipeline.producer_tail(ab_producer_state)
+
+        if warp_idx == self.scale_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_uniform_warps)
+
+            # print(f"[{os.path.basename(__file__)}:{inspect.currentframe().f_lineno}] sfa2_tensor: {sfa2_tensor}")
+            # print(f"[{os.path.basename(__file__)}:{inspect.currentframe().f_lineno}] sfb2_tensor: {sfb2_tensor}")
+            ext = self._make_extension(workspace_ptr)
+            scale_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_scale_stage)
+
+            tile_info_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_tile_stage)
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            scale_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_scale_stage)
+
+            while is_valid_tile:
+
+                work_tile_info = MoEWorkTileInfo(
+                    expert_idx=tile_info[0],
+                    tile_m_idx=tile_info[1],
+                    tile_n_idx=tile_info[2],
+                    k_tile_cnt=tile_info[3],
+                )
+                k_tile_cnt = work_tile_info.k_tile_cnt
+                ext.update_expert_info(padded_offsets, work_tile_info.expert_idx)
+
+                mSFA2_mkl_current, _ = ext.get_gmem_tensor("sfa2", sfa2_tensor, padded_offsets, work_tile_info)
+                mSFB2_nkl_current, _ = ext.get_gmem_tensor("sfb2", sfb2_tensor, padded_offsets, work_tile_info)
+
+                # print(f"[{os.path.basename(__file__)}:{inspect.currentframe().f_lineno}] mSFA2_mkl_current.layout: {mSFA2_mkl_current.layout}")
+                # print(f"[{os.path.basename(__file__)}:{inspect.currentframe().f_lineno}] mSFB2_nkl_current.layout: {mSFB2_nkl_current.layout}")
+
+                # if tidx == 352:
+                #    cute.printf("bidx: {}, mSFA2_mkl_current: {}", bidz, mSFA2_mkl_current)
+                #    cute.printf("bidx: {}, mSFB2_nkl_current: {}", bidz, mSFB2_nkl_current)
+
+                gSFA2_mkl = cute.local_tile(mSFA2_mkl_current, cute.slice_(self.cta_tile_shape_mnk, (None, 0, None)), (None, None, None))
+                gSFB2_nkl = cute.local_tile(mSFB2_nkl_current, cute.slice_(self.cta_tile_shape_mnk, (0, None, None)), (None, None, None))
+
+                # Create coordinate tensors
+                cSFA2_mkl = cute.make_identity_tensor(cute.shape(mSFA2_mkl_current))
+                cSFB2_nkl = cute.make_identity_tensor(cute.shape(mSFB2_nkl_current))
+                cSFA2 = cute.local_tile(cSFA2_mkl, cute.slice_(self.cta_tile_shape_mnk, (None, 0, None)), (None, None, None))
+                cSFB2 = cute.local_tile(cSFB2_nkl, cute.slice_(self.cta_tile_shape_mnk, (0, None, None)), (None, None, None))
+                # Partition tensors
+                tAgSFA2_mkl = thr_copy_sfa2.partition_S(gSFA2_mkl)
+                tBgSFB2_nkl = thr_copy_sfb2.partition_S(gSFB2_nkl)
+                tAcSFA2 = thr_copy_sfa2.partition_S(cSFA2)
+                tBcSFB2 = thr_copy_sfb2.partition_S(cSFB2)
+
+                mma_tile_coord_mnl = (work_tile_info.tile_m_idx, work_tile_info.tile_n_idx, 0)
+
+                #
+                # Prepare the mask for scaleA/scaleB
+                #
+                tApSFA2 = cute.make_rmem_tensor(
+                    cute.make_layout(cute.filter_zeros(cute.slice_(tAsSFA2, (None, None, None, 0))).shape),
+                    cutlass.Boolean,
+                )
+                tBpSFB2 = cute.make_rmem_tensor(
+                    cute.make_layout(cute.filter_zeros(cute.slice_(tBsSFB2, (None, None, None, 0))).shape),
+                    cutlass.Boolean,
+                )
+
+                # print(f"[{os.path.basename(__file__)}:{inspect.currentframe().f_lineno}] tApSFA2.layout: {tApSFA2.layout}")
+                # print(f"[{os.path.basename(__file__)}:{inspect.currentframe().f_lineno}] tBpSFB2.layout: {tBpSFB2.layout}")
+
+                # Peek (try_wait) SCALE buffer empty
+                scale_producer_state.reset_count()
+                peek_scale_empty_status = cutlass.Boolean(1)
+                if scale_producer_state.count < k_tile_cnt:
+                    peek_scale_empty_status = scale_pipeline.producer_try_acquire(scale_producer_state)
+
+                #
+                # load loop
+                #
+                for k_tile in cutlass.range(0, k_tile_cnt // k_tile_same_scale_factor, 1, unroll=1):
+                    #
+                    # Slice to per mma tile index
+                    #
+                    tAsSFA2_pipe = cute.filter_zeros(tAsSFA2[(None, None, None, scale_producer_state.index)])
+                    tBsSFB2_pipe = cute.filter_zeros(tBsSFB2[(None, None, None, scale_producer_state.index)])
+
+                    # print(f"[{os.path.basename(__file__)}:{inspect.currentframe().f_lineno}] tAgSFA2_mkl.layout: {tAgSFA2_mkl.layout}")
+                    # print(f"[{os.path.basename(__file__)}:{inspect.currentframe().f_lineno}] tBgSFB2_nkl.layout: {tBgSFB2_nkl.layout}")
+
+                    tAgSFA2_k = cute.filter_zeros(
+                        tAgSFA2_mkl[
+                            (
+                                None,
+                                None,
+                                None,
+                                mma_tile_coord_mnl[0],
+                                scale_producer_state.count * k_tile_same_scale_factor,
+                                mma_tile_coord_mnl[2],
+                            )
+                        ]
+                    )
+                    tBgSFB2_k = cute.filter_zeros(
+                        tBgSFB2_nkl[
+                            (
+                                None,
+                                None,
+                                None,
+                                mma_tile_coord_mnl[1],
+                                scale_producer_state.count * k_tile_same_scale_factor,
+                                mma_tile_coord_mnl[2],
+                            )
+                        ]
+                    )
+
+                    tAcSFA2_compact = cute.filter_zeros(
+                        cute.slice_(
+                            tAcSFA2,
+                            (
+                                None,
+                                None,
+                                None,
+                                mma_tile_coord_mnl[0],
+                                scale_producer_state.count * k_tile_same_scale_factor,
+                                mma_tile_coord_mnl[2],
+                            ),
+                        )
+                    )
+                    tBcSFB2_compact = cute.filter_zeros(
+                        cute.slice_(
+                            tBcSFB2,
+                            (
+                                None,
+                                None,
+                                None,
+                                mma_tile_coord_mnl[1],
+                                scale_producer_state.count * k_tile_same_scale_factor,
+                                mma_tile_coord_mnl[2],
+                            ),
+                        )
+                    )
+
+                    # {$nv-internal-release begin}
+                    # TODO: Skip more unnecessary load
+                    # {$nv-internal-release end}
+                    for i in cutlass.range_constexpr(cute.size(tApSFA2, mode=[1])):
+                        tApSFA2[((0, 0), i, (0, 0))] = cute.elem_less(tAcSFA2_compact[(i)][0], mSFA2_mkl_current.shape[0])
+                    for i in cutlass.range_constexpr(cute.size(tBpSFB2, mode=[1])):
+                        tBpSFB2[((0, 0), i, (0, 0))] = cute.elem_less(tBcSFB2_compact[(i)][0], mSFB2_nkl_current.shape[0])
+
+                    # Conditionally wait for Scale buffer empty
+                    scale_pipeline.producer_acquire(scale_producer_state, peek_scale_empty_status)
+
+                    # load scaleA/scaleB
+                    cute.copy(tiled_copy_sfa2, tAgSFA2_k, tAsSFA2_pipe, pred=tApSFA2)
+                    cute.copy(tiled_copy_sfb2, tBgSFB2_k, tBsSFB2_pipe, pred=tBpSFB2)
+
+                    scale_pipeline.producer_commit(scale_producer_state)
+
+                    # Peek (try_wait) Scale buffer empty
+                    scale_producer_state.advance()
+                    peek_scale_empty_status = cutlass.Boolean(1)
+                    if scale_producer_state.count < k_tile_cnt:
+                        peek_scale_empty_status = scale_pipeline.producer_try_acquire(scale_producer_state)
+
+                # Get next tile from scheduler
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+        #
+        # Specialized MMA warp
+        #
+        if warp_idx == self.mma_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_uniform_warps)
+            #
+            # Bar sync for retrieve tensor memory ptr from shared mem
+            #
+            tmem.wait_for_alloc()
+
+            #
+            # Retrieving tensor memory ptr and make accumulator tensor
+            #
+            acc_tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+
+            # Make SFA tmem tensor
+            sfa_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            # (MMA, MMA_M, MMA_K)
+            tCtSFA_layout = blockscaled_utils.make_tmem_layout_sfa(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfa_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFA = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout)
+
+            # Make SFB tmem tensor
+            sfb_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            # (MMA, MMA_N, MMA_K)
+            tCtSFB_layout = blockscaled_utils.make_tmem_layout_sfb(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfb_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFB = cute.make_tensor(sfb_tmem_ptr, tCtSFB_layout)
+
+            # Partition for S2T copy of SFA/SFB
+            #
+            (
+                tiled_copy_s2t_sfa,
+                tCsSFA_compact_s2t,
+                tCtSFA_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFA, tCtSFA)
+            (
+                tiled_copy_s2t_sfb,
+                tCsSFB_compact_s2t,
+                tCtSFB_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFB, tCtSFB)
+
+            ab_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_ab_stage)
+            acc_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_acc_stage)
+
+            tile_info_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_tile_stage)
+
+            # Get the first tile info (sInfo format: expert_idx, tile_m_idx, tile_n_idx, k_tile_cnt)
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            while is_valid_tile:
+
+                # Peek (try_wait) AB buffer full for k_tile = 0
+                peek_ab_full_status = cutlass.Boolean(1)
+                if k_tile_cnt > 0 and is_leader_cta:
+                    peek_ab_full_status = ab_pipeline.consumer_try_wait(ab_consumer_state)
+
+                # Peek (try_wait) Acc buffer empty for k_tile = 0
+                acc_producer_state.reset_count()
+                peek_acc_empty_status = cutlass.Boolean(1)
+                if acc_producer_state.count < k_tile_cnt and is_leader_cta:
+                    peek_acc_empty_status = acc_pipeline.producer_try_acquire(acc_producer_state)
+
+                # sInfo: (expert_idx, tile_m_idx, tile_n_idx, k_tile_cnt)
+                mma_tile_coord_mnl = (
+                    tile_info[1] // cute.size(tiled_mma.thr_id.shape),
+                    tile_info[2],
+                    cutlass.Int32(0),
+                )
+
+                # Get accumulator stage index
+                acc_stage_index = acc_producer_state.index
+
+                tCtSFB_mma = tCtSFB
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 192):
+                    # If this is an ODD tile, shift the TMEM start address for cta_tile_shape_n=192 case by two words (ignores first 64 columns of SFB)
+                    offset = cutlass.Int32(2) if mma_tile_coord_mnl[1] % 2 == 1 else cutlass.Int32(0)
+                    shifted_ptr = cute.recast_ptr(
+                        acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols + offset,
+                        dtype=self.sf_dtype,
+                    )
+                    tCtSFB_mma = cute.make_tensor(shifted_ptr, tCtSFB_layout)
+                elif cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
+                    # Move in increments of 64 columns of SFB
+                    offset = cutlass.Int32((mma_tile_coord_mnl[1] % 2) * 2)
+                    shifted_ptr = cute.recast_ptr(
+                        acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols + offset,
+                        dtype=self.sf_dtype,
+                    )
+                    tCtSFB_mma = cute.make_tensor(shifted_ptr, tCtSFB_layout)
+
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+
+                    # Set the correct accumulator buffer for each k_tile
+                    tCtAcc = tCtAcc_base[(None, None, None, acc_stage_index)]
+
+                    if k_tile % k_tile_same_scale_factor == 0:
+                        if is_leader_cta:
+                            # Wait for accumulator buffer empty
+                            acc_pipeline.producer_acquire(acc_producer_state, peek_acc_empty_status)
+
+                    # Reset the ACCUMULATE field for each tile
+                    tiled_mma.set(tcgen05.Field.ACCUMULATE, k_tile % k_tile_same_scale_factor > 0)
+
+                    if is_leader_cta:
+                        # Conditionally wait for AB buffer full
+                        ab_pipeline.consumer_wait(ab_consumer_state, peek_ab_full_status)
+                        ab_consumer_state_next = ab_consumer_state.clone()
+                        ab_consumer_state_next.advance()
+                        if k_tile < k_tile_cnt - 1:
+                            peek_ab_full_status = ab_pipeline.consumer_try_wait(ab_consumer_state_next)
+
+                        #  Copy SFA/SFB from smem to tmem
+                        s2t_stage_coord = (
+                            None,
+                            None,
+                            None,
+                            None,
+                            ab_consumer_state.index,
+                        )
+                        tCsSFA_compact_s2t_staged = tCsSFA_compact_s2t[s2t_stage_coord]
+                        tCsSFB_compact_s2t_staged = tCsSFB_compact_s2t[s2t_stage_coord]
+                        cute.copy(
+                            tiled_copy_s2t_sfa,
+                            tCsSFA_compact_s2t_staged,
+                            tCtSFA_compact_s2t,
+                        )
+                        cute.copy(
+                            tiled_copy_s2t_sfb,
+                            tCsSFB_compact_s2t_staged,
+                            tCtSFB_compact_s2t,
+                        )
+
+                        # tCtAcc += tCrA * tCrSFA * tCrB * tCrSFB
+                        num_kblocks = cute.size(tCrA, mode=[2])
+
+                        for kblock_idx in cutlass.range(num_kblocks, unroll_full=True):
+                            kblock_coord = (
+                                None,
+                                None,
+                                kblock_idx,
+                                ab_consumer_state.index,
+                            )
+
+                            # Set SFA/SFB tensor to tiled_mma
+                            sf_kblock_coord = (None, None, kblock_idx)
+                            tiled_mma.set(
+                                tcgen05.Field.SFA,
+                                tCtSFA[sf_kblock_coord].iterator,
+                            )
+                            tiled_mma.set(
+                                tcgen05.Field.SFB,
+                                tCtSFB_mma[sf_kblock_coord].iterator,
+                            )
+
+                            cute.gemm(
+                                tiled_mma,
+                                tCtAcc,
+                                tCrA[kblock_coord],
+                                tCrB[kblock_coord],
+                                tCtAcc,
+                            )
+                            # Enable accumulate on tCtAcc after first kblock
+                            tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+                        # Async arrive AB buffer empty
+                        ab_pipeline.consumer_release(ab_consumer_state)
+                        ab_consumer_state = ab_consumer_state_next
+
+                    if k_tile % k_tile_same_scale_factor == k_tile_same_scale_factor - 1:
+                        if is_leader_cta:
+                            # Async arrive accumulator buffer full(each kblock)
+                            acc_pipeline.producer_commit(acc_producer_state)
+
+                        # Peek (try_wait) Acc buffer empty for k_tile = k_tile + 1
+                        acc_producer_state.advance()
+                        acc_stage_index = acc_producer_state.index
+                        if acc_producer_state.count < k_tile_cnt:
+                            if is_leader_cta:
+                                peek_acc_empty_status = acc_pipeline.producer_try_acquire(acc_producer_state)
+
+                #
+                # Advance to next tile
+                #
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+            #
+            # Wait for accumulator buffer empty
+            #
+            acc_pipeline.producer_tail(acc_producer_state)
+
+        #
+        # Specialized Accumulator Update Warp
+        #
+        # Bounds compare, not `in`: tuple membership makes the 4.5 wheel's AST
+        # if-region flattening choke on captured Python objects.
+        if warp_idx >= self.accumulator_update_warp_id[0] and warp_idx <= self.accumulator_update_warp_id[-1]:
+            cute.arch.setmaxregister_increase(self.num_regs_acc_update_warps)
+            # Wait for TMEM allocation (done by epilogue warp)
+            tmem.wait_for_alloc()
+
+            # Retrieve TMEM pointer and create accumulator tensors
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            # tCtAcc_base: Read partial accumulators from MMA (via acc_pipeline stages)
+            tCtAcc_base = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+
+            # Final accumulated result is written to SMEM (sFinalAcc), not TMEM
+
+            # Shape-only partition on global tensor for partitioning setup
+            thr_mma_epi = tiled_mma.get_slice(mma_tile_coord_v)
+            gD_mnl_shape = cute.local_tile(mD_mnl, cute.slice_(self.mma_tiler_d, (None, None, 0)), (None, None, None))
+            tCgD_shape = thr_mma_epi.partition_C(gD_mnl_shape)
+
+            # Setup copy operations and partition tensors
+            acc_tidx = tidx
+            (
+                tiled_copy_t2r,
+                tiled_copy_r2s_acc,
+                tTR_tAcc_base,
+                tTR_rAcc,
+                tTR_rAcc_final,
+                tRS_sFinalAcc,
+                tTR_sSFA,
+                tTR_sSFB,
+            ) = self.acc_update_tmem_copy_and_partition(
+                acc_tidx,
+                tCtAcc_base,
+                tCgD_shape,
+                sSFA2_view_as_C,
+                sSFB2_view_as_C,
+                sFinalAcc,
+                epi_tile,
+            )
+
+            # Initialize pipeline states
+            # Consumer of acc_pipeline (receives partial accumulators from MMA)
+            acc_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_acc_stage)
+            # consumer of scale_pipeline (receives scale factors from scale load warp)
+            scale_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_scale_stage)
+            # Producer for epi_pipeline (sends final accumulator to epilogue)
+            epi_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_epi_stage)
+
+            # Initialize scheduler consumption
+            tile_info_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_tile_stage)
+
+            # Get first tile info from scheduler
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            # Main tile processing loop
+            while is_valid_tile:
+                # Extract k_tile_cnt from scheduler
+                k_tile_cnt = tile_info[3]
+
+                # Initialize final accumulator to zero
+                tTR_rAcc_final.fill(0.0)
+
+                tTR_rSFA = cute.make_rmem_tensor(
+                    cute.slice_(tTR_sSFA, (None, None, None, 0, None, 0)).shape,
+                    self.acc_dtype,
+                )
+                tTR_rSFB = cute.make_rmem_tensor(
+                    cute.slice_(tTR_sSFB, (None, None, None, 0, None, 0)).shape,
+                    self.acc_dtype,
+                )
+
+                # Reset and peek acc_pipeline (MMA produces partial accumulators)
+                acc_consumer_state.reset_count()
+                peek_acc_full_status = cutlass.Boolean(1)
+                if acc_consumer_state.count < k_tile_cnt:
+                    peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
+
+                # Peek (try_wait) Scale buffer full for k_tile = 0
+                scale_consumer_state.reset_count()
+                peek_scale_full_status = cutlass.Boolean(1)
+                if scale_consumer_state.count < k_tile_cnt:
+                    peek_scale_full_status = scale_pipeline.consumer_try_wait(scale_consumer_state)
+
+                # Loop over k_tiles to accumulate partial accumulators
+                for k_tile_idx in cutlass.range(0, k_tile_cnt // k_tile_same_scale_factor, 1, unroll=1):
+
+                    # Wait for scale buffer full
+                    scale_pipeline.consumer_wait(scale_consumer_state, peek_scale_full_status)
+
+                    tTR_sSFA_slice = cute.slice_(
+                        tTR_sSFA,
+                        (None, None, None, 0, None, scale_consumer_state.index),
+                    )
+                    tTR_sSFB_slice = cute.slice_(
+                        tTR_sSFB,
+                        (None, None, None, 0, None, scale_consumer_state.index),
+                    )
+                    scale_atom_copy = cute.make_copy_atom(
+                        cute.nvgpu.CopyUniversalOp(),
+                        self.acc_dtype,
+                        num_bits_per_copy=self.acc_dtype.width,
+                    )
+
+                    cute.copy(scale_atom_copy, tTR_sSFA_slice, tTR_rSFA)
+                    cute.copy(scale_atom_copy, tTR_sSFB_slice, tTR_rSFB)
+
+                    #
+                    # Async arrive scale buffer empty
+                    #
+                    scale_pipeline.consumer_release(scale_consumer_state)
+                    scale_consumer_state.advance()
+
+                    # Wait for MMA to produce partial accumulator for this k_tile
+                    acc_pipeline.consumer_wait(acc_consumer_state, peek_acc_full_status)
+
+                    # Index into TMEM buffer for current pipeline stage
+                    tTR_tAcc = tTR_tAcc_base[(None, None, None, None, None, acc_consumer_state.index)]
+
+                    # Group modes for subtile iteration
+                    tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+
+                    # Process each subtile (gate/up interleaving handled by layout)
+                    subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+                    scale_a = tTR_rSFA[(None, None, None, 0)].load()
+                    scale_b = tTR_rSFB[(None, None, None, 0)].load()
+                    scale = scale_a * scale_b
+                    for subtile_idx in cutlass.range(subtile_cnt, unroll_full=True):
+                        # Load partial accumulator from TMEM to register
+                        tTR_tAcc_mn = tTR_tAcc[(None, None, None, subtile_idx)]
+                        cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+
+                        # Accumulate: final += partial (no scaling)
+                        tTR_rAcc_subtile = tTR_rAcc_final[(None, None, None, subtile_idx)]
+                        acc_vec = tTR_rAcc.load()
+                        final_vec = tTR_rAcc_subtile.load()
+                        final_vec = acc_vec * scale + final_vec
+                        tTR_rAcc_subtile.store(final_vec.to(self.acc_dtype))
+
+                    # Release acc_pipeline buffer (MMA can reuse it)
+                    with cute.arch.elect_one():
+                        acc_pipeline.consumer_release(acc_consumer_state)
+                    acc_consumer_state.advance()
+
+                    # Peek next k_tile
+                    peek_acc_full_status = cutlass.Boolean(1)
+                    if acc_consumer_state.count < k_tile_cnt:
+                        peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
+
+                    peek_scale_full_status = cutlass.Boolean(1)
+                    if scale_consumer_state.count < k_tile_cnt:
+                        peek_scale_full_status = scale_pipeline.consumer_try_wait(scale_consumer_state)
+
+                # All k_tiles accumulated, now store final result to SMEM for epilogue
+                # Acquire epi_pipeline (wait for epilogue to be done with the buffer)
+                epi_pipeline.producer_acquire(epi_producer_state)
+
+                # Copy final accumulator from registers to SMEM, one epi subtile per slot.
+                # No proxy fence needed: producer and consumer both use the generic proxy,
+                # and producer_commit's mbarrier arrive has release semantics.
+                final_subtile_cnt = cute.size(tTR_rAcc_final.shape, mode=[3])
+                slot_base = epi_producer_state.index * final_subtile_cnt
+                for subtile_idx in cutlass.range(final_subtile_cnt, unroll_full=True):
+                    tRS_rFinal = tiled_copy_r2s_acc.retile(tTR_rAcc_final[(None, None, None, subtile_idx)])
+                    cute.copy(
+                        tiled_copy_r2s_acc,
+                        tRS_rFinal,
+                        tRS_sFinalAcc[(None, None, None, slot_base + subtile_idx)],
+                    )
+
+                # Commit to epi_pipeline (signal epilogue that data is ready)
+                epi_pipeline.producer_commit(epi_producer_state)
+                epi_producer_state.advance()
+
+                # Get next tile from scheduler
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+            # Signal epilogue that no more tiles
+            epi_pipeline.producer_tail(epi_producer_state)
+
+        #
+        # Specialized epilogue warps
+        #
+        # Bounds compare, not `in` (see accumulator warps above). Both sides are
+        # dynamic here (epilog_warp_id starts at 4, so neither const-folds like
+        # the accumulator group's `>= 0`), so combine with bitwise `&`, not
+        # Python `and`: `and` calls `__bool__` on a dynamic predicate, which the
+        # 4.5 wheel's tracer rejects.
+        if (warp_idx >= self.epilog_warp_id[0]) & (warp_idx <= self.epilog_warp_id[-1]):
+            cute.arch.setmaxregister_increase(self.num_regs_epilogue_warps)
+            #
+            # Alloc tensor memory buffer
+            #
+            tmem.allocate(self.num_tmem_alloc_cols)
+
+            #
+            # Bar sync for retrieve tensor memory ptr from shared memory
+            #
+            tmem.wait_for_alloc()
+
+            #
+            # Retrieving tensor memory ptr and make accumulator tensor
+            #
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            # (MMA, MMA_M, MMA_N, STAGE)
+            # Final accumulator now lives in SMEM (sFinalAcc); TMEM here is only used by
+            # MMA partials + SF. tCtAcc_base is a shape/TV-layout carrier for the t2r
+            # template below — it is never dereferenced as the load source in the epilogue.
+            tCtAcc_base = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+
+            #
+            # Partition for epilogue (SMEM/TMEM/register - invariant across experts)
+            #
+            epi_tidx = tidx % 128
+            (
+                tiled_copy_t2r,
+                tTR_tAcc_base,
+                tTR_rAcc,
+            ) = self.epilog_tmem_copy_and_partition(epi_tidx, tCtAcc_base, epi_tile, use_2cta_instrs)
+
+            tTR_rC1 = cute.make_rmem_tensor(tTR_rAcc.shape, self.c_dtype)
+            tTR_rC2 = cute.make_rmem_tensor(tTR_rAcc.shape, self.c_dtype)
+            tiled_copy_s2r, tRS_rC1, tRS_rC2, tRS_sC = self.epilog_smem_copy_and_partition_load(tiled_copy_t2r, tTR_rC1, tTR_rC2, epi_tidx, sC)
+
+            tTR_rD1 = cute.make_rmem_tensor(tTR_rAcc.shape, self.d_dtype)
+            tTR_rD2 = cute.make_rmem_tensor(tTR_rAcc.shape, self.d_dtype)
+            tiled_copy_r2s, tRS_rD1, tRS_rD2, tRS_sD = self.epilog_smem_copy_and_partition_store(tiled_copy_t2r, tTR_rD1, tTR_rD2, epi_tidx, sD)
+            if cutlass.const_expr(self.generate_sfd):
+                norm_const = cutlass.Float32(norm_const_tensor[0])
+                d_rcp_limits = get_dtype_rcp_limits(self.d_dtype)
+
+            # S2R load of the final accumulator from SMEM (written by acc-update warp)
+            tiled_copy_s2r_acc, tSR_sFinalAcc = self.epilog_smem_acc_load_and_partition(tiled_copy_t2r, epi_tidx, sFinalAcc)
+
+            # bf16 relay of the dGLU output through the sFinalAcc SMEM bytes (NVFP4 path):
+            # Pass 1 rounds d1/d2 to bf16 and stores them into slots 2*subtile + 0/1, which
+            # alias exactly onto the f32 acc subtile's bytes (bf16 d1+d2 == one f32 subtile,
+            # verified: bf16 8-slot layout == f32 4-slot layout == 65536 B).
+            # Pass 2 reloads and upcasts to f32 to quantize, dropping pass 2's C reload + dGLU
+            # recompute. A single universal copy atom is used for BOTH store and load so the
+            # store/load TV layouts match (a stmatrix store would not round-trip against the load).
+            if cutlass.const_expr(self.generate_sfd):
+                # sFinalAccBf16 was built with the smem tensors above — hoisted
+                # out of this warp-dispatch region for the 4.5 wheel.
+                copy_atom_dglu = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), cutlass.BFloat16)
+                tiled_copy_dglu = cute.make_tiled_copy_D(copy_atom_dglu, tiled_copy_t2r)
+                tRS_sFinalAccBf16 = tiled_copy_dglu.get_slice(epi_tidx).partition_D(sFinalAccBf16)
+                tTR_rDGLU1 = cute.make_rmem_tensor(tTR_rAcc.shape, cutlass.BFloat16)
+                tTR_rDGLU2 = cute.make_rmem_tensor(tTR_rAcc.shape, cutlass.BFloat16)
+                tRS_rDGLU1 = tiled_copy_dglu.retile(tTR_rDGLU1)
+                tRS_rDGLU2 = tiled_copy_dglu.retile(tTR_rDGLU2)
+
+            # Extension for per-expert domain conversion in epilogue
+            epi_ext = self._make_extension(workspace_ptr)
+
+            epi_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_epi_stage)
+
+            # Load C pipeline
+            c_pipeline_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_c_stage)
+            # C is now produced by this epilogue warp group (warp epilog_warp_id[0]
+            # issues the TMA); previously a dedicated warp owned this producer state.
+            c_pipeline_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_c_stage)
+
+            # Threads/warps participating in tma store pipeline
+            d_producer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                32 * len(self.epilog_warp_id),
+            )
+            d_pipeline = None
+            if cutlass.const_expr(not self.store_d_directly):
+                num_d_stages = self.num_d_stage // 2
+                d_pipeline = pipeline.PipelineTmaStore.create(
+                    num_stages=num_d_stages,
+                    producer_group=d_producer_group,
+                )
+
+            tile_info_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_tile_stage)
+
+            # Get the first tile info (sInfo format: expert_idx, tile_m_idx, tile_n_idx, k_tile_cnt)
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            num_prev_subtiles = cutlass.Int32(0)
+            # DSMEM rowwise-sfd2 sequence: all cluster CTAs walk the same
+            # cluster tile stream (the scheduler hands cluster tiles), so
+            # parity (bit 0) and mbarrier phase (bit 1) stay in lockstep
+            # across the whole cluster.
+            if cutlass.const_expr(self.row_dsmem):
+                row_dsmem_seq = cutlass.Int32(0)
+            while is_valid_tile:
+                # sInfo: (expert_idx, tile_m_idx, tile_n_idx, k_tile_cnt)
+                epi_work_tile_info = MoEWorkTileInfo(
+                    expert_idx=tile_info[0],
+                    tile_m_idx=tile_info[1],
+                    tile_n_idx=tile_info[2],
+                    k_tile_cnt=tile_info[3],
+                )
+                expert_idx = epi_work_tile_info.expert_idx
+                # N is doubled for dGLU dual output
+                mma_tile_coord_mnl = (
+                    epi_work_tile_info.tile_m_idx // cute.size(tiled_mma.thr_id.shape),
+                    epi_work_tile_info.tile_n_idx * 2,
+                    cutlass.Int32(0),
+                )
+
+                #
+                # Get alpha/beta for current expert
+                #
+                alpha_val = alpha[expert_idx]
+                beta_val = beta[expert_idx]
+                epi_ext.update_expert_info(padded_offsets, expert_idx)
+
+                #
+                # Per-expert gmem tensor setup via extension
+                #
+                real_d, _ = epi_ext.get_gmem_tensor("d", mD_mnl, padded_offsets, epi_work_tile_info)
+                gD_mnl_loop = cute.local_tile(real_d, cute.slice_(self.mma_tiler_d, (None, None, 0)), (None, None, None))
+                thr_mma_epi = tiled_mma.get_slice(mma_tile_coord_v)
+                tCgD_loop = thr_mma_epi.partition_C(gD_mnl_loop)
+
+                tgSFD2_up = None
+                tgSFD2_gate = None
+                if cutlass.const_expr(self.generate_sfd2):
+                    # Per-expert SFD2_up setup
+                    mSFD2_up_mnl, _ = epi_ext.get_gmem_tensor("sfd2", sfd2_up_tensor, padded_offsets, epi_work_tile_info)
+                    thread_tiler = cute.make_layout((128, 1))
+                    gSFD2_up_mnl = cute.local_tile(mSFD2_up_mnl, cute.slice_(self.mma_tiler_d, (None, None, 0)), (None, None, None))
+                    tCgSFD2_up = thr_mma_epi.partition_C(gSFD2_up_mnl)
+                    bSFD2_up = tCgSFD2_up[(None, None, None, *mma_tile_coord_mnl)]
+                    tgSFD2_up = cute.local_partition(bSFD2_up, thread_tiler, tidx)
+
+                    # Per-expert SFD2_gate setup
+                    mSFD2_gate_mnl, _ = epi_ext.get_gmem_tensor("sfd2", sfd2_gate_tensor, padded_offsets, epi_work_tile_info)
+                    gSFD2_gate_mnl = cute.local_tile(mSFD2_gate_mnl, cute.slice_(self.mma_tiler_d, (None, None, 0)), (None, None, None))
+                    tCgSFD2_gate = thr_mma_epi.partition_C(gSFD2_gate_mnl)
+                    bSFD2_gate = tCgSFD2_gate[(None, None, None, *mma_tile_coord_mnl)]
+                    tgSFD2_gate = cute.local_partition(bSFD2_gate, thread_tiler, tidx)
+
+                if cutlass.const_expr(not self.store_d_directly):
+                    bSG_sD, bSG_gD_partitioned = self.epilog_gmem_copy_and_partition(epi_tidx, tma_atom_d, tCgD_loop, epi_tile, sD)
+                    bSG_gD = bSG_gD_partitioned[(None, None, None, mma_tile_coord_mnl[0], mma_tile_coord_mnl[1], 0)]
+                    bSG_gD = cute.group_modes(bSG_gD, 1, cute.rank(bSG_gD))
+
+                epi_stage_index = 0
+
+                # Set tensor memory buffer for current tile
+                # (T2R, T2R_M, T2R_N, EPI_M, EPI_M)
+                tTR_tAcc = tTR_tAcc_base[(None, None, None, None, None, epi_stage_index)]
+
+                if cutlass.const_expr(self.generate_sfd):
+                    regPerSubtile = 4
+                    sfd_row_tile = (
+                        cute.make_layout(128),
+                        cute.make_layout(32 * regPerSubtile),
+                    )
+                    # SFD Row: tile_atom_to_shape_SF layout, same path as SFA
+                    real_sfd_row, _ = epi_ext.get_gmem_tensor("sfd", mSFDRow_mnl, padded_offsets, epi_work_tile_info)
+                    gSFDRow_mnl = cute.local_tile(real_sfd_row, sfd_row_tile, (None, None, None))
+
+                    # Don't ask why, AST is shit tracking the constexpr values to loop args.
+                    tiled_copy_t2r_local, _, _ = self.epilog_tmem_copy_and_partition(epi_tidx, tCtAcc_base, epi_tile, use_2cta_instrs)
+                    thr_copy_t2r_local = tiled_copy_t2r_local.get_slice(tidx % 128)
+                    tCgSFDRow_mnl = thr_copy_t2r_local.partition_D(gSFDRow_mnl)
+                    tCgSFDRow_mnl = cute.filter_zeros(tCgSFDRow_mnl)
+                    tCrSFDRow = cute.make_rmem_tensor(tCgSFDRow_mnl[(None, None, None, 0, 0, 0)].layout, self.sf_dtype)
+                    tCrSFDRow_pvscale = cute.make_rmem_tensor_like(tCrSFDRow, cutlass.Float32)
+                    tCgSFDRow_mn = tCgSFDRow_mnl[(None, None, None, None, None, 0)]
+
+                    # SMEM staging for coalesced SFD stores. One store event
+                    # (2 subtiles x d1/d2) covers one contiguous
+                    # (128 rows, 32*regPerSubtile values) block of the SFD
+                    # atom layout — 8 SF bytes per thread, but scattered at
+                    # 16B thread stride in gmem. Mirror the gmem tile/thread
+                    # partition onto an SMEM block with the identical atom
+                    # layout: the scatter goes to SMEM, the gmem store then
+                    # reads the block back linearly (one 8B word per thread).
+                    sfd_stage_size = 128 * 32 * regPerSubtile // self.sf_vec_size
+                    # sSFDRowStage_flat is pre-derived in the prologue: the 4.5
+                    # wheel cannot carry `storage` across the warp-dispatch if.
+                    sfd_stage_atom_layout = blockscaled_utils.tile_atom_to_shape_SF((128, 32 * regPerSubtile, 1), self.sf_vec_size)
+                    sSFDRowStage_atom = cute.make_tensor(sSFDRowStage_flat.iterator, sfd_stage_atom_layout)
+                    sSFDRowStage_tiled = cute.local_tile(sSFDRowStage_atom, sfd_row_tile, (None, None, None))
+                    tCsSFDRow_mnl = thr_copy_t2r_local.partition_D(sSFDRowStage_tiled)
+                    tCsSFDRow_mnl = cute.filter_zeros(tCsSFDRow_mnl)
+                    tCsSFDRow = tCsSFDRow_mnl[(None, None, None, 0, 0, 0)]
+                    if cutlass.const_expr(self.d_deinterleaved):
+                        # Readback view: 2B pieces (the deinterleave scatter's
+                        # granularity — gate/up alternate at 2 SF bytes).
+                        sSFDRowStage_half = cute.recast_tensor(sSFDRowStage_flat, cutlass.Int16)
+                    else:
+                        # Linear readback view: 8B words, one per epilogue thread.
+                        sSFDRowStage_words = cute.recast_tensor(sSFDRowStage_flat, cutlass.Int64)
+
+                #
+                # Get PROB (per-expert local M position)
+                #
+                real_prob, _ = epi_ext.get_gmem_tensor("prob", prob, padded_offsets, epi_work_tile_info)
+                mPosition = (
+                    (epi_work_tile_info.tile_m_idx // cute.size(tiled_mma.thr_id.shape)) * self.mma_tiler[0]
+                    + mma_tile_coord_v * (self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape))
+                    + tidx % 128
+                )
+                mProb = real_prob[mPosition, 0, 0]
+                if cutlass.const_expr(self.generate_dprob):
+                    dProbVal = cutlass.Float32(0.0)
+
+                #
+                # Build C (up/gate forward activations) GMEM->SMEM partition and
+                # PREFETCH the first C subtiles for this tile BEFORE waiting on the
+                # accumulator, so C TMA movement overlaps accumulator production.
+                # The epilogue warp group now owns the C producer (warp
+                # epilog_warp_id[0] issues) as well as the consumer; a dedicated
+                # C-load warp is no longer used.
+                #
+                real_c, _ = epi_ext.get_gmem_tensor("c", mC_mnl, padded_offsets, epi_work_tile_info)
+                gC_mnl_loop = cute.local_tile(real_c, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None))
+                tCgC_loop = thr_mma_epi.partition_C(gC_mnl_loop)
+                bGS_sC, bGS_gC_partitioned = self.epilog_gmem_copy_and_partition(epi_tidx, tma_atom_c, tCgC_loop, epi_tile, sC)
+                bGS_gC = bGS_gC_partitioned[(None, None, None, mma_tile_coord_mnl[0], mma_tile_coord_mnl[1], 0)]
+                bGS_gC = cute.group_modes(bGS_gC, 1, cute.rank(bGS_gC))
+                c_subtile_cnt = cute.size(bGS_gC.shape, mode=[1])
+                # Prefetch depth (in subtiles) is bounded by the C pipeline stages:
+                # 2 stages -> 1 subtile ahead, 4 stages -> 2 subtiles ahead.
+                c_prefetch_subtiles = self.num_c_stage // 2
+                #
+                # Wait for accumulator buffer full. The acc buffer is HELD across BOTH
+                # epilogue passes and released only after pass 2, so pass 2 can re-read
+                # the dy accumulator from resident sFinalAcc for free.
+                #
+                epi_pipeline.consumer_wait(epi_consumer_state)
+                tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+
+                # Initialize thread-local amax accumulator for this tile
+                # Use 0.0 as initial value since we're computing absolute maximum
+                thread_tile_amax_1 = cutlass.Float32(0.0)
+                thread_tile_amax_2 = cutlass.Float32(0.0)
+
+                #
+                # Store accumulator to global memory in subtiles
+                #
+                subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+                # Stage-aware base into the (double-buffered) sFinalAcc SMEM buffer.
+                # Mirrors the producer's slot_base = epi_producer_state.index * subtile_cnt.
+                # NOTE: this base applies ONLY to sFinalAcc SMEM reads; real_subtile_idx
+                # below stays in [0, subtile_cnt) because it also indexes per-tile GMEM/
+                # TMEM/SFD outputs which are not stage-multiplied.
+                sfinal_slot_base = epi_consumer_state.index * subtile_cnt
+                tTR_rAcc_0 = cute.make_rmem_tensor(tTR_rAcc.shape, cutlass.Float32)
+                tTR_rAcc_1 = cute.make_rmem_tensor(tTR_rAcc.shape, cutlass.Float32)
+
+                #
+                # PASS 1 (reduce): dGLU backward + amax / dprob / dbias reductions only.
+                # The full per-thread tile amax must be finalized before row-wise SFD
+                # generation, so NO SFD generation and NO D store happen in this pass.
+                #
+                if warp_idx == self.epilog_warp_id[0]:
+                    for c_pf in range(min(c_prefetch_subtiles, c_subtile_cnt)):
+                        c_pipeline.producer_acquire(c_pipeline_producer_state)
+                        cute.copy(
+                            tma_atom_c,
+                            bGS_gC[(None, 2 * c_pf + 0)],
+                            bGS_sC[(None, c_pipeline_producer_state.index)],
+                            tma_bar_ptr=c_pipeline.producer_get_barrier(c_pipeline_producer_state),
+                        )
+                        c_pipeline_producer_state.advance()
+                        c_pipeline.producer_acquire(c_pipeline_producer_state)
+                        cute.copy(
+                            tma_atom_c,
+                            bGS_gC[(None, 2 * c_pf + 1)],
+                            bGS_sC[(None, c_pipeline_producer_state.index)],
+                            tma_bar_ptr=c_pipeline.producer_get_barrier(c_pipeline_producer_state),
+                        )
+                        c_pipeline_producer_state.advance()
+
+                for subtile_idx in cutlass.range(0, subtile_cnt, 1, unroll=1):
+                    real_subtile_idx = subtile_idx
+                    real_subtile_idx_next = subtile_idx + 1
+                    #
+                    # Load final accumulator subtile(s) from SMEM (sFinalAcc, written by
+                    # the acc-update warp) into registers. sfinal_slot_base offsets into
+                    # the current epi pipeline stage's slots.
+                    #
+                    if cutlass.const_expr(self.epilogue_prefetch_more):
+                        # Double-buffered: on even subtiles, load current + next slot.
+                        if subtile_idx % 2 == 0:
+                            cute.copy(
+                                tiled_copy_s2r_acc,
+                                tSR_sFinalAcc[(None, None, None, sfinal_slot_base + real_subtile_idx)],
+                                tiled_copy_s2r_acc.retile(tTR_rAcc_0),
+                            )
+                            cute.copy(
+                                tiled_copy_s2r_acc,
+                                tSR_sFinalAcc[(None, None, None, sfinal_slot_base + real_subtile_idx_next)],
+                                tiled_copy_s2r_acc.retile(tTR_rAcc_1),
+                            )
+                            tTR_rAcc = tTR_rAcc_0
+                        else:
+                            tTR_rAcc = tTR_rAcc_1
+                    else:
+                        cute.copy(
+                            tiled_copy_s2r_acc,
+                            tSR_sFinalAcc[(None, None, None, sfinal_slot_base + real_subtile_idx)],
+                            tiled_copy_s2r_acc.retile(tTR_rAcc),
+                        )
+
+                    # Wait for C1/C2 load to complete
+                    c_pipeline.consumer_wait(c_pipeline_consumer_state)
+                    cute.copy(
+                        tiled_copy_s2r,
+                        tRS_sC[(None, None, None, c_pipeline_consumer_state.index)],
+                        tRS_rC1,
+                    )
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    c_pipeline.consumer_release(c_pipeline_consumer_state)
+                    c_pipeline_consumer_state.advance()
+                    c_pipeline.consumer_wait(c_pipeline_consumer_state)
+                    cute.copy(
+                        tiled_copy_s2r,
+                        tRS_sC[(None, None, None, c_pipeline_consumer_state.index)],
+                        tRS_rC2,
+                    )
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    c_pipeline.consumer_release(c_pipeline_consumer_state)
+                    c_pipeline_consumer_state.advance()
+
+                    # Refill the C pipeline: issue the TMA load for the subtile
+                    # c_prefetch_subtiles ahead (warp epilog_warp_id[0] only), keeping
+                    # the producer running ahead of this consumer within the tile.
+                    if warp_idx == self.epilog_warp_id[0]:
+                        c_pf_idx = real_subtile_idx + c_prefetch_subtiles
+                        if c_pf_idx < c_subtile_cnt:
+                            c_pipeline.producer_acquire(c_pipeline_producer_state)
+                            cute.copy(
+                                tma_atom_c,
+                                bGS_gC[(None, 2 * c_pf_idx + 0)],
+                                bGS_sC[(None, c_pipeline_producer_state.index)],
+                                tma_bar_ptr=c_pipeline.producer_get_barrier(c_pipeline_producer_state),
+                            )
+                            c_pipeline_producer_state.advance()
+                            c_pipeline.producer_acquire(c_pipeline_producer_state)
+                            cute.copy(
+                                tma_atom_c,
+                                bGS_gC[(None, 2 * c_pf_idx + 1)],
+                                bGS_sC[(None, c_pipeline_producer_state.index)],
+                                tma_bar_ptr=c_pipeline.producer_get_barrier(c_pipeline_producer_state),
+                            )
+                            c_pipeline_producer_state.advance()
+
+                    acc_vec = tiled_copy_r2s.retile(tTR_rAcc)
+                    ab1_vec_load = tiled_copy_r2s.retile(tRS_rC1)
+                    ab2_vec_load = tiled_copy_r2s.retile(tRS_rC2)
+                    if cutlass.const_expr(self.generate_dprob):
+                        dprob_swiglu = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
+                    else:
+                        dprob_swiglu = None
+
+                    #
+                    # Apply alpha, act, and prob
+                    #
+                    square_alpha = alpha_val * alpha_val
+                    if cutlass.const_expr(self.act_func == "dswiglu"):
+                        d1_vec, d2_vec, dprob_swiglu = self.dswiglu(acc_vec, ab1_vec_load, ab2_vec_load, mProb, beta_val, square_alpha, dprob_swiglu)
+                    elif cutlass.const_expr(self.act_func == "dgeglu"):
+                        d1_vec, d2_vec, dprob_swiglu = self.dgeglu(acc_vec, ab1_vec_load, ab2_vec_load, mProb, linear_offset, dprob_swiglu)
+
+                    if cutlass.const_expr(self.generate_dprob):
+                        # dprob sum reduction
+                        if cutlass.const_expr(self.vectorized_f32):
+                            dprob_pair_0 = cutlass.Float32(0.0)
+                            dprob_pair_1 = cutlass.Float32(0.0)
+                            for j in cutlass.range(0, cute.size(dprob_swiglu.shape), 2, unroll_full=True):
+                                (
+                                    dprob_pair_0,
+                                    dprob_pair_1,
+                                ) = cute.arch.add_packed_f32x2(
+                                    (dprob_pair_0, dprob_pair_1),
+                                    (dprob_swiglu[j], dprob_swiglu[j + 1]),
+                                    rnd="rn",
+                                    ftz=False,
+                                )
+                            dProbVal += dprob_pair_0 + dprob_pair_1
+                        else:
+                            dProbVal += dprob_swiglu.reduce(
+                                cute.ReductionOp.ADD,
+                                cutlass.Float32(0.0),
+                                0,
+                            )
+
+                    #
+                    # Generate dBias
+                    #
+                    if cutlass.const_expr(self.generate_dbias):
+                        n_base_d1 = epi_work_tile_info.tile_n_idx * (self.mma_tiler[1] * 2) + (2 * real_subtile_idx + 0) * self.epi_tile[1]
+                        n_base_d2 = epi_work_tile_info.tile_n_idx * (self.mma_tiler[1] * 2) + (2 * real_subtile_idx + 1) * self.epi_tile[1]
+                        dbias_n_total = cute.size(mDbias_tensor, mode=[1])
+                        self.dbias_reduction(
+                            d1_vec,
+                            d2_vec,
+                            warp_idx,
+                            sDbias,
+                            mDbias_tensor,
+                            expert_idx,
+                            n_base_d1,
+                            n_base_d2,
+                            dbias_n_total,
+                        )
+
+                    #
+                    # Generate subtile level amax
+                    #
+                    if cutlass.const_expr(self.generate_sfd2):
+                        thread_tile_amax_1 = self.amax_reduction_per_thread(d1_vec, thread_tile_amax_1)
+                        thread_tile_amax_2 = self.amax_reduction_per_thread(d2_vec, thread_tile_amax_2)
+
+                    #
+                    # Stash the bf16-rounded dGLU output into the accumulator's SMEM
+                    # slots (reused in place, slots 2*subtile + 0/1) for pass-2
+                    # quantization. Done AFTER the dprob/dbias/SFD2-amax reductions so
+                    # those stay on the f32 d1/d2_vec; the SFD amax + e2m1 D bytes then
+                    # derive from the bf16 value.
+                    #
+                    # The bf16 slots alias the f32 subtile's BYTES with a
+                    # different (row, col)->byte map, so one thread's stash
+                    # lands on OTHER threads' unread f32 rows (e.g. bf16 rows
+                    # 64..95 over f32 rows 32..47). Every thread must finish
+                    # its f32 subtile reads (incl. the prefetch path's
+                    # next-slot read, issued at even subtiles above) before
+                    # ANY thread overwrites the slot — without this barrier a
+                    # fast warp corrupts a slow warp's accumulator input
+                    # (racecheck: stash-vs-s2r-acc hazard; manifested as rare
+                    # 16-token x 1-subtile corruption at sg512 large shapes).
+                    #
+                    if cutlass.const_expr(self.generate_sfd):
+                        self.epilog_sync_barrier.arrive_and_wait()
+                        tRS_rDGLU1.store(d1_vec.to(cutlass.BFloat16))
+                        tRS_rDGLU2.store(d2_vec.to(cutlass.BFloat16))
+                        cute.copy(
+                            tiled_copy_dglu,
+                            tRS_rDGLU1,
+                            tRS_sFinalAccBf16[(None, None, None, 2 * (sfinal_slot_base + real_subtile_idx) + 0)],
+                        )
+                        cute.copy(
+                            tiled_copy_dglu,
+                            tRS_rDGLU2,
+                            tRS_sFinalAccBf16[(None, None, None, 2 * (sfinal_slot_base + real_subtile_idx) + 1)],
+                        )
+
+                # Generate SFD2
+                if cutlass.const_expr(self.generate_sfd2):
+                    # The second-level scale normalizes dy for its two-level target
+                    # encoding: divisor = max(D-quant data dtype) * max(SF dtype).
+                    # When D is quantized (generate_sfd) the data dtype is the real
+                    # d_dtype; otherwise SFD2 targets the NVFP4 e2m1 second level.
+                    sfd2_data_dtype = self.d_dtype if cutlass.const_expr(self.generate_sfd) else cutlass.Float4E2M1FN
+                    sfd2_norm = get_dtype_max(sfd2_data_dtype) * get_dtype_max(self.sf_dtype)
+                    sfd2_descale_1 = thread_tile_amax_1 / sfd2_norm
+                    sfd2_descale_2 = thread_tile_amax_2 / sfd2_norm
+                    if cutlass.const_expr(self.row_dsmem):
+                        # DSMEM rowwise reduction: the block's contributors are
+                        # exactly this cluster's N-peers (same M rank). Each
+                        # thread owns one row (thread_tiler (128,1)) and
+                        # max-reds its gate/up descale into EVERY N-peer's
+                        # parity slot ([cta_m gate | cta_m up]); the identical
+                        # bit-pattern u32 max the gmem helper uses, so results
+                        # stay byte-exact. Descales are non-negative, so the
+                        # trick is valid.
+                        _row_slot = (row_dsmem_seq & 1) * (2 * self.cta_tile_shape_mnk_d[0])
+                        _rp_gate = sSfd2RowDsmem.iterator + (_row_slot + epi_tidx)
+                        _rp_up = sSfd2RowDsmem.iterator + (_row_slot + self.cta_tile_shape_mnk_d[0] + epi_tidx)
+                        _row_m_rank = cta_rank_in_cluster % self.cluster_shape_mn[0]
+                        for _rt in cutlass.range_constexpr(self.cluster_shape_mn[1]):
+                            _row_peer = _row_m_rank + _rt * self.cluster_shape_mn[0]
+                            red_smem_cluster_max_f32(_rp_gate, sfd2_descale_1, Int32(_row_peer))
+                            red_smem_cluster_max_f32(_rp_up, sfd2_descale_2, Int32(_row_peer))
+                    else:  # GMEM reduction
+                        self.second_level_scale_row_wise_gen(sfd2_descale_2, tgSFD2_up)
+                        self.second_level_scale_row_wise_gen(sfd2_descale_1, tgSFD2_gate)
+
+                # Make the pass-1 bf16 dGLU stores visible to the pass-2 reloads (the
+                # store/load footprints coincide per thread; the barrier also covers the
+                # async-proxy copy).
+                if cutlass.const_expr(self.generate_sfd):
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+                    if cutlass.const_expr(self.row_dsmem):
+                        # DSMEM handoff (replaces the gmem counter + acquire
+                        # spin): the epilog barrier above ordered every
+                        # thread's reds; the elected thread's cluster release
+                        # fence publishes them, then one arrive lands on each
+                        # N-peer's parity mbarrier. A CTA passing its wait has
+                        # proof every peer's reds landed — its local slot holds
+                        # the final block descales.
+                        _row_parity = row_dsmem_seq & 1
+                        _row_phase = (row_dsmem_seq >> 1) & 1
+                        if warp_idx == self.epilog_warp_id[0]:
+                            with cute.arch.elect_one():
+                                cute.arch.fence_acq_rel_cluster()
+                                _row_am_rank = cta_rank_in_cluster % self.cluster_shape_mn[0]
+                                for _ra in cutlass.range_constexpr(self.cluster_shape_mn[1]):
+                                    mbarrier_arrive_cluster(
+                                        row_dsmem_mbar + _row_parity,
+                                        peer_cta_rank_in_cluster=Int32(_row_am_rank + _ra * self.cluster_shape_mn[0]),
+                                    )
+                        cute.arch.mbarrier_wait(row_dsmem_mbar + _row_parity, _row_phase)
+                        # Acquire side of the handoff: order the peers' reds
+                        # (published by their release fences) before this CTA's
+                        # smem reads below.
+                        cute.arch.fence_acq_rel_cluster()
+                    elif cutlass.const_expr(self.sfd2_n_contrib > 1):
+                        # Arrival protocol: one sfd2 block spans sfd2_n_contrib
+                        # N work-tiles (sgn/mma_tiler_n: 2 at sgn=256, 4 at
+                        # sgn=512 with the 128 tiler), so the block descale is
+                        # only final in gmem once EVERY contributing tile's
+                        # pass-1 atomic maxes have landed. Each tile announces
+                        # completion on a per-(m tile, n-block) u32 counter;
+                        # pass 2 spins until all contributors arrived, which
+                        # makes the volatile read-back below provably final.
+                        _n_tiles_f = cute.ceil_div(cute.shape(mD_mnl)[1], 2 * self.cta_tile_shape_mnk[1])
+                        _n_j = cute.ceil_div(_n_tiles_f, self.sfd2_n_contrib)
+                        _tok_off, _ = compute_expert_token_range(padded_offsets, epi_work_tile_info.expert_idx)
+                        _j = epi_work_tile_info.tile_n_idx // self.sfd2_n_contrib
+                        _counter_idx = (_tok_off // self.cta_tile_shape_mnk[0] + epi_work_tile_info.tile_m_idx) * _n_j + _j
+                        _counter_ptr = cute.make_ptr(
+                            cutlass.Int32,
+                            self._get_sfd2_counter_ptr(workspace_ptr).toint() + _counter_idx * 4,
+                            AddressSpace.gmem,
+                            assumed_align=4,
+                        )
+                        # Announce this tile's arrival (one thread per CTA).
+                        # The gpu-scope release fence orders every thread's
+                        # pass-1 atomic maxes (already CTA-ordered by the
+                        # barrier above) before the counter increment.
+                        if warp_idx == self.epilog_warp_id[0]:
+                            with cute.arch.elect_one():
+                                cute.arch.fence_acq_rel_gpu()
+                                atomic_add_i32_gmem(_counter_ptr.llvm_ptr, Int32(1))
+                        # The last block of a row may have fewer contributors
+                        # when the f-tile count is not a multiple of
+                        # sfd2_n_contrib (spinning for the full count there
+                        # would hang forever).
+                        _contrib = Int32(self.sfd2_n_contrib)
+                        _rem = _n_tiles_f - _j * self.sfd2_n_contrib
+                        if _rem < _contrib:
+                            _contrib = _rem
+                        # Acquire-spin: once the counter shows all arrivals,
+                        # every contributor's atomic maxes are visible.
+                        _arrived = load_acquire_i32_gpu(_counter_ptr.llvm_ptr)
+                        while _arrived < _contrib:
+                            nanosleep(sleep_time=64)
+                            _arrived = load_acquire_i32_gpu(_counter_ptr.llvm_ptr)
+
+                    if cutlass.const_expr(self.generate_sfd2):
+                        if cutlass.const_expr(self.row_dsmem):
+                            # DSMEM path: the local parity slot holds the final
+                            # block descales — plain LDS, no volatile gmem loads.
+                            _rq_slot = (row_dsmem_seq & 1) * (2 * self.cta_tile_shape_mnk_d[0])
+                            sfd2_descale_1 = sSfd2RowDsmem[_rq_slot + epi_tidx]
+                            sfd2_descale_2 = sSfd2RowDsmem[_rq_slot + self.cta_tile_shape_mnk_d[0] + epi_tidx]
+                            # Publish the finalized descales to the gmem sfd2
+                            # outputs (the gmem atomics that used to produce them
+                            # are skipped on this path): one CTA per contributor
+                            # group — the N-rank-0 peer — plain-stores its rows.
+                            if cta_rank_in_cluster // self.cluster_shape_mn[0] == 0:
+                                tgSFD2_gate[0] = sfd2_descale_1
+                                tgSFD2_up[0] = sfd2_descale_2
+                            # Recycle the parity slot for tile seq+2: reads above
+                            # are this thread's own (program order), and peers'
+                            # next reds into this slot chain through the seq+1
+                            # arrive whose fence publishes these zeroes.
+                            sSfd2RowDsmem[_rq_slot + epi_tidx] = Float32(0.0)
+                            sSfd2RowDsmem[_rq_slot + self.cta_tile_shape_mnk_d[0] + epi_tidx] = Float32(0.0)
+                            row_dsmem_seq = row_dsmem_seq + 1
+                        else:
+                            # Re-read the block descale from the sfd2 gmem reduction
+                            # for the pass-2 row-scale fold. atomic_max only returns
+                            # the PRE-max value, and the register thread_tile_amax
+                            # covers just this tile's columns: when one sfd2 block
+                            # spans multiple N work-tiles (sgn > tile f-width,
+                            # i.e. sfd2_n_contrib > 1), the block amax is
+                            # completed in gmem by the other tiles' atomics — the
+                            # arrival spin above guarantees they have all landed.
+                            # Volatile: the atomics reduce in L2, so the load must
+                            # not be served from a stale L1 line.
+                            sfd2_descale_1 = load_float32_volatile(tgSFD2_gate.iterator.llvm_ptr)
+                            sfd2_descale_2 = load_float32_volatile(tgSFD2_up.iterator.llvm_ptr)
+
+                #
+                # PASS 2 (quantize + store). NVFP4 path (generate_sfd): reload the
+                # bf16 dGLU output stashed in pass 1 from sFinalAcc, upcast to f32, and
+                # quantize — no C reload, no dGLU recompute. bf16-D path: re-drive C
+                # from GMEM and recompute dGLU (the full-tile amax is now available).
+                #
+                # C is only re-driven for the bf16-D recompute path; the NVFP4 path
+                # consumed C once in pass 1 and reloads dGLU from SMEM below.
+                if cutlass.const_expr(not self.generate_sfd):
+                    if warp_idx == self.epilog_warp_id[0]:
+                        for c_pf in range(min(c_prefetch_subtiles, c_subtile_cnt)):
+                            c_pipeline.producer_acquire(c_pipeline_producer_state)
+                            cute.copy(
+                                tma_atom_c,
+                                bGS_gC[(None, 2 * c_pf + 0)],
+                                bGS_sC[(None, c_pipeline_producer_state.index)],
+                                tma_bar_ptr=c_pipeline.producer_get_barrier(c_pipeline_producer_state),
+                            )
+                            c_pipeline_producer_state.advance()
+                            c_pipeline.producer_acquire(c_pipeline_producer_state)
+                            cute.copy(
+                                tma_atom_c,
+                                bGS_gC[(None, 2 * c_pf + 1)],
+                                bGS_sC[(None, c_pipeline_producer_state.index)],
+                                tma_bar_ptr=c_pipeline.producer_get_barrier(c_pipeline_producer_state),
+                            )
+                            c_pipeline_producer_state.advance()
+
+                for subtile_idx in cutlass.range(0, subtile_cnt, 1, unroll=1):
+                    real_subtile_idx = subtile_idx
+                    real_subtile_idx_next = subtile_idx + 1
+                    if cutlass.const_expr(self.generate_sfd):
+                        #
+                        # NVFP4 path: reload the bf16 dGLU output stashed by pass 1 from
+                        # the accumulator's SMEM slots (2*subtile + 0/1) and upcast to
+                        # f32. No C reload, no dGLU recompute — pass 1 did both.
+                        #
+                        cute.copy(
+                            tiled_copy_dglu,
+                            tRS_sFinalAccBf16[(None, None, None, 2 * (sfinal_slot_base + real_subtile_idx) + 0)],
+                            tRS_rDGLU1,
+                        )
+                        cute.copy(
+                            tiled_copy_dglu,
+                            tRS_sFinalAccBf16[(None, None, None, 2 * (sfinal_slot_base + real_subtile_idx) + 1)],
+                            tRS_rDGLU2,
+                        )
+                        d1_vec = tRS_rDGLU1.load().to(cutlass.Float32)
+                        d2_vec = tRS_rDGLU2.load().to(cutlass.Float32)
+                    else:
+                        #
+                        # Load final accumulator subtile(s) from SMEM (sFinalAcc, written by
+                        # the acc-update warp) into registers. sfinal_slot_base offsets into
+                        # the current epi pipeline stage's slots.
+                        #
+                        if cutlass.const_expr(self.epilogue_prefetch_more):
+                            # Double-buffered: on even subtiles, load current + next slot.
+                            if subtile_idx % 2 == 0:
+                                cute.copy(
+                                    tiled_copy_s2r_acc,
+                                    tSR_sFinalAcc[(None, None, None, sfinal_slot_base + real_subtile_idx)],
+                                    tiled_copy_s2r_acc.retile(tTR_rAcc_0),
+                                )
+                                cute.copy(
+                                    tiled_copy_s2r_acc,
+                                    tSR_sFinalAcc[(None, None, None, sfinal_slot_base + real_subtile_idx_next)],
+                                    tiled_copy_s2r_acc.retile(tTR_rAcc_1),
+                                )
+                                tTR_rAcc = tTR_rAcc_0
+                            else:
+                                tTR_rAcc = tTR_rAcc_1
+                        else:
+                            cute.copy(
+                                tiled_copy_s2r_acc,
+                                tSR_sFinalAcc[(None, None, None, sfinal_slot_base + real_subtile_idx)],
+                                tiled_copy_s2r_acc.retile(tTR_rAcc),
+                            )
+                        # Wait for C1/C2 load to complete
+                        c_pipeline.consumer_wait(c_pipeline_consumer_state)
+                        cute.copy(
+                            tiled_copy_s2r,
+                            tRS_sC[(None, None, None, c_pipeline_consumer_state.index)],
+                            tRS_rC1,
+                        )
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        c_pipeline.consumer_release(c_pipeline_consumer_state)
+                        c_pipeline_consumer_state.advance()
+                        c_pipeline.consumer_wait(c_pipeline_consumer_state)
+                        cute.copy(
+                            tiled_copy_s2r,
+                            tRS_sC[(None, None, None, c_pipeline_consumer_state.index)],
+                            tRS_rC2,
+                        )
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        c_pipeline.consumer_release(c_pipeline_consumer_state)
+                        c_pipeline_consumer_state.advance()
+
+                        # Refill the C pipeline: issue the TMA load for the subtile
+                        # c_prefetch_subtiles ahead (warp epilog_warp_id[0] only), keeping
+                        # the producer running ahead of this consumer within the tile.
+                        if warp_idx == self.epilog_warp_id[0]:
+                            c_pf_idx = real_subtile_idx + c_prefetch_subtiles
+                            if c_pf_idx < c_subtile_cnt:
+                                c_pipeline.producer_acquire(c_pipeline_producer_state)
+                                cute.copy(
+                                    tma_atom_c,
+                                    bGS_gC[(None, 2 * c_pf_idx + 0)],
+                                    bGS_sC[(None, c_pipeline_producer_state.index)],
+                                    tma_bar_ptr=c_pipeline.producer_get_barrier(c_pipeline_producer_state),
+                                )
+                                c_pipeline_producer_state.advance()
+                                c_pipeline.producer_acquire(c_pipeline_producer_state)
+                                cute.copy(
+                                    tma_atom_c,
+                                    bGS_gC[(None, 2 * c_pf_idx + 1)],
+                                    bGS_sC[(None, c_pipeline_producer_state.index)],
+                                    tma_bar_ptr=c_pipeline.producer_get_barrier(c_pipeline_producer_state),
+                                )
+                                c_pipeline_producer_state.advance()
+
+                        acc_vec = tiled_copy_r2s.retile(tTR_rAcc)
+                        ab1_vec_load = tiled_copy_r2s.retile(tRS_rC1)
+                        ab2_vec_load = tiled_copy_r2s.retile(tRS_rC2)
+                        if cutlass.const_expr(self.generate_dprob):
+                            dprob_swiglu = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
+                        else:
+                            dprob_swiglu = None
+
+                        #
+                        # Apply alpha, act, and prob
+                        #
+                        square_alpha = alpha_val * alpha_val
+                        if cutlass.const_expr(self.act_func == "dswiglu"):
+                            d1_vec, d2_vec, dprob_swiglu = self.dswiglu(acc_vec, ab1_vec_load, ab2_vec_load, mProb, beta_val, square_alpha, dprob_swiglu)
+                        elif cutlass.const_expr(self.act_func == "dgeglu"):
+                            d1_vec, d2_vec, dprob_swiglu = self.dgeglu(acc_vec, ab1_vec_load, ab2_vec_load, mProb, linear_offset, dprob_swiglu)
+
+                    #
+                    # Generate SFD (row-wise). thread_tile_amax_1/2 are now the full
+                    # per-tile amax (finalized in pass 1) and are available here.
+                    #
+                    if cutlass.const_expr(self.generate_sfd):
+                        #
+                        # Generate row major SFD
+                        #
+                        self.quant_sfd_row(
+                            (real_subtile_idx * 2 + 0) % 4,
+                            tiled_copy_r2s,
+                            d1_vec,
+                            tCrSFDRow_pvscale,
+                            norm_const,
+                            d_rcp_limits,
+                            tRS_rD1,
+                            sfd2_descale_1,
+                        )
+                        self.quant_sfd_row(
+                            (real_subtile_idx * 2 + 1) % 4,
+                            tiled_copy_r2s,
+                            d2_vec,
+                            tCrSFDRow_pvscale,
+                            norm_const,
+                            d_rcp_limits,
+                            tRS_rD2,
+                            sfd2_descale_2,
+                        )
+                        if subtile_idx % 2 == 1:
+                            local_m_tile = epi_work_tile_info.tile_m_idx
+                            local_n_tile = epi_work_tile_info.tile_n_idx
+                            sfd_row_idx_mn = (
+                                local_m_tile * self.epi_tile_cnt[0] + 0,
+                                local_n_tile * self.epi_tile_cnt[1] // 2 + (real_subtile_idx // 2),
+                            )
+
+                            tCgSFDRow = tCgSFDRow_mn[
+                                (
+                                    None,
+                                    None,
+                                    None,
+                                    *sfd_row_idx_mn,
+                                )
+                            ]
+                            if cutlass.const_expr(not self.use_fp8_ptx_cvt):
+                                tCrSFDRow.store(tCrSFDRow_pvscale.load().to(self.sf_dtype))
+                            else:
+                                self.cvt_f32x4_to_f8x4(tCrSFDRow_pvscale, tCrSFDRow)
+                            if sfd_row_idx_mn[1] * 32 * regPerSubtile < cute.size(cute.shape(mSFDRow_mnl.layout, mode=[1])):
+                                # Coalesced SFD store: scatter this thread's SF
+                                # bytes into the SMEM stage at their atom-layout
+                                # offsets, then write the contiguous block back
+                                # linearly — one 8B word per thread instead of
+                                # 2x4B gmem stores at 16B thread stride (which
+                                # waste 3/4 of every 32B sector). The
+                                # end-of-subtile epilog barrier orders this
+                                # readback before the next event's scatter.
+                                cute.autovec_copy(tCrSFDRow, tCsSFDRow)
+                                self.epilog_sync_barrier.arrive_and_wait()
+                                gSFDRow_evt = gSFDRow_mnl[(None, None, *sfd_row_idx_mn, 0)]
+                                if cutlass.const_expr(self.d_deinterleaved):
+                                    # DEINTERLEAVED scatter. Canonical stage byte
+                                    # a = r + 2p + 4*m4 + 16*m32 + 512*q0 (p =
+                                    # band_parity, q0 = band_pair, q1 =
+                                    # sfd_col_tile_idx) must land at the deint atom
+                                    # position r + 2*q0 + 4*m4 + 16*m32 + 512*q1 +
+                                    # 8f*p. Relative to the canonical tile base
+                                    # (rowblock + 1024*q1) the target offset is
+                                    #   t = a + p*(8f-2) - 510*q0 - 512*q1.
+                                    # Only p/q0/q1 move; r keeps 2B pieces
+                                    # contiguous, so each thread stores 4x Int16.
+                                    sfd_tile_base_addr = gSFDRow_evt.iterator.toint()
+                                    sfd_col_tile_idx = sfd_row_idx_mn[1]
+                                    if epi_tidx * 8 < sfd_stage_size:
+                                        for piece_idx in cutlass.range_constexpr(4):
+                                            stage_byte = epi_tidx * 8 + 2 * piece_idx
+                                            band_parity = (stage_byte // 2) % 2
+                                            band_pair = stage_byte // 512
+                                            deint_offset = stage_byte + band_parity * (4 * self.deint_n - 2) - band_pair * 510 - sfd_col_tile_idx * 512
+                                            gmem_piece = cute.make_tensor(
+                                                cute.make_ptr(
+                                                    cutlass.Int16,
+                                                    sfd_tile_base_addr + deint_offset,
+                                                    AddressSpace.gmem,
+                                                    assumed_align=2,
+                                                ),
+                                                cute.make_layout(1),
+                                            )
+                                            gmem_piece[0] = sSFDRowStage_half[stage_byte // 2]
+                                else:
+                                    # INTERLEAVED: the stage IS the gmem tile —
+                                    # linear copy, one 8B word per thread.
+                                    gSFDRow_words = cute.make_tensor(
+                                        cute.make_ptr(
+                                            cutlass.Int64,
+                                            gSFDRow_evt.iterator.toint(),
+                                            AddressSpace.gmem,
+                                            assumed_align=8,
+                                        ),
+                                        cute.make_layout(sfd_stage_size // 8),
+                                    )
+                                    if epi_tidx * 8 < sfd_stage_size:
+                                        gSFDRow_words[epi_tidx] = sSFDRowStage_words[epi_tidx]
+                    else:
+                        #
+                        # Convert to D type
+                        #
+                        tRS_rD1.store(d1_vec.to(self.d_dtype))
+                        tRS_rD2.store(d2_vec.to(self.d_dtype))
+
+                    #
+                    # Store D
+                    #
+                    if cutlass.const_expr(self.store_d_directly):
+                        self.epilog_sync_barrier.arrive_and_wait()
+                        d_idx_mn = (mma_tile_coord_mnl[0], mma_tile_coord_mnl[1])
+                        d_epilogue_subtile = (
+                            cute.make_layout(128),
+                            cute.make_layout(self.mma_tiler[1] * 2),
+                        )
+                        gD_sub_loop = cute.local_tile(real_d, d_epilogue_subtile, (None, None, None))
+                        tCgD_mnl_loop = thr_copy_t2r.partition_D(gD_sub_loop)
+                        tCgD_mnl_loop = cute.filter_zeros(tCgD_mnl_loop)
+                        tCgD1 = tCgD_mnl_loop[
+                            (
+                                None,
+                                0,  # T2R_M
+                                2 * real_subtile_idx + 0,  # T2R_N
+                                *d_idx_mn,  # RestM/N
+                                0,  # RestL
+                            )
+                        ]
+                        tCgD2 = tCgD_mnl_loop[
+                            (
+                                None,
+                                0,  # T2R_M
+                                2 * real_subtile_idx + 1,  # T2R_N
+                                *d_idx_mn,  # RestM/N
+                                0,  # RestL
+                            )
+                        ]
+                        self.store_global_memory_256b(tCgD1, tRS_rD1)
+                        self.store_global_memory_256b(tCgD2, tRS_rD2)
+                    else:
+                        if warp_idx == self.epilog_warp_id[0]:
+                            d_pipeline.producer_acquire()
+                        self.epilog_sync_barrier.arrive_and_wait()
+                        d1_buffer = num_prev_subtiles % self.num_d_stage
+                        num_prev_subtiles = num_prev_subtiles + 1
+                        cute.copy(
+                            tiled_copy_r2s,
+                            tRS_rD1,
+                            tRS_sD[(None, None, None, d1_buffer)],
+                        )
+                        d2_buffer = num_prev_subtiles % self.num_d_stage
+                        num_prev_subtiles = num_prev_subtiles + 1
+                        cute.copy(
+                            tiled_copy_r2s,
+                            tRS_rD2,
+                            tRS_sD[(None, None, None, d2_buffer)],
+                        )
+                        # Fence and barrier to make sure shared memory store is visible to TMA store
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        self.epilog_sync_barrier.arrive_and_wait()
+                        #
+                        # TMA store D to global memory
+                        #
+                        if warp_idx == self.epilog_warp_id[0]:
+                            cute.copy(
+                                tma_atom_d,
+                                bSG_sD[(None, d1_buffer)],
+                                bSG_gD[(None, 2 * real_subtile_idx + 0)],
+                            )
+                            cute.copy(
+                                tma_atom_d,
+                                bSG_sD[(None, d2_buffer)],
+                                bSG_gD[(None, 2 * real_subtile_idx + 1)],
+                            )
+                            # Fence and barrier to make sure shared memory store is visible to TMA store
+                            d_pipeline.producer_commit()
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+                #
+                # Async arrive accumulator buffer empty
+                #
+                epi_pipeline.consumer_release(epi_consumer_state)
+                epi_consumer_state.advance()
+
+                #
+                # Advance to next tile
+                #
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+                if cutlass.const_expr(self.generate_dprob):
+                    real_dprob, _ = epi_ext.get_gmem_tensor("dprob", dprob, padded_offsets, epi_work_tile_info)
+                    _ = atomic_add_float32(
+                        ptr=real_dprob[(mPosition, None, None)].iterator.llvm_ptr,
+                        value=dProbVal,
+                    )
+
+            #
+            # Wait for outstanding C TMA loads (producer side) to drain
+            #
+            if warp_idx == self.epilog_warp_id[0]:
+                c_pipeline.producer_tail(c_pipeline_producer_state)
+
+            #
+            # Dealloc the tensor memory buffer
+            #
+            tmem.relinquish_alloc_permit()
+            self.epilog_sync_barrier.arrive_and_wait()
+            tmem.free(tmem_ptr)
+            #
+            # Wait for D store complete
+            #
+            if cutlass.const_expr(not self.store_d_directly):
+                d_pipeline.producer_tail()
+        #
+
+    def epilog_tmem_copy_and_partition(
+        self,
+        tidx: cutlass.Int32,
+        tAcc: cute.Tensor,
+        epi_tile: cute.Tile,
+        use_2cta_instrs: Union[cutlass.Boolean, bool],
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for tensor memory load, then use it to partition tensor memory (source)
+        and derive register array shape from the TMEM partition (no gmem dependency).
+
+        :param tidx: The thread index in epilogue warp groups
+        :type tidx: cutlass.Int32
+        :param tAcc: The accumulator tensor to be copied and partitioned
+        :type tAcc: cute.Tensor
+        :param epi_tile: The epilogue tiler
+        :type epi_tile: cute.Tile
+        :param use_2cta_instrs: Whether use_2cta_instrs is enabled
+        :type use_2cta_instrs: bool
+
+        :return: A tuple containing (tiled_copy_t2r, tTR_tAcc, tTR_rAcc) where:
+            - tiled_copy_t2r: The tiled copy operation for tmem to register copy(t2r)
+            - tTR_tAcc: The partitioned accumulator tensor in TMEM
+            - tTR_rAcc: The register tensor for accumulator (shape derived from TMEM partition)
+        :rtype: Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]
+        """
+        copy_atom_t2r = sm100_utils.get_tmem_load_op(
+            self.cta_tile_shape_mnk,
+            self.d_layout,
+            self.d_dtype,
+            self.acc_dtype,
+            epi_tile,
+            use_2cta_instrs,
+        )
+
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, STAGE)
+        tAcc_epi = cute.flat_divide(
+            tAcc[((None, None), 0, 0, None)],
+            epi_tile,
+        )
+        # (EPI_TILE_M, EPI_TILE_N)
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tAcc_epi[(None, None, 0, 0, 0)])
+
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+        # (T2R, T2R_M, T2R_N, EPI_M, EPI_N, STAGE)
+        tTR_tAcc = thr_copy_t2r.partition_S(tAcc_epi)
+        tTR_rAcc = thr_copy_t2r.partition_D(tAcc_epi)
+
+        # Derive register shape from TMEM partition (no gmem D needed)
+        per_subtile_shape = cute.coalesce(tTR_rAcc[(None, None, None, 0, 0, 0)].layout, target_profile=((1, 1), 1, 1)).shape
+        tTR_rAcc = cute.make_rmem_tensor(per_subtile_shape, self.acc_dtype)
+        return tiled_copy_t2r, tTR_tAcc, tTR_rAcc
+
+    def acc_update_tmem_copy_and_partition(
+        self,
+        tidx: cutlass.Int32,
+        tCtAcc_base: cute.Tensor,
+        gD_mnl: cute.Tensor,
+        sSFA: cute.Tensor,
+        sSFB: cute.Tensor,
+        sFinalAcc: cute.Tensor,
+        epi_tile: cute.Tile,
+    ) -> Tuple[cute.TiledCopy, cute.TiledCopy, cute.Tensor, cute.Tensor, cute.Tensor, cute.Tensor, cute.Tensor, cute.Tensor]:
+        """
+        Create tiled copy operations and partition tensors for accumulator update warp.
+
+        This function sets up T2R (TMEM-to-Register) and R2S (Register-to-SMEM) copies
+        for the accumulator update warp to:
+        1. Load partial accumulators from TMEM (tCtAcc_base) to registers
+        2. Store final accumulated result from registers to SMEM (sFinalAcc)
+
+        The GLU gate/up interleaving is already handled by the TMEM layout, so we don't
+        need to explicitly separate them here.
+
+        :param tidx: Thread index within accumulator update warp group
+        :param tCtAcc_base: TMEM tensor for reading partial accumulators (from MMA)
+        :param gD_mnl: Global tensor D shape (for partitioning)
+        :param sFinalAcc: SMEM tensor for writing final accumulator (for epilogue)
+        :param epi_tile: Epilogue tile size
+        :return: Tuple of (tiled_copy_t2r, tiled_copy_r2s_acc, tTR_tAcc_base, tTR_rAcc,
+                          tTR_rAcc_final, tRS_sFinalAcc, tTR_sSFA, tTR_sSFB)
+        """
+        # Create TMEM load atom based on MMA tile size
+        if cutlass.const_expr(self.mma_tiler[0] == 64):
+            tmem_load_atom = cute.make_copy_atom(
+                tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(8)),
+                self.acc_dtype,
+            )
+        else:
+            tmem_load_atom = cute.make_copy_atom(
+                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)),
+                self.acc_dtype,
+            )
+
+        # Partition accumulator tensors by epilogue tile
+        tAcc_epi = cute.flat_divide(tCtAcc_base[((None, None), 0, 0, None)], epi_tile)
+
+        # Create tiled copy for T2R (TMEM to Register)
+        tiled_copy_t2r = tcgen05.make_tmem_copy(tmem_load_atom, tAcc_epi[(None, None, 0, 0, 0)])
+
+        # Get thread-specific slice
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+
+        # R2S (Register to SMEM) store of the final accumulator: reuse the T2R copy's
+        # thread-value layout with a universal copy atom (swizzle-safe for f32)
+        copy_atom_r2s_acc = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.acc_dtype)
+        tiled_copy_r2s_acc = cute.make_tiled_copy_D(copy_atom_r2s_acc, tiled_copy_t2r)
+        # (R2S, R2S_M, R2S_N, SUBTILE * STAGE)
+        tRS_sFinalAcc = tiled_copy_r2s_acc.get_slice(tidx).partition_D(sFinalAcc)
+
+        # Partition source for T2R: tCtAcc_base (read partial accumulators)
+        tTR_tAcc_base = thr_copy_t2r.partition_S(tAcc_epi)
+
+        # Partition gD_mnl for determining register buffer shape
+        gD_mnl_epi = cute.flat_divide(gD_mnl[((None, None), 0, 0, None, None, None)], epi_tile)
+        sSFA_epi = cute.flat_divide(sSFA, epi_tile)
+        sSFB_epi = cute.flat_divide(sSFB, epi_tile)
+
+        tTR_gC = thr_copy_t2r.partition_D(gD_mnl_epi)
+        tTR_sSFA = thr_copy_t2r.partition_D(sSFA_epi)
+        tTR_sSFB = thr_copy_t2r.partition_D(sSFB_epi)
+
+        # Create register tensor for T2R destination (holds one k_tile's partial accumulator)
+        tTR_rAcc = cute.make_rmem_tensor(tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].shape, self.acc_dtype)
+
+        # Create register tensor for final accumulated result across all k_tiles
+        # Shape: (T2R, T2R_M, T2R_N, EPI_M, EPI_N) -> grouped to (T2R, T2R_M, T2R_N, (EPI_M, EPI_N))
+        tTR_rAcc_final_ = cute.make_rmem_tensor(tTR_gC[(None, None, None, None, None, 0, 0, 0)].shape, self.acc_dtype)
+        tTR_rAcc_final = cute.group_modes(tTR_rAcc_final_, 3, cute.rank(tTR_rAcc_final_))
+
+        return (
+            tiled_copy_t2r,
+            tiled_copy_r2s_acc,
+            tTR_tAcc_base,
+            tTR_rAcc,
+            tTR_rAcc_final,
+            tRS_sFinalAcc,
+            tTR_sSFA,
+            tTR_sSFB,
+        )
+
+    def epilog_smem_acc_load_and_partition(self, tiled_copy_t2r, tidx, sFinalAcc):
+        """S2R load of the final accumulator from SMEM (sFinalAcc). Reuses the T2R copy's
+        thread-value layout with a universal f32 copy atom. Returns the tiled copy and the
+        partitioned SMEM source; register targets are retiled at the load site."""
+        copy_atom_s2r = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.acc_dtype)
+        tiled_copy_s2r = cute.make_tiled_copy_D(copy_atom_s2r, tiled_copy_t2r)
+        # (S2R, S2R_M, S2R_N, SUBTILE * STAGE)
+        tSR_sFinalAcc = tiled_copy_s2r.get_slice(tidx).partition_D(sFinalAcc)
+        return tiled_copy_s2r, tSR_sFinalAcc
+
+    def epilog_smem_copy_and_partition_load(
+        self,
+        tiled_copy_t2r: cute.TiledCopy,
+        tTR_rC: cute.Tensor,
+        tTR_rC1: cute.Tensor,
+        tidx: cutlass.Int32,
+        sC: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for shared memory load, then use it to partition register array (destination) and shared memory (source).
+
+        :param tiled_copy_t2r: The tiled copy operation for tmem to register copy(t2r)
+        :type tiled_copy_t2r: cute.TiledCopy
+        :param tTR_rC: The partitioned accumulator tensor
+        :type tTR_rC: cute.Tensor
+        :param tidx: The thread index in epilogue warp groups
+        :type tidx: cutlass.Int32
+        :param sC: The shared memory tensor to be copied and partitioned
+        :type sC: cute.Tensor
+
+        :return: A tuple containing (tiled_copy_s2r, tSR_rC, tSR_sC) where:
+            - tiled_copy_s2r: The tiled copy operation for smem to register copy(s2r)
+            - tSR_rC: The partitioned tensor C (register destination)
+            - tSR_sC: The partitioned tensor C (smem source)
+        :rtype: Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]
+        """
+        copy_atom_s2r = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.c_dtype)
+        tiled_copy_s2r = cute.make_tiled_copy_D(copy_atom_s2r, tiled_copy_t2r)
+        # (S2R, S2R_M, S2R_N, PIPE_C)
+        thr_copy_s2r = tiled_copy_s2r.get_slice(tidx)
+        tSR_sC = thr_copy_s2r.partition_D(sC)
+        # (S2R, S2R_M, S2R_N)
+        tSR_rC = tiled_copy_s2r.retile(tTR_rC)
+        tSR_rC1 = tiled_copy_s2r.retile(tTR_rC1)
+        return tiled_copy_s2r, tSR_rC, tSR_rC1, tSR_sC
+
+    def epilog_smem_copy_and_partition_store(
+        self,
+        tiled_copy_t2r: cute.TiledCopy,
+        tTR_rD1: cute.Tensor,
+        tTR_rD2: cute.Tensor,
+        tidx: cutlass.Int32,
+        sD: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for shared memory store, then use it to partition register array (source) and shared memory (destination).
+
+        :param tiled_copy_t2r: The tiled copy operation for tmem to register copy(t2r)
+        :type tiled_copy_t2r: cute.TiledCopy
+        :param tTR_rD1: The partitioned accumulator tensor
+        :type tTR_rD1: cute.Tensor
+        :param tTR_rD2: The partitioned accumulator tensor
+        :type tTR_rD2: cute.Tensor
+        :param tidx: The thread index in epilogue warp groups
+        :type tidx: cutlass.Int32
+        :param sD: The shared memory tensor to be copied and partitioned
+        :type sD: cute.Tensor
+
+        :return: A tuple containing (tiled_copy_r2s, tRS_rD, tRS_sD) where:
+            - tiled_copy_r2s: The tiled copy operation for register to smem copy(r2s)
+            - tRS_rD: The partitioned tensor D (register source)
+            - tRS_sD: The partitioned tensor D (smem destination)
+        :rtype: Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]
+        """
+        copy_atom_r2s = sm100_utils.get_smem_store_op(self.d_layout, self.d_dtype, self.acc_dtype, tiled_copy_t2r)
+        tiled_copy_r2s = cute.make_tiled_copy_D(copy_atom_r2s, tiled_copy_t2r)
+        # (R2S, R2S_M, R2S_N, PIPE_D)
+        thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+        tRS_sD = None
+        if cutlass.const_expr(sD is not None):
+            tRS_sD = thr_copy_r2s.partition_D(sD)
+        # (R2S, R2S_M, R2S_N)
+        tRS_rD1 = tiled_copy_r2s.retile(tTR_rD1)
+        tRS_rD2 = tiled_copy_r2s.retile(tTR_rD2)
+        return tiled_copy_r2s, tRS_rD1, tRS_rD2, tRS_sD
+
+    def epilog_gmem_copy_and_partition(
+        self,
+        tidx: cutlass.Int32,
+        atom: Union[cute.CopyAtom, cute.TiledCopy],
+        gD_mnl: cute.Tensor,
+        epi_tile: cute.Tile,
+        sD: cute.Tensor,
+    ) -> Tuple[cute.CopyAtom, cute.Tensor, cute.Tensor]:
+        """Make tiledCopy for global memory store, then use it to:
+        - partition register array (source) and global memory (destination) for none TMA store version;
+        - partition shared memory (source) and global memory (destination) for TMA store version.
+
+        :param tidx: The thread index in epilogue warp groups
+        :type tidx: cutlass.Int32
+        :param atom: The copy_atom_c to be used for TMA store version, or tiled_copy_t2r for none TMA store version
+        :type atom: cute.CopyAtom or cute.TiledCopy
+        :param gD_mnl: The global tensor D
+        :type gD_mnl: cute.Tensor
+        :param epi_tile: The epilogue tiler
+        :type epi_tile: cute.Tile
+        :param sD: The shared memory tensor to be copied and partitioned
+        :type sD: cute.Tensor
+
+        :return: A tuple containing :
+            - For TMA store: (tma_atom_d, bSG_sD, bSG_gD) where:
+                - tma_atom_d: The TMA copy atom
+                - bSG_sD: The partitioned shared memory tensor D
+                - bSG_gD: The partitioned global tensor D
+        :rtype: Tuple[cute.CopyAtom, cute.Tensor, cute.Tensor]
+        """
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, loopM, loopN, loopL)
+        gD_epi = cute.flat_divide(gD_mnl[((None, None), 0, 0, None, None, None)], epi_tile)
+        tma_atom_d = atom
+        sD_for_tma_partition = cute.group_modes(sD, 0, 2)
+        gD_for_tma_partition = cute.group_modes(gD_epi, 0, 2)
+        # ((ATOM_V, REST_V), EPI_M, EPI_N)
+        # ((ATOM_V, REST_V), EPI_M, EPI_N, loopM, loopN, loopL)
+        bSG_sD, bSG_gD = cpasync.tma_partition(
+            tma_atom_d,
+            0,
+            cute.make_layout(1),
+            sD_for_tma_partition,
+            gD_for_tma_partition,
+        )
+        return bSG_sD, bSG_gD
+
+    @staticmethod
+    def _compute_stages(
+        tiled_mma: cute.TiledMma,
+        mma_tiler_mnk: Tuple[int, int, int],
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
+        epi_tile: cute.Tile,
+        c_dtype: Type[cutlass.Numeric],
+        c_layout: utils.LayoutEnum,
+        d_dtype: Type[cutlass.Numeric],
+        d_layout: utils.LayoutEnum,
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        num_smem_capacity: int,
+        occupancy: int,
+        store_d_directly: bool,
+        generate_dbias: bool = False,
+        acc_dtype: Type[cutlass.Numeric] = None,
+        sf2_dtype: Type[cutlass.Numeric] = None,
+        sgm: int = 1,
+        sgn: int = 256,
+        sgk: int = 256,
+        num_epi_stage: int = 1,
+        row_dsmem: bool = False,
+    ) -> Tuple[int, int, int]:
+        """Computes the number of stages for A/B/D operands based on heuristics.
+
+        :param tiled_mma: The tiled MMA object defining the core computation.
+        :type tiled_mma: cute.TiledMma
+        :param mma_tiler_mnk: The shape (M, N, K) of the MMA tiler.
+        :type mma_tiler_mnk: tuple[int, int, int]
+        :param a_dtype: Data type of operand A.
+        :type a_dtype: type[cutlass.Numeric]
+        :param b_dtype: Data type of operand B.
+        :type b_dtype: type[cutlass.Numeric]
+        :param epi_tile: The epilogue tile shape.
+        :type epi_tile: cute.Tile
+        :param c_dtype: Data type of operand C (output).
+        :type c_dtype: type[cutlass.Numeric]
+        :param d_layout: Layout of operand D.
+        :type d_layout: utils.LayoutEnum
+        :param sf_dtype: Data type of scale factor.
+        :type sf_dtype: type[cutlass.Numeric]
+        :param sf_vec_size: Vector size of scale factor.
+        :type sf_vec_size: int
+        :param num_smem_capacity: Total available shared memory capacity in bytes.
+        :type num_smem_capacity: int
+        :param occupancy: Target number of CTAs per SM (occupancy).
+        :type occupancy: int
+
+        :return: A tuple containing the computed number of stages for:
+                 (ACC stages, A/B operand stages, D stages)
+        :rtype: tuple[int, int, int]
+        """
+        # Default ACC stages
+        num_acc_stage = 1 if mma_tiler_mnk[1] == 256 else 3
+
+        # Default C/D stages
+        num_c_stage = 4 if a_dtype.width == 8 else (4 if store_d_directly else 2)
+        num_d_stage = 2 if a_dtype.width == 8 else (0 if store_d_directly else 2)
+
+        # Default Tile info stages
+        num_tile_stage = 2
+
+        # Calculate smem layout and size for one stage of A, B, and D
+        a_smem_layout_stage_one = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            mma_tiler_mnk,
+            a_dtype,
+            1,  # a tmp 1 stage is provided
+        )
+        b_smem_layout_staged_one = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            mma_tiler_mnk,
+            b_dtype,
+            1,  # a tmp 1 stage is provided
+        )
+
+        sfa_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            mma_tiler_mnk,
+            sf_vec_size,
+            1,  # a tmp 1 stage is provided
+        )
+
+        sfb_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            mma_tiler_mnk,
+            sf_vec_size,
+            1,  # a tmp 1 stage is provided
+        )
+
+        c_smem_layout_staged_one = sm100_utils.make_smem_layout_epi(
+            c_dtype,
+            c_layout,
+            epi_tile,
+            1,
+        )
+
+        d_smem_layout_staged_one = sm100_utils.make_smem_layout_epi(
+            d_dtype,
+            d_layout,
+            epi_tile,
+            1,
+        )
+
+        # Compute second level scale factor layout
+        if sgm < mma_tiler_mnk[0]:
+            size_m = sgm
+        else:
+            size_m = mma_tiler_mnk[0]
+
+        if sgn < mma_tiler_mnk[1]:
+            size_n = sgn
+        else:
+            size_n = mma_tiler_mnk[1]
+
+        if sgk < mma_tiler_mnk[2]:
+            size_k = sgk
+        else:
+            size_k = mma_tiler_mnk[2]
+
+        scale_m_per_tile = mma_tiler_mnk[0] // size_m
+        scale_n_per_tile = mma_tiler_mnk[1] // size_n
+        scale_k_per_tile = mma_tiler_mnk[2] // size_k
+
+        sfa2_smem_layout_staged_one = cute.make_layout(
+            (
+                (size_m, scale_m_per_tile),
+                (size_k, scale_k_per_tile),
+                1,
+            ),
+            stride=(
+                (0, scale_k_per_tile),
+                (0, 1),
+                scale_k_per_tile * scale_m_per_tile,
+            ),
+        )
+        sfb2_smem_layout_staged_one = cute.make_layout(
+            (
+                (size_n, scale_n_per_tile),
+                (size_k, scale_k_per_tile),
+                1,
+            ),
+            stride=(
+                (0, scale_k_per_tile),
+                (0, 1),
+                scale_k_per_tile * scale_n_per_tile,
+            ),
+        )
+
+        ab_bytes_per_stage = (
+            cute.size_in_bytes(a_dtype, a_smem_layout_stage_one)
+            + cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfa_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
+            + cute.size_in_bytes(sf2_dtype, sfa2_smem_layout_staged_one)
+            + cute.size_in_bytes(sf2_dtype, sfb2_smem_layout_staged_one)
+        )
+
+        # Mbar bytes
+        mbar_helpers_bytes = 1024
+        # Sinfo bytes
+        sinfo_bytes = 4 * 4 * num_tile_stage
+        # C/D bytes
+        c_bytes_per_stage = cute.size_in_bytes(c_dtype, c_smem_layout_staged_one)
+        c_bytes = c_bytes_per_stage * num_c_stage
+        d_bytes_per_stage = cute.size_in_bytes(d_dtype, d_smem_layout_staged_one)
+        d_bytes = d_bytes_per_stage * num_d_stage
+        if d_dtype == cutlass.Float8E5M2 or d_dtype == cutlass.Float8E4M3FN:
+            d_bytes = d_bytes * 2
+        # AMAX bytes
+        amax_bytes = get_amax_smem_size() if d_dtype == cutlass.BFloat16 else 0
+        # dBias transpose buffer: (128, 64) column-major FP32 = 32 KB
+        dbias_bytes = 128 * 64 * cute.size_in_bytes(cutlass.Float32, cute.make_layout((1,))) if generate_dbias else 0
+        # Full-CTA-tile final accumulator buffer in SMEM (replaces the TMEM final region).
+        # The stage mode holds subtile_cnt full-tile slots per epi stage, so the
+        # buffer scales with num_epi_stage (double-buffered when num_epi_stage == 2).
+        cta_m = mma_tiler_mnk[0] // cute.size(tiled_mma.thr_id.shape)
+        cta_n = mma_tiler_mnk[1]
+        subtile_cnt = (cta_m // cute.size(epi_tile[0])) * (cta_n // cute.size(epi_tile[1]))
+        final_acc_smem_layout_one = sm100_utils.make_smem_layout_epi(
+            acc_dtype,
+            d_layout,
+            epi_tile,
+            subtile_cnt * num_epi_stage,
+        )
+        final_acc_bytes = cute.size_in_bytes(acc_dtype, final_acc_smem_layout_one)
+
+        # Epilogue bytes
+        # DSMEM rowwise-sfd2 reduction buffer: 2 parity slots x (cta_m gate +
+        # cta_m up) f32 row descales, counted BEFORE the greedy num_ab_stage
+        # computation below so it never overflows smem.
+        cta_m_rows = mma_tiler_mnk[0] // cute.size(tiled_mma.thr_id.shape)
+        row_dsmem_bytes = 2 * (2 * cta_m_rows) * 4 if row_dsmem else 0
+
+        epi_bytes = c_bytes + d_bytes + amax_bytes + dbias_bytes + final_acc_bytes + row_dsmem_bytes
+
+        # Calculate A/B stages:
+        # Start with total smem per CTA (capacity / occupancy)
+        # Subtract reserved bytes (mbar, epi, sinfo, sfa2, sfb2)
+        # Divide remaining by bytes needed per A/B stage
+        num_ab_stage = (num_smem_capacity // occupancy - (mbar_helpers_bytes + epi_bytes + sinfo_bytes)) // ab_bytes_per_stage
+        assert num_ab_stage >= 1, (
+            f"SMEM overflow: full-tile sFinalAcc ({final_acc_bytes} B) leaves no room for " f"AB stages (mma_tiler={mma_tiler_mnk}); reduce mma_tiler_mn"
+        )
+
+        total_bytes = occupancy * (ab_bytes_per_stage * num_ab_stage + epi_bytes + sinfo_bytes + mbar_helpers_bytes)
+        return num_acc_stage, num_ab_stage, num_c_stage, num_d_stage, num_tile_stage

--- a/python/cudnn/gemm/cutedsl/grouped/dswiglu_subchannel_scaled/moe_blockscaled_grouped_gemm_dswiglu_subchannel_scaled_rubin.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dswiglu_subchannel_scaled/moe_blockscaled_grouped_gemm_dswiglu_subchannel_scaled_rubin.py
@@ -1,0 +1,5264 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Subchannel-Scaled MoE Block-Scaled Grouped GEMM Kernel with dGLU (dSwiGLU) Backward Fusion (Rubin sm107).
+
+Rubin-native port of grouped_gemm_dswiglu_subchannel_scaled.py: same features, same
+``__init__``/``__call__`` surface (plus the trailing ``sf_fp8_dtype_override`` knob), with the
+sm107 MMA builders (``cutlass.utils.rubin_helpers``), register budgets, TMEM/SF packing and
+epilogue partitioning of the bs_ggemm_harness ``dgrad_dglu_rht_2/kernel_sm107.py`` kernel
+(its RHT paths are not carried over). E5M3 first-level scales (``FloatNV8E5M3FNU``) are
+accepted on this architecture; with e5m3 inputs the quantized-D row scales are e5m3-encoded
+as well (output scale format follows the input's).
+
+Supports:
+    - Static / Dynamic persistent tile scheduling (MoEPersistentTileScheduler)
+    - Dense (contiguous 3-D B) / Discrete (per-expert pointer array B) weight layout
+    - FP8/FP4 output quantization with row scale factors (SFD)
+    - AMAX reduction for FP8 calibration
+    - dGLU backward activation fusion (dSwiGLU / dGeGLU)
+
+This module contains only the kernel class.
+MoE scheduler components live in moe_persistent_scheduler.py / moe_sched_extension.py / moe_utils.py.
+"""
+
+from typing import Literal, Type, Tuple, Union, Optional
+from functools import partial
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import cpasync, tcgen05
+from cutlass.cute.nvgpu import OperandMajorMode
+from cutlass.cute.nvgpu.tcgen05 import CollectorOp
+from cutlass.cutlass_dsl import T
+from cutlass.utils.gemm.sm100 import transform_partitioned_tensor_layout
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.utils.rubin_helpers as sm107_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+
+from cutlass.cute.typing import Float32, Int32, AddressSpace
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import math, llvm
+from cutlass._mlir.dialects import vector, arith
+
+from ..moe_persistent_scheduler import (
+    MoEPersistentTileScheduler,
+    MoESchedulerParams,
+    MoEWorkTileInfo,
+)
+from ..moe_utils import (
+    MoEWeightMode,
+    TensormapWorkspace,
+    compute_expert_token_range,
+    store_tma_desc,
+)
+from ..moe_sched_extension import (
+    DiscreteWeightScaledGemmSchedExtension,
+    ContiguousAndConsistentGroupedGemmSchedExtension,
+)
+from ..moe_kernel_helpers import (
+    fmin,
+    fmax,
+    fmin_bf16x2,
+    fmax_bf16x2,
+    atomic_max_float32,
+    atomic_add_float32,
+    atomic_add_i32_gmem,
+    load_acquire_i32_gpu,
+    load_float32_volatile,
+    sigmoid_f32,
+    get_dtype_rcp_limits,
+    get_dtype_max,
+    get_amax_smem_size,
+    is_valid_layouts,
+    is_valid_mma_tiler_and_cluster_shape,
+    is_valid_tensor_alignment,
+    atomic_add_bf16x2,
+    nanosleep,
+    red_smem_cluster_max_f32,
+    mbarrier_arrive_cluster,
+)
+
+"""
+High-performance persistent blockscaled contiguous grouped dense GEMM (D = alpha * (SFA * A) * (SFB * B)) example for the NVIDIA Blackwell architecture
+using CUTE DSL.
+- Matrix A is MxKx1, A can be row-major("K"), ValidM is composed of valid m in different groups
+- Matrix B is NxKxL, B can be column-major("K"), L is grouped dimension
+- Matrix D is MxNx1, D can be row-major("N"), ValidM is composed of valid m in different groups
+- Matrix SFA layout is filled internally according to A shape and BlockScaledBasicChunk, which has M×ceil_div(K, sf_vec_size)×L elements respectively
+- Matrix SFB layout is filled internally according to B shape and BlockScaledBasicChunk, which has N×ceil_div(K, sf_vec_size)×L elements respectively
+
+Matrix A/D Memory Layout Diagrams:
+
+   ```
+    Group 0    Group 1   Group 2
+   -+---------+---------+---------+
+    |         |         |         |
+   K| ValidM0 | ValidM1 | ValidM2 |
+    |         |         |         |
+   -+---------+---------+---------+
+    |<-        ValidM           ->|
+   ```
+   Note: the Group(L) dimension will be flatted into M dimension, and the rest Group(L) size is 1.
+         each ValidM will be aligned to 256 or 128. The alignment is determined by the mma_tiler_mn parameter.
+         For NVFP4, 2CTA, the alignment is 256. For NVFP4, 1CTA, the alignment is 128. 
+
+This GEMM kernel supports the following features:
+    - Utilizes Tensor Memory Access (TMA) for efficient memory operations
+    - Utilizes Blackwell's tcgen05.mma for matrix multiply-accumulate (MMA) operations
+    - Implements TMA multicast with cluster to reduce L2 memory traffic
+    - Support persistent tile scheduling to better overlap memory load/store with mma between tiles
+    - Support warp specialization to avoid explicit pipelining between mainloop load and mma
+
+This GEMM works as follows:
+1. DMA warp: Load A and B matrices from global memory (GMEM) to shared memory (SMEM) using TMA operations.
+2. SCALE warp: Load scaleA and scaleB matrices from global memory (GMEM) to shared memory (SMEM) using non-TMA operations.
+2. MMA warp: 
+    - Load scale factor A/B from shared memory (SMEM) to tensor memory (TMEM) using tcgen05.cp instruction.
+    - Perform matrix multiply-accumulate (MMA) operations using tcgen05.mma instruction.
+3. EPILOGUE warp:
+    - Load completed accumulator from tensor memory (TMEM) to registers (RMEM) using tcgen05.ld.
+    - Apply alpha and update the final accumulator Final = alpha * acc
+    - Type convert Final matrix to output type.
+    - Store D matrix from registers (RMEM) to shared memory (SMEM) to global memory (GMEM) with TMA operations.
+
+SM100 tcgen05.mma.kind.block_scale instructions operate as follows:
+- Read matrix A from SMEM
+- Read matrix B from SMEM
+- Read scalefactor A from TMEM
+- Read scalefactor B from TMEM
+- Write accumulator to TMEM
+The accumulator in TMEM must then be loaded to registers before writing back to GMEM.
+
+.. code-block:: bash
+
+    python continugous_blockscaled_grouped_gemm_dglu_quant_fusion.py         \
+      --ab_dtype Float8E4M3FN --sf_dtype Float8E8M0FNU --c_dtype BFloat16    \
+      --d_dtype Float8E4M3FN --sf_vec_size 32 --mma_tiler_mn 256,256         \
+      --cluster_shape_mn 2,1 --nkl 4096,7168,8 --use_2cta_instrs             \
+      --m_aligned 256 --fixed_m 4096 --warmup_iterations 10 --iterations 30
+
+
+Constraints:
+* Supported input data types: mxf8, nvf4
+  see detailed valid dtype combinations in below Sm100BlockScaledPersistentDenseGemmKernel class documentation
+* A/B tensor must have the same data type, mixed data type is not supported (e.g., mxf8 x mxf4)
+* Mma tiler M must be 128 or 256(use_2cta_instrs)
+* Mma tiler N must be 64/128/192/256
+* Cluster shape M/N must be positive and power of 2, total cluster size <= 16
+* Cluster shape M must be multiple of 2 if Mma tiler M is 256(use_2cta_instrs)
+* The contiguous dimension of A/B/D tensors must be at least 16 bytes aligned,
+  i.e, number of elements is a multiple of 16 and 32 for Float8 and Float4, respectively.
+
+CUDA Graph Support:
+* For CUDA graph support, the A/D matrices and scale factor A can be padded to a larger size
+  (e.g., permuted_m = m*topK + num_local_experts*(FIX_PAD_SIZE-1), example: 4096*8 + 8*255 = 34808)
+* Use create_tensors() with permuted_m parameter to automatically pad:
+  - A matrix: padded to permuted_m rows (padding rows contain dummy data)
+  - D matrix: padded to permuted_m rows (output buffer for cuda_graph)
+  - Scale factor A: padded to match A matrix dimensions
+* Kernel handling of padding:
+  - Scheduler warp loads padded_offsets and calculates num_valid_tiles from padded_offsets[-1]
+  - Uses warp-parallel search (ballot + ffs) to find expert_idx for each tile
+  - Only valid tiles (tile_m_start < padded_offsets[-1]) are written to tile_info pipeline
+  - When no more valid tiles exist, outer loop exits and calls producer_tail()
+  - Consumer warps process only valid tiles from pipeline
+  - No deadlock or synchronization issues
+* Only rows within (aligned_groupm[0]+aligned_groupm[1]+...) contain valid data
+* Padding rows in D matrix will not be written by the kernel
+"""
+
+
+def _is_quant_dtype_combo(a_dtype, sf_dtype, d_dtype) -> bool:
+    """Whether the dtype triple selects the quantized-D epilogue
+    (generate_sfd). A plain module-level function so the result is a real
+    python bool even when called from traced code (the @cute.jit AST pass
+    rewrites `in`/`and` inside the kernel's __call__ into cutlass.Boolean,
+    which cannot feed SharedStorage sizing)."""
+    return (
+        a_dtype in (cutlass.Float8E5M2, cutlass.Float8E4M3FN, cutlass.Float4E2M1FN)
+        and sf_dtype in (cutlass.Float8E8M0FNU, cutlass.Float8E4M3FN, cutlass.FloatNV8E5M3FNU)
+        and d_dtype in (cutlass.Float8E5M2, cutlass.Float8E4M3FN, cutlass.Float4E2M1FN)
+    )
+
+
+def _deinterleave_n_coord_tensor(t, mode=1, n_static=None):
+    """View a tensor carrying d's interleaved n axis at `mode` with that mode
+    split (32, 2, n/64), strides (b, (n/2)*b, 32*b): callers keep indexing in
+    INTERLEAVED d coordinates, but interleaved 32-col band bd now lands at the
+    DEINTERLEAVED position 32*(bd//2) + (bd%2)*(n/2) — gate bands fill
+    [0, n/2), up bands [n/2, n). For d it is applied to the TMA coordinate
+    tensor AFTER make_tiled_tma_atom (sfb-192 precedent): the tensormap keeps
+    its plain 3-dim box, and each (128, 32) epi box still covers one whole
+    band = 32 contiguous deinterleaved columns. Also used for the plain
+    layout-addressed tensors: dbias (n at mode 1)."""
+    n = n_static if n_static is not None else t.shape[mode]
+    b = t.stride[mode]
+    shape = list(t.shape)
+    stride = list(t.stride)
+    shape[mode] = (32, 2, n // 64)
+    # ScaledBasis strides (the TMA coordinate tensors) only accept STATIC
+    # integer scales — pass n_static (a python int) for those; the plain
+    # layout-addressed tensors work with the dynamic extent.
+    stride[mode] = (b, (n // 2) * b, 32 * b)
+    new_layout = cute.make_layout(tuple(shape), stride=tuple(stride))
+    return cute.make_tensor(t.iterator, new_layout)
+
+
+# Supported launch configs: mma tiler (256, 128) with an M-only cluster (2, 1)
+# or the 2D clusters (2, 2)/(2, 4). cluster_n > 1 makes N-adjacent work tiles
+# cluster peers — the rowwise-sfd2 DSMEM geometry (sgn/cta_n == cluster_n) —
+# and enables A/SFA multicast. Cluster M stays 2: wider cluster-M tiles need a
+# per-expert-M cluster-tile-multiple gate the FE API cannot verify host-side
+# on ragged inputs (the kernel's static can_implement still accepts the full
+# harness set (2,1)/(4,1)/(2,2)/(2,4)/(4,2) with that gate, for parity).
+VALID_CTA_SHAPES = ((256, 128),)
+VALID_CLUSTER_SHAPES = ((2, 1), (2, 2), (2, 4))
+DEFAULT_CTA_SHAPE = (256, 128)
+DEFAULT_CLUSTER_SHAPE = (2, 1)
+
+
+class BlockScaledSubChannelMoEGroupedGemmDgluDbiasKernelSm107:
+    """Block-scaled grouped GEMM kernel with MoE tile scheduling and dGLU backward fusion.
+
+    Supports both dense and discrete weight layouts, static and dynamic
+    scheduling, and quantized output with row scale factors.
+
+    This version uses a fixed padding size (FIX_PAD_SIZE=256) that is decoupled from the kernel's tile size,
+    allowing users to pad their tensors without knowing the specific kernel implementation details.
+
+    :param sf_vec_size: Scalefactor vector size.
+    :type sf_vec_size: int
+    :param mma_tiler_mn: Shape of the Matrix Multiply-Accumulate (MMA) tile (M,N)
+    :type mma_tiler_mn: Tuple[int, int]
+    :param cluster_shape_mn: Cluster dimensions (M,N) for parallel processing
+    :type cluster_shape_mn: Tuple[int, int]
+
+    :note: In current version, A and B tensor must have the same data type
+        - i.e., Float8E4M3FN for A and Float8E5M2 for B is not supported
+
+    :note: Supported combinations of A/B data types, SF data typs and SF vector size:
+        - MXF8: A/B: Float8E5M2/Float8E4M3FN + SF: Float8E8M0FNU + sf_vec_size: 32
+        - MXF4: A/B: Float4E2M1FN + SF: Float8E8M0FNU + sf_vec_size: 32
+        - NVF4: A/B: Float4E2M1FN + SF: Float8E8M0FNU/Float8E4M3FN + sf_vec_size: 16
+
+    :note: Supported accumulator data types:
+        - Float32
+
+    :note: Supported D data types:
+        - BFloat16
+        - Float8E4M3FN/Float8E5M2
+
+    :note: Constraints:
+        - MMA tiler M must be 128 or 256 (use_2cta_instrs)
+        - MMA tiler N must be 64/128/192/256
+        - Cluster shape M must be multiple of 2 if Mma tiler M is 256
+        - Cluster shape M/N must be positive and power of 2, total cluster size <= 16
+        - Also, Cluster shape M/N must be <= 4 for scale factor multicasts due to limited size of scale factors
+        - FIX_PAD_SIZE (256) must be divisible by mma_tiler_mn[0]
+        - m_aligned parameter in create_mask() MUST equal FIX_PAD_SIZE (256)
+        - Each padded_offsets[i] will be a multiple of FIX_PAD_SIZE (guaranteed by m_aligned == FIX_PAD_SIZE)
+
+    :note: New Interface (padded_offsets):
+        Instead of tile_idx_to_expert_idx, num_non_exiting_tiles, and m_split_cumsum, users now provide:
+        - padded_offsets: shape (expert_cnt,), where padded_offsets[i] is the end position
+          of expert[i] in the padded A tensor.
+        - Expert i processes A[padded_offsets[i-1]:padded_offsets[i], :] (with padded_offsets[-1]=0)
+
+    """
+
+    # Fixed pad size for user-side padding (decoupled from kernel tile size)
+    FIX_PAD_SIZE = 256
+
+    @staticmethod
+    def is_valid_dtypes_and_scale_factor_vec_size(
+        ab_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        acc_dtype: Type[cutlass.Numeric],
+        d_dtype: Type[cutlass.Numeric],
+    ) -> bool:
+        """
+        Check if the data type / scale-factor vector-size combination is valid.
+
+        :return: True if valid, False otherwise
+        """
+        is_valid = True
+        if ab_dtype not in {
+            cutlass.Float4E2M1FN,
+        }:
+            is_valid = False
+
+        if sf_vec_size not in {16}:
+            is_valid = False
+
+        if sf_dtype not in {cutlass.Float8E8M0FNU, cutlass.Float8E4M3FN, cutlass.FloatNV8E5M3FNU}:
+            is_valid = False
+
+        if sf_dtype in {cutlass.Float8E4M3FN, cutlass.FloatNV8E5M3FNU} and sf_vec_size == 32:
+            is_valid = False
+        if ab_dtype in {cutlass.Float8E5M2, cutlass.Float8E4M3FN} and sf_vec_size == 16:
+            is_valid = False
+
+        if acc_dtype not in {cutlass.Float32}:
+            is_valid = False
+
+        if d_dtype not in {
+            cutlass.Float32,
+            cutlass.Float16,
+            cutlass.BFloat16,
+            cutlass.Float8E5M2,
+            cutlass.Float8E4M3FN,
+            cutlass.Float4E2M1FN,
+        }:
+            is_valid = False
+
+        if ab_dtype.width == 8 and d_dtype.width != 8:
+            is_valid = False
+
+        return is_valid
+
+    @staticmethod
+    def can_implement(
+        ab_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        acc_dtype: Type[cutlass.Numeric],
+        d_dtype: Type[cutlass.Numeric],
+        use_2cta_instrs: bool,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        m: int,
+        n: int,
+        k: int,
+        l: int,
+        a_major: str,
+        b_major: str,
+        cd_major: str,
+        m_aligned: int,
+        act_func: str,
+        weight_mode: MoEWeightMode = MoEWeightMode.DENSE,
+        sgn: int = 256,
+        sgk: int = 256,
+    ) -> bool:
+        FPS = BlockScaledSubChannelMoEGroupedGemmDgluDbiasKernelSm107.FIX_PAD_SIZE
+        result = True
+        if m_aligned != FPS:
+            result = False
+        if not BlockScaledSubChannelMoEGroupedGemmDgluDbiasKernelSm107.is_valid_dtypes_and_scale_factor_vec_size(
+            ab_dtype, sf_dtype, sf_vec_size, acc_dtype, d_dtype
+        ):
+            result = False
+        if not is_valid_layouts(ab_dtype, d_dtype, a_major, b_major, cd_major):
+            result = False
+        # Only supported launch configs for now: mma tiler (256, 128) with
+        # M-only clusters (2,1)/(4,1), or 2D clusters (2,2)/(2,4)/(4,2)
+        # (cluster_n > 1 makes N-adjacent work tiles cluster peers — the
+        # rowwise-sfd2 DSMEM geometry — and enables A/SFA multicast; total
+        # cluster size stays <= 8, the portable limit).
+        if tuple(mma_tiler_mn) != (256, 128) or tuple(cluster_shape_mn) not in (
+            (2, 1),
+            (4, 1),
+            (2, 2),
+            (2, 4),
+            (4, 2),
+        ):
+            result = False
+        # cluster_n > 1: the scheduler decomposes over CLUSTER N tiles, so
+        # the N work-tile count (n here is the GEMM half-width; tiles =
+        # ceil(n / cta_n), expert-uniform) must be a cluster_n multiple or
+        # the last N cluster's peers would map past the edge.
+        if cluster_shape_mn[1] > 1:
+            _n_work_tiles = -(-n // mma_tiler_mn[1])
+            if _n_work_tiles % cluster_shape_mn[1] != 0:
+                result = False
+        if not is_valid_mma_tiler_and_cluster_shape(
+            use_2cta_instrs,
+            mma_tiler_mn,
+            cluster_shape_mn,
+            m_aligned,
+            FPS,
+            allowed_cluster_tiler_m=(128, 256, 512),
+        ):
+            result = False
+        # Cluster (4,1)/(4,2) widens the cluster M tile to 512 rows sharing
+        # one multicast B load: a cluster must never straddle an expert
+        # boundary, so per-expert M must be a cluster-tile multiple.
+        _cluster_tiler_m = (cluster_shape_mn[0] // (2 if use_2cta_instrs else 1)) * mma_tiler_mn[0]
+        if (m // l) % _cluster_tiler_m != 0:
+            result = False
+        if not is_valid_tensor_alignment(m, n, k, l, ab_dtype, d_dtype, a_major, b_major, cd_major):
+            result = False
+        if not (a_major == "k"):
+            result = False
+        if act_func not in ["dswiglu", "dgeglu"]:
+            result = False
+        # SFD2 blocking (deinterleaved): one sfd2 block = sgn gate/up
+        # f-columns. The single per-thread atomic-max target / read-back and
+        # the tile_n_idx // sfd2_n_contrib block math require every N work
+        # tile to sit inside one block: sgn must be a multiple of the tile
+        # f-width.
+        if sgn % mma_tiler_mn[1] != 0:
+            result = False
+        # Discrete SFB2 per-expert base pointers are declared 16B-aligned in
+        # the sched extension (assumed_align=16). With back-to-back per-expert
+        # f32 (ceil(n/sgn), ceil(k/sgk)) blocks, every base past the first is
+        # misaligned unless the block byte size is a multiple of 16.
+        if weight_mode == MoEWeightMode.DISCRETE and l > 1:
+            sfb2_block_bytes = ((n + sgn - 1) // sgn) * ((k + sgk - 1) // sgk) * 4
+            if sfb2_block_bytes % 16 != 0:
+                result = False
+        return result
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        sgm: int,
+        sgn: int,
+        sgk: int,
+        acc_dtype: Type[cutlass.Numeric],
+        use_2cta_instrs: bool,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        vectorized_f32: bool,
+        expert_cnt: int,
+        weight_mode: MoEWeightMode = MoEWeightMode.DISCRETE,
+        use_dynamic_sched: bool = False,
+        act_func: str = "dswiglu",
+        generate_sfd2: bool = True,
+        glu_alpha: Optional[float] = None,
+        glu_clamp_max: Optional[float] = None,
+        glu_clamp_min: Optional[float] = None,
+        d_deinterleaved: bool = False,  # constexpr: True stores the n-axis
+        # outputs (D, its row SFs, dbias)
+        # DEINTERLEAVED ([gate | up]); False
+        # keeps d's interleaved band order
+        dsmem_rowwise: bool = True,  # allow the rowwise-sfd2 DSMEM reduction
+        # when the geometry is eligible
+        # (quantized D + sfd2 + sgn/cta_n ==
+        # cluster_n > 1); byte-exact vs the gmem
+        # protocol either way
+        deint_n: int = 0,  # STATIC interleaved d width (2*n); required for
+        # the TMA coordinate-tensor deinterleave rewrite
+        # (only when d_deinterleaved)
+        sf_fp8_dtype_override: Optional[Literal["e5m3"]] = None,
+    ):
+        """Initializes the configuration for a Rubin (sm107) blockscaled grouped GEMM dGLU kernel.
+
+        This configuration includes several key aspects:
+
+        1.  MMA Instruction Settings (tcgen05):
+            - acc_dtype: Data types for MMA accumulator.
+            - mma_tiler_mn: The (M, N) shape of the MMA instruction tiler.
+            - use_2cta_instrs: Boolean indicating if the tcgen05 MMA variant
+              with cta_group=2 should be used.
+
+        2.  Cluster Shape:
+            - cluster_shape_mn: The (ClusterM, ClusterN) shape of the CTA cluster.
+
+        3.  Expert Count:
+            - expert_cnt: Number of experts for MoE grouped GEMM.
+
+        4.  MoE Tile Scheduling:
+            - Uses MoEPersistentTileScheduler for tile iteration across experts
+            - Expert lookup is handled by the scheduler (cached O(1) fast path)
+
+        :param acc_dtype: Data type of the accumulator.
+        :type acc_dtype: type[cutlass.Numeric]
+        :param mma_tiler_mn: Tuple (M, N) shape of the MMA instruction.
+        :type mma_tiler_mn: Tuple[int, int]
+        :param use_2cta_instrs: Boolean, True to use cta_group=2 MMA variant.
+        :type use_2cta_instrs: bool
+        :param cluster_shape_mn: Tuple (ClusterM, ClusterN) shape of the cluster.
+        :type cluster_shape_mn: Tuple[int, int]
+        :param expert_cnt: Number of experts (compile-time constant).
+        :type expert_cnt: int
+        :param sf_fp8_dtype_override: Reinterpret the FP8-format block scale factors
+            as E5M3 instead of the E4M3 implied by their storage dtype. ``None``
+            (default) leaves the format inferred from the tensors. ``"e5m3"``
+            requires Rubin and the NVFP4 recipe; the scale tensors are still
+            supplied as ``torch.float8_e4m3fn`` storage because torch has no e5m3
+            dtype -- only the CuTe element type is overridden. The quantized-D row
+            scales are then e5m3-encoded too (output scale format == input's).
+
+        :raises ValueError: If FIX_PAD_SIZE is not compatible with mma_tiler_mn[0].
+        """
+        # Hardware MMA instruction M: 2CTA -> 256, 1CTA -> 128
+        mma_inst_m = 256 if use_2cta_instrs else 128
+        enable_breuse = mma_tiler_mn[0] // mma_inst_m == 2
+        if enable_breuse:
+            if mma_tiler_mn[0] % self.FIX_PAD_SIZE != 0:
+                raise ValueError(
+                    f"mma_tiler_mn[0] ({mma_tiler_mn[0]}) must be a multiple of "
+                    f"FIX_PAD_SIZE ({self.FIX_PAD_SIZE}) for breuse. "
+                    f"Also ensure callers use m_aligned=mma_tiler_mn[0] (={mma_tiler_mn[0]})."
+                )
+        else:
+            cta_tile_m = mma_tiler_mn[0] // (2 if use_2cta_instrs else 1)
+            if self.FIX_PAD_SIZE % cta_tile_m != 0:
+                raise ValueError(
+                    f"FIX_PAD_SIZE ({self.FIX_PAD_SIZE}) must be divisible by "
+                    f"cta_tile_m ({cta_tile_m}). "
+                    f"Supported mma_tiler_mn[0] values: 128, 256, 512."
+                )
+        if expert_cnt > 1024:
+            raise ValueError("Expert count > 1024 is not supported.")
+        if not isinstance(weight_mode, MoEWeightMode):
+            raise TypeError(f"weight_mode must be a MoEWeightMode, got {type(weight_mode)}")
+
+        self.sf_vec_size = sf_vec_size
+        self.sf_dtype_override: Optional[Type[cutlass.Numeric]] = cutlass.FloatNV8E5M3FNU if sf_fp8_dtype_override == "e5m3" else None
+        self.sgm = sgm
+        self.sgn = sgn
+        self.sgk = sgk
+        # Cross-tile sfd2 sync: number of N work-tiles whose atomics feed one
+        # sfd2 block element. sgn counts DEINTERLEAVED f-columns (one block =
+        # sgn gate/up columns); each tile covers mma_tiler_n f-columns.
+        self.sfd2_n_contrib = max(1, sgn // mma_tiler_mn[1])
+        self.expert_cnt = expert_cnt
+        self.acc_dtype: Type[cutlass.Numeric] = acc_dtype
+        self.use_2cta_instrs = use_2cta_instrs
+        self.cluster_shape_mn = cluster_shape_mn
+        # K dimension is deferred in _setup_attributes
+        self.mma_tiler = (*mma_tiler_mn, 1)
+        # B-reuse: enabled when the mma_tiler M is 2x the hardware instruction M
+        self.enable_breuse = enable_breuse
+
+        self.cta_group = tcgen05.CtaGroup.TWO if use_2cta_instrs else tcgen05.CtaGroup.ONE
+
+        self.occupancy = 1
+        self.accumulator_update_warp_id = (0, 1, 2, 3)
+        self.epilog_warp_id = (4, 5, 6, 7)
+        self.mma_warp_id = 8
+        self.tma_warp_id = 9
+        self.sched_warp_id = 10
+        self.scale_warp_id = 11
+        self.threads_per_warp = 32
+
+        # Register budgets (per-warp) for the three clean warpgroups (12 warps = 384 threads):
+        #   WG0 acc-update (0-3): alloc 248, WG1 epilog (4-7): alloc 232,
+        #   WG2 uniform (mma 8 / tma 9 / sched 10 / scale 11): dealloc 24.
+        # Total 32*(4*248 + 4*232 + 4*24) = 64512 <= 65536 regs/CTA.
+        self.num_regs_uniform_warps = 24
+        self.num_regs_sched_warps = 24
+        self.num_regs_epilogue_warps = 232
+        self.num_regs_acc_update_warps = 248
+
+        self.threads_per_cta = self.threads_per_warp * len(
+            (
+                *self.accumulator_update_warp_id,
+                *self.epilog_warp_id,
+                self.mma_warp_id,
+                self.tma_warp_id,
+                self.sched_warp_id,
+                self.scale_warp_id,
+            )
+        )
+        self.threads_wo_sched = self.threads_per_warp * len(
+            (
+                *self.accumulator_update_warp_id,
+                *self.epilog_warp_id,
+                self.mma_warp_id,
+                self.tma_warp_id,
+                self.scale_warp_id,
+            )
+        )
+
+        # Set barrier for cta sync, epilogue sync and tmem ptr sync
+        self.cta_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=self.threads_per_cta,
+        )
+        self.epilog_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=32 * len(self.epilog_warp_id),
+        )
+        self.tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=3,
+            num_threads=32 * len((self.mma_warp_id, *self.accumulator_update_warp_id, *self.epilog_warp_id)),
+        )
+        self.sched_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=4,
+            num_threads=self.threads_per_warp,
+        )
+        self.num_smem_capacity = utils.get_smem_capacity_in_bytes("sm_107")
+        self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols("sm_107")
+
+        self.vectorized_f32 = vectorized_f32
+        self.use_dynamic_sched = use_dynamic_sched
+
+        # Amax reduction configuration
+        self.num_epilog_warps = len(self.epilog_warp_id)
+
+        self.generate_sfd2 = generate_sfd2
+        self.weight_mode = weight_mode
+
+        self.act_func = act_func
+
+        self.glu_alpha = glu_alpha
+        self.glu_clamp_max = glu_clamp_max
+        self.glu_clamp_min = glu_clamp_min
+
+        if d_deinterleaved and deint_n <= 0:
+            raise ValueError("d_deinterleaved requires deint_n (the STATIC interleaved d " "width, 2*n) for the TMA coordinate-tensor rewrite")
+        self.d_deinterleaved = d_deinterleaved
+        self.deint_n = deint_n
+        self.dsmem_rowwise = dsmem_rowwise
+
+    def _get_mma_permutation_mnk(self, mma_inst_shape_mnk):
+        """Return MMA permutation for the Bkeep-Breuse pattern (2CTA only).
+        Only active when enable_breuse=True to avoid breaking the TMA atom
+        setup for the non-breuse 2CTA case.
+        """
+        if cutlass.const_expr(self.use_2cta_instrs and self.enable_breuse):
+            m_layout = cute.make_layout(
+                shape=(mma_inst_shape_mnk[0] // 2, 2, 2),
+                stride=(1, mma_inst_shape_mnk[0], mma_inst_shape_mnk[0] // 2),
+            )
+            return (m_layout, mma_inst_shape_mnk[1], mma_inst_shape_mnk[2])
+        return (1, 1, 1)
+
+    def _setup_attributes(self):
+        """Set up configurations that are dependent on GEMM inputs
+
+        This method configures various attributes based on the input tensor properties
+        (data types, leading dimensions) and kernel settings:
+        - Configuring tiled MMA
+        - Computing MMA/cluster/tile shapes
+        - Computing cluster layout
+        - Computing multicast CTAs for A/B
+        - Computing epilogue subtile
+        - Setting up A/B/D stage counts in shared memory
+        - Computing A/B/D shared memory layout
+        - Computing tensor memory allocation columns
+        """
+
+        # Hardware MMA instruction M: 2CTA -> 256, 1CTA -> 128
+        mma_inst_m = 256 if self.use_2cta_instrs else 128
+        self.mma_inst_shape_mn = (mma_inst_m, self.mma_tiler[1])
+        # (CTA_Tile_Shape_M, Round_Up(MMA_Tile_Shape_N, 128), MMA_Inst_Shape_K)
+        self.mma_inst_shape_mn_sfb = (
+            self.mma_inst_shape_mn[0] // (2 if self.use_2cta_instrs else 1),
+            cute.round_up(self.mma_inst_shape_mn[1], 128),
+        )
+
+        # K dim of the MMA instruction shape on Rubin sm107:
+        #  - SM107MmaMXF4NVF4Op (FP4 x FP4) requires K=128
+        #  - SM107BlockScaledMmaMXF8F6F4Op (FP8 or mixed) requires K=64
+        mma_inst_k = 128 if (self.a_dtype.width == 4 and self.b_dtype.width == 4) else 64
+        mma_inst_shape_mnk = (*self.mma_inst_shape_mn, mma_inst_k)
+        mma_inst_shape_mnk_sfb = (*self.mma_inst_shape_mn_sfb, mma_inst_k)
+
+        atom_layout_mnk = (1, 1, 1)
+        permutation_mnk = self._get_mma_permutation_mnk(mma_inst_shape_mnk)
+
+        # Configure tiled mma (Rubin sm107)
+        tiled_mma = sm107_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            mma_inst_shape_mnk,
+            a_collector_op=CollectorOp.DISCARD,
+            b_collector_op=CollectorOp.DISCARD,
+            atom_layout_mnk=atom_layout_mnk,
+            permutation_mnk=permutation_mnk,
+        )
+
+        tiled_mma_sfb = sm107_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            cute.nvgpu.tcgen05.CtaGroup.ONE,
+            mma_inst_shape_mnk_sfb,
+        )
+
+        # Compute mma/cluster/tile shapes
+        mma_inst_shape_k = cute.size(tiled_mma.shape_mnk, mode=[2])
+        mma_inst_tile_k = 2 if (self.a_dtype.width == 4 and self.sf_vec_size == 16) else 4
+        self.mma_tiler = (
+            self.mma_tiler[0],
+            self.mma_tiler[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+
+        self.mma_tiler_sfb = (
+            self.mma_inst_shape_mn_sfb[0],
+            self.mma_inst_shape_mn_sfb[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+
+        self.cta_tile_shape_mnk = (
+            self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler[1],
+            self.mma_tiler[2],
+        )
+        self.cta_tile_shape_mnk_sfb = (
+            self.mma_tiler_sfb[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler_sfb[1],
+            self.mma_tiler_sfb[2],
+        )
+
+        self.mma_tiler_d = (
+            self.mma_tiler[0],
+            self.mma_inst_shape_mn[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+        self.cta_tile_shape_mnk_d = (
+            self.mma_tiler_d[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler_d[1],
+            self.mma_tiler_d[2],
+        )
+        # Compute cluster layout
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma.thr_id.shape,),
+        )
+
+        self.cluster_layout_sfb_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma_sfb.thr_id.shape,),
+        )
+
+        # Compute number of multicast CTAs for A/B
+        self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+
+        # Set epilogue subtile
+        self.epi_tile = (128, 32)
+        self.epi_tile_cnt = (
+            self.cta_tile_shape_mnk_d[0] // self.epi_tile[0],
+            self.cta_tile_shape_mnk_d[1] // self.epi_tile[1],
+        )
+
+        # enable direct store D when it is NVFP4 input, BFlat16 output
+        self.store_d_directly = False
+
+        # Setup A/B/D/Scale stage count in shared memory and ACC stage count in tensor memory
+        # (num_epi_stage: pipeline stages for epi_pipeline, accumulator update -> epilogue)
+        (
+            self.num_acc_stage,
+            self.num_ab_stage,
+            self.num_c_stage,
+            self.num_d_stage,
+            self.num_tile_stage,
+            self.num_epi_stage,
+        ) = self._compute_stages(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.b_dtype,
+            self.epi_tile,
+            self.c_dtype,
+            self.c_layout,
+            self.d_dtype,
+            self.d_layout,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.num_smem_capacity,
+            self.occupancy,
+            self.store_d_directly,
+            self.generate_dbias,
+            self.enable_breuse,
+            acc_dtype=self.acc_dtype,
+            sf2_dtype=self.sf2_dtype,
+            sgm=self.sgm,
+            sgn=self.sgn,
+            sgk=self.sgk,
+            row_dsmem=self.row_dsmem,
+        )
+
+        # Second-level scale pipeline runs in lockstep with the AB pipeline
+        self.num_scale_stage = self.num_ab_stage
+
+        # Compute A/B/D/Scale shared memory layout
+        self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.num_ab_stage,
+        )
+        self.b_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            self.mma_tiler,
+            self.b_dtype,
+            self.num_ab_stage,
+        )
+        self.sfa_smem_layout_staged = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        self.sfb_smem_layout_staged = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+
+        self.c_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.c_dtype,
+            self.c_layout,
+            self.epi_tile,
+            self.num_c_stage,
+        )
+
+        if cutlass.const_expr(not self.store_d_directly):
+            self.d_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+                self.d_dtype,
+                self.d_layout,
+                self.epi_tile,
+                self.num_d_stage,
+            )
+        else:
+            self.d_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+                self.d_dtype,
+                self.d_layout,
+                self.epi_tile,
+                1,
+            )
+
+        # Full-CTA-tile SMEM buffer for the final accumulator; the "stage" mode of the
+        # epi layout doubles as the subtile-slot index (subtile_cnt slots per epi stage).
+        # Always allocated (unlike sD, which is conditional on store_d_directly).
+        self.final_acc_subtile_cnt = (self.cta_tile_shape_mnk[0] // cute.size(self.epi_tile[0])) * (self.cta_tile_shape_mnk[1] // cute.size(self.epi_tile[1]))
+        self.final_acc_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.acc_dtype,
+            self.d_layout,
+            self.epi_tile,
+            self.final_acc_subtile_cnt * self.num_epi_stage,
+        )
+
+        # Compute second level scale factor layout
+        # Store the per-tile scale block sizes (each clamped to the CTA tile) so
+        # the device kernel builds C-shaped scale views that match the CTA tile
+        # exactly, even when sg{m,n,k} > the tile extent (e.g. sgn=512 with a
+        # 128-wide N tile spans one scale block, broadcast across the tile).
+        if self.sgm < self.cta_tile_shape_mnk[0]:
+            size_m = self.sgm
+        else:
+            size_m = self.cta_tile_shape_mnk[0]
+
+        if self.sgn < self.cta_tile_shape_mnk[1]:
+            size_n = self.sgn
+        else:
+            size_n = self.cta_tile_shape_mnk[1]
+
+        if self.sgk < self.cta_tile_shape_mnk[2]:
+            size_k = self.sgk
+        else:
+            size_k = self.mma_tiler[2]
+
+        self.scale_size_m = size_m
+        self.scale_size_n = size_n
+        self.scale_size_k = size_k
+
+        self.scale_m_per_tile = self.cta_tile_shape_mnk[0] // size_m
+        self.scale_n_per_tile = self.cta_tile_shape_mnk[1] // size_n
+        self.scale_k_per_tile = self.cta_tile_shape_mnk[2] // size_k
+
+        self.sfa2_smem_layout_staged = cute.make_layout(
+            (
+                (size_m, self.scale_m_per_tile),
+                (size_k, self.scale_k_per_tile),
+                self.num_scale_stage,
+            ),
+            stride=(
+                (0, self.scale_k_per_tile),
+                (0, 1),
+                self.scale_k_per_tile * self.scale_m_per_tile,
+            ),
+        )
+        self.sfb2_smem_layout_staged = cute.make_layout(
+            (
+                (size_n, self.scale_n_per_tile),
+                (size_k, self.scale_k_per_tile),
+                self.num_scale_stage,
+            ),
+            stride=(
+                (0, self.scale_k_per_tile),
+                (0, 1),
+                self.scale_k_per_tile * self.scale_n_per_tile,
+            ),
+        )
+
+        # For breuse+N=192 or N=256, override num_acc_stage=1
+        if self.enable_breuse and self.mma_tiler[1] in {192, 256}:
+            self.num_acc_stage = 1
+
+        # Second-level design: the final accumulator lives in SMEM (sFinalAcc) and the
+        # accumulator-update warpgroup consumes one MMA partial per k-tile, so the
+        # overlapping-accumulator TMEM trick is disabled here.
+        self.overlapping_accum = False
+
+        # To prefetch more accumulator when overlapping_accum is enabled in epilogue
+        self.epilogue_prefetch_more = self.d_dtype.width == 8 and self.a_dtype.width == 8
+
+        # To generate dprob
+        self.generate_dprob = True
+
+        # Use ptx fp8 fp32 convert. The ptx pack path (cvt_f32x4_to_f8x4_pack_i32)
+        # only encodes 8-bit fp8x2 outputs; fp4 (Float4E2M1FN) outputs must fall
+        # back to the generic .to() conversion.
+        self.use_fp8_ptx_cvt = cutlass.const_expr(self.d_dtype in (cutlass.Float8E4M3FN, cutlass.Float8E5M2))
+
+        # Compute number of TMEM columns for SFA/SFB/Accumulator.
+        sf_atom_mn = 32
+        sf_pack_factor = 32 // self.sf_vec_size
+        self.num_sfa_tmem_cols = (self.cta_tile_shape_mnk[0] // sf_atom_mn) * mma_inst_tile_k * sf_pack_factor
+        self.num_sfb_tmem_cols = (self.cta_tile_shape_mnk_sfb[1] // sf_atom_mn) * mma_inst_tile_k * sf_pack_factor
+        self.num_sf_tmem_cols = self.num_sfa_tmem_cols + self.num_sfb_tmem_cols
+        if self.enable_breuse:
+            self.num_accumulator_tmem_cols = self.cta_tile_shape_mnk[1] * self.num_acc_stage * 2
+        elif self.overlapping_accum:
+            self.num_accumulator_tmem_cols = self.cta_tile_shape_mnk[1] * 2 - self.num_sf_tmem_cols
+        else:
+            self.num_accumulator_tmem_cols = self.cta_tile_shape_mnk[1] * self.num_acc_stage
+        if self.cta_tile_shape_mnk[1] == 192 and not self.enable_breuse:
+            self.num_accumulator_tmem_cols = self.num_tmem_alloc_cols - self.num_sf_tmem_cols
+            self.num_accumulator_tmem_stride = self.num_accumulator_tmem_cols - 192
+        else:
+            self.num_accumulator_tmem_stride = self.num_accumulator_tmem_cols
+
+        self.epi_tile_n_required = cute.size(self.epi_tile[1])
+        # Only when overlapping_accum is enabled, we need to release accumulator buffer early in epilogue
+        self.iter_acc_early_release_in_epilogue = (self.num_sf_tmem_cols + self.epi_tile_n_required - 1) // self.epi_tile_n_required - 1
+
+    def get_desc_workspace_bytes(self) -> int:
+        """Return descriptor workspace size in bytes."""
+        if self.weight_mode == MoEWeightMode.DISCRETE:
+            from ..moe_utils import DiscreteWeightTensormapConstructor
+
+            return DiscreteWeightTensormapConstructor.get_workspace_size(self.expert_cnt)
+        return 0
+
+    def get_workspace_bytes(self, sfd2_sync_counter_cnt: int = 0) -> int:
+        """Return descriptor workspace plus optional dynamic scheduler state,
+        plus optional sfd2 cross-tile arrival counters (one u32 per
+        (global m CTA tile, sfd2 n-block); the caller sizes the count — see
+        the wrapper — and it is nonzero only for quantized-D output with
+        sfd2_n_contrib > 1, i.e. sgn > mma_tiler_n)."""
+        desc_workspace_bytes = self.get_desc_workspace_bytes()
+        dynamic_sched_bytes = 4 if self.use_dynamic_sched else 0
+        return desc_workspace_bytes + dynamic_sched_bytes + 4 * sfd2_sync_counter_cnt
+
+    @cute.jit
+    def _get_sched_counter_ptr(self, workspace_ptr):
+        counter_addr = workspace_ptr.toint() + self.get_desc_workspace_bytes()
+        return cute.make_ptr(
+            cutlass.Int32,
+            counter_addr,
+            AddressSpace.gmem,
+            assumed_align=4,
+        )
+
+    @cute.jit
+    def _get_sfd2_counter_ptr(self, workspace_ptr):
+        """Base of the sfd2 arrival-counter array (after the tensormap
+        descriptors and the optional dynamic-sched counter)."""
+        counter_addr = workspace_ptr.toint() + self.get_desc_workspace_bytes() + (4 if self.use_dynamic_sched else 0)
+        return cute.make_ptr(
+            cutlass.Int32,
+            counter_addr,
+            AddressSpace.gmem,
+            assumed_align=4,
+        )
+
+    @cute.kernel
+    def sfd2_counter_zero_kernel(self, workspace_ptr, counter_cnt: Int32):
+        """Zero the sfd2 arrival counters before the main kernel (each launch
+        must start from 0: pass 2 spins until a counter reaches
+        sfd2 contributor count for its block)."""
+        bidx = cute.arch.block_idx()[0]
+        tidx = cute.arch.thread_idx()[0]
+        gdim = cute.arch.grid_dim()[0]
+        counters = cute.make_tensor(
+            self._get_sfd2_counter_ptr(workspace_ptr),
+            cute.make_layout((counter_cnt,)),
+        )
+        idx = Int32(bidx * 128 + tidx)
+        stride = Int32(gdim * 128)
+        while idx < counter_cnt:
+            counters[idx] = Int32(0)
+            idx += stride
+
+    @cute.kernel
+    def helper_kernel(
+        self,
+        ptrs_b: cute.Pointer,  # Device pointer to int64[expert_cnt] array of B addresses
+        ptrs_sfb: cute.Pointer,  # Device pointer to int64[expert_cnt] array of SFB addresses
+        n: Int32,
+        k: Int32,
+        b_stride_size: cutlass.Int64,
+        b_major_mode: cutlass.Constexpr,
+        workspace_ptr,
+        tiled_mma_arg: cute.TiledMma,
+        tiled_mma_sfb_arg: cute.TiledMma,
+        b_smem_layout_arg,
+        sfb_smem_layout_arg,
+        cluster_layout_vmnk_shape_arg: cutlass.Constexpr,
+        cluster_layout_sfb_vmnk_shape_arg: cutlass.Constexpr,
+    ):
+        """Pre-main-kernel initialization.
+
+        Launched with grid=(expert_cnt, 1, 1) for discrete mode, or
+        grid=(1, 1, 1) for dense+dynamic mode.
+
+        Discrete weight: each block builds B/SFB TMA descriptors for one expert.
+        Dynamic sched: block 0 resets the atomic tile counter to 0.
+        """
+        expert_idx = cute.arch.block_idx()[0]
+
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE):
+            b_tma_op_arg = sm100_utils.cluster_shape_to_tma_atom_B(self.cluster_shape_mn, tiled_mma_arg.thr_id)
+            sfb_tma_op_arg = sm100_utils.cluster_shape_to_tma_atom_SFB(self.cluster_shape_mn, tiled_mma_arg.thr_id)
+
+            b_ptr_tensor = cute.make_tensor(
+                cute.make_ptr(cutlass.Int64, ptrs_b.toint(), AddressSpace.gmem, assumed_align=8), cute.make_layout((self.expert_cnt,))
+            )
+            sfb_ptr_tensor = cute.make_tensor(
+                cute.make_ptr(cutlass.Int64, ptrs_sfb.toint(), AddressSpace.gmem, assumed_align=8), cute.make_layout((self.expert_cnt,))
+            )
+
+            c1 = cutlass.Int32(1)
+            c0 = cutlass.Int64(0)
+            c1_64 = 1
+            if cutlass.const_expr(b_major_mode == OperandMajorMode.K):
+                stride_n = b_stride_size
+                stride_k = c1_64
+            else:
+                stride_n = c1_64
+                stride_k = b_stride_size
+
+            b_ptr_val = b_ptr_tensor[expert_idx]
+            b_ptr = cute.make_ptr(self.b_dtype, b_ptr_val, AddressSpace.gmem)
+            b_tensor_i = cute.make_tensor(
+                b_ptr,
+                cute.make_layout((n, k, c1), stride=(stride_n, stride_k, c0)),
+            )
+            tma_atom_b, _ = cute.nvgpu.make_tiled_tma_atom_B(
+                b_tma_op_arg,
+                b_tensor_i,
+                b_smem_layout_arg,
+                self.mma_tiler,
+                tiled_mma_arg,
+                cluster_layout_vmnk_shape_arg,
+            )
+
+            workspace = TensormapWorkspace(workspace_ptr, ["b", "sfb"])
+            store_tma_desc(tma_atom_b, workspace.get_ptr("b", expert_idx))
+
+            sfb_ptr_val = sfb_ptr_tensor[expert_idx]
+            sfb_ptr = cute.make_ptr(self.sf_dtype, sfb_ptr_val, AddressSpace.gmem)
+            sfb_layout = blockscaled_utils.tile_atom_to_shape_SF((n, k, c1), self.sf_vec_size)
+            sfb_tensor_i = cute.make_tensor(sfb_ptr, sfb_layout)
+            tma_atom_sfb, _ = cute.nvgpu.make_tiled_tma_atom_B(
+                sfb_tma_op_arg,
+                sfb_tensor_i,
+                sfb_smem_layout_arg,
+                self.mma_tiler_sfb,
+                tiled_mma_sfb_arg,
+                cluster_layout_sfb_vmnk_shape_arg,
+                internal_type=cutlass.Uint64,
+            )
+            store_tma_desc(tma_atom_sfb, workspace.get_ptr("sfb", expert_idx))
+
+        if cutlass.const_expr(self.use_dynamic_sched):
+            if expert_idx == cutlass.Int32(0):
+                sched_counter = cute.make_tensor(
+                    self._get_sched_counter_ptr(workspace_ptr),
+                    cute.make_layout(1),
+                )
+                sched_counter[0] = cutlass.Int32(0)
+
+    @cute.jit
+    def __call__(
+        self,
+        a: cute.Tensor,
+        b,  # Dense: cute.Tensor (N,K,L) | Discrete: cute.Pointer to int64[]
+        sfb,  # Dense: cute.Tensor         | Discrete: cute.Pointer to int64[]
+        sfb2,  # Dense: cute.Tensor         | Discrete: cute.Pointer to int64[]
+        n: Int32,  # Ignored for dense mode
+        k: Int32,  # Ignored for dense mode
+        b_stride_size: cutlass.Int64,  # Ignored for dense mode
+        b_major_mode: cutlass.Constexpr,  # Ignored for dense mode
+        workspace_ptr,  # Descriptor workspace, plus dynamic scheduler counter when enabled
+        c: cute.Tensor,
+        d: cute.Tensor,
+        sfa: cute.Tensor,
+        sfa2: cute.Tensor,
+        sfd2_up: cute.Tensor,
+        sfd2_gate: cute.Tensor,
+        sfd_row_tensor: Optional[cute.Tensor],
+        norm_const_tensor: Optional[cute.Tensor],
+        padded_offsets: cute.Tensor,
+        alpha: cute.Tensor,
+        beta: cute.Tensor,
+        prob: cute.Tensor,
+        dprob: cute.Tensor,
+        linear_offset: Float32,
+        dbias_tensor: Optional[cute.Tensor],
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+    ):
+        """Execute the GEMM.
+
+        Dense mode: ``b`` and ``sfb`` are 3-D cute.Tensor (N, K, L).
+        Discrete mode: ``b`` and ``sfb`` are cute.Pointer to device int64[]
+        arrays of per-expert base addresses; ``n``, ``k``, ``b_stride_size``,
+        ``b_major_mode`` describe the uniform per-expert layout.
+        """
+        # Setup static attributes before smem/grid/tma computation
+        self.a_dtype: Type[cutlass.Numeric] = a.element_type
+        self.b_dtype: Type[cutlass.Numeric] = a.element_type  # B must match A dtype
+        self.c_dtype: Type[cutlass.Numeric] = c.element_type
+        self.d_dtype: Type[cutlass.Numeric] = d.element_type
+        # Scale factors may arrive under a stand-in element type: FloatNV8E5M3FNU has
+        # no torch dtype and TVM-FFI cannot marshal it, so e5m3 scales are passed as
+        # Float8E4M3FN storage of the same width and reinterpreted here. This must
+        # happen before _setup_attributes() (which picks the MMA atom off sf_dtype)
+        # and before the generate_sfd derivation below.
+        if cutlass.const_expr(self.sf_dtype_override is not None):
+            self.sf_dtype: Type[cutlass.Numeric] = self.sf_dtype_override
+        else:
+            self.sf_dtype: Type[cutlass.Numeric] = sfa.element_type
+        self.sf2_dtype: Type[cutlass.Numeric] = sfa2.element_type
+        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
+
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DENSE):
+            self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
+        else:
+            self.b_major_mode = b_major_mode
+        self.c_layout = utils.LayoutEnum.from_tensor(c)
+        self.d_layout = utils.LayoutEnum.from_tensor(d)
+
+        # dBias configuration
+        self.generate_dbias = dbias_tensor is not None
+        self.dbias_cross_warp_reduce = self.generate_dbias  # always cross-warp reduce
+
+        # Check if input data types are compatible with MMA instruction
+        if cutlass.const_expr(self.a_dtype != self.b_dtype):
+            raise TypeError(f"Type must match: {self.a_dtype} != {self.b_dtype}")
+
+        # Quantized-D mode is dtype-inferred. Derived BEFORE _setup_attributes()
+        # because the rowwise-sfd2 DSMEM eligibility below feeds smem sizing
+        # (_compute_stages).
+        # all() instead of an `and` chain: this runs inside the @cute.jit
+        # traced __call__, where the DSL AST pass rewrites `and` into a
+        # cutlass.Boolean — but these flags feed SharedStorage sizing and
+        # _compute_stages, which need plain python bools.
+        self.generate_sfd = _is_quant_dtype_combo(self.a_dtype, self.sf_dtype, self.d_dtype)
+        # ROWWISE sfd2 DSMEM: active when one block's N work-tile contributors
+        # are exactly one cluster's N-peers (sgn/cta_n == cluster_n > 1). The
+        # quantized-D row-scale fold is optional in this kernel (unlike the
+        # rht_2 source, where it is unconditionally on), so the quant + sfd2
+        # terms are AND-ed in.
+        self.row_dsmem = all(
+            (
+                self.dsmem_rowwise,
+                self.generate_sfd,
+                self.generate_sfd2,
+                self.cluster_shape_mn[1] > 1,
+                self.sfd2_n_contrib == self.cluster_shape_mn[1],
+            )
+        )
+
+        # Setup attributes that dependent on gemm inputs
+        self._setup_attributes()
+
+        # ---- SFA2 layout ----
+        sfa2_tensor = cute.make_tensor(
+            sfa2.iterator,
+            cute.make_layout(
+                (
+                    (self.sgm, sfa2.shape[0]),
+                    (self.sgk, sfa2.shape[1]),
+                    sfa2.shape[2],
+                ),
+                stride=(
+                    (0, sfa2.layout.stride[0]),
+                    (0, sfa2.layout.stride[1]),
+                    sfa2.layout.stride[2],
+                ),
+            ),
+        )
+
+        # ---- SFD2 layout ---- (None when sfd2 generation is off)
+        sfd2_up_tensor = None
+        sfd2_gate_tensor = None
+        if cutlass.const_expr(self.generate_sfd2):
+            # Inner N mode is 2*sgn: sgn counts deinterleaved f-columns, and
+            # the tensor is indexed in interleaved D-space coordinates where
+            # one block spans 2*sgn columns (sgn gate + sgn up 32-col bands).
+            sfd2_up_tensor = cute.make_tensor(
+                sfd2_up.iterator,
+                cute.make_layout(
+                    (
+                        (self.sgm, sfd2_up.shape[0]),
+                        (2 * self.sgn, sfd2_up.shape[1]),
+                        sfd2_up.shape[2],
+                    ),
+                    stride=(
+                        (0, sfd2_up.layout.stride[0]),
+                        (0, sfd2_up.layout.stride[1]),
+                        sfd2_up.layout.stride[2],
+                    ),
+                ),
+            )
+
+            sfd2_gate_tensor = cute.make_tensor(
+                sfd2_gate.iterator,
+                cute.make_layout(
+                    (
+                        (self.sgm, sfd2_gate.shape[0]),
+                        (2 * self.sgn, sfd2_gate.shape[1]),
+                        sfd2_gate.shape[2],
+                    ),
+                    stride=(
+                        (0, sfd2_gate.layout.stride[0]),
+                        (0, sfd2_gate.layout.stride[1]),
+                        sfd2_gate.layout.stride[2],
+                    ),
+                ),
+            )
+
+        c1 = cutlass.Int32(1)
+        c0 = cutlass.Int64(0)
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DENSE):
+            sfb2_ptr_typed = sfb2.iterator
+            sfb2_shape_0 = sfb2.shape[0]
+            sfb2_shape_1 = sfb2.shape[1]
+            sfb2_mode_2 = sfb2.shape[2]
+            sfb2_stride_0 = sfb2.layout.stride[0]
+            sfb2_stride_1 = sfb2.layout.stride[1]
+            sfb2_stride_2 = sfb2.layout.stride[2]
+        else:  # DISCRETE mode
+            # In discrete mode, sfb2 is a pointer to array of per-expert pointers (Int64[])
+            # Create a template tensor with correct element type (sf2_dtype) for get_gmem_tensor
+            # The pointer address is the pointer array address; get_gmem_tensor will load actual per-expert pointer
+            sfb2_ptr_typed = cute.make_ptr(
+                self.sf2_dtype,  # Correct data type so element_type is right
+                sfb2.toint(),  # Pointer array address (will be reinterpreted in get_gmem_tensor)
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            )
+            # Use computed scale values for template shape/stride
+            scale_n = cute.ceil_div(n, self.sgn)
+            scale_k = cute.ceil_div(k, self.sgk)
+            sfb2_shape_0 = scale_n
+            sfb2_shape_1 = scale_k
+            sfb2_mode_2 = c1
+            sfb2_stride_0 = c1
+            sfb2_stride_1 = scale_n
+            sfb2_stride_2 = c0
+
+        # ---- SFB2 layout ----
+        # Dense: use actual tensor shape/stride
+        # Discrete: use template shape/stride (get_gmem_tensor will load per-expert pointer)
+        sfb2_tensor = cute.make_tensor(
+            sfb2_ptr_typed,
+            cute.make_layout(
+                (
+                    (self.sgn, sfb2_shape_0),
+                    (self.sgk, sfb2_shape_1),
+                    sfb2_mode_2,
+                ),
+                stride=(
+                    (0, sfb2_stride_0),
+                    (0, sfb2_stride_1),
+                    sfb2_stride_2,
+                ),
+            ),
+        )
+
+        # ---- B / SFB setup (mode-dependent) ----
+        b_from_call_arg = b
+        sfb_from_call_arg = sfb
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DENSE):
+            sfb_layout = blockscaled_utils.tile_atom_to_shape_SF(b.shape, self.sf_vec_size)
+            sfb = cute.make_tensor(sfb.iterator, sfb_layout)
+        else:
+            c1 = cutlass.Int32(1)
+            c0 = cutlass.Int64(0)
+            c1_64 = 1
+            if cutlass.const_expr(b_major_mode == OperandMajorMode.K):
+                b_template_stride = (b_stride_size, c1_64, c0)
+            else:
+                b_template_stride = (c1_64, b_stride_size, c0)
+
+            # Creating a template layout and B tensor for a single expert
+            b_template_layout = cute.make_layout((n, k, c1), stride=b_template_stride)
+            b_ptr_typed = cute.make_ptr(self.b_dtype, b.toint(), AddressSpace.gmem, assumed_align=16)
+            b = cute.make_tensor(b_ptr_typed, b_template_layout)
+
+            sfb_ptr_typed = cute.make_ptr(self.sf_dtype, sfb.toint(), AddressSpace.gmem, assumed_align=16)
+            sfb_layout = blockscaled_utils.tile_atom_to_shape_SF((n, k, c1), self.sf_vec_size)
+            sfb = cute.make_tensor(sfb_ptr_typed, sfb_layout)
+
+        # Setup sfa tensor by filling A tensor to scale factor atom layout
+        # ((Atom_M, Rest_M),(Atom_K, Rest_K),RestL)
+        sfa_layout = blockscaled_utils.tile_atom_to_shape_SF(a.shape, self.sf_vec_size)
+        sfa = cute.make_tensor(sfa.iterator, sfa_layout)
+
+        # Dimensions of output
+        m, n_d, l = cute.shape(d)
+
+        # self.generate_sfd (the quantized-D mode) is derived above, before
+        # _setup_attributes(), so the rowwise-sfd2 DSMEM smem sizing sees it.
+
+        if cutlass.const_expr(self.d_deinterleaved and not self.generate_sfd):
+            # The deinterleaved layout is only harness-validated for the
+            # quantized-D + sfd2 configuration; check_support enforces this
+            # host-side, this is the trace-time backstop.
+            raise ValueError("d_deinterleaved requires quantized D output")
+
+        if cutlass.const_expr(dbias_tensor is not None and self.d_deinterleaved):
+            # Deinterleave dbias's n axis (mode 1). The bf16x2 atomics pair
+            # adjacent even/odd columns, which stay inside one 32-col band.
+            dbias_tensor = _deinterleave_n_coord_tensor(dbias_tensor, mode=1)
+
+        self._sfd2_sync_active = self.generate_sfd and self.generate_sfd2 and self.sfd2_n_contrib > 1
+
+        if cutlass.const_expr(self._sfd2_sync_active):
+            # One counter per (global m CTA tile, sfd2 n-block); must match
+            # the wrapper's workspace sizing and the epilogue's index math.
+            _sfd2_n_tiles_f = cute.ceil_div(n_d, 2 * self.cta_tile_shape_mnk[1])
+            _sfd2_n_j = cute.ceil_div(_sfd2_n_tiles_f, self.sfd2_n_contrib)
+            _sfd2_counter_cnt = (m // self.cta_tile_shape_mnk[0]) * _sfd2_n_j
+        else:
+            _sfd2_counter_cnt = Int32(0)
+
+        if cutlass.const_expr(self.generate_sfd):
+            output_sfd_shape = (m, n_d, l)
+            sfd_layout = blockscaled_utils.tile_atom_to_shape_SF(output_sfd_shape, self.sf_vec_size)
+            sfd_row_tensor = cute.make_tensor(sfd_row_tensor.iterator, sfd_layout)
+
+        # K dim of the MMA instruction shape on Rubin sm107:
+        #  - SM107MmaMXF4NVF4Op (FP4 x FP4) requires K=128
+        #  - SM107BlockScaledMmaMXF8F6F4Op (FP8 or mixed) requires K=64
+        mma_inst_k = 128 if (self.a_dtype.width == 4 and self.b_dtype.width == 4) else 64
+        mma_inst_shape_mnk = (*self.mma_inst_shape_mn, mma_inst_k)
+        mma_inst_shape_mnk_sfb = (*self.mma_inst_shape_mn_sfb, mma_inst_k)
+
+        atom_layout_mnk = (1, 1, 1)
+        permutation_mnk = self._get_mma_permutation_mnk(mma_inst_shape_mnk)
+
+        tiled_mma = sm107_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            mma_inst_shape_mnk,
+            a_collector_op=CollectorOp.DISCARD,
+            b_collector_op=CollectorOp.DISCARD,
+            atom_layout_mnk=atom_layout_mnk,
+            permutation_mnk=permutation_mnk,
+        )
+
+        tiled_mma_sfb = sm107_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            cute.nvgpu.tcgen05.CtaGroup.ONE,
+            mma_inst_shape_mnk_sfb,
+        )
+
+        tiled_mma_bkeep = None
+        tiled_mma_breuse = None
+        if cutlass.const_expr(self.enable_breuse):
+            tiled_mma_bkeep = sm107_utils.make_blockscaled_trivial_tiled_mma(
+                self.a_dtype,
+                self.b_dtype,
+                self.a_major_mode,
+                self.b_major_mode,
+                self.sf_dtype,
+                self.sf_vec_size,
+                self.cta_group,
+                mma_inst_shape_mnk,
+                a_collector_op=CollectorOp.DISCARD,
+                b_collector_op=CollectorOp.FILL,
+                atom_layout_mnk=atom_layout_mnk,
+                permutation_mnk=permutation_mnk,
+            )
+            tiled_mma_bkeep.set(tcgen05.Field.NEGATE_A, False)
+            tiled_mma_bkeep.set(tcgen05.Field.NEGATE_B, False)
+            tiled_mma_breuse = sm107_utils.make_blockscaled_trivial_tiled_mma(
+                self.a_dtype,
+                self.b_dtype,
+                self.a_major_mode,
+                self.b_major_mode,
+                self.sf_dtype,
+                self.sf_vec_size,
+                self.cta_group,
+                mma_inst_shape_mnk,
+                a_collector_op=CollectorOp.DISCARD,
+                b_collector_op=CollectorOp.LASTUSE,
+                atom_layout_mnk=atom_layout_mnk,
+                permutation_mnk=permutation_mnk,
+            )
+            tiled_mma_breuse.set(tcgen05.Field.NEGATE_A, False)
+            tiled_mma_breuse.set(tcgen05.Field.NEGATE_B, False)
+
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+
+        # Setup TMA load for A
+        a_op = sm100_utils.cluster_shape_to_tma_atom_A(self.cluster_shape_mn, tiled_mma.thr_id)
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        tma_atom_a, tma_tensor_a = cute.nvgpu.make_tiled_tma_atom_A(
+            a_op,
+            a,
+            a_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # Setup TMA load for B
+        b_op = sm100_utils.cluster_shape_to_tma_atom_B(self.cluster_shape_mn, tiled_mma.thr_id)
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op,
+            b,
+            b_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # Setup TMA load for SFA
+        sfa_op = sm100_utils.cluster_shape_to_tma_atom_A(self.cluster_shape_mn, tiled_mma.thr_id)
+        sfa_smem_layout = cute.slice_(self.sfa_smem_layout_staged, (None, None, None, 0))
+        tma_atom_sfa, tma_tensor_sfa = cute.nvgpu.make_tiled_tma_atom_A(
+            sfa_op,
+            sfa,
+            sfa_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=cutlass.Uint16,
+        )
+
+        # Setup TMA load for SFB
+        sfb_op = sm100_utils.cluster_shape_to_tma_atom_SFB(self.cluster_shape_mn, tiled_mma.thr_id)
+        sfb_smem_layout = cute.slice_(self.sfb_smem_layout_staged, (None, None, None, 0))
+        tma_atom_sfb, tma_tensor_sfb = cute.nvgpu.make_tiled_tma_atom_B(
+            sfb_op,
+            sfb,
+            sfb_smem_layout,
+            self.mma_tiler_sfb,
+            tiled_mma_sfb,
+            self.cluster_layout_sfb_vmnk.shape,
+            internal_type=cutlass.Uint64,
+        )
+
+        # N=192: do NOT reshape tma_tensor_sfb here; reshape real_sfb in mainloop.
+
+        a_copy_size = cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        b_copy_size = cute.size_in_bytes(self.b_dtype, b_smem_layout)
+        sfa_copy_size = cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+        sfb_copy_size = cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+        self.num_tma_load_bytes = (a_copy_size + b_copy_size + sfa_copy_size + sfb_copy_size) * atom_thr_size
+
+        # Setup TMA store for C
+        c_smem_layout = cute.slice_(self.c_smem_layout_staged, (None, None, 0))
+        self.tma_c_load_bytes = cute.size_in_bytes(self.c_dtype, c_smem_layout)
+        tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
+            c,
+            c_smem_layout,
+            self.epi_tile,
+        )
+
+        # Setup TMA store for D
+        tma_atom_d = None
+        tma_tensor_d = None
+        if cutlass.const_expr(not self.store_d_directly):
+            d_smem_layout = cute.slice_(self.d_smem_layout_staged, (None, None, 0))
+            tma_atom_d, tma_tensor_d = cpasync.make_tiled_tma_atom(
+                cpasync.CopyBulkTensorTileS2GOp(),
+                d,
+                d_smem_layout,
+                self.epi_tile,
+            )
+            if cutlass.const_expr(self.d_deinterleaved):
+                tma_tensor_d = _deinterleave_n_coord_tensor(tma_tensor_d, n_static=self.deint_n)
+        else:
+            if cutlass.const_expr(self.d_deinterleaved):
+                tma_tensor_d = _deinterleave_n_coord_tensor(d, n_static=self.deint_n)
+            else:
+                tma_tensor_d = d
+
+        # Compute grid size using MoE scheduler
+        # dGLU output has shape (m, 2*N_half, 1), but scheduling is over (m, N_half)
+        # expert_shape = (expert_cnt, N_half, K)
+        n_half = n_d // 2
+        sched_params = MoESchedulerParams(
+            scenario="2Dx3D",
+            expert_shape=(self.expert_cnt, n_half, cute.size(a.shape, mode=[1])),
+            cta_tile_shape_mnk=self.cta_tile_shape_mnk_d,
+            cluster_shape_mn=self.cluster_shape_mn,
+            use_dynamic_sched=self.use_dynamic_sched,
+        )
+        grid = MoESchedulerParams.get_grid_shape(sched_params, max_active_clusters)
+
+        self.buffer_align_bytes = 1024
+
+        # Define shared storage for kernel
+        # sD is not needed when storing D directly (and not generating SFD)
+        sD_size = 0 if (not self.generate_sfd and self.store_d_directly) else cute.cosize(self.d_smem_layout_staged.outer)
+        SchedulerStorage = MoEPersistentTileScheduler.make_storage_struct(self.num_tile_stage, self.use_dynamic_sched)
+
+        @cute.struct
+        class SharedStorage:
+            ab_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage * 2]
+            scale_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_scale_stage * 2]
+            acc_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage * 2]
+            epi_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_epi_stage * 2]
+            # DSMEM rowwise-sfd2 handoff: one cluster_n-arrival mbarrier per
+            # parity slot of sSfd2RowDsmem (every N-peer arrives after its
+            # red.shared::cluster maxes for a tile have been fenced).
+            row_dsmem_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 if self.row_dsmem else 0]
+            scheduler: SchedulerStorage
+            c_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_c_stage]
+            c_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_c_stage]
+            tmem_dealloc_mbar_ptr: cutlass.Int64
+            tmem_holding_buf: cutlass.Int32
+            # (EPI_TILE_M, EPI_TILE_N, STAGE)
+            sC: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.c_dtype,
+                    cute.cosize(self.c_smem_layout_staged.outer),
+                ],
+                self.buffer_align_bytes,
+            ]
+            sD: cute.struct.Align[
+                cute.struct.MemRange[self.d_dtype, sD_size],
+                self.buffer_align_bytes,
+            ]
+            sFinalAcc: cute.struct.Align[
+                cute.struct.MemRange[self.acc_dtype, cute.cosize(self.final_acc_smem_layout_staged.outer)],
+                self.buffer_align_bytes,
+            ]
+            # DSMEM rowwise-sfd2 reduction buffer (sgn/cta_n == cluster_n
+            # only): 2 parity slots x [cta_m gate | cta_m up] per-row block
+            # descales, max-reduced IN PLACE by every N-peer CTA via
+            # red.shared::cluster — each CTA ends up holding its 128 rows'
+            # final block descales locally (plain LDS before pass 2, no
+            # gmem counter spin / volatile read-backs).
+            sSfd2RowDsmem: cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Float32,
+                    2 * 2 * self.cta_tile_shape_mnk_d[0] if cutlass.const_expr(self.row_dsmem) else 0,
+                ],
+                16,
+            ]
+            # (MMA, MMA_M, MMA_K, STAGE)
+            sA: cute.struct.Align[
+                cute.struct.MemRange[self.a_dtype, cute.cosize(self.a_smem_layout_staged.outer)],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_N, MMA_K, STAGE)
+            sB: cute.struct.Align[
+                cute.struct.MemRange[self.b_dtype, cute.cosize(self.b_smem_layout_staged.outer)],
+                self.buffer_align_bytes,
+            ]
+            # (granularity_m, repeat_m), (granularity_k, repeat_k), num_scale_stage)
+            sSFA: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(self.sfa_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            # (granularity_n, repeat_n), (granularity_k, repeat_k), num_scale_stage)
+            sSFB: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(self.sfb_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sSFA2: cute.struct.Align[
+                cute.struct.MemRange[self.sf2_dtype, cute.cosize(self.sfa2_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sSFB2: cute.struct.Align[
+                cute.struct.MemRange[self.sf2_dtype, cute.cosize(self.sfb2_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            # SFD row-scale store staging: one (128 rows x 128 values) SFD
+            # store event in the gmem atom layout. The T2R row-per-thread
+            # mapping scatters each thread's SF bytes at 16B stride in that
+            # layout, so direct gmem stores waste 3/4 of every sector; the
+            # block is exchanged through SMEM and written back linearly.
+            sSFDRowStage: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.sf_dtype,
+                    128 * 32 * 4 // self.sf_vec_size if cutlass.const_expr(self.generate_sfd) else 1,
+                ],
+                128 if cutlass.const_expr(self.generate_sfd) else 4,
+            ]
+            if cutlass.const_expr(self.generate_dbias):
+                # dBias SMEM transpose buffer: (128, epi_tile_n*2) col-major FP32
+                sDbias: cute.struct.Align[
+                    cute.struct.MemRange[
+                        cutlass.Float32,
+                        128 * self.epi_tile[1] * 2 if self.generate_dbias else 1,
+                    ],
+                    128 if self.generate_dbias else 4,
+                ]
+
+        self.shared_storage = SharedStorage
+
+        # Initialize per-expert B/SFB TMA descriptors in workspace
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        sfb_smem_layout = cute.slice_(self.sfb_smem_layout_staged, (None, None, None, 0))
+        _need_helper = cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE or self.use_dynamic_sched)
+        if cutlass.const_expr(_need_helper):
+            _helper_grid_x = self.expert_cnt if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else 1
+            _helper_args = (
+                b_from_call_arg if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else cute.make_ptr(cutlass.Int64, 0, AddressSpace.gmem),
+                sfb_from_call_arg if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else cute.make_ptr(cutlass.Int64, 0, AddressSpace.gmem),
+                n if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else cutlass.Int32(0),
+                k if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else cutlass.Int32(0),
+                b_stride_size if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else cutlass.Int64(0),
+                b_major_mode if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else self.b_major_mode,
+                workspace_ptr,
+                tiled_mma,
+                tiled_mma_sfb,
+                b_smem_layout,
+                sfb_smem_layout,
+                self.cluster_layout_vmnk.shape,
+                self.cluster_layout_sfb_vmnk.shape,
+            )
+            self.helper_kernel(*_helper_args).launch(
+                grid=(_helper_grid_x, 1, 1),
+                block=(1, 1, 1),
+                stream=stream,
+                min_blocks_per_mp=1,
+            )
+
+        # Zero the sfd2 arrival counters (same stream, so ordered before the
+        # main kernel; each launch must restart the arrival protocol from 0).
+        if cutlass.const_expr(self._sfd2_sync_active):
+            self.sfd2_counter_zero_kernel(workspace_ptr, _sfd2_counter_cnt).launch(
+                grid=(32, 1, 1),
+                block=(128, 1, 1),
+                stream=stream,
+                min_blocks_per_mp=1,
+            )
+
+        # Launch the main kernel
+        self.kernel(
+            tiled_mma,
+            tiled_mma_bkeep,
+            tiled_mma_breuse,
+            tiled_mma_sfb,
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_sfa,
+            tma_tensor_sfa,
+            tma_atom_sfb,
+            tma_tensor_sfb,
+            sfa2_tensor,
+            sfb2_tensor,
+            sfd2_up_tensor,
+            sfd2_gate_tensor,
+            tma_atom_c,
+            tma_tensor_c,
+            tma_atom_d,
+            tma_tensor_d,
+            sfd_row_tensor,
+            norm_const_tensor,
+            padded_offsets,
+            alpha,
+            beta,
+            prob,
+            dprob,
+            linear_offset,
+            dbias_tensor,
+            workspace_ptr,
+            self.cluster_layout_vmnk,
+            self.cluster_layout_sfb_vmnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.sfa2_smem_layout_staged,
+            self.sfb2_smem_layout_staged,
+            self.c_smem_layout_staged,
+            self.d_smem_layout_staged,
+            self.final_acc_smem_layout_staged,
+            self.epi_tile,
+            sched_params,
+            epilogue_op,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            max_number_threads=[self.threads_per_cta, 1, 1],
+            smem=self.shared_storage.size_in_bytes(),
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+        return
+
+    # ------------------------------------------------------------------
+    # Internal: create extension based on weight_mode
+    # ------------------------------------------------------------------
+
+    @cute.jit
+    def _make_extension(self, workspace_ptr):
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE):
+            desc_workspace = TensormapWorkspace(workspace_ptr, ["b", "sfb"])
+            return DiscreteWeightScaledGemmSchedExtension(
+                tensormap_ctor=desc_workspace,
+                sf_vec_size=self.sf_vec_size,
+            )
+        else:
+            return ContiguousAndConsistentGroupedGemmSchedExtension(
+                sf_vec_size=self.sf_vec_size,
+            )
+
+    def mainloop_s2t_copy_and_partition(
+        self,
+        sSF: cute.Tensor,
+        tSF: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for smem to tmem load for scale factor tensor, then use it to partition smem memory (source) and tensor memory (destination).
+
+        :param sSF: The scale factor tensor in smem
+        :type sSF: cute.Tensor
+        :param tSF: The scale factor tensor in tmem
+        :type tSF: cute.Tensor
+
+        :return: A tuple containing (tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t) where:
+            - tiled_copy_s2t: The tiled copy operation for smem to tmem load for scale factor tensor(s2t)
+            - tCsSF_compact_s2t: The partitioned scale factor tensor in smem
+            - tSF_compact_s2t: The partitioned scale factor tensor in tmem
+        :rtype: Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]
+        """
+        # (MMA, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact = cute.filter_zeros(sSF)
+        # (MMA, MMA_MN, MMA_K)
+        tCtSF_compact = cute.filter_zeros(tSF)
+
+        # Make S2T CopyAtom and tiledCopy
+        copy_atom_s2t = cute.make_copy_atom(
+            tcgen05.Cp4x32x128bOp(self.cta_group),
+            self.sf_dtype,
+        )
+        tiled_copy_s2t = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSF_compact)
+        thr_copy_s2t = tiled_copy_s2t.get_slice(0)
+
+        # sm107 SF-to-TMEM smem-descriptor shape: append a stride-0 broadcast
+        # mode of extent sf_pack_factor(=4 for vec16) to the MN mode (pairs with
+        # the sf_pack_factor SF TMEM column count in _setup_attributes).
+        def _append_mn_broadcast_mode(smem_layout: cute.Layout):
+            mn_dim = cute.get(smem_layout, mode=[0, 0])
+            mn_dim = cute.append(mn_dim, cute.make_layout((4), stride=(0)))
+            layout = cute.append(cute.group_modes(mn_dim, 0), cute.get(smem_layout, mode=[0, 1]))
+            layout = cute.append(cute.group_modes(layout, 0), cute.get(smem_layout, mode=[1]))
+            layout = cute.append(layout, cute.get(smem_layout, mode=[2]))
+            layout = cute.append(layout, cute.get(smem_layout, mode=[3]))
+            return layout
+
+        tCsSF_compact_bcast = cute.make_tensor(tCsSF_compact.iterator, _append_mn_broadcast_mode(tCsSF_compact.layout))
+
+        # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact_s2t_ = thr_copy_s2t.partition_S(tCsSF_compact_bcast)
+        # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact_s2t = tcgen05.get_s2t_smem_desc_tensor(tiled_copy_s2t, tCsSF_compact_s2t_)
+        # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K)
+        tCtSF_compact_s2t = thr_copy_s2t.partition_D(tCtSF_compact)
+
+        return tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t
+
+    @cute.jit
+    def amax_reduction_per_thread(self, vec_fp32, amax_fp32) -> None:
+        vec_fp32_ssa = vec_fp32
+        abs_acc_values_ir = cutlass._mlir.dialects.math.absf(vec_fp32_ssa.ir_value())
+        abs_acc_values = type(vec_fp32_ssa)(abs_acc_values_ir, vec_fp32_ssa.shape, vec_fp32_ssa.dtype)
+        subtile_amax = abs_acc_values.reduce(cute.ReductionOp.MAX, cutlass.Float32(0.0), 0)
+        return cute.arch.fmax(amax_fp32, subtile_amax)
+
+    @cute.jit
+    def second_level_scale_row_wise_gen(self, thread_tile_amax, tgSFD2):
+        thread_gmem_ptr = tgSFD2.iterator.llvm_ptr
+        _ = atomic_max_float32(ptr=thread_gmem_ptr, value=thread_tile_amax)
+
+    @cute.jit
+    def cvt_f32x4_to_f8x4_pack_i32(self, fp32x4, fp8_type, loc=None, ip=None):
+        fp32x4 = fp32x4.load()
+        src_vec4 = fp32x4.ir_value(loc=loc, ip=ip) if hasattr(fp32x4, "ir_value") else fp32x4
+
+        src0 = Float32(vector.extract(src_vec4, [], [0])).ir_value(loc=loc, ip=ip)
+        src1 = Float32(vector.extract(src_vec4, [], [1])).ir_value(loc=loc, ip=ip)
+        src2 = Float32(vector.extract(src_vec4, [], [2])).ir_value(loc=loc, ip=ip)
+        src3 = Float32(vector.extract(src_vec4, [], [3])).ir_value(loc=loc, ip=ip)
+
+        cvt_instruction = ""
+        if cutlass.const_expr(fp8_type == cutlass.Float8E8M0FNU):
+            cvt_instruction = "cvt.rp.satfinite.ue8m0x2.f32"
+        elif cutlass.const_expr(fp8_type == cutlass.Float8E4M3FN):
+            cvt_instruction = "cvt.rn.satfinite.e4m3x2.f32"
+        else:
+            with cute.arch.elect_one():
+                cute.printf("error: unsupported fp8 element type")
+            return
+
+        asm_tmpl = (
+            "{\n"
+            "  .reg .b16 lo;\n"
+            "  .reg .b16 hi;\n"
+            f"  {cvt_instruction} lo, $2, $1;\n"
+            f"  {cvt_instruction} hi, $4, $3;\n"
+            "  mov.b32 $0, {lo, hi};\n"
+            "}"
+        )
+        packed_i32 = llvm.inline_asm(
+            T.i32(),
+            [src0, src1, src2, src3],
+            asm_tmpl,
+            "=r,f,f,f,f",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+
+        return packed_i32
+
+    @cute.jit
+    def cvt_f32x4_to_f8x4(self, fp32x4, fp8x4, loc=None, ip=None):
+        packed_i32 = self.cvt_f32x4_to_f8x4_pack_i32(fp32x4, fp8x4.element_type)
+        fp8x4_i32 = cute.recast_tensor(fp8x4, cutlass.Int32)
+        fp8x4_i32[0] = cutlass.Int32(packed_i32)
+        return
+
+    @cute.jit
+    def cvt_f32_to_f8_to_f32(self, fp32x1, fp8_type, loc=None, ip=None):
+        if cutlass.const_expr(fp8_type == cutlass.FloatNV8E5M3FNU):
+            # No PTX cvt exists for e5m3: explicit clamp to the format max,
+            # then scalar RN .to() and exact f32 decode-back -- the reference
+            # _QuantNvfp4 e5m3 recipe, byte-identical. The fmin clamp replaces
+            # the satfinite the e4m3 path relies on.
+            pv = fmin(Float32(fp32x1), Float32(61440.0), nan=True)
+            enc_r = cute.make_rmem_tensor((1,), cutlass.FloatNV8E5M3FNU)
+            enc_r[0] = pv.to(cutlass.FloatNV8E5M3FNU)
+            return enc_r[0].to(cutlass.Float32)
+
+        src_fp32 = Float32(fp32x1).ir_value(loc=loc, ip=ip)
+
+        cvt_instruction_downcast = ""
+        cvt_instruction_upcast = ""
+        # Intermediate float type used to upcast the fp8 value back to f32.
+        # ue8m0 needs bf16 (matching f32 exponent range); e4m3 must use f16
+        # since PTX has no direct e4m3->bf16 conversion (only cvt.rn.f16x2.e4m3x2).
+        upcast_vec_ty = "vector<2xbf16>"
+        if cutlass.const_expr(fp8_type == cutlass.Float8E8M0FNU):
+            cvt_instruction_downcast = "cvt.rp.satfinite.ue8m0x2.f32"
+            cvt_instruction_upcast = "cvt.rn.bf16x2.ue8m0x2"
+            upcast_vec_ty = "vector<2xbf16>"
+        elif cutlass.const_expr(fp8_type == cutlass.Float8E4M3FN):
+            cvt_instruction_downcast = "cvt.rn.satfinite.e4m3x2.f32"
+            cvt_instruction_upcast = "cvt.rn.f16x2.e4m3x2"
+            upcast_vec_ty = "vector<2xf16>"
+        else:
+            with cute.arch.elect_one():
+                cute.printf("error: unsupported fp8 element type")
+            return
+
+        asm_tmpl = "{\n" "  .reg .b16 bf_lo;\n" f"  {cvt_instruction_downcast} bf_lo, 0f00000000, $1;\n" f"  {cvt_instruction_upcast}  $0, bf_lo;\n" "}"
+        packed_i32 = llvm.inline_asm(
+            T.i32(),
+            [src_fp32],
+            asm_tmpl,
+            "=r,f",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+
+        vec_hi_ty = ir.Type.parse(upcast_vec_ty)
+        bf2_lo = llvm.bitcast(vec_hi_ty, packed_i32, loc=loc, ip=ip)
+        h0 = vector.extract(bf2_lo, [], [0], loc=loc, ip=ip)
+        dst_f32 = arith.extf(Float32.mlir_type, h0, loc=loc, ip=ip)
+
+        return dst_f32
+
+    @cute.jit
+    def quant_sfd_row(
+        self,
+        tile_idx,
+        tiled_copy_r2s,
+        src,
+        pvscale,
+        norm_const,
+        rcp_limit,
+        tRSrD,
+        sfd2_descale=None,
+    ) -> None:
+        # NOTE: `sfd2_descale` is the per-thread (per-row) second-level block
+        # descale (block_amax / (E2M1_MAX*E4M3_MAX)), read back from the sfd2
+        # gmem atomic-max reduction after pass 1 (see the pass-2 read-back in
+        # the epilogue) so it covers the FULL block even when one block spans
+        # multiple N work-tiles (sfd2_n_contrib > 1). Its reciprocal is folded
+        # into the first-level (row-wise) SFD scale below, so the e4m3 SF
+        # absorbs the per-block second-level magnitude.
+        # Get absolute max across a vector and Compute SFD
+        tCompute = cute.make_rmem_tensor(src.shape, self.acc_dtype)
+        tCompute.store(src)
+        tTR_rAcc_frg = cute.logical_divide(tCompute, cute.make_layout(self.sf_vec_size))
+        acc_frg = tTR_rAcc_frg.load()
+        abs_acc_frg_ir = cutlass._mlir.dialects.math.absf(acc_frg.ir_value())
+        abs_acc_frg = type(acc_frg)(abs_acc_frg_ir, acc_frg.shape, acc_frg.dtype)
+
+        sfd2_scale = cute.arch.rcp_approx(sfd2_descale)
+
+        for vi in cutlass.range_constexpr(abs_acc_frg.shape[1]):
+            pvscale[vi, None, tile_idx][0] = (
+                abs_acc_frg[None, vi].reduce(
+                    cute.ReductionOp.MAX,
+                    cutlass.Float32(0.0),
+                    0,  # Use 0.0 as init for abs values
+                )
+                * rcp_limit
+                * norm_const
+                * sfd2_scale
+            )
+
+        #
+        # Compute quantized output values and convert to D type
+        #
+
+        fp32_max = cutlass.Float32(3.40282346638528859812e38)
+        if cutlass.const_expr(self.vectorized_f32):
+            for vi in cutlass.range_constexpr(0, abs_acc_frg.shape[1], 2):
+                qpvscale_up_0 = self.cvt_f32_to_f8_to_f32(pvscale[vi, None, tile_idx][0], self.sf_dtype)
+                qpvscale_up_1 = self.cvt_f32_to_f8_to_f32(pvscale[vi + 1, None, tile_idx][0], self.sf_dtype)
+                acc_scale = cute.arch.mul_packed_f32x2(
+                    (
+                        cute.arch.rcp_approx(qpvscale_up_0),
+                        cute.arch.rcp_approx(qpvscale_up_1),
+                    ),
+                    (norm_const, norm_const),
+                )
+                acc_scale_min0 = fmin(acc_scale[0], fp32_max, nan=True)
+                acc_scale_min1 = fmin(acc_scale[1], fp32_max, nan=True)
+                vec0 = tTR_rAcc_frg[None, vi]
+                vec1 = tTR_rAcc_frg[None, vi + 1]
+                for ei in cutlass.range_constexpr(self.sf_vec_size):
+                    (
+                        vec0[ei],
+                        vec1[ei],
+                    ) = cute.arch.mul_packed_f32x2(
+                        (vec0[ei], vec1[ei]),
+                        (acc_scale_min0, acc_scale_min1),
+                        rnd="rn",
+                        ftz=False,
+                    )
+        else:
+            for vi in cutlass.range_constexpr(abs_acc_frg.shape[1]):
+                qpvscale_up = self.cvt_f32_to_f8_to_f32(pvscale[vi, None, tile_idx][0], self.sf_dtype)
+                acc_scale = norm_const * cute.arch.rcp_approx(qpvscale_up)
+                acc_scale = fmin(acc_scale, fp32_max, nan=True)
+                vec = tTR_rAcc_frg[None, vi]
+                for ei in cutlass.range_constexpr(self.sf_vec_size):
+                    vec[ei] = vec[ei] * acc_scale
+
+        acc_vec = tiled_copy_r2s.retile(tCompute).load()
+        if cutlass.const_expr(not self.use_fp8_ptx_cvt):
+            tRSrD.store(acc_vec.to(self.d_dtype))
+        else:
+            tRSrD_i32 = cute.recast_tensor(tRSrD, cutlass.Int32)
+            for ei in cutlass.range_constexpr(0, self.sf_vec_size, 4):
+                fp32x4 = cute.make_rmem_tensor(4, cutlass.Float32)
+                fp32x4[0] = acc_vec[ei + 0]
+                fp32x4[1] = acc_vec[ei + 1]
+                fp32x4[2] = acc_vec[ei + 2]
+                fp32x4[3] = acc_vec[ei + 3]
+                fp8x4_i32 = self.cvt_f32x4_to_f8x4_pack_i32(fp32x4, self.d_dtype)
+                tRSrD_i32[ei // 4] = cutlass.Int32(fp8x4_i32)
+
+    @cute.jit
+    def stg_256(self, ptr, vec8_f32, *, loc=None, ip=None):
+        """
+        Store 8xf32 (256b) to global memory with L1::no_allocate.
+        ptr: pointer (byte addressable)
+        vec8_f32: vector<8xf32> to store
+        """
+        dst = ptr.ir_value(loc=loc, ip=ip) if hasattr(ptr, "ir_value") else ptr
+        src = vec8_f32.ir_value(loc=loc, ip=ip) if hasattr(vec8_f32, "ir_value") else vec8_f32
+        dummy = llvm.inline_asm(
+            T.i32(),
+            [
+                dst,
+                vector.extract(src, [], [0], loc=loc, ip=ip),
+                vector.extract(src, [], [1], loc=loc, ip=ip),
+                vector.extract(src, [], [2], loc=loc, ip=ip),
+                vector.extract(src, [], [3], loc=loc, ip=ip),
+                vector.extract(src, [], [4], loc=loc, ip=ip),
+                vector.extract(src, [], [5], loc=loc, ip=ip),
+                vector.extract(src, [], [6], loc=loc, ip=ip),
+                vector.extract(src, [], [7], loc=loc, ip=ip),
+            ],
+            "st.global.L1::no_allocate.v8.f32 [$1], {$2, $3, $4, $5, $6, $7, $8, $9}; mov.u32 $0, 0;",
+            "=r,l,f,f,f,f,f,f,f,f",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+
+    @cute.jit
+    def store_global_memory_256b(self, dst: cute.Tensor, src: cute.Tensor):
+        vec_shape = cute.make_layout(8)
+        dst_f32 = cute.flatten(cute.recast_tensor(dst, cutlass.Float32))
+        src_f32 = cute.flatten(cute.recast_tensor(src, cutlass.Float32))
+        dst_vf32x8 = cute.logical_divide(dst_f32, vec_shape)
+        src_vf32x8 = cute.logical_divide(src_f32, vec_shape)
+        for ei in cutlass.range_constexpr(dst_vf32x8.shape[1]):
+            self.stg_256(dst_vf32x8[None, ei].iterator.llvm_ptr, src_vf32x8[None, ei].load())
+
+    @cute.jit
+    def dbias_reduction(
+        self,
+        d1_vec,
+        d2_vec,
+        warp_idx,
+        sDbias,
+        dbias_gmem_2d,
+        expert_idx,
+        n_base_d1,
+        n_base_d2,
+        dbias_n_total,
+    ) -> None:
+        """Merged dy1+dy2 dbias reduction via SMEM transpose."""
+        epi_n = self.epi_tile[1]
+        lane_idx = cute.arch.lane_idx()
+        warp_local = warp_idx - self.epilog_warp_id[0]
+
+        for n in cutlass.range(epi_n, unroll_full=True):
+            sDbias[(n, lane_idx, warp_local)] = d1_vec[n]
+            sDbias[(epi_n + n, lane_idx, warp_local)] = d2_vec[n]
+
+        self.epilog_sync_barrier.arrive_and_wait()
+
+        col_a = 2 * lane_idx if lane_idx < 16 else epi_n + 2 * (lane_idx - 16)
+        col_b = col_a + 1
+
+        copy_128bit_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), cutlass.Float32, num_bits_per_copy=128)
+        warp_base_ptr = sDbias.iterator + warp_local * epi_n * 2 * 32
+        swizzle_a = ((col_a >> 1) & 0x7) << 2
+        swizzle_b = ((col_b >> 1) & 0x7) << 2
+
+        sum_a = cutlass.Float32(0.0)
+        sum_b = cutlass.Float32(0.0)
+        rDst_a = cute.make_rmem_tensor(cute.make_layout((4,)), cutlass.Float32)
+        rDst_b = cute.make_rmem_tensor(cute.make_layout((4,)), cutlass.Float32)
+        for g in cutlass.range(8, unroll_full=True):
+            m_base = g * 4
+            sw_offset_a = col_a * 32 + (m_base ^ swizzle_a)
+            sSrc_a = cute.make_tensor(warp_base_ptr + sw_offset_a, cute.make_layout((4,)))
+            cute.copy_atom_call(copy_128bit_atom, sSrc_a, rDst_a)
+
+            sw_offset_b = col_b * 32 + (m_base ^ swizzle_b)
+            sSrc_b = cute.make_tensor(warp_base_ptr + sw_offset_b, cute.make_layout((4,)))
+            cute.copy_atom_call(copy_128bit_atom, sSrc_b, rDst_b)
+
+            for i in cutlass.range(4, unroll_full=True):
+                sum_a = sum_a + rDst_a[i]
+                sum_b = sum_b + rDst_b[i]
+
+        n_offset = (n_base_d1 + 2 * lane_idx) if lane_idx < 16 else (n_base_d2 + 2 * (lane_idx - 16))
+
+        if cutlass.const_expr(self.dbias_cross_warp_reduce):
+            reduce_base = sDbias.iterator
+            copy_64bit_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), cutlass.Float32, num_bits_per_copy=64)
+
+            self.epilog_sync_barrier.arrive_and_wait()
+            rSrc_partial = cute.make_rmem_tensor(cute.make_layout((2,)), cutlass.Float32)
+            rSrc_partial[0] = sum_a
+            rSrc_partial[1] = sum_b
+            sDst_partial = cute.make_tensor(reduce_base + warp_local * 64 + lane_idx * 2, cute.make_layout((2,)))
+            cute.copy_atom_call(copy_64bit_atom, rSrc_partial, sDst_partial)
+            self.epilog_sync_barrier.arrive_and_wait()
+
+            if warp_idx == self.epilog_warp_id[0]:
+                cta_sum_a = cutlass.Float32(0.0)
+                cta_sum_b = cutlass.Float32(0.0)
+                rDst_w = cute.make_rmem_tensor(cute.make_layout((2,)), cutlass.Float32)
+                for w in cutlass.range(self.num_epilog_warps):
+                    sSrc_w = cute.make_tensor(reduce_base + w * 64 + lane_idx * 2, cute.make_layout((2,)))
+                    cute.copy_atom_call(copy_64bit_atom, sSrc_w, rDst_w)
+                    cta_sum_a = cta_sum_a + rDst_w[0]
+                    cta_sum_b = cta_sum_b + rDst_w[1]
+                if n_offset < dbias_n_total:
+                    # f32 dbias accumulator (TESTING ONLY, selected by the dbias
+                    # tensor dtype): plain f32 atomics per column instead of the
+                    # packed bf16x2 reduction.
+                    if cutlass.const_expr(dbias_gmem_2d.element_type == cutlass.Float32):
+                        _ = atomic_add_float32(
+                            ptr=dbias_gmem_2d[(expert_idx, n_offset, None)].iterator.llvm_ptr,
+                            value=cta_sum_a,
+                        )
+                        _ = atomic_add_float32(
+                            ptr=dbias_gmem_2d[(expert_idx, n_offset + 1, None)].iterator.llvm_ptr,
+                            value=cta_sum_b,
+                        )
+                    else:
+                        gmem_ptr = dbias_gmem_2d[(expert_idx, n_offset, None)].iterator.llvm_ptr
+                        atomic_add_bf16x2(gmem_ptr, cta_sum_a, cta_sum_b)
+        else:
+            if n_offset < dbias_n_total:
+                if cutlass.const_expr(dbias_gmem_2d.element_type == cutlass.Float32):
+                    _ = atomic_add_float32(
+                        ptr=dbias_gmem_2d[(expert_idx, n_offset, None)].iterator.llvm_ptr,
+                        value=sum_a,
+                    )
+                    _ = atomic_add_float32(
+                        ptr=dbias_gmem_2d[(expert_idx, n_offset + 1, None)].iterator.llvm_ptr,
+                        value=sum_b,
+                    )
+                else:
+                    gmem_ptr = dbias_gmem_2d[(expert_idx, n_offset, None)].iterator.llvm_ptr
+                    atomic_add_bf16x2(gmem_ptr, sum_a, sum_b)
+
+    @cute.jit
+    def dswiglu(
+        self,
+        acc_vec: cute.Tensor,
+        ab1_vec_load: cute.Tensor,
+        ab2_vec_load: cute.Tensor,
+        mProb: cute.Tensor,
+        beta_val: Float32,
+        square_alpha: Float32,
+        dprob_swiglu: Optional[cute.Tensor] = None,
+    ):
+        # Compile-time GLU params (baked from the kernel object).
+        dglu_alpha = self.glu_alpha
+        dglu_clamp_max = self.glu_clamp_max
+        dglu_clamp_min = self.glu_clamp_min
+        LOG2_E = cutlass.Float32(1.4426950408889634)
+        if cutlass.const_expr(self.vectorized_f32):
+            ab1_vec_f32 = cute.make_rmem_tensor(ab1_vec_load.shape, cutlass.Float32)
+            ab2_vec_f32 = cute.make_rmem_tensor(ab2_vec_load.shape, cutlass.Float32)
+            for i in cutlass.range_constexpr(cute.size(ab1_vec_load)):
+                ab1_vec_f32[i] = ab1_vec_load[i].to(cutlass.Float32)
+                ab2_vec_f32[i] = ab2_vec_load[i].to(cutlass.Float32)
+            ab1_vec_load = ab1_vec_f32
+            ab2_vec_load = ab2_vec_f32
+            d1_vec = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
+            d2_vec = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
+            for i in cutlass.range(0, cute.size(acc_vec), 2, unroll_full=True):
+                # Apply scaling factors for FP8
+                (
+                    acc_vec[i + 0],
+                    acc_vec[i + 1],
+                ) = cute.arch.mul_packed_f32x2(
+                    (acc_vec[i + 0], acc_vec[i + 1]),
+                    (square_alpha, square_alpha),
+                    rnd="rn",
+                    ftz=False,
+                )
+                if cutlass.const_expr(dglu_alpha is not None and dglu_alpha != 1.0):
+                    (
+                        acc_vec[i + 0],
+                        acc_vec[i + 1],
+                    ) = cute.arch.mul_packed_f32x2(
+                        (acc_vec[i + 0], acc_vec[i + 1]),
+                        (dglu_alpha, dglu_alpha),
+                        rnd="rn",
+                        ftz=False,
+                    )
+
+                if cutlass.const_expr(dglu_clamp_max is not None and dglu_clamp_min is not None):
+                    ab1_vec_load[i + 0] = fmin(ab1_vec_load[i + 0], dglu_clamp_max)
+                    ab1_vec_load[i + 1] = fmin(ab1_vec_load[i + 1], dglu_clamp_max)
+                    ab2_vec_load[i + 0] = fmin(ab2_vec_load[i + 0], dglu_clamp_max)
+                    ab2_vec_load[i + 1] = fmin(ab2_vec_load[i + 1], dglu_clamp_max)
+                    ab2_vec_load[i + 0] = fmax(ab2_vec_load[i + 0], dglu_clamp_min)
+                    ab2_vec_load[i + 1] = fmax(ab2_vec_load[i + 1], dglu_clamp_min)
+
+                ab1_vec_acc_type = cute.arch.mul_packed_f32x2(
+                    (
+                        ab1_vec_load[i + 0].to(self.acc_dtype),
+                        ab1_vec_load[i + 1].to(self.acc_dtype),
+                    ),
+                    (beta_val, beta_val),
+                    rnd="rn",
+                    ftz=False,
+                )
+                ab2_vec_acc_type = cute.arch.mul_packed_f32x2(
+                    (
+                        ab2_vec_load[i + 0].to(self.acc_dtype),
+                        ab2_vec_load[i + 1].to(self.acc_dtype),
+                    ),
+                    (beta_val, beta_val),
+                    rnd="rn",
+                    ftz=False,
+                )
+                sig_rcp_0, sig_rcp_1 = cute.arch.mul_packed_f32x2(
+                    (ab1_vec_acc_type),
+                    (-LOG2_E, -LOG2_E),
+                    rnd="rn",
+                    ftz=False,
+                )
+                sig_rcp_0, sig_rcp_1 = cute.arch.add_packed_f32x2(
+                    (
+                        cute.math.exp2(sig_rcp_0, fastmath=True),
+                        cute.math.exp2(sig_rcp_1, fastmath=True),
+                    ),
+                    (1.0, 1.0),
+                    rnd="rn",
+                    ftz=False,
+                )
+                sig = (
+                    cute.arch.rcp_approx(sig_rcp_0),
+                    cute.arch.rcp_approx(sig_rcp_1),
+                )
+                swish = cute.arch.mul_packed_f32x2(
+                    ab1_vec_acc_type,
+                    sig,
+                    rnd="rn",
+                    ftz=False,
+                )
+                # calculate dprob
+                if cutlass.const_expr(self.generate_dprob):
+                    (
+                        dprob_swiglu[i + 0],
+                        dprob_swiglu[i + 1],
+                    ) = cute.arch.mul_packed_f32x2(
+                        (ab2_vec_acc_type[0], ab2_vec_acc_type[1]),
+                        swish,
+                    )
+                    (
+                        dprob_swiglu[i + 0],
+                        dprob_swiglu[i + 1],
+                    ) = cute.arch.mul_packed_f32x2(
+                        (dprob_swiglu[i + 0], dprob_swiglu[i + 1]),
+                        (acc_vec[i + 0], acc_vec[i + 1]),
+                    )
+                # calculate dswiglu
+                acc_vec_prob = cute.arch.mul_packed_f32x2(
+                    (acc_vec[i + 0], acc_vec[i + 1]),
+                    (mProb, mProb),
+                )
+                # calculate d2_vec
+                (
+                    d2_vec[i + 0],
+                    d2_vec[i + 1],
+                ) = cute.arch.mul_packed_f32x2(
+                    (acc_vec_prob[0], acc_vec_prob[1]),
+                    swish,
+                    rnd="rn",
+                    ftz=False,
+                )
+                # calculate d1_vec
+                (
+                    d1_vec[i + 0],
+                    d1_vec[i + 1],
+                ) = cute.arch.mul_packed_f32x2(
+                    (acc_vec_prob[0], acc_vec_prob[1]),
+                    (ab2_vec_acc_type[0], ab2_vec_acc_type[1]),
+                    rnd="rn",
+                    ftz=False,
+                )
+                (
+                    d1_vec[i + 0],
+                    d1_vec[i + 1],
+                ) = cute.arch.mul_packed_f32x2(
+                    (d1_vec[i + 0], d1_vec[i + 1]),
+                    sig,
+                    rnd="rn",
+                    ftz=False,
+                )
+                one_minus_sig = cute.arch.add_packed_f32x2(
+                    (1.0, 1.0),
+                    (-sig[0], -sig[1]),
+                    rnd="rn",
+                    ftz=False,
+                )
+                dsig = cute.arch.mul_packed_f32x2(
+                    ab1_vec_acc_type,
+                    one_minus_sig,
+                    rnd="rn",
+                    ftz=False,
+                )
+                dsig_add_1 = cute.arch.add_packed_f32x2(
+                    (dsig[0], dsig[1]),
+                    (1.0, 1.0),
+                    rnd="rn",
+                    ftz=False,
+                )
+                (
+                    d1_vec[i + 0],
+                    d1_vec[i + 1],
+                ) = cute.arch.mul_packed_f32x2(
+                    (d1_vec[i + 0], d1_vec[i + 1]),
+                    dsig_add_1,
+                    rnd="rn",
+                    ftz=False,
+                )
+            d1_vec = d1_vec.load()
+            d2_vec = d2_vec.load()
+            if cutlass.const_expr(self.generate_dprob):
+                dprob_swiglu = dprob_swiglu.load()
+            return d1_vec, d2_vec, dprob_swiglu
+        else:
+            ab1_f32 = cute.make_rmem_tensor(ab1_vec_load.shape, cutlass.Float32)
+            ab2_f32 = cute.make_rmem_tensor(ab2_vec_load.shape, cutlass.Float32)
+            for i in cutlass.range_constexpr(cute.size(ab1_vec_load)):
+                ab1_f32[i] = ab1_vec_load[i].to(cutlass.Float32)
+                ab2_f32[i] = ab2_vec_load[i].to(cutlass.Float32)
+                if cutlass.const_expr(dglu_clamp_max is not None and dglu_clamp_min is not None):
+                    ab1_f32[i] = fmin(ab1_f32[i], dglu_clamp_max)
+                    ab2_f32[i] = fmin(ab2_f32[i], dglu_clamp_max)
+                    ab2_f32[i] = fmax(ab2_f32[i], dglu_clamp_min)
+            ab1_vec_load = ab1_f32
+            ab2_vec_load = ab2_f32
+
+            acc_vec = acc_vec.load()
+            ab1_vec_load = ab1_vec_load.load()
+            ab2_vec_load = ab2_vec_load.load()
+
+            acc_vec = acc_vec * square_alpha  # apply scale for A*B
+            if cutlass.const_expr(dglu_alpha is not None and dglu_alpha != 1.0):
+                acc_vec = acc_vec * dglu_alpha
+            ab1_vec_load = ab1_vec_load * beta_val  # apply scale for C
+            ab2_vec_load = ab2_vec_load * beta_val  # apply scale for C
+
+            sig_rcp = (1 + cute.math.exp(-1 * ab1_vec_load, True)).to(self.acc_dtype)
+            res = cute.make_rmem_tensor(sig_rcp.shape, cutlass.Float32)
+            res.store(sig_rcp)
+            # let every res[?] be cute.arch.rcp_approx(res[?])
+            [res.__setitem__(i, cute.arch.rcp_approx(res[i])) for i in range(cute.size(res.shape))]
+            sig = res.load()
+            swish = ab1_vec_load * sig
+
+            # calculate dprob
+            if cutlass.const_expr(self.generate_dprob):
+                dprob_swiglu = ab2_vec_load * swish
+                dprob_swiglu = acc_vec * dprob_swiglu
+
+            # calculate dswiglu
+            d1_vec = acc_vec * mProb * ab2_vec_load * sig * (1 + ab1_vec_load * (1 - sig))
+            d2_vec = acc_vec * mProb * swish
+            return d1_vec, d2_vec, dprob_swiglu
+
+    @cute.jit
+    def dgeglu(
+        self,
+        acc_vec: cute.Tensor,
+        x1_vec_load: cute.Tensor,
+        x2_vec_load: cute.Tensor,
+        mProb: cute.Tensor,
+        linear_offset: Float32,
+        dprob_swiglu: Optional[cute.Tensor] = None,
+    ):
+        # Compile-time GLU params (baked from the kernel object).
+        dglu_alpha = self.glu_alpha
+        dglu_clamp_max = self.glu_clamp_max
+        dglu_clamp_min = self.glu_clamp_min
+        if cutlass.const_expr(dglu_clamp_max is None and dglu_clamp_min is None):
+            dglu_clamp_max = 7.0
+            dglu_clamp_min = -7.0
+        if cutlass.const_expr(dglu_alpha is None):
+            dglu_alpha = 1.702
+        LOG2_E = cutlass.Float32(1.4426950408889634)
+        x_dtype = x1_vec_load.element_type
+        geglu_max_value = x_dtype(dglu_clamp_max)
+        geglu_min_value = x_dtype(dglu_clamp_min)
+        geglu_max_value_f32 = cutlass.Float32(dglu_clamp_max)
+        geglu_min_value_f32 = cutlass.Float32(dglu_clamp_min)
+        zero_x_dtype = x_dtype(0.0)
+        fmul2 = partial(cute.arch.mul_packed_f32x2, rnd="rn", ftz=False)
+        fadd2 = partial(cute.arch.add_packed_f32x2, rnd="rn", ftz=False)
+        dglu_alpha_tuple = (dglu_alpha, dglu_alpha)
+        ones2 = (1.0, 1.0)
+        mprob2 = (mProb, mProb)
+        linear_offset2 = (linear_offset, linear_offset)
+
+        if cutlass.const_expr(self.vectorized_f32):
+            dx1_vec = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
+            dx2_vec = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
+            for i in cutlass.range(0, cute.size(acc_vec), 2, unroll_full=True):
+                acc = (acc_vec[i], acc_vec[i + 1])
+                x1_0 = x1_vec_load[i]
+                x1_1 = x1_vec_load[i + 1]
+                x2_0 = x2_vec_load[i]
+                x2_1 = x2_vec_load[i + 1]
+
+                y1_0 = 0.0
+                y1_1 = 0.0
+                y2_0 = 0.0
+                y2_1 = 0.0
+                if cutlass.const_expr(x_dtype == cutlass.BFloat16):
+                    y1_0, y1_1 = fmin_bf16x2(x1_0, x1_1, geglu_max_value, geglu_max_value)
+                    y2_0, y2_1 = fmax_bf16x2(x2_0, x2_1, geglu_min_value, geglu_min_value)
+                    y2_0, y2_1 = fmin_bf16x2(y2_0, y2_1, geglu_max_value, geglu_max_value)
+                    y1_0 = Float32(y1_0)
+                    y1_1 = Float32(y1_1)
+                    y2_0 = Float32(y2_0)
+                    y2_1 = Float32(y2_1)
+                else:
+                    y1_0 = fmin(x1_0, geglu_max_value)
+                    y1_1 = fmin(x1_1, geglu_max_value)
+                    y2_0 = fmin(x2_0, geglu_max_value)
+                    y2_1 = fmin(x2_1, geglu_max_value)
+                    y2_0 = fmax(y2_0, geglu_min_value)
+                    y2_1 = fmax(y2_1, geglu_min_value)
+                    y1_0 = Float32(y1_0)
+                    y1_1 = Float32(y1_1)
+                    y2_0 = Float32(y2_0)
+                    y2_1 = Float32(y2_1)
+
+                y1 = (y1_0, y1_1)
+                y2 = (y2_0, y2_1)
+
+                # y1 = dglu_alpha * x1
+                y1_scaled = fmul2(y1, dglu_alpha_tuple)
+
+                sigmoid_out_0 = sigmoid_f32(y1_scaled[0], fastmath=True)
+                sigmoid_out_1 = sigmoid_f32(y1_scaled[1], fastmath=True)
+
+                # g * sigmoid_out
+                acc_mul_sigmoid_out = fmul2(acc, (sigmoid_out_0, sigmoid_out_1))
+                acc_mul_sigmoid_prob = fmul2(acc_mul_sigmoid_out, mprob2)
+
+                # y1 = 1 + dglu_alpha * y1 * (1 - sigmoid_out)
+                one_minus_sigmoid_0, one_minus_sigmoid_1 = fadd2(ones2, (-sigmoid_out_0, -sigmoid_out_1))
+                y1_scaled = fadd2(
+                    fmul2(y1_scaled, (one_minus_sigmoid_0, one_minus_sigmoid_1)),
+                    ones2,
+                )
+
+                # y2 + linear_offset
+                y2_with_linear_offset_0, y2_with_linear_offset_1 = fadd2(y2, linear_offset2)
+
+                # dy1 = g * sigmoid_out * (y2 + linear_offset)
+                dy1_pre_0, dy1_pre_1 = fmul2(
+                    (y2_with_linear_offset_0, y2_with_linear_offset_1),
+                    acc_mul_sigmoid_out,
+                )
+                # dy1 = g * sigmoid_out * (y2 + linear_offset) * (1 + dglu_alpha * y1 * (1 - sigmoid_out)) * mProb
+                dy1_0, dy1_1 = fmul2((dy1_pre_0, dy1_pre_1), y1_scaled)
+                dy1_0, dy1_1 = fmul2((dy1_0, dy1_1), mprob2)
+
+                x1_filter_0 = y1_0 if x1_0 <= geglu_max_value else cutlass.Float32(0.0)
+                x1_filter_1 = y1_1 if x1_1 <= geglu_max_value else cutlass.Float32(0.0)
+
+                dx1_vec[i], dx1_vec[i + 1] = fmul2((dy1_0, dy1_1), (cutlass.Float32(x1_filter_0), cutlass.Float32(x1_filter_1)))
+
+                # dy2 = g * y1 * sigmoid_out * mProb
+                dy2_0, dy2_1 = fmul2(y1, acc_mul_sigmoid_prob)
+                x2_filter_0 = x2_0 if x2_0 <= geglu_max_value else x_dtype(0.0)
+                x2_filter_1 = x2_1 if x2_1 <= geglu_max_value else x_dtype(0.0)
+                x2_filter_0 = y2_0 if x2_filter_0 >= geglu_min_value else cutlass.Float32(0.0)
+                x2_filter_1 = y2_1 if x2_filter_1 >= geglu_min_value else cutlass.Float32(0.0)
+                dx2_vec[i], dx2_vec[i + 1] = fmul2((dy2_0, dy2_1), (cutlass.Float32(x2_filter_0), cutlass.Float32(x2_filter_1)))
+
+                if cutlass.const_expr(self.generate_dprob):
+                    prob_grad, prob_grad_1 = fmul2(
+                        (dy1_pre_0, dy1_pre_1),
+                        y1,
+                    )
+                    dprob_swiglu[i] = prob_grad
+                    dprob_swiglu[i + 1] = prob_grad_1
+            dx1_vec = dx1_vec.load()
+            dx2_vec = dx2_vec.load()
+            if cutlass.const_expr(self.generate_dprob):
+                dprob_swiglu = dprob_swiglu.load()
+            return dx1_vec, dx2_vec, dprob_swiglu
+        else:
+            element_count = cute.size(x1_vec_load)
+            acc_vec = acc_vec.load()
+            x1_vec_load = x1_vec_load.load().to(cutlass.Float32)
+            x2_vec_load = x2_vec_load.load().to(cutlass.Float32)
+            dx1_vec = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
+            dx2_vec = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
+
+            # y1 = clamp(x1, max=7.0); y2 = clamp(x2, min=-7.0, max=7.0)
+            for i in cutlass.range_constexpr(element_count):
+                # dgeglu applies alpha inside the sigmoid, not as an acc scale
+                # (matching the vectorized branch / reference).
+                fc2_dgrad = acc_vec[i]
+                g = fc2_dgrad * mProb
+                y1 = min(x1_vec_load[i], geglu_max_value_f32)
+                y2 = min(x2_vec_load[i], geglu_max_value_f32)
+                y2 = max(y2, geglu_min_value_f32)
+
+                sigmoid_out = sigmoid_f32(y1 * dglu_alpha, fastmath=True)
+
+                dy1 = g * sigmoid_out * (1 + dglu_alpha * y1 * (1 - sigmoid_out)) * (y2 + linear_offset)
+                dy2 = g * y1 * sigmoid_out
+
+                x1_filter = x1_vec_load[i] if x1_vec_load[i] <= geglu_max_value_f32 else 0.0
+                x2_filter = x2_vec_load[i] if x2_vec_load[i] <= geglu_max_value_f32 else 0.0
+                x2_filter = y2 if x2_filter >= geglu_min_value_f32 else 0.0
+
+                dx1_vec[i] = x1_filter * dy1
+                dx2_vec[i] = x2_filter * dy2
+
+                if cutlass.const_expr(self.generate_dprob):
+                    prob_grad = y1 * sigmoid_out * (y2 + linear_offset) * fc2_dgrad
+                    dprob_swiglu[i] = prob_grad
+
+            return dx1_vec.load(), dx2_vec.load(), dprob_swiglu.load()
+
+    # GPU device kernel
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tiled_mma_bkeep: Optional[cute.TiledMma],
+        tiled_mma_breuse: Optional[cute.TiledMma],
+        tiled_mma_sfb: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        mSFA_mkl: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        mSFB_nkl: cute.Tensor,
+        sfa2_tensor: cute.Tensor,
+        sfb2_tensor,  # can be cute.Tensor or cute.Pointer
+        sfd2_up_tensor: cute.Tensor,
+        sfd2_gate_tensor: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        tma_atom_d: cute.CopyAtom,
+        mD_mnl: cute.Tensor,
+        mSFDRow_mnl: Optional[cute.Tensor],
+        norm_const_tensor: Optional[cute.Tensor],
+        padded_offsets: cute.Tensor,
+        alpha: cute.Tensor,
+        beta: cute.Tensor,
+        prob: cute.Tensor,
+        dprob: cute.Tensor,
+        linear_offset: Float32,
+        mDbias_tensor: Optional[cute.Tensor],
+        workspace_ptr,
+        cluster_layout_vmnk: cute.Layout,
+        cluster_layout_sfb_vmnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        sfa2_smem_layout_staged: cute.Layout,
+        sfb2_smem_layout_staged: cute.Layout,
+        c_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout, None],
+        d_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout, None],
+        final_acc_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout, None],
+        epi_tile: cute.Tile,
+        sched_params: MoESchedulerParams,
+        epilogue_op: cutlass.Constexpr,
+    ):
+        """
+        GPU device kernel performing the Persistent batched GEMM computation.
+        """
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = tidx // 32
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        total_tokens = padded_offsets[self.expert_cnt - 1]
+
+        #
+        # Prefetch tma desc
+        #
+        if warp_idx == self.tma_warp_id:
+            cpasync.prefetch_descriptor(tma_atom_a)
+            cpasync.prefetch_descriptor(tma_atom_sfa)
+            if cutlass.const_expr(self.weight_mode == MoEWeightMode.DENSE):
+                cpasync.prefetch_descriptor(tma_atom_b)
+                cpasync.prefetch_descriptor(tma_atom_sfb)
+            cpasync.prefetch_descriptor(tma_atom_c)
+            if cutlass.const_expr(not self.store_d_directly):
+                cpasync.prefetch_descriptor(tma_atom_d)
+
+        use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+
+        #
+        # Setup cta/thread coordinates
+        #
+        # Coords inside cluster
+        bidx, bidy, bidz = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
+
+        block_in_cluster_coord_sfb_vmnk = cluster_layout_sfb_vmnk.get_flat_coord(cta_rank_in_cluster)
+
+        #
+        # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
+        #
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+        sched_storage = storage.scheduler
+
+        # Initialize mainloop ab_pipeline (barrier) and states
+        ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_tma_producer = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        ab_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, num_tma_producer)
+        ab_pipeline = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.ab_mbar_ptr.data_ptr(),
+            num_stages=self.num_ab_stage,
+            producer_group=ab_pipeline_producer_group,
+            consumer_group=ab_pipeline_consumer_group,
+            tx_count=self.num_tma_load_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        # scale_pipeline: scale-load warp (producer) -> accumulator-update warpgroup (consumer),
+        # staging sfa2/sfb2 in sSFA2/sSFB2 via cp.async.
+        scale_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * 1,
+        )
+        scale_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * len(self.accumulator_update_warp_id),
+        )
+        scale_pipeline = pipeline.PipelineCpAsync.create(
+            barrier_storage=storage.scale_mbar_ptr.data_ptr(),
+            num_stages=self.num_scale_stage,
+            producer_group=scale_pipeline_producer_group,
+            consumer_group=scale_pipeline_consumer_group,
+            defer_sync=True,
+        )
+
+        # Initialize acc_pipeline (barrier) and states. Consumer is the accumulator-update
+        # warpgroup (warps 0-3), not the epilogue.
+        acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_acc_consumer_threads = len(self.accumulator_update_warp_id) * (2 if use_2cta_instrs else 1)
+        acc_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, num_acc_consumer_threads)
+        acc_pipeline = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_stage,
+            producer_group=acc_pipeline_producer_group,
+            consumer_group=acc_pipeline_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        # Initialize epi_pipeline (barrier) connecting accumulator update -> epilogue
+        epi_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, self.threads_per_warp * len(self.accumulator_update_warp_id))
+        epi_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, self.threads_per_warp * len(self.epilog_warp_id))
+        epi_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.epi_mbar_ptr.data_ptr(),
+            num_stages=self.num_epi_stage,
+            producer_group=epi_pipeline_producer_group,
+            consumer_group=epi_pipeline_consumer_group,
+        )
+
+        # Load C pipeline
+        # Threads/warps participating in tma store pipeline
+        c_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        c_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            len(self.epilog_warp_id),
+        )
+        c_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.c_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_c_stage,
+            producer_group=c_producer_group,
+            consumer_group=c_consumer_group,
+            tx_count=self.tma_c_load_bytes,
+            defer_sync=True,
+        )
+
+        # Initialize tile info pipeline (barrier) and states
+        tile_info_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * 1,
+        )
+        tile_info_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_wo_sched,
+        )
+        tile_info_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=sched_storage.tile_info_mbar.data_ptr(),
+            num_stages=self.num_tile_stage,
+            producer_group=tile_info_pipeline_producer_group,
+            consumer_group=tile_info_pipeline_consumer_group,
+        )
+
+        scheduler = MoEPersistentTileScheduler.create(
+            sched_params,
+            padded_offsets,
+            cute.arch.block_idx(),
+            cute.arch.grid_dim(),
+            counter_ptr=self._get_sched_counter_ptr(workspace_ptr),
+            sched_storage=sched_storage,
+        )
+        scheduler.internal_init()
+
+        # dBias SMEM setup
+        if cutlass.const_expr(self.generate_dbias):
+            sDbias = storage.sDbias.get_tensor(
+                cute.make_layout(
+                    (self.epi_tile[1] * 2, 32, len(self.epilog_warp_id)),
+                    stride=(32, 1, self.epi_tile[1] * 2 * 32),
+                )
+            )
+
+        # Tensor memory dealloc barrier init
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr,
+            barrier_for_retrieve=self.tmem_alloc_barrier,
+            allocator_warp_id=self.epilog_warp_id[0],
+            is_two_cta=use_2cta_instrs,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr.ptr,
+            arch="sm_107",
+        )
+
+        # DSMEM rowwise-sfd2 reduction state (sgn/cta_n == cluster_n): the
+        # cluster_n N-peers red.shared::cluster-max their row-descale
+        # partials into EACH peer's sSfd2RowDsmem parity slot; a
+        # cluster_n-arrival mbarrier per parity replaces the gmem counter +
+        # acquire spin between pass 1 and pass 2.
+        if cutlass.const_expr(self.row_dsmem):
+            sSfd2RowDsmem = storage.sSfd2RowDsmem.get_tensor(cute.make_layout((2 * 2 * self.cta_tile_shape_mnk_d[0],)))
+            row_dsmem_mbar = storage.row_dsmem_mbar_ptr.data_ptr()
+            if warp_idx == 0:
+                with cute.arch.elect_one():
+                    cute.arch.mbarrier_init(row_dsmem_mbar + 0, self.cluster_shape_mn[1])
+                    cute.arch.mbarrier_init(row_dsmem_mbar + 1, self.cluster_shape_mn[1])
+                cute.arch.mbarrier_init_fence()
+                _rdsm_lane = cute.arch.lane_idx()
+                for _rdsm_zi in cutlass.range_constexpr(2 * 2 * self.cta_tile_shape_mnk_d[0] // 32):
+                    sSfd2RowDsmem[_rdsm_zi * 32 + _rdsm_lane] = Float32(0.0)
+                # Publish the zeroes at cluster scope: the peer's first reds
+                # into this buffer follow its cluster_wait (the relaxed
+                # arrive below carries no release — this fence does).
+                cute.arch.fence_acq_rel_cluster()
+
+        # Cluster arrive after barrier init
+        if cute.size(self.cluster_shape_mn) > 1:
+            cute.arch.cluster_arrive_relaxed()
+
+        #
+        # Setup smem tensor A/B/D/Scale
+        #
+        # (EPI_TILE_M, EPI_TILE_N, STAGE)
+        sC = storage.sC.get_tensor(c_smem_layout_staged.outer, swizzle=c_smem_layout_staged.inner)
+        sD = None
+        if cutlass.const_expr(not self.store_d_directly):
+            sD = storage.sD.get_tensor(d_smem_layout_staged.outer, swizzle=d_smem_layout_staged.inner)
+        # Full-CTA-tile final accumulator buffer (always allocated)
+        sFinalAcc = storage.sFinalAcc.get_tensor(final_acc_smem_layout_staged.outer, swizzle=final_acc_smem_layout_staged.inner)
+        # bf16 alias of the same bytes for the NVFP4 dGLU relay (see the epilogue).
+        # Built here, outside the warp-dispatch `if`: `storage` is a plain Python
+        # struct the 4.5 wheel cannot carry across a dynamic-if region boundary.
+        sFinalAccBf16 = None
+        if cutlass.const_expr(self.generate_sfd):
+            dglu_bf16_layout = sm100_utils.make_smem_layout_epi(
+                cutlass.BFloat16,
+                self.d_layout,
+                self.epi_tile,
+                self.final_acc_subtile_cnt * 2 * self.num_epi_stage,
+            )
+            sFinalAccBf16 = storage.sFinalAcc.get_tensor(
+                dglu_bf16_layout.outer,
+                swizzle=dglu_bf16_layout.inner,
+                dtype=cutlass.BFloat16,
+            )
+        # SFD row-stage SMEM tensor: same 4.5-wheel constraint as sFinalAccBf16 —
+        # derive it from `storage` out here (the epilogue's dynamic warp-dispatch
+        # `if` cannot carry the plain `storage` struct across its region boundary).
+        sSFDRowStage_flat = None
+        if cutlass.const_expr(self.generate_sfd):
+            # regPerSubtile == 4 in the epilogue SFD path.
+            _sfd_stage_size = 128 * 32 * 4 // self.sf_vec_size
+            sSFDRowStage_flat = storage.sSFDRowStage.get_tensor(cute.make_layout(_sfd_stage_size))
+        # (MMA, MMA_M, MMA_K, STAGE)
+        sA = storage.sA.get_tensor(a_smem_layout_staged.outer, swizzle=a_smem_layout_staged.inner)
+        # (MMA, MMA_N, MMA_K, STAGE)
+        sB = storage.sB.get_tensor(b_smem_layout_staged.outer, swizzle=b_smem_layout_staged.inner)
+        # (granularity_m, repeat_m), (granularity_k, repeat_k), num_scale_stage)
+        sSFA = storage.sSFA.get_tensor(sfa_smem_layout_staged)
+        # (granularity_n, repeat_n), (granularity_k, repeat_k), num_scale_stage)
+        sSFB = storage.sSFB.get_tensor(sfb_smem_layout_staged)
+        # (MMA, MMA_M, MMA_K, STAGE)
+        sSFA2 = storage.sSFA2.get_tensor(sfa2_smem_layout_staged)
+        # (MMA, MMA_N, MMA_K, STAGE)
+        sSFB2 = storage.sSFB2.get_tensor(sfb2_smem_layout_staged)
+        # (expert_idx, tile_m_idx, tile_n_idx, k_tile_cnt)
+        info_layout = cute.make_layout((4, self.num_tile_stage), stride=(1, 4))
+        sInfo = sched_storage.sInfo.get_tensor(info_layout)
+
+        #
+        # Compute multicast mask for A/B buffer full
+        #
+        a_full_mcast_mask = None
+        b_full_mcast_mask = None
+        sfa_full_mcast_mask = None
+        sfb_full_mcast_mask = None
+        if cutlass.const_expr(self.is_a_mcast or self.is_b_mcast or use_2cta_instrs):
+            a_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2)
+            b_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1)
+            sfa_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2)
+            sfb_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_sfb_vmnk, block_in_cluster_coord_sfb_vmnk, mcast_mode=1)
+
+        #
+        # Partition shared/tensor memory tensor for TiledMMA_A/B/D
+        #
+        # (MMA, MMA_M, MMA_K, STAGE)
+        tCrA = tiled_mma.make_fragment_A(sA)
+        # (MMA, MMA_N, MMA_K, STAGE)
+        tCrB = tiled_mma.make_fragment_B(sB)
+        # (MMA, MMA_M, MMA_N)
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+        # (MMA, MMA_M, MMA_N, STAGE)
+        if cutlass.const_expr(self.overlapping_accum):
+            num_acc_stage_overlapped = 2
+            tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, num_acc_stage_overlapped))
+            tCtAcc_fake = cute.make_tensor(
+                tCtAcc_fake.iterator,
+                cute.make_layout(
+                    tCtAcc_fake.shape,
+                    stride=(
+                        tCtAcc_fake.stride[0],
+                        tCtAcc_fake.stride[1],
+                        tCtAcc_fake.stride[2],
+                        (256 - self.num_sf_tmem_cols) * tCtAcc_fake.stride[0][1],
+                    ),
+                ),
+            )
+        elif cutlass.const_expr(self.cta_tile_shape_mnk[1] == 192):
+            tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, self.num_acc_stage))
+            tCtAcc_fake = cute.make_tensor(
+                tCtAcc_fake.iterator,
+                cute.make_layout(
+                    tCtAcc_fake.shape,
+                    stride=(
+                        tCtAcc_fake.stride[0],
+                        tCtAcc_fake.stride[1],
+                        tCtAcc_fake.stride[2],
+                        self.num_accumulator_tmem_stride,
+                    ),
+                ),
+            )
+        else:
+            tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, self.num_acc_stage))
+
+        #
+        # Preparing LDGSTS partition for second level scale factor tensor (scale warp)
+        #
+        lane_idx = cute.arch.lane_idx()
+        atom_scale2_copy = cute.make_copy_atom(
+            cute.nvgpu.cpasync.CopyG2SOp(),
+            self.sf2_dtype,
+            num_bits_per_copy=self.sf2_dtype.width,
+        )
+        tiled_copy_sfa2 = cute.make_tiled_copy_tv(atom_scale2_copy, cute.make_layout((32,)), cute.make_layout((1,)))
+        tiled_copy_sfb2 = cute.make_tiled_copy_tv(atom_scale2_copy, cute.make_layout((32,)), cute.make_layout((1,)))
+
+        thr_copy_sfa2 = tiled_copy_sfa2.get_slice(lane_idx)
+        thr_copy_sfb2 = tiled_copy_sfb2.get_slice(lane_idx)
+        tAsSFA2 = thr_copy_sfa2.partition_D(sSFA2)
+        tBsSFB2 = thr_copy_sfb2.partition_D(sSFB2)
+
+        #
+        # Scale viewed as C tensor
+        #
+        # N/M extents use the CTA-tile-clamped scale block size (scale_size_*),
+        # so the view spans exactly one CTA tile (size * per_tile == cta extent)
+        # regardless of whether sg{m,n} exceed the tile (e.g. sgn=512 > 128).
+        sSFA2_view_as_C_layout = cute.make_layout(
+            (
+                (self.scale_size_m, self.scale_m_per_tile),
+                self.cta_tile_shape_mnk[1],
+                self.num_scale_stage,
+            ),
+            stride=((0, 1), 0, self.scale_m_per_tile),
+        )
+        sSFB2_view_as_C_layout = cute.make_layout(
+            (
+                self.cta_tile_shape_mnk[0],
+                (self.scale_size_n, self.scale_n_per_tile),
+                self.num_scale_stage,
+            ),
+            stride=(0, (0, 1), self.scale_n_per_tile),
+        )
+        sSFA2_view_as_C = cute.make_tensor(sSFA2.iterator, sSFA2_view_as_C_layout)
+        sSFB2_view_as_C = cute.make_tensor(sSFB2.iterator, sSFB2_view_as_C_layout)
+
+        # Number of MMA k-tiles that share the same second-level scale factor.
+        # sgk may span multiple mma_tiler[2] k-tiles (e.g. sgk=512, mma_tiler_K=256 -> 2):
+        # those k-tiles are summed into one MMA partial and scaled once.
+        k_tile_same_scale_factor = self.sgk // self.mma_tiler[2]
+
+        #
+        # Cluster wait before tensor memory alloc
+        #
+        if cute.size(self.cluster_shape_mn) > 1:
+            cute.arch.cluster_wait()
+        else:
+            self.cta_sync_barrier.arrive_and_wait()
+
+        if total_tokens <= 0:
+            cute.arch.nvvm.exit()
+        k_tile_cnt = cute.ceil_div(cute.size(mB_nkl, mode=[1]), self.mma_tiler[2])
+
+        #
+        # Specialized Schedule warp (MoE Persistent Tile Scheduler)
+        #
+        if warp_idx == self.sched_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_sched_warps)
+            work_tile_info = scheduler.initial_work_tile_info()
+
+            tile_info_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_tile_stage)
+
+            while work_tile_info.is_valid_tile:
+                # sInfo format: (expert_idx, tile_m_idx, tile_n_idx, k_tile_cnt)
+                tile_info_pipeline.producer_acquire(tile_info_producer_state)
+                with cute.arch.elect_one():
+                    sInfo[(0, tile_info_producer_state.index)] = work_tile_info.expert_idx
+                    sInfo[(1, tile_info_producer_state.index)] = work_tile_info.tile_m_idx
+                    sInfo[(2, tile_info_producer_state.index)] = work_tile_info.tile_n_idx
+                    sInfo[(3, tile_info_producer_state.index)] = work_tile_info.k_tile_cnt
+                cute.arch.fence_proxy("async.shared", space="cta")
+
+                self.sched_sync_barrier.arrive_and_wait()
+                tile_info_pipeline.producer_commit(tile_info_producer_state)
+                tile_info_producer_state.advance()
+
+                work_tile_info = scheduler.advance_to_next_work()
+
+            # Send invalid tile signal: expert_idx = -1
+            tile_info_pipeline.producer_acquire(tile_info_producer_state)
+            with cute.arch.elect_one():
+                sInfo[(0, tile_info_producer_state.index)] = cutlass.Int32(-1)
+                sInfo[(1, tile_info_producer_state.index)] = cutlass.Int32(0)
+                sInfo[(2, tile_info_producer_state.index)] = cutlass.Int32(0)
+                sInfo[(3, tile_info_producer_state.index)] = cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            self.sched_sync_barrier.arrive_and_wait()
+            tile_info_pipeline.producer_commit(tile_info_producer_state)
+            tile_info_producer_state.advance()
+            tile_info_pipeline.producer_tail(tile_info_producer_state)
+
+        #
+        # Specialized TMA load warp
+        #
+        if warp_idx == self.tma_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_uniform_warps)
+            ext = self._make_extension(workspace_ptr)
+
+            ab_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_ab_stage)
+
+            tile_info_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_tile_stage)
+
+            # Get the first tile info
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            while is_valid_tile:
+                work_tile_info = MoEWorkTileInfo(
+                    expert_idx=tile_info[0],
+                    tile_m_idx=tile_info[1],
+                    tile_n_idx=tile_info[2],
+                    k_tile_cnt=tile_info[3],
+                )
+                # assert(k_tile_cnt == work_tile_info.k_tile_cnt)
+                ext.update_expert_info(padded_offsets, work_tile_info.expert_idx)
+
+                # Get per-expert real tensors + TMA desc ptrs via extension
+                real_a, _ = ext.get_gmem_tensor("a", mA_mkl, padded_offsets, work_tile_info)
+                real_b, desc_ptr_b = ext.get_gmem_tensor("b", mB_nkl, padded_offsets, work_tile_info)
+                real_sfa, _ = ext.get_gmem_tensor("sfa", mSFA_mkl, padded_offsets, work_tile_info)
+                real_sfb, desc_ptr_sfb = ext.get_gmem_tensor("sfb", mSFB_nkl, padded_offsets, work_tile_info)
+
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 192):
+                    # N=192: the SFB reshape is applied per tile here (not on
+                    # the host-side tma_tensor_sfb).
+                    x = real_sfb.stride[0][1]
+                    y = cute.ceil_div(real_sfb.shape[0][1], 4)
+                    new_shape = (
+                        (real_sfb.shape[0][0], ((2, 2), y)),
+                        real_sfb.shape[1],
+                        real_sfb.shape[2],
+                    )
+                    x_times_3 = 3 * x
+                    new_stride = (
+                        (real_sfb.stride[0][0], ((x, x), x_times_3)),
+                        real_sfb.stride[1],
+                        real_sfb.stride[2],
+                    )
+                    real_sfb = cute.make_tensor(real_sfb.iterator, cute.make_layout(new_shape, stride=new_stride))
+
+                # local_tile on per-expert tensors
+                gA_mkl = cute.local_tile(real_a, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None))
+                gB_nkl = cute.local_tile(real_b, cute.slice_(self.mma_tiler, (0, None, None)), (None, None, None))
+                gSFA_mkl = cute.local_tile(real_sfa, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None))
+                gSFB_nkl = cute.local_tile(real_sfb, cute.slice_(self.mma_tiler_sfb, (0, None, None)), (None, None, None))
+
+                # MMA partition
+                thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+                thr_mma_sfb = tiled_mma_sfb.get_slice(mma_tile_coord_v)
+                tCgA = thr_mma.partition_A(gA_mkl)
+                tCgB = thr_mma.partition_B(gB_nkl)
+                tCgSFA = thr_mma.partition_A(gSFA_mkl)
+                tCgSFB = thr_mma_sfb.partition_B(gSFB_nkl)
+
+                # TMA partition A
+                a_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape)
+                tAsA, tAgA = cpasync.tma_partition(
+                    tma_atom_a,
+                    block_in_cluster_coord_vmnk[2],
+                    a_cta_layout,
+                    cute.group_modes(sA, 0, 3),
+                    cute.group_modes(tCgA, 0, 3),
+                )
+                # TMA partition B
+                b_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape)
+                tBsB, tBgB = cpasync.tma_partition(
+                    tma_atom_b,
+                    block_in_cluster_coord_vmnk[1],
+                    b_cta_layout,
+                    cute.group_modes(sB, 0, 3),
+                    cute.group_modes(tCgB, 0, 3),
+                )
+                # TMA partition SFA
+                sfa_cta_layout = a_cta_layout
+                tAsSFA, tAgSFA = cpasync.tma_partition(
+                    tma_atom_sfa,
+                    block_in_cluster_coord_vmnk[2],
+                    sfa_cta_layout,
+                    cute.group_modes(sSFA, 0, 3),
+                    cute.group_modes(tCgSFA, 0, 3),
+                )
+                tAsSFA = cute.filter_zeros(tAsSFA)
+                tAgSFA = cute.filter_zeros(tAgSFA)
+                # TMA partition SFB
+                sfb_cta_layout = cute.make_layout(cute.slice_(cluster_layout_sfb_vmnk, (0, None, 0, 0)).shape)
+                tBsSFB, tBgSFB = cpasync.tma_partition(
+                    tma_atom_sfb,
+                    block_in_cluster_coord_sfb_vmnk[1],
+                    sfb_cta_layout,
+                    cute.group_modes(sSFB, 0, 3),
+                    cute.group_modes(tCgSFB, 0, 3),
+                )
+                tBsSFB = cute.filter_zeros(tBsSFB)
+                tBgSFB = cute.filter_zeros(tBgSFB)
+
+                # Slice to per mma tile index (L=0 since domain already offset'd)
+                mma_tile_coord_m = work_tile_info.tile_m_idx // cute.size(tiled_mma.thr_id.shape)
+                mma_tile_coord_n = work_tile_info.tile_n_idx
+                tAgA_slice = tAgA[(None, mma_tile_coord_m, None, 0)]
+                tBgB_slice = tBgB[(None, mma_tile_coord_n, None, 0)]
+                tAgSFA_slice = tAgSFA[(None, mma_tile_coord_m, None, 0)]
+                slice_n = mma_tile_coord_n
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
+                    slice_n = mma_tile_coord_n // 2
+                tBgSFB_slice = tBgSFB[(None, slice_n, None, 0)]
+
+                # Peek (try_wait) AB buffer empty
+                peek_ab_empty_status = cutlass.Boolean(1)
+                if k_tile_cnt > 0:
+                    peek_ab_empty_status = ab_pipeline.producer_try_acquire(ab_producer_state)
+
+                #
+                # Tma load loop
+                #
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                    tAgA_k = tAgA_slice[(None, k_tile)]
+                    tBgB_k = tBgB_slice[(None, k_tile)]
+                    tAgSFA_k = tAgSFA_slice[(None, k_tile)]
+                    tBgSFB_k = tBgSFB_slice[(None, k_tile)]
+                    tAsA_pipe = tAsA[(None, ab_producer_state.index)]
+                    tBsB_pipe = tBsB[(None, ab_producer_state.index)]
+                    tAsSFA_pipe = tAsSFA[(None, ab_producer_state.index)]
+                    tBsSFB_pipe = tBsSFB[(None, ab_producer_state.index)]
+
+                    tma_bar = ab_pipeline.producer_get_barrier(ab_producer_state)
+
+                    # Conditionally wait for AB buffer empty
+                    ab_pipeline.producer_acquire(ab_producer_state, peek_ab_empty_status)
+                    ab_producer_state_next = ab_producer_state.clone()
+                    ab_producer_state_next.advance()
+                    if k_tile < k_tile_cnt - 1:
+                        peek_ab_empty_status = ab_pipeline.producer_try_acquire(ab_producer_state_next)
+
+                    # TMA load A (contiguous, global desc)
+                    cute.copy(
+                        tma_atom_a,
+                        tAgA_k,
+                        tAsA_pipe,
+                        tma_bar_ptr=tma_bar,
+                        mcast_mask=a_full_mcast_mask,
+                    )
+                    # TMA load B (discrete, per-expert desc from workspace)
+                    cute.copy(
+                        tma_atom_b,
+                        tBgB_k,
+                        tBsB_pipe,
+                        tma_bar_ptr=tma_bar,
+                        mcast_mask=b_full_mcast_mask,
+                        tma_desc_ptr=desc_ptr_b,
+                    )
+                    # TMA load SFA (contiguous, global desc)
+                    cute.copy(
+                        tma_atom_sfa,
+                        tAgSFA_k,
+                        tAsSFA_pipe,
+                        tma_bar_ptr=tma_bar,
+                        mcast_mask=sfa_full_mcast_mask,
+                    )
+                    # TMA load SFB (discrete, per-expert desc from workspace)
+                    cute.copy(
+                        tma_atom_sfb,
+                        tBgSFB_k,
+                        tBsSFB_pipe,
+                        tma_bar_ptr=tma_bar,
+                        mcast_mask=sfb_full_mcast_mask,
+                        tma_desc_ptr=desc_ptr_sfb,
+                    )
+
+                    # Peek (try_wait) AB buffer empty for next k_tile
+                    ab_producer_state = ab_producer_state_next
+
+                #
+                # Advance to next tile
+                #
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+            #
+            # Wait A/B buffer empty
+            #
+            ab_pipeline.producer_tail(ab_producer_state)
+
+        if warp_idx == self.scale_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_uniform_warps)
+
+            # print(f"[{os.path.basename(__file__)}:{inspect.currentframe().f_lineno}] sfa2_tensor: {sfa2_tensor}")
+            # print(f"[{os.path.basename(__file__)}:{inspect.currentframe().f_lineno}] sfb2_tensor: {sfb2_tensor}")
+            ext = self._make_extension(workspace_ptr)
+            scale_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_scale_stage)
+
+            tile_info_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_tile_stage)
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            scale_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_scale_stage)
+
+            while is_valid_tile:
+
+                work_tile_info = MoEWorkTileInfo(
+                    expert_idx=tile_info[0],
+                    tile_m_idx=tile_info[1],
+                    tile_n_idx=tile_info[2],
+                    k_tile_cnt=tile_info[3],
+                )
+                k_tile_cnt = work_tile_info.k_tile_cnt
+                ext.update_expert_info(padded_offsets, work_tile_info.expert_idx)
+
+                mSFA2_mkl_current, _ = ext.get_gmem_tensor("sfa2", sfa2_tensor, padded_offsets, work_tile_info)
+                mSFB2_nkl_current, _ = ext.get_gmem_tensor("sfb2", sfb2_tensor, padded_offsets, work_tile_info)
+
+                # print(f"[{os.path.basename(__file__)}:{inspect.currentframe().f_lineno}] mSFA2_mkl_current.layout: {mSFA2_mkl_current.layout}")
+                # print(f"[{os.path.basename(__file__)}:{inspect.currentframe().f_lineno}] mSFB2_nkl_current.layout: {mSFB2_nkl_current.layout}")
+
+                # if tidx == 352:
+                #    cute.printf("bidx: {}, mSFA2_mkl_current: {}", bidz, mSFA2_mkl_current)
+                #    cute.printf("bidx: {}, mSFB2_nkl_current: {}", bidz, mSFB2_nkl_current)
+
+                gSFA2_mkl = cute.local_tile(mSFA2_mkl_current, cute.slice_(self.cta_tile_shape_mnk, (None, 0, None)), (None, None, None))
+                gSFB2_nkl = cute.local_tile(mSFB2_nkl_current, cute.slice_(self.cta_tile_shape_mnk, (0, None, None)), (None, None, None))
+
+                # Create coordinate tensors
+                cSFA2_mkl = cute.make_identity_tensor(cute.shape(mSFA2_mkl_current))
+                cSFB2_nkl = cute.make_identity_tensor(cute.shape(mSFB2_nkl_current))
+                cSFA2 = cute.local_tile(cSFA2_mkl, cute.slice_(self.cta_tile_shape_mnk, (None, 0, None)), (None, None, None))
+                cSFB2 = cute.local_tile(cSFB2_nkl, cute.slice_(self.cta_tile_shape_mnk, (0, None, None)), (None, None, None))
+                # Partition tensors
+                tAgSFA2_mkl = thr_copy_sfa2.partition_S(gSFA2_mkl)
+                tBgSFB2_nkl = thr_copy_sfb2.partition_S(gSFB2_nkl)
+                tAcSFA2 = thr_copy_sfa2.partition_S(cSFA2)
+                tBcSFB2 = thr_copy_sfb2.partition_S(cSFB2)
+
+                mma_tile_coord_mnl = (work_tile_info.tile_m_idx, work_tile_info.tile_n_idx, 0)
+
+                #
+                # Prepare the mask for scaleA/scaleB
+                #
+                tApSFA2 = cute.make_rmem_tensor(
+                    cute.make_layout(cute.filter_zeros(cute.slice_(tAsSFA2, (None, None, None, 0))).shape),
+                    cutlass.Boolean,
+                )
+                tBpSFB2 = cute.make_rmem_tensor(
+                    cute.make_layout(cute.filter_zeros(cute.slice_(tBsSFB2, (None, None, None, 0))).shape),
+                    cutlass.Boolean,
+                )
+
+                # print(f"[{os.path.basename(__file__)}:{inspect.currentframe().f_lineno}] tApSFA2.layout: {tApSFA2.layout}")
+                # print(f"[{os.path.basename(__file__)}:{inspect.currentframe().f_lineno}] tBpSFB2.layout: {tBpSFB2.layout}")
+
+                # Peek (try_wait) SCALE buffer empty
+                scale_producer_state.reset_count()
+                peek_scale_empty_status = cutlass.Boolean(1)
+                if scale_producer_state.count < k_tile_cnt:
+                    peek_scale_empty_status = scale_pipeline.producer_try_acquire(scale_producer_state)
+
+                #
+                # load loop
+                #
+                for k_tile in cutlass.range(0, k_tile_cnt // k_tile_same_scale_factor, 1, unroll=1):
+                    #
+                    # Slice to per mma tile index
+                    #
+                    tAsSFA2_pipe = cute.filter_zeros(tAsSFA2[(None, None, None, scale_producer_state.index)])
+                    tBsSFB2_pipe = cute.filter_zeros(tBsSFB2[(None, None, None, scale_producer_state.index)])
+
+                    # print(f"[{os.path.basename(__file__)}:{inspect.currentframe().f_lineno}] tAgSFA2_mkl.layout: {tAgSFA2_mkl.layout}")
+                    # print(f"[{os.path.basename(__file__)}:{inspect.currentframe().f_lineno}] tBgSFB2_nkl.layout: {tBgSFB2_nkl.layout}")
+
+                    tAgSFA2_k = cute.filter_zeros(
+                        tAgSFA2_mkl[
+                            (
+                                None,
+                                None,
+                                None,
+                                mma_tile_coord_mnl[0],
+                                scale_producer_state.count * k_tile_same_scale_factor,
+                                mma_tile_coord_mnl[2],
+                            )
+                        ]
+                    )
+                    tBgSFB2_k = cute.filter_zeros(
+                        tBgSFB2_nkl[
+                            (
+                                None,
+                                None,
+                                None,
+                                mma_tile_coord_mnl[1],
+                                scale_producer_state.count * k_tile_same_scale_factor,
+                                mma_tile_coord_mnl[2],
+                            )
+                        ]
+                    )
+
+                    tAcSFA2_compact = cute.filter_zeros(
+                        cute.slice_(
+                            tAcSFA2,
+                            (
+                                None,
+                                None,
+                                None,
+                                mma_tile_coord_mnl[0],
+                                scale_producer_state.count * k_tile_same_scale_factor,
+                                mma_tile_coord_mnl[2],
+                            ),
+                        )
+                    )
+                    tBcSFB2_compact = cute.filter_zeros(
+                        cute.slice_(
+                            tBcSFB2,
+                            (
+                                None,
+                                None,
+                                None,
+                                mma_tile_coord_mnl[1],
+                                scale_producer_state.count * k_tile_same_scale_factor,
+                                mma_tile_coord_mnl[2],
+                            ),
+                        )
+                    )
+
+                    # {$nv-internal-release begin}
+                    # TODO: Skip more unnecessary load
+                    # {$nv-internal-release end}
+                    for i in cutlass.range_constexpr(cute.size(tApSFA2, mode=[1])):
+                        tApSFA2[((0, 0), i, (0, 0))] = cute.elem_less(tAcSFA2_compact[(i)][0], mSFA2_mkl_current.shape[0])
+                    for i in cutlass.range_constexpr(cute.size(tBpSFB2, mode=[1])):
+                        tBpSFB2[((0, 0), i, (0, 0))] = cute.elem_less(tBcSFB2_compact[(i)][0], mSFB2_nkl_current.shape[0])
+
+                    # Conditionally wait for Scale buffer empty
+                    scale_pipeline.producer_acquire(scale_producer_state, peek_scale_empty_status)
+
+                    # load scaleA/scaleB
+                    cute.copy(tiled_copy_sfa2, tAgSFA2_k, tAsSFA2_pipe, pred=tApSFA2)
+                    cute.copy(tiled_copy_sfb2, tBgSFB2_k, tBsSFB2_pipe, pred=tBpSFB2)
+
+                    scale_pipeline.producer_commit(scale_producer_state)
+
+                    # Peek (try_wait) Scale buffer empty
+                    scale_producer_state.advance()
+                    peek_scale_empty_status = cutlass.Boolean(1)
+                    if scale_producer_state.count < k_tile_cnt:
+                        peek_scale_empty_status = scale_pipeline.producer_try_acquire(scale_producer_state)
+
+                # Get next tile from scheduler
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+        #
+        # Specialized MMA warp
+        #
+        if warp_idx == self.mma_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_uniform_warps)
+            #
+            # Bar sync for retrieve tensor memory ptr from shared mem
+            #
+            tmem.wait_for_alloc()
+
+            #
+            # Retrieving tensor memory ptr and make accumulator tensor
+            #
+            acc_tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+
+            # Make SFA tmem tensor
+            sfa_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            # (MMA, MMA_M, MMA_K)
+            tCtSFA_layout = blockscaled_utils.make_tmem_layout_sfa(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfa_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFA = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout)
+
+            # Make SFB tmem tensor
+            sfb_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            # (MMA, MMA_N, MMA_K)
+            tCtSFB_layout = blockscaled_utils.make_tmem_layout_sfb(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfb_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFB = cute.make_tensor(sfb_tmem_ptr, tCtSFB_layout)
+
+            # Partition for S2T copy of SFA/SFB
+            #
+            (
+                tiled_copy_s2t_sfa,
+                tCsSFA_compact_s2t,
+                tCtSFA_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFA, tCtSFA)
+            (
+                tiled_copy_s2t_sfb,
+                tCsSFB_compact_s2t,
+                tCtSFB_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFB, tCtSFB)
+
+            ab_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_ab_stage)
+            acc_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_acc_stage)
+
+            tile_info_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_tile_stage)
+
+            # Get the first tile info (sInfo format: expert_idx, tile_m_idx, tile_n_idx, k_tile_cnt)
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            while is_valid_tile:
+
+                # Peek (try_wait) AB buffer full for k_tile = 0
+                peek_ab_full_status = cutlass.Boolean(1)
+                if k_tile_cnt > 0 and is_leader_cta:
+                    peek_ab_full_status = ab_pipeline.consumer_try_wait(ab_consumer_state)
+
+                # Peek (try_wait) Acc buffer empty for k_tile = 0
+                acc_producer_state.reset_count()
+                peek_acc_empty_status = cutlass.Boolean(1)
+                if acc_producer_state.count < k_tile_cnt and is_leader_cta:
+                    peek_acc_empty_status = acc_pipeline.producer_try_acquire(acc_producer_state)
+
+                # sInfo: (expert_idx, tile_m_idx, tile_n_idx, k_tile_cnt)
+                mma_tile_coord_mnl = (
+                    tile_info[1] // cute.size(tiled_mma.thr_id.shape),
+                    tile_info[2],
+                    cutlass.Int32(0),
+                )
+
+                # Get accumulator stage index
+                acc_stage_index = acc_producer_state.index
+
+                tCtSFB_mma = tCtSFB
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 192):
+                    # If this is an ODD tile, shift the TMEM start address for cta_tile_shape_n=192 case by two words (ignores first 64 columns of SFB)
+                    offset = cutlass.Int32(2) if mma_tile_coord_mnl[1] % 2 == 1 else cutlass.Int32(0)
+                    shifted_ptr = cute.recast_ptr(
+                        acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols + offset,
+                        dtype=self.sf_dtype,
+                    )
+                    tCtSFB_mma = cute.make_tensor(shifted_ptr, tCtSFB_layout)
+                elif cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
+                    # Move in increments of 64 columns of SFB
+                    offset = cutlass.Int32((mma_tile_coord_mnl[1] % 2) * 2)
+                    shifted_ptr = cute.recast_ptr(
+                        acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols + offset,
+                        dtype=self.sf_dtype,
+                    )
+                    tCtSFB_mma = cute.make_tensor(shifted_ptr, tCtSFB_layout)
+
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+
+                    # Set the correct accumulator buffer for each k_tile
+                    tCtAcc = tCtAcc_base[(None, None, None, acc_stage_index)]
+
+                    if k_tile % k_tile_same_scale_factor == 0:
+                        if is_leader_cta:
+                            # Wait for accumulator buffer empty
+                            acc_pipeline.producer_acquire(acc_producer_state, peek_acc_empty_status)
+
+                    # Reset the ACCUMULATE field for each tile
+                    tiled_mma.set(tcgen05.Field.ACCUMULATE, k_tile % k_tile_same_scale_factor > 0)
+
+                    if is_leader_cta:
+                        # Conditionally wait for AB buffer full
+                        ab_pipeline.consumer_wait(ab_consumer_state, peek_ab_full_status)
+                        ab_consumer_state_next = ab_consumer_state.clone()
+                        ab_consumer_state_next.advance()
+                        if k_tile < k_tile_cnt - 1:
+                            peek_ab_full_status = ab_pipeline.consumer_try_wait(ab_consumer_state_next)
+
+                        #  Copy SFA/SFB from smem to tmem
+                        s2t_stage_coord = (
+                            None,
+                            None,
+                            None,
+                            None,
+                            ab_consumer_state.index,
+                        )
+                        tCsSFA_compact_s2t_staged = tCsSFA_compact_s2t[s2t_stage_coord]
+                        tCsSFB_compact_s2t_staged = tCsSFB_compact_s2t[s2t_stage_coord]
+                        cute.copy(
+                            tiled_copy_s2t_sfa,
+                            tCsSFA_compact_s2t_staged,
+                            tCtSFA_compact_s2t,
+                        )
+                        cute.copy(
+                            tiled_copy_s2t_sfb,
+                            tCsSFB_compact_s2t_staged,
+                            tCtSFB_compact_s2t,
+                        )
+
+                        # tCtAcc += tCrA * tCrSFA * tCrB * tCrSFB
+                        num_kblocks = cute.size(tCrA, mode=[2])
+
+                        for kblock_idx in cutlass.range(num_kblocks, unroll_full=True):
+                            kblock_coord = (
+                                None,
+                                None,
+                                kblock_idx,
+                                ab_consumer_state.index,
+                            )
+
+                            # Set SFA/SFB tensor to tiled_mma
+                            sf_kblock_coord = (None, None, kblock_idx)
+                            tiled_mma.set(
+                                tcgen05.Field.SFA,
+                                tCtSFA[sf_kblock_coord].iterator,
+                            )
+                            tiled_mma.set(
+                                tcgen05.Field.SFB,
+                                tCtSFB_mma[sf_kblock_coord].iterator,
+                            )
+
+                            cute.gemm(
+                                tiled_mma,
+                                tCtAcc,
+                                tCrA[kblock_coord],
+                                tCrB[kblock_coord],
+                                tCtAcc,
+                            )
+                            # Enable accumulate on tCtAcc after first kblock
+                            tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+                        # Async arrive AB buffer empty
+                        ab_pipeline.consumer_release(ab_consumer_state)
+                        ab_consumer_state = ab_consumer_state_next
+
+                    if k_tile % k_tile_same_scale_factor == k_tile_same_scale_factor - 1:
+                        if is_leader_cta:
+                            # Async arrive accumulator buffer full(each kblock)
+                            acc_pipeline.producer_commit(acc_producer_state)
+
+                        # Peek (try_wait) Acc buffer empty for k_tile = k_tile + 1
+                        acc_producer_state.advance()
+                        acc_stage_index = acc_producer_state.index
+                        if acc_producer_state.count < k_tile_cnt:
+                            if is_leader_cta:
+                                peek_acc_empty_status = acc_pipeline.producer_try_acquire(acc_producer_state)
+
+                #
+                # Advance to next tile
+                #
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+            #
+            # Wait for accumulator buffer empty
+            #
+            acc_pipeline.producer_tail(acc_producer_state)
+
+        #
+        # Specialized Accumulator Update Warp
+        #
+        # Bounds compare, not `in`: tuple membership makes the 4.5 wheel's AST
+        # if-region flattening choke on captured Python objects.
+        if warp_idx >= self.accumulator_update_warp_id[0] and warp_idx <= self.accumulator_update_warp_id[-1]:
+            cute.arch.warpgroup_reg_alloc(self.num_regs_acc_update_warps)
+            # Wait for TMEM allocation (done by epilogue warp)
+            tmem.wait_for_alloc()
+
+            # Retrieve TMEM pointer and create accumulator tensors
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            # tCtAcc_base: Read partial accumulators from MMA (via acc_pipeline stages)
+            tCtAcc_base = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+
+            # Final accumulated result is written to SMEM (sFinalAcc), not TMEM
+
+            # Shape-only partition on global tensor for partitioning setup
+            thr_mma_epi = tiled_mma.get_slice(mma_tile_coord_v)
+            gD_mnl_shape = cute.local_tile(mD_mnl, cute.slice_(self.mma_tiler_d, (None, None, 0)), (None, None, None))
+            tCgD_shape = thr_mma_epi.partition_C(gD_mnl_shape)
+
+            # Setup copy operations and partition tensors
+            acc_tidx = tidx
+            (
+                tiled_copy_t2r,
+                tiled_copy_r2s_acc,
+                tTR_tAcc_base,
+                tTR_rAcc,
+                tTR_rAcc_final,
+                tRS_sFinalAcc,
+                tTR_sSFA,
+                tTR_sSFB,
+            ) = self.acc_update_tmem_copy_and_partition(
+                acc_tidx,
+                tCtAcc_base,
+                tCgD_shape,
+                sSFA2_view_as_C,
+                sSFB2_view_as_C,
+                sFinalAcc,
+                epi_tile,
+                use_2cta_instrs,
+            )
+
+            scale_atom_copy = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                self.acc_dtype,
+                num_bits_per_copy=self.acc_dtype.width,
+            )
+
+            # Initialize pipeline states
+            # Consumer of acc_pipeline (receives partial accumulators from MMA)
+            acc_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_acc_stage)
+            # consumer of scale_pipeline (receives scale factors from scale load warp)
+            scale_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_scale_stage)
+            # Producer for epi_pipeline (sends final accumulator to epilogue)
+            epi_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_epi_stage)
+
+            # Initialize scheduler consumption
+            tile_info_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_tile_stage)
+
+            # Get first tile info from scheduler
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            # Main tile processing loop
+            while is_valid_tile:
+                # Extract k_tile_cnt from scheduler
+                k_tile_cnt = tile_info[3]
+
+                # Initialize final accumulator to zero
+                tTR_rAcc_final.fill(0.0)
+
+                tTR_rSFA = cute.make_rmem_tensor(
+                    cute.slice_(tTR_sSFA, (None, None, None, 0, None, 0)).shape,
+                    self.acc_dtype,
+                )
+                tTR_rSFB = cute.make_rmem_tensor(
+                    cute.slice_(tTR_sSFB, (None, None, None, 0, None, 0)).shape,
+                    self.acc_dtype,
+                )
+
+                # Reset and peek acc_pipeline (MMA produces partial accumulators)
+                acc_consumer_state.reset_count()
+                peek_acc_full_status = cutlass.Boolean(1)
+                if acc_consumer_state.count < k_tile_cnt:
+                    peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
+
+                # Peek (try_wait) Scale buffer full for k_tile = 0
+                scale_consumer_state.reset_count()
+                peek_scale_full_status = cutlass.Boolean(1)
+                if scale_consumer_state.count < k_tile_cnt:
+                    peek_scale_full_status = scale_pipeline.consumer_try_wait(scale_consumer_state)
+
+                # Loop over k_tiles to accumulate partial accumulators
+                for k_tile_idx in cutlass.range(0, k_tile_cnt // k_tile_same_scale_factor, 1, unroll=1):
+
+                    # Wait for scale buffer full
+                    scale_pipeline.consumer_wait(scale_consumer_state, peek_scale_full_status)
+
+                    tTR_sSFA_slice = cute.slice_(
+                        tTR_sSFA,
+                        (None, None, None, 0, None, scale_consumer_state.index),
+                    )
+                    tTR_sSFB_slice = cute.slice_(
+                        tTR_sSFB,
+                        (None, None, None, 0, None, scale_consumer_state.index),
+                    )
+                    cute.copy(scale_atom_copy, tTR_sSFA_slice, tTR_rSFA)
+                    cute.copy(scale_atom_copy, tTR_sSFB_slice, tTR_rSFB)
+
+                    #
+                    # Async arrive scale buffer empty
+                    #
+                    scale_pipeline.consumer_release(scale_consumer_state)
+                    scale_consumer_state.advance()
+
+                    # Wait for MMA to produce partial accumulator for this k_tile
+                    acc_pipeline.consumer_wait(acc_consumer_state, peek_acc_full_status)
+
+                    # Index into TMEM buffer for current pipeline stage
+                    tTR_tAcc = tTR_tAcc_base[(None, None, None, None, None, acc_consumer_state.index)]
+
+                    # Group modes for subtile iteration
+                    tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+
+                    # Process each subtile (gate/up interleaving handled by layout)
+                    subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+                    for subtile_idx in cutlass.range(subtile_cnt):
+                        # Load partial accumulator subtile from TMEM to registers.
+                        tTR_tAcc_mn = tTR_tAcc[(None, None, None, subtile_idx)]
+                        cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+
+                        # Second-level scale-multiply-accumulate: final += partial * sfa2 * sfb2.
+                        tTR_rAcc_subtile = tTR_rAcc_final[(None, None, None, subtile_idx)]
+                        acc_vec = tTR_rAcc.load()
+                        final_vec = tTR_rAcc_subtile.load()
+                        scale_a = tTR_rSFA[(None, None, None, subtile_idx)].load()
+                        scale_b = tTR_rSFB[(None, None, None, subtile_idx)].load()
+                        scale = scale_a * scale_b
+                        final_vec = acc_vec * scale + final_vec
+                        tTR_rAcc_subtile.store(final_vec.to(self.acc_dtype))
+
+                    # Release acc_pipeline buffer (MMA can reuse it)
+                    with cute.arch.elect_one():
+                        acc_pipeline.consumer_release(acc_consumer_state)
+                    acc_consumer_state.advance()
+
+                    # Peek next k_tile
+                    peek_acc_full_status = cutlass.Boolean(1)
+                    if acc_consumer_state.count < k_tile_cnt:
+                        peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
+
+                    peek_scale_full_status = cutlass.Boolean(1)
+                    if scale_consumer_state.count < k_tile_cnt:
+                        peek_scale_full_status = scale_pipeline.consumer_try_wait(scale_consumer_state)
+
+                # All k_tiles accumulated, now store final result to SMEM for epilogue
+                # Acquire epi_pipeline (wait for epilogue to be done with the buffer)
+                epi_pipeline.producer_acquire(epi_producer_state)
+
+                # Copy final accumulator from registers to SMEM, one epi subtile per slot.
+                # No proxy fence needed: producer and consumer both use the generic proxy,
+                # and producer_commit's mbarrier arrive has release semantics.
+                final_subtile_cnt = cute.size(tTR_rAcc_final.shape, mode=[3])
+                slot_base = epi_producer_state.index * final_subtile_cnt
+                for subtile_idx in cutlass.range(final_subtile_cnt, unroll_full=True):
+                    tRS_rFinal = tiled_copy_r2s_acc.retile(tTR_rAcc_final[(None, None, None, subtile_idx)])
+                    cute.copy(
+                        tiled_copy_r2s_acc,
+                        tRS_rFinal,
+                        tRS_sFinalAcc[(None, None, None, slot_base + subtile_idx)],
+                    )
+
+                # Commit to epi_pipeline (signal epilogue that data is ready)
+                epi_pipeline.producer_commit(epi_producer_state)
+                epi_producer_state.advance()
+
+                # Get next tile from scheduler
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+            # Signal epilogue that no more tiles
+            epi_pipeline.producer_tail(epi_producer_state)
+
+        #
+        # Specialized epilogue warps
+        #
+        # Bounds compare, not `in` (see accumulator warps above). Both sides are
+        # dynamic here (epilog_warp_id starts at 4, so neither const-folds like
+        # the accumulator group's `>= 0`), so combine with bitwise `&`, not
+        # Python `and`: `and` calls `__bool__` on a dynamic predicate, which the
+        # 4.5 wheel's tracer rejects.
+        if (warp_idx >= self.epilog_warp_id[0]) & (warp_idx <= self.epilog_warp_id[-1]):
+            cute.arch.warpgroup_reg_alloc(self.num_regs_epilogue_warps)
+            #
+            # Alloc tensor memory buffer
+            #
+            tmem.allocate(self.num_tmem_alloc_cols)
+
+            #
+            # Bar sync for retrieve tensor memory ptr from shared memory
+            #
+            tmem.wait_for_alloc()
+
+            #
+            # Retrieving tensor memory ptr and make accumulator tensor
+            #
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            # (MMA, MMA_M, MMA_N, STAGE)
+            # Final accumulator now lives in SMEM (sFinalAcc); TMEM here is only used by
+            # MMA partials + SF. tCtAcc_base is a shape/TV-layout carrier for the t2r
+            # template below — it is never dereferenced as the load source in the epilogue.
+            tCtAcc_base = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+
+            #
+            # Partition for epilogue (SMEM/TMEM/register - invariant across experts)
+            #
+            epi_tidx = tidx % 128
+
+            # Shape-only partition on global tensor (invariant setup for t2r copy atom)
+            thr_mma_epi = tiled_mma.get_slice(mma_tile_coord_v)
+            gD_mnl_shape = cute.local_tile(mD_mnl, cute.slice_(self.mma_tiler_d, (None, None, 0)), (None, None, None))
+            tCgD_shape = thr_mma_epi.partition_C(gD_mnl_shape)
+
+            if cutlass.const_expr(self.enable_breuse):
+                # Merge bkeep/breuse M-split (mode1=2) into the M dimension for epilogue
+                tCtAcc_epi_input = transform_partitioned_tensor_layout(tCtAcc_base)
+                tCgD_epi_input = transform_partitioned_tensor_layout(tCgD_shape)
+            else:
+                tCtAcc_epi_input = tCtAcc_base
+                tCgD_epi_input = tCgD_shape
+
+            (
+                tiled_copy_t2r,
+                tTR_tAcc_base,
+                tTR_rAcc,
+            ) = self.epilog_tmem_copy_and_partition(epi_tidx, tCtAcc_epi_input, tCgD_epi_input, epi_tile, use_2cta_instrs)
+
+            tTR_rC1 = cute.make_rmem_tensor(tTR_rAcc.shape, self.c_dtype)
+            tTR_rC2 = cute.make_rmem_tensor(tTR_rAcc.shape, self.c_dtype)
+            tiled_copy_s2r, tRS_rC1, tRS_rC2, tRS_sC = self.epilog_smem_copy_and_partition_load(tiled_copy_t2r, tTR_rC1, tTR_rC2, epi_tidx, sC)
+
+            tTR_rD1 = cute.make_rmem_tensor(tTR_rAcc.shape, self.d_dtype)
+            tTR_rD2 = cute.make_rmem_tensor(tTR_rAcc.shape, self.d_dtype)
+            tiled_copy_r2s, tRS_rD1, tRS_rD2, tRS_sD = self.epilog_smem_copy_and_partition_store(tiled_copy_t2r, tTR_rD1, tTR_rD2, epi_tidx, sD)
+            if cutlass.const_expr(self.generate_sfd):
+                norm_const = cutlass.Float32(norm_const_tensor[0])
+                d_rcp_limits = get_dtype_rcp_limits(self.d_dtype)
+
+            # S2R load of the final accumulator from SMEM (written by acc-update warp)
+            tiled_copy_s2r_acc, tSR_sFinalAcc = self.epilog_smem_acc_load_and_partition(tiled_copy_t2r, epi_tidx, sFinalAcc)
+
+            # bf16 relay of the dGLU output through the sFinalAcc SMEM bytes (NVFP4 path):
+            # Pass 1 rounds d1/d2 to bf16 and stores them into slots 2*subtile + 0/1, which
+            # alias exactly onto the f32 acc subtile's bytes (bf16 d1+d2 == one f32 subtile,
+            # verified: bf16 8-slot layout == f32 4-slot layout == 65536 B).
+            # Pass 2 reloads and upcasts to f32 to quantize, dropping pass 2's C reload + dGLU
+            # recompute. A single universal copy atom is used for BOTH store and load so the
+            # store/load TV layouts match (a stmatrix store would not round-trip against the load).
+            if cutlass.const_expr(self.generate_sfd):
+                # sFinalAccBf16 was built with the smem tensors above — hoisted
+                # out of this warp-dispatch region for the 4.5 wheel.
+                copy_atom_dglu = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), cutlass.BFloat16)
+                tiled_copy_dglu = cute.make_tiled_copy_D(copy_atom_dglu, tiled_copy_t2r)
+                tRS_sFinalAccBf16 = tiled_copy_dglu.get_slice(epi_tidx).partition_D(sFinalAccBf16)
+                tTR_rDGLU1 = cute.make_rmem_tensor(tTR_rAcc.shape, cutlass.BFloat16)
+                tTR_rDGLU2 = cute.make_rmem_tensor(tTR_rAcc.shape, cutlass.BFloat16)
+                tRS_rDGLU1 = tiled_copy_dglu.retile(tTR_rDGLU1)
+                tRS_rDGLU2 = tiled_copy_dglu.retile(tTR_rDGLU2)
+
+            # Extension for per-expert domain conversion in epilogue
+            epi_ext = self._make_extension(workspace_ptr)
+
+            epi_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_epi_stage)
+
+            # Load C pipeline
+            c_pipeline_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_c_stage)
+            # C is now produced by this epilogue warp group (warp epilog_warp_id[0]
+            # issues the TMA); previously a dedicated warp owned this producer state.
+            c_pipeline_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_c_stage)
+
+            # Threads/warps participating in tma store pipeline
+            d_producer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                32 * len(self.epilog_warp_id),
+            )
+            d_pipeline = None
+            if cutlass.const_expr(not self.store_d_directly):
+                num_d_stages = self.num_d_stage // 2
+                d_pipeline = pipeline.PipelineTmaStore.create(
+                    num_stages=num_d_stages,
+                    producer_group=d_producer_group,
+                )
+
+            tile_info_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_tile_stage)
+
+            # Get the first tile info (sInfo format: expert_idx, tile_m_idx, tile_n_idx, k_tile_cnt)
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            num_prev_subtiles = cutlass.Int32(0)
+            # DSMEM rowwise-sfd2 sequence: all cluster CTAs walk the same
+            # cluster tile stream (the scheduler hands cluster tiles), so
+            # parity (bit 0) and mbarrier phase (bit 1) stay in lockstep
+            # across the whole cluster.
+            if cutlass.const_expr(self.row_dsmem):
+                row_dsmem_seq = cutlass.Int32(0)
+            while is_valid_tile:
+                # sInfo: (expert_idx, tile_m_idx, tile_n_idx, k_tile_cnt)
+                epi_work_tile_info = MoEWorkTileInfo(
+                    expert_idx=tile_info[0],
+                    tile_m_idx=tile_info[1],
+                    tile_n_idx=tile_info[2],
+                    k_tile_cnt=tile_info[3],
+                )
+                expert_idx = epi_work_tile_info.expert_idx
+                # N is doubled for dGLU dual output
+                mma_tile_coord_mnl = (
+                    epi_work_tile_info.tile_m_idx // cute.size(tiled_mma.thr_id.shape),
+                    epi_work_tile_info.tile_n_idx * 2,
+                    cutlass.Int32(0),
+                )
+
+                #
+                # Get alpha/beta for current expert
+                #
+                alpha_val = alpha[expert_idx]
+                beta_val = beta[expert_idx]
+                epi_ext.update_expert_info(padded_offsets, expert_idx)
+
+                #
+                # Per-expert gmem tensor setup via extension
+                #
+                real_d, _ = epi_ext.get_gmem_tensor("d", mD_mnl, padded_offsets, epi_work_tile_info)
+                gD_mnl_loop = cute.local_tile(real_d, cute.slice_(self.mma_tiler_d, (None, None, 0)), (None, None, None))
+                thr_mma_epi = tiled_mma.get_slice(mma_tile_coord_v)
+                tCgD_loop = thr_mma_epi.partition_C(gD_mnl_loop)
+
+                tgSFD2_up = None
+                tgSFD2_gate = None
+                if cutlass.const_expr(self.generate_sfd2):
+                    # Per-expert SFD2_up setup
+                    mSFD2_up_mnl, _ = epi_ext.get_gmem_tensor("sfd2", sfd2_up_tensor, padded_offsets, epi_work_tile_info)
+                    thread_tiler = cute.make_layout((128, 1))
+                    gSFD2_up_mnl = cute.local_tile(mSFD2_up_mnl, cute.slice_(self.mma_tiler_d, (None, None, 0)), (None, None, None))
+                    tCgSFD2_up = thr_mma_epi.partition_C(gSFD2_up_mnl)
+                    bSFD2_up = tCgSFD2_up[(None, None, None, *mma_tile_coord_mnl)]
+                    tgSFD2_up = cute.local_partition(bSFD2_up, thread_tiler, tidx)
+
+                    # Per-expert SFD2_gate setup
+                    mSFD2_gate_mnl, _ = epi_ext.get_gmem_tensor("sfd2", sfd2_gate_tensor, padded_offsets, epi_work_tile_info)
+                    gSFD2_gate_mnl = cute.local_tile(mSFD2_gate_mnl, cute.slice_(self.mma_tiler_d, (None, None, 0)), (None, None, None))
+                    tCgSFD2_gate = thr_mma_epi.partition_C(gSFD2_gate_mnl)
+                    bSFD2_gate = tCgSFD2_gate[(None, None, None, *mma_tile_coord_mnl)]
+                    tgSFD2_gate = cute.local_partition(bSFD2_gate, thread_tiler, tidx)
+
+                if cutlass.const_expr(not self.store_d_directly):
+                    bSG_sD, bSG_gD_partitioned = self.epilog_gmem_copy_and_partition(epi_tidx, tma_atom_d, tCgD_loop, epi_tile, sD)
+                    bSG_gD = bSG_gD_partitioned[(None, None, None, mma_tile_coord_mnl[0], mma_tile_coord_mnl[1], 0)]
+                    bSG_gD = cute.group_modes(bSG_gD, 1, cute.rank(bSG_gD))
+
+                epi_stage_index = 0
+
+                # Set tensor memory buffer for current tile
+                # (T2R, T2R_M, T2R_N, EPI_M, EPI_M)
+                tTR_tAcc = tTR_tAcc_base[(None, None, None, None, None, epi_stage_index)]
+
+                if cutlass.const_expr(self.generate_sfd):
+                    regPerSubtile = 4
+                    sfd_row_tile = (
+                        cute.make_layout(128),
+                        cute.make_layout(32 * regPerSubtile),
+                    )
+                    # SFD Row: tile_atom_to_shape_SF layout, same path as SFA
+                    real_sfd_row, _ = epi_ext.get_gmem_tensor("sfd", mSFDRow_mnl, padded_offsets, epi_work_tile_info)
+                    gSFDRow_mnl = cute.local_tile(real_sfd_row, sfd_row_tile, (None, None, None))
+
+                    # Don't ask why, AST is shit tracking the constexpr values to loop args.
+                    tiled_copy_t2r_local, _, _ = self.epilog_tmem_copy_and_partition(epi_tidx, tCtAcc_epi_input, tCgD_epi_input, epi_tile, use_2cta_instrs)
+                    thr_copy_t2r_local = tiled_copy_t2r_local.get_slice(tidx % 128)
+                    tCgSFDRow_mnl = thr_copy_t2r_local.partition_D(gSFDRow_mnl)
+                    tCgSFDRow_mnl = cute.filter_zeros(tCgSFDRow_mnl)
+                    tCrSFDRow = cute.make_rmem_tensor(tCgSFDRow_mnl[(None, None, None, 0, 0, 0)].layout, self.sf_dtype)
+                    tCrSFDRow_pvscale = cute.make_rmem_tensor_like(tCrSFDRow, cutlass.Float32)
+                    tCgSFDRow_mn = tCgSFDRow_mnl[(None, None, None, None, None, 0)]
+
+                    # SMEM staging for coalesced SFD stores. One store event
+                    # (2 subtiles x d1/d2) covers one contiguous
+                    # (128 rows, 32*regPerSubtile values) block of the SFD
+                    # atom layout — 8 SF bytes per thread, but scattered at
+                    # 16B thread stride in gmem. Mirror the gmem tile/thread
+                    # partition onto an SMEM block with the identical atom
+                    # layout: the scatter goes to SMEM, the gmem store then
+                    # reads the block back linearly (one 8B word per thread).
+                    sfd_stage_size = 128 * 32 * regPerSubtile // self.sf_vec_size
+                    # sSFDRowStage_flat is pre-derived in the prologue: the 4.5
+                    # wheel cannot carry `storage` across the warp-dispatch if.
+                    sfd_stage_atom_layout = blockscaled_utils.tile_atom_to_shape_SF((128, 32 * regPerSubtile, 1), self.sf_vec_size)
+                    sSFDRowStage_atom = cute.make_tensor(sSFDRowStage_flat.iterator, sfd_stage_atom_layout)
+                    sSFDRowStage_tiled = cute.local_tile(sSFDRowStage_atom, sfd_row_tile, (None, None, None))
+                    tCsSFDRow_mnl = thr_copy_t2r_local.partition_D(sSFDRowStage_tiled)
+                    tCsSFDRow_mnl = cute.filter_zeros(tCsSFDRow_mnl)
+                    tCsSFDRow = tCsSFDRow_mnl[(None, None, None, 0, 0, 0)]
+                    if cutlass.const_expr(self.d_deinterleaved):
+                        # Readback view: 2B pieces (the deinterleave scatter's
+                        # granularity — gate/up alternate at 2 SF bytes).
+                        sSFDRowStage_half = cute.recast_tensor(sSFDRowStage_flat, cutlass.Int16)
+                    else:
+                        # Linear readback view: 8B words, one per epilogue thread.
+                        sSFDRowStage_words = cute.recast_tensor(sSFDRowStage_flat, cutlass.Int64)
+
+                #
+                # Get PROB (per-expert local M position)
+                #
+                real_prob, _ = epi_ext.get_gmem_tensor("prob", prob, padded_offsets, epi_work_tile_info)
+                mPosition = (
+                    (epi_work_tile_info.tile_m_idx // cute.size(tiled_mma.thr_id.shape)) * self.mma_tiler[0]
+                    + mma_tile_coord_v * (self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape))
+                    + tidx % 128
+                )
+                mProb = real_prob[mPosition, 0, 0]
+                if cutlass.const_expr(self.generate_dprob):
+                    dProbVal = cutlass.Float32(0.0)
+
+                #
+                # Build C (up/gate forward activations) GMEM->SMEM partition and
+                # PREFETCH the first C subtiles for this tile BEFORE waiting on the
+                # accumulator, so C TMA movement overlaps accumulator production.
+                # The epilogue warp group now owns the C producer (warp
+                # epilog_warp_id[0] issues) as well as the consumer; a dedicated
+                # C-load warp is no longer used.
+                #
+                real_c, _ = epi_ext.get_gmem_tensor("c", mC_mnl, padded_offsets, epi_work_tile_info)
+                gC_mnl_loop = cute.local_tile(real_c, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None))
+                tCgC_loop = thr_mma_epi.partition_C(gC_mnl_loop)
+                bGS_sC, bGS_gC_partitioned = self.epilog_gmem_copy_and_partition(epi_tidx, tma_atom_c, tCgC_loop, epi_tile, sC)
+                bGS_gC = bGS_gC_partitioned[(None, None, None, mma_tile_coord_mnl[0], mma_tile_coord_mnl[1], 0)]
+                bGS_gC = cute.group_modes(bGS_gC, 1, cute.rank(bGS_gC))
+                c_subtile_cnt = cute.size(bGS_gC.shape, mode=[1])
+                # Prefetch depth (in subtiles) is bounded by the C pipeline stages:
+                # 2 stages -> 1 subtile ahead, 4 stages -> 2 subtiles ahead.
+                c_prefetch_subtiles = self.num_c_stage // 2
+                #
+                # Wait for accumulator buffer full. The acc buffer is HELD across BOTH
+                # epilogue passes and released only after pass 2, so pass 2 can re-read
+                # the dy accumulator from resident sFinalAcc for free.
+                #
+                epi_pipeline.consumer_wait(epi_consumer_state)
+                tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+
+                # Initialize thread-local amax accumulator for this tile
+                # Use 0.0 as initial value since we're computing absolute maximum
+                thread_tile_amax_1 = cutlass.Float32(0.0)
+                thread_tile_amax_2 = cutlass.Float32(0.0)
+
+                #
+                # Store accumulator to global memory in subtiles
+                #
+                subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+                # Stage-aware base into the (double-buffered) sFinalAcc SMEM buffer.
+                # Mirrors the producer's slot_base = epi_producer_state.index * subtile_cnt.
+                # NOTE: this base applies ONLY to sFinalAcc SMEM reads; real_subtile_idx
+                # below stays in [0, subtile_cnt) because it also indexes per-tile GMEM/
+                # TMEM/SFD outputs which are not stage-multiplied.
+                sfinal_slot_base = epi_consumer_state.index * subtile_cnt
+                tTR_rAcc_0 = cute.make_rmem_tensor(tTR_rAcc.shape, cutlass.Float32)
+                tTR_rAcc_1 = cute.make_rmem_tensor(tTR_rAcc.shape, cutlass.Float32)
+
+                #
+                # PASS 1 (reduce): dGLU backward + amax / dprob / dbias reductions only.
+                # The full per-thread tile amax must be finalized before row-wise SFD
+                # generation, so NO SFD generation and NO D store happen in this pass.
+                #
+                if warp_idx == self.epilog_warp_id[0]:
+                    for c_pf in range(min(c_prefetch_subtiles, c_subtile_cnt)):
+                        c_pipeline.producer_acquire(c_pipeline_producer_state)
+                        cute.copy(
+                            tma_atom_c,
+                            bGS_gC[(None, 2 * c_pf + 0)],
+                            bGS_sC[(None, c_pipeline_producer_state.index)],
+                            tma_bar_ptr=c_pipeline.producer_get_barrier(c_pipeline_producer_state),
+                        )
+                        c_pipeline_producer_state.advance()
+                        c_pipeline.producer_acquire(c_pipeline_producer_state)
+                        cute.copy(
+                            tma_atom_c,
+                            bGS_gC[(None, 2 * c_pf + 1)],
+                            bGS_sC[(None, c_pipeline_producer_state.index)],
+                            tma_bar_ptr=c_pipeline.producer_get_barrier(c_pipeline_producer_state),
+                        )
+                        c_pipeline_producer_state.advance()
+
+                for subtile_idx in cutlass.range(0, subtile_cnt, 1, unroll=1):
+                    real_subtile_idx = subtile_idx
+                    real_subtile_idx_next = subtile_idx + 1
+                    #
+                    # Load final accumulator subtile(s) from SMEM (sFinalAcc, written by
+                    # the acc-update warp) into registers. sfinal_slot_base offsets into
+                    # the current epi pipeline stage's slots.
+                    #
+                    if cutlass.const_expr(self.epilogue_prefetch_more):
+                        # Double-buffered: on even subtiles, load current + next slot.
+                        if subtile_idx % 2 == 0:
+                            cute.copy(
+                                tiled_copy_s2r_acc,
+                                tSR_sFinalAcc[(None, None, None, sfinal_slot_base + real_subtile_idx)],
+                                tiled_copy_s2r_acc.retile(tTR_rAcc_0),
+                            )
+                            cute.copy(
+                                tiled_copy_s2r_acc,
+                                tSR_sFinalAcc[(None, None, None, sfinal_slot_base + real_subtile_idx_next)],
+                                tiled_copy_s2r_acc.retile(tTR_rAcc_1),
+                            )
+                            tTR_rAcc = tTR_rAcc_0
+                        else:
+                            tTR_rAcc = tTR_rAcc_1
+                    else:
+                        cute.copy(
+                            tiled_copy_s2r_acc,
+                            tSR_sFinalAcc[(None, None, None, sfinal_slot_base + real_subtile_idx)],
+                            tiled_copy_s2r_acc.retile(tTR_rAcc),
+                        )
+
+                    # Wait for C1/C2 load to complete
+                    c_pipeline.consumer_wait(c_pipeline_consumer_state)
+                    cute.copy(
+                        tiled_copy_s2r,
+                        tRS_sC[(None, None, None, c_pipeline_consumer_state.index)],
+                        tRS_rC1,
+                    )
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    c_pipeline.consumer_release(c_pipeline_consumer_state)
+                    c_pipeline_consumer_state.advance()
+                    c_pipeline.consumer_wait(c_pipeline_consumer_state)
+                    cute.copy(
+                        tiled_copy_s2r,
+                        tRS_sC[(None, None, None, c_pipeline_consumer_state.index)],
+                        tRS_rC2,
+                    )
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    c_pipeline.consumer_release(c_pipeline_consumer_state)
+                    c_pipeline_consumer_state.advance()
+
+                    # Refill the C pipeline: issue the TMA load for the subtile
+                    # c_prefetch_subtiles ahead (warp epilog_warp_id[0] only), keeping
+                    # the producer running ahead of this consumer within the tile.
+                    if warp_idx == self.epilog_warp_id[0]:
+                        c_pf_idx = real_subtile_idx + c_prefetch_subtiles
+                        if c_pf_idx < c_subtile_cnt:
+                            c_pipeline.producer_acquire(c_pipeline_producer_state)
+                            cute.copy(
+                                tma_atom_c,
+                                bGS_gC[(None, 2 * c_pf_idx + 0)],
+                                bGS_sC[(None, c_pipeline_producer_state.index)],
+                                tma_bar_ptr=c_pipeline.producer_get_barrier(c_pipeline_producer_state),
+                            )
+                            c_pipeline_producer_state.advance()
+                            c_pipeline.producer_acquire(c_pipeline_producer_state)
+                            cute.copy(
+                                tma_atom_c,
+                                bGS_gC[(None, 2 * c_pf_idx + 1)],
+                                bGS_sC[(None, c_pipeline_producer_state.index)],
+                                tma_bar_ptr=c_pipeline.producer_get_barrier(c_pipeline_producer_state),
+                            )
+                            c_pipeline_producer_state.advance()
+
+                    acc_vec = tiled_copy_r2s.retile(tTR_rAcc)
+                    ab1_vec_load = tiled_copy_r2s.retile(tRS_rC1)
+                    ab2_vec_load = tiled_copy_r2s.retile(tRS_rC2)
+                    if cutlass.const_expr(self.generate_dprob):
+                        dprob_swiglu = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
+                    else:
+                        dprob_swiglu = None
+
+                    #
+                    # Apply alpha, act, and prob
+                    #
+                    square_alpha = alpha_val * alpha_val
+                    if cutlass.const_expr(self.act_func == "dswiglu"):
+                        d1_vec, d2_vec, dprob_swiglu = self.dswiglu(acc_vec, ab1_vec_load, ab2_vec_load, mProb, beta_val, square_alpha, dprob_swiglu)
+                    elif cutlass.const_expr(self.act_func == "dgeglu"):
+                        d1_vec, d2_vec, dprob_swiglu = self.dgeglu(acc_vec, ab1_vec_load, ab2_vec_load, mProb, linear_offset, dprob_swiglu)
+
+                    if cutlass.const_expr(self.generate_dprob):
+                        # dprob sum reduction
+                        if cutlass.const_expr(self.vectorized_f32):
+                            dprob_pair_0 = cutlass.Float32(0.0)
+                            dprob_pair_1 = cutlass.Float32(0.0)
+                            for j in cutlass.range(0, cute.size(dprob_swiglu.shape), 2, unroll_full=True):
+                                (
+                                    dprob_pair_0,
+                                    dprob_pair_1,
+                                ) = cute.arch.add_packed_f32x2(
+                                    (dprob_pair_0, dprob_pair_1),
+                                    (dprob_swiglu[j], dprob_swiglu[j + 1]),
+                                    rnd="rn",
+                                    ftz=False,
+                                )
+                            dProbVal += dprob_pair_0 + dprob_pair_1
+                        else:
+                            dProbVal += dprob_swiglu.reduce(
+                                cute.ReductionOp.ADD,
+                                cutlass.Float32(0.0),
+                                0,
+                            )
+
+                    #
+                    # Generate dBias
+                    #
+                    if cutlass.const_expr(self.generate_dbias):
+                        n_base_d1 = epi_work_tile_info.tile_n_idx * (self.mma_tiler[1] * 2) + (2 * real_subtile_idx + 0) * self.epi_tile[1]
+                        n_base_d2 = epi_work_tile_info.tile_n_idx * (self.mma_tiler[1] * 2) + (2 * real_subtile_idx + 1) * self.epi_tile[1]
+                        dbias_n_total = cute.size(mDbias_tensor, mode=[1])
+                        self.dbias_reduction(
+                            d1_vec,
+                            d2_vec,
+                            warp_idx,
+                            sDbias,
+                            mDbias_tensor,
+                            expert_idx,
+                            n_base_d1,
+                            n_base_d2,
+                            dbias_n_total,
+                        )
+
+                    #
+                    # Generate subtile level amax
+                    #
+                    if cutlass.const_expr(self.generate_sfd2):
+                        thread_tile_amax_1 = self.amax_reduction_per_thread(d1_vec, thread_tile_amax_1)
+                        thread_tile_amax_2 = self.amax_reduction_per_thread(d2_vec, thread_tile_amax_2)
+
+                    #
+                    # Stash the bf16-rounded dGLU output into the accumulator's SMEM
+                    # slots (reused in place, slots 2*subtile + 0/1) for pass-2
+                    # quantization. Done AFTER the dprob/dbias/SFD2-amax reductions so
+                    # those stay on the f32 d1/d2_vec; the SFD amax + e2m1 D bytes then
+                    # derive from the bf16 value.
+                    #
+                    # The bf16 slots alias the f32 subtile's BYTES with a
+                    # different (row, col)->byte map, so one thread's stash
+                    # lands on OTHER threads' unread f32 rows (e.g. bf16 rows
+                    # 64..95 over f32 rows 32..47). Every thread must finish
+                    # its f32 subtile reads (incl. the prefetch path's
+                    # next-slot read, issued at even subtiles above) before
+                    # ANY thread overwrites the slot — without this barrier a
+                    # fast warp corrupts a slow warp's accumulator input
+                    # (racecheck: stash-vs-s2r-acc hazard; manifested as rare
+                    # 16-token x 1-subtile corruption at sg512 large shapes).
+                    #
+                    if cutlass.const_expr(self.generate_sfd):
+                        self.epilog_sync_barrier.arrive_and_wait()
+                        tRS_rDGLU1.store(d1_vec.to(cutlass.BFloat16))
+                        tRS_rDGLU2.store(d2_vec.to(cutlass.BFloat16))
+                        cute.copy(
+                            tiled_copy_dglu,
+                            tRS_rDGLU1,
+                            tRS_sFinalAccBf16[(None, None, None, 2 * (sfinal_slot_base + real_subtile_idx) + 0)],
+                        )
+                        cute.copy(
+                            tiled_copy_dglu,
+                            tRS_rDGLU2,
+                            tRS_sFinalAccBf16[(None, None, None, 2 * (sfinal_slot_base + real_subtile_idx) + 1)],
+                        )
+
+                # Generate SFD2
+                if cutlass.const_expr(self.generate_sfd2):
+                    # The second-level scale normalizes dy for its two-level target
+                    # encoding: divisor = max(D-quant data dtype) * max(SF dtype).
+                    # When D is quantized (generate_sfd) the data dtype is the real
+                    # d_dtype; otherwise SFD2 targets the NVFP4 e2m1 second level.
+                    sfd2_data_dtype = self.d_dtype if cutlass.const_expr(self.generate_sfd) else cutlass.Float4E2M1FN
+                    sfd2_norm = get_dtype_max(sfd2_data_dtype) * get_dtype_max(self.sf_dtype)
+                    sfd2_descale_1 = thread_tile_amax_1 / sfd2_norm
+                    sfd2_descale_2 = thread_tile_amax_2 / sfd2_norm
+                    if cutlass.const_expr(self.row_dsmem):
+                        # DSMEM rowwise reduction: the block's contributors are
+                        # exactly this cluster's N-peers (same M rank). Each
+                        # thread owns one row (thread_tiler (128,1)) and
+                        # max-reds its gate/up descale into EVERY N-peer's
+                        # parity slot ([cta_m gate | cta_m up]); the identical
+                        # bit-pattern u32 max the gmem helper uses, so results
+                        # stay byte-exact. Descales are non-negative, so the
+                        # trick is valid.
+                        _row_slot = (row_dsmem_seq & 1) * (2 * self.cta_tile_shape_mnk_d[0])
+                        _rp_gate = sSfd2RowDsmem.iterator + (_row_slot + epi_tidx)
+                        _rp_up = sSfd2RowDsmem.iterator + (_row_slot + self.cta_tile_shape_mnk_d[0] + epi_tidx)
+                        _row_m_rank = cta_rank_in_cluster % self.cluster_shape_mn[0]
+                        for _rt in cutlass.range_constexpr(self.cluster_shape_mn[1]):
+                            _row_peer = _row_m_rank + _rt * self.cluster_shape_mn[0]
+                            red_smem_cluster_max_f32(_rp_gate, sfd2_descale_1, Int32(_row_peer))
+                            red_smem_cluster_max_f32(_rp_up, sfd2_descale_2, Int32(_row_peer))
+                    else:  # GMEM reduction
+                        self.second_level_scale_row_wise_gen(sfd2_descale_2, tgSFD2_up)
+                        self.second_level_scale_row_wise_gen(sfd2_descale_1, tgSFD2_gate)
+
+                # Make the pass-1 bf16 dGLU stores visible to the pass-2 reloads (the
+                # store/load footprints coincide per thread; the barrier also covers the
+                # async-proxy copy).
+                if cutlass.const_expr(self.generate_sfd):
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+                    if cutlass.const_expr(self.row_dsmem):
+                        # DSMEM handoff (replaces the gmem counter + acquire
+                        # spin): the epilog barrier above ordered every
+                        # thread's reds; the elected thread's cluster release
+                        # fence publishes them, then one arrive lands on each
+                        # N-peer's parity mbarrier. A CTA passing its wait has
+                        # proof every peer's reds landed — its local slot holds
+                        # the final block descales.
+                        _row_parity = row_dsmem_seq & 1
+                        _row_phase = (row_dsmem_seq >> 1) & 1
+                        if warp_idx == self.epilog_warp_id[0]:
+                            with cute.arch.elect_one():
+                                cute.arch.fence_acq_rel_cluster()
+                                _row_am_rank = cta_rank_in_cluster % self.cluster_shape_mn[0]
+                                for _ra in cutlass.range_constexpr(self.cluster_shape_mn[1]):
+                                    mbarrier_arrive_cluster(
+                                        row_dsmem_mbar + _row_parity,
+                                        peer_cta_rank_in_cluster=Int32(_row_am_rank + _ra * self.cluster_shape_mn[0]),
+                                    )
+                        cute.arch.mbarrier_wait(row_dsmem_mbar + _row_parity, _row_phase)
+                        # Acquire side of the handoff: order the peers' reds
+                        # (published by their release fences) before this CTA's
+                        # smem reads below.
+                        cute.arch.fence_acq_rel_cluster()
+                    elif cutlass.const_expr(self.sfd2_n_contrib > 1):
+                        # Arrival protocol: one sfd2 block spans sfd2_n_contrib
+                        # N work-tiles (sgn/mma_tiler_n: 2 at sgn=256, 4 at
+                        # sgn=512 with the 128 tiler), so the block descale is
+                        # only final in gmem once EVERY contributing tile's
+                        # pass-1 atomic maxes have landed. Each tile announces
+                        # completion on a per-(m tile, n-block) u32 counter;
+                        # pass 2 spins until all contributors arrived, which
+                        # makes the volatile read-back below provably final.
+                        _n_tiles_f = cute.ceil_div(cute.shape(mD_mnl)[1], 2 * self.cta_tile_shape_mnk[1])
+                        _n_j = cute.ceil_div(_n_tiles_f, self.sfd2_n_contrib)
+                        _tok_off, _ = compute_expert_token_range(padded_offsets, epi_work_tile_info.expert_idx)
+                        _j = epi_work_tile_info.tile_n_idx // self.sfd2_n_contrib
+                        _counter_idx = (_tok_off // self.cta_tile_shape_mnk[0] + epi_work_tile_info.tile_m_idx) * _n_j + _j
+                        _counter_ptr = cute.make_ptr(
+                            cutlass.Int32,
+                            self._get_sfd2_counter_ptr(workspace_ptr).toint() + _counter_idx * 4,
+                            AddressSpace.gmem,
+                            assumed_align=4,
+                        )
+                        # Announce this tile's arrival (one thread per CTA).
+                        # The gpu-scope release fence orders every thread's
+                        # pass-1 atomic maxes (already CTA-ordered by the
+                        # barrier above) before the counter increment.
+                        if warp_idx == self.epilog_warp_id[0]:
+                            with cute.arch.elect_one():
+                                cute.arch.fence_acq_rel_gpu()
+                                atomic_add_i32_gmem(_counter_ptr.llvm_ptr, Int32(1))
+                        # The last block of a row may have fewer contributors
+                        # when the f-tile count is not a multiple of
+                        # sfd2_n_contrib (spinning for the full count there
+                        # would hang forever).
+                        _contrib = Int32(self.sfd2_n_contrib)
+                        _rem = _n_tiles_f - _j * self.sfd2_n_contrib
+                        if _rem < _contrib:
+                            _contrib = _rem
+                        # Acquire-spin: once the counter shows all arrivals,
+                        # every contributor's atomic maxes are visible.
+                        _arrived = load_acquire_i32_gpu(_counter_ptr.llvm_ptr)
+                        while _arrived < _contrib:
+                            nanosleep(sleep_time=64)
+                            _arrived = load_acquire_i32_gpu(_counter_ptr.llvm_ptr)
+
+                    if cutlass.const_expr(self.generate_sfd2):
+                        if cutlass.const_expr(self.row_dsmem):
+                            # DSMEM path: the local parity slot holds the final
+                            # block descales — plain LDS, no volatile gmem loads.
+                            _rq_slot = (row_dsmem_seq & 1) * (2 * self.cta_tile_shape_mnk_d[0])
+                            sfd2_descale_1 = sSfd2RowDsmem[_rq_slot + epi_tidx]
+                            sfd2_descale_2 = sSfd2RowDsmem[_rq_slot + self.cta_tile_shape_mnk_d[0] + epi_tidx]
+                            # Publish the finalized descales to the gmem sfd2
+                            # outputs (the gmem atomics that used to produce them
+                            # are skipped on this path): one CTA per contributor
+                            # group — the N-rank-0 peer — plain-stores its rows.
+                            if cta_rank_in_cluster // self.cluster_shape_mn[0] == 0:
+                                tgSFD2_gate[0] = sfd2_descale_1
+                                tgSFD2_up[0] = sfd2_descale_2
+                            # Recycle the parity slot for tile seq+2: reads above
+                            # are this thread's own (program order), and peers'
+                            # next reds into this slot chain through the seq+1
+                            # arrive whose fence publishes these zeroes.
+                            sSfd2RowDsmem[_rq_slot + epi_tidx] = Float32(0.0)
+                            sSfd2RowDsmem[_rq_slot + self.cta_tile_shape_mnk_d[0] + epi_tidx] = Float32(0.0)
+                            row_dsmem_seq = row_dsmem_seq + 1
+                        else:
+                            # Re-read the block descale from the sfd2 gmem reduction
+                            # for the pass-2 row-scale fold. atomic_max only returns
+                            # the PRE-max value, and the register thread_tile_amax
+                            # covers just this tile's columns: when one sfd2 block
+                            # spans multiple N work-tiles (sgn > tile f-width,
+                            # i.e. sfd2_n_contrib > 1), the block amax is
+                            # completed in gmem by the other tiles' atomics — the
+                            # arrival spin above guarantees they have all landed.
+                            # Volatile: the atomics reduce in L2, so the load must
+                            # not be served from a stale L1 line.
+                            sfd2_descale_1 = load_float32_volatile(tgSFD2_gate.iterator.llvm_ptr)
+                            sfd2_descale_2 = load_float32_volatile(tgSFD2_up.iterator.llvm_ptr)
+
+                #
+                # PASS 2 (quantize + store). NVFP4 path (generate_sfd): reload the
+                # bf16 dGLU output stashed in pass 1 from sFinalAcc, upcast to f32, and
+                # quantize — no C reload, no dGLU recompute. bf16-D path: re-drive C
+                # from GMEM and recompute dGLU (the full-tile amax is now available).
+                #
+                # C is only re-driven for the bf16-D recompute path; the NVFP4 path
+                # consumed C once in pass 1 and reloads dGLU from SMEM below.
+                if cutlass.const_expr(not self.generate_sfd):
+                    if warp_idx == self.epilog_warp_id[0]:
+                        for c_pf in range(min(c_prefetch_subtiles, c_subtile_cnt)):
+                            c_pipeline.producer_acquire(c_pipeline_producer_state)
+                            cute.copy(
+                                tma_atom_c,
+                                bGS_gC[(None, 2 * c_pf + 0)],
+                                bGS_sC[(None, c_pipeline_producer_state.index)],
+                                tma_bar_ptr=c_pipeline.producer_get_barrier(c_pipeline_producer_state),
+                            )
+                            c_pipeline_producer_state.advance()
+                            c_pipeline.producer_acquire(c_pipeline_producer_state)
+                            cute.copy(
+                                tma_atom_c,
+                                bGS_gC[(None, 2 * c_pf + 1)],
+                                bGS_sC[(None, c_pipeline_producer_state.index)],
+                                tma_bar_ptr=c_pipeline.producer_get_barrier(c_pipeline_producer_state),
+                            )
+                            c_pipeline_producer_state.advance()
+
+                for subtile_idx in cutlass.range(0, subtile_cnt, 1, unroll=1):
+                    real_subtile_idx = subtile_idx
+                    real_subtile_idx_next = subtile_idx + 1
+                    if cutlass.const_expr(self.generate_sfd):
+                        #
+                        # NVFP4 path: reload the bf16 dGLU output stashed by pass 1 from
+                        # the accumulator's SMEM slots (2*subtile + 0/1) and upcast to
+                        # f32. No C reload, no dGLU recompute — pass 1 did both.
+                        #
+                        cute.copy(
+                            tiled_copy_dglu,
+                            tRS_sFinalAccBf16[(None, None, None, 2 * (sfinal_slot_base + real_subtile_idx) + 0)],
+                            tRS_rDGLU1,
+                        )
+                        cute.copy(
+                            tiled_copy_dglu,
+                            tRS_sFinalAccBf16[(None, None, None, 2 * (sfinal_slot_base + real_subtile_idx) + 1)],
+                            tRS_rDGLU2,
+                        )
+                        d1_vec = tRS_rDGLU1.load().to(cutlass.Float32)
+                        d2_vec = tRS_rDGLU2.load().to(cutlass.Float32)
+                    else:
+                        #
+                        # Load final accumulator subtile(s) from SMEM (sFinalAcc, written by
+                        # the acc-update warp) into registers. sfinal_slot_base offsets into
+                        # the current epi pipeline stage's slots.
+                        #
+                        if cutlass.const_expr(self.epilogue_prefetch_more):
+                            # Double-buffered: on even subtiles, load current + next slot.
+                            if subtile_idx % 2 == 0:
+                                cute.copy(
+                                    tiled_copy_s2r_acc,
+                                    tSR_sFinalAcc[(None, None, None, sfinal_slot_base + real_subtile_idx)],
+                                    tiled_copy_s2r_acc.retile(tTR_rAcc_0),
+                                )
+                                cute.copy(
+                                    tiled_copy_s2r_acc,
+                                    tSR_sFinalAcc[(None, None, None, sfinal_slot_base + real_subtile_idx_next)],
+                                    tiled_copy_s2r_acc.retile(tTR_rAcc_1),
+                                )
+                                tTR_rAcc = tTR_rAcc_0
+                            else:
+                                tTR_rAcc = tTR_rAcc_1
+                        else:
+                            cute.copy(
+                                tiled_copy_s2r_acc,
+                                tSR_sFinalAcc[(None, None, None, sfinal_slot_base + real_subtile_idx)],
+                                tiled_copy_s2r_acc.retile(tTR_rAcc),
+                            )
+                        # Wait for C1/C2 load to complete
+                        c_pipeline.consumer_wait(c_pipeline_consumer_state)
+                        cute.copy(
+                            tiled_copy_s2r,
+                            tRS_sC[(None, None, None, c_pipeline_consumer_state.index)],
+                            tRS_rC1,
+                        )
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        c_pipeline.consumer_release(c_pipeline_consumer_state)
+                        c_pipeline_consumer_state.advance()
+                        c_pipeline.consumer_wait(c_pipeline_consumer_state)
+                        cute.copy(
+                            tiled_copy_s2r,
+                            tRS_sC[(None, None, None, c_pipeline_consumer_state.index)],
+                            tRS_rC2,
+                        )
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        c_pipeline.consumer_release(c_pipeline_consumer_state)
+                        c_pipeline_consumer_state.advance()
+
+                        # Refill the C pipeline: issue the TMA load for the subtile
+                        # c_prefetch_subtiles ahead (warp epilog_warp_id[0] only), keeping
+                        # the producer running ahead of this consumer within the tile.
+                        if warp_idx == self.epilog_warp_id[0]:
+                            c_pf_idx = real_subtile_idx + c_prefetch_subtiles
+                            if c_pf_idx < c_subtile_cnt:
+                                c_pipeline.producer_acquire(c_pipeline_producer_state)
+                                cute.copy(
+                                    tma_atom_c,
+                                    bGS_gC[(None, 2 * c_pf_idx + 0)],
+                                    bGS_sC[(None, c_pipeline_producer_state.index)],
+                                    tma_bar_ptr=c_pipeline.producer_get_barrier(c_pipeline_producer_state),
+                                )
+                                c_pipeline_producer_state.advance()
+                                c_pipeline.producer_acquire(c_pipeline_producer_state)
+                                cute.copy(
+                                    tma_atom_c,
+                                    bGS_gC[(None, 2 * c_pf_idx + 1)],
+                                    bGS_sC[(None, c_pipeline_producer_state.index)],
+                                    tma_bar_ptr=c_pipeline.producer_get_barrier(c_pipeline_producer_state),
+                                )
+                                c_pipeline_producer_state.advance()
+
+                        acc_vec = tiled_copy_r2s.retile(tTR_rAcc)
+                        ab1_vec_load = tiled_copy_r2s.retile(tRS_rC1)
+                        ab2_vec_load = tiled_copy_r2s.retile(tRS_rC2)
+                        if cutlass.const_expr(self.generate_dprob):
+                            dprob_swiglu = cute.make_rmem_tensor(acc_vec.shape, cutlass.Float32)
+                        else:
+                            dprob_swiglu = None
+
+                        #
+                        # Apply alpha, act, and prob
+                        #
+                        square_alpha = alpha_val * alpha_val
+                        if cutlass.const_expr(self.act_func == "dswiglu"):
+                            d1_vec, d2_vec, dprob_swiglu = self.dswiglu(acc_vec, ab1_vec_load, ab2_vec_load, mProb, beta_val, square_alpha, dprob_swiglu)
+                        elif cutlass.const_expr(self.act_func == "dgeglu"):
+                            d1_vec, d2_vec, dprob_swiglu = self.dgeglu(acc_vec, ab1_vec_load, ab2_vec_load, mProb, linear_offset, dprob_swiglu)
+
+                    #
+                    # Generate SFD (row-wise). thread_tile_amax_1/2 are now the full
+                    # per-tile amax (finalized in pass 1) and are available here.
+                    #
+                    if cutlass.const_expr(self.generate_sfd):
+                        #
+                        # Generate row major SFD
+                        #
+                        self.quant_sfd_row(
+                            (real_subtile_idx * 2 + 0) % 4,
+                            tiled_copy_r2s,
+                            d1_vec,
+                            tCrSFDRow_pvscale,
+                            norm_const,
+                            d_rcp_limits,
+                            tRS_rD1,
+                            sfd2_descale_1,
+                        )
+                        self.quant_sfd_row(
+                            (real_subtile_idx * 2 + 1) % 4,
+                            tiled_copy_r2s,
+                            d2_vec,
+                            tCrSFDRow_pvscale,
+                            norm_const,
+                            d_rcp_limits,
+                            tRS_rD2,
+                            sfd2_descale_2,
+                        )
+                        if subtile_idx % 2 == 1:
+                            local_m_tile = epi_work_tile_info.tile_m_idx
+                            local_n_tile = epi_work_tile_info.tile_n_idx
+                            sfd_row_idx_mn = (
+                                local_m_tile * self.epi_tile_cnt[0] + 0,
+                                local_n_tile * self.epi_tile_cnt[1] // 2 + (real_subtile_idx // 2),
+                            )
+
+                            tCgSFDRow = tCgSFDRow_mn[
+                                (
+                                    None,
+                                    None,
+                                    None,
+                                    *sfd_row_idx_mn,
+                                )
+                            ]
+                            if cutlass.const_expr(self.sf_dtype == cutlass.FloatNV8E5M3FNU):
+                                # Scalar clamp + RN .to() per element: no PTX cvt
+                                # (and no known-good vector .to()) exists for e5m3.
+                                # The raw pvscale is unclamped -- the e4m3 vector
+                                # .to() saturates implicitly; here the explicit
+                                # fmin keeps the stored byte identical to the
+                                # cvt_f32_to_f8_to_f32 decode the data was
+                                # rescaled with.
+                                for sfi in cutlass.range_constexpr(cute.size(tCrSFDRow.shape)):
+                                    pv_sf = fmin(tCrSFDRow_pvscale[sfi], Float32(61440.0), nan=True)
+                                    tCrSFDRow[sfi] = pv_sf.to(cutlass.FloatNV8E5M3FNU)
+                            elif cutlass.const_expr(not self.use_fp8_ptx_cvt):
+                                tCrSFDRow.store(tCrSFDRow_pvscale.load().to(self.sf_dtype))
+                            else:
+                                self.cvt_f32x4_to_f8x4(tCrSFDRow_pvscale, tCrSFDRow)
+                            if sfd_row_idx_mn[1] * 32 * regPerSubtile < cute.size(cute.shape(mSFDRow_mnl.layout, mode=[1])):
+                                # Coalesced SFD store: scatter this thread's SF
+                                # bytes into the SMEM stage at their atom-layout
+                                # offsets, then write the contiguous block back
+                                # linearly — one 8B word per thread instead of
+                                # 2x4B gmem stores at 16B thread stride (which
+                                # waste 3/4 of every 32B sector). The
+                                # end-of-subtile epilog barrier orders this
+                                # readback before the next event's scatter.
+                                cute.autovec_copy(tCrSFDRow, tCsSFDRow)
+                                self.epilog_sync_barrier.arrive_and_wait()
+                                gSFDRow_evt = gSFDRow_mnl[(None, None, *sfd_row_idx_mn, 0)]
+                                if cutlass.const_expr(self.d_deinterleaved):
+                                    # DEINTERLEAVED scatter. Canonical stage byte
+                                    # a = r + 2p + 4*m4 + 16*m32 + 512*q0 (p =
+                                    # band_parity, q0 = band_pair, q1 =
+                                    # sfd_col_tile_idx) must land at the deint atom
+                                    # position r + 2*q0 + 4*m4 + 16*m32 + 512*q1 +
+                                    # 8f*p. Relative to the canonical tile base
+                                    # (rowblock + 1024*q1) the target offset is
+                                    #   t = a + p*(8f-2) - 510*q0 - 512*q1.
+                                    # Only p/q0/q1 move; r keeps 2B pieces
+                                    # contiguous, so each thread stores 4x Int16.
+                                    sfd_tile_base_addr = gSFDRow_evt.iterator.toint()
+                                    sfd_col_tile_idx = sfd_row_idx_mn[1]
+                                    if epi_tidx * 8 < sfd_stage_size:
+                                        for piece_idx in cutlass.range_constexpr(4):
+                                            stage_byte = epi_tidx * 8 + 2 * piece_idx
+                                            band_parity = (stage_byte // 2) % 2
+                                            band_pair = stage_byte // 512
+                                            deint_offset = stage_byte + band_parity * (4 * self.deint_n - 2) - band_pair * 510 - sfd_col_tile_idx * 512
+                                            gmem_piece = cute.make_tensor(
+                                                cute.make_ptr(
+                                                    cutlass.Int16,
+                                                    sfd_tile_base_addr + deint_offset,
+                                                    AddressSpace.gmem,
+                                                    assumed_align=2,
+                                                ),
+                                                cute.make_layout(1),
+                                            )
+                                            gmem_piece[0] = sSFDRowStage_half[stage_byte // 2]
+                                else:
+                                    # INTERLEAVED: the stage IS the gmem tile —
+                                    # linear copy, one 8B word per thread.
+                                    gSFDRow_words = cute.make_tensor(
+                                        cute.make_ptr(
+                                            cutlass.Int64,
+                                            gSFDRow_evt.iterator.toint(),
+                                            AddressSpace.gmem,
+                                            assumed_align=8,
+                                        ),
+                                        cute.make_layout(sfd_stage_size // 8),
+                                    )
+                                    if epi_tidx * 8 < sfd_stage_size:
+                                        gSFDRow_words[epi_tidx] = sSFDRowStage_words[epi_tidx]
+                    else:
+                        #
+                        # Convert to D type
+                        #
+                        tRS_rD1.store(d1_vec.to(self.d_dtype))
+                        tRS_rD2.store(d2_vec.to(self.d_dtype))
+
+                    #
+                    # Store D
+                    #
+                    if cutlass.const_expr(self.store_d_directly):
+                        self.epilog_sync_barrier.arrive_and_wait()
+                        d_idx_mn = (mma_tile_coord_mnl[0], mma_tile_coord_mnl[1])
+                        d_epilogue_subtile = (
+                            cute.make_layout(128),
+                            cute.make_layout(self.mma_tiler[1] * 2),
+                        )
+                        gD_sub_loop = cute.local_tile(real_d, d_epilogue_subtile, (None, None, None))
+                        tCgD_mnl_loop = thr_copy_t2r.partition_D(gD_sub_loop)
+                        tCgD_mnl_loop = cute.filter_zeros(tCgD_mnl_loop)
+                        tCgD1 = tCgD_mnl_loop[
+                            (
+                                None,
+                                0,  # T2R_M
+                                2 * real_subtile_idx + 0,  # T2R_N
+                                *d_idx_mn,  # RestM/N
+                                0,  # RestL
+                            )
+                        ]
+                        tCgD2 = tCgD_mnl_loop[
+                            (
+                                None,
+                                0,  # T2R_M
+                                2 * real_subtile_idx + 1,  # T2R_N
+                                *d_idx_mn,  # RestM/N
+                                0,  # RestL
+                            )
+                        ]
+                        self.store_global_memory_256b(tCgD1, tRS_rD1)
+                        self.store_global_memory_256b(tCgD2, tRS_rD2)
+                    else:
+                        if warp_idx == self.epilog_warp_id[0]:
+                            d_pipeline.producer_acquire()
+                        self.epilog_sync_barrier.arrive_and_wait()
+                        d1_buffer = num_prev_subtiles % self.num_d_stage
+                        num_prev_subtiles = num_prev_subtiles + 1
+                        cute.copy(
+                            tiled_copy_r2s,
+                            tRS_rD1,
+                            tRS_sD[(None, None, None, d1_buffer)],
+                        )
+                        d2_buffer = num_prev_subtiles % self.num_d_stage
+                        num_prev_subtiles = num_prev_subtiles + 1
+                        cute.copy(
+                            tiled_copy_r2s,
+                            tRS_rD2,
+                            tRS_sD[(None, None, None, d2_buffer)],
+                        )
+                        # Fence and barrier to make sure shared memory store is visible to TMA store
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        self.epilog_sync_barrier.arrive_and_wait()
+                        #
+                        # TMA store D to global memory
+                        #
+                        if warp_idx == self.epilog_warp_id[0]:
+                            cute.copy(
+                                tma_atom_d,
+                                bSG_sD[(None, d1_buffer)],
+                                bSG_gD[(None, 2 * real_subtile_idx + 0)],
+                            )
+                            cute.copy(
+                                tma_atom_d,
+                                bSG_sD[(None, d2_buffer)],
+                                bSG_gD[(None, 2 * real_subtile_idx + 1)],
+                            )
+                            # Fence and barrier to make sure shared memory store is visible to TMA store
+                            d_pipeline.producer_commit()
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+                #
+                # Async arrive accumulator buffer empty
+                #
+                epi_pipeline.consumer_release(epi_consumer_state)
+                epi_consumer_state.advance()
+
+                #
+                # Advance to next tile
+                #
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+                if cutlass.const_expr(self.generate_dprob):
+                    real_dprob, _ = epi_ext.get_gmem_tensor("dprob", dprob, padded_offsets, epi_work_tile_info)
+                    _ = atomic_add_float32(
+                        ptr=real_dprob[(mPosition, None, None)].iterator.llvm_ptr,
+                        value=dProbVal,
+                    )
+
+            #
+            # Wait for outstanding C TMA loads (producer side) to drain
+            #
+            if warp_idx == self.epilog_warp_id[0]:
+                c_pipeline.producer_tail(c_pipeline_producer_state)
+
+            #
+            # Dealloc the tensor memory buffer
+            #
+            tmem.relinquish_alloc_permit()
+            self.epilog_sync_barrier.arrive_and_wait()
+            tmem.free(tmem_ptr)
+            #
+            # Wait for D store complete
+            #
+            if cutlass.const_expr(not self.store_d_directly):
+                d_pipeline.producer_tail()
+        #
+
+    def epilog_tmem_copy_and_partition(
+        self,
+        tidx: cutlass.Int32,
+        tAcc: cute.Tensor,
+        gD_mnl: cute.Tensor,
+        epi_tile: cute.Tile,
+        use_2cta_instrs: Union[cutlass.Boolean, bool],
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for tensor memory load, then use it to partition tensor memory (source)
+        and derive the register array shape from the (shape-only) gmem D partition.
+
+        For breuse: tAcc and gD_mnl have been through transform_partitioned_tensor_layout
+        so the M-split (mode1=2) is already merged into the M dimension.
+        For non-breuse: tAcc has shape (MMA, 1, 1, STAGE); strip with [0,0] internally.
+
+        :param tidx: The thread index in epilogue warp groups
+        :type tidx: cutlass.Int32
+        :param tAcc: The accumulator tensor to be copied and partitioned
+        :type tAcc: cute.Tensor
+        :param gD_mnl: The global D tensor (shape-only, for copy atom setup)
+        :type gD_mnl: cute.Tensor
+        :param epi_tile: The epilogue tiler
+        :type epi_tile: cute.Tile
+        :param use_2cta_instrs: Whether use_2cta_instrs is enabled
+        :type use_2cta_instrs: bool
+
+        :return: A tuple containing (tiled_copy_t2r, tTR_tAcc, tTR_rAcc) where:
+            - tiled_copy_t2r: The tiled copy operation for tmem to register copy(t2r)
+            - tTR_tAcc: The partitioned accumulator tensor in TMEM
+            - tTR_rAcc: The register tensor for accumulator (shape derived from TMEM partition)
+        :rtype: Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]
+        """
+        copy_atom_t2r = sm100_utils.get_tmem_load_op(
+            self.cta_tile_shape_mnk,
+            self.d_layout,
+            self.d_dtype,
+            self.acc_dtype,
+            epi_tile,
+            use_2cta_instrs,
+        )
+
+        if cutlass.const_expr(self.enable_breuse):
+            # After transform_partitioned_tensor_layout, tAcc has merged M-split;
+            # gD_mnl is also already transformed -- divide directly.
+            tAcc_epi = cute.flat_divide(tAcc, epi_tile)
+            gD_mnl_epi = cute.flat_divide(gD_mnl, epi_tile)
+        else:
+            # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, STAGE)
+            tAcc_epi = cute.flat_divide(
+                tAcc[((None, None), 0, 0, None)],
+                epi_tile,
+            )
+            gD_mnl_epi = cute.flat_divide(
+                gD_mnl[((None, None), 0, 0, None, None, None)],
+                epi_tile,
+            )
+        # (EPI_TILE_M, EPI_TILE_N)
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tAcc_epi[(None, None, 0, 0, 0)])
+
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+        # (T2R, T2R_M, T2R_N, EPI_M, EPI_N, STAGE)
+        tTR_tAcc = thr_copy_t2r.partition_S(tAcc_epi)
+        tTR_gD = thr_copy_t2r.partition_D(gD_mnl_epi)
+
+        # Derive register shape from gmem D partition
+        tTR_rAcc = cute.make_rmem_tensor(tTR_gD[(None, None, None, 0, 0, 0, 0, 0)].shape, self.acc_dtype)
+        return tiled_copy_t2r, tTR_tAcc, tTR_rAcc
+
+    def acc_update_tmem_copy_and_partition(
+        self,
+        tidx: cutlass.Int32,
+        tCtAcc_base: cute.Tensor,
+        gD_mnl: cute.Tensor,
+        sSFA: cute.Tensor,
+        sSFB: cute.Tensor,
+        sFinalAcc: cute.Tensor,
+        epi_tile: cute.Tile,
+        use_2cta_instrs: Union[cutlass.Boolean, bool],
+    ) -> Tuple[cute.TiledCopy, cute.TiledCopy, cute.Tensor, cute.Tensor, cute.Tensor, cute.Tensor, cute.Tensor, cute.Tensor]:
+        """
+        Create tiled copy operations and partition tensors for accumulator update warp.
+
+        This function sets up T2R (TMEM-to-Register) and R2S (Register-to-SMEM) copies
+        for the accumulator update warp to:
+        1. Load partial accumulators from TMEM (tCtAcc_base) to registers
+        2. Store final accumulated result from registers to SMEM (sFinalAcc)
+
+        The GLU gate/up interleaving is already handled by the TMEM layout, so we don't
+        need to explicitly separate them here.
+
+        :param tidx: Thread index within accumulator update warp group
+        :param tCtAcc_base: TMEM tensor for reading partial accumulators (from MMA)
+        :param gD_mnl: Global tensor D shape (for partitioning)
+        :param sFinalAcc: SMEM tensor for writing final accumulator (for epilogue)
+        :param epi_tile: Epilogue tile size
+        :param use_2cta_instrs: Whether use_2cta_instrs is enabled
+        :return: Tuple of (tiled_copy_t2r, tiled_copy_r2s_acc, tTR_tAcc_base, tTR_rAcc,
+                          tTR_rAcc_final, tRS_sFinalAcc, tTR_sSFA, tTR_sSFB)
+
+        The T2R copy atom is built identically to the epilogue's
+        (get_tmem_load_op over cta_tile_shape_mnk) so the sFinalAcc writer (here) and reader
+        (epilogue) agree on the SMEM partition TV layout.
+        """
+        copy_atom_t2r = sm100_utils.get_tmem_load_op(
+            self.cta_tile_shape_mnk,
+            self.d_layout,
+            self.d_dtype,
+            self.acc_dtype,
+            epi_tile,
+            use_2cta_instrs,
+        )
+
+        # Partition accumulator tensors by epilogue tile
+        tAcc_epi = cute.flat_divide(tCtAcc_base[((None, None), 0, 0, None)], epi_tile)
+
+        # Create tiled copy for T2R (TMEM to Register)
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tAcc_epi[(None, None, 0, 0, 0)])
+
+        # Get thread-specific slice
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+
+        # R2S (Register to SMEM) store of the final accumulator: reuse the T2R copy's
+        # thread-value layout with a universal copy atom (swizzle-safe for f32)
+        copy_atom_r2s_acc = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.acc_dtype)
+        tiled_copy_r2s_acc = cute.make_tiled_copy_D(copy_atom_r2s_acc, tiled_copy_t2r)
+        # (R2S, R2S_M, R2S_N, SUBTILE * STAGE)
+        tRS_sFinalAcc = tiled_copy_r2s_acc.get_slice(tidx).partition_D(sFinalAcc)
+
+        # Partition source for T2R: tCtAcc_base (read partial accumulators)
+        tTR_tAcc_base = thr_copy_t2r.partition_S(tAcc_epi)
+
+        # Partition gD_mnl for determining register buffer shape
+        gD_mnl_epi = cute.flat_divide(gD_mnl[((None, None), 0, 0, None, None, None)], epi_tile)
+        sSFA_epi = cute.flat_divide(sSFA, epi_tile)
+        sSFB_epi = cute.flat_divide(sSFB, epi_tile)
+
+        tTR_gC = thr_copy_t2r.partition_D(gD_mnl_epi)
+        tTR_sSFA = thr_copy_t2r.partition_D(sSFA_epi)
+        tTR_sSFB = thr_copy_t2r.partition_D(sSFB_epi)
+
+        # Create register tensor for T2R destination (holds one k_tile's partial accumulator)
+        tTR_rAcc = cute.make_rmem_tensor(tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].shape, self.acc_dtype)
+
+        # Create register tensor for final accumulated result across all k_tiles
+        # Shape: (T2R, T2R_M, T2R_N, EPI_M, EPI_N) -> grouped to (T2R, T2R_M, T2R_N, (EPI_M, EPI_N))
+        tTR_rAcc_final_ = cute.make_rmem_tensor(tTR_gC[(None, None, None, None, None, 0, 0, 0)].shape, self.acc_dtype)
+        tTR_rAcc_final = cute.group_modes(tTR_rAcc_final_, 3, cute.rank(tTR_rAcc_final_))
+
+        return (
+            tiled_copy_t2r,
+            tiled_copy_r2s_acc,
+            tTR_tAcc_base,
+            tTR_rAcc,
+            tTR_rAcc_final,
+            tRS_sFinalAcc,
+            tTR_sSFA,
+            tTR_sSFB,
+        )
+
+    def epilog_smem_acc_load_and_partition(self, tiled_copy_t2r, tidx, sFinalAcc):
+        """S2R load of the final accumulator from SMEM (sFinalAcc). Reuses the T2R copy's
+        thread-value layout with a universal f32 copy atom. Returns the tiled copy and the
+        partitioned SMEM source; register targets are retiled at the load site."""
+        copy_atom_s2r = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.acc_dtype)
+        tiled_copy_s2r = cute.make_tiled_copy_D(copy_atom_s2r, tiled_copy_t2r)
+        # (S2R, S2R_M, S2R_N, SUBTILE * STAGE)
+        tSR_sFinalAcc = tiled_copy_s2r.get_slice(tidx).partition_D(sFinalAcc)
+        return tiled_copy_s2r, tSR_sFinalAcc
+
+    def epilog_smem_copy_and_partition_load(
+        self,
+        tiled_copy_t2r: cute.TiledCopy,
+        tTR_rC: cute.Tensor,
+        tTR_rC1: cute.Tensor,
+        tidx: cutlass.Int32,
+        sC: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for shared memory load, then use it to partition register array (destination) and shared memory (source).
+
+        :param tiled_copy_t2r: The tiled copy operation for tmem to register copy(t2r)
+        :type tiled_copy_t2r: cute.TiledCopy
+        :param tTR_rC: The partitioned accumulator tensor
+        :type tTR_rC: cute.Tensor
+        :param tidx: The thread index in epilogue warp groups
+        :type tidx: cutlass.Int32
+        :param sC: The shared memory tensor to be copied and partitioned
+        :type sC: cute.Tensor
+
+        :return: A tuple containing (tiled_copy_s2r, tSR_rC, tSR_sC) where:
+            - tiled_copy_s2r: The tiled copy operation for smem to register copy(s2r)
+            - tSR_rC: The partitioned tensor C (register destination)
+            - tSR_sC: The partitioned tensor C (smem source)
+        :rtype: Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]
+        """
+        copy_atom_s2r = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.c_dtype)
+        tiled_copy_s2r = cute.make_tiled_copy_D(copy_atom_s2r, tiled_copy_t2r)
+        # (S2R, S2R_M, S2R_N, PIPE_C)
+        thr_copy_s2r = tiled_copy_s2r.get_slice(tidx)
+        tSR_sC = thr_copy_s2r.partition_D(sC)
+        # (S2R, S2R_M, S2R_N)
+        tSR_rC = tiled_copy_s2r.retile(tTR_rC)
+        tSR_rC1 = tiled_copy_s2r.retile(tTR_rC1)
+        return tiled_copy_s2r, tSR_rC, tSR_rC1, tSR_sC
+
+    def epilog_smem_copy_and_partition_store(
+        self,
+        tiled_copy_t2r: cute.TiledCopy,
+        tTR_rD1: cute.Tensor,
+        tTR_rD2: cute.Tensor,
+        tidx: cutlass.Int32,
+        sD: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for shared memory store, then use it to partition register array (source) and shared memory (destination).
+
+        :param tiled_copy_t2r: The tiled copy operation for tmem to register copy(t2r)
+        :type tiled_copy_t2r: cute.TiledCopy
+        :param tTR_rD1: The partitioned accumulator tensor
+        :type tTR_rD1: cute.Tensor
+        :param tTR_rD2: The partitioned accumulator tensor
+        :type tTR_rD2: cute.Tensor
+        :param tidx: The thread index in epilogue warp groups
+        :type tidx: cutlass.Int32
+        :param sD: The shared memory tensor to be copied and partitioned
+        :type sD: cute.Tensor
+
+        :return: A tuple containing (tiled_copy_r2s, tRS_rD, tRS_sD) where:
+            - tiled_copy_r2s: The tiled copy operation for register to smem copy(r2s)
+            - tRS_rD: The partitioned tensor D (register source)
+            - tRS_sD: The partitioned tensor D (smem destination)
+        :rtype: Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]
+        """
+        copy_atom_r2s = sm100_utils.get_smem_store_op(self.d_layout, self.d_dtype, self.acc_dtype, tiled_copy_t2r)
+        tiled_copy_r2s = cute.make_tiled_copy_D(copy_atom_r2s, tiled_copy_t2r)
+        # (R2S, R2S_M, R2S_N, PIPE_D)
+        thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+        tRS_sD = None
+        if cutlass.const_expr(sD is not None):
+            tRS_sD = thr_copy_r2s.partition_D(sD)
+        # (R2S, R2S_M, R2S_N)
+        tRS_rD1 = tiled_copy_r2s.retile(tTR_rD1)
+        tRS_rD2 = tiled_copy_r2s.retile(tTR_rD2)
+        return tiled_copy_r2s, tRS_rD1, tRS_rD2, tRS_sD
+
+    def epilog_gmem_copy_and_partition(
+        self,
+        tidx: cutlass.Int32,
+        atom: Union[cute.CopyAtom, cute.TiledCopy],
+        gD_mnl: cute.Tensor,
+        epi_tile: cute.Tile,
+        sD: cute.Tensor,
+    ) -> Tuple[cute.CopyAtom, cute.Tensor, cute.Tensor]:
+        """Make tiledCopy for global memory store, then use it to:
+        - partition register array (source) and global memory (destination) for none TMA store version;
+        - partition shared memory (source) and global memory (destination) for TMA store version.
+
+        :param tidx: The thread index in epilogue warp groups
+        :type tidx: cutlass.Int32
+        :param atom: The copy_atom_c to be used for TMA store version, or tiled_copy_t2r for none TMA store version
+        :type atom: cute.CopyAtom or cute.TiledCopy
+        :param gD_mnl: The global tensor D
+        :type gD_mnl: cute.Tensor
+        :param epi_tile: The epilogue tiler
+        :type epi_tile: cute.Tile
+        :param sD: The shared memory tensor to be copied and partitioned
+        :type sD: cute.Tensor
+
+        :return: A tuple containing :
+            - For TMA store: (tma_atom_d, bSG_sD, bSG_gD) where:
+                - tma_atom_d: The TMA copy atom
+                - bSG_sD: The partitioned shared memory tensor D
+                - bSG_gD: The partitioned global tensor D
+        :rtype: Tuple[cute.CopyAtom, cute.Tensor, cute.Tensor]
+        """
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, loopM, loopN, loopL)
+        gD_epi = cute.flat_divide(gD_mnl[((None, None), 0, 0, None, None, None)], epi_tile)
+        tma_atom_d = atom
+        sD_for_tma_partition = cute.group_modes(sD, 0, 2)
+        gD_for_tma_partition = cute.group_modes(gD_epi, 0, 2)
+        # ((ATOM_V, REST_V), EPI_M, EPI_N)
+        # ((ATOM_V, REST_V), EPI_M, EPI_N, loopM, loopN, loopL)
+        bSG_sD, bSG_gD = cpasync.tma_partition(
+            tma_atom_d,
+            0,
+            cute.make_layout(1),
+            sD_for_tma_partition,
+            gD_for_tma_partition,
+        )
+        return bSG_sD, bSG_gD
+
+    @staticmethod
+    def _compute_stages(
+        tiled_mma: cute.TiledMma,
+        mma_tiler_mnk: Tuple[int, int, int],
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
+        epi_tile: cute.Tile,
+        c_dtype: Type[cutlass.Numeric],
+        c_layout: utils.LayoutEnum,
+        d_dtype: Type[cutlass.Numeric],
+        d_layout: utils.LayoutEnum,
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        num_smem_capacity: int,
+        occupancy: int,
+        store_d_directly: bool,
+        generate_dbias: bool = False,
+        enable_breuse: bool = False,
+        acc_dtype: Type[cutlass.Numeric] = None,
+        sf2_dtype: Type[cutlass.Numeric] = None,
+        sgm: int = 1,
+        sgn: int = 256,
+        sgk: int = 256,
+        row_dsmem: bool = False,
+    ) -> Tuple[int, int, int, int, int, int]:
+        """Computes the number of stages for A/B/D operands based on heuristics.
+
+        :param tiled_mma: The tiled MMA object defining the core computation.
+        :type tiled_mma: cute.TiledMma
+        :param mma_tiler_mnk: The shape (M, N, K) of the MMA tiler.
+        :type mma_tiler_mnk: tuple[int, int, int]
+        :param a_dtype: Data type of operand A.
+        :type a_dtype: type[cutlass.Numeric]
+        :param b_dtype: Data type of operand B.
+        :type b_dtype: type[cutlass.Numeric]
+        :param epi_tile: The epilogue tile shape.
+        :type epi_tile: cute.Tile
+        :param c_dtype: Data type of operand C (output).
+        :type c_dtype: type[cutlass.Numeric]
+        :param d_layout: Layout of operand D.
+        :type d_layout: utils.LayoutEnum
+        :param sf_dtype: Data type of scale factor.
+        :type sf_dtype: type[cutlass.Numeric]
+        :param sf_vec_size: Vector size of scale factor.
+        :type sf_vec_size: int
+        :param num_smem_capacity: Total available shared memory capacity in bytes.
+        :type num_smem_capacity: int
+        :param occupancy: Target number of CTAs per SM (occupancy).
+        :type occupancy: int
+
+        :return: A tuple containing the computed number of stages for:
+                 (ACC stages, A/B operand stages, C stages, D stages, tile-info stages, epi stages)
+        :rtype: tuple[int, int, int, int, int, int]
+        """
+        # Default ACC stages
+        num_acc_stage = 1 if (mma_tiler_mnk[1] == 256 or (enable_breuse and mma_tiler_mnk[1] == 192)) else 2
+        # Second-level design: the acc-update warpgroup consumes one partial per k-tile, so
+        # deepen the acc pipeline for the small-N (non-breuse) tile to keep MMA fed.
+        num_acc_stage = 3 if (mma_tiler_mnk[1] == 128 and not enable_breuse) else num_acc_stage
+
+        # Default C/D stages
+        num_c_stage = 4 if a_dtype.width == 8 else (4 if store_d_directly else 2)
+        num_d_stage = 2 if a_dtype.width == 8 else (0 if store_d_directly else 2)
+
+        # Default Tile info stages
+        num_tile_stage = 2
+
+        # Calculate smem layout and size for one stage of A, B, and D
+        a_smem_layout_stage_one = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            mma_tiler_mnk,
+            a_dtype,
+            1,  # a tmp 1 stage is provided
+        )
+        b_smem_layout_staged_one = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            mma_tiler_mnk,
+            b_dtype,
+            1,  # a tmp 1 stage is provided
+        )
+
+        sfa_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            mma_tiler_mnk,
+            sf_vec_size,
+            1,  # a tmp 1 stage is provided
+        )
+
+        sfb_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            mma_tiler_mnk,
+            sf_vec_size,
+            1,  # a tmp 1 stage is provided
+        )
+
+        c_smem_layout_staged_one = sm100_utils.make_smem_layout_epi(
+            c_dtype,
+            c_layout,
+            epi_tile,
+            1,
+        )
+
+        d_smem_layout_staged_one = sm100_utils.make_smem_layout_epi(
+            d_dtype,
+            d_layout,
+            epi_tile,
+            1,
+        )
+
+        # Compute second level scale factor layout (one stage): sfa2/sfb2 are
+        # staged alongside AB. The M extent is the per-CTA tile (the 2-CTA MMA
+        # atom splits mma_tiler M across the CTA pair).
+        cta_m_sf = mma_tiler_mnk[0] // cute.size(tiled_mma.thr_id.shape)
+        if sgm < cta_m_sf:
+            size_m = sgm
+        else:
+            size_m = cta_m_sf
+
+        if sgn < mma_tiler_mnk[1]:
+            size_n = sgn
+        else:
+            size_n = mma_tiler_mnk[1]
+
+        if sgk < mma_tiler_mnk[2]:
+            size_k = sgk
+        else:
+            size_k = mma_tiler_mnk[2]
+
+        scale_m_per_tile = cta_m_sf // size_m
+        scale_n_per_tile = mma_tiler_mnk[1] // size_n
+        scale_k_per_tile = mma_tiler_mnk[2] // size_k
+
+        sfa2_smem_layout_staged_one = cute.make_layout(
+            (
+                (size_m, scale_m_per_tile),
+                (size_k, scale_k_per_tile),
+                1,
+            ),
+            stride=(
+                (0, scale_k_per_tile),
+                (0, 1),
+                scale_k_per_tile * scale_m_per_tile,
+            ),
+        )
+        sfb2_smem_layout_staged_one = cute.make_layout(
+            (
+                (size_n, scale_n_per_tile),
+                (size_k, scale_k_per_tile),
+                1,
+            ),
+            stride=(
+                (0, scale_k_per_tile),
+                (0, 1),
+                scale_k_per_tile * scale_n_per_tile,
+            ),
+        )
+
+        ab_bytes_per_stage = (
+            cute.size_in_bytes(a_dtype, a_smem_layout_stage_one)
+            + cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfa_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
+            + cute.size_in_bytes(sf2_dtype, sfa2_smem_layout_staged_one)
+            + cute.size_in_bytes(sf2_dtype, sfb2_smem_layout_staged_one)
+        )
+
+        # Mbar bytes
+        mbar_helpers_bytes = 1024
+        # Sinfo bytes
+        sinfo_bytes = 4 * 4 * num_tile_stage
+        # C/D bytes
+        c_bytes_per_stage = cute.size_in_bytes(c_dtype, c_smem_layout_staged_one)
+        c_bytes = c_bytes_per_stage * num_c_stage
+        d_bytes_per_stage = cute.size_in_bytes(d_dtype, d_smem_layout_staged_one)
+        d_bytes = d_bytes_per_stage * num_d_stage
+        if d_dtype == cutlass.Float8E5M2 or d_dtype == cutlass.Float8E4M3FN:
+            d_bytes = d_bytes * 2
+        # AMAX bytes
+        amax_bytes = get_amax_smem_size() if d_dtype == cutlass.BFloat16 else 0
+        # dBias transpose buffer: (128, 64) column-major FP32 = 32 KB
+        dbias_bytes = 128 * 64 * cute.size_in_bytes(cutlass.Float32, cute.make_layout((1,))) if generate_dbias else 0
+        # Pipeline stages for epi_pipeline (accumulator-update -> epilogue handoff).
+        num_epi_stage = 1
+
+        # Full-CTA-tile final accumulator buffer in SMEM (replaces the TMEM final region).
+        # The stage mode holds subtile_cnt full-tile slots per epi stage, so the
+        # buffer scales with num_epi_stage (double-buffered when num_epi_stage == 2).
+        cta_m = mma_tiler_mnk[0] // cute.size(tiled_mma.thr_id.shape)
+        cta_n = mma_tiler_mnk[1]
+        subtile_cnt = (cta_m // cute.size(epi_tile[0])) * (cta_n // cute.size(epi_tile[1]))
+        final_acc_smem_layout_one = sm100_utils.make_smem_layout_epi(
+            acc_dtype,
+            d_layout,
+            epi_tile,
+            subtile_cnt * num_epi_stage,
+        )
+        final_acc_bytes = cute.size_in_bytes(acc_dtype, final_acc_smem_layout_one)
+
+        # Epilogue bytes
+        # DSMEM rowwise-sfd2 reduction buffer: 2 parity slots x (cta_m gate +
+        # cta_m up) f32 row descales, counted BEFORE the greedy num_ab_stage
+        # computation below so it never overflows smem.
+        cta_m_rows = mma_tiler_mnk[0] // cute.size(tiled_mma.thr_id.shape)
+        row_dsmem_bytes = 2 * (2 * cta_m_rows) * 4 if row_dsmem else 0
+
+        epi_bytes = c_bytes + d_bytes + amax_bytes + dbias_bytes + final_acc_bytes + row_dsmem_bytes
+
+        # Calculate A/B stages:
+        # Start with total smem per CTA (capacity / occupancy)
+        # Subtract reserved bytes (mbar, epi, sinfo, sfa2, sfb2)
+        # Divide remaining by bytes needed per A/B stage
+        num_ab_stage = (num_smem_capacity // occupancy - (mbar_helpers_bytes + epi_bytes + sinfo_bytes)) // ab_bytes_per_stage
+        assert num_ab_stage >= 1, (
+            f"SMEM overflow: full-tile sFinalAcc ({final_acc_bytes} B) leaves no room for " f"AB stages (mma_tiler={mma_tiler_mnk}); reduce mma_tiler_mn"
+        )
+
+        total_bytes = occupancy * (ab_bytes_per_stage * num_ab_stage + epi_bytes + sinfo_bytes + mbar_helpers_bytes)
+        return num_acc_stage, num_ab_stage, num_c_stage, num_d_stage, num_tile_stage, num_epi_stage

--- a/python/cudnn/gemm/cutedsl/grouped/moe_kernel_helpers.py
+++ b/python/cudnn/gemm/cutedsl/grouped/moe_kernel_helpers.py
@@ -613,19 +613,24 @@ def is_valid_mma_tiler_and_cluster_shape(
     cluster_shape_mn: Tuple[int, int],
     m_aligned: int,
     fix_pad_size: int = FIX_PAD_SIZE,
+    allowed_mma_tiler_n: Tuple[int, ...] = (256,),
 ) -> bool:
     """
     Check if the MMA tiler and cluster shape are valid.
 
     :param fix_pad_size: The fixed pad size used by the kernel (default: FIX_PAD_SIZE).
+    :param allowed_mma_tiler_n: Accepted MMA tile N extents. The default (256,)
+        matches the fused GLU kernels (even iterations with Epi Tile N 64 for
+        swiGeLU fusion); kernels without that constraint (e.g. the unfused
+        subchannel-scaled GEMM, whose default tile is (256, 128)) opt in to
+        additional extents explicitly.
     :return: True if valid, False otherwise
     """
     is_valid = True
 
     if not ((not use_2cta_instrs and mma_tiler_mn[0] in [128]) or (use_2cta_instrs and mma_tiler_mn[0] in [256])):
         is_valid = False
-    # Needs to have even iterations with Epi Tile N 64 for swiGeLU fusion
-    if mma_tiler_mn[1] not in [256]:
+    if mma_tiler_mn[1] not in allowed_mma_tiler_n:
         is_valid = False
     if cluster_shape_mn[0] % (2 if use_2cta_instrs else 1) != 0:
         is_valid = False
@@ -701,11 +706,15 @@ def can_implement(
     cd_major: str,
     m_aligned: int,
     fix_pad_size: int = FIX_PAD_SIZE,
+    allowed_mma_tiler_n: Tuple[int, ...] = (256,),
 ) -> bool:
     """
     Check if the grouped GEMM can be implemented with the given parameters.
 
     :param fix_pad_size: The fixed pad size used by the kernel (default: FIX_PAD_SIZE).
+    :param allowed_mma_tiler_n: Accepted MMA tile N extents (see
+        ``is_valid_mma_tiler_and_cluster_shape``); the default preserves the
+        historical (256,)-only behavior for existing callers.
     :return: True if implementable, False otherwise
     """
     result = True
@@ -719,7 +728,7 @@ def can_implement(
     if not is_valid_layouts(ab_dtype, d_dtype, a_major, b_major, cd_major):
         result = False
 
-    if not is_valid_mma_tiler_and_cluster_shape(use_2cta_instrs, mma_tiler_mn, cluster_shape_mn, m_aligned, fix_pad_size):
+    if not is_valid_mma_tiler_and_cluster_shape(use_2cta_instrs, mma_tiler_mn, cluster_shape_mn, m_aligned, fix_pad_size, allowed_mma_tiler_n):
         result = False
 
     if not is_valid_tensor_alignment(m, n, k, l, ab_dtype, d_dtype, a_major, b_major, cd_major):

--- a/python/cudnn/gemm/cutedsl/grouped/moe_kernel_helpers.py
+++ b/python/cudnn/gemm/cutedsl/grouped/moe_kernel_helpers.py
@@ -1216,6 +1216,76 @@ def compute_stages_wgrad(
     return num_acc_stage, num_ab_stage, num_c_stage
 
 
+def compute_stages_wgrad_2nd_level(
+    tiled_mma: cute.TiledMma,
+    mma_tiler_mnk: Tuple[int, int, int],
+    a_dtype: Type[cutlass.Numeric],
+    b_dtype: Type[cutlass.Numeric],
+    epi_tile: cute.Tile,
+    c_dtype: Type[cutlass.Numeric],
+    c_layout: utils.LayoutEnum,
+    sf_dtype: Type[cutlass.Numeric],
+    sf_vec_size: int,
+    num_smem_capacity: int,
+    occupancy: int,
+    acc_dtype: Type[cutlass.Numeric],
+    sf2_dtype: Type[cutlass.Numeric],
+    sgk: int,
+) -> Tuple[int, int, int, int]:
+    """Pipeline stages for the wgrad kernel WITH the K-grouped second-level A
+    scale (SFA2, sgm = 1 — one f32 per M row per sgk-token K group).
+
+    Vs compute_stages_wgrad: each AB stage also carries the SFA2 slice
+    (mma_tiler_m f32), and a fixed full-CTA-tile f32 sFinalAcc buffer holds
+    the running accumulator between the acc-update warps and the epilogue.
+    num_acc_stage counts TMEM partial-accumulator stages: 3 at N=128, 1 at
+    N=256 (acc + SF TMEM columns must fit in 512). N=256 tilers land at 1 AB
+    stage — correct but slow."""
+    num_acc_stage = 1 if mma_tiler_mnk[1] == 256 else 3
+    num_c_stage = 2
+    num_tile_stage = 2
+    num_epi_stage = 1
+
+    a_smem_layout_stage_one = sm100_utils.make_smem_layout_a(tiled_mma, mma_tiler_mnk, a_dtype, 1)
+    b_smem_layout_staged_one = sm100_utils.make_smem_layout_b(tiled_mma, mma_tiler_mnk, b_dtype, 1)
+    sfa_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfa(tiled_mma, mma_tiler_mnk, sf_vec_size, 1)
+    sfb_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfb(tiled_mma, mma_tiler_mnk, sf_vec_size, 1)
+    c_smem_layout_staged_one = sm100_utils.make_smem_layout_epi(c_dtype, c_layout, epi_tile, 1)
+
+    # SFA2 slice per AB stage: sgm = 1 → one f32 per mma-tile M row per
+    # CTA-tile-clamped K group (the group axis lies on K).
+    size_k = min(sgk, mma_tiler_mnk[2])
+    scale_m_per_tile = mma_tiler_mnk[0]
+    scale_k_per_tile = mma_tiler_mnk[2] // size_k
+    sfa2_bytes_per_stage = scale_m_per_tile * scale_k_per_tile * (sf2_dtype.width // 8)
+
+    ab_bytes_per_stage = (
+        cute.size_in_bytes(a_dtype, a_smem_layout_stage_one)
+        + cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
+        + cute.size_in_bytes(sf_dtype, sfa_smem_layout_staged_one)
+        + cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
+        + sfa2_bytes_per_stage
+    )
+    mbar_helpers_bytes = 1024
+    sinfo_bytes = 4 * 4 * num_tile_stage
+    c_bytes_per_stage = cute.size_in_bytes(c_dtype, c_smem_layout_staged_one)
+    c_bytes = c_bytes_per_stage * num_c_stage
+
+    # Full-CTA-tile f32 final accumulator (subtile_cnt epi slots per epi stage)
+    cta_m = mma_tiler_mnk[0] // cute.size(tiled_mma.thr_id.shape)
+    cta_n = mma_tiler_mnk[1]
+    subtile_cnt = (cta_m // cute.size(epi_tile[0])) * (cta_n // cute.size(epi_tile[1]))
+    final_acc_smem_layout_one = sm100_utils.make_smem_layout_epi(acc_dtype, c_layout, epi_tile, subtile_cnt * num_epi_stage)
+    final_acc_bytes = cute.size_in_bytes(acc_dtype, final_acc_smem_layout_one)
+
+    num_ab_stage = (num_smem_capacity // occupancy - (mbar_helpers_bytes + c_bytes + final_acc_bytes + sinfo_bytes)) // ab_bytes_per_stage
+    assert num_ab_stage >= 1, (
+        f"SMEM overflow: full-tile sFinalAcc ({final_acc_bytes} B) leaves no " f"room for AB stages (mma_tiler={mma_tiler_mnk}); reduce mma_tiler_mn"
+    )
+
+    return num_acc_stage, num_ab_stage, num_c_stage, num_epi_stage
+
+
 def compute_stages_wgrad_bf16(
     tiled_mma: cute.TiledMma,
     mma_tiler_mnk: Tuple[int, int, int],

--- a/python/cudnn/gemm/cutedsl/grouped/moe_kernel_helpers.py
+++ b/python/cudnn/gemm/cutedsl/grouped/moe_kernel_helpers.py
@@ -453,6 +453,9 @@ def get_dtype_max(dtype: Type[cutlass.Numeric]) -> float:
         return 6.0
     if dtype == cutlass.Float8E4M3FN:
         return 448.0
+    # Rubin-only e5m3 scale factors (absent from older cutlass-dsl wheels).
+    if getattr(cutlass, "FloatNV8E5M3FNU", None) is not None and dtype == cutlass.FloatNV8E5M3FNU:
+        return 61440.0
     raise ValueError(f"unsupported quantized dtype {dtype}")
 
 

--- a/python/cudnn/gemm/cutedsl/grouped/moe_kernel_helpers.py
+++ b/python/cudnn/gemm/cutedsl/grouped/moe_kernel_helpers.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from typing import Type, Tuple, Union
 
+import inspect as _inspect
+
 import cutlass
 import cutlass.cute as cute
 import cutlass.cute.testing as testing
@@ -285,6 +287,173 @@ def atomic_add_float32(
     )
 
     return Float32(llvm.bitcast(T.f32(), old_value, loc=loc, ip=ip))
+
+
+def red_smem_cluster_max_f32(
+    ptr,
+    value: Float32,
+    cta_rank_in_cluster,
+    *,
+    loc=None,
+    ip=None,
+) -> None:
+    """Relaxed cluster-scope FP32 max-reduction into a cluster CTA's SMEM.
+
+    Bit-pattern u32 max on the DSMEM address obtained via mapa — valid for
+    non-negative floats only (the same IEEE-ordering trick as
+    atomic_max_float32 above). `ptr` is the LOCAL smem address of the slot;
+    `cta_rank_in_cluster` selects the target CTA (pass the caller's own rank
+    to reduce into its own buffer through the same path). The reduction is
+    RELAXED: producers must publish with a cluster-scope release fence +
+    mbarrier arrive, and readers must acquire (fence.acq_rel.cluster after
+    the mbarrier wait) before trusting the slot.
+    """
+    value_int = llvm.bitcast(T.i32(), value.ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
+    smem_addr = llvm.ptrtoint(T.i32(), ptr.llvm_ptr, loc=loc, ip=ip)
+    llvm.inline_asm(
+        res=None,
+        operands_=[
+            smem_addr,
+            value_int,
+            Int32(cta_rank_in_cluster).ir_value(loc=loc, ip=ip),
+        ],
+        asm_string="""{{
+            .reg .u32 remote_addr;
+            mapa.shared::cluster.u32 remote_addr, $0, $2;
+            red.relaxed.cluster.shared::cluster.max.u32 [remote_addr], $1;
+        }}""",
+        constraints="r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+# Remote mbarrier arrival with cluster-scoped ordering (DSMEM handoffs).
+# Some DSL wheels expose an explicit ``scope=`` on ``mbarrier_arrive``
+# (default CTA — DSMEM data handoffs must request CLUSTER for the cross-CTA
+# memory-model ordering); others lower via ``mbarrier_txn`` and derive the
+# cluster space solely from ``peer_cta_rank_in_cluster`` being set. Detect by
+# feature (does ``scope`` survive in the signature), not by version.
+if "scope" in _inspect.signature(cute.arch.mbarrier_arrive).parameters:
+
+    def mbarrier_arrive_cluster(mbar_ptr, peer_cta_rank_in_cluster, *, loc=None, ip=None):
+        """Remote mbarrier arrival with cluster-scoped ordering (DSMEM handoff)."""
+        cute.arch.mbarrier_arrive(
+            mbar_ptr,
+            peer_cta_rank_in_cluster=peer_cta_rank_in_cluster,
+            scope=nvvm.MemScopeKind.CLUSTER,
+            loc=loc,
+            ip=ip,
+        )
+
+else:
+
+    def mbarrier_arrive_cluster(mbar_ptr, peer_cta_rank_in_cluster, *, loc=None, ip=None):
+        """Remote mbarrier arrival with cluster-scoped ordering (DSMEM handoff)."""
+        cute.arch.mbarrier_arrive(
+            mbar_ptr,
+            peer_cta_rank_in_cluster=peer_cta_rank_in_cluster,
+            loc=loc,
+            ip=ip,
+        )
+
+
+def atomic_add_i32_gmem(
+    ptr,
+    value: Int32,
+    *,
+    loc=None,
+    ip=None,
+) -> Int32:
+    """Atomic i32 addition in global memory; returns the pre-add value."""
+    old_value = nvvm.atomicrmw(
+        op=AtomicOpKind.ADD,
+        ptr=ptr,
+        a=value.ir_value(loc=loc, ip=ip),
+        loc=loc,
+        ip=ip,
+    )
+    return Int32(old_value)
+
+
+def load_float32_volatile(
+    ptr,
+    *,
+    loc=None,
+    ip=None,
+) -> Float32:
+    """Volatile FP32 load from global memory.
+
+    Reads back a value produced by gmem atomic reductions (e.g. the sfd2
+    atomic-max): red/atom results are reduced in L2, and a volatile load
+    guarantees the read reaches L2 instead of being served from a stale L1
+    line or being hoisted/cached by the compiler."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [ptr],
+            "ld.volatile.global.f32 $0, [$1];",
+            "=f,l",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+def load_acquire_i32_gpu(
+    ptr,
+    *,
+    loc=None,
+    ip=None,
+) -> Int32:
+    """GPU-scope acquire load of an i32 from global memory.
+
+    Pairs with a release-ordered atomic (fence.acq_rel.gpu + atom.add) on the
+    writer side: once this load observes the writer's counter update, every
+    gmem write the writer made before its release fence is visible to loads
+    that follow this one."""
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [ptr],
+            "ld.acquire.gpu.global.u32 $0, [$1];",
+            "=r,l",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def nanosleep(*, sleep_time: int = 1000, loc=None, ip=None) -> None:
+    """nanosleep.u32 backoff (the current DSL builds do not expose
+    cute.arch.nanosleep). Used by the sfd2 cross-tile arrival spin-loop of the
+    subchannel-scaled dSwiGLU kernel."""
+    llvm.inline_asm(
+        None,
+        [Int32(sleep_time).ir_value(loc=loc, ip=ip)],
+        "nanosleep.u32 $0;",
+        "r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+def get_dtype_max(dtype: Type[cutlass.Numeric]) -> float:
+    """Largest finite magnitude of a narrow quantized element type (the
+    reciprocal of get_dtype_rcp_limits). Used to build the SFD2 second-level
+    divisor = max(data dtype) * max(scale-factor dtype)."""
+    if dtype == cutlass.Float4E2M1FN:
+        return 6.0
+    if dtype == cutlass.Float8E4M3FN:
+        return 448.0
+    raise ValueError(f"unsupported quantized dtype {dtype}")
 
 
 def cvt_f32x4_to_f8x4_pack_i32(fp32x4, fp8_type, loc=None, ip=None):
@@ -614,11 +783,16 @@ def is_valid_mma_tiler_and_cluster_shape(
     m_aligned: int,
     fix_pad_size: int = FIX_PAD_SIZE,
     allowed_mma_tiler_n: Tuple[int, ...] = (256,),
+    allowed_cluster_tiler_m: Tuple[int, ...] = (128, 256),
 ) -> bool:
     """
     Check if the MMA tiler and cluster shape are valid.
 
     :param fix_pad_size: The fixed pad size used by the kernel (default: FIX_PAD_SIZE).
+    :param allowed_cluster_tiler_m: Accepted cluster M tile extents (the
+        cluster's row span sharing one multicast B load). Callers opting into
+        wider tiles (e.g. 512 with cluster (4, 1)) must themselves gate
+        per-expert M alignment so a cluster never straddles an expert boundary.
     :param allowed_mma_tiler_n: Accepted MMA tile N extents. The default (256,)
         matches the fused GLU kernels (even iterations with Epi Tile N 64 for
         swiGeLU fusion); kernels without that constraint (e.g. the unfused
@@ -647,7 +821,7 @@ def is_valid_mma_tiler_and_cluster_shape(
         is_valid = False
     cluster_tiler_m = (cluster_shape_mn[0] // (2 if use_2cta_instrs else 1)) * mma_tiler_mn[0]
 
-    if cluster_tiler_m not in [128, 256]:
+    if cluster_tiler_m not in allowed_cluster_tiler_m:
         is_valid = False
 
     if m_aligned % mma_tiler_mn[0] != 0:

--- a/python/cudnn/gemm/cutedsl/grouped/moe_sched_extension.py
+++ b/python/cudnn/gemm/cutedsl/grouped/moe_sched_extension.py
@@ -102,13 +102,14 @@ class DiscreteWeightScaledGemmSchedExtension(MoESchedExtension):
     with GLU and quantization fusion.
 
     Handles domain conversion for: a, b, c, d, d_col, prob, dprob,
-    row_scale, sfa, sfd, sfd_col, sfb.
+    row_scale, sfa, sfa2, sfd, sfd_col, sfb, sfb2.
 
     B and SFB are discrete (per-expert pointer arrays) → use expert-wise
-    TMA descriptors from workspace.
+    TMA descriptors from workspace. SFB2 is a per-expert pointer array
+    loaded via LDGSTS (no TMA descriptor).
 
-    A, C, D, SFA are contiguous across experts (indexed by padded M offset)
-    → use global TMA descriptors with domain_offset.
+    A, C, D, SFA, SFA2 are contiguous across experts (indexed by padded M
+    offset) → use global TMA descriptors with domain_offset.
 
     Domain conversion:
         A:               (total_padded_M, K, 1)     → domain_offset M by token_offset, global desc
@@ -117,9 +118,13 @@ class DiscreteWeightScaledGemmSchedExtension(MoESchedExtension):
                          (total_padded_M, N_dim, 1)  → domain_offset M by token_offset, global desc
         SFA/SFD:         (total_padded_M, K_or_N, 1) → domain_offset M by token_offset,
                                                         tile_atom_to_shape_SF layout, global desc
+        SFA2:            ((sgm, total_padded_M), (sgk, K), 1)
+                                                      → domain_offset scale_m by token_offset, LDGSTS
         SFD_col:         (total_padded_M, N, 1)      → domain_offset M by token_offset,
                                                         BlockScaledBasicChunk layout, global desc
         SFB:             template                     → tile_atom_to_shape_SF layout, expert-wise desc
+        SFB2:            per-expert Int64 pointer array
+                                                      → rebuild ((sgn, scale_n), (sgk, scale_k), 1), LDGSTS
 
     :param tensormap_ctor: DiscreteWeightTensormapConstructor for B/SFB descs
     :param sf_vec_size: Scale factor vector size
@@ -216,6 +221,52 @@ class DiscreteWeightScaledGemmSchedExtension(MoESchedExtension):
             real = cute.make_tensor(real.iterator, cute.make_layout(sfd_col_layout.shape, stride=gmem_tensor_in_moe_view.stride))
             return (real, None)
 
+        elif cutlass.const_expr(tensor_name == "sfa2"):
+            # SFA2: ((sgm, total_padded_M), (sgk, K), 1) subchannel scale,
+            # grouped along M → offset scale_m by token_offset, global desc.
+            # Preserve the pre-built hierarchical layout (do NOT re-derive it).
+            real = cute.domain_offset(((0, token_offset), 0, 0), gmem_tensor_in_moe_view)
+            sgm = shape[0][0]
+            real_sfa2 = rewrite_tensor_shape(real, ((sgm, tokens_i), shape[1], c1))
+            return (real_sfa2, None)
+
+        elif cutlass.const_expr(tensor_name == "sfb2"):
+            # SFB2: discrete — load per-expert pointer from pointer array
+            # (uses LDGSTS, not TMA). gmem_tensor_in_moe_view.iterator points
+            # to an array of Int64 pointers (one per expert).
+
+            # 1. Compute address of the Int64 pointer for this expert
+            #    (each pointer is 8 bytes)
+            base_addr = gmem_tensor_in_moe_view.iterator.toint()
+            expert_ptr_addr = base_addr + expert_idx * cutlass.Int64(8)
+
+            # 2. Create tensor to load the Int64 pointer value
+            expert_ptr_tensor = cute.make_tensor(
+                cute.make_ptr(cutlass.Int64, expert_ptr_addr, cute.AddressSpace.gmem, assumed_align=8),
+                cute.make_layout((1,)),
+            )
+
+            # 3. Load the Int64 pointer value for this expert
+            expert_sfb2_ptr_int64 = expert_ptr_tensor[0]
+
+            # 4. Convert to typed pointer for SF2 data
+            expert_sfb2_ptr = cute.make_ptr(
+                gmem_tensor_in_moe_view.element_type,
+                expert_sfb2_ptr_int64,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            )
+
+            # 5. Extract shape/stride from template and rebuild per-expert tensor
+            sgn = shape[0][0]
+            sgk = shape[1][0]
+            scale_n = shape[0][1]
+            scale_k = shape[1][1]
+            stride = gmem_tensor_in_moe_view.stride
+            new_layout = cute.make_layout(((sgn, scale_n), (sgk, scale_k), c1), stride=stride)
+            real_sfb2 = cute.make_tensor(expert_sfb2_ptr, new_layout)
+            return (real_sfb2, None)  # No TMA descriptor - uses LDGSTS
+
         else:  # "sfb"
             # SFB: discrete — rewrite with tile_atom_to_shape_SF, expert-wise desc
             per_expert_shape = (shape[0], shape[1], c1)
@@ -247,8 +298,12 @@ class ContiguousAndConsistentGroupedGemmSchedExtension(MoESchedExtension):
         C/D/D_col/prob/dprob:
                          (total_padded_M, N, 1)  → domain_offset M by token_offset
         SFA/SFD:         (total_padded_M, K_or_N, 1) → domain_offset M, tile_atom_to_shape_SF
+        SFA2:            ((sgm, total_padded_M), (sgk, K), 1)
+                                                 → domain_offset scale_m by token_offset
         SFB:             (N, K, L)               → domain_offset L by expert_idx,
                                                     tile_atom_to_shape_SF
+        SFB2:            ((sgn, N), (sgk, K), L) → domain_offset L by expert_idx,
+                                                    keep hierarchical layout
         SFD_col:         (total_padded_M, N, 1)  → domain_offset M,
                                                     BlockScaledBasicChunk layout
 
@@ -332,6 +387,27 @@ class ContiguousAndConsistentGroupedGemmSchedExtension(MoESchedExtension):
             )
             real = cute.make_tensor(real.iterator, cute.make_layout(sfd_col_layout.shape, stride=gmem_tensor_in_moe_view.stride))
             return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "sfa2"):
+            # SFA2: ((sgm, total_padded_M), (sgk, K), 1) subchannel scale,
+            # grouped along M → offset scale_m by token_offset, global desc.
+            # Preserve the pre-built hierarchical layout (do NOT re-derive it).
+            real = cute.domain_offset(((0, token_offset), 0, 0), gmem_tensor_in_moe_view)
+            sgm = shape[0][0]
+            real_sfa2 = rewrite_tensor_shape(real, ((sgm, tokens_i), shape[1], c1))
+            return (real_sfa2, None)
+
+        elif cutlass.const_expr(tensor_name == "sfb2"):
+            # SFB2: ((sgn, N), (sgk, K), L) subchannel scale, grouped along L →
+            # offset L by expert_idx, preserve the pre-built hierarchical layout.
+            real = cute.domain_offset((0, 0, expert_idx), gmem_tensor_in_moe_view)
+            stride = gmem_tensor_in_moe_view.stride
+            new_layout = cute.make_layout(
+                (shape[0], shape[1], c1),  # keep original hierarchical shapes
+                stride=stride,
+            )
+            real_sfb2 = cute.make_tensor(real.iterator, new_layout)
+            return (real_sfb2, None)
 
         else:  # "sfb"
             # SFB: (N, K, L) → domain_offset along L by expert_idx,

--- a/python/cudnn/gemm/cutedsl/grouped/moe_sched_extension.py
+++ b/python/cudnn/gemm/cutedsl/grouped/moe_sched_extension.py
@@ -37,7 +37,7 @@ Architecture:
 """
 
 from abc import ABC, abstractmethod
-from typing import Tuple, Union
+from typing import Optional, Tuple, Union
 
 import cutlass
 import cutlass.cute as cute
@@ -439,7 +439,18 @@ class ContiguousAndConsistentGroupedGemmSchedExtension(MoESchedExtension):
 
 
 class WgradScaledGemmSchedExtension(MoESchedExtension):
-    """Scheduler extension for grouped GEMM wgrad (2Dx2D)."""
+    """Scheduler extension for grouped GEMM wgrad (2Dx2D).
+
+    With ``sgk`` set, the extension also serves the K-grouped second-level A
+    scale ``"sfa2"`` of the subchannel-scaled wgrad kernel (SFA2 only — wgrad
+    has no SFB2). In wgrad K is the ragged token axis, so unlike the dgrad
+    family's M-grouped sfa2 the scale group axis lies on K: the SFA2 grid is
+    ((sgm, M), (sgk, tokens_sum/sgk), 1) and an expert's view is a
+    domain_offset by token_offset // sgk whole scale COLUMNS. The host API
+    enforces token_counts[e] % sgk == 0, so every prior expert contributes
+    whole columns and the division is exact. SFA2 is loaded via LDGSTS — no
+    TMA descriptor, no tensormap slot.
+    """
 
     def __init__(
         self,
@@ -447,11 +458,13 @@ class WgradScaledGemmSchedExtension(MoESchedExtension):
         sf_vec_size: int,
         weight_mode: MoEWeightMode,
         input_order: WGradInputOrder = WGradInputOrder.Tensor2D,
+        sgk: Optional[int] = None,
     ):
         super().__init__(tensormap_ctor)
         self.sf_vec_size = sf_vec_size
         self.weight_mode = weight_mode
         self.input_order = input_order
+        self.sgk = sgk
 
     def __extract_mlir_values__(self):
         return extract_mlir_values(self.tensormap_ctor)
@@ -463,6 +476,7 @@ class WgradScaledGemmSchedExtension(MoESchedExtension):
             sf_vec_size=self.sf_vec_size,
             weight_mode=self.weight_mode,
             input_order=self.input_order,
+            sgk=self.sgk,
         )
 
     def update_expert_info(self, offs, expert_idx):
@@ -510,6 +524,19 @@ class WgradScaledGemmSchedExtension(MoESchedExtension):
             real = rewrite_tensor_shape(gmem_tensor_in_moe_view, sf_layout.shape)
             desc = tensormap_ptr_for_copy(self.tensormap_ctor.get_desc_ptr(tensor_name, expert_idx))
             return (real, desc)
+
+        if cutlass.const_expr(tensor_name == "sfa2"):
+            # SFA2: ((sgm, M), (sgk, tokens_sum/sgk), 1) 2nd-level scale,
+            # grouped along K → offset whole scale columns by
+            # token_offset // sgk (exact: all counts are sgk-aligned),
+            # preserving the pre-built hierarchical broadcast layout.
+            scale_col_offset = token_offset // self.sgk
+            scale_cols_i = tokens_i // self.sgk
+            real = cute.domain_offset(((0, 0), (0, scale_col_offset), 0), gmem_tensor_in_moe_view)
+            sgm = shape[0][0]
+            sgk = shape[1][0]
+            real_sfa2 = rewrite_tensor_shape(real, ((sgm, shape[0][1]), (sgk, scale_cols_i), c1))
+            return (real_sfa2, None)  # No TMA descriptor — LDGSTS
 
         raise ValueError(f"WgradScaledGemmSchedExtension: unknown tensor '{tensor_name}'")
 

--- a/python/cudnn/gemm/cutedsl/grouped/moe_sched_extension.py
+++ b/python/cudnn/gemm/cutedsl/grouped/moe_sched_extension.py
@@ -102,7 +102,7 @@ class DiscreteWeightScaledGemmSchedExtension(MoESchedExtension):
     with GLU and quantization fusion.
 
     Handles domain conversion for: a, b, c, d, d_col, prob, dprob,
-    row_scale, sfa, sfa2, sfd, sfd_col, sfb, sfb2.
+    row_scale, sfa, sfa2, sfd, sfd2, sfd_col, sfb, sfb2.
 
     B and SFB are discrete (per-expert pointer arrays) → use expert-wise
     TMA descriptors from workspace. SFB2 is a per-expert pointer array
@@ -229,6 +229,15 @@ class DiscreteWeightScaledGemmSchedExtension(MoESchedExtension):
             sgm = shape[0][0]
             real_sfa2 = rewrite_tensor_shape(real, ((sgm, tokens_i), shape[1], c1))
             return (real_sfa2, None)
+
+        elif cutlass.const_expr(tensor_name == "sfd2"):
+            # SFD2: ((sgm, total_padded_M), (2*sgn, N), 1) subchannel scale
+            # (sgn deinterleaved f-cols = 2*sgn interleaved D-cols per block),
+            # grouped along M → offset scale_m by token_offset, global desc.
+            real = cute.domain_offset(((0, token_offset), 0, 0), gmem_tensor_in_moe_view)
+            sgm = shape[0][0]
+            real_sfd2 = rewrite_tensor_shape(real, ((sgm, tokens_i), shape[1], c1))
+            return (real_sfd2, None)
 
         elif cutlass.const_expr(tensor_name == "sfb2"):
             # SFB2: discrete — load per-expert pointer from pointer array
@@ -396,6 +405,15 @@ class ContiguousAndConsistentGroupedGemmSchedExtension(MoESchedExtension):
             sgm = shape[0][0]
             real_sfa2 = rewrite_tensor_shape(real, ((sgm, tokens_i), shape[1], c1))
             return (real_sfa2, None)
+
+        elif cutlass.const_expr(tensor_name == "sfd2"):
+            # SFD2: ((sgm, total_padded_M), (2*sgn, N), 1) subchannel scale
+            # (sgn deinterleaved f-cols = 2*sgn interleaved D-cols per block),
+            # grouped along M → offset scale_m by token_offset, global desc.
+            real = cute.domain_offset(((0, token_offset), 0, 0), gmem_tensor_in_moe_view)
+            sgm = shape[0][0]
+            real_sfd2 = rewrite_tensor_shape(real, ((sgm, tokens_i), shape[1], c1))
+            return (real_sfd2, None)
 
         elif cutlass.const_expr(tensor_name == "sfb2"):
             # SFB2: ((sgn, N), (sgk, K), L) subchannel scale, grouped along L →

--- a/python/cudnn/gemm/cutedsl/grouped/unfused_subchannel_scaled/__init__.py
+++ b/python/cudnn/gemm/cutedsl/grouped/unfused_subchannel_scaled/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unfused subchannel-scaled (second-level-scaled) grouped GEMM for MoE workloads."""
+
+from .api import (
+    GroupedGemmUnfusedSubchannelScaledSm100,
+    grouped_gemm_unfused_subchannel_scaled_wrapper_sm100,
+)
+
+__all__ = [
+    "GroupedGemmUnfusedSubchannelScaledSm100",
+    "grouped_gemm_unfused_subchannel_scaled_wrapper_sm100",
+]

--- a/python/cudnn/gemm/cutedsl/grouped/unfused_subchannel_scaled/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/unfused_subchannel_scaled/api.py
@@ -1,0 +1,1238 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+API for the Unfused Subchannel-Scaled Grouped GEMM Kernel (SM100+)
+
+Second-level-scaled ("subchannel-scaled") unfused block-scaled grouped GEMM for
+MoE workloads: NVFP4 A/B inputs carry two scale levels -- per-(1, 16) FP8 block
+scale factors (SFA/SFB) plus FP32 second-level scales (SFA2/SFB2) at
+``block2_shape = (sgm, sgn, sgk)`` granularity -- and the BF16 output is
+``D = (second-level-scaled GEMM) * alpha * prob`` (plus ``prob * bias`` when a
+bias is fused). There is no output quantization: this is the unfused GEMM-only
+counterpart of the fused dGLU kernels.
+
+Supports both dense (contiguous) and discrete (per-expert pointer) weight
+modes through ``BlockScaledSubChannelMoEGroupedGemmKernel``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Literal, Optional, Tuple
+
+import cutlass
+import cutlass.cute as cute
+from cuda.bindings import driver as cuda
+from cutlass.cute.runtime import from_dlpack, make_fake_stream
+
+from cudnn.api_base import APIBase, TupleDict, ceil_div, get_device_type, is_power_of_2
+from cudnn.datatypes import _convert_to_cutlass_data_type
+from cudnn.tensor_adapter import (
+    allocate_byte_workspace,
+    canonicalize_unit_dim_strides,
+    cuda_is_available,
+    default_stream,
+    detect_framework,
+    framework_dtype,
+    get_compute_capability,
+    get_data_ptr,
+    get_device,
+)
+
+from .grouped_gemm_unfused_subchannel_scaled import (
+    BlockScaledSubChannelMoEGroupedGemmKernel,
+)
+from ..moe_utils import MoEWeightMode
+from cutlass.cute.nvgpu import OperandMajorMode
+
+_JAX_SF_LAYOUT_ERROR = (
+    "the block scale-factor tensors (sfa/sfb) are MMA-tiled "
+    "(32, 4, m//128, 4, rest_k, l) strided views that are not expressible as JAX arrays "
+    "(a row-major JAX array of that shape has different memory); pass torch tensors"
+)
+
+
+def _get_rubin_kernel():
+    from .moe_blockscaled_grouped_gemm_unfused_subchannel_scaled_rubin import (
+        BlockScaledSubChannelMoEGroupedGemmKernelSm107,
+    )
+
+    return BlockScaledSubChannelMoEGroupedGemmKernelSm107
+
+
+class GroupedGemmUnfusedSubchannelScaledSm100(APIBase):
+    """API for the unfused subchannel-scaled grouped GEMM operation on SM100+ GPUs.
+
+    This kernel performs a second-level-scaled block-scaled grouped GEMM
+    (``D = (sum over sgk-tiles of sfa2 * sfb2 * (A_fp4 @ B_fp4^T)) * alpha * prob``,
+    optionally ``+ prob * bias``) for MoE workloads. Inputs are NVFP4 with FP8
+    first-level scale factors and FP32 second-level (subchannel) scale factors;
+    the output D is BF16. Both dense (contiguous) and discrete (per-expert
+    pointer) weight layouts are supported through
+    ``BlockScaledSubChannelMoEGroupedGemmKernel``.
+
+    Weight mode is auto-detected from the constructor arguments:
+
+    - Dense: provide ``sample_b``, ``sample_sfb``, and ``sample_sfb2``.
+    - Discrete: provide ``num_experts``, ``b_shape``, and ``b_dtype``.
+    """
+
+    def __init__(
+        self,
+        sample_a: torch.Tensor,
+        sample_sfa: torch.Tensor,
+        sample_sfa2: torch.Tensor,
+        sample_padded_offsets: torch.Tensor,
+        sample_alpha: torch.Tensor,
+        sample_prob: torch.Tensor,
+        sample_d: torch.Tensor,
+        # Dense mode (contiguous) -- provide these:
+        sample_b: Optional[torch.Tensor] = None,
+        sample_sfb: Optional[torch.Tensor] = None,
+        sample_sfb2: Optional[torch.Tensor] = None,
+        sample_bias: Optional[torch.Tensor] = None,
+        # Discrete mode -- provide these instead:
+        num_experts: Optional[int] = None,
+        b_shape: Optional[Tuple[int, ...]] = None,
+        b_dtype: Optional[torch.dtype] = None,
+        # Configuration
+        acc_dtype: Optional[torch.dtype] = None,
+        block2_shape: Tuple[int, int, int] = (1, 256, 256),
+        mma_tiler_mn: Tuple[int, int] = (256, 128),
+        cluster_shape_mn: Optional[Tuple[int, int]] = None,
+        sf_vec_size: int = 16,
+        sf_fp8_dtype_override: Optional[Literal["e5m3"]] = None,
+        vector_f32: bool = True,
+        m_aligned: int = 256,
+        b_major: str = "k",
+        use_dynamic_sched: bool = False,
+    ):
+        """Initialize the GroupedGemmUnfusedSubchannelScaledSm100 API.
+
+        :param sample_a: Sample A tensor (valid_m, k, 1), FP4, k-major
+        :param sample_sfa: Sample first-level scale factor A tensor
+            (MMA-tiled (32, 4, valid_m//128, 4, rest_k, 1) view)
+        :param sample_sfa2: Sample second-level scale factor A tensor,
+            shape (ceil(valid_m / sgm), ceil(k / sgk), 1), FP32,
+            stride (1, rows, rows * cols) (rows-contiguous)
+        :param sample_padded_offsets: End offset for each expert after padding, shape (expert_cnt,)
+        :param sample_alpha: Per-group alpha scaling factors, shape (expert_cnt,)
+        :param sample_prob: Per-token probability tensor (valid_m, 1, 1), FP32.
+            Required: the kernel always fuses the prob multiply. Pass ones for
+            a plain GEMM.
+        :param sample_d: Sample D output tensor (valid_m, n, 1), BF16, n-major
+        :param sample_b: (Dense) Sample B tensor (n, k, l), FP4, k-major
+        :param sample_sfb: (Dense) Sample first-level scale factor B tensor
+        :param sample_sfb2: (Dense) Sample second-level scale factor B tensor,
+            shape (ceil(n / sgn), ceil(k / sgk), l), FP32,
+            stride (1, rows, rows * cols)
+        :param sample_bias: Optional bias tensor with shape (n, l), stride (1, n), BF16.
+            The epilogue computes ``d = gemm * alpha + prob * bias`` semantics
+            (prob scales the bias term).
+        :param num_experts: (Discrete) Number of experts
+        :param b_shape: (Discrete) Shape of a single expert B tensor, e.g. (n, k) with logical k
+        :param b_dtype: (Discrete) Data type of B tensors
+        :param acc_dtype: Accumulator data type (must be float32)
+        :param block2_shape: Second-level scale granularity (sgm, sgn, sgk):
+            SFA2 blocks cover (sgm rows x sgk k), SFB2 blocks (sgn cols x sgk k)
+        :param mma_tiler_mn: MMA tiler shape (M, N); (256, 128) or (256, 256)
+        :param cluster_shape_mn: Cluster shape (M, N); default (2, 1)
+        :param sf_vec_size: First-level scale factor vector size (must be 16)
+        :param sf_fp8_dtype_override: Reinterpret the FP8-format block scale factors
+            as E5M3 instead of the E4M3 implied by their storage dtype. Rubin-only;
+            the scale tensors are still supplied as ``torch.float8_e4m3fn`` because
+            torch has no e5m3 dtype -- only the CuTe element type is overridden.
+        :param vector_f32: Use vectorized (packed) f32 arithmetic. The default True
+            is the byte-exact-verified configuration.
+        :param m_aligned: Alignment for group M dimension (must be 256)
+        :param b_major: Major dimension for B tensor (must be "k" for FP4)
+        :param use_dynamic_sched: Enable dynamic tile scheduling for load balancing
+        """
+        framework = detect_framework(sample_a)
+        if framework == "jax":
+            raise ValueError(f"GroupedGemmUnfusedSubchannelScaledSm100 does not support JAX arrays: {_JAX_SF_LAYOUT_ERROR}")
+        if framework != "torch":
+            raise ValueError(f"Unsupported tensor framework '{framework}' for GroupedGemmUnfusedSubchannelScaledSm100; pass torch tensors")
+        if acc_dtype is None:
+            acc_dtype = cutlass.Float32
+        super().__init__()
+        self._framework = framework
+
+        self._warn_experimental_api()
+        self._logger.debug("Entering __init__")
+
+        # ---- Weight mode auto-detection ----
+        if sample_b is not None and num_experts is None:
+            self.weight_mode = MoEWeightMode.DENSE
+            if sample_sfb is None or sample_sfb2 is None:
+                raise ValueError("sample_sfb and sample_sfb2 are required when sample_b is provided (dense mode)")
+        elif num_experts is not None and sample_b is None:
+            self.weight_mode = MoEWeightMode.DISCRETE
+            if b_shape is None or b_dtype is None:
+                raise ValueError("b_shape and b_dtype are required in discrete mode")
+        else:
+            raise ValueError(
+                "Provide either (sample_b, sample_sfb, sample_sfb2) for dense mode " "or (num_experts, b_shape, b_dtype) for discrete mode, but not both."
+            )
+
+        self.a_desc = self._make_tensor_desc(sample_a, name="sample_a", canonical=True)
+        self.d_desc = self._make_tensor_desc(sample_d, name="sample_d", canonical=True)
+        self.sfa_desc = self._make_tensor_desc(sample_sfa, name="sample_sfa", canonical=True)
+        self.sfa2_desc = self._make_tensor_desc(sample_sfa2, name="sample_sfa2", canonical=True)
+        self.padded_offsets_desc = self._make_tensor_desc(sample_padded_offsets, name="sample_padded_offsets", canonical=True)
+        self.alpha_desc = self._make_tensor_desc(sample_alpha, name="sample_alpha", canonical=True)
+        self.prob_desc = self._make_tensor_desc(sample_prob, name="sample_prob", canonical=True)
+        self.bias_desc = self._make_tensor_desc(sample_bias, name="sample_bias", canonical=True)
+
+        if self.weight_mode == MoEWeightMode.DENSE:
+            self.b_desc = self._make_tensor_desc(sample_b, name="sample_b", canonical=True)
+            self.sfb_desc = self._make_tensor_desc(sample_sfb, name="sample_sfb", canonical=True)
+            self.sfb2_desc = self._make_tensor_desc(sample_sfb2, name="sample_sfb2", canonical=True)
+            self.expert_cnt = self.padded_offsets_desc.shape[0]
+        else:
+            self._value_error_if(num_experts == 0, "num_experts must be > 0")
+            self.expert_cnt = num_experts
+            self.b_shape = b_shape
+            self.b_dtype = _convert_to_cutlass_data_type(b_dtype)
+            self._value_error_if(
+                self.padded_offsets_desc.shape[0] != self.expert_cnt,
+                f"padded_offsets length ({self.padded_offsets_desc.shape[0]}) " f"must equal num_experts ({self.expert_cnt})",
+            )
+
+        self.acc_dtype = _convert_to_cutlass_data_type(acc_dtype)
+        self._value_error_if(
+            len(block2_shape) != 3,
+            f"block2_shape must be (sgm, sgn, sgk), got {block2_shape}",
+        )
+        self.block2_shape = tuple(block2_shape)
+        self.sgm, self.sgn, self.sgk = self.block2_shape
+        self.mma_tiler_mn = mma_tiler_mn
+        self.use_2cta_instrs = mma_tiler_mn[0] == 256
+        if cluster_shape_mn is None:
+            self.cluster_shape_mn = (2, 1) if self.use_2cta_instrs else (1, 1)
+        else:
+            self.cluster_shape_mn = cluster_shape_mn
+        self.sf_vec_size = sf_vec_size
+        self.sf_fp8_dtype_override = sf_fp8_dtype_override
+        self.vector_f32 = vector_f32
+        self.m_aligned = m_aligned
+        self.use_dynamic_sched = use_dynamic_sched
+        self.b_major = b_major
+
+        self._interpret_uint8_as_fp4x2 = True
+        self._has_bias = self.bias_desc is not None
+        self._kernel = _get_rubin_kernel() if self._is_rubin_kernel else BlockScaledSubChannelMoEGroupedGemmKernel
+
+        self.num_cluster_overlap_margin = int(os.getenv("CUDNNFE_CLUSTER_OVERLAP_MARGIN", "0"))
+        self._logger.debug(f"setting num_cluster_overlap_margin: {self.num_cluster_overlap_margin}")
+        self._workspace = None
+        self._logger.debug("__init__ completed")
+
+    def check_support(self) -> bool:
+        """Check if the kernel configuration is supported.
+
+        :return: True if supported, raises exception otherwise
+        """
+        self._logger.debug("Entering check_support")
+
+        self._value_error_if(
+            self.prob_desc is None,
+            "sample_prob is required: the kernel always fuses the per-token prob multiply " "(pass a tensor of ones for a plain GEMM)",
+        )
+
+        self._logger.debug("Checking tensor shapes and strides")
+        tensor_m, k, _one = self._tensor_shape(self.a_desc, name="sample_a")
+
+        if self.weight_mode == MoEWeightMode.DENSE:
+            n, _, l = self._tensor_shape(self.b_desc, name="sample_b")
+        else:
+            if len(self.b_shape) == 2:
+                n, b_k = self.b_shape
+            else:
+                n, b_k, _ = self.b_shape
+            self._value_error_if(b_k != k, f"B K dimension ({b_k}) must match A K dimension ({k})")
+            l = self.expert_cnt
+
+        self._check_tensor_shape(self.a_desc, (tensor_m, k, 1), "A")
+        if self.weight_mode == MoEWeightMode.DENSE:
+            self._check_tensor_shape(self.b_desc, (n, k, l), "B")
+        self._check_tensor_shape(self.d_desc, (tensor_m, n, 1), "D")
+
+        rest_k = ceil_div(ceil_div(k, self.sf_vec_size), 4)
+        self._check_tensor_shape(self.sfa_desc, (32, 4, ceil_div(tensor_m, 128), 4, rest_k, 1), "SFA")
+        if self.weight_mode == MoEWeightMode.DENSE:
+            self._check_tensor_shape(self.sfb_desc, (32, 4, ceil_div(n, 128), 4, rest_k, l), "SFB")
+
+        # ---- Second-level (subchannel) scale factors ----
+        self._value_error_if(
+            self.sgm < 1 or self.sgn < 1 or self.sgk < 1,
+            f"block2_shape components must be >= 1, got {self.block2_shape}",
+        )
+        self._value_error_if(
+            k % self.sgk != 0,
+            f"k ({k}) must be divisible by sgk ({self.sgk}): the second-level " "K loop assumes whole sgk-tiles",
+        )
+        self._value_error_if(
+            tensor_m % self.sgm != 0,
+            f"valid_m ({tensor_m}) must be divisible by sgm ({self.sgm})",
+        )
+        sfa2_rows = ceil_div(tensor_m, self.sgm)
+        sf2_cols = ceil_div(k, self.sgk)
+        self._check_tensor_shape(self.sfa2_desc, (sfa2_rows, sf2_cols, 1), "SFA2")
+        # Descriptors canonicalize the strides of extent-1 dims (unobservable by
+        # the kernel), so compare against the canonicalized expected stride.
+        sfa2_shape = (sfa2_rows, sf2_cols, 1)
+        _ = self._check_tensor_stride(
+            self.sfa2_desc,
+            stride=[canonicalize_unit_dim_strides(sfa2_shape, (1, sfa2_rows, sfa2_rows * sf2_cols))],
+            extra_error_msg=f"SFA2 must be rows-contiguous with stride (1, {sfa2_rows}, {sfa2_rows * sf2_cols})",
+        )
+        sfb2_rows = ceil_div(n, self.sgn)
+        if self.weight_mode == MoEWeightMode.DENSE:
+            sfb2_shape = (sfb2_rows, sf2_cols, l)
+            self._check_tensor_shape(self.sfb2_desc, sfb2_shape, "SFB2")
+            _ = self._check_tensor_stride(
+                self.sfb2_desc,
+                stride=[canonicalize_unit_dim_strides(sfb2_shape, (1, sfb2_rows, sfb2_rows * sf2_cols))],
+                extra_error_msg="SFB2 must be rows-contiguous per expert",
+            )
+        else:
+            # Discrete SFB2 per-expert base pointers are declared 16B-aligned in
+            # the sched extension (assumed_align=16). With back-to-back per-expert
+            # f32 (ceil(n/sgn), ceil(k/sgk)) blocks, every base past the first is
+            # misaligned unless the block byte size is a multiple of 16.
+            sfb2_block_bytes = sfb2_rows * sf2_cols * 4
+            self._value_error_if(
+                self.expert_cnt > 1 and sfb2_block_bytes % 16 != 0,
+                f"discrete SFB2 per-expert block ({sfb2_rows} x {sf2_cols} f32 = "
+                f"{sfb2_block_bytes} bytes) must be a multiple of 16 bytes when "
+                f"num_experts > 1 (per-expert bases are assumed 16B-aligned)",
+            )
+
+        self._check_tensor_shape(self.alpha_desc, (self.expert_cnt,), "alpha")
+        self._check_tensor_shape(self.prob_desc, (tensor_m, 1, 1), "prob")
+        self._check_tensor_shape(self.bias_desc, (n, l), "bias")
+        self._check_tensor_shape(self.padded_offsets_desc, (self.expert_cnt,), "padded_offsets")
+
+        _ = self._check_tensor_stride(
+            self.a_desc,
+            stride=[(k, 1, tensor_m * k)],
+            extra_error_msg="A must have k-major layout",
+        )
+        if self.weight_mode == MoEWeightMode.DENSE:
+            _ = self._check_tensor_stride(
+                self.b_desc,
+                stride=[(k, 1, n * k)],
+                extra_error_msg="B must have k-major layout (required for fp4 ab_dtype)",
+            )
+        _ = self._check_tensor_stride(
+            self.d_desc,
+            stride=[(n, 1, tensor_m * n)],
+            extra_error_msg="D must have n-major layout",
+        )
+        _ = self._check_tensor_stride(
+            self.bias_desc,
+            stride=[(1, n)],
+        )
+
+        self._logger.debug("Checking data types")
+        self.ab_dtype = self._check_dtype(
+            self.a_desc,
+            dtype=[
+                cutlass.Float4E2M1FN,
+                cutlass.Uint8,
+            ],
+            name="A/B",
+            extra_error_msg="only NVFP4 (fp4) inputs are supported",
+        )
+        if self.weight_mode == MoEWeightMode.DENSE:
+            self._check_dtype(
+                self.b_desc,
+                dtype=self.ab_dtype,
+                name="B",
+                extra_error_msg="B must have the same dtype as A",
+            )
+        else:
+            self._value_error_if(
+                self.b_dtype != self.ab_dtype,
+                f"b_dtype ({self.b_dtype}) must match A dtype ({self.ab_dtype})",
+            )
+            self._value_error_if(
+                self.b_major != "k",
+                f"b_major must be 'k' for fp4 ab_dtype, got {self.b_major}",
+            )
+        self._check_dtype(
+            self.bias_desc,
+            dtype=cutlass.BFloat16,
+            name="bias",
+            extra_error_msg="bias must be bfloat16",
+        )
+
+        self.sf_dtype = self._check_dtype(
+            self.sfa_desc,
+            dtype=cutlass.Float8E4M3FN,
+            name="SFA/SFB",
+            extra_error_msg="first-level scale factors must be torch.float8_e4m3fn (the NVFP4 recipe)",
+        )
+        if self.weight_mode == MoEWeightMode.DENSE:
+            self._check_dtype(
+                self.sfb_desc,
+                dtype=self.sf_dtype,
+                name="SFB",
+                extra_error_msg="SFB must have the same dtype as SFA",
+            )
+        self._check_dtype(
+            self.sfa2_desc,
+            dtype=cutlass.Float32,
+            name="SFA2",
+            extra_error_msg="second-level scale factors must be float32",
+        )
+        if self.weight_mode == MoEWeightMode.DENSE:
+            self._check_dtype(
+                self.sfb2_desc,
+                dtype=cutlass.Float32,
+                name="SFB2",
+                extra_error_msg="second-level scale factors must be float32",
+            )
+
+        self._value_error_if(
+            self.sf_vec_size != 16,
+            f"sf_vec_size must be 16 (NVFP4), got {self.sf_vec_size}",
+        )
+
+        # e5m3 is the only override currently supported; torch has no e5m3
+        # dtype, so e5m3 scale factors arrive as e4m3 storage and the Rubin
+        # kernel reinterprets the CuTe element type.
+        self._value_error_if(
+            self.sf_fp8_dtype_override not in (None, "e5m3"),
+            f"sf_fp8_dtype_override must be None or 'e5m3', got {self.sf_fp8_dtype_override!r}",
+        )
+        if self.sf_fp8_dtype_override == "e5m3":
+            self._value_error_if(
+                not self._is_rubin_kernel,
+                f"sf_fp8_dtype_override='e5m3' requires Rubin (SM107), got device type {self._device_type!r}",
+            )
+
+        self._check_dtype(
+            self.acc_dtype,
+            dtype=cutlass.Float32,
+            name="Accumulator",
+            extra_error_msg="Accumulator must be float32",
+        )
+        self.d_dtype = self._check_dtype(
+            self.d_desc,
+            dtype=cutlass.BFloat16,
+            name="D",
+            extra_error_msg="D must be bfloat16",
+        )
+        self._check_dtype(
+            self.alpha_desc,
+            dtype=cutlass.Float32,
+            name="alpha",
+        )
+        self._check_dtype(
+            self.prob_desc,
+            dtype=cutlass.Float32,
+            name="prob",
+        )
+        self._check_dtype(
+            self.padded_offsets_desc,
+            dtype=cutlass.Int32,
+            name="padded_offsets",
+        )
+
+        self._logger.debug("Checking MMA tile shape and cluster shape")
+        self._value_error_if(
+            self.mma_tiler_mn not in ((256, 128), (256, 256)),
+            f"mma_tiler_mn must be (256, 128) or (256, 256), got {self.mma_tiler_mn}",
+        )
+        self._value_error_if(
+            self.cluster_shape_mn[0] % (2 if self.use_2cta_instrs else 1) != 0,
+            f"cluster_shape_mn[0] must be divisible by 2 when use_2cta_instrs=True, got {self.cluster_shape_mn[0]}",
+        )
+        self._value_error_if(
+            not (
+                self.cluster_shape_mn[0] * self.cluster_shape_mn[1] <= 16
+                and self.cluster_shape_mn[0] > 0
+                and self.cluster_shape_mn[1] > 0
+                and self.cluster_shape_mn[0] <= 4
+                and self.cluster_shape_mn[1] <= 4
+                and is_power_of_2(self.cluster_shape_mn[0])
+                and is_power_of_2(self.cluster_shape_mn[1])
+            ),
+            f"Invalid cluster shape: expected values to be powers of 2 and cluster_shape_mn[0] * cluster_shape_mn[1] <= 16, got {self.cluster_shape_mn[0]},{self.cluster_shape_mn[1]}",
+        )
+        cluster_tiler_m = (self.cluster_shape_mn[0] // (2 if self.use_2cta_instrs else 1)) * self.mma_tiler_mn[0]
+        self._value_error_if(
+            cluster_tiler_m not in [128, 256],
+            f"Invalid cluster tiler shape: expected cluster_tiler_m in {{128, 256}}, got {cluster_tiler_m}",
+        )
+        self._value_error_if(
+            self.m_aligned % self.mma_tiler_mn[0] != 0,
+            f"Invalid m_aligned: expected m_aligned to be divisible by mma_tiler_mn[0], got {self.m_aligned} % {self.mma_tiler_mn[0]} != 0",
+        )
+        self._value_error_if(
+            self.m_aligned != self._kernel.FIX_PAD_SIZE,
+            f"m_aligned must be {self._kernel.FIX_PAD_SIZE} (FIX_PAD_SIZE), got {self.m_aligned}",
+        )
+        self._value_error_if(
+            n % 64 != 0,
+            f"n must be divisible by 64, got {n}",
+        )
+        self._value_error_if(
+            tensor_m % 256 != 0,
+            f"valid_m must be divisible by 256 (FIX_PAD_SIZE-aligned per-expert groups), got {tensor_m}",
+        )
+
+        self._logger.debug("Checking tensor alignment")
+
+        def check_contigous_16B_alignment(dtype, stride_order, tensor_shape):
+            is_mode0_major = stride_order == (0, 1, 2)
+            major_mode_idx = 0 if is_mode0_major else 1
+            num_major_elements = tensor_shape[major_mode_idx]
+            num_contiguous_elements = 16 * 8 // (_convert_to_cutlass_data_type(dtype, interpret_uint8_as_fp4x2=self._interpret_uint8_as_fp4x2).width)
+            return num_major_elements % num_contiguous_elements == 0
+
+        if self.weight_mode == MoEWeightMode.DENSE:
+            b_stride_order_for_check = self.b_desc.stride_order
+            b_shape_for_check = (n, k, l)
+        else:
+            b_stride_order_for_check = (1, 0, 2)
+            b_shape_for_check = (n, k, 1)
+
+        self._value_error_if(
+            not (
+                check_contigous_16B_alignment(self.ab_dtype, self.a_desc.stride_order, (tensor_m, k, l))
+                and check_contigous_16B_alignment(self.ab_dtype, b_stride_order_for_check, b_shape_for_check)
+                and check_contigous_16B_alignment(self.d_dtype, self.d_desc.stride_order, (tensor_m, n, 1))
+            ),
+            "Invalid tensor alignment: tensors must be 16B aligned",
+        )
+
+        self._value_error_if(
+            self.expert_cnt > 1024,
+            f"expert_cnt must be <= 1024, got {self.expert_cnt}",
+        )
+
+        if not cuda_is_available():
+            raise RuntimeError("CUDA is not available")
+        major, minor = get_compute_capability()
+        compute_capability = major * 10 + minor
+        if compute_capability < 100:
+            raise RuntimeError(f"GroupedGemmUnfusedSubchannelScaled requires SM100+ compute capability, but found SM{compute_capability}")
+
+        self._is_supported = True
+        self._logger.debug("check_support completed successfully")
+        return True
+
+    def compile(self) -> None:
+        """Compile the kernel."""
+        self._logger.debug("Entering compile")
+        self._ensure_support_checked()
+        if self._compiled_kernel is not None:
+            self._logger.debug("Kernel already compiled; skipping recompilation")
+            return
+        if self.a_desc.shape[0] == 0:
+            self._logger.debug("sample valid_m is zero, skipping kernel compilation")
+            return
+
+        kernel_kwargs = dict(
+            sf_vec_size=self.sf_vec_size,
+            sgm=self.sgm,
+            sgn=self.sgn,
+            sgk=self.sgk,
+            acc_dtype=_convert_to_cutlass_data_type(self.acc_dtype),
+            use_2cta_instrs=self.use_2cta_instrs,
+            mma_tiler_mn=self.mma_tiler_mn,
+            cluster_shape_mn=self.cluster_shape_mn,
+            vectorized_f32=self.vector_f32,
+            enable_bias=self._has_bias,
+            expert_cnt=self.expert_cnt,
+            weight_mode=self.weight_mode,
+            use_dynamic_sched=self.use_dynamic_sched,
+            # Only the Rubin kernel accepts sf_fp8_dtype_override, and check_support
+            # rejects "e5m3" unless _is_rubin_kernel -- the same flag that selected
+            # self._kernel. The kernel maps the string to FloatNV8E5M3FNU itself, so
+            # that internal-only type is never named outside the Rubin module.
+            **({"sf_fp8_dtype_override": self.sf_fp8_dtype_override} if self.sf_fp8_dtype_override == "e5m3" else {}),
+        )
+        gemm = self._kernel(**kernel_kwargs)
+
+        hardware_info = cutlass.utils.HardwareInfo()
+        max_active_clusters = hardware_info.get_max_active_clusters(self.cluster_shape_mn[0] * self.cluster_shape_mn[1])
+        max_active_clusters -= self.num_cluster_overlap_margin
+        self._value_error_if(
+            max_active_clusters <= 0,
+            "max_active_clusters must be > 0 after applying overlap margin; reduce CUDNNFE_CLUSTER_OVERLAP_MARGIN",
+        )
+        fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
+
+        workspace_bytes = gemm.get_workspace_bytes()
+        # Internal scratch in the caller's framework allocator; kernels write through its
+        # raw pointer and it is never surfaced as a framework array.
+        self._workspace = allocate_byte_workspace(self._framework, workspace_bytes, self.a_desc.device)
+
+        if self.weight_mode == MoEWeightMode.DENSE:
+            self._compile_dense(gemm, max_active_clusters, fake_stream)
+        else:
+            self._compile_discrete(gemm, max_active_clusters, fake_stream)
+
+        self._logger.debug("Kernel compiled successfully")
+
+    def _make_dynamic_m_fakes(self, valid_m):
+        """Fake tensors for the operands whose leading extent scales with valid_m."""
+        a_cute_fake = self._make_fake_cute_compact_tensor(
+            dtype=self.a_desc.dtype,
+            shape=(valid_m, *self.a_desc.shape[1:]),
+            stride_order=self.a_desc.stride_order,
+            assumed_align=32 if self._is_fp4x2(self.ab_dtype) else 16,
+        )
+        d_cute_fake = self._make_fake_cute_compact_tensor(
+            dtype=self.d_desc.dtype,
+            shape=(valid_m, *self.d_desc.shape[1:]),
+            stride_order=self.d_desc.stride_order,
+        )
+
+        tensor_m_128 = cute.sym_int()
+        stride_tensor_m_128 = cute.sym_int(divisibility=32 * 4 * 4)
+        sfa_shape = list(self.sfa_desc.shape)
+        sfa_shape[2] = tensor_m_128
+        sfa_stride = list(self.sfa_desc.stride)
+        sfa_stride[5] = stride_tensor_m_128
+        sfa_cute_fake = self._make_fake_cute_tensor(
+            dtype=self.sfa_desc.dtype,
+            shape=tuple(sfa_shape),
+            stride=tuple(sfa_stride),
+            assumed_align=16,
+        )
+
+        # SFA2 rows scale with valid_m (rows = valid_m / sgm); the kernel reads
+        # shape[0]/shape[1] and strides off the plain rank-3 tensor and rebuilds
+        # its hierarchical ((sgm, rows), (sgk, cols), 1) view internally.
+        sfa2_rows = cute.sym_int()
+        sfa2_stride_1 = cute.sym_int()
+        sfa2_stride_2 = cute.sym_int()
+        sfa2_cute_fake = self._make_fake_cute_tensor(
+            dtype=self.sfa2_desc.dtype,
+            shape=(sfa2_rows, self.sfa2_desc.shape[1], 1),
+            stride=(1, sfa2_stride_1, sfa2_stride_2),
+            assumed_align=16,
+        )
+
+        prob_cute_fake = self._make_fake_cute_tensor(
+            dtype=self.prob_desc.dtype,
+            shape=(valid_m, *self.prob_desc.shape[1:]),
+            stride=self.prob_desc.stride,
+            assumed_align=16,
+        )
+        return a_cute_fake, d_cute_fake, sfa_cute_fake, sfa2_cute_fake, prob_cute_fake
+
+    def _compile_dense(self, gemm, max_active_clusters, fake_stream) -> None:
+        """Compile for dense (contiguous) weight mode."""
+        fake_workspace_ptr = cute.runtime.nullptr(
+            dtype=cutlass.Uint8,
+            assumed_align=128,
+        )
+
+        self._logger.debug("Compiling grouped_gemm_unfused_subchannel_scaled kernel (dense)")
+
+        valid_m = cute.sym_int(divisibility=256)
+        a_cute_fake, d_cute_fake, sfa_cute_fake, sfa2_cute_fake, prob_cute_fake = self._make_dynamic_m_fakes(valid_m)
+
+        b_cute_fake = self._make_fake_cute_tensor_from_desc(self.b_desc, assumed_align=16)
+        sfb_cute_fake = self._make_fake_cute_tensor_from_desc(self.sfb_desc, assumed_align=16)
+        sfb2_cute_fake = self._make_fake_cute_tensor_from_desc(self.sfb2_desc, assumed_align=16)
+        bias_cute_fake = self._make_fake_cute_tensor_from_desc(self.bias_desc, assumed_align=16)
+
+        _compiled_kernel = cute.compile(
+            gemm,
+            a=a_cute_fake,
+            b=b_cute_fake,
+            sfb=sfb_cute_fake,
+            sfb2=sfb2_cute_fake,
+            n=cutlass.Int32(0),
+            k=cutlass.Int32(0),
+            b_stride_size=cutlass.Int64(0),
+            b_major_mode=OperandMajorMode.K,
+            workspace_ptr=fake_workspace_ptr,
+            d=d_cute_fake,
+            sfa=sfa_cute_fake,
+            sfa2=sfa2_cute_fake,
+            padded_offsets=self._make_fake_cute_tensor_from_desc(self.padded_offsets_desc, assumed_align=16),
+            alpha=self._make_fake_cute_tensor_from_desc(self.alpha_desc, assumed_align=16),
+            bias=bias_cute_fake,
+            prob=prob_cute_fake,
+            max_active_clusters=max_active_clusters,
+            stream=fake_stream,
+            options="--enable-tvm-ffi",
+        )
+
+        cached_workspace_ptr = from_dlpack(self._workspace, assumed_align=128).iterator
+
+        def tensor_api(
+            a_tensor: torch.Tensor,
+            b_tensor: torch.Tensor,
+            sfb_tensor: torch.Tensor,
+            sfb2_tensor: torch.Tensor,
+            d_tensor: torch.Tensor,
+            sfa_tensor: torch.Tensor,
+            sfa2_tensor: torch.Tensor,
+            padded_offsets: torch.Tensor,
+            alpha_tensor: torch.Tensor,
+            bias_tensor: Optional[torch.Tensor],
+            prob_tensor: torch.Tensor,
+            stream: cuda.CUstream,
+        ) -> None:
+            _compiled_kernel(
+                a_tensor,
+                b_tensor,
+                sfb_tensor,
+                sfb2_tensor,
+                cutlass.Int32(0),
+                cutlass.Int32(0),
+                cutlass.Int64(0),
+                cached_workspace_ptr,
+                d_tensor,
+                sfa_tensor,
+                sfa2_tensor,
+                padded_offsets,
+                alpha_tensor,
+                bias_tensor,
+                prob_tensor,
+                stream,
+            )
+
+        self._compiled_kernel = tensor_api
+
+    def _compile_discrete(self, gemm, max_active_clusters, fake_stream) -> None:
+        """Compile for discrete (per-expert pointer) weight mode."""
+        if len(self.b_shape) == 2:
+            n, k = self.b_shape
+        else:
+            n, k, _ = self.b_shape
+
+        b_major_mode = OperandMajorMode.K
+        b_stride_size = k
+
+        self._logger.debug("Compiling grouped_gemm_unfused_subchannel_scaled kernel (discrete)")
+
+        valid_m = cute.sym_int(divisibility=256)
+        a_cute_fake, d_cute_fake, sfa_cute_fake, sfa2_cute_fake, prob_cute_fake = self._make_dynamic_m_fakes(valid_m)
+
+        bias_cute_fake = self._make_fake_cute_tensor_from_desc(self.bias_desc, assumed_align=16)
+
+        # Compile-time placeholders for the pointer-array arguments: real device bytes
+        # (fake tensors have dummy iterators) allocated in the caller's framework,
+        # retyped to Int64 via the element_type override.
+        self._compile_b_ptrs = allocate_byte_workspace(self._framework, 8 * self.expert_cnt, self.a_desc.device)
+        self._compile_sfb_ptrs = allocate_byte_workspace(self._framework, 8 * self.expert_cnt, self.a_desc.device)
+        self._compile_sfb2_ptrs = allocate_byte_workspace(self._framework, 8 * self.expert_cnt, self.a_desc.device)
+        b_ptrs_placeholder = from_dlpack(self._compile_b_ptrs, assumed_align=8)
+        b_ptrs_placeholder.element_type = cutlass.Int64
+        b_ptrs_cute = b_ptrs_placeholder.iterator
+        sfb_ptrs_placeholder = from_dlpack(self._compile_sfb_ptrs, assumed_align=8)
+        sfb_ptrs_placeholder.element_type = cutlass.Int64
+        sfb_ptrs_cute = sfb_ptrs_placeholder.iterator
+        sfb2_ptrs_placeholder = from_dlpack(self._compile_sfb2_ptrs, assumed_align=8)
+        sfb2_ptrs_placeholder.element_type = cutlass.Int64
+        sfb2_ptrs_cute = sfb2_ptrs_placeholder.iterator
+        workspace_ptr_cute = from_dlpack(self._workspace, assumed_align=128).iterator
+
+        _compiled_kernel = cute.compile(
+            gemm,
+            a=a_cute_fake,
+            b=b_ptrs_cute,
+            sfb=sfb_ptrs_cute,
+            sfb2=sfb2_ptrs_cute,
+            n=cutlass.Int32(n),
+            k=cutlass.Int32(k),
+            b_stride_size=cutlass.Int64(b_stride_size),
+            b_major_mode=b_major_mode,
+            workspace_ptr=workspace_ptr_cute,
+            d=d_cute_fake,
+            sfa=sfa_cute_fake,
+            sfa2=sfa2_cute_fake,
+            padded_offsets=self._make_fake_cute_tensor_from_desc(self.padded_offsets_desc, assumed_align=16),
+            alpha=self._make_fake_cute_tensor_from_desc(self.alpha_desc, assumed_align=16),
+            bias=bias_cute_fake,
+            prob=prob_cute_fake,
+            max_active_clusters=max_active_clusters,
+            stream=fake_stream,
+            epilogue_op=lambda x: x,
+            options="--enable-tvm-ffi",
+        )
+
+        cached_workspace_ptr = from_dlpack(self._workspace, assumed_align=128).iterator
+        cached_n = cutlass.Int32(n)
+        cached_k = cutlass.Int32(k)
+        cached_b_stride = cutlass.Int64(b_stride_size)
+
+        def tensor_api(
+            a_tensor: torch.Tensor,
+            b_ptrs_device: torch.Tensor,
+            sfb_ptrs_device: torch.Tensor,
+            sfb2_ptrs_device: torch.Tensor,
+            d_tensor: torch.Tensor,
+            sfa_tensor: torch.Tensor,
+            sfa2_tensor: torch.Tensor,
+            padded_offsets: torch.Tensor,
+            alpha_tensor: torch.Tensor,
+            bias_tensor: Optional[torch.Tensor],
+            prob_tensor: torch.Tensor,
+            stream: cuda.CUstream,
+        ) -> None:
+            b_ptrs_addr = int(get_data_ptr(b_ptrs_device))
+            sfb_ptrs_addr = int(get_data_ptr(sfb_ptrs_device))
+            sfb2_ptrs_addr = int(get_data_ptr(sfb2_ptrs_device))
+            _compiled_kernel(
+                a_tensor,
+                b_ptrs_addr,
+                sfb_ptrs_addr,
+                sfb2_ptrs_addr,
+                cached_n,
+                cached_k,
+                cached_b_stride,
+                cached_workspace_ptr,
+                d_tensor,
+                sfa_tensor,
+                sfa2_tensor,
+                padded_offsets,
+                alpha_tensor,
+                bias_tensor,
+                prob_tensor,
+                stream,
+            )
+
+        self._compiled_kernel = tensor_api
+
+    def execute(
+        self,
+        a_tensor: torch.Tensor,
+        sfa_tensor: torch.Tensor,
+        sfa2_tensor: torch.Tensor,
+        padded_offsets: torch.Tensor,
+        alpha_tensor: torch.Tensor,
+        prob_tensor: torch.Tensor,
+        d_tensor: torch.Tensor,
+        # Dense mode:
+        b_tensor: Optional[torch.Tensor] = None,
+        sfb_tensor: Optional[torch.Tensor] = None,
+        sfb2_tensor: Optional[torch.Tensor] = None,
+        bias_tensor: Optional[torch.Tensor] = None,
+        # Discrete mode:
+        b_ptrs: Optional[torch.Tensor] = None,
+        sfb_ptrs: Optional[torch.Tensor] = None,
+        sfb2_ptrs: Optional[torch.Tensor] = None,
+        current_stream: Optional[cuda.CUstream] = None,
+    ) -> None:
+        """Execute the compiled kernel.
+
+        :param a_tensor: Input A tensor (valid_m, k, 1), FP4, k-major
+        :param sfa_tensor: First-level scale factor A (MMA-tiled view)
+        :param sfa2_tensor: Second-level scale factor A,
+            (ceil(valid_m / sgm), ceil(k / sgk), 1) FP32, stride (1, rows, rows * cols)
+        :param padded_offsets: End offset per expert after padding
+        :param alpha_tensor: Per-group scaling factors
+        :param prob_tensor: Per-token probability tensor (valid_m, 1, 1), FP32. Required.
+        :param d_tensor: Output D tensor (valid_m, n, 1), BF16
+        :param b_tensor: (Dense) Input B tensor (weights)
+        :param sfb_tensor: (Dense) First-level scale factor B
+        :param sfb2_tensor: (Dense) Second-level scale factor B,
+            (ceil(n / sgn), ceil(k / sgk), l) FP32, stride (1, rows, rows * cols)
+        :param bias_tensor: Optional bias tensor with shape (n, l) and stride (1, n).
+            Bias fusion is specialized at compile time: if ``sample_bias`` was omitted
+            at construction, ``bias_tensor`` must also be omitted at execute time.
+        :param b_ptrs: (Discrete) 1-D int64 device tensor of per-expert B data pointers
+        :param sfb_ptrs: (Discrete) 1-D int64 device tensor of per-expert SFB data pointers
+        :param sfb2_ptrs: (Discrete) 1-D int64 device tensor of per-expert SFB2 data pointers
+            (each base must be 16B-aligned)
+        :param current_stream: CUDA stream
+        """
+        self._logger.debug("Entering execute")
+        if current_stream is None:
+            # torch inputs stay ordered with the caller's current torch stream;
+            # other frameworks default to the CUDA legacy default stream.
+            current_stream = default_stream(detect_framework(a_tensor))
+
+        if a_tensor.shape[0] == 0:
+            self._logger.debug("execute: valid_m is zero, skipping kernel execution")
+            return
+        self._runtime_error_if(
+            self._compiled_kernel is None,
+            "Kernel not compiled; call compile() first",
+        )
+
+        self._value_error_if(
+            prob_tensor is None,
+            "prob_tensor is required (the kernel always fuses the prob multiply)",
+        )
+        if self._has_bias:
+            self._value_error_if(
+                bias_tensor is None,
+                "bias_tensor must be provided at execute() when the API was compiled with sample_bias",
+            )
+        else:
+            self._value_error_if(
+                bias_tensor is not None,
+                "bias_tensor must be omitted at execute() when the API was compiled without sample_bias",
+            )
+
+        self._logger.debug("Executing grouped_gemm_unfused_subchannel_scaled kernel")
+        if self.weight_mode == MoEWeightMode.DENSE:
+            self._compiled_kernel(
+                a_tensor=a_tensor,
+                b_tensor=b_tensor,
+                sfb_tensor=sfb_tensor,
+                sfb2_tensor=sfb2_tensor,
+                d_tensor=d_tensor,
+                sfa_tensor=sfa_tensor,
+                sfa2_tensor=sfa2_tensor,
+                padded_offsets=padded_offsets,
+                alpha_tensor=alpha_tensor,
+                bias_tensor=bias_tensor,
+                prob_tensor=prob_tensor,
+                stream=current_stream,
+            )
+        else:
+            self._compiled_kernel(
+                a_tensor=a_tensor,
+                b_ptrs_device=b_ptrs,
+                sfb_ptrs_device=sfb_ptrs,
+                sfb2_ptrs_device=sfb2_ptrs,
+                d_tensor=d_tensor,
+                sfa_tensor=sfa_tensor,
+                sfa2_tensor=sfa2_tensor,
+                padded_offsets=padded_offsets,
+                alpha_tensor=alpha_tensor,
+                bias_tensor=bias_tensor,
+                prob_tensor=prob_tensor,
+                stream=current_stream,
+            )
+
+        self._logger.debug("Execute completed")
+
+
+import logging
+
+_logger = logging.getLogger(__name__)
+_cache_of_GroupedGemmUnfusedSubchannelScaledSm100Objects = {}
+
+
+def grouped_gemm_unfused_subchannel_scaled_wrapper_sm100(
+    a_tensor: torch.Tensor,
+    sfa_tensor: torch.Tensor,
+    sfa2_tensor: torch.Tensor,
+    padded_offsets: torch.Tensor,
+    alpha_tensor: torch.Tensor,
+    prob_tensor: torch.Tensor,
+    b_tensor: Optional[torch.Tensor] = None,
+    sfb_tensor: Optional[torch.Tensor] = None,
+    sfb2_tensor: Optional[torch.Tensor] = None,
+    bias_tensor: Optional[torch.Tensor] = None,
+    b_ptrs: Optional[torch.Tensor] = None,
+    sfb_ptrs: Optional[torch.Tensor] = None,
+    sfb2_ptrs: Optional[torch.Tensor] = None,
+    n: Optional[int] = None,
+    b_dtype: Optional[torch.dtype] = None,
+    b_major: str = "k",
+    acc_dtype: Optional[torch.dtype] = None,
+    d_dtype: Optional[torch.dtype] = None,
+    d_tensor: Optional[torch.Tensor] = None,
+    cd_major: str = "n",
+    block2_shape: Tuple[int, int, int] = (1, 256, 256),
+    mma_tiler_mn: Tuple[int, int] = (256, 128),
+    cluster_shape_mn: Optional[Tuple[int, int]] = None,
+    sf_vec_size: int = 16,
+    sf_fp8_dtype_override: Optional[Literal["e5m3"]] = None,
+    vector_f32: bool = True,
+    m_aligned: int = 256,
+    use_dynamic_sched: bool = False,
+    current_stream: Optional[cuda.CUstream] = None,
+) -> TupleDict:
+    """Convenience wrapper for the unfused subchannel-scaled grouped GEMM operation.
+
+    This function creates the API, compiles, and executes in one call.
+    Compiled kernels are cached for reuse when called with the same configuration.
+
+    Args:
+        a_tensor: Input A tensor (valid_m, k, 1), FP4, k-major
+        sfa_tensor: First-level scale factor A (MMA-tiled (32, 4, valid_m//128, 4, rest_k, 1) view)
+        sfa2_tensor: Second-level scale factor A, shape (ceil(valid_m/sgm), ceil(k/sgk), 1) FP32,
+            stride (1, rows, rows * cols) (rows-contiguous; e.g. built via
+            ``torch.zeros((1, cols, rows)).permute(2, 1, 0)``)
+        padded_offsets: End offset per expert after padding (l,), int32, cumulative
+        alpha_tensor: Per-group scaling (l,), FP32
+        prob_tensor: Per-token probability tensor (valid_m, 1, 1), FP32. Required --
+            the kernel always fuses the prob multiply; pass ones for a plain GEMM.
+        b_tensor: (Dense) Weight B tensor (n, k, l), FP4, k-major
+        sfb_tensor: (Dense) First-level scale factor B (MMA-tiled view)
+        sfb2_tensor: (Dense) Second-level scale factor B, shape (ceil(n/sgn), ceil(k/sgk), l) FP32,
+            stride (1, rows, rows * cols)
+        bias_tensor: Optional per-expert bias, shape (n, l), stride (1, n), BF16.
+            The epilogue computes ``d = gemm * alpha + prob * bias``.
+        b_ptrs: (Discrete) 1-D int64 device tensor of per-expert B data pointers
+        sfb_ptrs: (Discrete) 1-D int64 device tensor of per-expert SFB data pointers
+        sfb2_ptrs: (Discrete) 1-D int64 device tensor of per-expert SFB2 data pointers
+            (each base must be 16B-aligned; per-expert block bytes must be a
+            multiple of 16 when num_experts > 1)
+        n: (Discrete) B weight N dimension
+        b_dtype: (Discrete) B weight data type
+        b_major: (Discrete) B tensor major dimension (must be "k" for FP4)
+        acc_dtype: Accumulator data type (must be float32)
+        d_dtype: Output D tensor data type (must be bfloat16)
+        d_tensor: Optional preallocated output tensor to write into instead of
+            allocating. Must match the internal layout: shape (valid_m, n_out, 1),
+            stride (n_out, 1, valid_m * n_out), dtype bfloat16, on a_tensor.device.
+        cd_major: CD major dimension (only "n"-major layout is supported)
+        block2_shape: Second-level scale granularity (sgm, sgn, sgk)
+        mma_tiler_mn: MMA tiler shape; (256, 128) or (256, 256)
+        cluster_shape_mn: Cluster shape; default (2, 1)
+        sf_vec_size: First-level scale factor vector size (must be 16)
+        sf_fp8_dtype_override: Reinterpret FP8 block scale factors as E5M3 (Rubin-only);
+            scale tensors are still passed as ``torch.float8_e4m3fn``.
+        vector_f32: Use vectorized (packed) f32 arithmetic (default True -- the
+            byte-exact-verified configuration)
+        m_aligned: M alignment (must be 256)
+        use_dynamic_sched: Enable dynamic tile scheduling
+        current_stream: CUDA stream
+
+    Returns:
+        TupleDict: A dictionary-like object containing the output tensor:
+            - **d_tensor** (torch.Tensor): BF16 output tensor (valid_m, n, 1)
+    """
+    from cudnn.gemm.cutedsl.grouped.unfused._bf16_api import _validate_pointer_tensor
+
+    framework = detect_framework(a_tensor)
+    if framework == "jax":
+        raise ValueError(f"grouped_gemm_unfused_subchannel_scaled_wrapper_sm100 does not support JAX arrays: {_JAX_SF_LAYOUT_ERROR}")
+    if framework != "torch":
+        raise ValueError(f"Unsupported tensor framework '{framework}' for grouped_gemm_unfused_subchannel_scaled_wrapper_sm100; pass torch tensors")
+    import torch
+
+    acc_dtype = _convert_to_cutlass_data_type(acc_dtype) if acc_dtype is not None else cutlass.Float32
+    d_dtype = _convert_to_cutlass_data_type(d_dtype) if d_dtype is not None else cutlass.BFloat16
+    b_dtype = _convert_to_cutlass_data_type(b_dtype) if b_dtype is not None else None
+
+    is_dense = b_tensor is not None
+    is_discrete = b_ptrs is not None
+
+    if is_dense and is_discrete:
+        raise ValueError("Provide either (b_tensor, sfb_tensor, sfb2_tensor) or (b_ptrs, sfb_ptrs, sfb2_ptrs), not both")
+    if not is_dense and not is_discrete:
+        raise ValueError("Must provide either (b_tensor, sfb_tensor, sfb2_tensor) or (b_ptrs, sfb_ptrs, sfb2_ptrs)")
+    if prob_tensor is None:
+        raise ValueError("prob_tensor is required (the kernel always fuses the prob multiply); pass ones for a plain GEMM")
+
+    valid_m, k_physical, _ = a_tensor.shape
+    if is_dense:
+        weight_mode = MoEWeightMode.DENSE
+        if sfb_tensor is None or sfb2_tensor is None:
+            raise ValueError("sfb_tensor and sfb2_tensor are required in dense mode")
+        n_out, _, l = b_tensor.shape
+        if bias_tensor is not None and tuple(bias_tensor.shape) != (n_out, l):
+            raise ValueError(f"bias_tensor must have shape {(n_out, l)}, got {tuple(bias_tensor.shape)}")
+        num_experts = None
+        b_shape = None
+    else:
+        weight_mode = MoEWeightMode.DISCRETE
+        num_experts = _validate_pointer_tensor(b_ptrs, "b_ptrs")
+        _validate_pointer_tensor(sfb_ptrs, "sfb_ptrs", num_experts)
+        _validate_pointer_tensor(sfb2_ptrs, "sfb2_ptrs", num_experts)
+        if n is None or b_dtype is None:
+            raise ValueError("n and b_dtype are required for discrete mode")
+        k_logical = k_physical * 2 if b_dtype in (cutlass.Float4E2M1FN, cutlass.Uint8) else k_physical
+        b_shape = (n, k_logical)
+        n_out = n
+        l = num_experts
+        if bias_tensor is not None and tuple(bias_tensor.shape) != (n_out, num_experts):
+            raise ValueError(f"bias_tensor must have shape {(n_out, num_experts)}, got {tuple(bias_tensor.shape)}")
+
+    _logger.debug("grouped_gemm_unfused_subchannel_scaled_wrapper_sm100: Creating output tensors")
+
+    if cd_major == "n":
+        expected_shape = (valid_m, n_out, 1)
+        expected_stride = (n_out, 1, valid_m * n_out)
+        if d_tensor is None:
+            d_tensor = torch.empty_strided(expected_shape, expected_stride, dtype=framework_dtype(d_dtype, "torch"), device=a_tensor.device)
+        elif (
+            tuple(d_tensor.shape) != expected_shape
+            or tuple(d_tensor.stride()) != expected_stride
+            or _convert_to_cutlass_data_type(d_tensor.dtype) != d_dtype
+            or get_device(d_tensor) != get_device(a_tensor)
+        ):
+            raise ValueError(
+                f"d_tensor must have shape {expected_shape}, stride {expected_stride}, "
+                f"dtype {d_dtype}, device {a_tensor.device}, but got shape {tuple(d_tensor.shape)}, "
+                f"stride {tuple(d_tensor.stride())}, dtype {d_tensor.dtype}, device {d_tensor.device}."
+            )
+    else:
+        raise ValueError(f"cd_major must be 'n', got {cd_major}")
+
+    if valid_m == 0:
+        _logger.debug("grouped_gemm_unfused_subchannel_scaled_wrapper_sm100: valid_m is zero, skipping kernel execution")
+        return TupleDict(d_tensor=d_tensor)
+
+    def tensor_signature(tensor: Optional[torch.Tensor]) -> Tuple[Optional[Tuple[int, ...]], Optional[Tuple[int, ...]], Optional[torch.dtype]]:
+        if tensor is None:
+            return None, None, None
+        return tuple(tensor.shape), tuple(tensor.stride()), tensor.dtype
+
+    def stride_order(tensor: torch.Tensor) -> Tuple[int, ...]:
+        return tuple(i for i, s in sorted(enumerate(tensor.stride()), key=lambda x: x[1]))
+
+    def dynamic_m_tensor_signature(
+        tensor: Optional[torch.Tensor], static_shape_suffix: Tuple[int, ...], dynamic_stride_dims: Tuple[int, ...] = ()
+    ) -> Tuple[Optional[Tuple[int, ...]], Optional[Tuple[int, ...]], Optional[torch.dtype]]:
+        if tensor is None:
+            return None, None, None
+        stride_signature = tuple(None if i in dynamic_stride_dims else s for i, s in enumerate(tensor.stride()))
+        return static_shape_suffix, stride_signature, tensor.dtype
+
+    device_type = get_device_type()
+
+    common_key_tail = (
+        tuple(padded_offsets.shape),
+        tuple(padded_offsets.stride()),
+        padded_offsets.dtype,
+        acc_dtype,
+        d_dtype,
+        cd_major,
+        tuple(block2_shape),
+        mma_tiler_mn,
+        cluster_shape_mn,
+        sf_vec_size,
+        sf_fp8_dtype_override,
+        vector_f32,
+        m_aligned,
+        use_dynamic_sched,
+    )
+    dynamic_m_key = (
+        a_tensor.shape[1:],
+        stride_order(a_tensor),
+        a_tensor.dtype,
+        d_tensor.shape[1:],
+        stride_order(d_tensor),
+        *dynamic_m_tensor_signature(sfa_tensor, (sfa_tensor.shape[4], 1), dynamic_stride_dims=(5,)),
+        *dynamic_m_tensor_signature(sfa2_tensor, (sfa2_tensor.shape[1], 1), dynamic_stride_dims=(1, 2)),
+        *dynamic_m_tensor_signature(prob_tensor, (1, 1)),
+        *tensor_signature(alpha_tensor),
+    )
+    if is_dense:
+        cache_key = (
+            device_type,
+            weight_mode,
+            *dynamic_m_key,
+            *tensor_signature(b_tensor),
+            *tensor_signature(sfb_tensor),
+            *tensor_signature(sfb2_tensor),
+            *tensor_signature(bias_tensor),
+            *common_key_tail,
+        )
+    else:
+        cache_key = (
+            device_type,
+            weight_mode,
+            *dynamic_m_key,
+            b_shape,
+            b_dtype,
+            *tensor_signature(bias_tensor),
+            tuple(b_ptrs.shape),
+            b_ptrs.dtype,
+            tuple(sfb_ptrs.shape),
+            sfb_ptrs.dtype,
+            tuple(sfb2_ptrs.shape),
+            sfb2_ptrs.dtype,
+            *common_key_tail,
+            b_major,
+            num_experts,
+        )
+
+    if cache_key in _cache_of_GroupedGemmUnfusedSubchannelScaledSm100Objects:
+        _logger.debug("grouped_gemm_unfused_subchannel_scaled_wrapper_sm100: Using previously cached object")
+        api = _cache_of_GroupedGemmUnfusedSubchannelScaledSm100Objects[cache_key]
+    else:
+        _logger.debug("grouped_gemm_unfused_subchannel_scaled_wrapper_sm100: No previously cached object found, creating new one")
+        if is_dense:
+            api = GroupedGemmUnfusedSubchannelScaledSm100(
+                sample_a=a_tensor,
+                sample_sfa=sfa_tensor,
+                sample_sfa2=sfa2_tensor,
+                sample_padded_offsets=padded_offsets,
+                sample_alpha=alpha_tensor,
+                sample_prob=prob_tensor,
+                sample_d=d_tensor,
+                sample_b=b_tensor,
+                sample_sfb=sfb_tensor,
+                sample_sfb2=sfb2_tensor,
+                sample_bias=bias_tensor,
+                acc_dtype=acc_dtype,
+                block2_shape=block2_shape,
+                mma_tiler_mn=mma_tiler_mn,
+                cluster_shape_mn=cluster_shape_mn,
+                sf_vec_size=sf_vec_size,
+                sf_fp8_dtype_override=sf_fp8_dtype_override,
+                vector_f32=vector_f32,
+                m_aligned=m_aligned,
+                use_dynamic_sched=use_dynamic_sched,
+            )
+        else:
+            api = GroupedGemmUnfusedSubchannelScaledSm100(
+                sample_a=a_tensor,
+                sample_sfa=sfa_tensor,
+                sample_sfa2=sfa2_tensor,
+                sample_padded_offsets=padded_offsets,
+                sample_alpha=alpha_tensor,
+                sample_prob=prob_tensor,
+                sample_d=d_tensor,
+                num_experts=num_experts,
+                b_shape=b_shape,
+                b_dtype=b_dtype,
+                sample_bias=bias_tensor,
+                acc_dtype=acc_dtype,
+                block2_shape=block2_shape,
+                mma_tiler_mn=mma_tiler_mn,
+                cluster_shape_mn=cluster_shape_mn,
+                sf_vec_size=sf_vec_size,
+                sf_fp8_dtype_override=sf_fp8_dtype_override,
+                vector_f32=vector_f32,
+                m_aligned=m_aligned,
+                b_major=b_major,
+                use_dynamic_sched=use_dynamic_sched,
+            )
+
+        assert api.check_support(), "Unsupported configuration"
+        api.compile()
+        _cache_of_GroupedGemmUnfusedSubchannelScaledSm100Objects[cache_key] = api
+
+    if is_dense:
+        api.execute(
+            a_tensor=a_tensor,
+            sfa_tensor=sfa_tensor,
+            sfa2_tensor=sfa2_tensor,
+            padded_offsets=padded_offsets,
+            alpha_tensor=alpha_tensor,
+            prob_tensor=prob_tensor,
+            d_tensor=d_tensor,
+            b_tensor=b_tensor,
+            sfb_tensor=sfb_tensor,
+            sfb2_tensor=sfb2_tensor,
+            bias_tensor=bias_tensor,
+            current_stream=current_stream,
+        )
+    else:
+        api.execute(
+            a_tensor=a_tensor,
+            sfa_tensor=sfa_tensor,
+            sfa2_tensor=sfa2_tensor,
+            padded_offsets=padded_offsets,
+            alpha_tensor=alpha_tensor,
+            prob_tensor=prob_tensor,
+            d_tensor=d_tensor,
+            b_ptrs=b_ptrs,
+            sfb_ptrs=sfb_ptrs,
+            sfb2_ptrs=sfb2_ptrs,
+            bias_tensor=bias_tensor,
+            current_stream=current_stream,
+        )
+
+    return TupleDict(d_tensor=d_tensor)

--- a/python/cudnn/gemm/cutedsl/grouped/unfused_subchannel_scaled/grouped_gemm_unfused_subchannel_scaled.py
+++ b/python/cudnn/gemm/cutedsl/grouped/unfused_subchannel_scaled/grouped_gemm_unfused_subchannel_scaled.py
@@ -2504,15 +2504,5 @@ class BlockScaledSubChannelMoEGroupedGemmKernel:
             )
         else:
             return ContiguousAndConsistentGroupedGemmSchedExtension(
-        # Discrete mode resolves per-expert B/SFB via prebuilt TMA descriptors;
-        # dense mode uses the contiguous grouped-GEMM scheduler extension
-        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE):
-            desc_workspace = TensormapWorkspace(workspace_ptr, ["b", "sfb"])
-            return DiscreteWeightScaledGemmSchedExtension(
-                tensormap_ctor=desc_workspace,
-                sf_vec_size=self.sf_vec_size,
-            )
-        else:
-            return ContiguousAndConsistentGroupedGemmSchedExtension(
                 sf_vec_size=self.sf_vec_size,
             )

--- a/python/cudnn/gemm/cutedsl/grouped/unfused_subchannel_scaled/grouped_gemm_unfused_subchannel_scaled.py
+++ b/python/cudnn/gemm/cutedsl/grouped/unfused_subchannel_scaled/grouped_gemm_unfused_subchannel_scaled.py
@@ -2041,7 +2041,7 @@ class BlockScaledSubChannelMoEGroupedGemmKernel:
                             kblock_coord = (None, None, kblock_idx, ab_consumer_state.index)
                             sf_kblock_coord = (None, None, kblock_idx)
                             tiled_mma.set(tcgen05.Field.SFA, tCtSFA[sf_kblock_coord].iterator)
-                            tiled_mma.set(tcgen05.Field.SFB, tCtSFB_mma[sf_kblock_coord].iterator)
+                            tiled_mma.set(tcgen05.Field.SFB, tCtSFB[sf_kblock_coord].iterator)
                             cute.gemm(tiled_mma, tCtAcc, tCrA[kblock_coord], tCrB[kblock_coord], tCtAcc)
                             tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
 
@@ -2494,6 +2494,16 @@ class BlockScaledSubChannelMoEGroupedGemmKernel:
 
     @cute.jit
     def _make_extension(self, workspace_ptr):
+        # Discrete mode resolves per-expert B/SFB via prebuilt TMA descriptors;
+        # dense mode uses the contiguous grouped-GEMM scheduler extension
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE):
+            desc_workspace = TensormapWorkspace(workspace_ptr, ["b", "sfb"])
+            return DiscreteWeightScaledGemmSchedExtension(
+                tensormap_ctor=desc_workspace,
+                sf_vec_size=self.sf_vec_size,
+            )
+        else:
+            return ContiguousAndConsistentGroupedGemmSchedExtension(
         # Discrete mode resolves per-expert B/SFB via prebuilt TMA descriptors;
         # dense mode uses the contiguous grouped-GEMM scheduler extension
         if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE):

--- a/python/cudnn/gemm/cutedsl/grouped/unfused_subchannel_scaled/grouped_gemm_unfused_subchannel_scaled.py
+++ b/python/cudnn/gemm/cutedsl/grouped/unfused_subchannel_scaled/grouped_gemm_unfused_subchannel_scaled.py
@@ -1,0 +1,2508 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Second-Level-Scaled (Subchannel-Scaled) MoE Block-Scaled Grouped GEMM Kernel.
+
+Supports:
+    - Static / Dynamic persistent tile scheduling (MoEPersistentTileScheduler)
+    - Dense (contiguous 3-D B) / Discrete (per-expert pointer array B) weight layout
+    - Optional bias and routing-probability (prob) fusion
+
+This module contains only the kernel class.
+MoE scheduler components live in moe_persistent_scheduler.py / moe_sched_extension.py / moe_utils.py.
+"""
+
+from typing import Type, Tuple, Union, Optional
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import cpasync, tcgen05
+from cutlass.cute.nvgpu import OperandMajorMode
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+from cutlass.cute.typing import Float32, Int32, AddressSpace
+
+from cutlass._mlir.dialects.nvvm import (
+    SetMaxRegisterAction,
+)
+
+from ..moe_persistent_scheduler import (
+    MoEPersistentTileScheduler,
+    MoESchedulerParams,
+    MoEWorkTileInfo,
+)
+from ..moe_utils import (
+    compute_expert_token_range,
+    MoEWeightMode,
+    TensormapWorkspace,
+    store_tma_desc,
+)
+from ..moe_sched_extension import (
+    DiscreteWeightScaledGemmSchedExtension,
+    ContiguousAndConsistentGroupedGemmSchedExtension,
+)
+from ..moe_kernel_helpers import (
+    compute_stages,
+    compute_grid,
+    can_implement,
+    epilog_gmem_copy_and_partition,
+)
+
+# Valid launch-config space for THIS kernel (can_implement still prunes per
+# problem). cta shape == mma_tiler_mn. Default matches dgrad_dglu's pinned
+# config for iso-tile benchmark baselines.
+VALID_CTA_SHAPES = ((256, 128), (256, 256))
+VALID_CLUSTER_SHAPES = ((1, 1), (2, 1), (2, 2), (4, 1), (4, 2))
+DEFAULT_CTA_SHAPE = (256, 128)
+DEFAULT_CLUSTER_SHAPE = (2, 1)
+
+
+class BlockScaledSubChannelMoEGroupedGemmKernel:
+    """Sub-channel scaled block-scaled grouped GEMM kernel with MoE tile scheduling.
+
+    Supports both dense and discrete weight layouts and static and dynamic
+    scheduling. Inputs carry two scale levels (per-(1,16) SFA/SFB plus f32
+    SFA2/SFB2 subchannel scales); the output D is plain BF16.
+
+    :param sf_vec_size: Scale-factor vector size (16 or 32).
+    :param acc_dtype: Accumulator data type (Float32).
+    :param use_2cta_instrs: Use 2-CTA MMA instructions.
+    :param mma_tiler_mn: MMA tile shape (M, N).
+    :param cluster_shape_mn: Cluster shape (M, N).
+    :param vectorized_f32: Use packed FP32 arithmetic.
+    :param enable_bias: Fuse bias addition.
+    :param expert_cnt: Number of experts.
+    :param weight_mode: ``MoEWeightMode.DENSE`` or ``MoEWeightMode.DISCRETE``.
+    :param use_dynamic_sched: Enable dynamic tile scheduling.
+    """
+
+    FIX_PAD_SIZE = 256
+
+    @staticmethod
+    def can_implement(
+        ab_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        acc_dtype: Type[cutlass.Numeric],
+        d_dtype: Type[cutlass.Numeric],
+        use_2cta_instrs: bool,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        m: int,
+        n: int,
+        k: int,
+        l: int,
+        a_major: str,
+        b_major: str,
+        cd_major: str,
+        m_aligned: int,
+        weight_mode: MoEWeightMode = MoEWeightMode.DENSE,
+        sgn: int = 256,
+        sgk: int = 256,
+    ) -> bool:
+        result = can_implement(
+            ab_dtype,
+            sf_dtype,
+            sf_vec_size,
+            acc_dtype,
+            d_dtype,
+            use_2cta_instrs,
+            mma_tiler_mn,
+            cluster_shape_mn,
+            m,
+            n,
+            k,
+            l,
+            a_major,
+            b_major,
+            cd_major,
+            m_aligned,
+            fix_pad_size=BlockScaledSubChannelMoEGroupedGemmKernel.FIX_PAD_SIZE,
+            allowed_mma_tiler_n=(256, 128),
+        )
+        # Discrete SFB2 per-expert base pointers are declared 16B-aligned in
+        # the sched extension (assumed_align=16). With back-to-back per-expert
+        # f32 (ceil(n/sgn), ceil(k/sgk)) blocks, every base past the first is
+        # misaligned unless the block byte size is a multiple of 16.
+        if weight_mode == MoEWeightMode.DISCRETE and l > 1:
+            sfb2_block_bytes = ((n + sgn - 1) // sgn) * ((k + sgk - 1) // sgk) * 4
+            if sfb2_block_bytes % 16 != 0:
+                result = False
+        return result
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        sgm: int,
+        sgn: int,
+        sgk: int,
+        acc_dtype: Type[cutlass.Numeric],
+        use_2cta_instrs: bool,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        vectorized_f32: bool,
+        enable_bias: bool,
+        expert_cnt: int,
+        weight_mode: MoEWeightMode = MoEWeightMode.DENSE,
+        use_dynamic_sched: bool = False,
+    ):
+        # Validate constructor arguments before storing any configuration
+        mma_tile_m = mma_tiler_mn[0]
+        if self.FIX_PAD_SIZE % mma_tile_m != 0:
+            raise ValueError(
+                f"FIX_PAD_SIZE ({self.FIX_PAD_SIZE}) must be divisible by " f"mma_tiler_mn[0] ({mma_tile_m}). " f"Supported mma_tiler_mn[0] values: 128, 256."
+            )
+        if expert_cnt > 1024:
+            raise ValueError("Expert count > 1024 is not supported.")
+        if not isinstance(weight_mode, MoEWeightMode):
+            raise TypeError(f"weight_mode must be a MoEWeightMode, got {type(weight_mode)}")
+
+        # Store core GEMM / block-scale configuration
+        self.sf_vec_size = sf_vec_size
+        self.sgm = sgm
+        self.sgn = sgn
+        self.sgk = sgk
+        self.expert_cnt = expert_cnt
+        self.acc_dtype: Type[cutlass.Numeric] = acc_dtype
+        self.use_2cta_instrs = use_2cta_instrs
+        self.cluster_shape_mn = cluster_shape_mn
+        self.mma_tiler = (*mma_tiler_mn, 1)
+
+        # Select 1-CTA or 2-CTA MMA instruction group
+        self.cta_group = tcgen05.CtaGroup.TWO if use_2cta_instrs else tcgen05.CtaGroup.ONE
+
+        # Warp specialization: assign a fixed warp id to each role
+        # The bias load rides on the scale warp: a 13th warp would leave a
+        # partial warpgroup, which is illegal for setmaxregister (the CTA must
+        # be a whole number of 128-thread warpgroups).
+        self.occupancy = 1
+        self.accumulator_update_warp_id = (0, 1, 2, 3)
+        self.epilog_warp_id = (4, 5, 6, 7)
+        self.mma_warp_id = 8
+        self.tma_warp_id = 9
+        self.sched_warp_id = 10
+        self.scale_warp_id = 11
+        self.threads_per_warp = 32
+        all_warps = [
+            *self.accumulator_update_warp_id,
+            *self.epilog_warp_id,
+            self.mma_warp_id,
+            self.tma_warp_id,
+            self.sched_warp_id,
+            self.scale_warp_id,
+        ]
+        # Per-role register budgets applied via setmaxregister (uniform vs compute warps)
+        self.num_regs_uniform_warps = 24
+        self.num_regs_sched_warps = 24
+        self.num_regs_epilogue_warps = 168
+        self.num_regs_acc_update_warps = 176
+        warps_wo_sched = [*self.accumulator_update_warp_id, *self.epilog_warp_id, self.mma_warp_id, self.tma_warp_id, self.scale_warp_id]
+        # Total threads per CTA (with and without the scheduler warp)
+        self.threads_per_cta = self.threads_per_warp * len(all_warps)
+        self.threads_wo_sched = self.threads_per_warp * len(warps_wo_sched)
+
+        # Named barriers for cross-warp synchronization
+        self.cta_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=self.threads_per_cta,
+        )
+        self.epilog_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=32 * len(self.epilog_warp_id),
+        )
+        self.tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=3,
+            num_threads=32 * len((self.mma_warp_id, *self.accumulator_update_warp_id, *self.epilog_warp_id)),
+        )
+        self.sched_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=4,
+            num_threads=self.threads_per_warp,
+        )
+        # Query SMEM/TMEM hardware capacities used later for stage sizing
+        self.num_smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        SM100_TMEM_CAPACITY_COLUMNS = 512
+        self.num_tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
+
+        # Store remaining feature flags and modes
+        self.vectorized_f32 = vectorized_f32
+        self.enable_bias = enable_bias
+
+        self.weight_mode = weight_mode
+        self.use_dynamic_sched = use_dynamic_sched
+
+        self.epilogue_use_functor = False
+
+        # Cache warp-group sizes for the compute warps
+        self.num_accumulator_update_warps = len(self.accumulator_update_warp_id)
+        self.num_epilog_warps = len(self.epilog_warp_id)
+
+    # ------------------------------------------------------------------
+    # _setup_attributes
+    # ------------------------------------------------------------------
+
+    def _setup_attributes(self):
+        """Configure MMA / tile / stage / SMEM layouts from GEMM inputs."""
+
+        # MMA instruction MN shape, plus a separate SFB variant (1-CTA, N rounded to 128)
+        self.mma_inst_shape_mn = (self.mma_tiler[0], self.mma_tiler[1])
+        self.mma_inst_shape_mn_sfb = (
+            self.mma_inst_shape_mn[0] // (2 if self.use_2cta_instrs else 1),
+            cute.round_up(self.mma_inst_shape_mn[1], 128),
+        )
+
+        # Build the tiled MMA (and an SFB-only tiled MMA) for the block-scaled GEMM
+        tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            self.mma_inst_shape_mn,
+        )
+        tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            cute.nvgpu.tcgen05.CtaGroup.ONE,
+            self.mma_inst_shape_mn_sfb,
+        )
+
+        # Extend the MMA tiler with the K extent (instruction K times tiles-per-loop)
+        mma_inst_shape_k = cute.size(tiled_mma.shape_mnk, mode=[2])
+        mma_inst_tile_k = 4
+        self.mma_tiler = (
+            self.mma_tiler[0],
+            self.mma_tiler[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+        self.mma_tiler_sfb = (
+            self.mma_inst_shape_mn_sfb[0],
+            self.mma_inst_shape_mn_sfb[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+
+        # Per-CTA tile shapes (MMA tiler divided by the number of CTAs in the MMA group)
+        self.cta_tile_shape_mnk = (
+            self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler[1],
+            self.mma_tiler[2],
+        )
+        self.cta_tile_shape_mnk_sfb = (
+            self.mma_tiler_sfb[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler_sfb[1],
+            self.mma_tiler_sfb[2],
+        )
+
+        # Output (D) MMA tiler and its per-CTA tile shape
+        self.mma_tiler_d = (
+            self.mma_inst_shape_mn[0],
+            self.mma_inst_shape_mn[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+
+        self.cta_tile_shape_mnk_d = (
+            self.mma_tiler_d[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler_d[1],
+            self.mma_tiler_d[2],
+        )
+
+        # Cluster layouts (V, M, N, K) for A/B and for SFB multicast partitioning
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma.thr_id.shape,),
+        )
+        self.cluster_layout_sfb_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma_sfb.thr_id.shape,),
+        )
+
+        # Number of CTAs each A/B tile is multicast to across the cluster
+        self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+
+        # Epilogue subtile shape used to stream the accumulator out to D
+        self.epi_tile = sm100_utils.compute_epilogue_tile_shape(
+            self.cta_tile_shape_mnk,
+            self.use_2cta_instrs,
+            self.d_layout,
+            self.d_dtype,
+        )
+
+        # Derive pipeline stage counts from the available SMEM budget
+        (
+            self.num_acc_stage,
+            self.num_ab_stage,
+            self.num_d_stage,
+            self.num_tile_stage,
+            self.num_bias_stage,
+            self.num_epi_stage,
+        ) = self._compute_stages(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.b_dtype,
+            self.epi_tile,
+            self.d_dtype,
+            self.d_layout,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.num_smem_capacity,
+            self.occupancy,
+            self.bias_dtype if self.enable_bias else None,
+            acc_dtype=self.acc_dtype,
+            sf2_dtype=self.sf2_dtype,
+            sgm=self.sgm,
+            sgn=self.sgn,
+            sgk=self.sgk,
+        )
+
+        # Second-level scale pipeline runs in lockstep with the AB pipeline
+        self.num_scale_stage = self.num_ab_stage
+
+        # Staged SMEM layouts for A/B operands and their first-level scale factors
+        self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.num_ab_stage,
+        )
+        self.b_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            self.mma_tiler,
+            self.b_dtype,
+            self.num_ab_stage,
+        )
+        self.sfa_smem_layout_staged = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        self.sfb_smem_layout_staged = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+
+        # Store the per-tile scale block sizes (each clamped to the CTA tile) so
+        # the device kernel builds C-shaped scale views that match the CTA tile
+        # exactly, even when sg{m,n,k} > the tile extent (e.g. sgn=512 with a
+        # 256-wide N tile spans one scale block, broadcast across the tile).
+        if self.sgm < self.cta_tile_shape_mnk[0]:
+            size_m = self.sgm
+        else:
+            size_m = self.cta_tile_shape_mnk[0]
+
+        if self.sgn < self.cta_tile_shape_mnk[1]:
+            size_n = self.sgn
+        else:
+            size_n = self.cta_tile_shape_mnk[1]
+
+        if self.sgk < self.cta_tile_shape_mnk[2]:
+            size_k = self.sgk
+        else:
+            size_k = self.cta_tile_shape_mnk[2]
+
+        self.scale_size_m = size_m
+        self.scale_size_n = size_n
+        self.scale_size_k = size_k
+
+        # How many scale blocks fit along each CTA-tile dimension
+        self.scale_m_per_tile = self.cta_tile_shape_mnk[0] // size_m
+        self.scale_n_per_tile = self.cta_tile_shape_mnk[1] // size_n
+        self.scale_k_per_tile = self.cta_tile_shape_mnk[2] // size_k
+
+        # Staged SMEM layouts for the second-level (f32) A/B scales; extent-0 modes broadcast
+        self.sfa2_smem_layout_staged = cute.make_layout(
+            (
+                (size_m, self.scale_m_per_tile),
+                (size_k, self.scale_k_per_tile),
+                self.num_scale_stage,
+            ),
+            stride=(
+                (0, self.scale_k_per_tile),
+                (0, 1),
+                self.scale_k_per_tile * self.scale_m_per_tile,
+            ),
+        )
+        self.sfb2_smem_layout_staged = cute.make_layout(
+            (
+                (size_n, self.scale_n_per_tile),
+                (size_k, self.scale_k_per_tile),
+                self.num_scale_stage,
+            ),
+            stride=(
+                (0, self.scale_k_per_tile),
+                (0, 1),
+                self.scale_k_per_tile * self.scale_n_per_tile,
+            ),
+        )
+
+        # Staged SMEM layout for the epilogue output (D) buffer
+        self.d_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.d_dtype,
+            self.d_layout,
+            self.epi_tile,
+            self.num_d_stage,
+        )
+
+        # Full-CTA-tile SMEM buffer for the final accumulator; the "stage" mode of the
+        # epi layout doubles as the subtile-slot index (subtile_cnt slots per epi stage)
+        self.final_acc_subtile_cnt = (self.cta_tile_shape_mnk[0] // cute.size(self.epi_tile[0])) * (self.cta_tile_shape_mnk[1] // cute.size(self.epi_tile[1]))
+        self.final_acc_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.acc_dtype,
+            self.d_layout,
+            self.epi_tile,
+            self.final_acc_subtile_cnt * self.num_epi_stage,
+        )
+
+        # Staged SMEM layout for bias (only allocated when bias fusion is enabled)
+        if self.enable_bias:
+            self.bias_smem_layout_staged = cute.make_layout(
+                (self.mma_tiler[1], self.num_bias_stage),
+                stride=(1, self.mma_tiler[1]),
+            )
+        else:
+            self.bias_smem_layout_staged = cute.make_layout((1, 1))
+
+        self.overlapping_accum = self.num_acc_stage == 1 and self.mma_tiler[1] == 256
+        self.epilogue_prefetch_more = False
+
+        # TMEM column budget: accumulator columns followed by SFA/SFB scale columns
+        sf_atom_mn = 32
+        self.num_sfa_tmem_cols = (self.cta_tile_shape_mnk[0] // sf_atom_mn) * mma_inst_tile_k
+        self.num_sfb_tmem_cols = (self.cta_tile_shape_mnk_sfb[1] // sf_atom_mn) * mma_inst_tile_k
+        self.num_sf_tmem_cols = self.num_sfa_tmem_cols + self.num_sfb_tmem_cols
+        self.num_accumulator_tmem_cols = self.cta_tile_shape_mnk[1] * self.num_acc_stage
+
+        # Epilogue N tile width and how early the accumulator TMEM can be released
+        self.epi_tile_n_required = cute.size(self.epi_tile[1])
+        self.iter_acc_early_release_in_epilogue = (self.num_sf_tmem_cols + self.epi_tile_n_required - 1) // self.epi_tile_n_required - 1
+
+    # ------------------------------------------------------------------
+    # _compute_stages (with bias support)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _compute_stages(
+        tiled_mma,
+        mma_tiler_mnk,
+        a_dtype,
+        b_dtype,
+        epi_tile,
+        d_dtype,
+        d_layout,
+        sf_dtype,
+        sf_vec_size,
+        num_smem_capacity,
+        occupancy,
+        bias_dtype,
+        acc_dtype=None,
+        sf2_dtype=None,
+        sgm=1,
+        sgn=256,
+        sgk=256,
+    ):
+        # Fixed stage counts; the AB stage count is derived from leftover SMEM below
+        num_acc_stage = 1 if mma_tiler_mnk[1] == 256 else 3
+        num_d_stage = 1
+        num_tile_stage = 2
+
+        # Single-stage layouts, used only to measure per-stage byte sizes
+        a_smem_layout_stage_one = sm100_utils.make_smem_layout_a(tiled_mma, mma_tiler_mnk, a_dtype, 1)
+        b_smem_layout_staged_one = sm100_utils.make_smem_layout_b(tiled_mma, mma_tiler_mnk, b_dtype, 1)
+        sfa_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfa(tiled_mma, mma_tiler_mnk, sf_vec_size, 1)
+        sfb_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfb(tiled_mma, mma_tiler_mnk, sf_vec_size, 1)
+        d_smem_layout_staged_one = sm100_utils.make_smem_layout_epi(d_dtype, d_layout, epi_tile, 1)
+
+        # Compute second level scale factor layout
+        # Store the per-tile scale block sizes (each clamped to the CTA tile) so
+        # the device kernel builds C-shaped scale views that match the CTA tile
+        # exactly, even when sg{m,n,k} > the tile extent (e.g. sgn=512 with a
+        # 256-wide N tile spans one scale block, broadcast across the tile).
+        if sgm < mma_tiler_mnk[0]:
+            size_m = sgm
+        else:
+            size_m = mma_tiler_mnk[0]
+
+        if sgn < mma_tiler_mnk[1]:
+            size_n = sgn
+        else:
+            size_n = mma_tiler_mnk[1]
+
+        if sgk < mma_tiler_mnk[2]:
+            size_k = sgk
+        else:
+            size_k = mma_tiler_mnk[2]
+
+        scale_m_per_tile = mma_tiler_mnk[0] // size_m
+        scale_n_per_tile = mma_tiler_mnk[1] // size_n
+        scale_k_per_tile = mma_tiler_mnk[2] // size_k
+
+        # Second-level scale factor layouts
+        sfa2_smem_layout_staged_one = cute.make_layout(
+            (
+                (size_m, scale_m_per_tile),
+                (size_k, scale_k_per_tile),
+                1,
+            ),
+            stride=(
+                (0, scale_k_per_tile),
+                (0, 1),
+                scale_k_per_tile * scale_m_per_tile,
+            ),
+        )
+        sfb2_smem_layout_staged_one = cute.make_layout(
+            (
+                (size_n, scale_n_per_tile),
+                (size_k, scale_k_per_tile),
+                1,
+            ),
+            stride=(
+                (0, scale_k_per_tile),
+                (0, 1),
+                scale_k_per_tile * scale_n_per_tile,
+            ),
+        )
+
+        # Bytes consumed by one AB stage (operands plus both scale-factor levels)
+        ab_bytes_per_stage = (
+            cute.size_in_bytes(a_dtype, a_smem_layout_stage_one)
+            + cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfa_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
+            + cute.size_in_bytes(sf2_dtype, sfa2_smem_layout_staged_one)
+            + cute.size_in_bytes(sf2_dtype, sfb2_smem_layout_staged_one)
+        )
+        # Fixed overheads: mbarriers, scheduler tile-info, and staged D output
+        mbar_helpers_bytes = 1024
+        sinfo_bytes = 4 * 4 * num_tile_stage
+        d_bytes_per_stage = cute.size_in_bytes(d_dtype, d_smem_layout_staged_one)
+        d_bytes = d_bytes_per_stage * num_d_stage
+
+        # Bias staging bytes (zero when bias is disabled)
+        if bias_dtype is not None:
+            num_bias_stage = 2
+            bias_epi_tile_n = mma_tiler_mnk[1]
+            bias_bytes = bias_epi_tile_n * num_bias_stage * (bias_dtype.width // 8)
+        else:
+            num_bias_stage = 0
+            bias_bytes = 0
+
+        num_epi_stage = 1  # Pipeline stages for epi_pipeline (accumulator update -> epilogue)
+
+        # Full-CTA-tile final accumulator buffer in SMEM (replaces the TMEM final region)
+        cta_m = mma_tiler_mnk[0] // cute.size(tiled_mma.thr_id.shape)
+        cta_n = mma_tiler_mnk[1]
+        subtile_cnt = (cta_m // cute.size(epi_tile[0])) * (cta_n // cute.size(epi_tile[1]))
+        final_acc_smem_layout_one = sm100_utils.make_smem_layout_epi(
+            acc_dtype,
+            d_layout,
+            epi_tile,
+            subtile_cnt * num_epi_stage,
+        )
+        final_acc_bytes = cute.size_in_bytes(acc_dtype, final_acc_smem_layout_one)
+
+        # SMEM left after fixed + epilogue usage is divided into as many AB stages as fit
+        epi_bytes = d_bytes + bias_bytes + final_acc_bytes
+        num_ab_stage = (num_smem_capacity // occupancy - (mbar_helpers_bytes + epi_bytes + sinfo_bytes)) // ab_bytes_per_stage
+        assert num_ab_stage >= 1, (
+            f"SMEM overflow: full-tile sFinalAcc ({final_acc_bytes} B) leaves no room for " f"AB stages (mma_tiler={mma_tiler_mnk}); reduce mma_tiler_mn"
+        )
+
+        return num_acc_stage, num_ab_stage, num_d_stage, num_tile_stage, num_bias_stage, num_epi_stage
+
+    # ------------------------------------------------------------------
+    # Workspace helpers
+    # ------------------------------------------------------------------
+
+    def get_desc_workspace_bytes(self) -> int:
+        # Bytes for per-expert TMA descriptors (discrete weight mode only)
+        if self.weight_mode == MoEWeightMode.DISCRETE:
+            from ..moe_utils import DiscreteWeightTensormapConstructor
+
+            return DiscreteWeightTensormapConstructor.get_workspace_size(self.expert_cnt)
+        return 0
+
+    def get_workspace_bytes(self) -> int:
+        # Total workspace = TMA descriptor region + optional 4B dynamic-sched counter
+        desc_workspace_bytes = self.get_desc_workspace_bytes()
+        dynamic_sched_bytes = 4 if self.use_dynamic_sched else 0
+        return desc_workspace_bytes + dynamic_sched_bytes
+
+    @cute.jit
+    def _get_sched_counter_ptr(self, workspace_ptr):
+        # Atomic tile counter lives just past the descriptor region in the workspace
+        counter_addr = workspace_ptr.toint() + self.get_desc_workspace_bytes()
+        return cute.make_ptr(
+            cutlass.Int32,
+            counter_addr,
+            AddressSpace.gmem,
+            assumed_align=4,
+        )
+
+    # ------------------------------------------------------------------
+    # helper_kernel: pre-main-kernel initialization
+    #   - discrete weight: build per-expert B/SFB TMA descriptors
+    #   - dynamic sched: reset the atomic tile counter
+    # ------------------------------------------------------------------
+    @cute.kernel
+    def helper_kernel(
+        self,
+        # Discrete-only params (unused in dense mode, but must be present for signature)
+        ptrs_b: cute.Pointer,
+        ptrs_sfb: cute.Pointer,
+        n: Int32,
+        k: Int32,
+        b_stride_size: cutlass.Int64,
+        b_major_mode: cutlass.Constexpr,
+        workspace_ptr,
+        tiled_mma_arg: cute.TiledMma,
+        tiled_mma_sfb_arg: cute.TiledMma,
+        b_smem_layout_arg,
+        sfb_smem_layout_arg,
+        cluster_layout_vmnk_shape_arg: cutlass.Constexpr,
+        cluster_layout_sfb_vmnk_shape_arg: cutlass.Constexpr,
+    ):
+        """Pre-main-kernel initialization.
+
+        Launched with grid=(expert_cnt, 1, 1) for discrete mode, or
+        grid=(1, 1, 1) for dense+dynamic mode.
+
+        Discrete weight: each block builds B/SFB TMA descriptors for one expert.
+        Dynamic sched: block 0 resets the atomic tile counter to 0.
+        """
+        # One block per expert (discrete) or a single block (dense + dynamic sched)
+        expert_idx = cute.arch.block_idx()[0]
+
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE):
+            # TMA copy atoms for B / SFB given the cluster shape
+            b_tma_op_arg = sm100_utils.cluster_shape_to_tma_atom_B(self.cluster_shape_mn, tiled_mma_arg.thr_id)
+            sfb_tma_op_arg = sm100_utils.cluster_shape_to_tma_atom_SFB(self.cluster_shape_mn, tiled_mma_arg.thr_id)
+
+            # Wrap the device pointer arrays as tensors indexed by expert
+            b_ptr_tensor = cute.make_tensor(
+                cute.make_ptr(cutlass.Int64, ptrs_b.toint(), AddressSpace.gmem, assumed_align=8), cute.make_layout((self.expert_cnt,))
+            )
+            sfb_ptr_tensor = cute.make_tensor(
+                cute.make_ptr(cutlass.Int64, ptrs_sfb.toint(), AddressSpace.gmem, assumed_align=8), cute.make_layout((self.expert_cnt,))
+            )
+
+            # B strides depend on whether B is K-major or N-major
+            c1 = cutlass.Int32(1)
+            c0 = cutlass.Int64(0)
+            c1_64 = 1
+            if cutlass.const_expr(b_major_mode == OperandMajorMode.K):
+                stride_n = b_stride_size
+                stride_k = c1_64
+            else:
+                stride_n = c1_64
+                stride_k = b_stride_size
+
+            # Build this expert's B tensor and its TMA descriptor
+            b_ptr_val = b_ptr_tensor[expert_idx]
+            b_ptr = cute.make_ptr(self.b_dtype, b_ptr_val, AddressSpace.gmem)
+            b_tensor_i = cute.make_tensor(
+                b_ptr,
+                cute.make_layout((n, k, c1), stride=(stride_n, stride_k, c0)),
+            )
+            tma_atom_b, _ = cute.nvgpu.make_tiled_tma_atom_B(
+                b_tma_op_arg,
+                b_tensor_i,
+                b_smem_layout_arg,
+                self.mma_tiler,
+                tiled_mma_arg,
+                cluster_layout_vmnk_shape_arg,
+            )
+
+            # Store the B descriptor into this expert's workspace slot
+            workspace = TensormapWorkspace(workspace_ptr, ["b", "sfb"])
+            store_tma_desc(tma_atom_b, workspace.get_ptr("b", expert_idx))
+
+            # Build this expert's SFB tensor and its TMA descriptor, then store it
+            sfb_ptr_val = sfb_ptr_tensor[expert_idx]
+            sfb_ptr = cute.make_ptr(self.sf_dtype, sfb_ptr_val, AddressSpace.gmem)
+            sfb_layout = blockscaled_utils.tile_atom_to_shape_SF((n, k, c1), self.sf_vec_size)
+            sfb_tensor_i = cute.make_tensor(sfb_ptr, sfb_layout)
+            tma_atom_sfb, _ = cute.nvgpu.make_tiled_tma_atom_B(
+                sfb_tma_op_arg,
+                sfb_tensor_i,
+                sfb_smem_layout_arg,
+                self.mma_tiler_sfb,
+                tiled_mma_sfb_arg,
+                cluster_layout_sfb_vmnk_shape_arg,
+                internal_type=cutlass.Uint64,
+            )
+            store_tma_desc(tma_atom_sfb, workspace.get_ptr("sfb", expert_idx))
+
+        # Dynamic sched: block 0 zeroes the atomic tile counter
+        if cutlass.const_expr(self.use_dynamic_sched):
+            if expert_idx == cutlass.Int32(0):
+                sched_counter = cute.make_tensor(
+                    self._get_sched_counter_ptr(workspace_ptr),
+                    cute.make_layout(1),
+                )
+                sched_counter[0] = cutlass.Int32(0)
+
+    # ------------------------------------------------------------------
+    # __call__
+    # ------------------------------------------------------------------
+    @cute.jit
+    def __call__(
+        self,
+        a: cute.Tensor,
+        b,  # Dense: cute.Tensor (N,K,L) | Discrete: cute.Pointer to int64[]
+        sfb,  # Dense: cute.Tensor         | Discrete: cute.Pointer to int64[]
+        sfb2,  # Dense: cute.Tensor         | Discrete: cute.Pointer to int64[]
+        n: Int32,  # Ignored for dense mode
+        k: Int32,  # Ignored for dense mode
+        b_stride_size: cutlass.Int64,  # Ignored for dense mode
+        b_major_mode: cutlass.Constexpr,  # Ignored for dense mode
+        workspace_ptr,
+        d: cute.Tensor,
+        sfa: cute.Tensor,
+        sfa2: cute.Tensor,
+        padded_offsets: cute.Tensor,
+        alpha: cute.Tensor,
+        bias: Optional[cute.Tensor],
+        prob: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+    ):
+        """Execute the GEMM.
+
+        Dense mode: ``b`` and ``sfb`` are 3-D cute.Tensor (N, K, L).
+        Discrete mode: ``b`` and ``sfb`` are cute.Pointer to device int64[]
+        arrays of per-expert base addresses; ``n``, ``k``, ``b_stride_size``,
+        ``b_major_mode`` describe the uniform per-expert layout.
+        """
+        # Resolve operand/output dtypes and A/D major modes from the input tensors
+        self.a_dtype: Type[cutlass.Numeric] = a.element_type
+        self.b_dtype: Type[cutlass.Numeric] = a.element_type
+        self.d_dtype: Type[cutlass.Numeric] = d.element_type
+        self.sf_dtype: Type[cutlass.Numeric] = sfa.element_type
+        self.sf2_dtype: Type[cutlass.Numeric] = sfa2.element_type
+        self.bias_dtype = bias.element_type if cutlass.const_expr(self.enable_bias) else cutlass.BFloat16
+        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
+        self.d_layout = utils.LayoutEnum.from_tensor(d)
+
+        # Dense B carries its own layout; discrete mode passes b_major_mode explicitly
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DENSE):
+            self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
+        else:
+            self.b_major_mode = b_major_mode
+
+        if cutlass.const_expr(self.a_dtype != self.b_dtype):
+            raise TypeError(f"A/B dtype must match: {self.a_dtype} != {self.b_dtype}")
+
+        # Compute derived tile / stage / SMEM-layout attributes
+        self._setup_attributes()
+
+        # ---- SFA layout ----
+        sfa_layout = blockscaled_utils.tile_atom_to_shape_SF(a.shape, self.sf_vec_size)
+        sfa = cute.make_tensor(sfa.iterator, sfa_layout)
+
+        # ---- SFA2 layout ----
+        sfa2_tensor = cute.make_tensor(
+            sfa2.iterator,
+            cute.make_layout(
+                (
+                    (self.sgm, sfa2.shape[0]),
+                    (self.sgk, sfa2.shape[1]),
+                    sfa2.shape[2],
+                ),
+                stride=(
+                    (0, sfa2.layout.stride[0]),
+                    (0, sfa2.layout.stride[1]),
+                    sfa2.layout.stride[2],
+                ),
+            ),
+        )
+
+        c1 = cutlass.Int32(1)
+        c0 = cutlass.Int64(0)
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DENSE):
+            sfb2_ptr_typed = sfb2.iterator
+            sfb2_shape_0 = sfb2.shape[0]
+            sfb2_shape_1 = sfb2.shape[1]
+            sfb2_mode_2 = sfb2.shape[2]
+            sfb2_stride_0 = sfb2.layout.stride[0]
+            sfb2_stride_1 = sfb2.layout.stride[1]
+            sfb2_stride_2 = sfb2.layout.stride[2]
+        else:  # DISCRETE mode
+            # In discrete mode, sfb2 is a pointer to array of per-expert pointers (Int64[])
+            # Create a template tensor with correct element type (sf2_dtype) for get_gmem_tensor
+            # The pointer address is the pointer array address; get_gmem_tensor will load actual per-expert pointer
+            sfb2_ptr_typed = cute.make_ptr(
+                self.sf2_dtype,  # Correct data type so element_type is right
+                sfb2.toint(),  # Pointer array address (will be reinterpreted in get_gmem_tensor)
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            )
+            # Use computed scale values for template shape/stride
+            scale_n = cute.ceil_div(n, self.sgn)
+            scale_k = cute.ceil_div(k, self.sgk)
+            sfb2_shape_0 = scale_n
+            sfb2_shape_1 = scale_k
+            sfb2_mode_2 = c1
+            sfb2_stride_0 = c1
+            sfb2_stride_1 = scale_n
+            sfb2_stride_2 = c0
+
+        # ---- SFB2 layout ----
+        # Dense: use actual tensor shape/stride
+        # Discrete: use template shape/stride (get_gmem_tensor will load per-expert pointer)
+        sfb2_tensor = cute.make_tensor(
+            sfb2_ptr_typed,
+            cute.make_layout(
+                (
+                    (self.sgn, sfb2_shape_0),
+                    (self.sgk, sfb2_shape_1),
+                    sfb2_mode_2,
+                ),
+                stride=(
+                    (0, sfb2_stride_0),
+                    (0, sfb2_stride_1),
+                    sfb2_stride_2,
+                ),
+            ),
+        )
+
+        # ---- B / SFB setup (mode-dependent) ----
+        # Save the call-arg b/sfb before the discrete branch overwrites them
+        # with template tensors.  helper_kernel needs the original Pointers.
+        b_from_call_arg = b
+        sfb_from_call_arg = sfb
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DENSE):
+            sfb_layout = blockscaled_utils.tile_atom_to_shape_SF(b.shape, self.sf_vec_size)
+            sfb = cute.make_tensor(sfb.iterator, sfb_layout)
+        else:
+            c1 = cutlass.Int32(1)
+            c0 = cutlass.Int64(0)
+            c1_64 = 1
+            if cutlass.const_expr(b_major_mode == OperandMajorMode.K):
+                b_template_stride = (b_stride_size, c1_64, c0)
+            else:
+                b_template_stride = (c1_64, b_stride_size, c0)
+
+            # Creating a template layout and B tensor for a single expert
+            b_template_layout = cute.make_layout((n, k, c1), stride=b_template_stride)
+            b_ptr_typed = cute.make_ptr(self.b_dtype, b.toint(), AddressSpace.gmem, assumed_align=16)
+            b = cute.make_tensor(b_ptr_typed, b_template_layout)
+
+            # Creating a template layout and SFB tensor for a single expert
+            sfb_ptr_typed = cute.make_ptr(self.sf_dtype, sfb.toint(), AddressSpace.gmem, assumed_align=16)
+            sfb_layout = blockscaled_utils.tile_atom_to_shape_SF((n, k, c1), self.sf_vec_size)
+            sfb = cute.make_tensor(sfb_ptr_typed, sfb_layout)
+
+        # ---- TMA atoms ----
+        # Rebuild the tiled MMAs on the now-resolved dtypes / major modes
+        tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            self.mma_inst_shape_mn,
+        )
+        tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            cute.nvgpu.tcgen05.CtaGroup.ONE,
+            self.mma_inst_shape_mn_sfb,
+        )
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+
+        # A operand TMA atom
+        a_op = sm100_utils.cluster_shape_to_tma_atom_A(self.cluster_shape_mn, tiled_mma.thr_id)
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        tma_atom_a, tma_tensor_a = cute.nvgpu.make_tiled_tma_atom_A(
+            a_op,
+            a,
+            a_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # B operand TMA atom
+        b_op = sm100_utils.cluster_shape_to_tma_atom_B(self.cluster_shape_mn, tiled_mma.thr_id)
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op,
+            b,
+            b_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # SFA (first-level A scale) TMA atom
+        sfa_op = sm100_utils.cluster_shape_to_tma_atom_A(self.cluster_shape_mn, tiled_mma.thr_id)
+        sfa_smem_layout = cute.slice_(self.sfa_smem_layout_staged, (None, None, None, 0))
+        tma_atom_sfa, tma_tensor_sfa = cute.nvgpu.make_tiled_tma_atom_A(
+            sfa_op,
+            sfa,
+            sfa_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=cutlass.Int16,
+        )
+
+        # SFB (first-level B scale) TMA atom
+        sfb_op = sm100_utils.cluster_shape_to_tma_atom_SFB(self.cluster_shape_mn, tiled_mma.thr_id)
+        sfb_smem_layout = cute.slice_(self.sfb_smem_layout_staged, (None, None, None, 0))
+        tma_atom_sfb, tma_tensor_sfb = cute.nvgpu.make_tiled_tma_atom_B(
+            sfb_op,
+            sfb,
+            sfb_smem_layout,
+            self.mma_tiler_sfb,
+            tiled_mma_sfb,
+            self.cluster_layout_sfb_vmnk.shape,
+            internal_type=cutlass.Uint64,
+        )
+
+        # Total bytes moved per TMA load (used to size the AB pipeline barrier)
+        a_copy_size = cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        b_copy_size = cute.size_in_bytes(self.b_dtype, b_smem_layout)
+        sfa_copy_size = cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+        sfb_copy_size = cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+        self.num_tma_load_bytes = (a_copy_size + b_copy_size + sfa_copy_size + sfb_copy_size) * atom_thr_size
+
+        # D output TMA atom (SMEM -> GMEM bulk tensor store)
+        d_smem_layout = cute.slice_(self.d_smem_layout_staged, (None, None, 0))
+        tma_atom_d, tma_tensor_d = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileS2GOp(),
+            d,
+            d_smem_layout,
+            self.epi_tile,
+        )
+
+        # ---- Helper kernel: TMA desc init (discrete) + sched counter reset (dynamic) ----
+        _need_helper = cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE or self.use_dynamic_sched)
+        if cutlass.const_expr(_need_helper):
+            _helper_grid_x = self.expert_cnt if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else 1
+            _helper_args = (
+                b_from_call_arg if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else cute.make_ptr(cutlass.Int64, 0, AddressSpace.gmem),
+                sfb_from_call_arg if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else cute.make_ptr(cutlass.Int64, 0, AddressSpace.gmem),
+                n if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else cutlass.Int32(0),
+                k if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else cutlass.Int32(0),
+                b_stride_size if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else cutlass.Int64(0),
+                b_major_mode if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else self.b_major_mode,
+                workspace_ptr,
+                tiled_mma,
+                tiled_mma_sfb,
+                b_smem_layout,
+                sfb_smem_layout,
+                self.cluster_layout_vmnk.shape,
+                self.cluster_layout_sfb_vmnk.shape,
+            )
+            self.helper_kernel(*_helper_args).launch(
+                grid=(_helper_grid_x, 1, 1),
+                block=(1, 1, 1),
+                stream=stream,
+                min_blocks_per_mp=1,
+            )
+
+        # ---- Grid computation via MoE scheduler ----
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DENSE):
+            b_n, b_k, b_l = cute.shape(b)  # B is (N, K, L)
+            sched_expert_shape = (self.expert_cnt, b_n, b_k)
+        else:
+            sched_expert_shape = (self.expert_cnt, n, k)
+
+        sched_params = MoESchedulerParams(
+            scenario="2Dx3D",
+            expert_shape=sched_expert_shape,
+            cta_tile_shape_mnk=self.cta_tile_shape_mnk,
+            cluster_shape_mn=self.cluster_shape_mn,
+            use_dynamic_sched=self.use_dynamic_sched,
+        )
+        self.sched_params, grid = compute_grid(sched_params, max_active_clusters, self.use_2cta_instrs)
+
+        self.buffer_align_bytes = 1024
+
+        # ---- Shared storage ----
+        SchedulerStorage = MoEPersistentTileScheduler.make_storage_struct(self.num_tile_stage, self.use_dynamic_sched)
+
+        # Per-CTA SMEM layout: pipeline mbarriers, scheduler state, and all staged buffers
+        @cute.struct
+        class SharedStorage:
+            ab_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage * 2]
+            scale_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_scale_stage * 2]
+            acc_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage * 2]
+            epi_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_epi_stage * 2]
+            if cutlass.const_expr(self.enable_bias):
+                bias_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_bias_stage * 2]
+            scheduler: SchedulerStorage
+            tmem_dealloc_mbar_ptr: cutlass.Int64
+            tmem_holding_buf: cutlass.Int32
+            sD: cute.struct.Align[
+                cute.struct.MemRange[self.d_dtype, cute.cosize(self.d_smem_layout_staged.outer)],
+                self.buffer_align_bytes,
+            ]
+            sFinalAcc: cute.struct.Align[
+                cute.struct.MemRange[self.acc_dtype, cute.cosize(self.final_acc_smem_layout_staged.outer)],
+                self.buffer_align_bytes,
+            ]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[self.a_dtype, cute.cosize(self.a_smem_layout_staged.outer)],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[self.b_dtype, cute.cosize(self.b_smem_layout_staged.outer)],
+                self.buffer_align_bytes,
+            ]
+            sSFA: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(self.sfa_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sSFB: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(self.sfb_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sSFA2: cute.struct.Align[
+                cute.struct.MemRange[self.sf2_dtype, cute.cosize(self.sfa2_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sSFB2: cute.struct.Align[
+                cute.struct.MemRange[self.sf2_dtype, cute.cosize(self.sfb2_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            if cutlass.const_expr(self.enable_bias):
+                sBias: cute.struct.Align[
+                    cute.struct.MemRange[self.bias_dtype, cute.cosize(self.bias_smem_layout_staged)],
+                    16,
+                ]
+
+        self.shared_storage = SharedStorage
+
+        # ---- Launch ----
+        self.kernel(
+            tiled_mma,
+            tiled_mma_sfb,
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_sfa,
+            tma_tensor_sfa,
+            tma_atom_sfb,
+            tma_tensor_sfb,
+            sfa2_tensor,
+            sfb2_tensor,
+            tma_atom_d,
+            tma_tensor_d,
+            padded_offsets,
+            alpha,
+            bias,
+            prob,
+            workspace_ptr,
+            self.cluster_layout_vmnk,
+            self.cluster_layout_sfb_vmnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.sfa2_smem_layout_staged,
+            self.sfb2_smem_layout_staged,
+            self.d_smem_layout_staged,
+            self.final_acc_smem_layout_staged,
+            self.bias_smem_layout_staged,
+            self.epi_tile,
+            self.sched_params,
+            epilogue_op,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            max_number_threads=[self.threads_per_cta, 1, 1],
+            smem=self.shared_storage.size_in_bytes(),
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+        return
+
+    # ------------------------------------------------------------------
+    # Helper methods
+    # ------------------------------------------------------------------
+
+    def mainloop_s2t_copy_and_partition(self, sSF, tSF):
+        # Build the SMEM->TMEM copy for scale factors and partition src/dst (zeros filtered out)
+        tCsSF_compact = cute.filter_zeros(sSF)
+        tCtSF_compact = cute.filter_zeros(tSF)
+        copy_atom_s2t = cute.make_copy_atom(tcgen05.Cp4x32x128bOp(self.cta_group), self.sf_dtype)
+        tiled_copy_s2t = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSF_compact)
+        thr_copy_s2t = tiled_copy_s2t.get_slice(0)
+        tCsSF_compact_s2t_ = thr_copy_s2t.partition_S(tCsSF_compact)
+        # Convert the SMEM source into an S2T descriptor tensor expected by the copy
+        tCsSF_compact_s2t = tcgen05.get_s2t_smem_desc_tensor(tiled_copy_s2t, tCsSF_compact_s2t_)
+        tCtSF_compact_s2t = thr_copy_s2t.partition_D(tCtSF_compact)
+        return tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t
+
+    def acc_update_tmem_copy_and_partition(self, tidx, tCtAcc_base, gD_mnl, sSFA, sSFB, sFinalAcc, epi_tile):
+        """
+        Create tiled copy operations and partition tensors for accumulator update warp.
+
+        This function sets up T2R (TMEM-to-Register) and R2S (Register-to-SMEM) copies
+        for the accumulator update warp to:
+        1. Load partial accumulators from TMEM (tCtAcc_base) to registers
+        2. Store final accumulated result from registers to SMEM (sFinalAcc)
+
+        :param tidx: Thread index within accumulator update warp group
+        :param tCtAcc_base: TMEM tensor for reading partial accumulators (from MMA)
+        :param sFinalAcc: SMEM tensor for writing final accumulator (for epilogue)
+        :param epi_tile: Epilogue tile size
+        :return: Tuple of (tiled_copy_t2r, tiled_copy_r2s_acc, tTR_tAcc_base, tTR_rAcc,
+                          tTR_rAcc_final, tRS_sFinalAcc, tTR_sSFA, tTR_sSFB)
+        """
+        # Create TMEM load atom based on MMA tile size
+        if cutlass.const_expr(self.mma_tiler[0] == 64):
+            tmem_load_atom = cute.make_copy_atom(
+                tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(8)),
+                self.acc_dtype,
+            )
+        else:
+            tmem_load_atom = cute.make_copy_atom(
+                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)),
+                self.acc_dtype,
+            )
+
+        # Partition accumulator tensors by epilogue tile
+        tAcc_epi = cute.flat_divide(tCtAcc_base[((None, None), 0, 0, None)], epi_tile)
+
+        # Create tiled copy for T2R (TMEM to Register)
+        tiled_copy_t2r = tcgen05.make_tmem_copy(tmem_load_atom, tAcc_epi[(None, None, 0, 0, 0)])
+        # Get thread-specific slices
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+
+        # R2S (Register to SMEM) store of the final accumulator: reuse the T2R copy's
+        # thread-value layout with a universal copy atom (swizzle-safe for f32)
+        copy_atom_r2s_acc = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.acc_dtype)
+        tiled_copy_r2s_acc = cute.make_tiled_copy_D(copy_atom_r2s_acc, tiled_copy_t2r)
+        thr_copy_r2s_acc = tiled_copy_r2s_acc.get_slice(tidx)
+
+        # (R2S, R2S_M, R2S_N, SUBTILE * STAGE)
+        tRS_sFinalAcc = thr_copy_r2s_acc.partition_D(sFinalAcc)
+
+        # Partition source for T2R: tCtAcc_base (read partial accumulators)
+        tTR_tAcc_base = thr_copy_t2r.partition_S(tAcc_epi)
+
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, loopM, loopN, loopL)
+        gD_mnl_epi = cute.flat_divide(gD_mnl[((None, None), 0, 0, None, None, None)], epi_tile)
+        sSFA_epi = cute.flat_divide(sSFA, epi_tile)
+        sSFB_epi = cute.flat_divide(sSFB, epi_tile)
+
+        tTR_gC = thr_copy_t2r.partition_D(gD_mnl_epi)
+        tTR_sSFA = thr_copy_t2r.partition_D(sSFA_epi)
+        tTR_sSFB = thr_copy_t2r.partition_D(sSFB_epi)
+
+        # Create register tensor for T2R destination (holds one k_tile's partial accumulator)
+        # Shape: (T2R, T2R_M, T2R_N)
+        tTR_rAcc = cute.make_rmem_tensor(tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].shape, self.acc_dtype)
+
+        # Create register tensor for final accumulated result across all k_tiles
+        # Shape: (T2R, T2R_M, T2R_N, EPI_M, EPI_N) -> grouped to (T2R, T2R_M, T2R_N, (EPI_M, EPI_N))
+        tTR_rAcc_final_ = cute.make_rmem_tensor(tTR_gC[(None, None, None, None, None, 0, 0, 0)].shape, self.acc_dtype)
+        tTR_rAcc_final = cute.group_modes(tTR_rAcc_final_, 3, cute.rank(tTR_rAcc_final_))
+
+        return (
+            tiled_copy_t2r,
+            tiled_copy_r2s_acc,
+            tTR_tAcc_base,
+            tTR_rAcc,
+            tTR_rAcc_final,
+            tRS_sFinalAcc,
+            tTR_sSFA,
+            tTR_sSFB,
+        )
+
+    def epilog_tmem_copy_and_partition(self, tidx, tAcc, gD_mnl, epi_tile, use_2cta_instrs):
+        # Build the TMEM->register load for the epilogue and partition acc/output by epi tile
+        copy_atom_t2r = sm100_utils.get_tmem_load_op(
+            self.cta_tile_shape_mnk,
+            self.d_layout,
+            self.d_dtype,
+            self.acc_dtype,
+            epi_tile,
+            use_2cta_instrs,
+        )
+        tAcc_epi = cute.flat_divide(tAcc[((None, None), 0, 0, None)], epi_tile)
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tAcc_epi[(None, None, 0, 0, 0)])
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+        tTR_tAcc = thr_copy_t2r.partition_S(tAcc_epi)
+        gD_mnl_epi = cute.flat_divide(gD_mnl[((None, None), 0, 0, None, None, None)], epi_tile)
+        tTR_gC = thr_copy_t2r.partition_D(gD_mnl_epi)
+        tTR_rAcc = cute.make_rmem_tensor(tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].shape, self.acc_dtype)
+        return tiled_copy_t2r, tTR_tAcc, tTR_rAcc
+
+    def epilog_smem_copy_and_partition(self, tiled_copy_t2r, tTR_rD, tidx, sD):
+        # Build the register->SMEM store for the D output and partition it
+        copy_atom_r2s = sm100_utils.get_smem_store_op(self.d_layout, self.d_dtype, self.acc_dtype, tiled_copy_t2r)
+        tiled_copy_r2s = cute.make_tiled_copy_D(copy_atom_r2s, tiled_copy_t2r)
+        thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+        tRS_sD = thr_copy_r2s.partition_D(sD)
+        tRS_rD = tiled_copy_r2s.retile(tTR_rD)
+        return tiled_copy_r2s, tRS_rD, tRS_sD
+
+    def epilog_smem_load_copy_and_partition(self, tiled_copy_t2r, tTR_rAcc, tidx, sFinalAcc):
+        # S2R load of the final accumulator: reuse the T2R copy's thread-value layout
+        # with a universal copy atom; tSR_rAcc is a register view of tTR_rAcc
+        copy_atom_s2r = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.acc_dtype)
+        tiled_copy_s2r = cute.make_tiled_copy_D(copy_atom_s2r, tiled_copy_t2r)
+        thr_copy_s2r = tiled_copy_s2r.get_slice(tidx)
+        # (S2R, S2R_M, S2R_N, SUBTILE * STAGE)
+        tSR_sFinalAcc = thr_copy_s2r.partition_D(sFinalAcc)
+        tSR_rAcc = tiled_copy_s2r.retile(tTR_rAcc)
+        return tiled_copy_s2r, tSR_rAcc, tSR_sFinalAcc
+
+    # ------------------------------------------------------------------
+    # GPU device kernel
+    # ------------------------------------------------------------------
+
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tiled_mma_sfb: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        mSFA_mkl: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        mSFB_nkl: cute.Tensor,
+        sfa2_tensor: cute.Tensor,
+        sfb2_tensor,  # can be cute.Tensor or cute.Pointer
+        tma_atom_d: cute.CopyAtom,
+        mD_mnl: cute.Tensor,
+        padded_offsets: cute.Tensor,
+        alpha: cute.Tensor,
+        mBias_nl: Optional[cute.Tensor],
+        prob: cute.Tensor,
+        workspace_ptr,
+        cluster_layout_vmnk: cute.Layout,
+        cluster_layout_sfb_vmnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        sfa2_smem_layout_staged: cute.Layout,
+        sfb2_smem_layout_staged: cute.Layout,
+        d_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout, None],
+        final_acc_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout, None],
+        bias_smem_layout_staged: Optional[cute.Layout],
+        epi_tile: cute.Tile,
+        sched_params: MoESchedulerParams,
+        epilogue_op: cutlass.Constexpr,
+    ):
+        """GPU device kernel for the persistent second-level-scaled MoE grouped GEMM."""
+        # Per-thread warp / lane identity used for warp specialization
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        lane_idx = cute.arch.lane_idx()
+
+        # TMA warp prefetches all TMA descriptors up front (B/SFB only for dense)
+        if warp_idx == self.tma_warp_id:
+            cpasync.prefetch_descriptor(tma_atom_a)
+            cpasync.prefetch_descriptor(tma_atom_sfa)
+            if cutlass.const_expr(self.weight_mode == MoEWeightMode.DENSE):
+                cpasync.prefetch_descriptor(tma_atom_b)
+                cpasync.prefetch_descriptor(tma_atom_sfb)
+            cpasync.prefetch_descriptor(tma_atom_d)
+
+        # total_token is the last padded offset (0 => nothing to do for this launch)
+        use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+        total_token = padded_offsets[self.expert_cnt - 1]
+
+        # Block/cluster coordinates and this CTA's MMA V (leader/follower) coordinate
+        bidx, bidy, bidz = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
+        block_in_cluster_coord_sfb_vmnk = cluster_layout_sfb_vmnk.get_flat_coord(cta_rank_in_cluster)
+        tidx, _, _ = cute.arch.thread_idx()
+
+        # Allocate this CTA's shared storage struct
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+        sched_storage = storage.scheduler
+
+        # Initialize mainloop ab_pipeline and states
+        ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_tma_producer = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        ab_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, num_tma_producer)
+        ab_pipeline = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.ab_mbar_ptr.data_ptr(),
+            num_stages=self.num_ab_stage,
+            producer_group=ab_pipeline_producer_group,
+            consumer_group=ab_pipeline_consumer_group,
+            tx_count=self.num_tma_load_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )
+
+        # Initialize scale_pipeline and states
+        scale_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * 1,
+        )
+        scale_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * len(self.epilog_warp_id),
+        )
+        scale_pipeline = pipeline.PipelineCpAsync.create(
+            barrier_storage=storage.scale_mbar_ptr.data_ptr(),
+            num_stages=self.num_scale_stage,
+            producer_group=scale_pipeline_producer_group,
+            consumer_group=scale_pipeline_consumer_group,
+            defer_sync=True,
+        )
+
+        # Initialize acc_pipeline and states
+        acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_acc_consumer_threads = len(self.accumulator_update_warp_id) * (2 if use_2cta_instrs else 1)
+        acc_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, num_acc_consumer_threads)
+        acc_pipeline = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_stage,
+            producer_group=acc_pipeline_producer_group,
+            consumer_group=acc_pipeline_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )
+
+        # Initialize epi_pipeline and states
+        epi_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, self.threads_per_warp * len(self.accumulator_update_warp_id))
+        epi_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, self.threads_per_warp * len(self.epilog_warp_id))
+        epi_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.epi_mbar_ptr.data_ptr(),
+            num_stages=self.num_epi_stage,
+            producer_group=epi_pipeline_producer_group,
+            consumer_group=epi_pipeline_consumer_group,
+        )
+
+        # Initialize tile_info_pipeline and states
+        tile_info_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, self.threads_per_warp * 1)
+        tile_info_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, self.threads_wo_sched)
+        tile_info_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=sched_storage.tile_info_mbar.data_ptr(),
+            num_stages=self.num_tile_stage,
+            producer_group=tile_info_pipeline_producer_group,
+            consumer_group=tile_info_pipeline_consumer_group,
+        )
+
+        if cutlass.const_expr(self.enable_bias):
+            # Initialize bias_pipeline and states
+            bias_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, self.threads_per_warp)
+            bias_pipeline_consumer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                self.threads_per_warp * len(self.epilog_warp_id),
+            )
+            bias_pipeline = pipeline.PipelineCpAsync.create(
+                barrier_storage=storage.bias_mbar_ptr.data_ptr(),
+                num_stages=self.num_bias_stage,
+                producer_group=bias_pipeline_producer_group,
+                consumer_group=bias_pipeline_consumer_group,
+            )
+            sBias = storage.sBias.get_tensor(bias_smem_layout_staged)
+
+        # Create and initialize the persistent MoE tile scheduler
+        scheduler = MoEPersistentTileScheduler.create(
+            sched_params,
+            padded_offsets,
+            cute.arch.block_idx(),
+            cute.arch.grid_dim(),
+            counter_ptr=self._get_sched_counter_ptr(workspace_ptr),
+            sched_storage=sched_storage,
+        )
+        scheduler.internal_init()
+
+        # TMEM allocator holding the accumulator plus SFA/SFB scale columns
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr,
+            barrier_for_retrieve=self.tmem_alloc_barrier,
+            allocator_warp_id=self.epilog_warp_id[0],
+            is_two_cta=use_2cta_instrs,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr.ptr,
+        )
+
+        # Relaxed cluster arrive; the matching cluster_wait happens before specialization
+        if cute.size(self.cluster_shape_mn) > 1:
+            cute.arch.cluster_arrive_relaxed()
+
+        # Materialize SMEM tensor views over the staged buffers
+        sD = storage.sD.get_tensor(d_smem_layout_staged.outer, swizzle=d_smem_layout_staged.inner)
+        sFinalAcc = storage.sFinalAcc.get_tensor(final_acc_smem_layout_staged.outer, swizzle=final_acc_smem_layout_staged.inner)
+        sA = storage.sA.get_tensor(a_smem_layout_staged.outer, swizzle=a_smem_layout_staged.inner)
+        sB = storage.sB.get_tensor(b_smem_layout_staged.outer, swizzle=b_smem_layout_staged.inner)
+        sSFA = storage.sSFA.get_tensor(sfa_smem_layout_staged)
+        sSFB = storage.sSFB.get_tensor(sfb_smem_layout_staged)
+        sSFA2 = storage.sSFA2.get_tensor(sfa2_smem_layout_staged)
+        sSFB2 = storage.sSFB2.get_tensor(sfb2_smem_layout_staged)
+        info_layout = cute.make_layout((4, self.num_tile_stage), stride=(1, 4))
+        sInfo = sched_storage.sInfo.get_tensor(info_layout)
+
+        # Multicast masks — must create ALL when any mcast or 2CTA is active
+        a_full_mcast_mask = None
+        b_full_mcast_mask = None
+        sfa_full_mcast_mask = None
+        sfb_full_mcast_mask = None
+        if cutlass.const_expr(self.is_a_mcast or self.is_b_mcast or use_2cta_instrs):
+            a_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2)
+            b_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1)
+            sfa_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2)
+            sfb_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_sfb_vmnk, block_in_cluster_coord_sfb_vmnk, mcast_mode=1)
+
+        # MMA partition (for tCtAcc_fake shape computation only)
+        thr_mma_common = tiled_mma.get_slice(0)
+        tCsA_common = thr_mma_common.partition_A(sA)
+        tCsB_common = thr_mma_common.partition_B(sB)
+        tCsA_common = cute.filter_zeros(tCsA_common)
+        tCsB_common = cute.filter_zeros(tCsB_common)
+
+        # Preparing LDGSTS partition for second level scale factor tensor
+        atom_scale2_copy = cute.make_copy_atom(
+            cute.nvgpu.cpasync.CopyG2SOp(),
+            self.sf2_dtype,
+            num_bits_per_copy=self.sf2_dtype.width,
+        )
+        tiled_copy_sfa2 = cute.make_tiled_copy_tv(atom_scale2_copy, cute.make_layout((32,)), cute.make_layout((1,)))
+        tiled_copy_sfb2 = cute.make_tiled_copy_tv(atom_scale2_copy, cute.make_layout((32,)), cute.make_layout((1,)))
+
+        # Per-lane G2S partition of the SFA2/SFB2 SMEM destinations
+        thr_copy_sfa2 = tiled_copy_sfa2.get_slice(lane_idx)
+        thr_copy_sfb2 = tiled_copy_sfb2.get_slice(lane_idx)
+        tAsSFA2 = thr_copy_sfa2.partition_D(sSFA2)
+        tBsSFB2 = thr_copy_sfb2.partition_D(sSFB2)
+
+        # Scale viewed as C tensor
+        # N/M extents use the CTA-tile-clamped scale block size (scale_size_*),
+        # so the view spans exactly one CTA tile (size * per_tile == cta extent)
+        # regardless of whether sg{m,n} exceed the tile (e.g. sgn=512 > 256).
+        sSFA2_view_as_C_layout = cute.make_layout(
+            (
+                (self.scale_size_m, self.scale_m_per_tile),
+                self.cta_tile_shape_mnk[1],
+                self.num_scale_stage,
+            ),
+            stride=((0, 1), 0, self.scale_m_per_tile),
+        )
+        sSFB2_view_as_C_layout = cute.make_layout(
+            (
+                self.cta_tile_shape_mnk[0],
+                (self.scale_size_n, self.scale_n_per_tile),
+                self.num_scale_stage,
+            ),
+            stride=(0, (0, 1), self.scale_n_per_tile),
+        )
+        sSFA2_view_as_C = cute.make_tensor(sSFA2.iterator, sSFA2_view_as_C_layout)
+        sSFB2_view_as_C = cute.make_tensor(sSFB2.iterator, sSFB2_view_as_C_layout)
+
+        # Number of K MMA tiles that share a single second-level scale block
+        k_tile_same_scale_factor = self.sgk // self.mma_tiler[2]
+        # SMEM fragments for MMA (used by MMA warp)
+        tCrA = tiled_mma.make_fragment_A(sA)
+        tCrB = tiled_mma.make_fragment_B(sB)
+
+        # TMEM accumulator shape
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+        tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, self.num_acc_stage))
+
+        # Cluster sync before warp specialization
+        if cute.size(self.cluster_shape_mn) > 1:
+            cute.arch.cluster_wait()
+        else:
+            self.cta_sync_barrier.arrive_and_wait()
+
+        # No tokens routed to any expert this launch => every warp exits early
+        if total_token <= 0:
+            cute.arch.nvvm.exit()
+
+        # ==============================================================
+        # Scheduler warp (MoE Persistent Tile Scheduler)
+        # ==============================================================
+        if warp_idx == self.sched_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_sched_warps)
+            work_tile_info = scheduler.initial_work_tile_info()
+            tile_info_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_tile_stage)
+            # Publish each valid work tile's info into the tile-info pipeline
+            while work_tile_info.is_valid_tile:
+                tile_info_pipeline.producer_acquire(tile_info_producer_state)
+                with cute.arch.elect_one():
+                    sInfo[(0, tile_info_producer_state.index)] = work_tile_info.expert_idx
+                    sInfo[(1, tile_info_producer_state.index)] = work_tile_info.tile_m_idx
+                    sInfo[(2, tile_info_producer_state.index)] = work_tile_info.tile_n_idx
+                    sInfo[(3, tile_info_producer_state.index)] = work_tile_info.k_tile_cnt
+                cute.arch.fence_proxy("async.shared", space="cta")
+                self.sched_sync_barrier.arrive_and_wait()
+                tile_info_pipeline.producer_commit(tile_info_producer_state)
+                tile_info_producer_state.advance()
+                work_tile_info = scheduler.advance_to_next_work()
+
+            # Push a sentinel tile (expert_idx = -1) to signal end of work
+            tile_info_pipeline.producer_acquire(tile_info_producer_state)
+            with cute.arch.elect_one():
+                sInfo[(0, tile_info_producer_state.index)] = cutlass.Int32(-1)
+                sInfo[(1, tile_info_producer_state.index)] = cutlass.Int32(0)
+                sInfo[(2, tile_info_producer_state.index)] = cutlass.Int32(0)
+                sInfo[(3, tile_info_producer_state.index)] = cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            self.sched_sync_barrier.arrive_and_wait()
+            tile_info_pipeline.producer_commit(tile_info_producer_state)
+            tile_info_producer_state.advance()
+            tile_info_pipeline.producer_tail(tile_info_producer_state)
+
+        # ==============================================================
+        # DMA / TMA load warp
+        # ==============================================================
+        if warp_idx == self.tma_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_uniform_warps)
+
+            ext = self._make_extension(workspace_ptr)
+            ab_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_ab_stage)
+            tile_info_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_tile_stage)
+
+            # Prime the loop with the first work tile from the scheduler
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            while is_valid_tile:
+                work_tile_info = MoEWorkTileInfo(
+                    expert_idx=tile_info[0],
+                    tile_m_idx=tile_info[1],
+                    tile_n_idx=tile_info[2],
+                    k_tile_cnt=tile_info[3],
+                )
+                k_tile_cnt = work_tile_info.k_tile_cnt
+                ext.update_expert_info(padded_offsets, work_tile_info.expert_idx)
+
+                # Resolve this expert's A/B and first-level SFA/SFB gmem tensors, then tile them
+                real_a, _ = ext.get_gmem_tensor("a", mA_mkl, padded_offsets, work_tile_info)
+                real_b, desc_ptr_b = ext.get_gmem_tensor("b", mB_nkl, padded_offsets, work_tile_info)
+                real_sfa, _ = ext.get_gmem_tensor("sfa", mSFA_mkl, padded_offsets, work_tile_info)
+                real_sfb, desc_ptr_sfb = ext.get_gmem_tensor("sfb", mSFB_nkl, padded_offsets, work_tile_info)
+
+                gA_mkl = cute.local_tile(real_a, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None))
+                gB_nkl = cute.local_tile(real_b, cute.slice_(self.mma_tiler, (0, None, None)), (None, None, None))
+                gSFA_mkl = cute.local_tile(real_sfa, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None))
+                gSFB_nkl = cute.local_tile(real_sfb, cute.slice_(self.mma_tiler_sfb, (0, None, None)), (None, None, None))
+                # MMA partition on gmem tensors
+                thr_mma_dma = tiled_mma.get_slice(mma_tile_coord_v)
+                thr_mma_sfb_dma = tiled_mma_sfb.get_slice(mma_tile_coord_v)
+                tCgA = thr_mma_dma.partition_A(gA_mkl)
+                tCgB = thr_mma_dma.partition_B(gB_nkl)
+                tCgSFA = thr_mma_dma.partition_A(gSFA_mkl)
+                tCgSFB = thr_mma_sfb_dma.partition_B(gSFB_nkl)
+
+                # TMA partition A
+                a_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape)
+                tAsA, tAgA = cpasync.tma_partition(
+                    tma_atom_a,
+                    block_in_cluster_coord_vmnk[2],
+                    a_cta_layout,
+                    cute.group_modes(sA, 0, 3),
+                    cute.group_modes(tCgA, 0, 3),
+                )
+                # TMA partition B
+                b_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape)
+                tBsB, tBgB = cpasync.tma_partition(
+                    tma_atom_b,
+                    block_in_cluster_coord_vmnk[1],
+                    b_cta_layout,
+                    cute.group_modes(sB, 0, 3),
+                    cute.group_modes(tCgB, 0, 3),
+                )
+                # TMA partition SFA
+                sfa_cta_layout = a_cta_layout
+                tAsSFA, tAgSFA = cpasync.tma_partition(
+                    tma_atom_sfa,
+                    block_in_cluster_coord_vmnk[2],
+                    sfa_cta_layout,
+                    cute.group_modes(sSFA, 0, 3),
+                    cute.group_modes(tCgSFA, 0, 3),
+                )
+                tAsSFA = cute.filter_zeros(tAsSFA)
+                tAgSFA = cute.filter_zeros(tAgSFA)
+                # TMA partition SFB
+                sfb_cta_layout = cute.make_layout(cute.slice_(cluster_layout_sfb_vmnk, (0, None, 0, 0)).shape)
+                tBsSFB, tBgSFB = cpasync.tma_partition(
+                    tma_atom_sfb,
+                    block_in_cluster_coord_sfb_vmnk[1],
+                    sfb_cta_layout,
+                    cute.group_modes(sSFB, 0, 3),
+                    cute.group_modes(tCgSFB, 0, 3),
+                )
+                tBsSFB = cute.filter_zeros(tBsSFB)
+                tBgSFB = cute.filter_zeros(tBgSFB)
+
+                # Fix this tile's M/N coordinate and slice each operand down to it
+                mma_tile_coord_m = work_tile_info.tile_m_idx // cute.size(tiled_mma.thr_id.shape)
+                mma_tile_coord_n = work_tile_info.tile_n_idx
+                tAgA_slice = tAgA[(None, mma_tile_coord_m, None, 0)]
+                tBgB_slice = tBgB[(None, mma_tile_coord_n, None, 0)]
+                tAgSFA_slice = tAgSFA[(None, mma_tile_coord_m, None, 0)]
+                slice_n = mma_tile_coord_n
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
+                    slice_n = mma_tile_coord_n // 2
+                tBgSFB_slice = tBgSFB[(None, slice_n, None, 0)]
+
+                # Peek whether the first AB buffer stage is free before the k loop
+                ab_producer_state.reset_count()
+                peek_ab_empty_status = cutlass.Boolean(1)
+                if ab_producer_state.count < k_tile_cnt:
+                    peek_ab_empty_status = ab_pipeline.producer_try_acquire(ab_producer_state)
+
+                # k_tile loop
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                    tAgA_k = tAgA_slice[(None, ab_producer_state.count)]
+                    tBgB_k = tBgB_slice[(None, ab_producer_state.count)]
+                    tAgSFA_k = tAgSFA_slice[(None, ab_producer_state.count)]
+                    tBgSFB_k = tBgSFB_slice[(None, ab_producer_state.count)]
+                    tAsA_pipe = tAsA[(None, ab_producer_state.index)]
+                    tBsB_pipe = tBsB[(None, ab_producer_state.index)]
+                    tAsSFA_pipe = tAsSFA[(None, ab_producer_state.index)]
+                    tBsSFB_pipe = tBsSFB[(None, ab_producer_state.index)]
+
+                    # Acquire the stage, then TMA-load A/B/SFA/SFB for this k tile on one barrier
+                    tma_bar = ab_pipeline.producer_get_barrier(ab_producer_state)
+                    ab_pipeline.producer_acquire(ab_producer_state, peek_ab_empty_status)
+
+                    cute.copy(tma_atom_a, tAgA_k, tAsA_pipe, tma_bar_ptr=tma_bar, mcast_mask=a_full_mcast_mask)
+                    cute.copy(tma_atom_b, tBgB_k, tBsB_pipe, tma_bar_ptr=tma_bar, mcast_mask=b_full_mcast_mask, tma_desc_ptr=desc_ptr_b)
+                    cute.copy(tma_atom_sfa, tAgSFA_k, tAsSFA_pipe, tma_bar_ptr=tma_bar, mcast_mask=sfa_full_mcast_mask)
+                    cute.copy(tma_atom_sfb, tBgSFB_k, tBsSFB_pipe, tma_bar_ptr=tma_bar, mcast_mask=sfb_full_mcast_mask, tma_desc_ptr=desc_ptr_sfb)
+
+                    ab_producer_state.advance()
+                    peek_ab_empty_status = cutlass.Boolean(1)
+                    if ab_producer_state.count < k_tile_cnt:
+                        peek_ab_empty_status = ab_pipeline.producer_try_acquire(ab_producer_state)
+
+                # Get next tile from scheduler
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+            ab_pipeline.producer_tail(ab_producer_state)
+
+        # ==============================================================
+        # Second level scale load warp
+        # ==============================================================
+        if warp_idx == self.scale_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_uniform_warps)
+
+            ext = self._make_extension(workspace_ptr)
+            scale_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_scale_stage)
+
+            # Bias load shares this warp (a dedicated 13th warp would break the
+            # setmaxregister warpgroup alignment). One 2-stage cp.async produce
+            # per tile, consumed by the epilogue warpgroup.
+            if cutlass.const_expr(self.enable_bias):
+                bias_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_bias_stage)
+                # Per-lane G2S copy for streaming a bias column into SMEM
+                bias_g2s_atom = cute.make_copy_atom(
+                    cute.nvgpu.cpasync.CopyG2SOp(cache_mode=cute.nvgpu.cpasync.LoadCacheMode.GLOBAL),
+                    self.bias_dtype,
+                    num_bits_per_copy=128,
+                )
+                bias_g2s_tiled = cute.make_tiled_copy_tv(
+                    bias_g2s_atom,
+                    cute.make_layout((32,)),
+                    cute.make_layout((8,)),
+                )
+                thr_bias_g2s = bias_g2s_tiled.get_slice(cute.arch.lane_idx())
+                tBs_sBias = thr_bias_g2s.partition_D(sBias)
+
+            tile_info_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_tile_stage)
+            # Prime the loop with the first work tile from the scheduler
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            scale_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_scale_stage)
+
+            while is_valid_tile:
+
+                work_tile_info = MoEWorkTileInfo(
+                    expert_idx=tile_info[0],
+                    tile_m_idx=tile_info[1],
+                    tile_n_idx=tile_info[2],
+                    k_tile_cnt=tile_info[3],
+                )
+                k_tile_cnt = work_tile_info.k_tile_cnt
+                ext.update_expert_info(padded_offsets, work_tile_info.expert_idx)
+
+                # Get current tensors
+                mSFA2_mkl_current, _ = ext.get_gmem_tensor("sfa2", sfa2_tensor, padded_offsets, work_tile_info)
+                mSFB2_nkl_current, _ = ext.get_gmem_tensor("sfb2", sfb2_tensor, padded_offsets, work_tile_info)
+
+                # Create global memory tiled tensors
+                gSFA2_mkl = cute.local_tile(mSFA2_mkl_current, cute.slice_(self.cta_tile_shape_mnk, (None, 0, None)), (None, None, None))
+                gSFB2_nkl = cute.local_tile(mSFB2_nkl_current, cute.slice_(self.cta_tile_shape_mnk, (0, None, None)), (None, None, None))
+
+                # Create coordinate tensors
+                cSFA2_mkl = cute.make_identity_tensor(cute.shape(mSFA2_mkl_current))
+                cSFB2_nkl = cute.make_identity_tensor(cute.shape(mSFB2_nkl_current))
+                cSFA2 = cute.local_tile(cSFA2_mkl, cute.slice_(self.cta_tile_shape_mnk, (None, 0, None)), (None, None, None))
+                cSFB2 = cute.local_tile(cSFB2_nkl, cute.slice_(self.cta_tile_shape_mnk, (0, None, None)), (None, None, None))
+
+                # Partition tensors
+                tAgSFA2_mkl = thr_copy_sfa2.partition_S(gSFA2_mkl)
+                tBgSFB2_nkl = thr_copy_sfb2.partition_S(gSFB2_nkl)
+                tAcSFA2 = thr_copy_sfa2.partition_S(cSFA2)
+                tBcSFB2 = thr_copy_sfb2.partition_S(cSFB2)
+
+                mma_tile_coord_mnl = (work_tile_info.tile_m_idx, work_tile_info.tile_n_idx, 0)
+
+                # Prepare the mask for scaleA/scaleB
+                tApSFA2 = cute.make_rmem_tensor(
+                    cute.make_layout(cute.filter_zeros(cute.slice_(tAsSFA2, (None, None, None, 0))).shape),
+                    cutlass.Boolean,
+                )
+                tBpSFB2 = cute.make_rmem_tensor(
+                    cute.make_layout(cute.filter_zeros(cute.slice_(tBsSFB2, (None, None, None, 0))).shape),
+                    cutlass.Boolean,
+                )
+
+                # Peek (try_wait) SCALE buffer empty
+                scale_producer_state.reset_count()
+                peek_scale_empty_status = cutlass.Boolean(1)
+                if scale_producer_state.count < k_tile_cnt:
+                    peek_scale_empty_status = scale_pipeline.producer_try_acquire(scale_producer_state)
+
+                # k_tile loop
+                for k_tile in cutlass.range(0, k_tile_cnt // k_tile_same_scale_factor, 1, unroll=1):
+
+                    # Slice to per mma tile index
+                    tAsSFA2_pipe = cute.filter_zeros(tAsSFA2[(None, None, None, scale_producer_state.index)])
+                    tBsSFB2_pipe = cute.filter_zeros(tBsSFB2[(None, None, None, scale_producer_state.index)])
+
+                    tAgSFA2_k = cute.filter_zeros(
+                        tAgSFA2_mkl[
+                            (
+                                None,
+                                None,
+                                None,
+                                mma_tile_coord_mnl[0],
+                                scale_producer_state.count * k_tile_same_scale_factor,
+                                mma_tile_coord_mnl[2],
+                            )
+                        ]
+                    )
+                    tBgSFB2_k = cute.filter_zeros(
+                        tBgSFB2_nkl[
+                            (
+                                None,
+                                None,
+                                None,
+                                mma_tile_coord_mnl[1],
+                                scale_producer_state.count * k_tile_same_scale_factor,
+                                mma_tile_coord_mnl[2],
+                            )
+                        ]
+                    )
+
+                    tAcSFA2_compact = cute.filter_zeros(
+                        cute.slice_(
+                            tAcSFA2,
+                            (
+                                None,
+                                None,
+                                None,
+                                mma_tile_coord_mnl[0],
+                                scale_producer_state.count * k_tile_same_scale_factor,
+                                mma_tile_coord_mnl[2],
+                            ),
+                        )
+                    )
+                    tBcSFB2_compact = cute.filter_zeros(
+                        cute.slice_(
+                            tBcSFB2,
+                            (
+                                None,
+                                None,
+                                None,
+                                mma_tile_coord_mnl[1],
+                                scale_producer_state.count * k_tile_same_scale_factor,
+                                mma_tile_coord_mnl[2],
+                            ),
+                        )
+                    )
+
+                    # Skip more unnecessary load
+                    for i in cutlass.range_constexpr(cute.size(tApSFA2, mode=[1])):
+                        tApSFA2[((0, 0), i, (0, 0))] = cute.elem_less(tAcSFA2_compact[(i)][0], mSFA2_mkl_current.shape[0])
+                    for i in cutlass.range_constexpr(cute.size(tBpSFB2, mode=[1])):
+                        tBpSFB2[((0, 0), i, (0, 0))] = cute.elem_less(tBcSFB2_compact[(i)][0], mSFB2_nkl_current.shape[0])
+
+                    # Conditionally wait for Scale buffer empty
+                    scale_pipeline.producer_acquire(scale_producer_state, peek_scale_empty_status)
+
+                    # load scaleA/scaleB
+                    cute.copy(tiled_copy_sfa2, tAgSFA2_k, tAsSFA2_pipe, pred=tApSFA2)
+                    cute.copy(tiled_copy_sfb2, tBgSFB2_k, tBsSFB2_pipe, pred=tBpSFB2)
+
+                    scale_pipeline.producer_commit(scale_producer_state)
+
+                    # Peek (try_wait) Scale buffer empty
+                    scale_producer_state.advance()
+                    peek_scale_empty_status = cutlass.Boolean(1)
+                    if scale_producer_state.count < k_tile_cnt:
+                        peek_scale_empty_status = scale_pipeline.producer_try_acquire(scale_producer_state)
+
+                # Bias produce for this tile — after the k-tile loop so a
+                # blocking bias acquire never throttles scale prefetch.
+                if cutlass.const_expr(self.enable_bias):
+                    bias_producer_state.reset_count()
+                    # Slice this expert's bias down to the current N tile
+                    real_bias, _ = ext.get_gmem_tensor("bias", mBias_nl, padded_offsets, work_tile_info)
+                    gBias_expert = cute.local_tile(real_bias, cute.slice_(self.mma_tiler[:2], (0, None)), (None, None))
+                    bias_tile = gBias_expert[(None, work_tile_info.tile_n_idx, 0)]
+                    bias_identity_tensor = cute.make_identity_tensor(bias_tile.shape)
+                    bias_partitioned_by_g2s = thr_bias_g2s.partition_S(bias_tile)
+                    bias_coord_partitioned_by_g2s = thr_bias_g2s.partition_S(bias_identity_tensor)
+
+                    # Predicate out lanes past the valid N extent (ragged final tile)
+                    residue_n = sched_params.intermediate - work_tile_info.tile_n_idx * self.cta_tile_shape_mnk[1]
+                    bias_pred_tensor = cute.make_rmem_tensor(bias_coord_partitioned_by_g2s[(None, 0)].shape, cutlass.Boolean)
+                    for vi in cutlass.range_constexpr(cute.size(bias_pred_tensor)):
+                        bias_pred_tensor[vi] = cute.elem_less(bias_coord_partitioned_by_g2s[(vi, 0)], (residue_n,))
+                    bias_pred_tensor = bias_pred_tensor[((0, None),)]
+
+                    # Issue the predicated G2S bias load into the bias pipeline
+                    bias_pipeline.producer_acquire(bias_producer_state)
+                    cute.copy(bias_g2s_tiled, bias_partitioned_by_g2s[(None, 0)], tBs_sBias[(None, 0, bias_producer_state.index)], pred=bias_pred_tensor)
+                    bias_pipeline.producer_commit(bias_producer_state)
+                    bias_producer_state.advance()
+
+                # Get next tile from scheduler
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+            if cutlass.const_expr(self.enable_bias):
+                bias_pipeline.producer_tail(bias_producer_state)
+
+        # ==============================================================
+        # MMA warp
+        # ==============================================================
+        if warp_idx == self.mma_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_uniform_warps)
+            # Wait for TMEM allocation and view the accumulator region
+            tmem.wait_for_alloc()
+            acc_tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+
+            # SFA TMEM tensor
+            sfa_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            tCtSFA_layout = blockscaled_utils.make_tmem_layout_sfa(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfa_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFA = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout)
+
+            # SFB TMEM tensor
+            sfb_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            tCtSFB_layout = blockscaled_utils.make_tmem_layout_sfb(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfb_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFB = cute.make_tensor(sfb_tmem_ptr, tCtSFB_layout)
+
+            # S2T copy partition for SFA/SFB
+            (
+                tiled_copy_s2t_sfa,
+                tCsSFA_compact_s2t,
+                tCtSFA_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFA, tCtSFA)
+            (
+                tiled_copy_s2t_sfb,
+                tCsSFB_compact_s2t,
+                tCtSFB_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFB, tCtSFB)
+
+            ab_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_ab_stage)
+            acc_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_acc_stage)
+
+            tile_info_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_tile_stage)
+            # Prime the loop with the first work tile from the scheduler
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            while is_valid_tile:
+                k_tile_cnt = tile_info[3]
+
+                # Peek AB buffer full
+                ab_consumer_state.reset_count()
+                peek_ab_full_status = cutlass.Boolean(1)
+                if ab_consumer_state.count < k_tile_cnt and is_leader_cta:
+                    peek_ab_full_status = ab_pipeline.consumer_try_wait(ab_consumer_state)
+
+                # Peek Acc buffer empty
+                acc_producer_state.reset_count()
+                peek_acc_empty_status = cutlass.Boolean(1)
+                if ab_consumer_state.count < k_tile_cnt and is_leader_cta:
+                    peek_acc_empty_status = acc_pipeline.producer_try_acquire(acc_producer_state)
+
+                # This tile's (M, N, L=expert) MMA coordinate
+                mma_tile_coord_mnl = (
+                    tile_info[1] // cute.size(tiled_mma.thr_id.shape),
+                    tile_info[2],
+                    tile_info[0],
+                )
+
+                acc_stage_index = acc_producer_state.index
+
+                # k_tile loop
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+
+                    tCtAcc = tCtAcc_base[(None, None, None, acc_producer_state.index)]
+
+                    # Acquire a fresh accumulator stage at the start of each scale block
+                    if k_tile % k_tile_same_scale_factor == 0:
+                        if is_leader_cta:
+                            acc_pipeline.producer_acquire(acc_producer_state, peek_acc_empty_status)
+
+                    # Reset the ACCUMULATE field for the first tile within each scale block
+                    tiled_mma.set(tcgen05.Field.ACCUMULATE, k_tile % k_tile_same_scale_factor > 0)
+
+                    if is_leader_cta:
+                        # Wait for this k tile's operands, then stage SFA/SFB from SMEM into TMEM
+                        ab_pipeline.consumer_wait(ab_consumer_state, peek_ab_full_status)
+
+                        s2t_stage_coord = (None, None, None, None, ab_consumer_state.index)
+                        cute.copy(tiled_copy_s2t_sfa, tCsSFA_compact_s2t[s2t_stage_coord], tCtSFA_compact_s2t)
+                        cute.copy(tiled_copy_s2t_sfb, tCsSFB_compact_s2t[s2t_stage_coord], tCtSFB_compact_s2t)
+
+                        # Peek the next stage's fullness so the acquire can be non-blocking
+                        num_kblocks = cute.size(tCrA, mode=[2])
+                        ab_consumer_state_next = ab_consumer_state.clone()
+                        ab_consumer_state_next.advance()
+                        if ab_consumer_state_next.count < k_tile_cnt:
+                            peek_ab_full_status = ab_pipeline.consumer_try_wait(ab_consumer_state_next)
+
+                        # Issue one block-scaled MMA per K block, binding SFA/SFB each time
+                        for kblock_idx in cutlass.range(num_kblocks, unroll_full=True):
+                            kblock_coord = (None, None, kblock_idx, ab_consumer_state.index)
+                            sf_kblock_coord = (None, None, kblock_idx)
+                            tiled_mma.set(tcgen05.Field.SFA, tCtSFA[sf_kblock_coord].iterator)
+                            tiled_mma.set(tcgen05.Field.SFB, tCtSFB_mma[sf_kblock_coord].iterator)
+                            cute.gemm(tiled_mma, tCtAcc, tCrA[kblock_coord], tCrB[kblock_coord], tCtAcc)
+                            tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+                        ab_pipeline.consumer_release(ab_consumer_state)
+                        ab_consumer_state = ab_consumer_state_next
+
+                    # At the end of each scale block, commit the accumulator stage to consumers
+                    if k_tile % k_tile_same_scale_factor == k_tile_same_scale_factor - 1:
+                        if is_leader_cta:
+                            acc_pipeline.producer_commit(acc_producer_state)
+
+                        acc_producer_state.advance()
+                        if acc_producer_state.count < k_tile_cnt:
+                            if is_leader_cta:
+                                peek_acc_empty_status = acc_pipeline.producer_try_acquire(acc_producer_state)
+
+                # Get next tile from scheduler
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+            # Wait for accumulator buffer empty
+            acc_pipeline.producer_tail(acc_producer_state)
+
+        # ==============================================================
+        # Accumulator Update warps
+        # ==============================================================
+        if warp_idx in self.accumulator_update_warp_id and total_token > 0:
+            cute.arch.setmaxregister_increase(self.num_regs_acc_update_warps)
+
+            # Wait for TMEM allocation (done by epilogue warp)
+            tmem.wait_for_alloc()
+
+            # Retrieve TMEM pointer and create accumulator tensors
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+
+            # tCtAcc_base: Read partial accumulators from MMA (via acc_pipeline stages)
+            tCtAcc_base = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+
+            # Shape-only partition on global tensor (invariant setup for t2r copy atom)
+            gD_mnl_shape = cute.local_tile(mD_mnl, cute.slice_(self.mma_tiler_d, (None, None, 0)), (None, None, None))
+            thr_mma_epi = tiled_mma.get_slice(mma_tile_coord_v)
+            tCgD_shape = thr_mma_epi.partition_C(gD_mnl_shape)
+
+            # Consumer of acc_pipeline (receives partial accumulators from MMA)
+            acc_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_acc_stage)
+
+            # Consumer of scale_pipeline (receives partial accumulators from Scale Load Warp)
+            scale_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_scale_stage)
+
+            # Producer for epi_pipeline (sends final accumulator to epilogue)
+            epi_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_epi_stage)
+
+            # Call partitioning function to setup copy operations
+            acc_tidx = tidx
+            (
+                tiled_copy_t2r,
+                tiled_copy_r2s_acc,
+                tTR_tAcc_base,
+                tTR_rAcc,
+                tTR_rAcc_final,
+                tRS_sFinalAcc,
+                tTR_sSFA,
+                tTR_sSFB,
+            ) = self.acc_update_tmem_copy_and_partition(
+                acc_tidx,
+                tCtAcc_base,
+                tCgD_shape,
+                sSFA2_view_as_C,
+                sSFB2_view_as_C,
+                sFinalAcc,
+                epi_tile,
+            )
+
+            tile_info_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_tile_stage)
+            # Prime the loop with the first work tile from the scheduler
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            # Main tile processing loop
+            while is_valid_tile:
+
+                # Extract k_tile_cnt from scheduler
+                k_tile_cnt = tile_info[3]
+
+                # Initialize final accumulator to zero
+                tTR_rAcc_final.fill(0.0)
+
+                tTR_rSFA = cute.make_rmem_tensor(
+                    cute.slice_(tTR_sSFA, (None, None, None, 0, None, 0)).shape,
+                    self.acc_dtype,
+                )
+                tTR_rSFB = cute.make_rmem_tensor(
+                    cute.slice_(tTR_sSFB, (None, None, None, 0, None, 0)).shape,
+                    self.acc_dtype,
+                )
+
+                # Reset and peek acc_pipeline (MMA produces partial accumulators)
+                acc_consumer_state.reset_count()
+                peek_acc_full_status = cutlass.Boolean(1)
+                if acc_consumer_state.count < k_tile_cnt:
+                    peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
+
+                # Peek (try_wait) Scale buffer full for k_tile = 0
+                scale_consumer_state.reset_count()
+                peek_scale_full_status = cutlass.Boolean(1)
+                if scale_consumer_state.count < k_tile_cnt:
+                    peek_scale_full_status = scale_pipeline.consumer_try_wait(scale_consumer_state)
+
+                # k_tile loop
+                for k_tile in cutlass.range(0, k_tile_cnt // k_tile_same_scale_factor, 1, unroll=1):
+
+                    # Wait for scale buffer full
+                    scale_pipeline.consumer_wait(scale_consumer_state, peek_scale_full_status)
+
+                    tTR_sSFA_slice = cute.slice_(
+                        tTR_sSFA,
+                        (None, None, None, 0, None, scale_consumer_state.index),
+                    )
+                    tTR_sSFB_slice = cute.slice_(
+                        tTR_sSFB,
+                        (None, None, None, 0, None, scale_consumer_state.index),
+                    )
+                    scale_atom_copy = cute.make_copy_atom(
+                        cute.nvgpu.CopyUniversalOp(),
+                        self.acc_dtype,
+                        num_bits_per_copy=self.acc_dtype.width,
+                    )
+
+                    cute.copy(scale_atom_copy, tTR_sSFA_slice, tTR_rSFA)
+                    cute.copy(scale_atom_copy, tTR_sSFB_slice, tTR_rSFB)
+
+                    # Async arrive scale buffer empty
+                    scale_pipeline.consumer_release(scale_consumer_state)
+                    scale_consumer_state.advance()
+
+                    # Wait for MMA to produce partial accumulator for this k_tile
+                    acc_pipeline.consumer_wait(acc_consumer_state, peek_acc_full_status)
+
+                    # Index into TMEM buffer for current pipeline stage
+                    tTR_tAcc = tTR_tAcc_base[(None, None, None, None, None, acc_consumer_state.index)]
+
+                    # Group modes for subtile iteration
+                    tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+
+                    # Process each subtile
+                    subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+                    for subtile_idx in cutlass.range(subtile_cnt):
+
+                        # Load partial accumulator from TMEM to register
+                        tTR_tAcc_mn = tTR_tAcc[(None, None, None, subtile_idx)]
+                        cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+
+                        # Accumulate: final += partial (no scaling)
+                        tTR_rAcc_subtile = tTR_rAcc_final[(None, None, None, subtile_idx)]
+                        acc_vec = tTR_rAcc.load()
+                        final_vec = tTR_rAcc_subtile.load()
+                        scale_a = tTR_rSFA[(None, None, None, subtile_idx)].load()
+                        scale_b = tTR_rSFB[(None, None, None, subtile_idx)].load()
+                        scale = scale_a * scale_b
+                        final_vec = acc_vec * scale + final_vec  # Simple accumulation
+                        tTR_rAcc_subtile.store(final_vec.to(self.acc_dtype))
+
+                    # Release acc_pipeline buffer (MMA can reuse it)
+                    with cute.arch.elect_one():
+                        acc_pipeline.consumer_release(acc_consumer_state)
+                    acc_consumer_state.advance()
+
+                    # Peek next k_tile
+                    peek_acc_full_status = cutlass.Boolean(1)
+                    if acc_consumer_state.count < k_tile_cnt:
+                        peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
+
+                    peek_scale_full_status = cutlass.Boolean(1)
+                    if scale_consumer_state.count < k_tile_cnt:
+                        peek_scale_full_status = scale_pipeline.consumer_try_wait(scale_consumer_state)
+
+                # All k_tiles accumulated, now store final result to SMEM for epilogue
+                # Acquire epi_pipeline (wait for epilogue to be done with the buffer)
+                epi_pipeline.producer_acquire(epi_producer_state)
+
+                # Copy final accumulator from registers to SMEM, one epi subtile per slot.
+                # No proxy fence needed: producer and consumer both use the generic proxy,
+                # and producer_commit's mbarrier arrive has release semantics.
+                final_subtile_cnt = cute.size(tTR_rAcc_final.shape, mode=[3])
+                slot_base = epi_producer_state.index * final_subtile_cnt
+                for subtile_idx in cutlass.range(final_subtile_cnt, unroll_full=True):
+                    tRS_rFinal = tiled_copy_r2s_acc.retile(tTR_rAcc_final[(None, None, None, subtile_idx)])
+                    cute.copy(
+                        tiled_copy_r2s_acc,
+                        tRS_rFinal,
+                        tRS_sFinalAcc[(None, None, None, slot_base + subtile_idx)],
+                    )
+
+                # Commit to epi_pipeline (signal epilogue that data is ready)
+                epi_pipeline.producer_commit(epi_producer_state)
+                epi_producer_state.advance()
+
+                # Get next tile from scheduler
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+        # ==============================================================
+        # Epilogue warps
+        # ==============================================================
+        if warp_idx in self.epilog_warp_id and total_token > 0:
+            cute.arch.setmaxregister_increase(self.num_regs_epilogue_warps)
+            tmem.allocate(self.num_tmem_alloc_cols)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+
+            # Final accumulator now lives in SMEM (sFinalAcc); TMEM here is only used
+            # by MMA partials + SF. tCtAcc_base_ is a shape/TV-layout carrier for the
+            # t2r template below — it is never dereferenced in the epilogue.
+            tCtAcc_base_ = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+
+            # Shape-only partition on global tensor (invariant setup for t2r copy atom)
+            gD_mnl_shape = cute.local_tile(mD_mnl, cute.slice_(self.mma_tiler_d, (None, None, 0)), (None, None, None))
+            thr_mma_epi = tiled_mma.get_slice(mma_tile_coord_v)
+            tCgD_shape = thr_mma_epi.partition_C(gD_mnl_shape)
+
+            epi_tidx = tidx % 128
+            (
+                tiled_copy_t2r,
+                tTR_tAcc_base,
+                tTR_rAcc,
+            ) = self.epilog_tmem_copy_and_partition(
+                epi_tidx,
+                tCtAcc_base_,
+                tCgD_shape,
+                epi_tile,
+                use_2cta_instrs,
+            )
+
+            tTR_rD = cute.make_rmem_tensor(tTR_rAcc.shape, self.d_dtype)
+            tiled_copy_r2s, tRS_rD, tRS_sD = self.epilog_smem_copy_and_partition(
+                tiled_copy_t2r,
+                tTR_rD,
+                epi_tidx,
+                sD,
+            )
+            tiled_copy_s2r, tSR_rAcc, tSR_sFinalAcc = self.epilog_smem_load_copy_and_partition(
+                tiled_copy_t2r,
+                tTR_rAcc,
+                epi_tidx,
+                sFinalAcc,
+            )
+
+            epi_ext = self._make_extension(workspace_ptr)
+
+            # Consume from epi_pipeline (from accumulator update warp)
+            epi_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_epi_stage)
+            d_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 32 * len(self.epilog_warp_id))
+            d_pipeline = pipeline.PipelineTmaStore.create(num_stages=self.num_d_stage, producer_group=d_producer_group)
+
+            tile_info_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_tile_stage)
+            # Prime the loop with the first work tile from the scheduler
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            if cutlass.const_expr(self.enable_bias):
+                bias_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_bias_stage)
+                bias_s2r_tom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.bias_dtype, num_bits_per_copy=128)
+                # epi_tile_n_required: compute_epilogue_tile_shape returns Layout
+                # modes on current DSLs; make_layout needs the plain host-side extent.
+                tTR_rBias = cute.make_rmem_tensor(cute.make_layout(self.epi_tile_n_required), self.bias_dtype)
+
+            num_prev_subtiles = cutlass.Int32(0)
+            while is_valid_tile:
+                epi_work_tile_info = MoEWorkTileInfo(
+                    expert_idx=tile_info[0],
+                    tile_m_idx=tile_info[1],
+                    tile_n_idx=tile_info[2],
+                    k_tile_cnt=tile_info[3],
+                )
+                expert_idx = epi_work_tile_info.expert_idx
+                epi_ext.update_expert_info(padded_offsets, expert_idx)
+
+                alpha_val = alpha[expert_idx]
+
+                if cutlass.const_expr(self.enable_bias):
+                    bias_consumer_state.reset_count()
+                    bias_pipeline.consumer_wait(bias_consumer_state)
+                    sBias_stage = sBias[(None, bias_consumer_state.index)]
+                    sBias_subtiles = cute.flat_divide(sBias_stage, cute.make_layout(self.epi_tile_n_required))
+
+                real_d, _ = epi_ext.get_gmem_tensor("d", mD_mnl, padded_offsets, epi_work_tile_info)
+
+                thr_mma_epi_loop = tiled_mma.get_slice(mma_tile_coord_v)
+
+                gD_mnl_loop = cute.local_tile(real_d, cute.slice_(self.mma_tiler_d, (None, None, 0)), (None, None, None))
+                tCgD_loop = thr_mma_epi_loop.partition_C(gD_mnl_loop)
+                _, bSG_sD, bSG_gD_partitioned = epilog_gmem_copy_and_partition(
+                    epi_tidx,
+                    tma_atom_d,
+                    tCgD_loop,
+                    epi_tile,
+                    sD,
+                )
+
+                epi_mma_tile_coord = (
+                    epi_work_tile_info.tile_m_idx // cute.size(tiled_mma.thr_id.shape),
+                    epi_work_tile_info.tile_n_idx,
+                    0,
+                )
+
+                bSG_gD = bSG_gD_partitioned[(None, None, None, *epi_mma_tile_coord)]
+                bSG_gD = cute.group_modes(bSG_gD, 1, cute.rank(bSG_gD))
+
+                mPosition = epi_work_tile_info.tile_m_idx * self.cta_tile_shape_mnk[0] + tidx % 128
+                real_prob, _ = epi_ext.get_gmem_tensor("prob", prob, padded_offsets, epi_work_tile_info)
+                mProb = real_prob[mPosition, 0, 0]
+
+                epi_stage_index = 0  # epi_pipeline has num_epi_stage=1
+
+                tTR_tAcc = tTR_tAcc_base[(None, None, None, None, None, epi_stage_index)]
+                tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+
+                # Wait on epi_pipeline for final accumulator from accumulator update warp
+                epi_pipeline.consumer_wait(epi_consumer_state)
+
+                subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+
+                for subtile_idx in cutlass.range(0, subtile_cnt, 1, unroll=1):
+                    # No reverse subtile logic needed (epi_pipeline has 1 stage)
+                    real_subtile_idx = subtile_idx
+
+                    # Load final accumulator subtile from SMEM (written by acc-update warp)
+                    final_slot = epi_stage_index * subtile_cnt + real_subtile_idx
+                    cute.copy(
+                        tiled_copy_s2r,
+                        tSR_sFinalAcc[(None, None, None, final_slot)],
+                        tSR_rAcc,
+                    )
+
+                    if cutlass.const_expr(self.enable_bias):
+                        # m7 fix: use real_subtile_idx directly (matches contiguous)
+                        sBias_sub = sBias_subtiles[(None, real_subtile_idx)]
+                        cute.copy(bias_s2r_tom, sBias_sub, tTR_rBias)
+                        bias_vec = tTR_rBias.load()
+                        if cutlass.const_expr(self.vectorized_f32):
+                            for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
+                                bias_f32_0 = bias_vec[i].to(cutlass.Float32)
+                                bias_f32_1 = bias_vec[i + 1].to(cutlass.Float32)
+                                bias_f32_0, bias_f32_1 = cute.arch.mul_packed_f32x2(
+                                    (mProb, mProb),
+                                    (bias_f32_0, bias_f32_1),
+                                    rnd="rn",
+                                    ftz=False,
+                                )
+                                tTR_rAcc[i], tTR_rAcc[i + 1] = cute.arch.fma_packed_f32x2(
+                                    (tTR_rAcc[i], tTR_rAcc[i + 1]),
+                                    (cutlass.Float32(alpha_val), cutlass.Float32(alpha_val)),
+                                    (bias_f32_0, bias_f32_1),
+                                    rnd="rn",
+                                    ftz=False,
+                                )
+                        else:
+                            for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
+                                tTR_rAcc[i] = tTR_rAcc[i] * cutlass.Float32(alpha_val) + bias_vec[i].to(cutlass.Float32) * mProb
+                    else:
+                        if cutlass.const_expr(self.vectorized_f32):
+                            for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
+                                tTR_rAcc[i], tTR_rAcc[i + 1] = cute.arch.mul_packed_f32x2(
+                                    (tTR_rAcc[i], tTR_rAcc[i + 1]),
+                                    (cutlass.Float32(alpha_val), cutlass.Float32(alpha_val)),
+                                    rnd="rn",
+                                    ftz=False,
+                                )
+                        else:
+                            for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
+                                tTR_rAcc[i] = tTR_rAcc[i] * cutlass.Float32(alpha_val)
+
+                    acc_vec = tTR_rAcc.load()
+                    if cutlass.const_expr(not self.enable_bias):
+                        tCompute = cute.make_rmem_tensor(acc_vec.shape, self.acc_dtype)
+                        if cutlass.const_expr(self.vectorized_f32):
+                            for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
+                                tCompute[i], tCompute[i + 1] = cute.arch.mul_packed_f32x2(
+                                    (acc_vec[i], acc_vec[i + 1]),
+                                    (mProb, mProb),
+                                    rnd="rn",
+                                    ftz=False,
+                                )
+                        else:
+                            for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
+                                tCompute[i] = acc_vec[i] * mProb
+                    else:
+                        tCompute = tTR_rAcc
+
+                    acc_vec = tiled_copy_r2s.retile(tCompute).load()
+                    tRS_rD.store(acc_vec.to(self.d_dtype))
+
+                    d_buffer = num_prev_subtiles % self.num_d_stage
+                    num_prev_subtiles = num_prev_subtiles + 1
+                    cute.copy(tiled_copy_r2s, tRS_rD, tRS_sD[(None, None, None, d_buffer)])
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    self.epilog_sync_barrier.arrive_and_wait()
+                    if warp_idx == self.epilog_warp_id[0]:
+                        cute.copy(tma_atom_d, bSG_sD[(None, d_buffer)], bSG_gD[(None, real_subtile_idx)])
+                        d_pipeline.producer_commit()
+                        d_pipeline.producer_acquire()
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+                epi_pipeline.consumer_release(epi_consumer_state)
+                epi_consumer_state.advance()
+
+                if cutlass.const_expr(self.enable_bias):
+                    bias_pipeline.consumer_release(bias_consumer_state)
+                    bias_consumer_state.advance()
+
+                # Get next tile from scheduler
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+            tmem.relinquish_alloc_permit()
+            self.epilog_sync_barrier.arrive_and_wait()
+            tmem.free(tmem_ptr)
+            d_pipeline.producer_tail()
+
+    # ------------------------------------------------------------------
+    # Internal: create extension based on weight_mode
+    # ------------------------------------------------------------------
+
+    @cute.jit
+    def _make_extension(self, workspace_ptr):
+        # Discrete mode resolves per-expert B/SFB via prebuilt TMA descriptors;
+        # dense mode uses the contiguous grouped-GEMM scheduler extension
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE):
+            desc_workspace = TensormapWorkspace(workspace_ptr, ["b", "sfb"])
+            return DiscreteWeightScaledGemmSchedExtension(
+                tensormap_ctor=desc_workspace,
+                sf_vec_size=self.sf_vec_size,
+            )
+        else:
+            return ContiguousAndConsistentGroupedGemmSchedExtension(
+                sf_vec_size=self.sf_vec_size,
+            )

--- a/python/cudnn/gemm/cutedsl/grouped/unfused_subchannel_scaled/moe_blockscaled_grouped_gemm_unfused_subchannel_scaled_rubin.py
+++ b/python/cudnn/gemm/cutedsl/grouped/unfused_subchannel_scaled/moe_blockscaled_grouped_gemm_unfused_subchannel_scaled_rubin.py
@@ -1,0 +1,2527 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Second-Level-Scaled (Subchannel-Scaled) MoE Block-Scaled Grouped GEMM Kernel (Rubin sm107).
+
+Supports:
+    - Static / Dynamic persistent tile scheduling (MoEPersistentTileScheduler)
+    - Dense (contiguous 3-D B) / Discrete (per-expert pointer array B) weight layout
+    - Optional bias and routing-probability (prob) fusion
+
+This module contains only the kernel class.
+MoE scheduler components live in moe_persistent_scheduler.py / moe_sched_extension.py / moe_utils.py.
+"""
+
+from typing import Literal, Type, Tuple, Union, Optional
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import cpasync, tcgen05
+from cutlass.cute.nvgpu import OperandMajorMode
+from cutlass.cute.nvgpu.tcgen05 import CollectorOp
+from cutlass.utils.gemm.sm100 import transform_partitioned_tensor_layout
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.utils.rubin_helpers as sm107_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+from cutlass.cute.typing import Float32, Int32, AddressSpace
+from ..moe_persistent_scheduler import (
+    MoEPersistentTileScheduler,
+    MoESchedulerParams,
+    MoEWorkTileInfo,
+)
+from ..moe_utils import (
+    MoEWeightMode,
+    TensormapWorkspace,
+    store_tma_desc,
+)
+from ..moe_sched_extension import (
+    DiscreteWeightScaledGemmSchedExtension,
+    ContiguousAndConsistentGroupedGemmSchedExtension,
+)
+from ..moe_kernel_helpers import (
+    compute_grid,
+    can_implement,
+    epilog_gmem_copy_and_partition,
+    is_valid_dtypes_and_scale_factor_vec_size,
+    is_valid_layouts,
+    is_valid_tensor_alignment,
+    FIX_PAD_SIZE,
+)
+
+# Valid launch-config space for THIS kernel (can_implement still prunes per
+# problem). cta shape == mma_tiler_mn. The upstream B-reuse (512, 256) tile and
+# N=192 tiles are deliberately NOT exposed yet — Blackwell-kernel parity first.
+VALID_CTA_SHAPES = ((256, 128), (256, 256))
+VALID_CLUSTER_SHAPES = ((1, 1), (2, 1), (2, 2), (4, 1), (4, 2))
+DEFAULT_CTA_SHAPE = (256, 128)
+DEFAULT_CLUSTER_SHAPE = (2, 1)
+
+
+class BlockScaledSubChannelMoEGroupedGemmKernelSm107:
+    """Second-level-scaled block-scaled grouped GEMM kernel with MoE tile scheduling (Rubin sm107).
+
+    Supports both dense and discrete weight layouts and static and dynamic
+    scheduling. Inputs carry two scale levels (per-(1,16) SFA/SFB plus f32
+    SFA2/SFB2 subchannel scales); the output D is plain BF16.
+
+    :param sf_vec_size: Scale-factor vector size (16 or 32).
+    :param acc_dtype: Accumulator data type (Float32).
+    :param use_2cta_instrs: Use 2-CTA MMA instructions.
+    :param mma_tiler_mn: MMA tile shape (M, N).
+    :param cluster_shape_mn: Cluster shape (M, N).
+    :param vectorized_f32: Use packed FP32 arithmetic.
+    :param enable_bias: Fuse bias addition.
+    :param expert_cnt: Number of experts.
+    :param weight_mode: ``MoEWeightMode.DENSE`` or ``MoEWeightMode.DISCRETE``.
+    :param use_dynamic_sched: Enable dynamic tile scheduling.
+    :param sf_fp8_dtype_override: Reinterpret the FP8-format block scale factors
+        as E5M3 instead of the E4M3 implied by their storage dtype. ``None``
+        (default) leaves the format inferred, as every caller did before this
+        knob existed. ``"e5m3"`` requires Rubin and the NVFP4 recipe, and the
+        scale tensors are still supplied as ``torch.float8_e4m3fn`` because
+        torch has no e5m3 dtype -- only the CuTe element type is overridden.
+    """
+
+    FIX_PAD_SIZE = 256
+
+    @staticmethod
+    def can_implement(
+        ab_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        acc_dtype: Type[cutlass.Numeric],
+        d_dtype: Type[cutlass.Numeric],
+        use_2cta_instrs: bool,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        m: int,
+        n: int,
+        k: int,
+        l: int,
+        a_major: str,
+        b_major: str,
+        cd_major: str,
+        m_aligned: int,
+        weight_mode: MoEWeightMode = MoEWeightMode.DENSE,
+        sgn: int = 256,
+        sgk: int = 256,
+    ) -> bool:
+        result = None
+        # B-reuse case: 2CTA + mma_tiler_mn[0] = 512 (two 256-M instructions per tile)
+        if use_2cta_instrs and mma_tiler_mn[0] == 512:
+            # Pad alignment: per CTA tile = 256 M rows
+            result = (
+                is_valid_dtypes_and_scale_factor_vec_size(ab_dtype, sf_dtype, sf_vec_size, acc_dtype, d_dtype)
+                and is_valid_layouts(ab_dtype, d_dtype, a_major, b_major, cd_major)
+                and is_valid_tensor_alignment(m, n, k, l, ab_dtype, d_dtype, a_major, b_major, cd_major)
+                and mma_tiler_mn[1] in {192, 256}
+                and cluster_shape_mn[0] % 2 == 0
+                and m_aligned % mma_tiler_mn[0] == 0
+                and m % mma_tiler_mn[0] == 0
+            )
+        # Allow N=192 in addition to the shared helper's N=256 constraint.
+        elif mma_tiler_mn[1] == 192:
+            result = (
+                m_aligned == FIX_PAD_SIZE
+                and ab_dtype.width != 8
+                and is_valid_dtypes_and_scale_factor_vec_size(ab_dtype, sf_dtype, sf_vec_size, acc_dtype, d_dtype)
+                and is_valid_layouts(ab_dtype, d_dtype, a_major, b_major, cd_major)
+                and is_valid_tensor_alignment(m, n, k, l, ab_dtype, d_dtype, a_major, b_major, cd_major)
+                and a_major == "k"
+                and b_major == "k"
+                and n % 64 == 0
+                and m % 256 == 0
+                and use_2cta_instrs
+                and mma_tiler_mn[0] == 256
+                and cluster_shape_mn[0] % 2 == 0
+            )
+        else:
+            result = can_implement(
+                ab_dtype,
+                sf_dtype,
+                sf_vec_size,
+                acc_dtype,
+                d_dtype,
+                use_2cta_instrs,
+                mma_tiler_mn,
+                cluster_shape_mn,
+                m,
+                n,
+                k,
+                l,
+                a_major,
+                b_major,
+                cd_major,
+                m_aligned,
+                fix_pad_size=BlockScaledSubChannelMoEGroupedGemmKernelSm107.FIX_PAD_SIZE,
+                allowed_mma_tiler_n=(256, 128),
+            )
+        # Discrete SFB2 per-expert base pointers are declared 16B-aligned in
+        # the sched extension (assumed_align=16). With back-to-back per-expert
+        # f32 (ceil(n/sgn), ceil(k/sgk)) blocks, every base past the first is
+        # misaligned unless the block byte size is a multiple of 16.
+        if weight_mode == MoEWeightMode.DISCRETE and l > 1:
+            sfb2_block_bytes = ((n + sgn - 1) // sgn) * ((k + sgk - 1) // sgk) * 4
+            if sfb2_block_bytes % 16 != 0:
+                result = False
+        return result
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        sgm: int,
+        sgn: int,
+        sgk: int,
+        acc_dtype: Type[cutlass.Numeric],
+        use_2cta_instrs: bool,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        vectorized_f32: bool,
+        enable_bias: bool,
+        expert_cnt: int,
+        weight_mode: MoEWeightMode = MoEWeightMode.DENSE,
+        use_dynamic_sched: bool = False,
+        sf_fp8_dtype_override: Optional[Literal["e5m3"]] = None,
+    ):
+        # Hardware MMA instruction M: 2CTA → 256, 1CTA → 128
+        mma_inst_m = 256 if use_2cta_instrs else 128
+        enable_breuse = mma_tiler_mn[0] // mma_inst_m == 2
+        # For non-breuse: FIX_PAD_SIZE must be divisible by the per-CTA tile M.
+        # For breuse: mma_tiler_mn[0] (the D tile span) must be a multiple of FIX_PAD_SIZE,
+        # so that expert padding to mma_tiler_mn[0] is also compatible with FIX_PAD_SIZE.
+        if enable_breuse:
+            if mma_tiler_mn[0] % self.FIX_PAD_SIZE != 0:
+                raise ValueError(
+                    f"mma_tiler_mn[0] ({mma_tiler_mn[0]}) must be a multiple of "
+                    f"FIX_PAD_SIZE ({self.FIX_PAD_SIZE}) for breuse. "
+                    f"Also ensure callers use m_aligned=mma_tiler_mn[0] (={mma_tiler_mn[0]})."
+                )
+        else:
+            cta_tile_m = mma_tiler_mn[0] // (2 if use_2cta_instrs else 1)
+            if self.FIX_PAD_SIZE % cta_tile_m != 0:
+                raise ValueError(
+                    f"FIX_PAD_SIZE ({self.FIX_PAD_SIZE}) must be divisible by "
+                    f"cta_tile_m ({cta_tile_m}). "
+                    f"Supported mma_tiler_mn[0] values: 128, 256, 512."
+                )
+        if expert_cnt > 1024:
+            raise ValueError("Expert count > 1024 is not supported.")
+        if not isinstance(weight_mode, MoEWeightMode):
+            raise TypeError(f"weight_mode must be a MoEWeightMode, got {type(weight_mode)}")
+
+        self.sf_vec_size = sf_vec_size
+        self.sf_dtype_override: Optional[Type[cutlass.Numeric]] = cutlass.FloatNV8E5M3FNU if sf_fp8_dtype_override == "e5m3" else None
+        self.sgm = sgm
+        self.sgn = sgn
+        self.sgk = sgk
+        self.expert_cnt = expert_cnt
+        self.acc_dtype: Type[cutlass.Numeric] = acc_dtype
+        self.use_2cta_instrs = use_2cta_instrs
+        self.cluster_shape_mn = cluster_shape_mn
+        self.mma_tiler = (*mma_tiler_mn, 1)
+        # B-reuse: enabled when the mma_tiler M is 2× the hardware instruction M
+        # (2CTA instruction M = 256; 1CTA instruction M = 128)
+        self.enable_breuse = mma_tiler_mn[0] // mma_inst_m == 2
+
+        self.cta_group = tcgen05.CtaGroup.TWO if use_2cta_instrs else tcgen05.CtaGroup.ONE
+
+        self.occupancy = 1
+        # Second-level design: separate accumulator-update warpgroup (warps 0-3) distinct
+        # from the epilogue warpgroup (warps 4-7), plus a dedicated scale-load warp (11).
+        # The bias load rides on the scale warp: a 13th warp would leave a partial
+        # warpgroup, which is illegal for setmaxnregs (CTA must be a multiple of 128
+        # threads) and hangs at the lone warpgroup_reg_dealloc.
+        self.accumulator_update_warp_id = (0, 1, 2, 3)
+        self.epilog_warp_id = (4, 5, 6, 7)
+        self.mma_warp_id = 8
+        self.tma_warp_id = 9
+        self.sched_warp_id = 10
+        self.scale_warp_id = 11
+        self.threads_per_warp = 32
+        all_warps = [
+            *self.accumulator_update_warp_id,
+            *self.epilog_warp_id,
+            self.mma_warp_id,
+            self.tma_warp_id,
+            self.sched_warp_id,
+            self.scale_warp_id,
+        ]
+        warps_wo_sched = [
+            *self.accumulator_update_warp_id,
+            *self.epilog_warp_id,
+            self.mma_warp_id,
+            self.tma_warp_id,
+            self.scale_warp_id,
+        ]
+        self.threads_per_cta = self.threads_per_warp * len(all_warps)
+        self.threads_wo_sched = self.threads_per_warp * len(warps_wo_sched)
+
+        # Register budgets (per-warp) for the separate warpgroups.
+        self.num_regs_uniform_warps = 24
+        self.num_regs_sched_warps = 24
+        self.num_regs_epilogue_warps = 232
+        self.num_regs_acc_update_warps = 248
+
+        self.cta_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=self.threads_per_cta,
+        )
+        self.epilog_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=32 * len(self.epilog_warp_id),
+        )
+        self.tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=3,
+            num_threads=32 * len((self.mma_warp_id, *self.accumulator_update_warp_id, *self.epilog_warp_id)),
+        )
+        self.sched_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=4,
+            num_threads=self.threads_per_warp,
+        )
+        self.num_smem_capacity = utils.get_smem_capacity_in_bytes("sm_107")
+        self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols("sm_107")
+
+        self.vectorized_f32 = vectorized_f32
+        self.enable_bias = enable_bias
+
+        self.weight_mode = weight_mode
+        self.use_dynamic_sched = use_dynamic_sched
+
+        self.epilogue_use_functor = False
+
+        self.num_epilog_warps = len(self.epilog_warp_id)
+        self.num_accumulator_update_warps = len(self.accumulator_update_warp_id)
+
+    # ------------------------------------------------------------------
+    # _setup_attributes
+    # ------------------------------------------------------------------
+
+    def _get_mma_permutation_mnk(self):
+        """Return MMA permutation for the Bkeep-Breuse pattern (2CTA only)."""
+        if cutlass.const_expr(self.use_2cta_instrs and self.enable_breuse):
+            mma_inst_k = 128 if (self.a_dtype.width == 4 and self.b_dtype.width == 4) else 64
+            m_layout = cute.make_layout(
+                shape=(self.mma_inst_shape_mn[0] // 2, 2, 2),
+                stride=(1, self.mma_inst_shape_mn[0], self.mma_inst_shape_mn[0] // 2),
+            )
+            return (m_layout, self.mma_inst_shape_mn[1], mma_inst_k)
+        else:
+            return (1, 1, 1)
+
+    def _setup_attributes(self):
+        """Configure MMA / tile / stage / SMEM layouts from GEMM inputs."""
+
+        # Hardware MMA instruction M: always 256 for 2CTA, 128 for 1CTA
+        mma_inst_m = 256 if self.use_2cta_instrs else 128
+        self.mma_inst_shape_mn = (mma_inst_m, self.mma_tiler[1])
+        self.mma_inst_shape_mn_sfb = (
+            self.mma_inst_shape_mn[0] // (2 if self.use_2cta_instrs else 1),
+            cute.round_up(self.mma_inst_shape_mn[1], 128),
+        )
+
+        # K dim: sm107 uses K=128 for FP4×FP4, K=64 for FP8/mixed
+        mma_inst_k = 128 if (self.a_dtype.width == 4 and self.b_dtype.width == 4) else 64
+        mma_inst_shape_mnk = (*self.mma_inst_shape_mn, mma_inst_k)
+        mma_inst_shape_mnk_sfb = (*self.mma_inst_shape_mn_sfb, mma_inst_k)
+
+        atom_layout_mnk = (1, 1, 1)
+        permutation_mnk = self._get_mma_permutation_mnk()
+        tiled_mma = sm107_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            mma_inst_shape_mnk,
+            a_collector_op=CollectorOp.DISCARD,
+            b_collector_op=CollectorOp.DISCARD,
+            atom_layout_mnk=atom_layout_mnk,
+            permutation_mnk=permutation_mnk,
+        )
+        tiled_mma_sfb = sm107_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            cute.nvgpu.tcgen05.CtaGroup.ONE,
+            mma_inst_shape_mnk_sfb,
+        )
+
+        mma_inst_shape_k = cute.size(tiled_mma.shape_mnk, mode=[2])
+        mma_inst_tile_k = 2 if (self.a_dtype.width == 4 and self.sf_vec_size == 16) else 4
+        self.mma_tiler = (
+            self.mma_tiler[0],
+            self.mma_tiler[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+        self.mma_tiler_sfb = (
+            self.mma_inst_shape_mn_sfb[0],
+            self.mma_inst_shape_mn_sfb[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+
+        self.cta_tile_shape_mnk = (
+            self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler[1],
+            self.mma_tiler[2],
+        )
+        self.cta_tile_shape_mnk_sfb = (
+            self.mma_tiler_sfb[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler_sfb[1],
+            self.mma_tiler_sfb[2],
+        )
+
+        # For breuse, D tiler M = mma_tiler[0] (512 for 2CTA+breuse) so each CTA writes
+        # all its output rows (bkeep + breuse = 256 per CTA).
+        # For non-breuse, mma_tiler[0] == mma_inst_shape_mn[0] so this is equivalent.
+        self.mma_tiler_d = (
+            self.mma_tiler[0],
+            self.mma_inst_shape_mn[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+        self.cta_tile_shape_mnk_d = (
+            self.mma_tiler_d[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler_d[1],
+            self.mma_tiler_d[2],
+        )
+
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma.thr_id.shape,),
+        )
+        self.cluster_layout_sfb_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma_sfb.thr_id.shape,),
+        )
+
+        self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+
+        self.epi_tile = (128, 32)
+
+        (
+            self.num_acc_stage,
+            self.num_ab_stage,
+            self.num_d_stage,
+            self.num_tile_stage,
+            self.num_bias_stage,
+            self.num_epi_stage,
+        ) = self._compute_stages(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.b_dtype,
+            self.epi_tile,
+            self.d_dtype,
+            self.d_layout,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.num_smem_capacity,
+            self.occupancy,
+            self.bias_dtype if self.enable_bias else None,
+            self.enable_breuse,
+            acc_dtype=self.acc_dtype,
+            sf2_dtype=self.sf2_dtype,
+            sgm=self.sgm,
+            sgn=self.sgn,
+            sgk=self.sgk,
+        )
+        # Second-level scale pipeline uses the same depth as the AB pipeline.
+        self.num_scale_stage = self.num_ab_stage
+
+        self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.num_ab_stage,
+        )
+        self.b_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            self.mma_tiler,
+            self.b_dtype,
+            self.num_ab_stage,
+        )
+        self.sfa_smem_layout_staged = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        self.sfb_smem_layout_staged = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        self.d_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.d_dtype,
+            self.d_layout,
+            self.epi_tile,
+            self.num_d_stage,
+        )
+
+        # Full-CTA-tile SMEM buffer for the final accumulator. The "stage" mode of the
+        # epi layout doubles as the subtile-slot index (final_acc_subtile_cnt slots per
+        # epi stage): the accumulator-update warpgroup writes slots, the epilogue reads
+        # them. This replaces the TMEM final-accumulator region used by the base kernel.
+        self.final_acc_subtile_cnt = (self.cta_tile_shape_mnk[0] // cute.size(self.epi_tile[0])) * (self.cta_tile_shape_mnk[1] // cute.size(self.epi_tile[1]))
+        self.final_acc_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.acc_dtype,
+            self.d_layout,
+            self.epi_tile,
+            self.final_acc_subtile_cnt * self.num_epi_stage,
+        )
+
+        # ---- Second-level scale-factor SMEM layouts ----
+        # size_* = scale-group extent clamped to the CTA tile; scale_*_per_tile = number of
+        # distinct scale groups spanning the CTA tile. Inner (broadcast) dim has stride 0.
+        size_m = self.sgm if self.sgm < self.cta_tile_shape_mnk[0] else self.cta_tile_shape_mnk[0]
+        size_n = self.sgn if self.sgn < self.cta_tile_shape_mnk[1] else self.cta_tile_shape_mnk[1]
+        size_k = self.sgk if self.sgk < self.cta_tile_shape_mnk[2] else self.cta_tile_shape_mnk[2]
+        self.scale_m_per_tile = self.cta_tile_shape_mnk[0] // size_m
+        self.scale_n_per_tile = self.cta_tile_shape_mnk[1] // size_n
+        self.scale_k_per_tile = self.cta_tile_shape_mnk[2] // size_k
+
+        self.sfa2_smem_layout_staged = cute.make_layout(
+            (
+                (size_m, self.scale_m_per_tile),
+                (size_k, self.scale_k_per_tile),
+                self.num_scale_stage,
+            ),
+            stride=(
+                (0, self.scale_k_per_tile),
+                (0, 1),
+                self.scale_k_per_tile * self.scale_m_per_tile,
+            ),
+        )
+        self.sfb2_smem_layout_staged = cute.make_layout(
+            (
+                (size_n, self.scale_n_per_tile),
+                (size_k, self.scale_k_per_tile),
+                self.num_scale_stage,
+            ),
+            stride=(
+                (0, self.scale_k_per_tile),
+                (0, 1),
+                self.scale_k_per_tile * self.scale_n_per_tile,
+            ),
+        )
+
+        if self.enable_bias:
+            self.bias_smem_layout_staged = cute.make_layout(
+                (self.mma_tiler[1], self.num_bias_stage),
+                stride=(1, self.mma_tiler[1]),
+            )
+        else:
+            self.bias_smem_layout_staged = cute.make_layout((1, 1))
+
+        # Second-level design: the final accumulator lives in SMEM (sFinalAcc) and the
+        # accumulator-update warpgroup consumes one MMA partial per k-tile, so the
+        # overlapping-accumulator TMEM trick is disabled here.
+        self.overlapping_accum = False
+        self.epilogue_prefetch_more = False
+
+        sf_atom_mn = 32
+        sf_pack_factor = 32 // self.sf_vec_size
+        self.num_sfa_tmem_cols = (self.cta_tile_shape_mnk[0] // sf_atom_mn) * mma_inst_tile_k * sf_pack_factor
+        self.num_sfb_tmem_cols = (self.cta_tile_shape_mnk_sfb[1] // sf_atom_mn) * mma_inst_tile_k * sf_pack_factor
+        self.num_sf_tmem_cols = self.num_sfa_tmem_cols + self.num_sfb_tmem_cols
+        if self.enable_breuse:
+            # Breuse: 2 accumulators (bkeep + breuse) active simultaneously
+            self.num_accumulator_tmem_cols = self.cta_tile_shape_mnk[1] * self.num_acc_stage * 2
+        elif self.overlapping_accum:
+            self.num_accumulator_tmem_cols = self.cta_tile_shape_mnk[1] * 2 - self.num_sf_tmem_cols
+        else:
+            self.num_accumulator_tmem_cols = self.cta_tile_shape_mnk[1] * self.num_acc_stage
+        # N=192 non-breuse: 192 cols don't fill a full TMEM row, so pack two acc stages
+        # into the remaining space (overlapping with SF area isn't an option here).
+        # For breuse+N=192 this is skipped: breuse already sets acc=2*192=384 correctly.
+        if self.cta_tile_shape_mnk[1] == 192 and not self.enable_breuse:
+            self.num_accumulator_tmem_cols = self.num_tmem_alloc_cols - self.num_sf_tmem_cols
+            self.num_accumulator_tmem_stride = self.num_accumulator_tmem_cols - 192
+        else:
+            self.num_accumulator_tmem_stride = self.num_accumulator_tmem_cols
+
+        self.epi_tile_n_required = cute.size(self.epi_tile[1])
+        self.iter_acc_early_release_in_epilogue = (self.num_sf_tmem_cols + self.epi_tile_n_required - 1) // self.epi_tile_n_required - 1
+
+    # ------------------------------------------------------------------
+    # _compute_stages (with bias support)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _compute_stages(
+        tiled_mma,
+        mma_tiler_mnk,
+        a_dtype,
+        b_dtype,
+        epi_tile,
+        d_dtype,
+        d_layout,
+        sf_dtype,
+        sf_vec_size,
+        num_smem_capacity,
+        occupancy,
+        bias_dtype,
+        enable_breuse=False,
+        acc_dtype=None,
+        sf2_dtype=None,
+        sgm=1,
+        sgn=256,
+        sgk=256,
+    ):
+        num_acc_stage = 1 if (mma_tiler_mnk[1] == 256 or (enable_breuse and mma_tiler_mnk[1] == 192)) else 2
+        num_acc_stage = 3 if (mma_tiler_mnk[1] == 128 and not enable_breuse) else num_acc_stage
+        num_d_stage = 1
+        num_tile_stage = 2
+
+        a_smem_layout_stage_one = sm100_utils.make_smem_layout_a(tiled_mma, mma_tiler_mnk, a_dtype, 1)
+        b_smem_layout_staged_one = sm100_utils.make_smem_layout_b(tiled_mma, mma_tiler_mnk, b_dtype, 1)
+        sfa_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfa(tiled_mma, mma_tiler_mnk, sf_vec_size, 1)
+        sfb_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfb(tiled_mma, mma_tiler_mnk, sf_vec_size, 1)
+        d_smem_layout_staged_one = sm100_utils.make_smem_layout_epi(d_dtype, d_layout, epi_tile, 1)
+
+        # Second-level scale factor layouts (one stage): sfa2/sfb2 are staged alongside AB.
+        cta_m_sf = mma_tiler_mnk[0] // cute.size(tiled_mma.thr_id.shape)
+        size_m_sf = sgm if sgm < cta_m_sf else cta_m_sf
+        size_n_sf = sgn if sgn < mma_tiler_mnk[1] else mma_tiler_mnk[1]
+        size_k_sf = sgk if sgk < mma_tiler_mnk[2] else mma_tiler_mnk[2]
+        scale_m_per = cta_m_sf // size_m_sf
+        scale_n_per = mma_tiler_mnk[1] // size_n_sf
+        scale_k_per = mma_tiler_mnk[2] // size_k_sf
+        sfa2_smem_layout_staged_one = cute.make_layout(
+            ((size_m_sf, scale_m_per), (size_k_sf, scale_k_per), 1),
+            stride=((0, scale_k_per), (0, 1), scale_k_per * scale_m_per),
+        )
+        sfb2_smem_layout_staged_one = cute.make_layout(
+            ((size_n_sf, scale_n_per), (size_k_sf, scale_k_per), 1),
+            stride=((0, scale_k_per), (0, 1), scale_k_per * scale_n_per),
+        )
+
+        ab_bytes_per_stage = (
+            cute.size_in_bytes(a_dtype, a_smem_layout_stage_one)
+            + cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfa_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
+            + cute.size_in_bytes(sf2_dtype, sfa2_smem_layout_staged_one)
+            + cute.size_in_bytes(sf2_dtype, sfb2_smem_layout_staged_one)
+        )
+        mbar_helpers_bytes = 1024
+        sinfo_bytes = 4 * 4 * num_tile_stage
+        d_bytes_per_stage = cute.size_in_bytes(d_dtype, d_smem_layout_staged_one)
+        d_bytes = d_bytes_per_stage * num_d_stage
+
+        if bias_dtype is not None:
+            num_bias_stage = 2
+            bias_epi_tile_n = mma_tiler_mnk[1]
+            bias_bytes = bias_epi_tile_n * num_bias_stage * (bias_dtype.width // 8)
+        else:
+            num_bias_stage = 0
+            bias_bytes = 0
+
+        # Pipeline stages for epi_pipeline (accumulator-update -> epilogue handoff).
+        num_epi_stage = 1
+
+        # Full-CTA-tile final accumulator buffer in SMEM (replaces the TMEM final region).
+        cta_m = mma_tiler_mnk[0] // cute.size(tiled_mma.thr_id.shape)
+        cta_n = mma_tiler_mnk[1]
+        subtile_cnt = (cta_m // cute.size(epi_tile[0])) * (cta_n // cute.size(epi_tile[1]))
+        final_acc_smem_layout_one = sm100_utils.make_smem_layout_epi(
+            acc_dtype,
+            d_layout,
+            epi_tile,
+            subtile_cnt * num_epi_stage,
+        )
+        final_acc_bytes = cute.size_in_bytes(acc_dtype, final_acc_smem_layout_one)
+
+        epi_bytes = d_bytes + bias_bytes + final_acc_bytes
+        num_ab_stage = (num_smem_capacity // occupancy - (mbar_helpers_bytes + epi_bytes + sinfo_bytes)) // ab_bytes_per_stage
+        assert num_ab_stage >= 1, (
+            f"SMEM overflow: full-tile sFinalAcc ({final_acc_bytes} B) leaves no room for " f"AB stages (mma_tiler={mma_tiler_mnk}); reduce mma_tiler_mn"
+        )
+
+        return num_acc_stage, num_ab_stage, num_d_stage, num_tile_stage, num_bias_stage, num_epi_stage
+
+    # ------------------------------------------------------------------
+    # Workspace helpers
+    # ------------------------------------------------------------------
+
+    def get_desc_workspace_bytes(self) -> int:
+        if self.weight_mode == MoEWeightMode.DISCRETE:
+            from ..moe_utils import DiscreteWeightTensormapConstructor
+
+            return DiscreteWeightTensormapConstructor.get_workspace_size(self.expert_cnt)
+        return 0
+
+    def get_workspace_bytes(self) -> int:
+        desc_workspace_bytes = self.get_desc_workspace_bytes()
+        dynamic_sched_bytes = 4 if self.use_dynamic_sched else 0
+        return desc_workspace_bytes + dynamic_sched_bytes
+
+    @cute.jit
+    def _get_sched_counter_ptr(self, workspace_ptr):
+        counter_addr = workspace_ptr.toint() + self.get_desc_workspace_bytes()
+        return cute.make_ptr(
+            cutlass.Int32,
+            counter_addr,
+            AddressSpace.gmem,
+            assumed_align=4,
+        )
+
+    # ------------------------------------------------------------------
+    # helper_kernel: pre-main-kernel initialization
+    #   - discrete weight: build per-expert B/SFB TMA descriptors
+    #   - dynamic sched: reset the atomic tile counter
+    # ------------------------------------------------------------------
+
+    @cute.kernel
+    def helper_kernel(
+        self,
+        # Discrete-only params (unused in dense mode, but must be present for signature)
+        ptrs_b: cute.Pointer,
+        ptrs_sfb: cute.Pointer,
+        n: Int32,
+        k: Int32,
+        b_stride_size: cutlass.Int64,
+        b_major_mode: cutlass.Constexpr,
+        workspace_ptr,
+        tiled_mma_arg: cute.TiledMma,
+        tiled_mma_sfb_arg: cute.TiledMma,
+        b_smem_layout_arg,
+        sfb_smem_layout_arg,
+        cluster_layout_vmnk_shape_arg: cutlass.Constexpr,
+        cluster_layout_sfb_vmnk_shape_arg: cutlass.Constexpr,
+    ):
+        """Pre-main-kernel initialization.
+
+        Launched with grid=(expert_cnt, 1, 1) for discrete mode, or
+        grid=(1, 1, 1) for dense+dynamic mode.
+
+        Discrete weight: each block builds B/SFB TMA descriptors for one expert.
+        Dynamic sched: block 0 resets the atomic tile counter to 0.
+        """
+        expert_idx = cute.arch.block_idx()[0]
+
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE):
+            b_tma_op_arg = sm100_utils.cluster_shape_to_tma_atom_B(self.cluster_shape_mn, tiled_mma_arg.thr_id)
+            sfb_tma_op_arg = sm100_utils.cluster_shape_to_tma_atom_SFB(self.cluster_shape_mn, tiled_mma_arg.thr_id)
+
+            b_ptr_tensor = cute.make_tensor(
+                cute.make_ptr(cutlass.Int64, ptrs_b.toint(), AddressSpace.gmem, assumed_align=8), cute.make_layout((self.expert_cnt,))
+            )
+            sfb_ptr_tensor = cute.make_tensor(
+                cute.make_ptr(cutlass.Int64, ptrs_sfb.toint(), AddressSpace.gmem, assumed_align=8), cute.make_layout((self.expert_cnt,))
+            )
+
+            c0 = cutlass.Int64(0)
+            c1_64 = 1
+            if cutlass.const_expr(b_major_mode == OperandMajorMode.K):
+                stride_n = b_stride_size
+                stride_k = c1_64
+            else:
+                stride_n = c1_64
+                stride_k = b_stride_size
+
+            b_ptr_val = b_ptr_tensor[expert_idx]
+            b_ptr = cute.make_ptr(self.b_dtype, b_ptr_val, AddressSpace.gmem)
+            b_tensor_i = cute.make_tensor(
+                b_ptr,
+                cute.make_layout((n, k, cutlass.Int32(1)), stride=(stride_n, stride_k, c0)),
+            )
+            tma_atom_b, _ = cute.nvgpu.make_tiled_tma_atom_B(
+                b_tma_op_arg,
+                b_tensor_i,
+                b_smem_layout_arg,
+                self.mma_tiler,
+                tiled_mma_arg,
+                cluster_layout_vmnk_shape_arg,
+            )
+            workspace = TensormapWorkspace(workspace_ptr, ["b", "sfb"])
+            store_tma_desc(tma_atom_b, workspace.get_ptr("b", expert_idx))
+
+            sfb_ptr_val = sfb_ptr_tensor[expert_idx]
+            sfb_ptr = cute.make_ptr(self.sf_dtype, sfb_ptr_val, AddressSpace.gmem)
+            sfb_layout = blockscaled_utils.tile_atom_to_shape_SF((n, k, cutlass.Int32(1)), self.sf_vec_size)
+            sfb_tensor_i = cute.make_tensor(sfb_ptr, sfb_layout)
+            tma_atom_sfb, _ = cute.nvgpu.make_tiled_tma_atom_B(
+                sfb_tma_op_arg,
+                sfb_tensor_i,
+                sfb_smem_layout_arg,
+                self.mma_tiler_sfb,
+                tiled_mma_sfb_arg,
+                cluster_layout_sfb_vmnk_shape_arg,
+                internal_type=cutlass.Uint64,
+            )
+            store_tma_desc(tma_atom_sfb, workspace.get_ptr("sfb", expert_idx))
+
+        if cutlass.const_expr(self.use_dynamic_sched):
+            if expert_idx == cutlass.Int32(0):
+                sched_counter = cute.make_tensor(
+                    self._get_sched_counter_ptr(workspace_ptr),
+                    cute.make_layout(1),
+                )
+                sched_counter[0] = cutlass.Int32(0)
+
+    @cute.jit
+    def __call__(
+        self,
+        a: cute.Tensor,
+        b,  # Dense: cute.Tensor (N,K,L) | Discrete: cute.Pointer to int64[]
+        sfb,  # Dense: cute.Tensor         | Discrete: cute.Pointer to int64[]
+        sfb2,  # Dense: cute.Tensor         | Discrete: cute.Pointer to int64[] (2nd-level)
+        n: Int32,  # Ignored for dense mode
+        k: Int32,  # Ignored for dense mode
+        b_stride_size: cutlass.Int64,  # Ignored for dense mode
+        b_major_mode: cutlass.Constexpr,  # Ignored for dense mode
+        workspace_ptr,
+        d: cute.Tensor,
+        sfa: cute.Tensor,
+        sfa2: cute.Tensor,  # Second-level scale factor for A
+        padded_offsets: cute.Tensor,
+        alpha: cute.Tensor,
+        bias: Optional[cute.Tensor],
+        prob: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+    ):
+        """Execute the GEMM.
+
+        Dense mode: ``b`` and ``sfb`` are 3-D cute.Tensor (N, K, L).
+        Discrete mode: ``b`` and ``sfb`` are cute.Pointer to device int64[]
+        arrays of per-expert base addresses; ``n``, ``k``, ``b_stride_size``,
+        ``b_major_mode`` describe the uniform per-expert layout.
+        """
+        self.a_dtype: Type[cutlass.Numeric] = a.element_type
+        self.b_dtype: Type[cutlass.Numeric] = a.element_type
+        self.d_dtype: Type[cutlass.Numeric] = d.element_type
+        # Scale factors may arrive under a stand-in element type: FloatNV8E5M3FNU has
+        # no torch dtype and TVM-FFI cannot marshal it, so e5m3 scales are passed as
+        # Float8E4M3FN storage of the same width and reinterpreted here. This must
+        # happen before _setup_attributes(), which picks the MMA atom off sf_dtype.
+        if cutlass.const_expr(self.sf_dtype_override is not None):
+            self.sf_dtype: Type[cutlass.Numeric] = self.sf_dtype_override
+        else:
+            self.sf_dtype: Type[cutlass.Numeric] = sfa.element_type
+        self.sf2_dtype: Type[cutlass.Numeric] = sfa2.element_type
+        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
+        self.d_layout = utils.LayoutEnum.from_tensor(d)
+        self.bias_dtype = bias.element_type if cutlass.const_expr(self.enable_bias) else cutlass.BFloat16
+
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DENSE):
+            self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
+        else:
+            self.b_major_mode = b_major_mode
+
+        if cutlass.const_expr(self.a_dtype != self.b_dtype):
+            raise TypeError(f"A/B dtype must match: {self.a_dtype} != {self.b_dtype}")
+
+        self._setup_attributes()
+
+        # ---- SFA layout ----
+        sfa_layout = blockscaled_utils.tile_atom_to_shape_SF(a.shape, self.sf_vec_size)
+        sfa = cute.make_tensor(sfa.iterator, sfa_layout)
+
+        # ---- SFA2 layout (second-level scale for A; broadcast within each sgm x sgk group) ----
+        sfa2_tensor = cute.make_tensor(
+            sfa2.iterator,
+            cute.make_layout(
+                (
+                    (self.sgm, sfa2.shape[0]),
+                    (self.sgk, sfa2.shape[1]),
+                    sfa2.shape[2],
+                ),
+                stride=(
+                    (0, sfa2.layout.stride[0]),
+                    (0, sfa2.layout.stride[1]),
+                    sfa2.layout.stride[2],
+                ),
+            ),
+        )
+
+        # ---- SFB2 layout (second-level scale for B) ----
+        c1 = cutlass.Int32(1)
+        c0 = cutlass.Int64(0)
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DENSE):
+            sfb2_ptr_typed = sfb2.iterator
+            sfb2_shape_0 = sfb2.shape[0]
+            sfb2_shape_1 = sfb2.shape[1]
+            sfb2_mode_2 = sfb2.shape[2]
+            sfb2_stride_0 = sfb2.layout.stride[0]
+            sfb2_stride_1 = sfb2.layout.stride[1]
+            sfb2_stride_2 = sfb2.layout.stride[2]
+        else:  # DISCRETE mode: sfb2 is a pointer array of per-expert Int64 base addresses
+            sfb2_ptr_typed = cute.make_ptr(self.sf2_dtype, sfb2.toint(), cute.AddressSpace.gmem, assumed_align=16)
+            scale_n = cute.ceil_div(n, self.sgn)
+            scale_k = cute.ceil_div(k, self.sgk)
+            sfb2_shape_0 = scale_n
+            sfb2_shape_1 = scale_k
+            sfb2_mode_2 = c1
+            sfb2_stride_0 = c1
+            sfb2_stride_1 = scale_n
+            sfb2_stride_2 = c0
+
+        sfb2_tensor = cute.make_tensor(
+            sfb2_ptr_typed,
+            cute.make_layout(
+                (
+                    (self.sgn, sfb2_shape_0),
+                    (self.sgk, sfb2_shape_1),
+                    sfb2_mode_2,
+                ),
+                stride=(
+                    (0, sfb2_stride_0),
+                    (0, sfb2_stride_1),
+                    sfb2_stride_2,
+                ),
+            ),
+        )
+
+        # ---- B / SFB setup (mode-dependent) ----
+        # Save the call-arg b/sfb before the discrete branch overwrites them
+        # with template tensors.  helper_kernel needs the original Pointers.
+        b_from_call_arg = b
+        sfb_from_call_arg = sfb
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DENSE):
+            sfb_layout = blockscaled_utils.tile_atom_to_shape_SF(b.shape, self.sf_vec_size)
+            sfb = cute.make_tensor(sfb.iterator, sfb_layout)
+        else:
+            c0 = cutlass.Int64(0)
+            c1_64 = 1
+            if cutlass.const_expr(b_major_mode == OperandMajorMode.K):
+                b_template_stride = (b_stride_size, c1_64, c0)
+            else:
+                b_template_stride = (c1_64, b_stride_size, c0)
+            b_template_layout = cute.make_layout((n, k, cutlass.Int32(1)), stride=b_template_stride)
+            b_ptr_typed = cute.make_ptr(self.b_dtype, b.toint(), AddressSpace.gmem, assumed_align=16)
+            b = cute.make_tensor(b_ptr_typed, b_template_layout)
+
+            sfb_ptr_typed = cute.make_ptr(self.sf_dtype, sfb.toint(), AddressSpace.gmem, assumed_align=16)
+            sfb_layout = blockscaled_utils.tile_atom_to_shape_SF((n, k, cutlass.Int32(1)), self.sf_vec_size)
+            sfb = cute.make_tensor(sfb_ptr_typed, sfb_layout)
+
+        # ---- TMA atoms ----
+        mma_inst_k = 128 if (self.a_dtype.width == 4 and self.b_dtype.width == 4) else 64
+        mma_inst_shape_mnk = (*self.mma_inst_shape_mn, mma_inst_k)
+        mma_inst_shape_mnk_sfb = (*self.mma_inst_shape_mn_sfb, mma_inst_k)
+
+        atom_layout_mnk = (1, 1, 1)
+        permutation_mnk = self._get_mma_permutation_mnk()
+        tiled_mma = sm107_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            mma_inst_shape_mnk,
+            a_collector_op=CollectorOp.DISCARD,
+            b_collector_op=CollectorOp.DISCARD,
+            atom_layout_mnk=atom_layout_mnk,
+            permutation_mnk=permutation_mnk,
+        )
+        tiled_mma_sfb = sm107_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            cute.nvgpu.tcgen05.CtaGroup.ONE,
+            mma_inst_shape_mnk_sfb,
+        )
+
+        tiled_mma_bkeep = None
+        tiled_mma_breuse = None
+        if cutlass.const_expr(self.enable_breuse):
+            tiled_mma_bkeep = sm107_utils.make_blockscaled_trivial_tiled_mma(
+                self.a_dtype,
+                self.b_dtype,
+                self.a_major_mode,
+                self.b_major_mode,
+                self.sf_dtype,
+                self.sf_vec_size,
+                self.cta_group,
+                mma_inst_shape_mnk,
+                a_collector_op=CollectorOp.DISCARD,
+                b_collector_op=CollectorOp.FILL,
+                atom_layout_mnk=atom_layout_mnk,
+                permutation_mnk=permutation_mnk,
+            )
+            tiled_mma_bkeep.set(tcgen05.Field.NEGATE_A, False)
+            tiled_mma_bkeep.set(tcgen05.Field.NEGATE_B, False)
+            tiled_mma_breuse = sm107_utils.make_blockscaled_trivial_tiled_mma(
+                self.a_dtype,
+                self.b_dtype,
+                self.a_major_mode,
+                self.b_major_mode,
+                self.sf_dtype,
+                self.sf_vec_size,
+                self.cta_group,
+                mma_inst_shape_mnk,
+                a_collector_op=CollectorOp.DISCARD,
+                b_collector_op=CollectorOp.LASTUSE,
+                atom_layout_mnk=atom_layout_mnk,
+                permutation_mnk=permutation_mnk,
+            )
+            tiled_mma_breuse.set(tcgen05.Field.NEGATE_A, False)
+            tiled_mma_breuse.set(tcgen05.Field.NEGATE_B, False)
+
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+
+        a_op = sm100_utils.cluster_shape_to_tma_atom_A(self.cluster_shape_mn, tiled_mma.thr_id)
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        tma_atom_a, tma_tensor_a = cute.nvgpu.make_tiled_tma_atom_A(
+            a_op,
+            a,
+            a_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        b_op = sm100_utils.cluster_shape_to_tma_atom_B(self.cluster_shape_mn, tiled_mma.thr_id)
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op,
+            b,
+            b_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        sfa_op = sm100_utils.cluster_shape_to_tma_atom_A(self.cluster_shape_mn, tiled_mma.thr_id)
+        sfa_smem_layout = cute.slice_(self.sfa_smem_layout_staged, (None, None, None, 0))
+        tma_atom_sfa, tma_tensor_sfa = cute.nvgpu.make_tiled_tma_atom_A(
+            sfa_op,
+            sfa,
+            sfa_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=cutlass.Int16,
+        )
+
+        sfb_op = sm100_utils.cluster_shape_to_tma_atom_SFB(self.cluster_shape_mn, tiled_mma.thr_id)
+        sfb_smem_layout = cute.slice_(self.sfb_smem_layout_staged, (None, None, None, 0))
+        tma_atom_sfb, tma_tensor_sfb = cute.nvgpu.make_tiled_tma_atom_B(
+            sfb_op,
+            sfb,
+            sfb_smem_layout,
+            self.mma_tiler_sfb,
+            tiled_mma_sfb,
+            self.cluster_layout_sfb_vmnk.shape,
+            internal_type=cutlass.Uint64,
+        )
+
+        a_copy_size = cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        b_copy_size = cute.size_in_bytes(self.b_dtype, b_smem_layout)
+        sfa_copy_size = cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+        sfb_copy_size = cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+        self.num_tma_load_bytes = (a_copy_size + b_copy_size + sfa_copy_size + sfb_copy_size) * atom_thr_size
+
+        d_smem_layout = cute.slice_(self.d_smem_layout_staged, (None, None, 0))
+        tma_atom_d, tma_tensor_d = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileS2GOp(),
+            d,
+            d_smem_layout,
+            self.epi_tile,
+        )
+
+        # ---- Helper kernel: TMA desc init (discrete) + sched counter reset (dynamic) ----
+        _need_helper = cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE or self.use_dynamic_sched)
+        if cutlass.const_expr(_need_helper):
+            _helper_grid_x = self.expert_cnt if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else 1
+            _helper_args = (
+                b_from_call_arg if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else cute.make_ptr(cutlass.Int64, 0, AddressSpace.gmem),
+                sfb_from_call_arg if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else cute.make_ptr(cutlass.Int64, 0, AddressSpace.gmem),
+                n if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else cutlass.Int32(0),
+                k if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else cutlass.Int32(0),
+                b_stride_size if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else cutlass.Int64(0),
+                b_major_mode if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else self.b_major_mode,
+                workspace_ptr,
+                tiled_mma,
+                tiled_mma_sfb,
+                b_smem_layout,
+                sfb_smem_layout,
+                self.cluster_layout_vmnk.shape,
+                self.cluster_layout_sfb_vmnk.shape,
+            )
+            self.helper_kernel(*_helper_args).launch(
+                grid=(_helper_grid_x, 1, 1),
+                block=(1, 1, 1),
+                stream=stream,
+                min_blocks_per_mp=1,
+            )
+
+        # ---- Grid computation via MoE scheduler ----
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DENSE):
+            b_n, b_k, b_l = cute.shape(b)  # B is (N, K, L)
+            sched_expert_shape = (self.expert_cnt, b_n, b_k)
+        else:
+            sched_expert_shape = (self.expert_cnt, n, k)
+
+        sched_params = MoESchedulerParams(
+            scenario="2Dx3D",
+            expert_shape=sched_expert_shape,
+            cta_tile_shape_mnk=self.cta_tile_shape_mnk,
+            cluster_shape_mn=self.cluster_shape_mn,
+            use_dynamic_sched=self.use_dynamic_sched,
+        )
+        self.sched_params, grid = compute_grid(sched_params, max_active_clusters, self.use_2cta_instrs)
+
+        self.buffer_align_bytes = 1024
+
+        # ---- Shared storage ----
+        SchedulerStorage = MoEPersistentTileScheduler.make_storage_struct(self.num_tile_stage, self.use_dynamic_sched)
+
+        @cute.struct
+        class SharedStorage:
+            ab_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage * 2]
+            scale_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_scale_stage * 2]
+            acc_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage * 2]
+            epi_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_epi_stage * 2]
+            scheduler: SchedulerStorage
+            if cutlass.const_expr(self.enable_bias):
+                bias_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_bias_stage * 2]
+            tmem_dealloc_mbar_ptr: cutlass.Int64
+            tmem_holding_buf: cutlass.Int32
+            sD: cute.struct.Align[
+                cute.struct.MemRange[self.d_dtype, cute.cosize(self.d_smem_layout_staged.outer)],
+                self.buffer_align_bytes,
+            ]
+            sFinalAcc: cute.struct.Align[
+                cute.struct.MemRange[self.acc_dtype, cute.cosize(self.final_acc_smem_layout_staged.outer)],
+                self.buffer_align_bytes,
+            ]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[self.a_dtype, cute.cosize(self.a_smem_layout_staged.outer)],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[self.b_dtype, cute.cosize(self.b_smem_layout_staged.outer)],
+                self.buffer_align_bytes,
+            ]
+            sSFA: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(self.sfa_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sSFB: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(self.sfb_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sSFA2: cute.struct.Align[
+                cute.struct.MemRange[self.sf2_dtype, cute.cosize(self.sfa2_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sSFB2: cute.struct.Align[
+                cute.struct.MemRange[self.sf2_dtype, cute.cosize(self.sfb2_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            if cutlass.const_expr(self.enable_bias):
+                sBias: cute.struct.Align[
+                    cute.struct.MemRange[self.bias_dtype, cute.cosize(self.bias_smem_layout_staged)],
+                    16,
+                ]
+
+        self.shared_storage = SharedStorage
+
+        # ---- Launch ----
+        self.kernel(
+            tiled_mma,
+            tiled_mma_bkeep,
+            tiled_mma_breuse,
+            tiled_mma_sfb,
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_sfa,
+            tma_tensor_sfa,
+            tma_atom_sfb,
+            tma_tensor_sfb,
+            sfa2_tensor,
+            sfb2_tensor,
+            tma_atom_d,
+            tma_tensor_d,
+            padded_offsets,
+            alpha,
+            bias,
+            prob,
+            workspace_ptr,
+            self.cluster_layout_vmnk,
+            self.cluster_layout_sfb_vmnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.sfa2_smem_layout_staged,
+            self.sfb2_smem_layout_staged,
+            self.d_smem_layout_staged,
+            self.final_acc_smem_layout_staged,
+            self.bias_smem_layout_staged,
+            self.epi_tile,
+            self.sched_params,
+            epilogue_op,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            max_number_threads=[self.threads_per_cta, 1, 1],
+            smem=self.shared_storage.size_in_bytes(),
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+        return
+
+    # ------------------------------------------------------------------
+    # Helper methods
+    # ------------------------------------------------------------------
+
+    def mainloop_s2t_copy_and_partition(self, sSF, tSF):
+        tCsSF_compact = cute.filter_zeros(sSF)
+        tCtSF_compact = cute.filter_zeros(tSF)
+        copy_atom_s2t = cute.make_copy_atom(tcgen05.Cp4x32x128bOp(self.cta_group), self.sf_dtype)
+        tiled_copy_s2t = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSF_compact)
+        thr_copy_s2t = tiled_copy_s2t.get_slice(0)
+
+        # Rubin sm107 workaround: append stride-0 broadcast mode so partition_S
+        # produces the right shape for NVF4 (sf_vec_size=16); idempotent for sf_vec_size=32.
+        def _append_mn_broadcast_mode(smem_layout: cute.Layout):
+            mn_dim = cute.get(smem_layout, mode=[0, 0])
+            mn_dim = cute.append(mn_dim, cute.make_layout((4), stride=(0)))
+            layout = cute.append(cute.group_modes(mn_dim, 0), cute.get(smem_layout, mode=[0, 1]))
+            layout = cute.append(cute.group_modes(layout, 0), cute.get(smem_layout, mode=[1]))
+            layout = cute.append(layout, cute.get(smem_layout, mode=[2]))
+            layout = cute.append(layout, cute.get(smem_layout, mode=[3]))
+            return layout
+
+        tCsSF_compact_bcast = cute.make_tensor(tCsSF_compact.iterator, _append_mn_broadcast_mode(tCsSF_compact.layout))
+        tCsSF_compact_s2t_ = thr_copy_s2t.partition_S(tCsSF_compact_bcast)
+        tCsSF_compact_s2t = tcgen05.get_s2t_smem_desc_tensor(tiled_copy_s2t, tCsSF_compact_s2t_)
+        tCtSF_compact_s2t = thr_copy_s2t.partition_D(tCtSF_compact)
+        return tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t
+
+    def epilog_tmem_copy_and_partition(self, tidx, tAcc, gD_mnl, epi_tile, use_2cta_instrs):
+        # For breuse:  tAcc and gD_mnl have been through transform_partitioned_tensor_layout
+        #   and have merged M-split into the first mode.  No [0,0] selection needed.
+        # For non-breuse: tAcc has shape (MMA, 1, 1, STAGE); strip with [0,0] internally.
+        copy_atom_t2r = sm100_utils.get_tmem_load_op(
+            self.cta_tile_shape_mnk,
+            self.d_layout,
+            self.d_dtype,
+            self.acc_dtype,
+            epi_tile,
+            use_2cta_instrs,
+        )
+        if cutlass.const_expr(self.enable_breuse):
+            tAcc_epi = cute.flat_divide(tAcc, epi_tile)
+            gD_mnl_epi = cute.flat_divide(gD_mnl, epi_tile)
+        else:
+            tAcc_epi = cute.flat_divide(tAcc[((None, None), 0, 0, None)], epi_tile)
+            gD_mnl_epi = cute.flat_divide(gD_mnl[((None, None), 0, 0, None, None, None)], epi_tile)
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tAcc_epi[(None, None, 0, 0, 0)])
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+        tTR_tAcc = thr_copy_t2r.partition_S(tAcc_epi)
+        tTR_gC = thr_copy_t2r.partition_D(gD_mnl_epi)
+        tTR_rAcc = cute.make_rmem_tensor(tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].shape, self.acc_dtype)
+        return tiled_copy_t2r, tTR_tAcc, tTR_rAcc
+
+    def epilog_smem_copy_and_partition(self, tiled_copy_t2r, tTR_rD, tidx, sD):
+        copy_atom_r2s = sm100_utils.get_smem_store_op(self.d_layout, self.d_dtype, self.acc_dtype, tiled_copy_t2r)
+        tiled_copy_r2s = cute.make_tiled_copy_D(copy_atom_r2s, tiled_copy_t2r)
+        thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+        tRS_sD = thr_copy_r2s.partition_D(sD)
+        tRS_rD = tiled_copy_r2s.retile(tTR_rD)
+        return tiled_copy_r2s, tRS_rD, tRS_sD
+
+    def acc_update_tmem_copy_and_partition(
+        self,
+        tidx,
+        tCtAcc_base,
+        gD_mnl,
+        sSFA,
+        sSFB,
+        sFinalAcc,
+        epi_tile,
+        use_2cta_instrs,
+    ):
+        """Build T2R (TMEM->reg) and R2S (reg->sFinalAcc) copies for the accumulator-update
+        warpgroup, plus the second-level-scale SMEM partitions (tTR_sSFA/tTR_sSFB).
+
+        sSFA/sSFB are the second-level scale SMEM buffers re-viewed as "C-tile" tensors
+        (broadcast over the non-scaled dimension), partitioned by the T2R thread layout so
+        each thread reads the scale that applies to its accumulator elements.
+        """
+        # TMEM load op for reading MMA partials (matches the Blackwell reference).
+        if cutlass.const_expr(self.mma_tiler[0] == 64):
+            copy_atom_t2r = cute.make_copy_atom(
+                tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(8)),
+                self.acc_dtype,
+            )
+        else:
+            copy_atom_t2r = cute.make_copy_atom(
+                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)),
+                self.acc_dtype,
+            )
+        # Partition partial-accumulator TMEM by epilogue tile
+        tAcc_epi = cute.flat_divide(tCtAcc_base[((None, None), 0, 0, None)], epi_tile)
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tAcc_epi[(None, None, 0, 0, 0)])
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+
+        # R2S store of the final accumulator into SMEM (sFinalAcc): reuse the T2R TV layout.
+        copy_atom_r2s_acc = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.acc_dtype)
+        tiled_copy_r2s_acc = cute.make_tiled_copy_D(copy_atom_r2s_acc, tiled_copy_t2r)
+        thr_copy_r2s_acc = tiled_copy_r2s_acc.get_slice(tidx)
+        # (R2S, R2S_M, R2S_N, SUBTILE * STAGE)
+        tRS_sFinalAcc = thr_copy_r2s_acc.partition_D(sFinalAcc)
+
+        tTR_tAcc_base = thr_copy_t2r.partition_S(tAcc_epi)
+
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, loopM, loopN, loopL)
+        gD_mnl_epi = cute.flat_divide(gD_mnl[((None, None), 0, 0, None, None, None)], epi_tile)
+        sSFA_epi = cute.flat_divide(sSFA, epi_tile)
+        sSFB_epi = cute.flat_divide(sSFB, epi_tile)
+        tTR_gC = thr_copy_t2r.partition_D(gD_mnl_epi)
+        tTR_sSFA = thr_copy_t2r.partition_D(sSFA_epi)
+        tTR_sSFB = thr_copy_t2r.partition_D(sSFB_epi)
+
+        # Register tensor holding one k-tile's partial accumulator: (T2R, T2R_M, T2R_N)
+        tTR_rAcc = cute.make_rmem_tensor(tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].shape, self.acc_dtype)
+        # Register tensor for the final accumulated result across all k-tiles/subtiles:
+        # (T2R, T2R_M, T2R_N, (EPI_M, EPI_N))
+        tTR_rAcc_final_ = cute.make_rmem_tensor(tTR_gC[(None, None, None, None, None, 0, 0, 0)].shape, self.acc_dtype)
+        tTR_rAcc_final = cute.group_modes(tTR_rAcc_final_, 3, cute.rank(tTR_rAcc_final_))
+
+        return (
+            tiled_copy_t2r,
+            tiled_copy_r2s_acc,
+            tTR_tAcc_base,
+            tTR_rAcc,
+            tTR_rAcc_final,
+            tRS_sFinalAcc,
+            tTR_sSFA,
+            tTR_sSFB,
+        )
+
+    def epilog_smem_load_copy_and_partition(self, tiled_copy_t2r, tTR_rAcc, tidx, sFinalAcc):
+        # S2R load of the final accumulator from SMEM: reuse the T2R TV layout so the
+        # partitioning matches what the accumulator-update warpgroup wrote.
+        copy_atom_s2r = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.acc_dtype)
+        tiled_copy_s2r = cute.make_tiled_copy_D(copy_atom_s2r, tiled_copy_t2r)
+        thr_copy_s2r = tiled_copy_s2r.get_slice(tidx)
+        # (S2R, S2R_M, S2R_N, SUBTILE * STAGE)
+        tSR_sFinalAcc = thr_copy_s2r.partition_D(sFinalAcc)
+        tSR_rAcc = tiled_copy_s2r.retile(tTR_rAcc)
+        return tiled_copy_s2r, tSR_rAcc, tSR_sFinalAcc
+
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tiled_mma_bkeep: Optional[cute.TiledMma],
+        tiled_mma_breuse: Optional[cute.TiledMma],
+        tiled_mma_sfb: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        mSFA_mkl: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        mSFB_nkl: cute.Tensor,
+        sfa2_tensor: cute.Tensor,
+        sfb2_tensor,  # Dense: cute.Tensor | Discrete: cute.Pointer
+        tma_atom_d: cute.CopyAtom,
+        mD_mnl: cute.Tensor,
+        padded_offsets: cute.Tensor,
+        alpha: cute.Tensor,
+        mBias_nl: Optional[cute.Tensor],
+        prob: cute.Tensor,
+        workspace_ptr,
+        cluster_layout_vmnk: cute.Layout,
+        cluster_layout_sfb_vmnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        sfa2_smem_layout_staged: cute.Layout,
+        sfb2_smem_layout_staged: cute.Layout,
+        d_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout, None],
+        final_acc_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout, None],
+        bias_smem_layout_staged: Optional[cute.Layout],
+        epi_tile: cute.Tile,
+        sched_params: MoESchedulerParams,
+        epilogue_op: cutlass.Constexpr,
+    ):
+        """GPU device kernel for persistent MoE grouped GEMM."""
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        lane_idx = cute.arch.lane_idx()
+
+        if warp_idx == self.tma_warp_id:
+            cpasync.prefetch_descriptor(tma_atom_a)
+            cpasync.prefetch_descriptor(tma_atom_sfa)
+            if cutlass.const_expr(self.weight_mode == MoEWeightMode.DENSE):
+                cpasync.prefetch_descriptor(tma_atom_b)
+                cpasync.prefetch_descriptor(tma_atom_sfb)
+            cpasync.prefetch_descriptor(tma_atom_d)
+
+        use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+        total_token = padded_offsets[self.expert_cnt - 1]
+
+        bidx, bidy, bidz = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
+        block_in_cluster_coord_sfb_vmnk = cluster_layout_sfb_vmnk.get_flat_coord(cta_rank_in_cluster)
+        tidx, _, _ = cute.arch.thread_idx()
+
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+        sched_storage = storage.scheduler
+
+        ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_tma_producer = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        ab_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, num_tma_producer)
+        ab_pipeline = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.ab_mbar_ptr.data_ptr(),
+            num_stages=self.num_ab_stage,
+            producer_group=ab_pipeline_producer_group,
+            consumer_group=ab_pipeline_consumer_group,
+            tx_count=self.num_tma_load_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )
+
+        # scale_pipeline: scale-load warp (producer) -> accumulator-update warpgroup (consumer),
+        # staging sfa2/sfb2 in sSFA2/sSFB2 via cp.async.
+        scale_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * 1,
+        )
+        scale_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * len(self.accumulator_update_warp_id),
+        )
+        scale_pipeline = pipeline.PipelineCpAsync.create(
+            barrier_storage=storage.scale_mbar_ptr.data_ptr(),
+            num_stages=self.num_scale_stage,
+            producer_group=scale_pipeline_producer_group,
+            consumer_group=scale_pipeline_consumer_group,
+            defer_sync=True,
+        )
+
+        acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_acc_consumer_threads = len(self.accumulator_update_warp_id) * (2 if use_2cta_instrs else 1)
+        acc_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, num_acc_consumer_threads)
+        acc_pipeline = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_stage,
+            producer_group=acc_pipeline_producer_group,
+            consumer_group=acc_pipeline_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )
+
+        # epi_pipeline: accumulator-update warpgroup (producer) -> epilogue warpgroup (consumer),
+        # handing off the final accumulator staged in sFinalAcc.
+        epi_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, self.threads_per_warp * len(self.accumulator_update_warp_id))
+        epi_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, self.threads_per_warp * len(self.epilog_warp_id))
+        epi_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.epi_mbar_ptr.data_ptr(),
+            num_stages=self.num_epi_stage,
+            producer_group=epi_pipeline_producer_group,
+            consumer_group=epi_pipeline_consumer_group,
+        )
+
+        tile_info_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, self.threads_per_warp * 1)
+        tile_info_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, self.threads_wo_sched)
+        tile_info_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=sched_storage.tile_info_mbar.data_ptr(),
+            num_stages=self.num_tile_stage,
+            producer_group=tile_info_pipeline_producer_group,
+            consumer_group=tile_info_pipeline_consumer_group,
+        )
+
+        if cutlass.const_expr(self.enable_bias):
+            bias_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, self.threads_per_warp)
+            bias_pipeline_consumer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                self.threads_per_warp * len(self.epilog_warp_id),
+            )
+            bias_pipeline = pipeline.PipelineCpAsync.create(
+                barrier_storage=storage.bias_mbar_ptr.data_ptr(),
+                num_stages=self.num_bias_stage,
+                producer_group=bias_pipeline_producer_group,
+                consumer_group=bias_pipeline_consumer_group,
+            )
+            sBias = storage.sBias.get_tensor(bias_smem_layout_staged)
+
+        scheduler = MoEPersistentTileScheduler.create(
+            sched_params,
+            padded_offsets,
+            cute.arch.block_idx(),
+            cute.arch.grid_dim(),
+            counter_ptr=self._get_sched_counter_ptr(workspace_ptr),
+            sched_storage=sched_storage,
+        )
+        scheduler.internal_init()
+
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr,
+            barrier_for_retrieve=self.tmem_alloc_barrier,
+            allocator_warp_id=self.epilog_warp_id[0],
+            is_two_cta=use_2cta_instrs,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr.ptr,
+            arch="sm_107",
+        )
+
+        if cute.size(self.cluster_shape_mn) > 1:
+            cute.arch.cluster_arrive_relaxed()
+
+        sD = storage.sD.get_tensor(d_smem_layout_staged.outer, swizzle=d_smem_layout_staged.inner)
+        sFinalAcc = storage.sFinalAcc.get_tensor(final_acc_smem_layout_staged.outer, swizzle=final_acc_smem_layout_staged.inner)
+        sA = storage.sA.get_tensor(a_smem_layout_staged.outer, swizzle=a_smem_layout_staged.inner)
+        sB = storage.sB.get_tensor(b_smem_layout_staged.outer, swizzle=b_smem_layout_staged.inner)
+        sSFA = storage.sSFA.get_tensor(sfa_smem_layout_staged)
+        sSFB = storage.sSFB.get_tensor(sfb_smem_layout_staged)
+        sSFA2 = storage.sSFA2.get_tensor(sfa2_smem_layout_staged)
+        sSFB2 = storage.sSFB2.get_tensor(sfb2_smem_layout_staged)
+        info_layout = cute.make_layout((4, self.num_tile_stage), stride=(1, 4))
+        sInfo = sched_storage.sInfo.get_tensor(info_layout)
+
+        # Multicast masks — must create ALL when any mcast or 2CTA is active
+        a_full_mcast_mask = None
+        b_full_mcast_mask = None
+        sfa_full_mcast_mask = None
+        sfb_full_mcast_mask = None
+        if cutlass.const_expr(self.is_a_mcast or self.is_b_mcast or use_2cta_instrs):
+            a_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2)
+            b_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1)
+            sfa_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2)
+            sfb_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_sfb_vmnk, block_in_cluster_coord_sfb_vmnk, mcast_mode=1)
+
+        # MMA partition (for tCtAcc_fake shape computation only)
+        thr_mma_common = tiled_mma.get_slice(0)
+        tCsA_common = thr_mma_common.partition_A(sA)
+        tCsB_common = thr_mma_common.partition_B(sB)
+        tCsA_common = cute.filter_zeros(tCsA_common)
+        tCsB_common = cute.filter_zeros(tCsB_common)
+
+        # ---- cp.async (LDGSTS) machinery for second-level scale loads (scale warp) ----
+        atom_scale2_copy = cute.make_copy_atom(
+            cute.nvgpu.cpasync.CopyG2SOp(),
+            self.sf2_dtype,
+            num_bits_per_copy=self.sf2_dtype.width,
+        )
+        tiled_copy_sfa2 = cute.make_tiled_copy_tv(atom_scale2_copy, cute.make_layout((32,)), cute.make_layout((1,)))
+        tiled_copy_sfb2 = cute.make_tiled_copy_tv(atom_scale2_copy, cute.make_layout((32,)), cute.make_layout((1,)))
+        thr_copy_sfa2 = tiled_copy_sfa2.get_slice(lane_idx)
+        thr_copy_sfb2 = tiled_copy_sfb2.get_slice(lane_idx)
+        tAsSFA2 = thr_copy_sfa2.partition_D(sSFA2)
+        tBsSFB2 = thr_copy_sfb2.partition_D(sSFB2)
+
+        # ---- Second-level scales re-viewed as "C-tile" tensors (broadcast) for the
+        #      accumulator-update warpgroup: sfa2 broadcasts over N, sfb2 over M. ----
+        sSFA2_view_as_C_layout = cute.make_layout(
+            (
+                (self.sgm, self.scale_m_per_tile),
+                self.cta_tile_shape_mnk[1],
+                self.num_scale_stage,
+            ),
+            stride=((0, 1), 0, self.scale_m_per_tile),
+        )
+        sSFB2_view_as_C_layout = cute.make_layout(
+            (
+                self.cta_tile_shape_mnk[0],
+                (self.sgn, self.scale_n_per_tile),
+                self.num_scale_stage,
+            ),
+            stride=(0, (0, 1), self.scale_n_per_tile),
+        )
+        sSFA2_view_as_C = cute.make_tensor(sSFA2.iterator, sSFA2_view_as_C_layout)
+        sSFB2_view_as_C = cute.make_tensor(sSFB2.iterator, sSFB2_view_as_C_layout)
+
+        # Calculating number of k_tiles which share the same scale factor
+        k_tile_same_scale_factor = self.sgk // self.mma_tiler[2]
+
+        # SMEM fragments for MMA (used by MMA warp)
+        tCrA = tiled_mma.make_fragment_A(sA)
+        tCrB = tiled_mma.make_fragment_B(sB)
+
+        # TMEM accumulator shape
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+        if cutlass.const_expr(self.overlapping_accum):
+            num_acc_stage_overlapped = 2
+            tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, num_acc_stage_overlapped))
+            tCtAcc_fake = cute.make_tensor(
+                tCtAcc_fake.iterator,
+                cute.make_layout(
+                    tCtAcc_fake.shape,
+                    stride=(
+                        tCtAcc_fake.stride[0],
+                        tCtAcc_fake.stride[1],
+                        tCtAcc_fake.stride[2],
+                        (256 - self.num_sf_tmem_cols) * tCtAcc_fake.stride[0][1],
+                    ),
+                ),
+            )
+        elif cutlass.const_expr(self.cta_tile_shape_mnk[1] == 192):
+            tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, self.num_acc_stage))
+            tCtAcc_fake = cute.make_tensor(
+                tCtAcc_fake.iterator,
+                cute.make_layout(
+                    tCtAcc_fake.shape,
+                    stride=(
+                        tCtAcc_fake.stride[0],
+                        tCtAcc_fake.stride[1],
+                        tCtAcc_fake.stride[2],
+                        self.num_accumulator_tmem_stride,
+                    ),
+                ),
+            )
+        else:
+            tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, self.num_acc_stage))
+
+        # Cluster sync before warp specialization
+        if cute.size(self.cluster_shape_mn) > 1:
+            cute.arch.cluster_wait()
+        else:
+            self.cta_sync_barrier.arrive_and_wait()
+
+        if total_token <= 0:
+            cute.arch.nvvm.exit()
+
+        # ==============================================================
+        # Scheduler warp (MoE Persistent Tile Scheduler)
+        # ==============================================================
+        if warp_idx == self.sched_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_sched_warps)
+            work_tile_info = scheduler.initial_work_tile_info()
+            tile_info_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_tile_stage)
+            while work_tile_info.is_valid_tile:
+                tile_info_pipeline.producer_acquire(tile_info_producer_state)
+                with cute.arch.elect_one():
+                    sInfo[(0, tile_info_producer_state.index)] = work_tile_info.expert_idx
+                    sInfo[(1, tile_info_producer_state.index)] = work_tile_info.tile_m_idx
+                    sInfo[(2, tile_info_producer_state.index)] = work_tile_info.tile_n_idx
+                    sInfo[(3, tile_info_producer_state.index)] = work_tile_info.k_tile_cnt
+                cute.arch.fence_proxy("async.shared", space="cta")
+                self.sched_sync_barrier.arrive_and_wait()
+                tile_info_pipeline.producer_commit(tile_info_producer_state)
+                tile_info_producer_state.advance()
+                work_tile_info = scheduler.advance_to_next_work()
+
+            tile_info_pipeline.producer_acquire(tile_info_producer_state)
+            with cute.arch.elect_one():
+                sInfo[(0, tile_info_producer_state.index)] = cutlass.Int32(-1)
+                sInfo[(1, tile_info_producer_state.index)] = cutlass.Int32(0)
+                sInfo[(2, tile_info_producer_state.index)] = cutlass.Int32(0)
+                sInfo[(3, tile_info_producer_state.index)] = cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            self.sched_sync_barrier.arrive_and_wait()
+            tile_info_pipeline.producer_commit(tile_info_producer_state)
+            tile_info_producer_state.advance()
+            tile_info_pipeline.producer_tail(tile_info_producer_state)
+
+        # ==============================================================
+        # DMA / TMA load warp
+        # ==============================================================
+        if warp_idx == self.tma_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_uniform_warps)
+            ext = self._make_extension(workspace_ptr)
+            ab_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_ab_stage)
+            tile_info_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_tile_stage)
+
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            while is_valid_tile:
+                work_tile_info = MoEWorkTileInfo(
+                    expert_idx=tile_info[0],
+                    tile_m_idx=tile_info[1],
+                    tile_n_idx=tile_info[2],
+                    k_tile_cnt=tile_info[3],
+                )
+                k_tile_cnt = work_tile_info.k_tile_cnt
+                ext.update_expert_info(padded_offsets, work_tile_info.expert_idx)
+
+                real_a, _ = ext.get_gmem_tensor("a", mA_mkl, padded_offsets, work_tile_info)
+                real_b, desc_ptr_b = ext.get_gmem_tensor("b", mB_nkl, padded_offsets, work_tile_info)
+                real_sfa, _ = ext.get_gmem_tensor("sfa", mSFA_mkl, padded_offsets, work_tile_info)
+                real_sfb, desc_ptr_sfb = ext.get_gmem_tensor("sfb", mSFB_nkl, padded_offsets, work_tile_info)
+
+                # N=192: the SFB TMEM layout uses a nested ((2,2), y) shape to
+                # map the 192-column tile onto TMEM correctly.
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 192):
+                    x = real_sfb.stride[0][1]
+                    y = cute.ceil_div(real_sfb.shape[0][1], 4)
+                    new_shape = (
+                        (real_sfb.shape[0][0], ((2, 2), y)),
+                        real_sfb.shape[1],
+                        real_sfb.shape[2],
+                    )
+                    new_stride = (
+                        (real_sfb.stride[0][0], ((x, x), 3 * x)),
+                        real_sfb.stride[1],
+                        real_sfb.stride[2],
+                    )
+                    real_sfb = cute.make_tensor(
+                        real_sfb.iterator,
+                        cute.make_layout(new_shape, stride=new_stride),
+                    )
+
+                gA_mkl = cute.local_tile(real_a, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None))
+                gB_nkl = cute.local_tile(real_b, cute.slice_(self.mma_tiler, (0, None, None)), (None, None, None))
+                gSFA_mkl = cute.local_tile(real_sfa, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None))
+                gSFB_nkl = cute.local_tile(real_sfb, cute.slice_(self.mma_tiler_sfb, (0, None, None)), (None, None, None))
+
+                # MMA partition on gmem tensors
+                thr_mma_dma = tiled_mma.get_slice(mma_tile_coord_v)
+                thr_mma_sfb_dma = tiled_mma_sfb.get_slice(mma_tile_coord_v)
+                tCgA = thr_mma_dma.partition_A(gA_mkl)
+                tCgB = thr_mma_dma.partition_B(gB_nkl)
+                tCgSFA = thr_mma_dma.partition_A(gSFA_mkl)
+                tCgSFB = thr_mma_sfb_dma.partition_B(gSFB_nkl)
+
+                # TMA partition A
+                a_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape)
+                tAsA, tAgA = cpasync.tma_partition(
+                    tma_atom_a,
+                    block_in_cluster_coord_vmnk[2],
+                    a_cta_layout,
+                    cute.group_modes(sA, 0, 3),
+                    cute.group_modes(tCgA, 0, 3),
+                )
+                # TMA partition B
+                b_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape)
+                tBsB, tBgB = cpasync.tma_partition(
+                    tma_atom_b,
+                    block_in_cluster_coord_vmnk[1],
+                    b_cta_layout,
+                    cute.group_modes(sB, 0, 3),
+                    cute.group_modes(tCgB, 0, 3),
+                )
+                # TMA partition SFA
+                sfa_cta_layout = a_cta_layout
+                tAsSFA, tAgSFA = cpasync.tma_partition(
+                    tma_atom_sfa,
+                    block_in_cluster_coord_vmnk[2],
+                    sfa_cta_layout,
+                    cute.group_modes(sSFA, 0, 3),
+                    cute.group_modes(tCgSFA, 0, 3),
+                )
+                tAsSFA = cute.filter_zeros(tAsSFA)
+                tAgSFA = cute.filter_zeros(tAgSFA)
+                # TMA partition SFB
+                sfb_cta_layout = cute.make_layout(cute.slice_(cluster_layout_sfb_vmnk, (0, None, 0, 0)).shape)
+                tBsSFB, tBgSFB = cpasync.tma_partition(
+                    tma_atom_sfb,
+                    block_in_cluster_coord_sfb_vmnk[1],
+                    sfb_cta_layout,
+                    cute.group_modes(sSFB, 0, 3),
+                    cute.group_modes(tCgSFB, 0, 3),
+                )
+                tBsSFB = cute.filter_zeros(tBsSFB)
+                tBgSFB = cute.filter_zeros(tBgSFB)
+
+                mma_tile_coord_m = work_tile_info.tile_m_idx // cute.size(tiled_mma.thr_id.shape)
+                mma_tile_coord_n = work_tile_info.tile_n_idx
+                tAgA_slice = tAgA[(None, mma_tile_coord_m, None, 0)]
+                tBgB_slice = tBgB[(None, mma_tile_coord_n, None, 0)]
+                tAgSFA_slice = tAgSFA[(None, mma_tile_coord_m, None, 0)]
+                slice_n = mma_tile_coord_n
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
+                    slice_n = mma_tile_coord_n // 2
+                tBgSFB_slice = tBgSFB[(None, slice_n, None, 0)]
+
+                ab_producer_state.reset_count()
+                peek_ab_empty_status = cutlass.Boolean(1)
+                if ab_producer_state.count < k_tile_cnt:
+                    peek_ab_empty_status = ab_pipeline.producer_try_acquire(ab_producer_state)
+
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                    tAgA_k = tAgA_slice[(None, ab_producer_state.count)]
+                    tBgB_k = tBgB_slice[(None, ab_producer_state.count)]
+                    tAgSFA_k = tAgSFA_slice[(None, ab_producer_state.count)]
+                    tBgSFB_k = tBgSFB_slice[(None, ab_producer_state.count)]
+                    tAsA_pipe = tAsA[(None, ab_producer_state.index)]
+                    tBsB_pipe = tBsB[(None, ab_producer_state.index)]
+                    tAsSFA_pipe = tAsSFA[(None, ab_producer_state.index)]
+                    tBsSFB_pipe = tBsSFB[(None, ab_producer_state.index)]
+
+                    tma_bar = ab_pipeline.producer_get_barrier(ab_producer_state)
+                    ab_pipeline.producer_acquire(ab_producer_state, peek_ab_empty_status)
+
+                    cute.copy(tma_atom_a, tAgA_k, tAsA_pipe, tma_bar_ptr=tma_bar, mcast_mask=a_full_mcast_mask)
+                    cute.copy(tma_atom_b, tBgB_k, tBsB_pipe, tma_bar_ptr=tma_bar, mcast_mask=b_full_mcast_mask, tma_desc_ptr=desc_ptr_b)
+                    cute.copy(tma_atom_sfa, tAgSFA_k, tAsSFA_pipe, tma_bar_ptr=tma_bar, mcast_mask=sfa_full_mcast_mask)
+                    cute.copy(tma_atom_sfb, tBgSFB_k, tBsSFB_pipe, tma_bar_ptr=tma_bar, mcast_mask=sfb_full_mcast_mask, tma_desc_ptr=desc_ptr_sfb)
+
+                    ab_producer_state.advance()
+                    peek_ab_empty_status = cutlass.Boolean(1)
+                    if ab_producer_state.count < k_tile_cnt:
+                        peek_ab_empty_status = ab_pipeline.producer_try_acquire(ab_producer_state)
+
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+            ab_pipeline.producer_tail(ab_producer_state)
+
+        # ==============================================================
+        # Second-level scale load warp
+        #   Per k-tile, cp.async-loads sfa2/sfb2 from GMEM into sSFA2/sSFB2 and drives
+        #   scale_pipeline for the accumulator-update warpgroup.
+        # ==============================================================
+        if warp_idx == self.scale_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_uniform_warps)
+            ext = self._make_extension(workspace_ptr)
+            scale_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_scale_stage)
+
+            # Bias load shares this warp (a dedicated 13th warp would break the
+            # setmaxnregs warpgroup alignment). One 2-stage cp.async produce per
+            # tile, consumed by the epilogue warpgroup.
+            if cutlass.const_expr(self.enable_bias):
+                bias_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_bias_stage)
+                bias_g2s_atom = cute.make_copy_atom(
+                    cute.nvgpu.cpasync.CopyG2SOp(cache_mode=cute.nvgpu.cpasync.LoadCacheMode.GLOBAL),
+                    self.bias_dtype,
+                    num_bits_per_copy=128,
+                )
+                bias_g2s_tiled = cute.make_tiled_copy_tv(
+                    bias_g2s_atom,
+                    cute.make_layout((32,)),
+                    cute.make_layout((8,)),
+                )
+                thr_bias_g2s = bias_g2s_tiled.get_slice(cute.arch.lane_idx())
+                tBs_sBias = thr_bias_g2s.partition_D(sBias)
+
+            tile_info_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_tile_stage)
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            while is_valid_tile:
+                work_tile_info = MoEWorkTileInfo(
+                    expert_idx=tile_info[0],
+                    tile_m_idx=tile_info[1],
+                    tile_n_idx=tile_info[2],
+                    k_tile_cnt=tile_info[3],
+                )
+                k_tile_cnt = work_tile_info.k_tile_cnt
+                ext.update_expert_info(padded_offsets, work_tile_info.expert_idx)
+
+                mSFA2_mkl_current, _ = ext.get_gmem_tensor("sfa2", sfa2_tensor, padded_offsets, work_tile_info)
+                mSFB2_nkl_current, _ = ext.get_gmem_tensor("sfb2", sfb2_tensor, padded_offsets, work_tile_info)
+
+                gSFA2_mkl = cute.local_tile(mSFA2_mkl_current, cute.slice_(self.cta_tile_shape_mnk, (None, 0, None)), (None, None, None))
+                gSFB2_nkl = cute.local_tile(mSFB2_nkl_current, cute.slice_(self.cta_tile_shape_mnk, (0, None, None)), (None, None, None))
+
+                cSFA2_mkl = cute.make_identity_tensor(cute.shape(mSFA2_mkl_current))
+                cSFB2_nkl = cute.make_identity_tensor(cute.shape(mSFB2_nkl_current))
+                cSFA2 = cute.local_tile(cSFA2_mkl, cute.slice_(self.cta_tile_shape_mnk, (None, 0, None)), (None, None, None))
+                cSFB2 = cute.local_tile(cSFB2_nkl, cute.slice_(self.cta_tile_shape_mnk, (0, None, None)), (None, None, None))
+                tAgSFA2_mkl = thr_copy_sfa2.partition_S(gSFA2_mkl)
+                tBgSFB2_nkl = thr_copy_sfb2.partition_S(gSFB2_nkl)
+                tAcSFA2 = thr_copy_sfa2.partition_S(cSFA2)
+                tBcSFB2 = thr_copy_sfb2.partition_S(cSFB2)
+
+                mma_tile_coord_mnl = (
+                    work_tile_info.tile_m_idx,
+                    work_tile_info.tile_n_idx,
+                    0,
+                )
+
+                tApSFA2 = cute.make_rmem_tensor(
+                    cute.make_layout(cute.filter_zeros(cute.slice_(tAsSFA2, (None, None, None, 0))).shape),
+                    cutlass.Boolean,
+                )
+                tBpSFB2 = cute.make_rmem_tensor(
+                    cute.make_layout(cute.filter_zeros(cute.slice_(tBsSFB2, (None, None, None, 0))).shape),
+                    cutlass.Boolean,
+                )
+
+                scale_producer_state.reset_count()
+                peek_scale_empty_status = cutlass.Boolean(1)
+                if scale_producer_state.count < k_tile_cnt:
+                    peek_scale_empty_status = scale_pipeline.producer_try_acquire(scale_producer_state)
+
+                for k_tile in cutlass.range(0, k_tile_cnt // k_tile_same_scale_factor, 1, unroll=1):
+                    tAsSFA2_pipe = cute.filter_zeros(tAsSFA2[(None, None, None, scale_producer_state.index)])
+                    tBsSFB2_pipe = cute.filter_zeros(tBsSFB2[(None, None, None, scale_producer_state.index)])
+                    tAgSFA2_k = cute.filter_zeros(
+                        tAgSFA2_mkl[(None, None, None, mma_tile_coord_mnl[0], scale_producer_state.count * k_tile_same_scale_factor, mma_tile_coord_mnl[2])]
+                    )
+                    tBgSFB2_k = cute.filter_zeros(
+                        tBgSFB2_nkl[(None, None, None, mma_tile_coord_mnl[1], scale_producer_state.count * k_tile_same_scale_factor, mma_tile_coord_mnl[2])]
+                    )
+                    tAcSFA2_compact = cute.filter_zeros(
+                        cute.slice_(
+                            tAcSFA2,
+                            (None, None, None, mma_tile_coord_mnl[0], scale_producer_state.count * k_tile_same_scale_factor, mma_tile_coord_mnl[2]),
+                        )
+                    )
+                    tBcSFB2_compact = cute.filter_zeros(
+                        cute.slice_(
+                            tBcSFB2,
+                            (None, None, None, mma_tile_coord_mnl[1], scale_producer_state.count * k_tile_same_scale_factor, mma_tile_coord_mnl[2]),
+                        )
+                    )
+
+                    for i in cutlass.range_constexpr(cute.size(tApSFA2, mode=[1])):
+                        tApSFA2[((0, 0), i, (0, 0))] = cute.elem_less(tAcSFA2_compact[(i)][0], mSFA2_mkl_current.shape[0])
+                    for i in cutlass.range_constexpr(cute.size(tBpSFB2, mode=[1])):
+                        tBpSFB2[((0, 0), i, (0, 0))] = cute.elem_less(tBcSFB2_compact[(i)][0], mSFB2_nkl_current.shape[0])
+
+                    scale_pipeline.producer_acquire(scale_producer_state, peek_scale_empty_status)
+                    cute.copy(tiled_copy_sfa2, tAgSFA2_k, tAsSFA2_pipe, pred=tApSFA2)
+                    cute.copy(tiled_copy_sfb2, tBgSFB2_k, tBsSFB2_pipe, pred=tBpSFB2)
+                    scale_pipeline.producer_commit(scale_producer_state)
+
+                    scale_producer_state.advance()
+                    peek_scale_empty_status = cutlass.Boolean(1)
+                    if scale_producer_state.count < k_tile_cnt:
+                        peek_scale_empty_status = scale_pipeline.producer_try_acquire(scale_producer_state)
+
+                if cutlass.const_expr(self.enable_bias):
+                    bias_producer_state.reset_count()
+                    real_bias, _ = ext.get_gmem_tensor("bias", mBias_nl, padded_offsets, work_tile_info)
+                    gBias_expert = cute.local_tile(real_bias, cute.slice_(self.mma_tiler[:2], (0, None)), (None, None))
+                    bias_tile = gBias_expert[(None, work_tile_info.tile_n_idx, 0)]
+                    bias_identity_tensor = cute.make_identity_tensor(bias_tile.shape)
+                    bias_partitioned_by_g2s = thr_bias_g2s.partition_S(bias_tile)
+                    bias_coord_partitioned_by_g2s = thr_bias_g2s.partition_S(bias_identity_tensor)
+
+                    residue_n = sched_params.intermediate - work_tile_info.tile_n_idx * self.cta_tile_shape_mnk[1]
+                    bias_pred_tensor = cute.make_rmem_tensor(bias_coord_partitioned_by_g2s[(None, 0)].shape, cutlass.Boolean)
+                    for vi in cutlass.range_constexpr(cute.size(bias_pred_tensor)):
+                        bias_pred_tensor[vi] = cute.elem_less(bias_coord_partitioned_by_g2s[(vi, 0)], (residue_n,))
+                    bias_pred_tensor = bias_pred_tensor[((0, None),)]
+
+                    bias_pipeline.producer_acquire(bias_producer_state)
+                    cute.copy(bias_g2s_tiled, bias_partitioned_by_g2s[(None, 0)], tBs_sBias[(None, 0, bias_producer_state.index)], pred=bias_pred_tensor)
+                    bias_pipeline.producer_commit(bias_producer_state)
+                    bias_producer_state.advance()
+
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+            if cutlass.const_expr(self.enable_bias):
+                bias_pipeline.producer_tail(bias_producer_state)
+
+        # ==============================================================
+        # MMA warp
+        # ==============================================================
+        if warp_idx == self.mma_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_uniform_warps)
+            tmem.wait_for_alloc()
+            acc_tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+
+            # SFA TMEM tensor
+            sfa_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            tCtSFA_layout = blockscaled_utils.make_tmem_layout_sfa(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfa_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFA = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout)
+
+            # SFB TMEM tensor
+            sfb_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            tCtSFB_layout = blockscaled_utils.make_tmem_layout_sfb(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfb_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFB = cute.make_tensor(sfb_tmem_ptr, tCtSFB_layout)
+
+            # S2T copy partition for SFA/SFB
+            (
+                tiled_copy_s2t_sfa,
+                tCsSFA_compact_s2t,
+                tCtSFA_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFA, tCtSFA)
+            (
+                tiled_copy_s2t_sfb,
+                tCsSFB_compact_s2t,
+                tCtSFB_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFB, tCtSFB)
+
+            ab_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_ab_stage)
+            acc_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_acc_stage)
+
+            tile_info_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_tile_stage)
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            while is_valid_tile:
+                k_tile_cnt = tile_info[3]
+
+                # Peek AB buffer full
+                ab_consumer_state.reset_count()
+                peek_ab_full_status = cutlass.Boolean(1)
+                if ab_consumer_state.count < k_tile_cnt and is_leader_cta:
+                    peek_ab_full_status = ab_pipeline.consumer_try_wait(ab_consumer_state)
+
+                # Peek Acc buffer empty
+                acc_producer_state.reset_count()
+                peek_acc_empty_status = cutlass.Boolean(1)
+                if ab_consumer_state.count < k_tile_cnt and is_leader_cta:
+                    peek_acc_empty_status = acc_pipeline.producer_try_acquire(acc_producer_state)
+
+                mma_tile_coord_mnl = (
+                    tile_info[1] // cute.size(tiled_mma.thr_id.shape),
+                    tile_info[2],
+                    tile_info[0],
+                )
+
+                tCtSFB_mma = tCtSFB
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 192):
+                    offset = cutlass.Int32(2) if mma_tile_coord_mnl[1] % 2 == 1 else cutlass.Int32(0)
+                    shifted_ptr = cute.recast_ptr(
+                        acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols + offset,
+                        dtype=self.sf_dtype,
+                    )
+                    tCtSFB_mma = cute.make_tensor(shifted_ptr, tCtSFB_layout)
+                elif cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
+                    offset = cutlass.Int32((mma_tile_coord_mnl[1] % 2) * 2)
+                    shifted_ptr = cute.recast_ptr(
+                        acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols + offset,
+                        dtype=self.sf_dtype,
+                    )
+                    tCtSFB_mma = cute.make_tensor(shifted_ptr, tCtSFB_layout)
+
+                # Second-level design: emit ONE partial accumulator per k-tile (reset
+                # ACCUMULATE and commit acc_pipeline each iteration). The accumulator-update
+                # warpgroup performs the outer (scaled) accumulation across k-tiles.
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                    tCtAcc = tCtAcc_base[(None, None, None, acc_producer_state.index)]
+
+                    if k_tile % k_tile_same_scale_factor == 0:
+                        if is_leader_cta:
+                            acc_pipeline.producer_acquire(acc_producer_state, peek_acc_empty_status)
+
+                    tiled_mma.set(tcgen05.Field.ACCUMULATE, k_tile % k_tile_same_scale_factor > 0)
+
+                    if is_leader_cta:
+                        ab_pipeline.consumer_wait(ab_consumer_state, peek_ab_full_status)
+
+                        s2t_stage_coord = (None, None, None, None, ab_consumer_state.index)
+                        cute.copy(tiled_copy_s2t_sfa, tCsSFA_compact_s2t[s2t_stage_coord], tCtSFA_compact_s2t)
+                        cute.copy(tiled_copy_s2t_sfb, tCsSFB_compact_s2t[s2t_stage_coord], tCtSFB_compact_s2t)
+
+                        num_kblocks = cute.size(tCrA, mode=[2])
+                        ab_consumer_state_next = ab_consumer_state.clone()
+                        ab_consumer_state_next.advance()
+                        if ab_consumer_state_next.count < k_tile_cnt:
+                            peek_ab_full_status = ab_pipeline.consumer_try_wait(ab_consumer_state_next)
+
+                        for kblock_idx in cutlass.range(num_kblocks, unroll_full=True):
+                            kblock_coord = (None, None, kblock_idx, ab_consumer_state.index)
+                            sf_kblock_coord = (None, None, kblock_idx)
+                            tiled_mma.set(tcgen05.Field.SFA, tCtSFA[sf_kblock_coord].iterator)
+                            tiled_mma.set(tcgen05.Field.SFB, tCtSFB_mma[sf_kblock_coord].iterator)
+                            cute.gemm(tiled_mma, tCtAcc, tCrA[kblock_coord], tCrB[kblock_coord], tCtAcc)
+                            tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+                        ab_pipeline.consumer_release(ab_consumer_state)
+                        ab_consumer_state = ab_consumer_state_next
+
+                    if k_tile % k_tile_same_scale_factor == k_tile_same_scale_factor - 1:
+                        if is_leader_cta:
+                            acc_pipeline.producer_commit(acc_producer_state)
+
+                        acc_producer_state.advance()
+                        if acc_producer_state.count < k_tile_cnt:
+                            if is_leader_cta:
+                                peek_acc_empty_status = acc_pipeline.producer_try_acquire(acc_producer_state)
+
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+            acc_pipeline.producer_tail(acc_producer_state)
+
+        # ==============================================================
+        # Accumulator-update warpgroup (second-level scaling)
+        #   Consumes one MMA partial per k-tile (acc_pipeline) and its sfa2/sfb2 scales
+        #   (scale_pipeline), computes final += partial * (sfa2 * sfb2), stages the result
+        #   into sFinalAcc SMEM, and hands it to the epilogue via epi_pipeline.
+        # ==============================================================
+        if warp_idx in self.accumulator_update_warp_id and total_token > 0:
+            cute.arch.warpgroup_reg_alloc(self.num_regs_acc_update_warps)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            # tCtAcc_base: read MMA partial accumulators from TMEM (via acc_pipeline stages).
+            # The final accumulator is written to SMEM (sFinalAcc), not TMEM.
+            tCtAcc_base = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+
+            gD_mnl_shape = cute.local_tile(mD_mnl, cute.slice_(self.mma_tiler_d, (None, None, 0)), (None, None, None))
+            thr_mma_acc = tiled_mma.get_slice(mma_tile_coord_v)
+            tCgD_shape = thr_mma_acc.partition_C(gD_mnl_shape)
+
+            acc_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_acc_stage)
+            scale_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_scale_stage)
+            epi_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_epi_stage)
+
+            acc_tidx = tidx
+            (
+                tiled_copy_t2r,
+                tiled_copy_r2s_acc,
+                tTR_tAcc_base,
+                tTR_rAcc,
+                tTR_rAcc_final,
+                tRS_sFinalAcc,
+                tTR_sSFA,
+                tTR_sSFB,
+            ) = self.acc_update_tmem_copy_and_partition(
+                acc_tidx,
+                tCtAcc_base,
+                tCgD_shape,
+                sSFA2_view_as_C,
+                sSFB2_view_as_C,
+                sFinalAcc,
+                epi_tile,
+                use_2cta_instrs,
+            )
+
+            scale_atom_copy = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                self.acc_dtype,
+                num_bits_per_copy=self.acc_dtype.width,
+            )
+
+            tile_info_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_tile_stage)
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            while is_valid_tile:
+                k_tile_cnt = tile_info[3]
+
+                # Zero the register-resident final accumulator for this tile.
+                tTR_rAcc_final.fill(0.0)
+
+                # Register views of the per-subtile second-level scales.
+                tTR_rSFA = cute.make_rmem_tensor(cute.slice_(tTR_sSFA, (None, None, None, 0, None, 0)).shape, self.acc_dtype)
+                tTR_rSFB = cute.make_rmem_tensor(cute.slice_(tTR_sSFB, (None, None, None, 0, None, 0)).shape, self.acc_dtype)
+
+                acc_consumer_state.reset_count()
+                peek_acc_full_status = cutlass.Boolean(1)
+                if acc_consumer_state.count < k_tile_cnt:
+                    peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
+
+                scale_consumer_state.reset_count()
+                peek_scale_full_status = cutlass.Boolean(1)
+                if scale_consumer_state.count < k_tile_cnt:
+                    peek_scale_full_status = scale_pipeline.consumer_try_wait(scale_consumer_state)
+
+                for k_tile in cutlass.range(0, k_tile_cnt // k_tile_same_scale_factor, 1, unroll=1):
+                    # Wait for this k-tile's second-level scales, load them to registers.
+                    scale_pipeline.consumer_wait(scale_consumer_state, peek_scale_full_status)
+                    tTR_sSFA_slice = cute.slice_(tTR_sSFA, (None, None, None, 0, None, scale_consumer_state.index))
+                    tTR_sSFB_slice = cute.slice_(tTR_sSFB, (None, None, None, 0, None, scale_consumer_state.index))
+                    cute.copy(scale_atom_copy, tTR_sSFA_slice, tTR_rSFA)
+                    cute.copy(scale_atom_copy, tTR_sSFB_slice, tTR_rSFB)
+                    scale_pipeline.consumer_release(scale_consumer_state)
+                    scale_consumer_state.advance()
+
+                    # Wait for MMA to produce this k-tile's partial accumulator.
+                    acc_pipeline.consumer_wait(acc_consumer_state, peek_acc_full_status)
+
+                    tTR_tAcc = tTR_tAcc_base[(None, None, None, None, None, acc_consumer_state.index)]
+                    tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+
+                    subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+                    for subtile_idx in cutlass.range(subtile_cnt):
+                        # Load partial accumulator subtile from TMEM to registers.
+                        tTR_tAcc_mn = tTR_tAcc[(None, None, None, subtile_idx)]
+                        cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+
+                        # Second-level scale-multiply-accumulate: final += partial * sfa2 * sfb2.
+                        tTR_rAcc_subtile = tTR_rAcc_final[(None, None, None, subtile_idx)]
+                        acc_vec = tTR_rAcc.load()
+                        final_vec = tTR_rAcc_subtile.load()
+                        scale_a = tTR_rSFA[(None, None, None, subtile_idx)].load()
+                        scale_b = tTR_rSFB[(None, None, None, subtile_idx)].load()
+                        scale = scale_a * scale_b
+                        final_vec = acc_vec * scale + final_vec
+                        tTR_rAcc_subtile.store(final_vec.to(self.acc_dtype))
+
+                    with cute.arch.elect_one():
+                        acc_pipeline.consumer_release(acc_consumer_state)
+                    acc_consumer_state.advance()
+
+                    peek_acc_full_status = cutlass.Boolean(1)
+                    if acc_consumer_state.count < k_tile_cnt:
+                        peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
+                    peek_scale_full_status = cutlass.Boolean(1)
+                    if scale_consumer_state.count < k_tile_cnt:
+                        peek_scale_full_status = scale_pipeline.consumer_try_wait(scale_consumer_state)
+
+                # All k-tiles accumulated: stage the final result into sFinalAcc for epilogue.
+                epi_pipeline.producer_acquire(epi_producer_state)
+                final_subtile_cnt = cute.size(tTR_rAcc_final.shape, mode=[3])
+                slot_base = epi_producer_state.index * final_subtile_cnt
+                for subtile_idx in cutlass.range(final_subtile_cnt, unroll_full=True):
+                    tRS_rFinal = tiled_copy_r2s_acc.retile(tTR_rAcc_final[(None, None, None, subtile_idx)])
+                    cute.copy(
+                        tiled_copy_r2s_acc,
+                        tRS_rFinal,
+                        tRS_sFinalAcc[(None, None, None, slot_base + subtile_idx)],
+                    )
+                # No proxy fence needed: producer and consumer both use the generic proxy,
+                # and epi_pipeline.producer_commit's mbarrier arrive has release semantics.
+                epi_pipeline.producer_commit(epi_producer_state)
+                epi_producer_state.advance()
+
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+        # ==============================================================
+        # Epilogue warps
+        # ==============================================================
+        if warp_idx in self.epilog_warp_id and total_token > 0:
+            cute.arch.warpgroup_reg_alloc(self.num_regs_epilogue_warps)
+            tmem.allocate(self.num_tmem_alloc_cols)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            tCtAcc_base = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+
+            epi_tidx = tidx % 128
+            thr_mma_epi = tiled_mma.get_slice(mma_tile_coord_v)
+
+            # Shape-only partition on global tensor (invariant setup for t2r copy atom)
+            gD_mnl_shape = cute.local_tile(mD_mnl, cute.slice_(self.mma_tiler_d, (None, None, 0)), (None, None, None))
+            tCgD_shape = thr_mma_epi.partition_C(gD_mnl_shape)
+
+            if cutlass.const_expr(self.enable_breuse):
+                # Merge bkeep/breuse M-split (mode1=2) into the M dimension for epilogue
+                tCtAcc_epi_input = transform_partitioned_tensor_layout(tCtAcc_base)
+                tCgD_epi_input = transform_partitioned_tensor_layout(tCgD_shape)
+            else:
+                tCtAcc_epi_input = tCtAcc_base
+                tCgD_epi_input = tCgD_shape
+
+            tiled_copy_t2r, tTR_tAcc_base, tTR_rAcc = self.epilog_tmem_copy_and_partition(
+                epi_tidx,
+                tCtAcc_epi_input,
+                tCgD_epi_input,
+                epi_tile,
+                use_2cta_instrs,
+            )
+
+            tTR_rD = cute.make_rmem_tensor(tTR_rAcc.shape, self.d_dtype)
+            tiled_copy_r2s, tRS_rD, tRS_sD = self.epilog_smem_copy_and_partition(
+                tiled_copy_t2r,
+                tTR_rD,
+                epi_tidx,
+                sD,
+            )
+
+            # Second-level design: the epilogue reads the final accumulator from SMEM
+            # (sFinalAcc) written by the accumulator-update warpgroup, not from TMEM.
+            tiled_copy_s2r, tSR_rAcc, tSR_sFinalAcc = self.epilog_smem_load_copy_and_partition(
+                tiled_copy_t2r,
+                tTR_rAcc,
+                epi_tidx,
+                sFinalAcc,
+            )
+
+            epi_ext = self._make_extension(workspace_ptr)
+
+            epi_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_epi_stage)
+            d_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 32 * len(self.epilog_warp_id))
+            d_pipeline = pipeline.PipelineTmaStore.create(num_stages=self.num_d_stage, producer_group=d_producer_group)
+
+            tile_info_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_tile_stage)
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            if cutlass.const_expr(self.enable_bias):
+                bias_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_bias_stage)
+                bias_s2r_tom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.bias_dtype, num_bits_per_copy=128)
+                tTR_rBias = cute.make_rmem_tensor(cute.make_layout(self.epi_tile[1]), self.bias_dtype)
+
+            num_prev_subtiles = cutlass.Int32(0)
+            while is_valid_tile:
+                epi_work_tile_info = MoEWorkTileInfo(
+                    expert_idx=tile_info[0],
+                    tile_m_idx=tile_info[1],
+                    tile_n_idx=tile_info[2],
+                    k_tile_cnt=tile_info[3],
+                )
+                expert_idx = epi_work_tile_info.expert_idx
+                epi_ext.update_expert_info(padded_offsets, expert_idx)
+
+                alpha_val = alpha[expert_idx]
+
+                if cutlass.const_expr(self.enable_bias):
+                    bias_consumer_state.reset_count()
+                    bias_pipeline.consumer_wait(bias_consumer_state)
+                    sBias_stage = sBias[(None, bias_consumer_state.index)]
+                    sBias_subtiles = cute.flat_divide(sBias_stage, cute.make_layout(self.epi_tile[1]))
+
+                real_d, _ = epi_ext.get_gmem_tensor("d", mD_mnl, padded_offsets, epi_work_tile_info)
+
+                thr_mma_epi_loop = tiled_mma.get_slice(mma_tile_coord_v)
+
+                gD_mnl_loop = cute.local_tile(real_d, cute.slice_(self.mma_tiler_d, (None, None, 0)), (None, None, None))
+                tCgD_loop = thr_mma_epi_loop.partition_C(gD_mnl_loop)
+                if cutlass.const_expr(self.enable_breuse):
+                    tCgD_loop_epi = transform_partitioned_tensor_layout(tCgD_loop)
+                    gD_epi_tr = cute.flat_divide(tCgD_loop_epi, epi_tile)
+                    sD_for_tma = cute.group_modes(sD, 0, 2)
+                    gD_for_tma_tr = cute.group_modes(gD_epi_tr, 0, 2)
+                    bSG_sD, bSG_gD_partitioned = cpasync.tma_partition(
+                        tma_atom_d,
+                        0,
+                        cute.make_layout(1),
+                        sD_for_tma,
+                        gD_for_tma_tr,
+                    )
+                else:
+                    _, bSG_sD, bSG_gD_partitioned = epilog_gmem_copy_and_partition(
+                        epi_tidx,
+                        tma_atom_d,
+                        tCgD_loop,
+                        epi_tile,
+                        sD,
+                    )
+
+                epi_mma_tile_coord = (
+                    epi_work_tile_info.tile_m_idx // cute.size(tiled_mma.thr_id.shape),
+                    epi_work_tile_info.tile_n_idx,
+                    0,
+                )
+                bSG_gD = bSG_gD_partitioned[(None, None, None, *epi_mma_tile_coord)]
+                bSG_gD = cute.group_modes(bSG_gD, 1, cute.rank(bSG_gD))
+
+                real_prob, _ = epi_ext.get_gmem_tensor("prob", prob, padded_offsets, epi_work_tile_info)
+                if cutlass.const_expr(self.enable_breuse):
+                    # Two M halves: bkeep (rows 0..cta_m/2-1) and breuse (rows cta_m/2..cta_m-1)
+                    mPosition_bk = epi_work_tile_info.tile_m_idx * self.cta_tile_shape_mnk[0] + epi_tidx
+                    mPosition_br = mPosition_bk + (self.cta_tile_shape_mnk[0] // 2)
+                    mProb_bk = real_prob[mPosition_bk, 0, 0]
+                    mProb_br = real_prob[mPosition_br, 0, 0]
+                    mProb = mProb_bk  # default; will be overridden per subtile below
+                else:
+                    mPosition = epi_work_tile_info.tile_m_idx * self.cta_tile_shape_mnk[0] + epi_tidx
+                    mProb = real_prob[mPosition, 0, 0]
+
+                # Second-level design: single epi_pipeline stage; the final accumulator
+                # comes from sFinalAcc (SMEM), so no TMEM acc-stage phase logic is needed.
+                epi_stage_index = 0
+
+                tTR_tAcc = tTR_tAcc_base[(None, None, None, None, None, epi_stage_index)]
+                tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+
+                # Wait for the accumulator-update warpgroup to fill sFinalAcc.
+                epi_pipeline.consumer_wait(epi_consumer_state)
+
+                subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+
+                for subtile_idx in cutlass.range(0, subtile_cnt, 1, unroll=1):
+                    real_subtile_idx = subtile_idx
+                    if cutlass.const_expr(self.overlapping_accum):
+                        if reverse_subtile:
+                            real_subtile_idx = self.cta_tile_shape_mnk[1] // self.epi_tile_n_required - 1 - subtile_idx
+
+                    # C1 fix: fence + early release for overlapping_accum
+                    if cutlass.const_expr(self.overlapping_accum):
+                        if subtile_idx == self.iter_acc_early_release_in_epilogue:
+                            cute.arch.fence_view_async_tmem_load()
+                            with cute.arch.elect_one():
+                                acc_pipeline.consumer_release(acc_consumer_state)
+                            acc_consumer_state.advance()
+
+                    # Load the final accumulator subtile from SMEM (written by acc-update warp).
+                    final_slot = epi_stage_index * subtile_cnt + real_subtile_idx
+                    cute.copy(
+                        tiled_copy_s2r,
+                        tSR_sFinalAcc[(None, None, None, final_slot)],
+                        tSR_rAcc,
+                    )
+
+                    # For breuse, update mProb based on which M half this subtile belongs to.
+                    # With transform, subtiles interleave M groups: even = bkeep, odd = breuse.
+                    if cutlass.const_expr(self.enable_breuse):
+                        if real_subtile_idx % 2 == 0:
+                            mProb = mProb_bk
+                        else:
+                            mProb = mProb_br
+
+                    if cutlass.const_expr(self.enable_bias):
+                        # m7 fix: use real_subtile_idx directly (matches contiguous)
+                        sBias_sub = sBias_subtiles[(None, real_subtile_idx)]
+                        cute.copy(bias_s2r_tom, sBias_sub, tTR_rBias)
+                        bias_vec = tTR_rBias.load()
+                        if cutlass.const_expr(self.vectorized_f32):
+                            for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
+                                bias_f32_0 = bias_vec[i].to(cutlass.Float32)
+                                bias_f32_1 = bias_vec[i + 1].to(cutlass.Float32)
+                                bias_f32_0, bias_f32_1 = cute.arch.mul_packed_f32x2(
+                                    (mProb, mProb),
+                                    (bias_f32_0, bias_f32_1),
+                                    rnd="rn",
+                                    ftz=False,
+                                )
+                                tTR_rAcc[i], tTR_rAcc[i + 1] = cute.arch.fma_packed_f32x2(
+                                    (tTR_rAcc[i], tTR_rAcc[i + 1]),
+                                    (cutlass.Float32(alpha_val), cutlass.Float32(alpha_val)),
+                                    (bias_f32_0, bias_f32_1),
+                                    rnd="rn",
+                                    ftz=False,
+                                )
+                        else:
+                            for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
+                                tTR_rAcc[i] = tTR_rAcc[i] * cutlass.Float32(alpha_val) + bias_vec[i].to(cutlass.Float32) * mProb
+                    else:
+                        if cutlass.const_expr(self.vectorized_f32):
+                            for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
+                                tTR_rAcc[i], tTR_rAcc[i + 1] = cute.arch.mul_packed_f32x2(
+                                    (tTR_rAcc[i], tTR_rAcc[i + 1]),
+                                    (cutlass.Float32(alpha_val), cutlass.Float32(alpha_val)),
+                                    rnd="rn",
+                                    ftz=False,
+                                )
+                        else:
+                            for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
+                                tTR_rAcc[i] = tTR_rAcc[i] * cutlass.Float32(alpha_val)
+
+                    acc_vec = tTR_rAcc.load()
+                    if cutlass.const_expr(not self.enable_bias):
+                        tCompute = cute.make_rmem_tensor(acc_vec.shape, self.acc_dtype)
+                        if cutlass.const_expr(self.vectorized_f32):
+                            for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
+                                tCompute[i], tCompute[i + 1] = cute.arch.mul_packed_f32x2(
+                                    (acc_vec[i], acc_vec[i + 1]),
+                                    (mProb, mProb),
+                                    rnd="rn",
+                                    ftz=False,
+                                )
+                        else:
+                            for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
+                                tCompute[i] = acc_vec[i] * mProb
+                    else:
+                        tCompute = tTR_rAcc
+
+                    acc_vec = tiled_copy_r2s.retile(tCompute).load()
+                    tRS_rD.store(acc_vec.to(self.d_dtype))
+
+                    d_buffer = num_prev_subtiles % self.num_d_stage
+                    num_prev_subtiles = num_prev_subtiles + 1
+                    cute.copy(tiled_copy_r2s, tRS_rD, tRS_sD[(None, None, None, d_buffer)])
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    self.epilog_sync_barrier.arrive_and_wait()
+                    if warp_idx == self.epilog_warp_id[0]:
+                        cute.copy(tma_atom_d, bSG_sD[(None, d_buffer)], bSG_gD[(None, real_subtile_idx)])
+                        d_pipeline.producer_commit()
+                        d_pipeline.producer_acquire()
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+                # Release the sFinalAcc buffer back to the accumulator-update warpgroup.
+                epi_pipeline.consumer_release(epi_consumer_state)
+                epi_consumer_state.advance()
+
+                if cutlass.const_expr(self.enable_bias):
+                    bias_pipeline.consumer_release(bias_consumer_state)
+                    bias_consumer_state.advance()
+
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[0] >= cutlass.Int32(0)
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+            tmem.relinquish_alloc_permit()
+            self.epilog_sync_barrier.arrive_and_wait()
+            tmem.free(tmem_ptr)
+            d_pipeline.producer_tail()
+
+    # ------------------------------------------------------------------
+    # Internal: create extension based on weight_mode
+    # ------------------------------------------------------------------
+
+    @cute.jit
+    def _make_extension(self, workspace_ptr):
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE):
+            desc_workspace = TensormapWorkspace(workspace_ptr, ["b", "sfb"])
+            return DiscreteWeightScaledGemmSchedExtension(
+                tensormap_ctor=desc_workspace,
+                sf_vec_size=self.sf_vec_size,
+            )
+        else:
+            return ContiguousAndConsistentGroupedGemmSchedExtension(
+                sf_vec_size=self.sf_vec_size,
+            )

--- a/python/cudnn/gemm/cutedsl/grouped/wgrad_subchannel_scaled/__init__.py
+++ b/python/cudnn/gemm/cutedsl/grouped/wgrad_subchannel_scaled/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Subchannel-scaled (second-level SFA2) grouped GEMM weight gradient for MoE workloads."""
+
+from .api import (
+    GroupedGemmWgradSubchannelScaledSm100,
+    grouped_gemm_wgrad_subchannel_scaled_wrapper_sm100,
+)
+
+__all__ = [
+    "GroupedGemmWgradSubchannelScaledSm100",
+    "grouped_gemm_wgrad_subchannel_scaled_wrapper_sm100",
+]

--- a/python/cudnn/gemm/cutedsl/grouped/wgrad_subchannel_scaled/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/wgrad_subchannel_scaled/api.py
@@ -1,0 +1,745 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""FE API for the subchannel-scaled (second-level SFA2) grouped GEMM weight gradient on SM100+.
+
+Per expert ``e`` with token range ``[k0, k1)`` split into ``sgk``-token scale blocks ``b``::
+
+    dW[e] = sum_b (A[:, b] @ B[b, :]) * sfa2[:, b_idx]      # f32, ascending b
+    dW[e] = (dW[e] * global_scale_a[e] * global_scale_b[e]).to(bf16)
+
+``A = a_fp4 * sfa`` and ``B = b_fp4 * sfb`` are the first-level NVFP4 operands (K = the ragged
+token axis), and ``sfa2`` is the per-(hidden row x sgk tokens) f32 second-level A scale (no
+second-level B scale in wgrad). Every expert's token count must be a multiple of ``sgk`` so
+that second-level scale blocks never straddle experts.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Literal, Optional, Tuple
+
+import cutlass
+import cutlass.cute as cute
+from cuda.bindings import driver as cuda
+from cutlass.cute.runtime import from_dlpack, make_fake_stream
+
+from cudnn.api_base import APIBase, TensorDesc, TupleDict, ceil_div, get_device_type
+from cudnn.datatypes import _convert_to_cutlass_data_type
+from cudnn.gemm.cutedsl.grouped.unfused._bf16_api import _validate_pointer_tensor
+from cudnn.tensor_adapter import canonicalize_unit_dim_strides, detect_framework, framework_dtype, get_shape, is_torch_tensor
+
+from ..backend_utils import _torch_stream_context
+from ..moe_utils import MoEWeightMode, WGradInputOrder
+from ..wgrad.api import _wgrad_tensor_signature
+from .grouped_gemm_wgrad_subchannel_scaled import (
+    BlockScaledSubChannelMoEGroupedGemmWgradKernel,
+    DEFAULT_CTA_SHAPE,
+    VALID_CLUSTER_SHAPES,
+    VALID_CTA_SHAPES,
+)
+
+# NVFP4 first level: e4m3 scale per (1, 16) block; the MMA K tile is 256 tokens.
+_SF_VEC_SIZE = 16
+_MMA_TILER_K = 256
+
+
+def _get_rubin_kernel():
+    from .moe_blockscaled_grouped_gemm_wgrad_subchannel_scaled_rubin import (
+        BlockScaledSubChannelMoEGroupedGemmWgradKernelSm107,
+    )
+
+    return BlockScaledSubChannelMoEGroupedGemmWgradKernelSm107
+
+
+def _round_up(a: int, b: int) -> int:
+    return ceil_div(a, b) * b
+
+
+class GroupedGemmWgradSubchannelScaledSm100(APIBase):
+    """Subchannel-scaled grouped GEMM wgrad (2Dx2D) FE API for SM100+ GPUs.
+
+    :param sample_a: ``(hidden, tokens_sum)`` packed fp4 dY^T, K(token)-major
+    :param sample_b: ``(tokens_sum, intermediate)`` packed fp4 activations, K(token)-major
+    :param sample_sfa: ``(round_up(hidden, 128), round_up(tokens_sum / 16, 4))`` e4m3 first-level A
+        scales in the assembled (MMA-tiled, per-expert) block-scaled layout
+    :param sample_sfb: same for B over ``intermediate``
+    :param sample_sfa2: ``(hidden, tokens_sum / sgk)`` f32 second-level A scales, hidden-contiguous
+        (strides ``(1, hidden)`` -- the rowwise-quant producer's ``sf2`` view, consumed zero-copy)
+    :param sample_offsets: ``(expert_cnt,)`` int32 cumulative END token offsets
+    :param sgk: second-level scale group size along the token axis (multiple of 256)
+    :param sample_wgrad: dense mode: ``(expert_cnt, hidden, intermediate)`` bf16 output
+    :param sample_wgrad_expert / num_experts / wgrad_shape / wgrad_dtype: discrete (per-expert
+        pointer array) output mode, as in ``GroupedGemmWgradSm100``
+    :param sample_global_scale_a / sample_global_scale_b: optional ``(expert_cnt,)`` f32 per-expert
+        tensorwise scales (applied as ``alpha = gsa[e] * gsb[e]``; both or neither)
+    :param mma_tiler_mn: ``(128, 128)`` or ``(256, 128)`` (2-CTA MMA iff M == 256)
+    :param cluster_shape_mn: cluster shape; default ``(2, 1)`` for 2-CTA tilers, ``(1, 1)`` otherwise
+    :param sf_fp8_dtype_override: ``"e5m3"`` reinterprets the e4m3-typed first-level scales as
+        e5m3 (Rubin only)
+    :param accumulate_on_output: TMA reduce-add into the caller's output instead of storing
+    """
+
+    def __init__(
+        self,
+        sample_a: torch.Tensor,
+        sample_b: torch.Tensor,
+        sample_sfa: torch.Tensor,
+        sample_sfb: torch.Tensor,
+        sample_sfa2: torch.Tensor,
+        sample_offsets: torch.Tensor,
+        sgk: int,
+        sample_wgrad: Optional[torch.Tensor] = None,
+        sample_wgrad_expert: Optional[torch.Tensor] = None,
+        num_experts: Optional[int] = None,
+        wgrad_shape: Optional[Tuple[int, int]] = None,
+        wgrad_dtype: Optional[torch.dtype] = None,
+        sample_global_scale_a: Optional[torch.Tensor] = None,
+        sample_global_scale_b: Optional[torch.Tensor] = None,
+        acc_dtype: Optional[torch.dtype] = None,
+        mma_tiler_mn: Tuple[int, int] = DEFAULT_CTA_SHAPE,
+        cluster_shape_mn: Optional[Tuple[int, int]] = None,
+        sf_fp8_dtype_override: Optional[Literal["e5m3"]] = None,
+        accumulate_on_output: bool = False,
+    ):
+        if sample_a is not None and not is_torch_tensor(sample_a):
+            raise ValueError(
+                "GroupedGemmWgradSubchannelScaledSm100 supports torch tensors only: its fp4 operands and "
+                "hidden-contiguous second-level scales require layouts that are not expressible as row-major JAX arrays"
+            )
+        import torch
+
+        acc_dtype = framework_dtype(acc_dtype, "torch") if acc_dtype is not None else torch.float32
+        wgrad_dtype = framework_dtype(wgrad_dtype, "torch") if wgrad_dtype is not None else None
+        super().__init__()
+        self._warn_experimental_api()
+        self.input_order = WGradInputOrder.Tensor2D
+
+        if sample_wgrad is not None and num_experts is None:
+            self.weight_mode = MoEWeightMode.DENSE
+        elif sample_wgrad is None and num_experts is not None:
+            self.weight_mode = MoEWeightMode.DISCRETE
+            if wgrad_shape is None or wgrad_dtype is None:
+                raise ValueError("wgrad_shape and wgrad_dtype are required in discrete mode")
+        else:
+            raise ValueError("Provide either sample_wgrad for dense mode or (num_experts, wgrad_shape, wgrad_dtype) for discrete mode, but not both")
+
+        self._interpret_uint8_as_fp4x2 = True
+        self.sample_a_tensor = sample_a if self._is_fp4x2(sample_a) else None
+        self.sample_b_tensor = sample_b if self._is_fp4x2(sample_b) else None
+        self.a_desc = self._make_tensor_desc(sample_a, name="sample_a")
+        self.b_desc = self._make_tensor_desc(sample_b, name="sample_b")
+        self.sfa_desc = self._make_tensor_desc(sample_sfa, name="sample_sfa")
+        self.sfb_desc = self._make_tensor_desc(sample_sfb, name="sample_sfb")
+        self.sfa2_desc = self._make_tensor_desc(sample_sfa2, name="sample_sfa2")
+        self.offsets_desc = self._make_tensor_desc(sample_offsets, name="sample_offsets")
+        self.global_scale_a_desc = self._make_tensor_desc(sample_global_scale_a, name="sample_global_scale_a")
+        self.global_scale_b_desc = self._make_tensor_desc(sample_global_scale_b, name="sample_global_scale_b")
+        self.sf_vec_size = _SF_VEC_SIZE
+        self.sgk = int(sgk)
+        self.sf_fp8_dtype_override = sf_fp8_dtype_override
+        tokens_sum_a = self.a_desc.shape[1]
+        tokens_sum_b = self.b_desc.shape[0]
+        self._value_error_if(
+            tokens_sum_a != tokens_sum_b,
+            f"sample_a and sample_b token dimensions must match, got {tokens_sum_a} and {tokens_sum_b}",
+        )
+        self._offset_values = self._validate_offsets(sample_offsets, tokens_sum_a, name="sample_offsets")
+        self._scale_cols = _round_up(ceil_div(tokens_sum_a, self.sf_vec_size), 4)
+
+        if self.weight_mode == MoEWeightMode.DENSE:
+            self.wgrad_desc = self._make_tensor_desc(sample_wgrad, name="sample_wgrad")
+            self.expert_cnt = self.wgrad_desc.shape[0]
+            self.wgrad_shape = self.wgrad_desc.shape[1:]
+            self.wgrad_dtype = self.wgrad_desc.dtype
+            self.single_expert_wgrad_desc = TensorDesc(
+                dtype=self.wgrad_desc.dtype,
+                shape=self.wgrad_desc.shape[1:],
+                stride=self.wgrad_desc.stride[1:],
+                stride_order=tuple(i for i, s in sorted(enumerate(self.wgrad_desc.stride[1:]), key=lambda x: x[1])),
+                device=self.wgrad_desc.device,
+                name="single_expert_wgrad",
+            )
+        else:  # MoEWeightMode.DISCRETE
+            self.expert_cnt = num_experts
+            self.wgrad_shape = tuple(wgrad_shape)
+            self.wgrad_dtype = wgrad_dtype
+            self.wgrad_desc = None
+            if sample_wgrad_expert is not None:
+                self.single_expert_wgrad_desc = self._make_tensor_desc(sample_wgrad_expert, name="sample_wgrad_expert")
+            else:
+                self.single_expert_wgrad_desc = TensorDesc(
+                    dtype=wgrad_dtype,
+                    shape=self.wgrad_shape,
+                    stride=(self.wgrad_shape[1], 1),
+                    stride_order=(1, 0),
+                    device=self.a_desc.device,
+                    name="single_expert_wgrad",
+                )
+
+        self.acc_dtype = acc_dtype
+        self.mma_tiler_mn = tuple(mma_tiler_mn)
+        self.use_2cta_instrs = self.mma_tiler_mn[0] == 256
+        self.cluster_shape_mn = tuple(cluster_shape_mn) if cluster_shape_mn is not None else ((2, 1) if self.use_2cta_instrs else (1, 1))
+        self.accumulate_on_output = accumulate_on_output
+        self._kernel = _get_rubin_kernel() if self._is_rubin_kernel else BlockScaledSubChannelMoEGroupedGemmWgradKernel
+        self._workspace = None
+
+    def _validate_offsets(self, offsets_tensor: torch.Tensor, tokens_sum: int, name: str) -> Tuple[int, ...]:
+        self._value_error_if(offsets_tensor.ndim != 1, f"{name} must be rank-1, got shape {tuple(offsets_tensor.shape)}")
+
+        offset_values = tuple(int(offset) for offset in offsets_tensor.detach().cpu().tolist())
+        prev_offset = 0
+        for idx, offset in enumerate(offset_values):
+            self._value_error_if(
+                offset < prev_offset,
+                f"{name} must be a non-decreasing cumulative sum, but index {idx} has {offset} after {prev_offset}",
+            )
+            prev_offset = offset
+
+        self._value_error_if(not offset_values, f"{name} cannot be empty")
+        self._value_error_if(
+            offset_values[-1] > tokens_sum,
+            f"{name} last value must not exceed total tokens {tokens_sum}, got {offset_values[-1]}",
+        )
+        return offset_values
+
+    def check_support(self) -> bool:
+        import torch
+
+        m, tokens_sum = self._tensor_shape(self.a_desc, name="sample_a")
+        _, n = self._tensor_shape(self.b_desc, name="sample_b")
+
+        _ = self._check_tensor_shape(self.a_desc, (m, tokens_sum), "sample_a")
+        _ = self._check_tensor_shape(self.b_desc, (tokens_sum, n), "sample_b")
+        _ = self._check_tensor_shape(self.sfa_desc, (_round_up(m, 128), self._scale_cols), "sample_sfa")
+        _ = self._check_tensor_shape(self.sfb_desc, (_round_up(n, 128), self._scale_cols), "sample_sfb")
+        _ = self._check_tensor_shape(self.offsets_desc, (self.expert_cnt,), "sample_offsets")
+
+        dtype = self._check_dtype(self.a_desc, [torch.float4_e2m1fn_x2, torch.uint8], "sample_a")
+        self._check_dtype(self.b_desc, dtype, "sample_b", extra_error_msg="sample_b must have the same dtype as sample_a")
+        self._check_dtype(self.sfa_desc, torch.float8_e4m3fn, "sample_sfa", extra_error_msg="sample_sfa must have dtype float8_e4m3fn (NVFP4 first level)")
+        self._check_dtype(self.sfb_desc, torch.float8_e4m3fn, "sample_sfb", extra_error_msg="sample_sfb must have dtype float8_e4m3fn (NVFP4 first level)")
+        self._check_dtype(self.offsets_desc, torch.int32, "sample_offsets", extra_error_msg="sample_offsets must be int32")
+        self._check_dtype(self.wgrad_dtype, torch.bfloat16, "wgrad_dtype", extra_error_msg="wgrad_dtype must be bfloat16")
+        self._value_error_if(self.acc_dtype != torch.float32, f"acc_dtype must be float32, got {self.acc_dtype}")
+
+        # The tcgen05 block-scaled MMA consumes K-major fp4 operands; the kernel transposes B by
+        # stride swap, so both A (hidden, tokens) and B (tokens, intermediate) must be token-innermost.
+        self._value_error_if(
+            self.a_desc.stride[1] != 1 or self.b_desc.stride[0] != 1,
+            "sample_a (hidden, tokens_sum) and sample_b (tokens_sum, intermediate) must be K(token)-major",
+        )
+        # SF atom layouts tile M/N in 128-row atoms.
+        self._value_error_if(m % 128 != 0 or n % 128 != 0, f"hidden and intermediate must be multiples of 128, got hidden={m}, intermediate={n}")
+
+        # Second-level scale group and its grid.
+        self._value_error_if(
+            self.sgk <= 0 or self.sgk % _MMA_TILER_K != 0,
+            f"sgk must be a positive multiple of the {_MMA_TILER_K}-token MMA K tile, got {self.sgk}",
+        )
+        self._value_error_if(
+            tokens_sum % self.sgk != 0,
+            f"tokens_sum ({tokens_sum}) must be a multiple of sgk ({self.sgk})",
+        )
+        # Whole scale blocks per expert: token_offset // sgk is the exact per-expert SFA2 column
+        # offset only when no block straddles experts. This is checked on the sample offsets; the
+        # same contract holds for every execute() with different offsets.
+        prev = 0
+        for idx, end in enumerate(self._offset_values):
+            self._value_error_if(
+                (end - prev) % self.sgk != 0,
+                f"per-expert token count must be sgk-aligned so second-level scale blocks never straddle experts, "
+                f"but expert {idx} has {end - prev} tokens (sgk={self.sgk})",
+            )
+            prev = end
+        scale_cols = tokens_sum // self.sgk
+        _ = self._check_tensor_shape(self.sfa2_desc, (m, scale_cols), "sample_sfa2")
+        self._check_dtype(self.sfa2_desc, torch.float32, "sample_sfa2", extra_error_msg="sample_sfa2 must be float32")
+        expected_sfa2_stride = canonicalize_unit_dim_strides((m, scale_cols), (1, m))
+        self._value_error_if(
+            tuple(self.sfa2_desc.stride) != tuple(expected_sfa2_stride),
+            f"sample_sfa2 must be hidden-contiguous with strides {expected_sfa2_stride} (the rowwise-quant producer's sf2 view), "
+            f"got {tuple(self.sfa2_desc.stride)}",
+        )
+
+        # torch has no e5m3 dtype and TVM-FFI cannot marshal FloatNV8E5M3FNU, so e5m3 scale
+        # factors arrive as e4m3 storage of the same width and the Rubin kernel reinterprets them.
+        self._value_error_if(
+            self.sf_fp8_dtype_override not in (None, "e5m3"),
+            f"sf_fp8_dtype_override must be None or 'e5m3', got {self.sf_fp8_dtype_override!r}",
+        )
+        if self.sf_fp8_dtype_override == "e5m3":
+            self._value_error_if(
+                not self._is_rubin_kernel,
+                f"sf_fp8_dtype_override='e5m3' requires Rubin (SM107), got device type {self._device_type!r}",
+            )
+
+        if self.weight_mode == MoEWeightMode.DENSE:
+            self._check_tensor_shape(self.wgrad_desc, (self.expert_cnt, m, n), "sample_wgrad")
+            self._value_error_if(
+                tuple(self.wgrad_desc.stride) != tuple(canonicalize_unit_dim_strides((self.expert_cnt, m, n), (m * n, n, 1))),
+                f"sample_wgrad must be a contiguous (expert_cnt, hidden, intermediate) tensor, got strides {tuple(self.wgrad_desc.stride)}",
+            )
+        else:
+            self._check_tensor_shape(self.wgrad_shape, (m, n), "wgrad_shape")
+            self._check_tensor_shape(self.single_expert_wgrad_desc, (m, n), "single_expert_wgrad")
+            self._check_dtype(
+                self.single_expert_wgrad_desc,
+                self.wgrad_dtype,
+                "sample_wgrad_expert",
+                extra_error_msg="sample_wgrad_expert must have the same dtype as wgrad_dtype",
+            )
+
+        self._value_error_if(self.mma_tiler_mn not in VALID_CTA_SHAPES, f"mma_tiler_mn must be one of {VALID_CTA_SHAPES}, got {self.mma_tiler_mn}")
+        self._value_error_if(
+            self.cluster_shape_mn not in VALID_CLUSTER_SHAPES, f"cluster_shape_mn must be one of {VALID_CLUSTER_SHAPES}, got {self.cluster_shape_mn}"
+        )
+        self._value_error_if(
+            self.cluster_shape_mn[0] % (2 if self.use_2cta_instrs else 1) != 0,
+            f"cluster_shape_mn[0] must be even for the 2-CTA (M=256) tiler, got {self.cluster_shape_mn[0]}",
+        )
+
+        has_global_scale = self.global_scale_a_desc is not None or self.global_scale_b_desc is not None
+        if has_global_scale:
+            self._value_error_if(
+                self.global_scale_a_desc is None or self.global_scale_b_desc is None,
+                "sample_global_scale_a and sample_global_scale_b must be provided together",
+            )
+            self._check_tensor_shape(self.global_scale_a_desc, (self.expert_cnt,), "sample_global_scale_a")
+            self._check_tensor_shape(self.global_scale_b_desc, (self.expert_cnt,), "sample_global_scale_b")
+            self._check_dtype(self.global_scale_a_desc, torch.float32, "sample_global_scale_a")
+            self._check_dtype(self.global_scale_b_desc, torch.float32, "sample_global_scale_b")
+
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA is not available")
+        device = torch.cuda.current_device()
+        major, minor = torch.cuda.get_device_capability(device)
+        compute_capability = major * 10 + minor
+        if compute_capability < 100:
+            raise RuntimeError(f"GroupedGemmWgradSubchannelScaled requires SM100+ compute capability, but found SM{compute_capability} on device {device}")
+
+        self._is_supported = True
+        return True
+
+    def compile(self) -> None:
+        import torch
+
+        self._ensure_support_checked()
+        if self._compiled_kernel is not None:
+            return
+
+        kernel = self._kernel(
+            sf_vec_size=self.sf_vec_size,
+            sgk=self.sgk,
+            acc_dtype=_convert_to_cutlass_data_type(self.acc_dtype),
+            use_2cta_instrs=self.use_2cta_instrs,
+            mma_tiler_mn=self.mma_tiler_mn,
+            cluster_shape_mn=self.cluster_shape_mn,
+            accumulate_on_output=self.accumulate_on_output,
+            expert_cnt=self.expert_cnt,
+            weight_mode=self.weight_mode,
+            input_order=self.input_order,
+            sf_fp8_dtype_override=self.sf_fp8_dtype_override,
+        )
+
+        hardware_info = cutlass.utils.HardwareInfo()
+        max_active_clusters = hardware_info.get_max_active_clusters(self.cluster_shape_mn[0] * self.cluster_shape_mn[1])
+        self._workspace = torch.empty(max(kernel.get_workspace_bytes(), 1), dtype=torch.uint8, device=self.a_desc.device)
+        fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
+
+        if self.weight_mode == MoEWeightMode.DENSE:
+            self._compile_dense(kernel, max_active_clusters, fake_stream)
+        else:
+            self._compile_discrete(kernel, max_active_clusters, fake_stream)
+
+        if self.sample_a_tensor is not None:
+            del self.sample_a_tensor
+        if self.sample_b_tensor is not None:
+            del self.sample_b_tensor
+
+    def _make_operand_fakes(self):
+        """A/B/SFA/SFB/SFA2 fake tensors with the ragged token axis dynamic (one compile serves
+        every token distribution)."""
+        a_fake = (
+            from_dlpack(self.sample_a_tensor, assumed_align=16, enable_tvm_ffi=True).mark_compact_shape_dynamic(
+                mode=1,
+                stride_order=self.sample_a_tensor.dim_order(),
+                divisibility=16,
+            )
+            if self.sample_a_tensor is not None
+            else self._make_fake_cute_compact_tensor(
+                dtype=self.a_desc.dtype,
+                shape=self.a_desc.shape,
+                stride_order=self.a_desc.stride_order,
+                assumed_align=16,
+                dynamic_mode=1,
+                divisibility=16,
+            )
+        )
+        b_fake = (
+            from_dlpack(self.sample_b_tensor, assumed_align=16, enable_tvm_ffi=True).mark_compact_shape_dynamic(
+                mode=0,
+                stride_order=self.sample_b_tensor.dim_order(),
+                divisibility=16,
+            )
+            if self.sample_b_tensor is not None
+            else self._make_fake_cute_compact_tensor(
+                dtype=self.b_desc.dtype,
+                shape=self.b_desc.shape,
+                stride_order=self.b_desc.stride_order,
+                assumed_align=16,
+                dynamic_mode=0,
+                divisibility=16,
+            )
+        )
+        sfa_fake = self._make_fake_cute_compact_tensor(
+            dtype=self.sfa_desc.dtype,
+            shape=self.sfa_desc.shape,
+            stride_order=self.sfa_desc.stride_order,
+            assumed_align=16,
+            dynamic_mode=1,
+            divisibility=4,
+        )
+        sfb_fake = self._make_fake_cute_compact_tensor(
+            dtype=self.sfb_desc.dtype,
+            shape=self.sfb_desc.shape,
+            stride_order=self.sfb_desc.stride_order,
+            assumed_align=16,
+            dynamic_mode=1,
+            divisibility=4,
+        )
+        # (hidden, tokens_sum / sgk), hidden-contiguous; the column count follows the token axis.
+        sfa2_fake = self._make_fake_cute_compact_tensor(
+            dtype=self.sfa2_desc.dtype,
+            shape=self.sfa2_desc.shape,
+            stride_order=self.sfa2_desc.stride_order,
+            assumed_align=16,
+            dynamic_mode=1,
+            divisibility=1,
+        )
+        return a_fake, b_fake, sfa_fake, sfb_fake, sfa2_fake
+
+    def _compile_dense(self, kernel, max_active_clusters, fake_stream) -> None:
+        a_fake, b_fake, sfa_fake, sfb_fake, sfa2_fake = self._make_operand_fakes()
+        wgrad_fake = self._make_fake_cute_tensor_from_desc(self.wgrad_desc, assumed_align=16)
+        offsets_fake = self._make_fake_cute_tensor_from_desc(self.offsets_desc, assumed_align=4)
+        workspace_fake = from_dlpack(self._workspace, assumed_align=128, enable_tvm_ffi=True)
+        gs_a_fake = self._make_fake_cute_tensor_from_desc(self.global_scale_a_desc, assumed_align=4)
+        gs_b_fake = self._make_fake_cute_tensor_from_desc(self.global_scale_b_desc, assumed_align=4)
+
+        compiled = cute.compile(
+            kernel,
+            a_fake,
+            b_fake,
+            sfa_fake,
+            sfb_fake,
+            sfa2_fake,
+            wgrad_fake,
+            offsets_fake,
+            workspace_fake,
+            max_active_clusters,
+            fake_stream,
+            gs_a_fake,
+            gs_b_fake,
+            None,
+            options="--enable-tvm-ffi",
+        )
+
+        cached_workspace = from_dlpack(self._workspace, assumed_align=128, enable_tvm_ffi=True)
+
+        def tensor_api(
+            a_tensor: torch.Tensor,
+            b_tensor: torch.Tensor,
+            sfa_tensor: torch.Tensor,
+            sfb_tensor: torch.Tensor,
+            sfa2_tensor: torch.Tensor,
+            wgrad_tensor: torch.Tensor,
+            offsets_tensor: torch.Tensor,
+            stream: cuda.CUstream,
+            global_scale_a: Optional[torch.Tensor],
+            global_scale_b: Optional[torch.Tensor],
+        ) -> None:
+            compiled(
+                a_tensor,
+                b_tensor,
+                sfa_tensor,
+                sfb_tensor,
+                sfa2_tensor,
+                wgrad_tensor,
+                offsets_tensor,
+                cached_workspace,
+                stream,
+                global_scale_a,
+                global_scale_b,
+                None,
+            )
+
+        self._compiled_kernel = tensor_api
+
+    def _compile_discrete(self, kernel, max_active_clusters, fake_stream) -> None:
+        import torch
+
+        a_fake, b_fake, sfa_fake, sfb_fake, sfa2_fake = self._make_operand_fakes()
+        offsets_fake = self._make_fake_cute_tensor_from_desc(self.offsets_desc, assumed_align=4)
+        workspace_fake = from_dlpack(self._workspace, assumed_align=128, enable_tvm_ffi=True)
+        gs_a_fake = self._make_fake_cute_tensor_from_desc(self.global_scale_a_desc, assumed_align=4)
+        gs_b_fake = self._make_fake_cute_tensor_from_desc(self.global_scale_b_desc, assumed_align=4)
+        wgrad_ptrs_placeholder = torch.empty((self.expert_cnt,), dtype=torch.int64, device=self.a_desc.device)
+        wgrad_ptrs_fake = from_dlpack(wgrad_ptrs_placeholder, assumed_align=8, enable_tvm_ffi=True).iterator
+        single_expert_fake = self._make_fake_cute_tensor(
+            dtype=self.single_expert_wgrad_desc.dtype,
+            shape=self.single_expert_wgrad_desc.shape,
+            stride=self.single_expert_wgrad_desc.stride,
+            assumed_align=16,
+        )
+
+        compiled = cute.compile(
+            kernel,
+            a_fake,
+            b_fake,
+            sfa_fake,
+            sfb_fake,
+            sfa2_fake,
+            wgrad_ptrs_fake,
+            offsets_fake,
+            workspace_fake,
+            max_active_clusters,
+            fake_stream,
+            gs_a_fake,
+            gs_b_fake,
+            single_expert_fake,
+            options="--enable-tvm-ffi",
+        )
+
+        cached_workspace = from_dlpack(self._workspace, assumed_align=128, enable_tvm_ffi=True)
+        single_expert_placeholder = torch.empty_strided(
+            self.single_expert_wgrad_desc.shape,
+            self.single_expert_wgrad_desc.stride,
+            dtype=self.single_expert_wgrad_desc.dtype,
+            device=self.single_expert_wgrad_desc.device,
+        )
+        cached_single_expert = from_dlpack(single_expert_placeholder, assumed_align=16, enable_tvm_ffi=True)
+
+        def tensor_api(
+            a_tensor: torch.Tensor,
+            b_tensor: torch.Tensor,
+            sfa_tensor: torch.Tensor,
+            sfb_tensor: torch.Tensor,
+            sfa2_tensor: torch.Tensor,
+            wgrad_ptrs: torch.Tensor,
+            offsets_tensor: torch.Tensor,
+            stream: cuda.CUstream,
+            global_scale_a: Optional[torch.Tensor],
+            global_scale_b: Optional[torch.Tensor],
+        ) -> None:
+            compiled(
+                a_tensor,
+                b_tensor,
+                sfa_tensor,
+                sfb_tensor,
+                sfa2_tensor,
+                wgrad_ptrs.data_ptr(),
+                offsets_tensor,
+                cached_workspace,
+                stream,
+                global_scale_a,
+                global_scale_b,
+                cached_single_expert,
+            )
+
+        self._compiled_kernel = tensor_api
+
+    def execute(
+        self,
+        a_tensor: torch.Tensor,
+        b_tensor: torch.Tensor,
+        sfa_tensor: torch.Tensor,
+        sfb_tensor: torch.Tensor,
+        sfa2_tensor: torch.Tensor,
+        offsets_tensor: torch.Tensor,
+        wgrad_tensor: Optional[torch.Tensor] = None,
+        wgrad_ptrs: Optional[torch.Tensor] = None,
+        global_scale_a: Optional[torch.Tensor] = None,
+        global_scale_b: Optional[torch.Tensor] = None,
+        current_stream: Optional[cuda.CUstream] = None,
+    ) -> None:
+        import torch
+
+        current_stream = self._get_default_stream(current_stream)
+        self._runtime_error_if(self._compiled_kernel is None, "Kernel not compiled; call compile() first")
+
+        if self.weight_mode == MoEWeightMode.DENSE:
+            self._value_error_if(wgrad_tensor is None, "wgrad_tensor is required in dense mode")
+            self._compiled_kernel(
+                a_tensor,
+                b_tensor,
+                sfa_tensor,
+                sfb_tensor,
+                sfa2_tensor,
+                wgrad_tensor,
+                offsets_tensor,
+                current_stream,
+                global_scale_a,
+                global_scale_b,
+            )
+            return
+
+        if wgrad_ptrs is None:
+            self._value_error_if(wgrad_tensor is None, "Provide wgrad_tensor or wgrad_ptrs in discrete mode")
+            self._value_error_if(wgrad_tensor.ndim != 3, f"wgrad_tensor must be rank-3, got {tuple(wgrad_tensor.shape)}")
+            self._value_error_if(not wgrad_tensor.is_cuda, f"wgrad_tensor must be a CUDA tensor, got {wgrad_tensor.device}")
+            if wgrad_tensor.shape[0] == 0:
+                wgrad_ptrs = torch.empty((0,), dtype=torch.int64, device=wgrad_tensor.device)
+            else:
+                expert_stride_bytes = wgrad_tensor.stride(0) * wgrad_tensor.element_size()
+                ptrs = [wgrad_tensor.data_ptr() + i * expert_stride_bytes for i in range(wgrad_tensor.shape[0])]
+                wgrad_ptrs = torch.tensor(ptrs, dtype=torch.int64, device=wgrad_tensor.device)
+        _validate_pointer_tensor(wgrad_ptrs, "wgrad_ptrs", self.expert_cnt)
+        self._compiled_kernel(
+            a_tensor,
+            b_tensor,
+            sfa_tensor,
+            sfb_tensor,
+            sfa2_tensor,
+            wgrad_ptrs,
+            offsets_tensor,
+            current_stream,
+            global_scale_a,
+            global_scale_b,
+        )
+
+
+_cache_of_GroupedGemmWgradSubchannelScaledSm100Objects = {}
+
+
+def grouped_gemm_wgrad_subchannel_scaled_wrapper_sm100(
+    a_tensor: torch.Tensor,
+    b_tensor: torch.Tensor,
+    sfa_tensor: torch.Tensor,
+    sfb_tensor: torch.Tensor,
+    sfa2_tensor: torch.Tensor,
+    offsets_tensor: torch.Tensor,
+    sgk: int,
+    output_mode: str = "dense",
+    wgrad_tensor: Optional[torch.Tensor] = None,
+    wgrad_ptrs: Optional[torch.Tensor] = None,
+    global_scale_a: Optional[torch.Tensor] = None,
+    global_scale_b: Optional[torch.Tensor] = None,
+    acc_dtype: Optional[torch.dtype] = None,
+    wgrad_dtype: Optional[torch.dtype] = None,
+    mma_tiler_mn: Tuple[int, int] = DEFAULT_CTA_SHAPE,
+    cluster_shape_mn: Optional[Tuple[int, int]] = None,
+    sf_fp8_dtype_override: Optional[Literal["e5m3"]] = None,
+    accumulate_on_output: bool = False,
+    current_stream: Optional[cuda.CUstream] = None,
+) -> TupleDict:
+    """Compile (cached) and execute the subchannel-scaled grouped GEMM wgrad; returns ``wgrad_tensor``.
+
+    The compiled kernel is cached on the operand signatures with the token axis dynamic, so
+    successive calls with different per-expert token counts reuse one compile. When
+    ``wgrad_tensor``/``wgrad_ptrs`` are omitted the wrapper allocates the ``(expert_cnt, hidden,
+    intermediate)`` bf16 output (zero-initialized when ``accumulate_on_output``)."""
+    framework = detect_framework(a_tensor)
+    if framework != "torch":
+        raise ValueError(f"Unsupported tensor framework '{framework}' for grouped_gemm_wgrad_subchannel_scaled_wrapper_sm100; pass torch tensors")
+    import torch
+
+    acc_dtype = _convert_to_cutlass_data_type(acc_dtype) if acc_dtype is not None else cutlass.Float32
+    wgrad_dtype = _convert_to_cutlass_data_type(wgrad_dtype) if wgrad_dtype is not None else cutlass.BFloat16
+    if output_mode not in ("dense", "discrete"):
+        raise ValueError(f'output_mode must be "dense" or "discrete", got {output_mode}')
+    if len(get_shape(a_tensor)) != 2 or len(get_shape(b_tensor)) != 2:
+        raise ValueError("a_tensor and b_tensor must both be rank-2")
+    hidden, tokens_sum = get_shape(a_tensor)
+    tokens_b, intermediate = get_shape(b_tensor)
+    if tokens_sum != tokens_b:
+        raise ValueError(f"a_tensor and b_tensor token dimensions must match, got {tokens_sum} and {tokens_b}")
+    if len(get_shape(offsets_tensor)) != 1:
+        raise ValueError(f"offsets_tensor must be rank-1, got shape {get_shape(offsets_tensor)}")
+    expert_cnt = get_shape(offsets_tensor)[0]
+    if output_mode == "dense" and wgrad_ptrs is not None:
+        raise ValueError("dense output_mode forbids wgrad_ptrs")
+    if wgrad_ptrs is not None:
+        _validate_pointer_tensor(wgrad_ptrs, "wgrad_ptrs", expert_cnt)
+    if wgrad_tensor is None and wgrad_ptrs is None:
+        allocator = torch.zeros if accumulate_on_output else torch.empty
+        with _torch_stream_context(current_stream, a_tensor.device):
+            wgrad_tensor = allocator((expert_cnt, hidden, intermediate), dtype=framework_dtype(wgrad_dtype, "torch"), device=a_tensor.device)
+
+    cache_key = (
+        get_device_type(),
+        output_mode,
+        _wgrad_tensor_signature(a_tensor, dynamic_dims=(1,), exact_stride=False),
+        _wgrad_tensor_signature(b_tensor, dynamic_dims=(0,), exact_stride=False),
+        _wgrad_tensor_signature(sfa_tensor, dynamic_dims=(1,), exact_stride=False),
+        _wgrad_tensor_signature(sfb_tensor, dynamic_dims=(1,), exact_stride=False),
+        _wgrad_tensor_signature(sfa2_tensor, dynamic_dims=(1,), exact_stride=False),
+        _wgrad_tensor_signature(offsets_tensor, exact_stride=True),
+        _wgrad_tensor_signature(wgrad_tensor, exact_stride=True),
+        _wgrad_tensor_signature(wgrad_ptrs, exact_stride=True),
+        _wgrad_tensor_signature(global_scale_a, exact_stride=True),
+        _wgrad_tensor_signature(global_scale_b, exact_stride=True),
+        int(sgk),
+        acc_dtype,
+        wgrad_dtype,
+        tuple(mma_tiler_mn),
+        tuple(cluster_shape_mn) if cluster_shape_mn is not None else None,
+        sf_fp8_dtype_override,
+        accumulate_on_output,
+        int(os.getenv("CUDNNFE_CLUSTER_OVERLAP_MARGIN", "0")),
+    )
+    op = _cache_of_GroupedGemmWgradSubchannelScaledSm100Objects.get(cache_key)
+    if op is None:
+        common = dict(
+            sample_a=a_tensor,
+            sample_b=b_tensor,
+            sample_sfa=sfa_tensor,
+            sample_sfb=sfb_tensor,
+            sample_sfa2=sfa2_tensor,
+            sample_offsets=offsets_tensor,
+            sgk=sgk,
+            sample_global_scale_a=global_scale_a,
+            sample_global_scale_b=global_scale_b,
+            acc_dtype=acc_dtype,
+            mma_tiler_mn=mma_tiler_mn,
+            cluster_shape_mn=cluster_shape_mn,
+            sf_fp8_dtype_override=sf_fp8_dtype_override,
+            accumulate_on_output=accumulate_on_output,
+        )
+        if output_mode == "dense":
+            common["sample_wgrad"] = wgrad_tensor
+        else:
+            sample_wgrad_expert = (
+                wgrad_tensor[0]
+                if wgrad_tensor is not None
+                else torch.empty((hidden, intermediate), dtype=framework_dtype(wgrad_dtype, "torch"), device=a_tensor.device)
+            )
+            common.update(
+                sample_wgrad_expert=sample_wgrad_expert,
+                num_experts=expert_cnt,
+                wgrad_shape=(hidden, intermediate),
+                wgrad_dtype=wgrad_dtype,
+            )
+        op = GroupedGemmWgradSubchannelScaledSm100(**common)
+        if not op.check_support():
+            raise RuntimeError("Unsupported configuration")
+        op.compile()
+        _cache_of_GroupedGemmWgradSubchannelScaledSm100Objects[cache_key] = op
+    op.execute(
+        a_tensor=a_tensor,
+        b_tensor=b_tensor,
+        sfa_tensor=sfa_tensor,
+        sfb_tensor=sfb_tensor,
+        sfa2_tensor=sfa2_tensor,
+        offsets_tensor=offsets_tensor,
+        wgrad_tensor=wgrad_tensor,
+        wgrad_ptrs=wgrad_ptrs,
+        global_scale_a=global_scale_a,
+        global_scale_b=global_scale_b,
+        current_stream=current_stream,
+    )
+    return TupleDict(wgrad_tensor=wgrad_tensor)
+
+
+__all__ = ["GroupedGemmWgradSubchannelScaledSm100", "grouped_gemm_wgrad_subchannel_scaled_wrapper_sm100"]

--- a/python/cudnn/gemm/cutedsl/grouped/wgrad_subchannel_scaled/grouped_gemm_wgrad_subchannel_scaled.py
+++ b/python/cudnn/gemm/cutedsl/grouped/wgrad_subchannel_scaled/grouped_gemm_wgrad_subchannel_scaled.py
@@ -1,0 +1,2089 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+MoE Block-Scaled Grouped GEMM Kernel — Weight Gradient (2Dx2D) with a
+SECOND-LEVEL A scale (SFA2 only; wgrad has no SFB2).
+
+Computes:  A(hidden, tokens_sum) x B(tokens_sum, intermediate)
+        -> C(experts, hidden, intermediate)
+
+where C is the weight gradient.  K (tokens) varies per expert;
+M (hidden) and N (intermediate) are fixed across all experts.
+
+Copy-and-extend of kernels/wgrad_baseline/kernel.py with the dgrad_quant
+kernel's accumulator-splitting machinery grafted in: K is partitioned into
+sgk-token scale blocks (k_tile_same_scale_factor = sgk / mma_tiler_k MMA
+K-tiles each); the MMA warp produces one CLEAN TMEM partial accumulator per
+block; a dedicated 4-warp accumulator-update warpgroup rescales each partial
+by its per-M-row f32 SFA2 (sgm = 1: one scale per hidden row per sgk-token
+group, the dgrad_dglu_rht_2 producer's rht_quant_sf2 grid) and sums in f32
+registers; the running tile lands in an SMEM sFinalAcc buffer that the
+epilogue warpgroup reads instead of TMEM. A/SFA/B/SFB TMA loads, the
+per-expert tensormap helper kernel, and the CLC scheduler are byte-identical
+to wgrad_baseline; SFA2 rides a cp.async (LDGSTS) pipeline on a dedicated
+scale warp — 12 warps = 3 whole 128-thread warpgroups (setmaxregister-safe).
+
+Ragged K x sgk: the wrapper enforces token_counts[e] % sgk == 0 (the RHT
+producer's own gate), so every expert's k_tile_cnt divides exactly into
+whole scale blocks and an expert's SFA2 columns are a domain_offset by
+token_offset // sgk on the global (hidden, tokens_sum/sgk) grid.
+
+Supports (unchanged from wgrad_baseline):
+    - CLC-based dynamic persistent tile scheduling
+    - Dense (contiguous 3-D C) / Discrete (per-expert pointer array C) output
+    - accumulate_on_output (TMA reduce for atomic accumulation)
+    - NVFP4 global_scale support (epilogue alpha)
+    - k_tile_cnt == 0 handling (zero output for empty experts — the
+      acc-update warpgroup zero-fills and still produces the epi stage)
+
+Scheduler: moe_persistent_scheduler.py (CLC mode, scenario="2Dx2D")
+Extension: moe_sched_extension.WgradScaledGemmSchedExtension (sgk-aware "sfa2" branch)
+Source provenance: bs_ggemm_harness kernels/wgrad/kernel.py
+"""
+
+import re
+from importlib.metadata import PackageNotFoundError, version
+from typing import Literal, Type, Tuple, Optional
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import cpasync, tcgen05
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+from ..moe_persistent_scheduler import (
+    MoEPersistentTileScheduler,
+    MoESchedulerParams,
+    MoEWorkTileInfo,
+)
+from ..moe_utils import (
+    MoEWeightMode,
+    WGradInputOrder,
+    WgradSfTensormapConstructor,
+)
+from ..moe_sched_extension import (
+    WgradScaledGemmSchedExtension,
+)
+from ..moe_kernel_helpers import (
+    compute_stages_wgrad_2nd_level,
+    epilog_gmem_copy_and_partition,
+)
+
+# Same launch-config space as wgrad_baseline; 2-CTA instructions pair with
+# the 256-M tilers. N=256 tilers run with 1 TMEM acc stage and 1 AB stage
+# (SMEM: full-tile f32 sFinalAcc) — correct but unpipelined, like
+# dgrad_quant's (256, 256) config.
+VALID_CTA_SHAPES = ((128, 128), (256, 128))
+VALID_CLUSTER_SHAPES = (
+    (1, 1),
+    (1, 2),
+    (2, 1),
+    (2, 2),
+    (1, 4),
+    (4, 1),
+    (2, 4),
+    (4, 2),
+    (4, 4),
+)
+DEFAULT_CTA_SHAPE = (256, 128)
+DEFAULT_CLUSTER_SHAPE = (2, 1)
+
+
+def _using_internal_cutlass_dsl() -> bool:
+    try:
+        version("nvidia-cutlass-dsl-internal")
+    except PackageNotFoundError:
+        return False
+    return True
+
+
+def _cutlass_dsl_needs_fp4_layout_workaround() -> bool:
+    # Public cutlass-dsl wheels before 4.8 interpret packed sub-byte
+    # from_dlpack layouts in byte units, so the FP4 A/B layouts must be
+    # recast to element units.
+    if _using_internal_cutlass_dsl():
+        return False
+    match = re.match(r"(\d+)\.(\d+)", getattr(cutlass, "__version__", "") or "")
+    if match is None:
+        return False
+    return (int(match.group(1)), int(match.group(2))) < (4, 8)
+
+
+_NEEDS_FP4_LAYOUT_WORKAROUND = _cutlass_dsl_needs_fp4_layout_workaround()
+
+
+class BlockScaledSubChannelMoEGroupedGemmWgradKernel:
+    """Block-scaled grouped GEMM kernel for MoE weight gradient (2Dx2D) with
+    a K-grouped second-level A scale (SFA2 only).
+
+    :param sf_vec_size: First-level scale-factor vector size (16 or 32).
+    :param sgk: Second-level scale group size along K (tokens); one f32 SFA2
+        per (1 M row x sgk tokens). Must be a multiple of the MMA K tile
+        (256 for NVFP4) — sgk in {256, 512}.
+    :param acc_dtype: Accumulator data type (Float32).
+    :param use_2cta_instrs: Use 2-CTA MMA instructions.
+    :param mma_tiler_mn: MMA tile shape (M, N).
+    :param cluster_shape_mn: Cluster shape (M, N).
+    :param accumulate_on_output: Use TMA reduce for atomic accumulation.
+    :param expert_cnt: Number of experts.
+    :param weight_mode: ``MoEWeightMode.DENSE`` or ``MoEWeightMode.DISCRETE`` for output.
+    :param input_order: ``WGradInputOrder.Tensor2D`` (default) or
+        ``WGradInputOrder.TensorRagged`` — see wgrad_baseline.
+    """
+
+    FIX_PAD_SIZE = 256  # every expert's token count (K_e) must be 256-aligned
+    # sgm is fixed: SFA2 is per-M-row (the rht_quant_sf2 grid)
+    SGM = 1
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        sgk: int,
+        acc_dtype: Type[cutlass.Numeric] = cutlass.Float32,
+        use_2cta_instrs: bool = False,
+        mma_tiler_mn: Tuple[int, int] = (128, 128),
+        cluster_shape_mn: Tuple[int, int] = (1, 1),
+        accumulate_on_output: bool = False,
+        expert_cnt: int = 1,
+        weight_mode: MoEWeightMode = MoEWeightMode.DENSE,
+        input_order: WGradInputOrder = WGradInputOrder.Tensor2D,
+        sf_fp8_dtype_override: Optional[Literal["e5m3"]] = None,
+    ):
+        self.sf_vec_size = sf_vec_size
+        self.sf_dtype_override: Optional[Type[cutlass.Numeric]] = cutlass.FloatNV8E5M3FNU if sf_fp8_dtype_override == "e5m3" else None
+        self.sgm = self.SGM
+        self.sgk = sgk
+        self.expert_cnt = expert_cnt
+        self.acc_dtype = acc_dtype
+        self.use_2cta_instrs = use_2cta_instrs
+        self.cluster_shape_mn = cluster_shape_mn
+        self.mma_tiler = (*mma_tiler_mn, 1)
+        self.accumulate_on_output = accumulate_on_output
+        self.weight_mode = weight_mode
+        self.input_order = input_order
+
+        self.cta_group = tcgen05.CtaGroup.TWO if use_2cta_instrs else tcgen05.CtaGroup.ONE
+
+        # Warp specialization (the dgrad_quant layout): 12 warps = 3 whole
+        # 128-thread warpgroups — a partial warpgroup is illegal for
+        # setmaxregister, so every role must pack into whole groups.
+        self.occupancy = 1
+        self.accumulator_update_warp_id = (0, 1, 2, 3)
+        self.epilog_warp_id = (4, 5, 6, 7)
+        self.mma_warp_id = 8
+        self.tma_warp_id = 9
+        self.sched_warp_id = 10
+        self.scale_warp_id = 11
+        self.threads_per_warp = 32
+        all_warps = [
+            *self.accumulator_update_warp_id,
+            *self.epilog_warp_id,
+            self.mma_warp_id,
+            self.tma_warp_id,
+            self.sched_warp_id,
+            self.scale_warp_id,
+        ]
+        # Per-role register budgets applied via setmaxregister (uniform per
+        # warpgroup: warps 0-3 acc-update, 4-7 epilogue, 8-11 uniform)
+        self.num_regs_uniform_warps = 24
+        self.num_regs_epilogue_warps = 168
+        self.num_regs_acc_update_warps = 176
+        self.threads_per_cta = self.threads_per_warp * len(all_warps)
+
+        self.epilog_sync_bar_id = 1
+        self.tmem_alloc_sync_bar_id = 2
+        self.tmem_dealloc_sync_bar_id = 3
+
+        self.architecture = "sm_100"
+        self.smem_capacity = utils.get_smem_capacity_in_bytes(self.architecture)
+        self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(self.architecture)
+
+    # ------------------------------------------------------------------
+    # Workspace
+    # ------------------------------------------------------------------
+
+    def get_workspace_bytes(self) -> int:
+        return WgradSfTensormapConstructor.get_workspace_size(self.input_order, self.weight_mode, self.expert_cnt)
+
+    # ------------------------------------------------------------------
+    # _setup_attributes
+    # ------------------------------------------------------------------
+
+    def _setup_attributes(self) -> None:
+        self.mma_inst_shape_mn = (self.mma_tiler[0], self.mma_tiler[1])
+        self.mma_inst_shape_mn_sfb = (
+            self.mma_inst_shape_mn[0] // (2 if self.use_2cta_instrs else 1),
+            cute.round_up(self.mma_inst_shape_mn[1], 128),
+        )
+
+        tiled_mma = self._create_tiled_mma()
+        tiled_mma_sfb = self._create_tiled_mma_sfb()
+
+        mma_inst_shape_k = cute.size(tiled_mma.shape_mnk, mode=[2])
+        mma_inst_tile_k = 4
+        mma_tiler_k = mma_inst_shape_k * mma_inst_tile_k
+        self.mma_tiler = (
+            self.mma_inst_shape_mn[0],
+            self.mma_inst_shape_mn[1],
+            mma_tiler_k,
+        )
+        self.mma_tiler_sfb = (
+            self.mma_inst_shape_mn_sfb[0],
+            self.mma_inst_shape_mn_sfb[1],
+            mma_tiler_k,
+        )
+        self.cta_tile_shape_mnk = (
+            self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler[1],
+            self.mma_tiler[2],
+        )
+        self.cta_tile_shape_mnk_sfb = (
+            self.mma_tiler_sfb[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler_sfb[1],
+            self.mma_tiler_sfb[2],
+        )
+
+        # Every expert's k_tile_cnt must divide into whole scale blocks
+        # (wrapper gate token_counts % sgk == 0 makes this per-expert exact).
+        assert self.sgk % self.mma_tiler[2] == 0, f"sgk ({self.sgk}) must be a multiple of the MMA K tile " f"({self.mma_tiler[2]})"
+
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma.thr_id.shape,),
+        )
+        self.cluster_layout_sfb_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma_sfb.thr_id.shape,),
+        )
+
+        self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+
+        self.epi_tile = sm100_utils.compute_epilogue_tile_shape(
+            self.cta_tile_shape_mnk,
+            self.use_2cta_instrs,
+            self.c_layout,
+            self.c_dtype,
+        )
+        self.epi_tile_n = cute.size(self.epi_tile[1])
+        # The acc-update warpgroup's SFA2-as-C partition fixes the epi M
+        # iterator at 0 (the dgrad_quant scheme) — needs one epi tile per M.
+        assert cute.size(self.epi_tile[0]) == self.cta_tile_shape_mnk[0], (
+            f"epi tile M ({cute.size(self.epi_tile[0])}) must equal the CTA " f"tile M ({self.cta_tile_shape_mnk[0]})"
+        )
+
+        (
+            self.num_acc_stage,
+            self.num_ab_stage,
+            self.num_c_stage,
+            self.num_epi_stage,
+        ) = compute_stages_wgrad_2nd_level(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.b_dtype,
+            self.epi_tile,
+            self.c_dtype,
+            self.c_layout,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.smem_capacity,
+            self.occupancy,
+            self.acc_dtype,
+            self.sf2_dtype,
+            self.sgk,
+        )
+        self.num_sched_stages = 2
+        # Second-level scale pipeline runs in lockstep with the AB pipeline
+        self.num_scale_stage = self.num_ab_stage
+
+        self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.num_ab_stage,
+        )
+        self.b_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            self.mma_tiler,
+            self.b_dtype,
+            self.num_ab_stage,
+        )
+        self.sfa_smem_layout_staged = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        self.sfb_smem_layout_staged = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        self.c_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.c_dtype,
+            self.c_layout,
+            self.epi_tile,
+            self.num_c_stage,
+        )
+
+        # Per-CTA-tile scale block sizes, clamped to the tile (dgrad_quant's
+        # scheme; here sgm = 1 so the M axis is per-row and only K clamps).
+        size_m = self.sgm if self.sgm < self.cta_tile_shape_mnk[0] else self.cta_tile_shape_mnk[0]
+        size_k = self.sgk if self.sgk < self.cta_tile_shape_mnk[2] else self.cta_tile_shape_mnk[2]
+        self.scale_size_m = size_m
+        self.scale_size_k = size_k
+        self.scale_m_per_tile = self.cta_tile_shape_mnk[0] // size_m
+        self.scale_k_per_tile = self.cta_tile_shape_mnk[2] // size_k
+
+        # Staged SMEM layout for the second-level (f32) A scale; extent-0
+        # inner modes broadcast one stored f32 across its whole block.
+        self.sfa2_smem_layout_staged = cute.make_layout(
+            (
+                (size_m, self.scale_m_per_tile),
+                (size_k, self.scale_k_per_tile),
+                self.num_scale_stage,
+            ),
+            stride=(
+                (0, self.scale_k_per_tile),
+                (0, 1),
+                self.scale_k_per_tile * self.scale_m_per_tile,
+            ),
+        )
+
+        # Full-CTA-tile SMEM buffer for the final accumulator; the "stage"
+        # mode of the epi layout doubles as the subtile-slot index
+        # (final_acc_subtile_cnt slots per epi stage).
+        self.final_acc_subtile_cnt = (self.cta_tile_shape_mnk[0] // cute.size(self.epi_tile[0])) * (self.cta_tile_shape_mnk[1] // cute.size(self.epi_tile[1]))
+        self.final_acc_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.acc_dtype,
+            self.c_layout,
+            self.epi_tile,
+            self.final_acc_subtile_cnt * self.num_epi_stage,
+        )
+
+        # TMEM column budget: partial accumulators followed by SFA/SFB scale
+        # columns (no overlapping-accum trick: at N=256 num_acc_stage is 1, so
+        # 256 acc + 48 SF <= 512; at N=128, 384 + 32 <= 512).
+        sf_atom_mn = 32
+        mma_inst_tile_k = 4
+        self.num_sfa_tmem_cols = (self.cta_tile_shape_mnk[0] // sf_atom_mn) * mma_inst_tile_k
+        self.num_sfb_tmem_cols = (self.cta_tile_shape_mnk_sfb[1] // sf_atom_mn) * mma_inst_tile_k
+        self.num_sf_tmem_cols = self.num_sfa_tmem_cols + self.num_sfb_tmem_cols
+        self.num_accumulator_tmem_cols = self.cta_tile_shape_mnk[1] * self.num_acc_stage
+        assert self.num_accumulator_tmem_cols + self.num_sf_tmem_cols <= self.num_tmem_alloc_cols, (
+            f"TMEM overflow: {self.num_accumulator_tmem_cols} acc + " f"{self.num_sf_tmem_cols} SF columns > {self.num_tmem_alloc_cols}"
+        )
+
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        sfa_smem_layout = cute.slice_(self.sfa_smem_layout_staged, (None, None, None, 0))
+        sfb_smem_layout = cute.slice_(self.sfb_smem_layout_staged, (None, None, None, 0))
+        a_copy_size = cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        b_copy_size = cute.size_in_bytes(self.b_dtype, b_smem_layout)
+        sfa_copy_size = cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+        sfb_copy_size = cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+        self.num_tma_load_bytes = (a_copy_size + b_copy_size + sfa_copy_size + sfb_copy_size) * atom_thr_size
+
+    # ------------------------------------------------------------------
+    # MMA helpers
+    # ------------------------------------------------------------------
+
+    def _create_tiled_mma(self):
+        return sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            self.mma_inst_shape_mn,
+        )
+
+    def _create_tiled_mma_sfb(self):
+        return sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            tcgen05.CtaGroup.ONE,
+            self.mma_inst_shape_mn_sfb,
+        )
+
+    def mainloop_s2t_copy_and_partition(self, sSF, tSF):
+        tCsSF_compact = cute.filter_zeros(sSF)
+        tCtSF_compact = cute.filter_zeros(tSF)
+        copy_atom_s2t = cute.make_copy_atom(
+            tcgen05.Cp4x32x128bOp(self.cta_group),
+            self.sf_dtype,
+        )
+        tiled_copy_s2t = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSF_compact)
+        thr_copy_s2t = tiled_copy_s2t.get_slice(0)
+        tCsSF_compact_s2t_ = thr_copy_s2t.partition_S(tCsSF_compact)
+        tCsSF_compact_s2t = tcgen05.get_s2t_smem_desc_tensor(tiled_copy_s2t, tCsSF_compact_s2t_)
+        tCtSF_compact_s2t = thr_copy_s2t.partition_D(tCtSF_compact)
+        return tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t
+
+    # ------------------------------------------------------------------
+    # Acc-update / epilogue partition helpers (ported from dgrad_quant)
+    # ------------------------------------------------------------------
+
+    def acc_update_tmem_copy_and_partition(
+        self,
+        tidx,
+        tCtAcc_base,
+        gC_mnl,
+        sSFA2,
+        sFinalAcc,
+        epi_tile,
+    ):
+        """T2R (partial accumulator TMEM->reg), R2S (final acc reg->SMEM) and
+        the SFA2-as-C SMEM partition for the accumulator-update warpgroup.
+        One subtile's partial (tTR_rAcc) is live at a time; tTR_rAcc_final
+        spans the full CTA tile grouped by epi subtile."""
+        if cutlass.const_expr(self.mma_tiler[0] == 64):
+            tmem_load_atom = cute.make_copy_atom(
+                tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(8)),
+                self.acc_dtype,
+            )
+        else:
+            tmem_load_atom = cute.make_copy_atom(
+                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)),
+                self.acc_dtype,
+            )
+
+        tAcc_epi = cute.flat_divide(tCtAcc_base[((None, None), 0, 0, None)], epi_tile)
+        tiled_copy_t2r = tcgen05.make_tmem_copy(tmem_load_atom, tAcc_epi[(None, None, 0, 0, 0)])
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+
+        # R2S store of the final accumulator: reuse the T2R copy's TV layout
+        # with a universal copy atom (swizzle-safe for f32)
+        copy_atom_r2s_acc = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.acc_dtype)
+        tiled_copy_r2s_acc = cute.make_tiled_copy_D(copy_atom_r2s_acc, tiled_copy_t2r)
+        thr_copy_r2s_acc = tiled_copy_r2s_acc.get_slice(tidx)
+        # (R2S, R2S_M, R2S_N, SUBTILE * STAGE)
+        tRS_sFinalAcc = thr_copy_r2s_acc.partition_D(sFinalAcc)
+
+        tTR_tAcc_base = thr_copy_t2r.partition_S(tAcc_epi)
+
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, loopM, loopN, loopL)
+        gC_mnl_epi = cute.flat_divide(gC_mnl[((None, None), 0, 0, None, None, None)], epi_tile)
+        sSFA2_epi = cute.flat_divide(sSFA2, epi_tile)
+
+        tTR_gC = thr_copy_t2r.partition_D(gC_mnl_epi)
+        tTR_sSFA2 = thr_copy_t2r.partition_D(sSFA2_epi)
+
+        # One k_tile's partial accumulator: (T2R, T2R_M, T2R_N)
+        tTR_rAcc = cute.make_rmem_tensor(tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].shape, self.acc_dtype)
+        # Final accumulated result across all scale blocks:
+        # (T2R, T2R_M, T2R_N, (EPI_M, EPI_N))
+        tTR_rAcc_final_ = cute.make_rmem_tensor(tTR_gC[(None, None, None, None, None, 0, 0, 0)].shape, self.acc_dtype)
+        tTR_rAcc_final = cute.group_modes(tTR_rAcc_final_, 3, cute.rank(tTR_rAcc_final_))
+
+        return (
+            tiled_copy_t2r,
+            tiled_copy_r2s_acc,
+            tTR_tAcc_base,
+            tTR_rAcc,
+            tTR_rAcc_final,
+            tRS_sFinalAcc,
+            tTR_sSFA2,
+        )
+
+    def epilog_tmem_copy_and_partition(self, tidx, tAcc, gC_mnl, epi_tile, use_2cta_instrs):
+        # Shape/TV-layout carrier only — the epilogue never reads TMEM data;
+        # this defines the tiled T2R copy whose TV layout the r2s/s2r reuse.
+        copy_atom_t2r = sm100_utils.get_tmem_load_op(
+            self.cta_tile_shape_mnk,
+            self.c_layout,
+            self.c_dtype,
+            self.acc_dtype,
+            epi_tile,
+            use_2cta_instrs,
+        )
+        tAcc_epi = cute.flat_divide(tAcc[((None, None), 0, 0, None)], epi_tile)
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tAcc_epi[(None, None, 0, 0, 0)])
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+        tTR_tAcc = thr_copy_t2r.partition_S(tAcc_epi)
+        gC_mnl_epi = cute.flat_divide(gC_mnl[((None, None), 0, 0, None, None, None)], epi_tile)
+        tTR_gC = thr_copy_t2r.partition_D(gC_mnl_epi)
+        tTR_rAcc = cute.make_rmem_tensor(tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].shape, self.acc_dtype)
+        return tiled_copy_t2r, tTR_tAcc, tTR_rAcc
+
+    def epilog_smem_copy_and_partition(self, tiled_copy_t2r, tTR_rC, tidx, sC):
+        copy_atom_r2s = sm100_utils.get_smem_store_op(self.c_layout, self.c_dtype, self.acc_dtype, tiled_copy_t2r)
+        tiled_copy_r2s = cute.make_tiled_copy_D(copy_atom_r2s, tiled_copy_t2r)
+        thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+        tRS_sC = thr_copy_r2s.partition_D(sC)
+        tRS_rC = tiled_copy_r2s.retile(tTR_rC)
+        return tiled_copy_r2s, tRS_rC, tRS_sC
+
+    def epilog_smem_load_copy_and_partition(self, tiled_copy_t2r, tTR_rAcc, tidx, sFinalAcc):
+        # S2R load of the final accumulator: reuse the T2R copy's TV layout
+        # with a universal copy atom; tSR_rAcc is a register view of tTR_rAcc
+        copy_atom_s2r = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.acc_dtype)
+        tiled_copy_s2r = cute.make_tiled_copy_D(copy_atom_s2r, tiled_copy_t2r)
+        thr_copy_s2r = tiled_copy_s2r.get_slice(tidx)
+        # (S2R, S2R_M, S2R_N, SUBTILE * STAGE)
+        tSR_sFinalAcc = thr_copy_s2r.partition_D(sFinalAcc)
+        tSR_rAcc = tiled_copy_s2r.retile(tTR_rAcc)
+        return tiled_copy_s2r, tSR_rAcc, tSR_sFinalAcc
+
+    @cute.jit
+    def __call__(
+        self,
+        mat_a: cute.Tensor,  # (hidden, tokens_sum) — activation-grad^T
+        mat_b: cute.Tensor,  # (tokens_sum, intermediate) — activation
+        scale_a: cute.Tensor,  # SFA (assembled block-scaled layout)
+        scale_b: cute.Tensor,  # SFB (assembled block-scaled layout)
+        scale_a2: cute.Tensor,  # SFA2 (hidden, tokens_sum/sgk[, 1]) f32, hidden contiguous
+        out,  # Dense: cute.Tensor (experts, hidden, intermediate)
+        # Discrete: cute.Pointer to int64[]
+        offs,  # Union[cute.Tensor, cute.Pointer] (experts,) cumsum end offsets, int32
+        workspace: cute.Tensor,  # expert-wise TMA desc (discrete only)
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        global_scale_a: Optional[cute.Tensor] = None,
+        global_scale_b: Optional[cute.Tensor] = None,
+        # Discrete-only: template tensor for a single expert's output (M, N) or (M, N, 1)
+        out_single_expert: Optional[cute.Tensor] = None,
+    ) -> None:
+
+        # Public CUTLASS DSL < 4.8 needs the packed-FP4 from_dlpack layout
+        # workaround. Rubin, the internal DSL wheel, and public wheels >= 4.8
+        # consume the native 4-bit layout directly.
+        needs_fp4_layout_workaround = self.architecture != "sm_107" and _NEEDS_FP4_LAYOUT_WORKAROUND
+        if cutlass.const_expr(needs_fp4_layout_workaround and mat_a.iterator.dtype.width < 8):
+            mat_a = cute.make_tensor(
+                mat_a.iterator,
+                cute.recast_layout(mat_a.iterator.dtype.width, 8, mat_a.layout),
+            )
+        if cutlass.const_expr(needs_fp4_layout_workaround and mat_b.iterator.dtype.width < 8):
+            mat_b = cute.make_tensor(
+                mat_b.iterator,
+                cute.recast_layout(mat_b.iterator.dtype.width, 8, mat_b.layout),
+            )
+
+        # =================================================================
+        # Step 1: Transform to GEMM domain (2Dx2D)
+        # =================================================================
+        c1 = cutlass.Int32(1)
+        c0 = cutlass.Int32(0)
+
+        # mat_a: (hidden, tokens_sum) -> A: (M=hidden, K=tokens_sum, L=1)
+        hidden, tokens_sum = mat_a.shape
+        a_gemm = cute.make_tensor(
+            mat_a.iterator,
+            cute.make_layout(
+                (hidden, tokens_sum, c1),
+                stride=(mat_a.stride[0], mat_a.stride[1], c0),
+            ),
+        )
+        # mat_b: (tokens_sum, intermediate) -> B: (N=intermediate, K=tokens_sum, L=1)
+        tokens_sum_b, intermediate = mat_b.shape
+        b_gemm = cute.make_tensor(
+            mat_b.iterator,
+            cute.make_layout(
+                (intermediate, tokens_sum_b, c1),
+                stride=(mat_b.stride[1], mat_b.stride[0], c0),
+            ),
+        )
+
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DENSE):
+            # out: (experts, hidden, intermediate) -> C: (M=hidden, N=intermediate, L=experts)
+            experts, hidden_c, intermediate_c = out.shape
+            c_gemm = cute.make_tensor(
+                out.iterator,
+                cute.make_layout(
+                    (hidden_c, intermediate_c, experts),
+                    stride=(out.stride[1], out.stride[2], out.stride[0]),
+                ),
+            )
+            expert_cnt = experts
+        else:
+            # Discrete: out is a Pointer to int64[] of per-expert base addresses
+            expert_cnt = self.expert_cnt
+            # Normalize out_single_expert to rank-3 (M, N, 1) if rank-2
+            if cutlass.const_expr(cute.rank(out_single_expert.layout) == 2):
+                out_single_expert = cute.make_tensor(
+                    out_single_expert.iterator,
+                    cute.make_layout(
+                        (*out_single_expert.shape, c1),
+                        stride=(*out_single_expert.stride, c0),
+                    ),
+                )
+            c_gemm = out_single_expert
+
+        intermediate_dim = intermediate
+        hidden_dim = hidden
+
+        # SFA: (hidden_padded, tokens_sum_padded_sf)
+        hidden_padded = scale_a.shape[0]
+        tokens_sum_padded = scale_a.shape[1] * self.sf_vec_size
+        sfa_gemm = cute.make_tensor(
+            scale_a.iterator,
+            blockscaled_utils.tile_atom_to_shape_SF((hidden_padded, tokens_sum_padded, c1), self.sf_vec_size),
+        )
+        # SFB: (intermediate_padded, tokens_sum_padded_sf)
+        intermediate_padded = scale_b.shape[0]
+        sfb_gemm = cute.make_tensor(
+            scale_b.iterator,
+            blockscaled_utils.tile_atom_to_shape_SF((intermediate_padded, tokens_sum_padded, c1), self.sf_vec_size),
+        )
+
+        # Accept the producer's rank-2 (hidden, tokens_sum/sgk) SFA2 view directly.
+        if cutlass.const_expr(cute.rank(scale_a2.layout) == 2):
+            scale_a2 = cute.make_tensor(
+                scale_a2.iterator,
+                cute.make_layout((*scale_a2.shape, c1), stride=(*scale_a2.stride, c0)),
+            )
+
+        # SFA2: (hidden, tokens_sum/sgk, 1) f32 → hierarchical broadcast view
+        # ((sgm, hidden), (sgk, scale_cols), 1) with stride-0 inner modes so
+        # one f32 covers its whole (1 row x sgk tokens) block (the dgrad_quant
+        # sfa2 template with the group axis on K).
+        sfa2_gemm = cute.make_tensor(
+            scale_a2.iterator,
+            cute.make_layout(
+                (
+                    (self.sgm, scale_a2.shape[0]),
+                    (self.sgk, scale_a2.shape[1]),
+                    scale_a2.shape[2],
+                ),
+                stride=(
+                    (0, scale_a2.layout.stride[0]),
+                    (0, scale_a2.layout.stride[1]),
+                    scale_a2.layout.stride[2],
+                ),
+            ),
+        )
+
+        # =================================================================
+        # Step 2: Infer dtypes and major modes
+        # =================================================================
+        self.a_dtype = a_gemm.element_type
+        self.b_dtype = b_gemm.element_type
+        self.c_dtype = c_gemm.element_type
+        # Scale factors may arrive under a stand-in element type: FloatNV8E5M3FNU has
+        # no torch dtype and TVM-FFI cannot marshal it, so e5m3 scales are passed as
+        # Float8E4M3FN storage of the same width and reinterpreted here. This must
+        # happen before _setup_attributes(), which picks the MMA atom off sf_dtype.
+        if cutlass.const_expr(self.sf_dtype_override is not None):
+            self.sf_dtype = self.sf_dtype_override
+        else:
+            self.sf_dtype = sfa_gemm.element_type
+        self.sf2_dtype = scale_a2.element_type
+        self.a_major_mode = utils.LayoutEnum.from_tensor(a_gemm).mma_major_mode()
+        self.b_major_mode = utils.LayoutEnum.from_tensor(b_gemm).mma_major_mode()
+        self.c_layout = utils.LayoutEnum.from_tensor(c_gemm)
+
+        # =================================================================
+        # Step 3: Setup kernel attributes
+        # =================================================================
+        self._setup_attributes()
+        tiled_mma = self._create_tiled_mma()
+        tiled_mma_sfb = self._create_tiled_mma_sfb()
+
+        # =================================================================
+        # Step 4: Create TMA ops (atoms built after helper kernel)
+        # =================================================================
+        # TMA load A
+        a_op = sm100_utils.cluster_shape_to_tma_atom_A(self.cluster_shape_mn, tiled_mma.thr_id)
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+
+        # TMA load B
+        b_op = sm100_utils.cluster_shape_to_tma_atom_B(self.cluster_shape_mn, tiled_mma.thr_id)
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+
+        # TMA ops for SFA/SFB
+        sfa_op = sm100_utils.cluster_shape_to_tma_atom_A(self.cluster_shape_mn, tiled_mma.thr_id)
+        sfb_op = sm100_utils.cluster_shape_to_tma_atom_SFB(self.cluster_shape_mn, tiled_mma.thr_id)
+
+        # TMA store/reduce C
+        if cutlass.const_expr(self.accumulate_on_output):
+            c_tma_op = cpasync.CopyReduceBulkTensorTileS2GOp()
+        else:
+            c_tma_op = cpasync.CopyBulkTensorTileS2GOp()
+
+        # =================================================================
+        # Step 5: Scheduler params and grid
+        # =================================================================
+        sched_params = MoESchedulerParams(
+            scenario="2Dx2D",
+            expert_shape=(expert_cnt, intermediate_dim, hidden_dim),
+            cta_tile_shape_mnk=self.cta_tile_shape_mnk,
+            cluster_shape_mn=self.cluster_shape_mn,
+        )
+        grid = MoESchedulerParams.get_grid_shape(sched_params, max_active_clusters)
+
+        # =================================================================
+        # Step 6: Launch helper kernel (both Dense and Discrete)
+        # =================================================================
+        # Identical to wgrad_baseline — SFA2 has no tensormap slot (LDGSTS).
+        sfa_smem_layout = cute.slice_(self.sfa_smem_layout_staged, (None, None, None, 0))
+        sfb_smem_layout = cute.slice_(self.sfb_smem_layout_staged, (None, None, None, 0))
+        epi_smem_layout_helper = cute.select(self.c_smem_layout_staged, mode=[0, 1]) if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else None
+        if cutlass.const_expr(self.input_order == WGradInputOrder.TensorRagged):
+            a_smem_layout_helper = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+            b_smem_layout_helper = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+            a_gemm_helper = a_gemm
+            b_gemm_helper = b_gemm
+            a_op_helper = a_op
+            b_op_helper = b_op
+        else:
+            a_smem_layout_helper = None
+            b_smem_layout_helper = None
+            a_gemm_helper = None
+            b_gemm_helper = None
+            a_op_helper = None
+            b_op_helper = None
+
+        self.helper_kernel(
+            sfa_gemm,
+            sfb_gemm,
+            offs,
+            workspace.iterator,
+            sfa_op,
+            sfa_smem_layout,
+            sfb_op,
+            sfb_smem_layout,
+            tiled_mma,
+            tiled_mma_sfb,
+            self.cluster_layout_vmnk.shape,
+            self.cluster_layout_sfb_vmnk.shape,
+            out if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else None,
+            c_gemm if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else None,
+            c_tma_op if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else None,
+            epi_smem_layout_helper,
+            self.epi_tile if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else None,
+            a_gemm_helper,
+            b_gemm_helper,
+            a_op_helper,
+            b_op_helper,
+            a_smem_layout_helper,
+            b_smem_layout_helper,
+        ).launch(
+            grid=(expert_cnt, 1, 1),
+            block=(1, 1, 1),
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+        # Build A, B, SFA, SFB, C TMA atoms AFTER the helper kernel launch
+        # (see wgrad_baseline for the host-region contamination rationale).
+        tma_atom_a, tma_tensor_a = cute.nvgpu.make_tiled_tma_atom_A(
+            a_op,
+            a_gemm,
+            a_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+        tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op,
+            b_gemm,
+            b_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+        sfa_smem_layout = cute.slice_(self.sfa_smem_layout_staged, (None, None, None, 0))
+        tma_atom_sfa, tma_tensor_sfa = cute.nvgpu.make_tiled_tma_atom_A(
+            sfa_op,
+            sfa_gemm,
+            sfa_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=cutlass.Uint64,
+        )
+        sfb_smem_layout = cute.slice_(self.sfb_smem_layout_staged, (None, None, None, 0))
+        tma_atom_sfb, tma_tensor_sfb = cute.nvgpu.make_tiled_tma_atom_B(
+            sfb_op,
+            sfb_gemm,
+            sfb_smem_layout,
+            self.mma_tiler_sfb,
+            tiled_mma_sfb,
+            self.cluster_layout_sfb_vmnk.shape,
+            internal_type=cutlass.Uint64,
+        )
+        epi_smem_layout = cute.select(self.c_smem_layout_staged, mode=[0, 1])
+        tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+            c_tma_op,
+            c_gemm,
+            epi_smem_layout,
+            self.epi_tile,
+        )
+
+        # =================================================================
+        # Step 7: Launch main kernel
+        # =================================================================
+        self.kernel(
+            tiled_mma,
+            tiled_mma_sfb,
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_sfa,
+            tma_tensor_sfa,
+            tma_atom_sfb,
+            tma_tensor_sfb,
+            sfa2_gemm,
+            tma_atom_c,
+            tma_tensor_c,
+            a_gemm,
+            b_gemm,
+            c_gemm,
+            sfa_gemm,
+            sfb_gemm,
+            offs,
+            sched_params,
+            workspace.iterator,
+            self.cluster_layout_vmnk,
+            self.cluster_layout_sfb_vmnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.sfa2_smem_layout_staged,
+            self.c_smem_layout_staged,
+            self.final_acc_smem_layout_staged,
+            self.epi_tile,
+            global_scale_a,
+            global_scale_b,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            stream=stream,
+            min_blocks_per_mp=self.occupancy,
+        )
+
+    # ------------------------------------------------------------------
+    # helper_kernel (expert-wise TMA desc init via construct_and_write)
+    # ------------------------------------------------------------------
+
+    @cute.kernel
+    def helper_kernel(
+        self,
+        sfa_gemm: cute.Tensor,
+        sfb_gemm: cute.Tensor,
+        offs: cute.Tensor,
+        workspace_ptr,
+        sfa_tma_op: cutlass.Constexpr,
+        sfa_smem_layout,
+        sfb_tma_op: cutlass.Constexpr,
+        sfb_smem_layout,
+        tiled_mma: cute.TiledMma,
+        tiled_mma_sfb: cute.TiledMma,
+        cluster_layout_vmnk_shape: cutlass.Constexpr,
+        cluster_layout_sfb_vmnk_shape: cutlass.Constexpr,
+        c_ptrs=None,
+        c_single_expert=None,
+        c_tma_op: cutlass.Constexpr = None,
+        epi_smem_layout=None,
+        epi_tile=None,
+        a_tensor=None,
+        b_tensor=None,
+        a_tma_op: cutlass.Constexpr = None,
+        b_tma_op: cutlass.Constexpr = None,
+        a_smem_layout=None,
+        b_smem_layout=None,
+    ):
+        """Build per-expert TMA descriptors (identical to wgrad_baseline)."""
+        from ..moe_utils import (
+            WgradSfTensormapConstructor,
+        )
+
+        ctor = WgradSfTensormapConstructor(
+            sf_vec_size=self.sf_vec_size,
+            weight_mode=self.weight_mode,
+            sfa_tma_op=sfa_tma_op,
+            sfb_tma_op=sfb_tma_op,
+            sfa_smem_layout=sfa_smem_layout,
+            sfb_smem_layout=sfb_smem_layout,
+            tiled_mma=tiled_mma,
+            tiled_mma_sfb=tiled_mma_sfb,
+            mma_tiler=self.mma_tiler,
+            mma_tiler_sfb=self.mma_tiler_sfb,
+            cluster_layout_vmnk_shape=cluster_layout_vmnk_shape,
+            cluster_layout_sfb_vmnk_shape=cluster_layout_sfb_vmnk_shape,
+            sfa_tensor=sfa_gemm,
+            sfb_tensor=sfb_gemm,
+            offs=offs,
+            workspace_ptr=workspace_ptr,
+            c_tma_op=c_tma_op,
+            epi_smem_layout=epi_smem_layout,
+            epi_tile=epi_tile,
+            c_ptrs=c_ptrs,
+            c_single_expert=c_single_expert,
+            expert_cnt=self.expert_cnt,
+            input_order=self.input_order,
+            a_tma_op=a_tma_op,
+            b_tma_op=b_tma_op,
+            a_smem_layout=a_smem_layout,
+            b_smem_layout=b_smem_layout,
+            a_major_mode=self.a_major_mode,
+            b_major_mode=self.b_major_mode,
+            a_tensor=a_tensor,
+            b_tensor=b_tensor,
+        )
+        expert_idx = cute.arch.block_idx()[0]
+        ctor.construct_and_write(expert_idx)
+
+    # ------------------------------------------------------------------
+    # kernel (GPU device kernel)
+    # ------------------------------------------------------------------
+
+    helper_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tiled_mma_sfb: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        mSFA_mkl: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        mSFB_nkl: cute.Tensor,
+        sfa2_tensor: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        a_gemm: cute.Tensor,
+        b_gemm: cute.Tensor,
+        c_gemm: cute.Tensor,
+        sfa_gemm: cute.Tensor,
+        sfb_gemm: cute.Tensor,
+        offs: cute.Tensor,
+        sched_params: MoESchedulerParams,
+        workspace_ptr,
+        cluster_layout_vmnk: cute.Layout,
+        cluster_layout_sfb_vmnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        sfa2_smem_layout_staged: cute.Layout,
+        c_smem_layout_staged: cute.ComposedLayout,
+        final_acc_smem_layout_staged: cute.ComposedLayout,
+        epi_tile: cute.Tile,
+        global_scale_a: Optional[cute.Tensor],
+        global_scale_b: Optional[cute.Tensor],
+    ):
+        """GPU device kernel for MoE wgrad with second-level A scaling."""
+
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        lane_idx = cute.arch.lane_idx()
+        use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+
+        bidx, bidy, bidz = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
+        block_in_cluster_coord_sfb_vmnk = cluster_layout_sfb_vmnk.get_flat_coord(cta_rank_in_cluster)
+        tidx, _, _ = cute.arch.thread_idx()
+
+        # =================================================================
+        # SharedStorage
+        # =================================================================
+        SchedulerStorage = MoEPersistentTileScheduler.make_storage_struct(self.num_sched_stages, use_dynamic_sched=True)
+
+        @cute.struct
+        class SharedStorage:
+            ab_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage * 2]
+            acc_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage * 2]
+            scale_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_scale_stage * 2]
+            epi_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_epi_stage * 2]
+            scheduler: SchedulerStorage
+            tmem_dealloc_mbar_ptr: cutlass.Int64
+            tmem_holding_buf: cutlass.Int32
+
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        sched_storage = storage.scheduler
+
+        # =================================================================
+        # Pipelines
+        # =================================================================
+
+        ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_tma_producer = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        ab_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, num_tma_producer)
+        ab_producer, ab_consumer = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.ab_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_ab_stage,
+            producer_group=ab_pipeline_producer_group,
+            consumer_group=ab_pipeline_consumer_group,
+            tx_count=self.num_tma_load_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+
+        # Partial-accumulator pipeline: MMA warp (producer, one stage per
+        # scale block) -> acc-update warpgroup (consumer, elect_one release
+        # per warp: 4 arrivals, x2 across the 2-CTA pair).
+        acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_acc_consumer_threads = len(self.accumulator_update_warp_id) * (2 if use_2cta_instrs else 1)
+        acc_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, num_acc_consumer_threads)
+        acc_pipeline = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_stage,
+            producer_group=acc_pipeline_producer_group,
+            consumer_group=acc_pipeline_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        # SFA2 pipeline: scale warp (cp.async producer) -> acc-update warps
+        scale_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * 1,
+        )
+        scale_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * len(self.accumulator_update_warp_id),
+        )
+        scale_pipeline = pipeline.PipelineCpAsync.create(
+            barrier_storage=storage.scale_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_scale_stage,
+            producer_group=scale_pipeline_producer_group,
+            consumer_group=scale_pipeline_consumer_group,
+            defer_sync=True,
+        )
+
+        # Final-accumulator pipeline: acc-update warps -> epilogue warps
+        epi_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * len(self.accumulator_update_warp_id),
+        )
+        epi_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * len(self.epilog_warp_id),
+        )
+        epi_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.epi_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_epi_stage,
+            producer_group=epi_pipeline_producer_group,
+            consumer_group=epi_pipeline_consumer_group,
+            defer_sync=True,
+        )
+
+        # Scheduler pipeline (sched warp -> every other warp)
+        sched_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 32)
+        num_sched_consumer_threads = 32 * len(
+            (
+                self.tma_warp_id,
+                self.mma_warp_id,
+                self.scale_warp_id,
+                *self.accumulator_update_warp_id,
+                *self.epilog_warp_id,
+            )
+        )
+        sched_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, num_sched_consumer_threads)
+        sched_pipeline = pipeline.PipelineAsync.create(
+            num_stages=self.num_sched_stages,
+            producer_group=sched_producer_group,
+            consumer_group=sched_consumer_group,
+            barrier_storage=sched_storage.tile_info_mbar.data_ptr(),
+            defer_sync=True,
+        )
+
+        # TMEM allocator (allocated by epilogue warp 4; MMA + acc-update +
+        # epilogue warps all retrieve → the barrier spans those 9 warps)
+        tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=self.tmem_alloc_sync_bar_id,
+            num_threads=32
+            * len(
+                (
+                    self.mma_warp_id,
+                    *self.accumulator_update_warp_id,
+                    *self.epilog_warp_id,
+                )
+            ),
+        )
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr,
+            barrier_for_retrieve=tmem_alloc_barrier,
+            allocator_warp_id=self.epilog_warp_id[0],
+            is_two_cta=use_2cta_instrs,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr.ptr,
+            arch=self.architecture,
+        )
+
+        # Scheduler (CLC-based for 2Dx2D)
+        scheduler = MoEPersistentTileScheduler.create(
+            sched_params,
+            offs,
+            cute.arch.block_idx(),
+            cute.arch.grid_dim(),
+            counter_ptr=None,
+            sched_storage=sched_storage,
+        )
+        scheduler.internal_init()
+
+        # Cluster barrier sync after init
+        pipeline_init_arrive(cluster_shape_mn=self.cluster_shape_mn, is_relaxed=True)
+
+        # =================================================================
+        # SMEM tensors
+        # =================================================================
+        sA = smem.allocate_tensor(
+            element_type=self.a_dtype,
+            layout=a_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=a_smem_layout_staged.inner,
+        )
+        sB = smem.allocate_tensor(
+            element_type=self.b_dtype,
+            layout=b_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=b_smem_layout_staged.inner,
+        )
+        sSFA = smem.allocate_tensor(
+            element_type=self.sf_dtype,
+            layout=sfa_smem_layout_staged,
+            byte_alignment=128,
+        )
+        sSFB = smem.allocate_tensor(
+            element_type=self.sf_dtype,
+            layout=sfb_smem_layout_staged,
+            byte_alignment=128,
+        )
+        sSFA2 = smem.allocate_tensor(
+            element_type=self.sf2_dtype,
+            layout=sfa2_smem_layout_staged,
+            byte_alignment=128,
+        )
+        sFinalAcc = smem.allocate_tensor(
+            element_type=self.acc_dtype,
+            layout=final_acc_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=final_acc_smem_layout_staged.inner,
+        )
+
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+        tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, self.num_acc_stage))
+
+        # Scheduler buf tensor for sched_pipeline broadcast
+        sched_buf_ptr = sched_storage.sInfo.data_ptr()
+        sched_copy_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), cutlass.Int32, num_bits_per_copy=128)
+        sched_buf_tensor = cute.make_tensor(
+            sched_buf_ptr,
+            cute.make_layout((4, self.num_sched_stages), stride=(1, 4)),
+        )
+
+        # LDGSTS (cp.async) setup for the second-level A scale
+        atom_scale2_copy = cute.make_copy_atom(
+            cute.nvgpu.cpasync.CopyG2SOp(),
+            self.sf2_dtype,
+            num_bits_per_copy=self.sf2_dtype.width,
+        )
+        tiled_copy_sfa2 = cute.make_tiled_copy_tv(atom_scale2_copy, cute.make_layout((32,)), cute.make_layout((1,)))
+        thr_copy_sfa2 = tiled_copy_sfa2.get_slice(lane_idx)
+        tAsSFA2 = thr_copy_sfa2.partition_D(sSFA2)
+
+        # SFA2 viewed as a C-tile tensor: M is the CTA-tile-clamped scale
+        # block grid (sgm = 1 → per-row), N fully broadcast (no SFB2).
+        sSFA2_view_as_C_layout = cute.make_layout(
+            (
+                (self.scale_size_m, self.scale_m_per_tile),
+                self.cta_tile_shape_mnk[1],
+                self.num_scale_stage,
+            ),
+            stride=((0, 1), 0, self.scale_m_per_tile),
+        )
+        sSFA2_view_as_C = cute.make_tensor(sSFA2.iterator, sSFA2_view_as_C_layout)
+
+        # Number of K MMA tiles that share a single second-level scale block
+        k_tile_same_scale_factor = self.sgk // self.mma_tiler[2]
+
+        # Build extension
+        from ..moe_utils import (
+            TensormapWorkspace,
+            WgradSfTensormapConstructor,
+        )
+
+        slot_names = WgradSfTensormapConstructor.slot_names(self.input_order, self.weight_mode)
+        desc_workspace = TensormapWorkspace(workspace_ptr, slot_names)
+        ext = WgradScaledGemmSchedExtension(
+            tensormap_ctor=desc_workspace,
+            sf_vec_size=self.sf_vec_size,
+            sgk=self.sgk,
+            weight_mode=self.weight_mode,
+            input_order=self.input_order,
+        )
+
+        # Cluster wait
+        pipeline_init_wait(cluster_shape_mn=self.cluster_shape_mn)
+
+        # =================================================================
+        # Scheduler warp (warp 10)
+        # =================================================================
+        if warp_idx == self.sched_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_uniform_warps)
+            sched_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_sched_stages)
+
+            work_tile_info = scheduler.initial_work_tile_info()
+
+            sched_pipeline.producer_acquire(sched_producer_state)
+            rmem = work_tile_info.to_rmem_tensor()
+            cute.copy(
+                sched_copy_atom,
+                rmem,
+                sched_buf_tensor[(None, sched_producer_state.index)],
+            )
+            cute.arch.fence_proxy("async.shared", space="cta")
+            sched_pipeline.producer_commit(sched_producer_state)
+            sched_producer_state.advance()
+
+            work_tile_info = scheduler.advance_to_next_work()
+            while work_tile_info.is_valid_tile:
+                sched_pipeline.producer_acquire(sched_producer_state)
+                rmem = work_tile_info.to_rmem_tensor()
+                cute.copy(
+                    sched_copy_atom,
+                    rmem,
+                    sched_buf_tensor[(None, sched_producer_state.index)],
+                )
+                cute.arch.fence_proxy("async.shared", space="cta")
+                sched_pipeline.producer_commit(sched_producer_state)
+                sched_producer_state.advance()
+
+                work_tile_info = scheduler.advance_to_next_work()
+
+            sched_pipeline.producer_acquire(sched_producer_state)
+            sentinel = MoEWorkTileInfo(
+                cutlass.Int32(-1),
+                cutlass.Int32(0),
+                cutlass.Int32(0),
+                cutlass.Int32(0),
+            )
+            rmem = sentinel.to_rmem_tensor()
+            cute.copy(
+                sched_copy_atom,
+                rmem,
+                sched_buf_tensor[(None, sched_producer_state.index)],
+            )
+            cute.arch.fence_proxy("async.shared", space="cta")
+            sched_pipeline.producer_commit(sched_producer_state)
+            sched_pipeline.producer_tail(sched_producer_state)
+
+        # =================================================================
+        # TMA load warp (warp 9) — identical to wgrad_baseline
+        # =================================================================
+        if warp_idx == self.tma_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_uniform_warps)
+            a_full_mcast_mask = None
+            b_full_mcast_mask = None
+            sfa_full_mcast_mask = None
+            sfb_full_mcast_mask = None
+            if cutlass.const_expr(self.is_a_mcast or self.is_b_mcast or use_2cta_instrs):
+                a_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2)
+                b_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1)
+                sfa_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2)
+                sfb_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                    cluster_layout_sfb_vmnk,
+                    block_in_cluster_coord_sfb_vmnk,
+                    mcast_mode=1,
+                )
+
+            sched_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_sched_stages)
+
+            sched_pipeline.consumer_wait(sched_consumer_state)
+            rmem = cute.make_rmem_tensor((4,), cutlass.Int32)
+            cute.copy(
+                sched_copy_atom,
+                sched_buf_tensor[(None, sched_consumer_state.index)],
+                rmem,
+            )
+            work_tile_info = MoEWorkTileInfo.from_rmem_tensor(rmem)
+            cute.arch.fence_acq_rel_cta()
+            sched_pipeline.consumer_release(sched_consumer_state)
+            sched_consumer_state.advance()
+
+            while work_tile_info.is_valid_tile:
+                k_tile_cnt = work_tile_info.k_tile_cnt
+                ext.update_expert_info(offs, work_tile_info.expert_idx)
+
+                real_a, desc_ptr_a = ext.get_gmem_tensor(
+                    "a",
+                    mA_mkl,
+                    offs,
+                    work_tile_info,
+                )
+                real_b, desc_ptr_b = ext.get_gmem_tensor(
+                    "b",
+                    mB_nkl,
+                    offs,
+                    work_tile_info,
+                )
+                real_sfa, desc_ptr_sfa = ext.get_gmem_tensor(
+                    "sfa",
+                    mSFA_mkl,
+                    offs,
+                    work_tile_info,
+                )
+                real_sfb, desc_ptr_sfb = ext.get_gmem_tensor(
+                    "sfb",
+                    mSFB_nkl,
+                    offs,
+                    work_tile_info,
+                )
+
+                gA_mkl = cute.local_tile(
+                    real_a,
+                    cute.slice_(self.mma_tiler, (None, 0, None)),
+                    (None, None, None),
+                )
+                gB_nkl = cute.local_tile(
+                    real_b,
+                    cute.slice_(self.mma_tiler, (0, None, None)),
+                    (None, None, None),
+                )
+                gSFA_mkl = cute.local_tile(
+                    real_sfa,
+                    cute.slice_(self.mma_tiler, (None, 0, None)),
+                    (None, None, None),
+                )
+                gSFB_nkl = cute.local_tile(
+                    real_sfb,
+                    cute.slice_(self.mma_tiler_sfb, (0, None, None)),
+                    (None, None, None),
+                )
+
+                thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+                thr_mma_sfb = tiled_mma_sfb.get_slice(mma_tile_coord_v)
+                tCgA = thr_mma.partition_A(gA_mkl)
+                tCgB = thr_mma.partition_B(gB_nkl)
+                tCgSFA = thr_mma.partition_A(gSFA_mkl)
+                tCgSFB = thr_mma_sfb.partition_B(gSFB_nkl)
+
+                a_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape)
+                tAsA, tAgA = cpasync.tma_partition(
+                    tma_atom_a,
+                    block_in_cluster_coord_vmnk[2],
+                    a_cta_layout,
+                    cute.group_modes(sA, 0, 3),
+                    cute.group_modes(tCgA, 0, 3),
+                )
+                b_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape)
+                tBsB, tBgB = cpasync.tma_partition(
+                    tma_atom_b,
+                    block_in_cluster_coord_vmnk[1],
+                    b_cta_layout,
+                    cute.group_modes(sB, 0, 3),
+                    cute.group_modes(tCgB, 0, 3),
+                )
+                sfa_cta_layout = a_cta_layout
+                tAsSFA, tAgSFA = cpasync.tma_partition(
+                    tma_atom_sfa,
+                    block_in_cluster_coord_vmnk[2],
+                    sfa_cta_layout,
+                    cute.group_modes(sSFA, 0, 3),
+                    cute.group_modes(tCgSFA, 0, 3),
+                )
+                tAsSFA = cute.filter_zeros(tAsSFA)
+                tAgSFA = cute.filter_zeros(tAgSFA)
+                sfb_cta_layout = cute.make_layout(cute.slice_(cluster_layout_sfb_vmnk, (0, None, 0, 0)).shape)
+                tBsSFB, tBgSFB = cpasync.tma_partition(
+                    tma_atom_sfb,
+                    block_in_cluster_coord_sfb_vmnk[1],
+                    sfb_cta_layout,
+                    cute.group_modes(sSFB, 0, 3),
+                    cute.group_modes(tCgSFB, 0, 3),
+                )
+                tBsSFB = cute.filter_zeros(tBsSFB)
+                tBgSFB = cute.filter_zeros(tBgSFB)
+
+                mma_tile_m = work_tile_info.tile_m_idx // cute.size(tiled_mma.thr_id.shape)
+                tAgA_slice = tAgA[(None, mma_tile_m, None, 0)]
+                tBgB_slice = tBgB[(None, work_tile_info.tile_n_idx, None, 0)]
+                tAgSFA_slice = tAgSFA[(None, mma_tile_m, None, 0)]
+                slice_n = work_tile_info.tile_n_idx
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
+                    slice_n = work_tile_info.tile_n_idx // 2
+                tBgSFB_slice = tBgSFB[(None, slice_n, None, 0)]
+
+                ab_producer.reset()
+                peek_ab_empty_status = ab_producer.try_acquire()
+
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                    handle = ab_producer.acquire_and_advance(peek_ab_empty_status)
+                    peek_ab_empty_status = cutlass.Boolean(1)
+                    if handle.count + 1 < k_tile_cnt:
+                        peek_ab_empty_status = ab_producer.try_acquire()
+                    cute.copy(
+                        tma_atom_a,
+                        tAgA_slice[(None, handle.count)],
+                        tAsA[(None, handle.index)],
+                        tma_bar_ptr=handle.barrier,
+                        tma_desc_ptr=desc_ptr_a,
+                        mcast_mask=a_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_b,
+                        tBgB_slice[(None, handle.count)],
+                        tBsB[(None, handle.index)],
+                        tma_bar_ptr=handle.barrier,
+                        tma_desc_ptr=desc_ptr_b,
+                        mcast_mask=b_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_sfa,
+                        tAgSFA_slice[(None, handle.count)],
+                        tAsSFA[(None, handle.index)],
+                        tma_bar_ptr=handle.barrier,
+                        tma_desc_ptr=desc_ptr_sfa,
+                        mcast_mask=sfa_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_sfb,
+                        tBgSFB_slice[(None, handle.count)],
+                        tBsSFB[(None, handle.index)],
+                        tma_bar_ptr=handle.barrier,
+                        tma_desc_ptr=desc_ptr_sfb,
+                        mcast_mask=sfb_full_mcast_mask,
+                    )
+
+                sched_pipeline.consumer_wait(sched_consumer_state)
+                rmem = cute.make_rmem_tensor((4,), cutlass.Int32)
+                cute.copy(
+                    sched_copy_atom,
+                    sched_buf_tensor[(None, sched_consumer_state.index)],
+                    rmem,
+                )
+                work_tile_info = MoEWorkTileInfo.from_rmem_tensor(rmem)
+                cute.arch.fence_acq_rel_cta()
+                sched_pipeline.consumer_release(sched_consumer_state)
+                sched_consumer_state.advance()
+            ab_producer.tail()
+
+        # =================================================================
+        # Second-level scale load warp (warp 11)
+        # =================================================================
+        if warp_idx == self.scale_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_uniform_warps)
+
+            scale_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_scale_stage)
+            sched_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_sched_stages)
+
+            sched_pipeline.consumer_wait(sched_consumer_state)
+            rmem = cute.make_rmem_tensor((4,), cutlass.Int32)
+            cute.copy(
+                sched_copy_atom,
+                sched_buf_tensor[(None, sched_consumer_state.index)],
+                rmem,
+            )
+            work_tile_info = MoEWorkTileInfo.from_rmem_tensor(rmem)
+            cute.arch.fence_acq_rel_cta()
+            sched_pipeline.consumer_release(sched_consumer_state)
+            sched_consumer_state.advance()
+
+            while work_tile_info.is_valid_tile:
+                k_tile_cnt = work_tile_info.k_tile_cnt
+                ext.update_expert_info(offs, work_tile_info.expert_idx)
+
+                mSFA2_mkl_current, _ = ext.get_gmem_tensor(
+                    "sfa2",
+                    sfa2_tensor,
+                    offs,
+                    work_tile_info,
+                )
+
+                gSFA2_mkl = cute.local_tile(
+                    mSFA2_mkl_current,
+                    cute.slice_(self.cta_tile_shape_mnk, (None, 0, None)),
+                    (None, None, None),
+                )
+                cSFA2_mkl = cute.make_identity_tensor(cute.shape(mSFA2_mkl_current))
+                cSFA2 = cute.local_tile(
+                    cSFA2_mkl,
+                    cute.slice_(self.cta_tile_shape_mnk, (None, 0, None)),
+                    (None, None, None),
+                )
+
+                tAgSFA2_mkl = thr_copy_sfa2.partition_S(gSFA2_mkl)
+                tAcSFA2 = thr_copy_sfa2.partition_S(cSFA2)
+
+                # SFA2 tiling is per-CTA: raw (CTA-granular) tile_m_idx
+                tile_m_cta = work_tile_info.tile_m_idx
+
+                # OOB predication mask over the M rows this lane loads
+                tApSFA2 = cute.make_rmem_tensor(
+                    cute.make_layout(cute.filter_zeros(cute.slice_(tAsSFA2, (None, None, None, 0))).shape),
+                    cutlass.Boolean,
+                )
+
+                scale_producer_state.reset_count()
+                peek_scale_empty_status = cutlass.Boolean(1)
+                if scale_producer_state.count < k_tile_cnt:
+                    peek_scale_empty_status = scale_pipeline.producer_try_acquire(scale_producer_state)
+
+                for k_tile in cutlass.range(0, k_tile_cnt // k_tile_same_scale_factor, 1, unroll=1):
+                    tAsSFA2_pipe = cute.filter_zeros(tAsSFA2[(None, None, None, scale_producer_state.index)])
+                    tAgSFA2_k = cute.filter_zeros(
+                        tAgSFA2_mkl[
+                            (
+                                None,
+                                None,
+                                None,
+                                tile_m_cta,
+                                scale_producer_state.count * k_tile_same_scale_factor,
+                                0,
+                            )
+                        ]
+                    )
+                    tAcSFA2_compact = cute.filter_zeros(
+                        cute.slice_(
+                            tAcSFA2,
+                            (
+                                None,
+                                None,
+                                None,
+                                tile_m_cta,
+                                scale_producer_state.count * k_tile_same_scale_factor,
+                                0,
+                            ),
+                        )
+                    )
+
+                    for i in cutlass.range_constexpr(cute.size(tApSFA2, mode=[1])):
+                        tApSFA2[((0, 0), i, (0, 0))] = cute.elem_less(tAcSFA2_compact[(i)][0], mSFA2_mkl_current.shape[0])
+
+                    scale_pipeline.producer_acquire(scale_producer_state, peek_scale_empty_status)
+                    cute.copy(tiled_copy_sfa2, tAgSFA2_k, tAsSFA2_pipe, pred=tApSFA2)
+                    scale_pipeline.producer_commit(scale_producer_state)
+
+                    scale_producer_state.advance()
+                    peek_scale_empty_status = cutlass.Boolean(1)
+                    if scale_producer_state.count < k_tile_cnt:
+                        peek_scale_empty_status = scale_pipeline.producer_try_acquire(scale_producer_state)
+
+                sched_pipeline.consumer_wait(sched_consumer_state)
+                rmem = cute.make_rmem_tensor((4,), cutlass.Int32)
+                cute.copy(
+                    sched_copy_atom,
+                    sched_buf_tensor[(None, sched_consumer_state.index)],
+                    rmem,
+                )
+                work_tile_info = MoEWorkTileInfo.from_rmem_tensor(rmem)
+                cute.arch.fence_acq_rel_cta()
+                sched_pipeline.consumer_release(sched_consumer_state)
+                sched_consumer_state.advance()
+
+        # =================================================================
+        # MMA warp (warp 8) — one clean partial accumulator per scale block
+        # =================================================================
+        if warp_idx == self.mma_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_uniform_warps)
+            tCrA = tiled_mma.make_fragment_A(sA)
+            tCrB = tiled_mma.make_fragment_B(sB)
+
+            tmem.wait_for_alloc()
+            acc_tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+
+            sfa_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            tCtSFA_layout = blockscaled_utils.make_tmem_layout_sfa(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfa_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFA = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout)
+
+            sfb_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            tCtSFB_layout = blockscaled_utils.make_tmem_layout_sfb(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfb_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFB = cute.make_tensor(sfb_tmem_ptr, tCtSFB_layout)
+
+            (
+                tiled_copy_s2t_sfa,
+                tCsSFA_compact_s2t,
+                tCtSFA_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFA, tCtSFA)
+            (
+                tiled_copy_s2t_sfb,
+                tCsSFB_compact_s2t,
+                tCtSFB_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFB, tCtSFB)
+
+            acc_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_acc_stage)
+            sched_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_sched_stages)
+
+            sched_pipeline.consumer_wait(sched_consumer_state)
+            rmem = cute.make_rmem_tensor((4,), cutlass.Int32)
+            cute.copy(
+                sched_copy_atom,
+                sched_buf_tensor[(None, sched_consumer_state.index)],
+                rmem,
+            )
+            work_tile_info = MoEWorkTileInfo.from_rmem_tensor(rmem)
+            cute.arch.fence_acq_rel_cta()
+            sched_pipeline.consumer_release(sched_consumer_state)
+            sched_consumer_state.advance()
+
+            while work_tile_info.is_valid_tile:
+                k_tile_cnt = work_tile_info.k_tile_cnt
+
+                tCtSFB_mma = tCtSFB
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
+                    offset = cutlass.Int32((work_tile_info.tile_n_idx % 2) * 2)
+                    shifted_ptr = cute.recast_ptr(
+                        acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols + offset,
+                        dtype=self.sf_dtype,
+                    )
+                    tCtSFB_mma = cute.make_tensor(shifted_ptr, tCtSFB_layout)
+
+                acc_producer_state.reset_count()
+                peek_acc_empty_status = cutlass.Boolean(1)
+                if is_leader_cta and k_tile_cnt > 0:
+                    peek_acc_empty_status = acc_pipeline.producer_try_acquire(acc_producer_state)
+
+                if is_leader_cta:
+                    ab_consumer.reset()
+                peek_ab_full_status = cutlass.Boolean(1)
+                if is_leader_cta and k_tile_cnt > 0:
+                    peek_ab_full_status = ab_consumer.try_wait()
+
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                    # Acquire a fresh accumulator stage at each scale block start
+                    if k_tile % k_tile_same_scale_factor == 0:
+                        if is_leader_cta:
+                            acc_pipeline.producer_acquire(acc_producer_state, peek_acc_empty_status)
+
+                    if is_leader_cta:
+                        tCtAcc = tCtAcc_base[(None, None, None, acc_producer_state.index)]
+
+                        handle = ab_consumer.wait_and_advance(peek_ab_full_status)
+                        peek_ab_full_status = cutlass.Boolean(1)
+                        if handle.count + 1 < k_tile_cnt:
+                            peek_ab_full_status = ab_consumer.try_wait()
+
+                        s2t_stage_coord = (None, None, None, None, handle.index)
+                        cute.copy(
+                            tiled_copy_s2t_sfa,
+                            tCsSFA_compact_s2t[s2t_stage_coord],
+                            tCtSFA_compact_s2t,
+                        )
+                        cute.copy(
+                            tiled_copy_s2t_sfb,
+                            tCsSFB_compact_s2t[s2t_stage_coord],
+                            tCtSFB_compact_s2t,
+                        )
+
+                        # Clean accumulator on the first tile of each block
+                        tiled_mma.set(
+                            tcgen05.Field.ACCUMULATE,
+                            k_tile % k_tile_same_scale_factor > 0,
+                        )
+                        tile_crd = (None, None, None, handle.index)
+                        cute.gemm(
+                            tiled_mma,
+                            tCtAcc,
+                            [tCrA[tile_crd], tCtSFA],
+                            [tCrB[tile_crd], tCtSFB_mma],
+                            tCtAcc,
+                        )
+                        handle.release()
+
+                    # Commit the block's partial accumulator to the consumers
+                    if k_tile % k_tile_same_scale_factor == k_tile_same_scale_factor - 1:
+                        if is_leader_cta:
+                            acc_pipeline.producer_commit(acc_producer_state)
+                        acc_producer_state.advance()
+                        peek_acc_empty_status = cutlass.Boolean(1)
+                        if acc_producer_state.count < k_tile_cnt:
+                            if is_leader_cta:
+                                peek_acc_empty_status = acc_pipeline.producer_try_acquire(acc_producer_state)
+
+                sched_pipeline.consumer_wait(sched_consumer_state)
+                rmem = cute.make_rmem_tensor((4,), cutlass.Int32)
+                cute.copy(
+                    sched_copy_atom,
+                    sched_buf_tensor[(None, sched_consumer_state.index)],
+                    rmem,
+                )
+                work_tile_info = MoEWorkTileInfo.from_rmem_tensor(rmem)
+                cute.arch.fence_acq_rel_cta()
+                sched_pipeline.consumer_release(sched_consumer_state)
+                sched_consumer_state.advance()
+
+            acc_pipeline.producer_tail(acc_producer_state)
+
+        # =================================================================
+        # SMEM tensor C (allocated after MMA section)
+        # =================================================================
+        sC = smem.allocate_tensor(
+            element_type=self.c_dtype,
+            layout=c_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=c_smem_layout_staged.inner,
+        )
+
+        # =================================================================
+        # Accumulator-update warps (warps 0-3): per scale block,
+        # final += partial * sfa2 in f32 registers; result -> sFinalAcc.
+        # NO empty-work early exit: k_tile_cnt == 0 tiles still zero-fill
+        # and produce the epi stage so empty experts write zeros.
+        # =================================================================
+        if warp_idx in self.accumulator_update_warp_id:
+            cute.arch.setmaxregister_increase(self.num_regs_acc_update_warps)
+
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            tCtAcc_base = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+
+            # Shape-only partition on the output tensor (invariant t2r setup;
+            # never dereferenced — expert-uniform C shape)
+            gC_mnl_shape = cute.local_tile(
+                mC_mnl,
+                cute.slice_(self.mma_tiler, (None, None, 0)),
+                (None, None, None),
+            )
+            thr_mma_acc = tiled_mma.get_slice(mma_tile_coord_v)
+            tCgC_shape = thr_mma_acc.partition_C(gC_mnl_shape)
+
+            acc_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_acc_stage)
+            scale_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_scale_stage)
+            epi_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_epi_stage)
+
+            (
+                tiled_copy_t2r,
+                tiled_copy_r2s_acc,
+                tTR_tAcc_base,
+                tTR_rAcc,
+                tTR_rAcc_final,
+                tRS_sFinalAcc,
+                tTR_sSFA2,
+            ) = self.acc_update_tmem_copy_and_partition(
+                tidx,
+                tCtAcc_base,
+                tCgC_shape,
+                sSFA2_view_as_C,
+                sFinalAcc,
+                epi_tile,
+            )
+
+            sched_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_sched_stages)
+
+            sched_pipeline.consumer_wait(sched_consumer_state)
+            rmem = cute.make_rmem_tensor((4,), cutlass.Int32)
+            cute.copy(
+                sched_copy_atom,
+                sched_buf_tensor[(None, sched_consumer_state.index)],
+                rmem,
+            )
+            work_tile_info = MoEWorkTileInfo.from_rmem_tensor(rmem)
+            cute.arch.fence_acq_rel_cta()
+            sched_pipeline.consumer_release(sched_consumer_state)
+            sched_consumer_state.advance()
+
+            while work_tile_info.is_valid_tile:
+                k_tile_cnt = work_tile_info.k_tile_cnt
+
+                tTR_rAcc_final.fill(0.0)
+
+                tTR_rSFA2 = cute.make_rmem_tensor(
+                    cute.slice_(tTR_sSFA2, (None, None, None, 0, None, 0)).shape,
+                    self.acc_dtype,
+                )
+
+                acc_consumer_state.reset_count()
+                peek_acc_full_status = cutlass.Boolean(1)
+                if acc_consumer_state.count < k_tile_cnt:
+                    peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
+
+                scale_consumer_state.reset_count()
+                peek_scale_full_status = cutlass.Boolean(1)
+                if scale_consumer_state.count < k_tile_cnt:
+                    peek_scale_full_status = scale_pipeline.consumer_try_wait(scale_consumer_state)
+
+                for k_tile in cutlass.range(0, k_tile_cnt // k_tile_same_scale_factor, 1, unroll=1):
+                    # This scale block's per-row SFA2 from SMEM into registers
+                    scale_pipeline.consumer_wait(scale_consumer_state, peek_scale_full_status)
+                    tTR_sSFA2_slice = cute.slice_(
+                        tTR_sSFA2,
+                        (None, None, None, 0, None, scale_consumer_state.index),
+                    )
+                    scale_atom_copy = cute.make_copy_atom(
+                        cute.nvgpu.CopyUniversalOp(),
+                        self.acc_dtype,
+                        num_bits_per_copy=self.acc_dtype.width,
+                    )
+                    cute.copy(scale_atom_copy, tTR_sSFA2_slice, tTR_rSFA2)
+
+                    scale_pipeline.consumer_release(scale_consumer_state)
+                    scale_consumer_state.advance()
+
+                    # Wait for the block's partial accumulator from the MMA
+                    acc_pipeline.consumer_wait(acc_consumer_state, peek_acc_full_status)
+
+                    tTR_tAcc = tTR_tAcc_base[(None, None, None, None, None, acc_consumer_state.index)]
+                    tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+
+                    subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+                    assert cute.size(tTR_rAcc) % 2 == 0
+                    for subtile_idx in cutlass.range(subtile_cnt):
+                        tTR_tAcc_mn = tTR_tAcc[(None, None, None, subtile_idx)]
+                        cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+
+                        # final += partial * sfa2, as SEPARATELY-ROUNDED f32
+                        # mul then add: mul.rn is non-contractible (PTX), so
+                        # ptxas cannot fuse this into an FFMA — keeping the
+                        # kernel byte-exact vs the torch mul+add reference
+                        # for ARBITRARY f32 scales (the RHT producer's
+                        # amax/(6*448) descales are not powers of two).
+                        tTR_rAcc_subtile = tTR_rAcc_final[(None, None, None, subtile_idx)]
+                        tTR_rSFA2_sub = tTR_rSFA2[(None, None, None, subtile_idx)]
+                        for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
+                            s0, s1 = cute.arch.mul_packed_f32x2(
+                                (tTR_rAcc[i], tTR_rAcc[i + 1]),
+                                (tTR_rSFA2_sub[i], tTR_rSFA2_sub[i + 1]),
+                                rnd="rn",
+                                ftz=False,
+                            )
+                            tTR_rAcc_subtile[i] = tTR_rAcc_subtile[i] + s0
+                            tTR_rAcc_subtile[i + 1] = tTR_rAcc_subtile[i + 1] + s1
+
+                    with cute.arch.elect_one():
+                        acc_pipeline.consumer_release(acc_consumer_state)
+                    acc_consumer_state.advance()
+
+                    peek_acc_full_status = cutlass.Boolean(1)
+                    if acc_consumer_state.count < k_tile_cnt:
+                        peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
+                    peek_scale_full_status = cutlass.Boolean(1)
+                    if scale_consumer_state.count < k_tile_cnt:
+                        peek_scale_full_status = scale_pipeline.consumer_try_wait(scale_consumer_state)
+
+                # All scale blocks accumulated (or none: zeros) — publish the
+                # final tile to the epilogue through sFinalAcc.
+                epi_pipeline.producer_acquire(epi_producer_state)
+
+                final_subtile_cnt = cute.size(tTR_rAcc_final.shape, mode=[3])
+                slot_base = epi_producer_state.index * final_subtile_cnt
+                for subtile_idx in cutlass.range(final_subtile_cnt, unroll_full=True):
+                    tRS_rFinal = tiled_copy_r2s_acc.retile(tTR_rAcc_final[(None, None, None, subtile_idx)])
+                    cute.copy(
+                        tiled_copy_r2s_acc,
+                        tRS_rFinal,
+                        tRS_sFinalAcc[(None, None, None, slot_base + subtile_idx)],
+                    )
+
+                epi_pipeline.producer_commit(epi_producer_state)
+                epi_producer_state.advance()
+
+                sched_pipeline.consumer_wait(sched_consumer_state)
+                rmem = cute.make_rmem_tensor((4,), cutlass.Int32)
+                cute.copy(
+                    sched_copy_atom,
+                    sched_buf_tensor[(None, sched_consumer_state.index)],
+                    rmem,
+                )
+                work_tile_info = MoEWorkTileInfo.from_rmem_tensor(rmem)
+                cute.arch.fence_acq_rel_cta()
+                sched_pipeline.consumer_release(sched_consumer_state)
+                sched_consumer_state.advance()
+
+        # =================================================================
+        # Epilogue warps (warps 4-7): sFinalAcc -> alpha -> bf16 -> TMA C
+        # =================================================================
+        if warp_idx in self.epilog_warp_id:
+            cute.arch.setmaxregister_increase(self.num_regs_epilogue_warps)
+            tmem.allocate(self.num_tmem_alloc_cols)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+
+            # Shape/TV-layout carrier only — the final accumulator lives in
+            # SMEM (sFinalAcc); TMEM holds just MMA partials + SF.
+            tCtAcc_base_ = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+
+            gC_mnl_shape = cute.local_tile(
+                mC_mnl,
+                cute.slice_(self.mma_tiler, (None, None, 0)),
+                (None, None, None),
+            )
+            thr_mma_epi = tiled_mma.get_slice(mma_tile_coord_v)
+            tCgC_shape = thr_mma_epi.partition_C(gC_mnl_shape)
+
+            epi_tidx = tidx % 128
+            (
+                tiled_copy_t2r,
+                tTR_tAcc_base,
+                tTR_rAcc,
+            ) = self.epilog_tmem_copy_and_partition(
+                epi_tidx,
+                tCtAcc_base_,
+                tCgC_shape,
+                epi_tile,
+                use_2cta_instrs,
+            )
+
+            tTR_rC = cute.make_rmem_tensor(tTR_rAcc.shape, self.c_dtype)
+            tiled_copy_r2s, tRS_rC, tRS_sC = self.epilog_smem_copy_and_partition(
+                tiled_copy_t2r,
+                tTR_rC,
+                epi_tidx,
+                sC,
+            )
+            tiled_copy_s2r, tSR_rAcc, tSR_sFinalAcc = self.epilog_smem_load_copy_and_partition(
+                tiled_copy_t2r,
+                tTR_rAcc,
+                epi_tidx,
+                sFinalAcc,
+            )
+
+            epi_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_epi_stage)
+            sched_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_sched_stages)
+            c_producer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                32 * len(self.epilog_warp_id),
+            )
+            c_pipeline = pipeline.PipelineTmaStore.create(num_stages=self.num_c_stage, producer_group=c_producer_group)
+
+            epilog_sync_barrier = pipeline.NamedBarrier(
+                barrier_id=self.epilog_sync_bar_id,
+                num_threads=32 * len(self.epilog_warp_id),
+            )
+
+            num_prev_subtiles = cutlass.Int32(0)
+
+            sched_pipeline.consumer_wait(sched_consumer_state)
+            rmem = cute.make_rmem_tensor((4,), cutlass.Int32)
+            cute.copy(
+                sched_copy_atom,
+                sched_buf_tensor[(None, sched_consumer_state.index)],
+                rmem,
+            )
+            work_tile_info = MoEWorkTileInfo.from_rmem_tensor(rmem)
+            cute.arch.fence_acq_rel_cta()
+            sched_pipeline.consumer_release(sched_consumer_state)
+            sched_consumer_state.advance()
+
+            while work_tile_info.is_valid_tile:
+                ext.update_expert_info(offs, work_tile_info.expert_idx)
+
+                real_c, desc_ptr_c = ext.get_gmem_tensor(
+                    "c",
+                    mC_mnl,
+                    offs,
+                    work_tile_info,
+                )
+
+                gC_mnl_loop = cute.local_tile(
+                    real_c,
+                    cute.slice_(self.mma_tiler, (None, None, 0)),
+                    (None, None, None),
+                )
+                tCgC_loop = thr_mma_epi.partition_C(gC_mnl_loop)
+                _, bSG_sC, bSG_gC_partitioned = epilog_gmem_copy_and_partition(
+                    epi_tidx,
+                    tma_atom_c,
+                    tCgC_loop,
+                    epi_tile,
+                    sC,
+                )
+
+                mma_tile_coord_mnl = (
+                    work_tile_info.tile_m_idx // cute.size(tiled_mma.thr_id.shape),
+                    work_tile_info.tile_n_idx,
+                    cutlass.Int32(0),
+                )
+                bSG_gC = bSG_gC_partitioned[(None, None, None, *mma_tile_coord_mnl)]
+                bSG_gC = cute.group_modes(bSG_gC, 1, cute.rank(bSG_gC))
+
+                if cutlass.const_expr(global_scale_a is not None):
+                    expert_idx = work_tile_info.expert_idx
+                    current_scale_a_iter = global_scale_a.iterator + expert_idx
+                    current_scale_b_iter = global_scale_b.iterator + expert_idx
+                    alpha = cute.arch.load(current_scale_a_iter.llvm_ptr, cutlass.Float32) * cute.arch.load(current_scale_b_iter.llvm_ptr, cutlass.Float32)
+                else:
+                    alpha = None
+
+                epi_stage_index = epi_consumer_state.index
+
+                # Wait for the final accumulator from the acc-update warps
+                epi_pipeline.consumer_wait(epi_consumer_state)
+
+                subtile_cnt = self.final_acc_subtile_cnt
+                for subtile_idx in cutlass.range(0, subtile_cnt, 1, unroll=1):
+                    final_slot = epi_stage_index * subtile_cnt + subtile_idx
+                    cute.copy(
+                        tiled_copy_s2r,
+                        tSR_sFinalAcc[(None, None, None, final_slot)],
+                        tSR_rAcc,
+                    )
+
+                    acc_vec = tiled_copy_r2s.retile(tTR_rAcc).load()
+                    if cutlass.const_expr(global_scale_a is not None):
+                        acc_vec = acc_vec * alpha
+                    acc_vec = acc_vec.to(self.c_dtype)
+                    tRS_rC.store(acc_vec)
+
+                    c_buffer = num_prev_subtiles % self.num_c_stage
+                    num_prev_subtiles = num_prev_subtiles + 1
+                    cute.copy(tiled_copy_r2s, tRS_rC, tRS_sC[(None, None, None, c_buffer)])
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    epilog_sync_barrier.arrive_and_wait()
+
+                    if warp_idx == self.epilog_warp_id[0]:
+                        cute.copy(
+                            tma_atom_c,
+                            bSG_sC[(None, c_buffer)],
+                            bSG_gC[(None, subtile_idx)],
+                            tma_desc_ptr=desc_ptr_c,
+                        )
+                        c_pipeline.producer_commit()
+                        c_pipeline.producer_acquire()
+                    epilog_sync_barrier.arrive_and_wait()
+
+                epi_pipeline.consumer_release(epi_consumer_state)
+                epi_consumer_state.advance()
+
+                sched_pipeline.consumer_wait(sched_consumer_state)
+                rmem = cute.make_rmem_tensor((4,), cutlass.Int32)
+                cute.copy(
+                    sched_copy_atom,
+                    sched_buf_tensor[(None, sched_consumer_state.index)],
+                    rmem,
+                )
+                work_tile_info = MoEWorkTileInfo.from_rmem_tensor(rmem)
+                cute.arch.fence_acq_rel_cta()
+                sched_pipeline.consumer_release(sched_consumer_state)
+                sched_consumer_state.advance()
+
+            c_pipeline.producer_tail()
+
+            tmem.relinquish_alloc_permit()
+            epilog_sync_barrier.arrive_and_wait()
+            tmem.free(tmem_ptr)
+
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)

--- a/python/cudnn/gemm/cutedsl/grouped/wgrad_subchannel_scaled/moe_blockscaled_grouped_gemm_wgrad_subchannel_scaled_rubin.py
+++ b/python/cudnn/gemm/cutedsl/grouped/wgrad_subchannel_scaled/moe_blockscaled_grouped_gemm_wgrad_subchannel_scaled_rubin.py
@@ -1,0 +1,2142 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+MoE Block-Scaled Grouped GEMM Kernel — Weight Gradient (2Dx2D) with a
+SECOND-LEVEL A scale (SFA2 only; wgrad has no SFB2) — Rubin (sm107) port.
+
+Arch-delta port of kernels/wgrad/kernel.py (the Blackwell kernel), applying
+the same mechanical Blackwell->Rubin transformations that separate
+dgrad_quant/kernel.py from dgrad_quant/kernel_sm107.py and nothing else:
+rubin_helpers MMA builders (CollectorOp.DISCARD, fixed inst M = 256/128,
+inst K = 128 for FP4xFP4, inst_tile_k = 2 at sf_vec 16), the s2t SF-copy
+stride-0 broadcast workaround, warpgroup_reg_alloc/dealloc budgets
+(248 acc-update / 232 epilogue / 24 uniform), sm_107 SMEM/TMEM capacities
+(SF TMEM columns gain the x(32 // sf_vec_size) pack factor), and the
+utils.TmemAllocator with arch="sm_107". __init__ and __call__
+signatures are identical to the Blackwell class, so the wrapper only forks
+the kernel module/class by arch. e5m3 (FloatNV8E5M3FNU) first-level scales
+flow through untouched — sf_dtype is read from sfa_gemm.element_type and the
+sm107 MMA op decodes UE5M3 in hardware (the reason this port unlocks e5m3
+for wgrad).
+
+Computes:  A(hidden, tokens_sum) x B(tokens_sum, intermediate)
+        -> C(experts, hidden, intermediate)
+
+where C is the weight gradient.  K (tokens) varies per expert;
+M (hidden) and N (intermediate) are fixed across all experts.
+
+Copy-and-extend of kernels/wgrad_baseline/kernel.py with the dgrad_quant
+kernel's accumulator-splitting machinery grafted in: K is partitioned into
+sgk-token scale blocks (k_tile_same_scale_factor = sgk / mma_tiler_k MMA
+K-tiles each); the MMA warp produces one CLEAN TMEM partial accumulator per
+block; a dedicated 4-warp accumulator-update warpgroup rescales each partial
+by its per-M-row f32 SFA2 (sgm = 1: one scale per hidden row per sgk-token
+group, the dgrad_dglu_rht_2 producer's rht_quant_sf2 grid) and sums in f32
+registers; the running tile lands in an SMEM sFinalAcc buffer that the
+epilogue warpgroup reads instead of TMEM. A/SFA/B/SFB TMA loads, the
+per-expert tensormap helper kernel, and the CLC scheduler are byte-identical
+to wgrad_baseline; SFA2 rides a cp.async (LDGSTS) pipeline on a dedicated
+scale warp — 12 warps = 3 whole 128-thread warpgroups (setmaxnregs-safe).
+
+Ragged K x sgk: the wrapper enforces token_counts[e] % sgk == 0 (the RHT
+producer's own gate), so every expert's k_tile_cnt divides exactly into
+whole scale blocks and an expert's SFA2 columns are a domain_offset by
+token_offset // sgk on the global (hidden, tokens_sum/sgk) grid.
+
+Supports (unchanged from wgrad_baseline):
+    - CLC-based dynamic persistent tile scheduling
+    - Dense (contiguous 3-D C) / Discrete (per-expert pointer array C) output
+    - accumulate_on_output (TMA reduce for atomic accumulation)
+    - NVFP4 global_scale support (epilogue alpha)
+    - k_tile_cnt == 0 handling (zero output for empty experts — the
+      acc-update warpgroup zero-fills and still produces the epi stage)
+
+Scheduler: moe_persistent_scheduler.py (CLC mode, scenario="2Dx2D")
+Extension: moe_sched_extension.WgradScaledGemmSchedExtension (sgk-aware "sfa2" branch)
+Source provenance: bs_ggemm_harness kernels/wgrad/kernel_sm107.py
+"""
+
+import re
+from importlib.metadata import PackageNotFoundError, version
+from typing import Literal, Type, Tuple, Optional
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import cpasync, tcgen05
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.utils.rubin_helpers as sm107_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+from cutlass.cute.nvgpu.tcgen05 import CollectorOp
+from ..moe_persistent_scheduler import (
+    MoEPersistentTileScheduler,
+    MoESchedulerParams,
+    MoEWorkTileInfo,
+)
+from ..moe_utils import (
+    MoEWeightMode,
+    WGradInputOrder,
+    WgradSfTensormapConstructor,
+)
+from ..moe_sched_extension import (
+    WgradScaledGemmSchedExtension,
+)
+from ..moe_kernel_helpers import (
+    compute_stages_wgrad_2nd_level,
+    epilog_gmem_copy_and_partition,
+)
+
+# Same launch-config space as wgrad_baseline; 2-CTA instructions pair with
+# the 256-M tilers. N=256 tilers run with 1 TMEM acc stage and 1 AB stage
+# (SMEM: full-tile f32 sFinalAcc) — correct but unpipelined, like
+# dgrad_quant's (256, 256) config.
+VALID_CTA_SHAPES = ((128, 128), (256, 128))
+VALID_CLUSTER_SHAPES = (
+    (1, 1),
+    (1, 2),
+    (2, 1),
+    (2, 2),
+    (1, 4),
+    (4, 1),
+    (2, 4),
+    (4, 2),
+    (4, 4),
+)
+DEFAULT_CTA_SHAPE = (256, 128)
+DEFAULT_CLUSTER_SHAPE = (2, 1)
+
+
+def _using_internal_cutlass_dsl() -> bool:
+    try:
+        version("nvidia-cutlass-dsl-internal")
+    except PackageNotFoundError:
+        return False
+    return True
+
+
+def _cutlass_dsl_needs_fp4_layout_workaround() -> bool:
+    # Public cutlass-dsl wheels before 4.8 interpret packed sub-byte
+    # from_dlpack layouts in byte units, so the FP4 A/B layouts must be
+    # recast to element units.
+    if _using_internal_cutlass_dsl():
+        return False
+    match = re.match(r"(\d+)\.(\d+)", getattr(cutlass, "__version__", "") or "")
+    if match is None:
+        return False
+    return (int(match.group(1)), int(match.group(2))) < (4, 8)
+
+
+_NEEDS_FP4_LAYOUT_WORKAROUND = _cutlass_dsl_needs_fp4_layout_workaround()
+
+
+class BlockScaledSubChannelMoEGroupedGemmWgradKernelSm107:
+    """Block-scaled grouped GEMM kernel for MoE weight gradient (2Dx2D) with
+    a K-grouped second-level A scale (SFA2 only).
+
+    :param sf_vec_size: First-level scale-factor vector size (16 or 32).
+    :param sgk: Second-level scale group size along K (tokens); one f32 SFA2
+        per (1 M row x sgk tokens). Must be a multiple of the MMA K tile
+        (256 for NVFP4) — sgk in {256, 512}.
+    :param acc_dtype: Accumulator data type (Float32).
+    :param use_2cta_instrs: Use 2-CTA MMA instructions.
+    :param mma_tiler_mn: MMA tile shape (M, N).
+    :param cluster_shape_mn: Cluster shape (M, N).
+    :param accumulate_on_output: Use TMA reduce for atomic accumulation.
+    :param expert_cnt: Number of experts.
+    :param weight_mode: ``MoEWeightMode.DENSE`` or ``MoEWeightMode.DISCRETE`` for output.
+    :param input_order: ``WGradInputOrder.Tensor2D`` (default) or
+        ``WGradInputOrder.TensorRagged`` — see wgrad_baseline.
+    """
+
+    FIX_PAD_SIZE = 256  # every expert's token count (K_e) must be 256-aligned
+    # sgm is fixed: SFA2 is per-M-row (the rht_quant_sf2 grid)
+    SGM = 1
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        sgk: int,
+        acc_dtype: Type[cutlass.Numeric] = cutlass.Float32,
+        use_2cta_instrs: bool = False,
+        mma_tiler_mn: Tuple[int, int] = (128, 128),
+        cluster_shape_mn: Tuple[int, int] = (1, 1),
+        accumulate_on_output: bool = False,
+        expert_cnt: int = 1,
+        weight_mode: MoEWeightMode = MoEWeightMode.DENSE,
+        input_order: WGradInputOrder = WGradInputOrder.Tensor2D,
+        sf_fp8_dtype_override: Optional[Literal["e5m3"]] = None,
+    ):
+        self.sf_vec_size = sf_vec_size
+        self.sf_dtype_override: Optional[Type[cutlass.Numeric]] = cutlass.FloatNV8E5M3FNU if sf_fp8_dtype_override == "e5m3" else None
+        self.sgm = self.SGM
+        self.sgk = sgk
+        self.expert_cnt = expert_cnt
+        self.acc_dtype = acc_dtype
+        self.use_2cta_instrs = use_2cta_instrs
+        self.cluster_shape_mn = cluster_shape_mn
+        self.mma_tiler = (*mma_tiler_mn, 1)
+        self.accumulate_on_output = accumulate_on_output
+        self.weight_mode = weight_mode
+        self.input_order = input_order
+
+        self.cta_group = tcgen05.CtaGroup.TWO if use_2cta_instrs else tcgen05.CtaGroup.ONE
+
+        # Warp specialization (the dgrad_quant layout): 12 warps = 3 whole
+        # 128-thread warpgroups — a partial warpgroup is illegal for
+        # setmaxnregs, so every role must pack into whole groups.
+        self.occupancy = 1
+        self.accumulator_update_warp_id = (0, 1, 2, 3)
+        self.epilog_warp_id = (4, 5, 6, 7)
+        self.mma_warp_id = 8
+        self.tma_warp_id = 9
+        self.sched_warp_id = 10
+        self.scale_warp_id = 11
+        self.threads_per_warp = 32
+        all_warps = [
+            *self.accumulator_update_warp_id,
+            *self.epilog_warp_id,
+            self.mma_warp_id,
+            self.tma_warp_id,
+            self.sched_warp_id,
+            self.scale_warp_id,
+        ]
+        # Per-role register budgets applied via warpgroup_reg_alloc/dealloc
+        # (uniform per
+        # warpgroup: warps 0-3 acc-update, 4-7 epilogue, 8-11 uniform)
+        self.num_regs_uniform_warps = 24
+        self.num_regs_epilogue_warps = 232
+        self.num_regs_acc_update_warps = 248
+        self.threads_per_cta = self.threads_per_warp * len(all_warps)
+
+        self.epilog_sync_bar_id = 1
+        self.tmem_alloc_sync_bar_id = 2
+        self.tmem_dealloc_sync_bar_id = 3
+
+        self.architecture = "sm_107"
+        self.smem_capacity = utils.get_smem_capacity_in_bytes(self.architecture)
+        self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(self.architecture)
+
+    # ------------------------------------------------------------------
+    # Workspace
+    # ------------------------------------------------------------------
+
+    def get_workspace_bytes(self) -> int:
+        return WgradSfTensormapConstructor.get_workspace_size(self.input_order, self.weight_mode, self.expert_cnt)
+
+    # ------------------------------------------------------------------
+    # _setup_attributes
+    # ------------------------------------------------------------------
+
+    def _setup_attributes(self) -> None:
+        # Hardware MMA instruction M: always 256 for 2CTA, 128 for 1CTA
+        # (numerically identical to the tiler M for wgrad's valid tilers,
+        # but the sm107 builder wants the instruction shape, not the tiler).
+        mma_inst_m = 256 if self.use_2cta_instrs else 128
+        self.mma_inst_shape_mn = (mma_inst_m, self.mma_tiler[1])
+        self.mma_inst_shape_mn_sfb = (
+            self.mma_inst_shape_mn[0] // (2 if self.use_2cta_instrs else 1),
+            cute.round_up(self.mma_inst_shape_mn[1], 128),
+        )
+
+        tiled_mma = self._create_tiled_mma()
+        tiled_mma_sfb = self._create_tiled_mma_sfb()
+
+        mma_inst_shape_k = cute.size(tiled_mma.shape_mnk, mode=[2])
+        # sm107: the FP4xFP4 atom is K=128 (vs 64 on sm100), so 2 instruction
+        # tiles keep mma_tiler_k at 256 and the sgk block structure unchanged.
+        mma_inst_tile_k = 2 if (self.a_dtype.width == 4 and self.sf_vec_size == 16) else 4
+        mma_tiler_k = mma_inst_shape_k * mma_inst_tile_k
+        self.mma_tiler = (
+            self.mma_inst_shape_mn[0],
+            self.mma_inst_shape_mn[1],
+            mma_tiler_k,
+        )
+        self.mma_tiler_sfb = (
+            self.mma_inst_shape_mn_sfb[0],
+            self.mma_inst_shape_mn_sfb[1],
+            mma_tiler_k,
+        )
+        self.cta_tile_shape_mnk = (
+            self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler[1],
+            self.mma_tiler[2],
+        )
+        self.cta_tile_shape_mnk_sfb = (
+            self.mma_tiler_sfb[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler_sfb[1],
+            self.mma_tiler_sfb[2],
+        )
+
+        # Every expert's k_tile_cnt must divide into whole scale blocks
+        # (wrapper gate token_counts % sgk == 0 makes this per-expert exact).
+        assert self.sgk % self.mma_tiler[2] == 0, f"sgk ({self.sgk}) must be a multiple of the MMA K tile " f"({self.mma_tiler[2]})"
+
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma.thr_id.shape,),
+        )
+        self.cluster_layout_sfb_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma_sfb.thr_id.shape,),
+        )
+
+        self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+
+        self.epi_tile = sm100_utils.compute_epilogue_tile_shape(
+            self.cta_tile_shape_mnk,
+            self.use_2cta_instrs,
+            self.c_layout,
+            self.c_dtype,
+        )
+        self.epi_tile_n = cute.size(self.epi_tile[1])
+        # The acc-update warpgroup's SFA2-as-C partition fixes the epi M
+        # iterator at 0 (the dgrad_quant scheme) — needs one epi tile per M.
+        assert cute.size(self.epi_tile[0]) == self.cta_tile_shape_mnk[0], (
+            f"epi tile M ({cute.size(self.epi_tile[0])}) must equal the CTA " f"tile M ({self.cta_tile_shape_mnk[0]})"
+        )
+
+        (
+            self.num_acc_stage,
+            self.num_ab_stage,
+            self.num_c_stage,
+            self.num_epi_stage,
+        ) = compute_stages_wgrad_2nd_level(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.b_dtype,
+            self.epi_tile,
+            self.c_dtype,
+            self.c_layout,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.smem_capacity,
+            self.occupancy,
+            self.acc_dtype,
+            self.sf2_dtype,
+            self.sgk,
+        )
+        self.num_sched_stages = 2
+        # Second-level scale pipeline runs in lockstep with the AB pipeline
+        self.num_scale_stage = self.num_ab_stage
+
+        self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.num_ab_stage,
+        )
+        self.b_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            self.mma_tiler,
+            self.b_dtype,
+            self.num_ab_stage,
+        )
+        self.sfa_smem_layout_staged = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        self.sfb_smem_layout_staged = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        self.c_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.c_dtype,
+            self.c_layout,
+            self.epi_tile,
+            self.num_c_stage,
+        )
+
+        # Per-CTA-tile scale block sizes, clamped to the tile (dgrad_quant's
+        # scheme; here sgm = 1 so the M axis is per-row and only K clamps).
+        size_m = self.sgm if self.sgm < self.cta_tile_shape_mnk[0] else self.cta_tile_shape_mnk[0]
+        size_k = self.sgk if self.sgk < self.cta_tile_shape_mnk[2] else self.cta_tile_shape_mnk[2]
+        self.scale_size_m = size_m
+        self.scale_size_k = size_k
+        self.scale_m_per_tile = self.cta_tile_shape_mnk[0] // size_m
+        self.scale_k_per_tile = self.cta_tile_shape_mnk[2] // size_k
+
+        # Staged SMEM layout for the second-level (f32) A scale; extent-0
+        # inner modes broadcast one stored f32 across its whole block.
+        self.sfa2_smem_layout_staged = cute.make_layout(
+            (
+                (size_m, self.scale_m_per_tile),
+                (size_k, self.scale_k_per_tile),
+                self.num_scale_stage,
+            ),
+            stride=(
+                (0, self.scale_k_per_tile),
+                (0, 1),
+                self.scale_k_per_tile * self.scale_m_per_tile,
+            ),
+        )
+
+        # Full-CTA-tile SMEM buffer for the final accumulator; the "stage"
+        # mode of the epi layout doubles as the subtile-slot index
+        # (final_acc_subtile_cnt slots per epi stage).
+        self.final_acc_subtile_cnt = (self.cta_tile_shape_mnk[0] // cute.size(self.epi_tile[0])) * (self.cta_tile_shape_mnk[1] // cute.size(self.epi_tile[1]))
+        self.final_acc_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.acc_dtype,
+            self.c_layout,
+            self.epi_tile,
+            self.final_acc_subtile_cnt * self.num_epi_stage,
+        )
+
+        # TMEM column budget: partial accumulators followed by SFA/SFB scale
+        # columns. On sm107 the SF columns carry a x(32 // sf_vec_size) pack
+        # factor which exactly cancels the halved mma_inst_tile_k at
+        # sf_vec 16, so the counts match Blackwell's: at N=128 tilers,
+        # 384 acc + 32 SF <= 576 (the sm107 TMEM allocation limit).
+        sf_atom_mn = 32
+        sf_pack_factor = 32 // self.sf_vec_size
+        self.num_sfa_tmem_cols = (self.cta_tile_shape_mnk[0] // sf_atom_mn) * mma_inst_tile_k * sf_pack_factor
+        self.num_sfb_tmem_cols = (self.cta_tile_shape_mnk_sfb[1] // sf_atom_mn) * mma_inst_tile_k * sf_pack_factor
+        self.num_sf_tmem_cols = self.num_sfa_tmem_cols + self.num_sfb_tmem_cols
+        self.num_accumulator_tmem_cols = self.cta_tile_shape_mnk[1] * self.num_acc_stage
+        assert self.num_accumulator_tmem_cols + self.num_sf_tmem_cols <= self.num_tmem_alloc_cols, (
+            f"TMEM overflow: {self.num_accumulator_tmem_cols} acc + " f"{self.num_sf_tmem_cols} SF columns > {self.num_tmem_alloc_cols}"
+        )
+
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        sfa_smem_layout = cute.slice_(self.sfa_smem_layout_staged, (None, None, None, 0))
+        sfb_smem_layout = cute.slice_(self.sfb_smem_layout_staged, (None, None, None, 0))
+        a_copy_size = cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        b_copy_size = cute.size_in_bytes(self.b_dtype, b_smem_layout)
+        sfa_copy_size = cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+        sfb_copy_size = cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+        self.num_tma_load_bytes = (a_copy_size + b_copy_size + sfa_copy_size + sfb_copy_size) * atom_thr_size
+
+    # ------------------------------------------------------------------
+    # MMA helpers
+    # ------------------------------------------------------------------
+
+    def _mma_inst_k(self):
+        # sm107: K=128 for FP4xFP4, K=64 for FP8/mixed
+        return 128 if (self.a_dtype.width == 4 and self.b_dtype.width == 4) else 64
+
+    def _create_tiled_mma(self):
+        return sm107_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            (*self.mma_inst_shape_mn, self._mma_inst_k()),
+            a_collector_op=CollectorOp.DISCARD,
+            b_collector_op=CollectorOp.DISCARD,
+            atom_layout_mnk=(1, 1, 1),
+            permutation_mnk=(1, 1, 1),
+        )
+
+    def _create_tiled_mma_sfb(self):
+        return sm107_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            tcgen05.CtaGroup.ONE,
+            (*self.mma_inst_shape_mn_sfb, self._mma_inst_k()),
+        )
+
+    def mainloop_s2t_copy_and_partition(self, sSF, tSF):
+        tCsSF_compact = cute.filter_zeros(sSF)
+        tCtSF_compact = cute.filter_zeros(tSF)
+        copy_atom_s2t = cute.make_copy_atom(
+            tcgen05.Cp4x32x128bOp(self.cta_group),
+            self.sf_dtype,
+        )
+        tiled_copy_s2t = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSF_compact)
+        thr_copy_s2t = tiled_copy_s2t.get_slice(0)
+
+        # Rubin sm107 workaround: append stride-0 broadcast mode so
+        # partition_S produces the right shape for NVF4 (sf_vec_size=16);
+        # idempotent for sf_vec_size=32.
+        def _append_mn_broadcast_mode(smem_layout: cute.Layout):
+            mn_dim = cute.get(smem_layout, mode=[0, 0])
+            mn_dim = cute.append(mn_dim, cute.make_layout((4), stride=(0)))
+            layout = cute.append(cute.group_modes(mn_dim, 0), cute.get(smem_layout, mode=[0, 1]))
+            layout = cute.append(cute.group_modes(layout, 0), cute.get(smem_layout, mode=[1]))
+            layout = cute.append(layout, cute.get(smem_layout, mode=[2]))
+            layout = cute.append(layout, cute.get(smem_layout, mode=[3]))
+            return layout
+
+        tCsSF_compact_bcast = cute.make_tensor(
+            tCsSF_compact.iterator,
+            _append_mn_broadcast_mode(tCsSF_compact.layout),
+        )
+        tCsSF_compact_s2t_ = thr_copy_s2t.partition_S(tCsSF_compact_bcast)
+        tCsSF_compact_s2t = tcgen05.get_s2t_smem_desc_tensor(tiled_copy_s2t, tCsSF_compact_s2t_)
+        tCtSF_compact_s2t = thr_copy_s2t.partition_D(tCtSF_compact)
+        return tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t
+
+    # ------------------------------------------------------------------
+    # Acc-update / epilogue partition helpers (ported from dgrad_quant)
+    # ------------------------------------------------------------------
+
+    def acc_update_tmem_copy_and_partition(
+        self,
+        tidx,
+        tCtAcc_base,
+        gC_mnl,
+        sSFA2,
+        sFinalAcc,
+        epi_tile,
+    ):
+        """T2R (partial accumulator TMEM->reg), R2S (final acc reg->SMEM) and
+        the SFA2-as-C SMEM partition for the accumulator-update warpgroup.
+        One subtile's partial (tTR_rAcc) is live at a time; tTR_rAcc_final
+        spans the full CTA tile grouped by epi subtile."""
+        if cutlass.const_expr(self.mma_tiler[0] == 64):
+            tmem_load_atom = cute.make_copy_atom(
+                tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(8)),
+                self.acc_dtype,
+            )
+        else:
+            tmem_load_atom = cute.make_copy_atom(
+                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)),
+                self.acc_dtype,
+            )
+
+        tAcc_epi = cute.flat_divide(tCtAcc_base[((None, None), 0, 0, None)], epi_tile)
+        tiled_copy_t2r = tcgen05.make_tmem_copy(tmem_load_atom, tAcc_epi[(None, None, 0, 0, 0)])
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+
+        # R2S store of the final accumulator: reuse the T2R copy's TV layout
+        # with a universal copy atom (swizzle-safe for f32)
+        copy_atom_r2s_acc = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.acc_dtype)
+        tiled_copy_r2s_acc = cute.make_tiled_copy_D(copy_atom_r2s_acc, tiled_copy_t2r)
+        thr_copy_r2s_acc = tiled_copy_r2s_acc.get_slice(tidx)
+        # (R2S, R2S_M, R2S_N, SUBTILE * STAGE)
+        tRS_sFinalAcc = thr_copy_r2s_acc.partition_D(sFinalAcc)
+
+        tTR_tAcc_base = thr_copy_t2r.partition_S(tAcc_epi)
+
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, loopM, loopN, loopL)
+        gC_mnl_epi = cute.flat_divide(gC_mnl[((None, None), 0, 0, None, None, None)], epi_tile)
+        sSFA2_epi = cute.flat_divide(sSFA2, epi_tile)
+
+        tTR_gC = thr_copy_t2r.partition_D(gC_mnl_epi)
+        tTR_sSFA2 = thr_copy_t2r.partition_D(sSFA2_epi)
+
+        # One k_tile's partial accumulator: (T2R, T2R_M, T2R_N)
+        tTR_rAcc = cute.make_rmem_tensor(tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].shape, self.acc_dtype)
+        # Final accumulated result across all scale blocks:
+        # (T2R, T2R_M, T2R_N, (EPI_M, EPI_N))
+        tTR_rAcc_final_ = cute.make_rmem_tensor(tTR_gC[(None, None, None, None, None, 0, 0, 0)].shape, self.acc_dtype)
+        tTR_rAcc_final = cute.group_modes(tTR_rAcc_final_, 3, cute.rank(tTR_rAcc_final_))
+
+        return (
+            tiled_copy_t2r,
+            tiled_copy_r2s_acc,
+            tTR_tAcc_base,
+            tTR_rAcc,
+            tTR_rAcc_final,
+            tRS_sFinalAcc,
+            tTR_sSFA2,
+        )
+
+    def epilog_tmem_copy_and_partition(self, tidx, tAcc, gC_mnl, epi_tile, use_2cta_instrs):
+        # Shape/TV-layout carrier only — the epilogue never reads TMEM data;
+        # this defines the tiled T2R copy whose TV layout the r2s/s2r reuse.
+        copy_atom_t2r = sm100_utils.get_tmem_load_op(
+            self.cta_tile_shape_mnk,
+            self.c_layout,
+            self.c_dtype,
+            self.acc_dtype,
+            epi_tile,
+            use_2cta_instrs,
+        )
+        tAcc_epi = cute.flat_divide(tAcc[((None, None), 0, 0, None)], epi_tile)
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tAcc_epi[(None, None, 0, 0, 0)])
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+        tTR_tAcc = thr_copy_t2r.partition_S(tAcc_epi)
+        gC_mnl_epi = cute.flat_divide(gC_mnl[((None, None), 0, 0, None, None, None)], epi_tile)
+        tTR_gC = thr_copy_t2r.partition_D(gC_mnl_epi)
+        tTR_rAcc = cute.make_rmem_tensor(tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].shape, self.acc_dtype)
+        return tiled_copy_t2r, tTR_tAcc, tTR_rAcc
+
+    def epilog_smem_copy_and_partition(self, tiled_copy_t2r, tTR_rC, tidx, sC):
+        copy_atom_r2s = sm100_utils.get_smem_store_op(self.c_layout, self.c_dtype, self.acc_dtype, tiled_copy_t2r)
+        tiled_copy_r2s = cute.make_tiled_copy_D(copy_atom_r2s, tiled_copy_t2r)
+        thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+        tRS_sC = thr_copy_r2s.partition_D(sC)
+        tRS_rC = tiled_copy_r2s.retile(tTR_rC)
+        return tiled_copy_r2s, tRS_rC, tRS_sC
+
+    def epilog_smem_load_copy_and_partition(self, tiled_copy_t2r, tTR_rAcc, tidx, sFinalAcc):
+        # S2R load of the final accumulator: reuse the T2R copy's TV layout
+        # with a universal copy atom; tSR_rAcc is a register view of tTR_rAcc
+        copy_atom_s2r = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.acc_dtype)
+        tiled_copy_s2r = cute.make_tiled_copy_D(copy_atom_s2r, tiled_copy_t2r)
+        thr_copy_s2r = tiled_copy_s2r.get_slice(tidx)
+        # (S2R, S2R_M, S2R_N, SUBTILE * STAGE)
+        tSR_sFinalAcc = thr_copy_s2r.partition_D(sFinalAcc)
+        tSR_rAcc = tiled_copy_s2r.retile(tTR_rAcc)
+        return tiled_copy_s2r, tSR_rAcc, tSR_sFinalAcc
+
+    @cute.jit
+    def __call__(
+        self,
+        mat_a: cute.Tensor,  # (hidden, tokens_sum) — activation-grad^T
+        mat_b: cute.Tensor,  # (tokens_sum, intermediate) — activation
+        scale_a: cute.Tensor,  # SFA (assembled block-scaled layout)
+        scale_b: cute.Tensor,  # SFB (assembled block-scaled layout)
+        scale_a2: cute.Tensor,  # SFA2 (hidden, tokens_sum/sgk[, 1]) f32, hidden contiguous
+        out,  # Dense: cute.Tensor (experts, hidden, intermediate)
+        # Discrete: cute.Pointer to int64[]
+        offs,  # Union[cute.Tensor, cute.Pointer] (experts,) cumsum end offsets, int32
+        workspace: cute.Tensor,  # expert-wise TMA desc (discrete only)
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        global_scale_a: Optional[cute.Tensor] = None,
+        global_scale_b: Optional[cute.Tensor] = None,
+        # Discrete-only: template tensor for a single expert's output (M, N) or (M, N, 1)
+        out_single_expert: Optional[cute.Tensor] = None,
+    ) -> None:
+
+        # Public CUTLASS DSL < 4.8 needs the packed-FP4 from_dlpack layout
+        # workaround. Rubin, the internal DSL wheel, and public wheels >= 4.8
+        # consume the native 4-bit layout directly.
+        needs_fp4_layout_workaround = self.architecture != "sm_107" and _NEEDS_FP4_LAYOUT_WORKAROUND
+        if cutlass.const_expr(needs_fp4_layout_workaround and mat_a.iterator.dtype.width < 8):
+            mat_a = cute.make_tensor(
+                mat_a.iterator,
+                cute.recast_layout(mat_a.iterator.dtype.width, 8, mat_a.layout),
+            )
+        if cutlass.const_expr(needs_fp4_layout_workaround and mat_b.iterator.dtype.width < 8):
+            mat_b = cute.make_tensor(
+                mat_b.iterator,
+                cute.recast_layout(mat_b.iterator.dtype.width, 8, mat_b.layout),
+            )
+
+        # =================================================================
+        # Step 1: Transform to GEMM domain (2Dx2D)
+        # =================================================================
+        c1 = cutlass.Int32(1)
+        c0 = cutlass.Int32(0)
+
+        # mat_a: (hidden, tokens_sum) -> A: (M=hidden, K=tokens_sum, L=1)
+        hidden, tokens_sum = mat_a.shape
+        a_gemm = cute.make_tensor(
+            mat_a.iterator,
+            cute.make_layout(
+                (hidden, tokens_sum, c1),
+                stride=(mat_a.stride[0], mat_a.stride[1], c0),
+            ),
+        )
+        # mat_b: (tokens_sum, intermediate) -> B: (N=intermediate, K=tokens_sum, L=1)
+        tokens_sum_b, intermediate = mat_b.shape
+        b_gemm = cute.make_tensor(
+            mat_b.iterator,
+            cute.make_layout(
+                (intermediate, tokens_sum_b, c1),
+                stride=(mat_b.stride[1], mat_b.stride[0], c0),
+            ),
+        )
+
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DENSE):
+            # out: (experts, hidden, intermediate) -> C: (M=hidden, N=intermediate, L=experts)
+            experts, hidden_c, intermediate_c = out.shape
+            c_gemm = cute.make_tensor(
+                out.iterator,
+                cute.make_layout(
+                    (hidden_c, intermediate_c, experts),
+                    stride=(out.stride[1], out.stride[2], out.stride[0]),
+                ),
+            )
+            expert_cnt = experts
+        else:
+            # Discrete: out is a Pointer to int64[] of per-expert base addresses
+            expert_cnt = self.expert_cnt
+            # Normalize out_single_expert to rank-3 (M, N, 1) if rank-2
+            if cutlass.const_expr(cute.rank(out_single_expert.layout) == 2):
+                out_single_expert = cute.make_tensor(
+                    out_single_expert.iterator,
+                    cute.make_layout(
+                        (*out_single_expert.shape, c1),
+                        stride=(*out_single_expert.stride, c0),
+                    ),
+                )
+            c_gemm = out_single_expert
+
+        intermediate_dim = intermediate
+        hidden_dim = hidden
+
+        # SFA: (hidden_padded, tokens_sum_padded_sf)
+        hidden_padded = scale_a.shape[0]
+        tokens_sum_padded = scale_a.shape[1] * self.sf_vec_size
+        sfa_gemm = cute.make_tensor(
+            scale_a.iterator,
+            blockscaled_utils.tile_atom_to_shape_SF((hidden_padded, tokens_sum_padded, c1), self.sf_vec_size),
+        )
+        # SFB: (intermediate_padded, tokens_sum_padded_sf)
+        intermediate_padded = scale_b.shape[0]
+        sfb_gemm = cute.make_tensor(
+            scale_b.iterator,
+            blockscaled_utils.tile_atom_to_shape_SF((intermediate_padded, tokens_sum_padded, c1), self.sf_vec_size),
+        )
+
+        # Accept the producer's rank-2 (hidden, tokens_sum/sgk) SFA2 view directly.
+        if cutlass.const_expr(cute.rank(scale_a2.layout) == 2):
+            scale_a2 = cute.make_tensor(
+                scale_a2.iterator,
+                cute.make_layout((*scale_a2.shape, c1), stride=(*scale_a2.stride, c0)),
+            )
+
+        # SFA2: (hidden, tokens_sum/sgk, 1) f32 → hierarchical broadcast view
+        # ((sgm, hidden), (sgk, scale_cols), 1) with stride-0 inner modes so
+        # one f32 covers its whole (1 row x sgk tokens) block (the dgrad_quant
+        # sfa2 template with the group axis on K).
+        sfa2_gemm = cute.make_tensor(
+            scale_a2.iterator,
+            cute.make_layout(
+                (
+                    (self.sgm, scale_a2.shape[0]),
+                    (self.sgk, scale_a2.shape[1]),
+                    scale_a2.shape[2],
+                ),
+                stride=(
+                    (0, scale_a2.layout.stride[0]),
+                    (0, scale_a2.layout.stride[1]),
+                    scale_a2.layout.stride[2],
+                ),
+            ),
+        )
+
+        # =================================================================
+        # Step 2: Infer dtypes and major modes
+        # =================================================================
+        self.a_dtype = a_gemm.element_type
+        self.b_dtype = b_gemm.element_type
+        self.c_dtype = c_gemm.element_type
+        # Scale factors may arrive under a stand-in element type: FloatNV8E5M3FNU has
+        # no torch dtype and TVM-FFI cannot marshal it, so e5m3 scales are passed as
+        # Float8E4M3FN storage of the same width and reinterpreted here. This must
+        # happen before _setup_attributes(), which picks the MMA atom off sf_dtype.
+        if cutlass.const_expr(self.sf_dtype_override is not None):
+            self.sf_dtype = self.sf_dtype_override
+        else:
+            self.sf_dtype = sfa_gemm.element_type
+        self.sf2_dtype = scale_a2.element_type
+        self.a_major_mode = utils.LayoutEnum.from_tensor(a_gemm).mma_major_mode()
+        self.b_major_mode = utils.LayoutEnum.from_tensor(b_gemm).mma_major_mode()
+        self.c_layout = utils.LayoutEnum.from_tensor(c_gemm)
+
+        # =================================================================
+        # Step 3: Setup kernel attributes
+        # =================================================================
+        self._setup_attributes()
+        tiled_mma = self._create_tiled_mma()
+        tiled_mma_sfb = self._create_tiled_mma_sfb()
+
+        # =================================================================
+        # Step 4: Create TMA ops (atoms built after helper kernel)
+        # =================================================================
+        # TMA load A
+        a_op = sm100_utils.cluster_shape_to_tma_atom_A(self.cluster_shape_mn, tiled_mma.thr_id)
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+
+        # TMA load B
+        b_op = sm100_utils.cluster_shape_to_tma_atom_B(self.cluster_shape_mn, tiled_mma.thr_id)
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+
+        # TMA ops for SFA/SFB
+        sfa_op = sm100_utils.cluster_shape_to_tma_atom_A(self.cluster_shape_mn, tiled_mma.thr_id)
+        sfb_op = sm100_utils.cluster_shape_to_tma_atom_SFB(self.cluster_shape_mn, tiled_mma.thr_id)
+
+        # TMA store/reduce C
+        if cutlass.const_expr(self.accumulate_on_output):
+            c_tma_op = cpasync.CopyReduceBulkTensorTileS2GOp()
+        else:
+            c_tma_op = cpasync.CopyBulkTensorTileS2GOp()
+
+        # =================================================================
+        # Step 5: Scheduler params and grid
+        # =================================================================
+        sched_params = MoESchedulerParams(
+            scenario="2Dx2D",
+            expert_shape=(expert_cnt, intermediate_dim, hidden_dim),
+            cta_tile_shape_mnk=self.cta_tile_shape_mnk,
+            cluster_shape_mn=self.cluster_shape_mn,
+        )
+        grid = MoESchedulerParams.get_grid_shape(sched_params, max_active_clusters)
+
+        # =================================================================
+        # Step 6: Launch helper kernel (both Dense and Discrete)
+        # =================================================================
+        # Identical to wgrad_baseline — SFA2 has no tensormap slot (LDGSTS).
+        sfa_smem_layout = cute.slice_(self.sfa_smem_layout_staged, (None, None, None, 0))
+        sfb_smem_layout = cute.slice_(self.sfb_smem_layout_staged, (None, None, None, 0))
+        epi_smem_layout_helper = cute.select(self.c_smem_layout_staged, mode=[0, 1]) if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else None
+        if cutlass.const_expr(self.input_order == WGradInputOrder.TensorRagged):
+            a_smem_layout_helper = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+            b_smem_layout_helper = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+            a_gemm_helper = a_gemm
+            b_gemm_helper = b_gemm
+            a_op_helper = a_op
+            b_op_helper = b_op
+        else:
+            a_smem_layout_helper = None
+            b_smem_layout_helper = None
+            a_gemm_helper = None
+            b_gemm_helper = None
+            a_op_helper = None
+            b_op_helper = None
+
+        self.helper_kernel(
+            sfa_gemm,
+            sfb_gemm,
+            offs,
+            workspace.iterator,
+            sfa_op,
+            sfa_smem_layout,
+            sfb_op,
+            sfb_smem_layout,
+            tiled_mma,
+            tiled_mma_sfb,
+            self.cluster_layout_vmnk.shape,
+            self.cluster_layout_sfb_vmnk.shape,
+            out if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else None,
+            c_gemm if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else None,
+            c_tma_op if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else None,
+            epi_smem_layout_helper,
+            self.epi_tile if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else None,
+            a_gemm_helper,
+            b_gemm_helper,
+            a_op_helper,
+            b_op_helper,
+            a_smem_layout_helper,
+            b_smem_layout_helper,
+        ).launch(
+            grid=(expert_cnt, 1, 1),
+            block=(1, 1, 1),
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+        # Build A, B, SFA, SFB, C TMA atoms AFTER the helper kernel launch
+        # (see wgrad_baseline for the host-region contamination rationale).
+        tma_atom_a, tma_tensor_a = cute.nvgpu.make_tiled_tma_atom_A(
+            a_op,
+            a_gemm,
+            a_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+        tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op,
+            b_gemm,
+            b_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+        sfa_smem_layout = cute.slice_(self.sfa_smem_layout_staged, (None, None, None, 0))
+        tma_atom_sfa, tma_tensor_sfa = cute.nvgpu.make_tiled_tma_atom_A(
+            sfa_op,
+            sfa_gemm,
+            sfa_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=cutlass.Uint64,
+        )
+        sfb_smem_layout = cute.slice_(self.sfb_smem_layout_staged, (None, None, None, 0))
+        tma_atom_sfb, tma_tensor_sfb = cute.nvgpu.make_tiled_tma_atom_B(
+            sfb_op,
+            sfb_gemm,
+            sfb_smem_layout,
+            self.mma_tiler_sfb,
+            tiled_mma_sfb,
+            self.cluster_layout_sfb_vmnk.shape,
+            internal_type=cutlass.Uint64,
+        )
+        epi_smem_layout = cute.select(self.c_smem_layout_staged, mode=[0, 1])
+        tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+            c_tma_op,
+            c_gemm,
+            epi_smem_layout,
+            self.epi_tile,
+        )
+
+        # =================================================================
+        # Step 7: Launch main kernel
+        # =================================================================
+        self.kernel(
+            tiled_mma,
+            tiled_mma_sfb,
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_sfa,
+            tma_tensor_sfa,
+            tma_atom_sfb,
+            tma_tensor_sfb,
+            sfa2_gemm,
+            tma_atom_c,
+            tma_tensor_c,
+            a_gemm,
+            b_gemm,
+            c_gemm,
+            sfa_gemm,
+            sfb_gemm,
+            offs,
+            sched_params,
+            workspace.iterator,
+            self.cluster_layout_vmnk,
+            self.cluster_layout_sfb_vmnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.sfa2_smem_layout_staged,
+            self.c_smem_layout_staged,
+            self.final_acc_smem_layout_staged,
+            self.epi_tile,
+            global_scale_a,
+            global_scale_b,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            stream=stream,
+            min_blocks_per_mp=self.occupancy,
+        )
+
+    # ------------------------------------------------------------------
+    # helper_kernel (expert-wise TMA desc init via construct_and_write)
+    # ------------------------------------------------------------------
+
+    @cute.kernel
+    def helper_kernel(
+        self,
+        sfa_gemm: cute.Tensor,
+        sfb_gemm: cute.Tensor,
+        offs: cute.Tensor,
+        workspace_ptr,
+        sfa_tma_op: cutlass.Constexpr,
+        sfa_smem_layout,
+        sfb_tma_op: cutlass.Constexpr,
+        sfb_smem_layout,
+        tiled_mma: cute.TiledMma,
+        tiled_mma_sfb: cute.TiledMma,
+        cluster_layout_vmnk_shape: cutlass.Constexpr,
+        cluster_layout_sfb_vmnk_shape: cutlass.Constexpr,
+        c_ptrs=None,
+        c_single_expert=None,
+        c_tma_op: cutlass.Constexpr = None,
+        epi_smem_layout=None,
+        epi_tile=None,
+        a_tensor=None,
+        b_tensor=None,
+        a_tma_op: cutlass.Constexpr = None,
+        b_tma_op: cutlass.Constexpr = None,
+        a_smem_layout=None,
+        b_smem_layout=None,
+    ):
+        """Build per-expert TMA descriptors (identical to wgrad_baseline)."""
+        from ..moe_utils import (
+            WgradSfTensormapConstructor,
+        )
+
+        ctor = WgradSfTensormapConstructor(
+            sf_vec_size=self.sf_vec_size,
+            weight_mode=self.weight_mode,
+            sfa_tma_op=sfa_tma_op,
+            sfb_tma_op=sfb_tma_op,
+            sfa_smem_layout=sfa_smem_layout,
+            sfb_smem_layout=sfb_smem_layout,
+            tiled_mma=tiled_mma,
+            tiled_mma_sfb=tiled_mma_sfb,
+            mma_tiler=self.mma_tiler,
+            mma_tiler_sfb=self.mma_tiler_sfb,
+            cluster_layout_vmnk_shape=cluster_layout_vmnk_shape,
+            cluster_layout_sfb_vmnk_shape=cluster_layout_sfb_vmnk_shape,
+            sfa_tensor=sfa_gemm,
+            sfb_tensor=sfb_gemm,
+            offs=offs,
+            workspace_ptr=workspace_ptr,
+            c_tma_op=c_tma_op,
+            epi_smem_layout=epi_smem_layout,
+            epi_tile=epi_tile,
+            c_ptrs=c_ptrs,
+            c_single_expert=c_single_expert,
+            expert_cnt=self.expert_cnt,
+            input_order=self.input_order,
+            a_tma_op=a_tma_op,
+            b_tma_op=b_tma_op,
+            a_smem_layout=a_smem_layout,
+            b_smem_layout=b_smem_layout,
+            a_major_mode=self.a_major_mode,
+            b_major_mode=self.b_major_mode,
+            a_tensor=a_tensor,
+            b_tensor=b_tensor,
+        )
+        expert_idx = cute.arch.block_idx()[0]
+        ctor.construct_and_write(expert_idx)
+
+    # ------------------------------------------------------------------
+    # kernel (GPU device kernel)
+    # ------------------------------------------------------------------
+
+    helper_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tiled_mma_sfb: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        mSFA_mkl: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        mSFB_nkl: cute.Tensor,
+        sfa2_tensor: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        a_gemm: cute.Tensor,
+        b_gemm: cute.Tensor,
+        c_gemm: cute.Tensor,
+        sfa_gemm: cute.Tensor,
+        sfb_gemm: cute.Tensor,
+        offs: cute.Tensor,
+        sched_params: MoESchedulerParams,
+        workspace_ptr,
+        cluster_layout_vmnk: cute.Layout,
+        cluster_layout_sfb_vmnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        sfa2_smem_layout_staged: cute.Layout,
+        c_smem_layout_staged: cute.ComposedLayout,
+        final_acc_smem_layout_staged: cute.ComposedLayout,
+        epi_tile: cute.Tile,
+        global_scale_a: Optional[cute.Tensor],
+        global_scale_b: Optional[cute.Tensor],
+    ):
+        """GPU device kernel for MoE wgrad with second-level A scaling."""
+
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        lane_idx = cute.arch.lane_idx()
+        use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+
+        bidx, bidy, bidz = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
+        block_in_cluster_coord_sfb_vmnk = cluster_layout_sfb_vmnk.get_flat_coord(cta_rank_in_cluster)
+        tidx, _, _ = cute.arch.thread_idx()
+
+        # =================================================================
+        # SharedStorage
+        # =================================================================
+        SchedulerStorage = MoEPersistentTileScheduler.make_storage_struct(self.num_sched_stages, use_dynamic_sched=True)
+
+        @cute.struct
+        class SharedStorage:
+            ab_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage * 2]
+            acc_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage * 2]
+            scale_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_scale_stage * 2]
+            epi_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_epi_stage * 2]
+            scheduler: SchedulerStorage
+            tmem_dealloc_mbar_ptr: cutlass.Int64
+            tmem_holding_buf: cutlass.Int32
+
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        sched_storage = storage.scheduler
+
+        # =================================================================
+        # Pipelines
+        # =================================================================
+
+        ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_tma_producer = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        ab_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, num_tma_producer)
+        ab_producer, ab_consumer = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.ab_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_ab_stage,
+            producer_group=ab_pipeline_producer_group,
+            consumer_group=ab_pipeline_consumer_group,
+            tx_count=self.num_tma_load_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+
+        # Partial-accumulator pipeline: MMA warp (producer, one stage per
+        # scale block) -> acc-update warpgroup (consumer, elect_one release
+        # per warp: 4 arrivals, x2 across the 2-CTA pair).
+        acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_acc_consumer_threads = len(self.accumulator_update_warp_id) * (2 if use_2cta_instrs else 1)
+        acc_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, num_acc_consumer_threads)
+        acc_pipeline = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_stage,
+            producer_group=acc_pipeline_producer_group,
+            consumer_group=acc_pipeline_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        # SFA2 pipeline: scale warp (cp.async producer) -> acc-update warps
+        scale_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * 1,
+        )
+        scale_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * len(self.accumulator_update_warp_id),
+        )
+        scale_pipeline = pipeline.PipelineCpAsync.create(
+            barrier_storage=storage.scale_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_scale_stage,
+            producer_group=scale_pipeline_producer_group,
+            consumer_group=scale_pipeline_consumer_group,
+            defer_sync=True,
+        )
+
+        # Final-accumulator pipeline: acc-update warps -> epilogue warps
+        epi_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * len(self.accumulator_update_warp_id),
+        )
+        epi_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * len(self.epilog_warp_id),
+        )
+        epi_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.epi_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_epi_stage,
+            producer_group=epi_pipeline_producer_group,
+            consumer_group=epi_pipeline_consumer_group,
+            defer_sync=True,
+        )
+
+        # Scheduler pipeline (sched warp -> every other warp)
+        sched_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 32)
+        num_sched_consumer_threads = 32 * len(
+            (
+                self.tma_warp_id,
+                self.mma_warp_id,
+                self.scale_warp_id,
+                *self.accumulator_update_warp_id,
+                *self.epilog_warp_id,
+            )
+        )
+        sched_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, num_sched_consumer_threads)
+        sched_pipeline = pipeline.PipelineAsync.create(
+            num_stages=self.num_sched_stages,
+            producer_group=sched_producer_group,
+            consumer_group=sched_consumer_group,
+            barrier_storage=sched_storage.tile_info_mbar.data_ptr(),
+            defer_sync=True,
+        )
+
+        # TMEM allocator (allocated by epilogue warp 4; MMA + acc-update +
+        # epilogue warps all retrieve → the barrier spans those 9 warps)
+        tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=self.tmem_alloc_sync_bar_id,
+            num_threads=32
+            * len(
+                (
+                    self.mma_warp_id,
+                    *self.accumulator_update_warp_id,
+                    *self.epilog_warp_id,
+                )
+            ),
+        )
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr,
+            barrier_for_retrieve=tmem_alloc_barrier,
+            allocator_warp_id=self.epilog_warp_id[0],
+            is_two_cta=use_2cta_instrs,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr.ptr,
+            arch="sm_107",
+        )
+
+        # Scheduler (CLC-based for 2Dx2D)
+        scheduler = MoEPersistentTileScheduler.create(
+            sched_params,
+            offs,
+            cute.arch.block_idx(),
+            cute.arch.grid_dim(),
+            counter_ptr=None,
+            sched_storage=sched_storage,
+        )
+        scheduler.internal_init()
+
+        # Cluster barrier sync after init
+        pipeline_init_arrive(cluster_shape_mn=self.cluster_shape_mn, is_relaxed=True)
+
+        # =================================================================
+        # SMEM tensors
+        # =================================================================
+        sA = smem.allocate_tensor(
+            element_type=self.a_dtype,
+            layout=a_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=a_smem_layout_staged.inner,
+        )
+        sB = smem.allocate_tensor(
+            element_type=self.b_dtype,
+            layout=b_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=b_smem_layout_staged.inner,
+        )
+        sSFA = smem.allocate_tensor(
+            element_type=self.sf_dtype,
+            layout=sfa_smem_layout_staged,
+            byte_alignment=128,
+        )
+        sSFB = smem.allocate_tensor(
+            element_type=self.sf_dtype,
+            layout=sfb_smem_layout_staged,
+            byte_alignment=128,
+        )
+        sSFA2 = smem.allocate_tensor(
+            element_type=self.sf2_dtype,
+            layout=sfa2_smem_layout_staged,
+            byte_alignment=128,
+        )
+        sFinalAcc = smem.allocate_tensor(
+            element_type=self.acc_dtype,
+            layout=final_acc_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=final_acc_smem_layout_staged.inner,
+        )
+
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+        tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, self.num_acc_stage))
+
+        # Scheduler buf tensor for sched_pipeline broadcast
+        sched_buf_ptr = sched_storage.sInfo.data_ptr()
+        sched_copy_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), cutlass.Int32, num_bits_per_copy=128)
+        sched_buf_tensor = cute.make_tensor(
+            sched_buf_ptr,
+            cute.make_layout((4, self.num_sched_stages), stride=(1, 4)),
+        )
+
+        # LDGSTS (cp.async) setup for the second-level A scale
+        atom_scale2_copy = cute.make_copy_atom(
+            cute.nvgpu.cpasync.CopyG2SOp(),
+            self.sf2_dtype,
+            num_bits_per_copy=self.sf2_dtype.width,
+        )
+        tiled_copy_sfa2 = cute.make_tiled_copy_tv(atom_scale2_copy, cute.make_layout((32,)), cute.make_layout((1,)))
+        thr_copy_sfa2 = tiled_copy_sfa2.get_slice(lane_idx)
+        tAsSFA2 = thr_copy_sfa2.partition_D(sSFA2)
+
+        # SFA2 viewed as a C-tile tensor: M is the CTA-tile-clamped scale
+        # block grid (sgm = 1 → per-row), N fully broadcast (no SFB2).
+        sSFA2_view_as_C_layout = cute.make_layout(
+            (
+                (self.scale_size_m, self.scale_m_per_tile),
+                self.cta_tile_shape_mnk[1],
+                self.num_scale_stage,
+            ),
+            stride=((0, 1), 0, self.scale_m_per_tile),
+        )
+        sSFA2_view_as_C = cute.make_tensor(sSFA2.iterator, sSFA2_view_as_C_layout)
+
+        # Number of K MMA tiles that share a single second-level scale block
+        k_tile_same_scale_factor = self.sgk // self.mma_tiler[2]
+
+        # Build extension
+        from ..moe_utils import (
+            TensormapWorkspace,
+            WgradSfTensormapConstructor,
+        )
+
+        slot_names = WgradSfTensormapConstructor.slot_names(self.input_order, self.weight_mode)
+        desc_workspace = TensormapWorkspace(workspace_ptr, slot_names)
+        ext = WgradScaledGemmSchedExtension(
+            tensormap_ctor=desc_workspace,
+            sf_vec_size=self.sf_vec_size,
+            sgk=self.sgk,
+            weight_mode=self.weight_mode,
+            input_order=self.input_order,
+        )
+
+        # Cluster wait
+        pipeline_init_wait(cluster_shape_mn=self.cluster_shape_mn)
+
+        # =================================================================
+        # Scheduler warp (warp 10)
+        # =================================================================
+        if warp_idx == self.sched_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_uniform_warps)
+            sched_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_sched_stages)
+
+            work_tile_info = scheduler.initial_work_tile_info()
+
+            sched_pipeline.producer_acquire(sched_producer_state)
+            rmem = work_tile_info.to_rmem_tensor()
+            cute.copy(
+                sched_copy_atom,
+                rmem,
+                sched_buf_tensor[(None, sched_producer_state.index)],
+            )
+            cute.arch.fence_proxy("async.shared", space="cta")
+            sched_pipeline.producer_commit(sched_producer_state)
+            sched_producer_state.advance()
+
+            work_tile_info = scheduler.advance_to_next_work()
+            while work_tile_info.is_valid_tile:
+                sched_pipeline.producer_acquire(sched_producer_state)
+                rmem = work_tile_info.to_rmem_tensor()
+                cute.copy(
+                    sched_copy_atom,
+                    rmem,
+                    sched_buf_tensor[(None, sched_producer_state.index)],
+                )
+                cute.arch.fence_proxy("async.shared", space="cta")
+                sched_pipeline.producer_commit(sched_producer_state)
+                sched_producer_state.advance()
+
+                work_tile_info = scheduler.advance_to_next_work()
+
+            sched_pipeline.producer_acquire(sched_producer_state)
+            sentinel = MoEWorkTileInfo(
+                cutlass.Int32(-1),
+                cutlass.Int32(0),
+                cutlass.Int32(0),
+                cutlass.Int32(0),
+            )
+            rmem = sentinel.to_rmem_tensor()
+            cute.copy(
+                sched_copy_atom,
+                rmem,
+                sched_buf_tensor[(None, sched_producer_state.index)],
+            )
+            cute.arch.fence_proxy("async.shared", space="cta")
+            sched_pipeline.producer_commit(sched_producer_state)
+            sched_pipeline.producer_tail(sched_producer_state)
+
+        # =================================================================
+        # TMA load warp (warp 9) — identical to wgrad_baseline
+        # =================================================================
+        if warp_idx == self.tma_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_uniform_warps)
+            a_full_mcast_mask = None
+            b_full_mcast_mask = None
+            sfa_full_mcast_mask = None
+            sfb_full_mcast_mask = None
+            if cutlass.const_expr(self.is_a_mcast or self.is_b_mcast or use_2cta_instrs):
+                a_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2)
+                b_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1)
+                sfa_full_mcast_mask = cpasync.create_tma_multicast_mask(cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2)
+                sfb_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                    cluster_layout_sfb_vmnk,
+                    block_in_cluster_coord_sfb_vmnk,
+                    mcast_mode=1,
+                )
+
+            sched_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_sched_stages)
+
+            sched_pipeline.consumer_wait(sched_consumer_state)
+            rmem = cute.make_rmem_tensor((4,), cutlass.Int32)
+            cute.copy(
+                sched_copy_atom,
+                sched_buf_tensor[(None, sched_consumer_state.index)],
+                rmem,
+            )
+            work_tile_info = MoEWorkTileInfo.from_rmem_tensor(rmem)
+            cute.arch.fence_acq_rel_cta()
+            sched_pipeline.consumer_release(sched_consumer_state)
+            sched_consumer_state.advance()
+
+            while work_tile_info.is_valid_tile:
+                k_tile_cnt = work_tile_info.k_tile_cnt
+                ext.update_expert_info(offs, work_tile_info.expert_idx)
+
+                real_a, desc_ptr_a = ext.get_gmem_tensor(
+                    "a",
+                    mA_mkl,
+                    offs,
+                    work_tile_info,
+                )
+                real_b, desc_ptr_b = ext.get_gmem_tensor(
+                    "b",
+                    mB_nkl,
+                    offs,
+                    work_tile_info,
+                )
+                real_sfa, desc_ptr_sfa = ext.get_gmem_tensor(
+                    "sfa",
+                    mSFA_mkl,
+                    offs,
+                    work_tile_info,
+                )
+                real_sfb, desc_ptr_sfb = ext.get_gmem_tensor(
+                    "sfb",
+                    mSFB_nkl,
+                    offs,
+                    work_tile_info,
+                )
+
+                gA_mkl = cute.local_tile(
+                    real_a,
+                    cute.slice_(self.mma_tiler, (None, 0, None)),
+                    (None, None, None),
+                )
+                gB_nkl = cute.local_tile(
+                    real_b,
+                    cute.slice_(self.mma_tiler, (0, None, None)),
+                    (None, None, None),
+                )
+                gSFA_mkl = cute.local_tile(
+                    real_sfa,
+                    cute.slice_(self.mma_tiler, (None, 0, None)),
+                    (None, None, None),
+                )
+                gSFB_nkl = cute.local_tile(
+                    real_sfb,
+                    cute.slice_(self.mma_tiler_sfb, (0, None, None)),
+                    (None, None, None),
+                )
+
+                thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+                thr_mma_sfb = tiled_mma_sfb.get_slice(mma_tile_coord_v)
+                tCgA = thr_mma.partition_A(gA_mkl)
+                tCgB = thr_mma.partition_B(gB_nkl)
+                tCgSFA = thr_mma.partition_A(gSFA_mkl)
+                tCgSFB = thr_mma_sfb.partition_B(gSFB_nkl)
+
+                a_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape)
+                tAsA, tAgA = cpasync.tma_partition(
+                    tma_atom_a,
+                    block_in_cluster_coord_vmnk[2],
+                    a_cta_layout,
+                    cute.group_modes(sA, 0, 3),
+                    cute.group_modes(tCgA, 0, 3),
+                )
+                b_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape)
+                tBsB, tBgB = cpasync.tma_partition(
+                    tma_atom_b,
+                    block_in_cluster_coord_vmnk[1],
+                    b_cta_layout,
+                    cute.group_modes(sB, 0, 3),
+                    cute.group_modes(tCgB, 0, 3),
+                )
+                sfa_cta_layout = a_cta_layout
+                tAsSFA, tAgSFA = cpasync.tma_partition(
+                    tma_atom_sfa,
+                    block_in_cluster_coord_vmnk[2],
+                    sfa_cta_layout,
+                    cute.group_modes(sSFA, 0, 3),
+                    cute.group_modes(tCgSFA, 0, 3),
+                )
+                tAsSFA = cute.filter_zeros(tAsSFA)
+                tAgSFA = cute.filter_zeros(tAgSFA)
+                sfb_cta_layout = cute.make_layout(cute.slice_(cluster_layout_sfb_vmnk, (0, None, 0, 0)).shape)
+                tBsSFB, tBgSFB = cpasync.tma_partition(
+                    tma_atom_sfb,
+                    block_in_cluster_coord_sfb_vmnk[1],
+                    sfb_cta_layout,
+                    cute.group_modes(sSFB, 0, 3),
+                    cute.group_modes(tCgSFB, 0, 3),
+                )
+                tBsSFB = cute.filter_zeros(tBsSFB)
+                tBgSFB = cute.filter_zeros(tBgSFB)
+
+                mma_tile_m = work_tile_info.tile_m_idx // cute.size(tiled_mma.thr_id.shape)
+                tAgA_slice = tAgA[(None, mma_tile_m, None, 0)]
+                tBgB_slice = tBgB[(None, work_tile_info.tile_n_idx, None, 0)]
+                tAgSFA_slice = tAgSFA[(None, mma_tile_m, None, 0)]
+                slice_n = work_tile_info.tile_n_idx
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
+                    slice_n = work_tile_info.tile_n_idx // 2
+                tBgSFB_slice = tBgSFB[(None, slice_n, None, 0)]
+
+                ab_producer.reset()
+                peek_ab_empty_status = ab_producer.try_acquire()
+
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                    handle = ab_producer.acquire_and_advance(peek_ab_empty_status)
+                    peek_ab_empty_status = cutlass.Boolean(1)
+                    if handle.count + 1 < k_tile_cnt:
+                        peek_ab_empty_status = ab_producer.try_acquire()
+                    cute.copy(
+                        tma_atom_a,
+                        tAgA_slice[(None, handle.count)],
+                        tAsA[(None, handle.index)],
+                        tma_bar_ptr=handle.barrier,
+                        tma_desc_ptr=desc_ptr_a,
+                        mcast_mask=a_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_b,
+                        tBgB_slice[(None, handle.count)],
+                        tBsB[(None, handle.index)],
+                        tma_bar_ptr=handle.barrier,
+                        tma_desc_ptr=desc_ptr_b,
+                        mcast_mask=b_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_sfa,
+                        tAgSFA_slice[(None, handle.count)],
+                        tAsSFA[(None, handle.index)],
+                        tma_bar_ptr=handle.barrier,
+                        tma_desc_ptr=desc_ptr_sfa,
+                        mcast_mask=sfa_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_sfb,
+                        tBgSFB_slice[(None, handle.count)],
+                        tBsSFB[(None, handle.index)],
+                        tma_bar_ptr=handle.barrier,
+                        tma_desc_ptr=desc_ptr_sfb,
+                        mcast_mask=sfb_full_mcast_mask,
+                    )
+
+                sched_pipeline.consumer_wait(sched_consumer_state)
+                rmem = cute.make_rmem_tensor((4,), cutlass.Int32)
+                cute.copy(
+                    sched_copy_atom,
+                    sched_buf_tensor[(None, sched_consumer_state.index)],
+                    rmem,
+                )
+                work_tile_info = MoEWorkTileInfo.from_rmem_tensor(rmem)
+                cute.arch.fence_acq_rel_cta()
+                sched_pipeline.consumer_release(sched_consumer_state)
+                sched_consumer_state.advance()
+            ab_producer.tail()
+
+        # =================================================================
+        # Second-level scale load warp (warp 11)
+        # =================================================================
+        if warp_idx == self.scale_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_uniform_warps)
+
+            scale_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_scale_stage)
+            sched_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_sched_stages)
+
+            sched_pipeline.consumer_wait(sched_consumer_state)
+            rmem = cute.make_rmem_tensor((4,), cutlass.Int32)
+            cute.copy(
+                sched_copy_atom,
+                sched_buf_tensor[(None, sched_consumer_state.index)],
+                rmem,
+            )
+            work_tile_info = MoEWorkTileInfo.from_rmem_tensor(rmem)
+            cute.arch.fence_acq_rel_cta()
+            sched_pipeline.consumer_release(sched_consumer_state)
+            sched_consumer_state.advance()
+
+            while work_tile_info.is_valid_tile:
+                k_tile_cnt = work_tile_info.k_tile_cnt
+                ext.update_expert_info(offs, work_tile_info.expert_idx)
+
+                mSFA2_mkl_current, _ = ext.get_gmem_tensor(
+                    "sfa2",
+                    sfa2_tensor,
+                    offs,
+                    work_tile_info,
+                )
+
+                gSFA2_mkl = cute.local_tile(
+                    mSFA2_mkl_current,
+                    cute.slice_(self.cta_tile_shape_mnk, (None, 0, None)),
+                    (None, None, None),
+                )
+                cSFA2_mkl = cute.make_identity_tensor(cute.shape(mSFA2_mkl_current))
+                cSFA2 = cute.local_tile(
+                    cSFA2_mkl,
+                    cute.slice_(self.cta_tile_shape_mnk, (None, 0, None)),
+                    (None, None, None),
+                )
+
+                tAgSFA2_mkl = thr_copy_sfa2.partition_S(gSFA2_mkl)
+                tAcSFA2 = thr_copy_sfa2.partition_S(cSFA2)
+
+                # SFA2 tiling is per-CTA: raw (CTA-granular) tile_m_idx
+                tile_m_cta = work_tile_info.tile_m_idx
+
+                # OOB predication mask over the M rows this lane loads
+                tApSFA2 = cute.make_rmem_tensor(
+                    cute.make_layout(cute.filter_zeros(cute.slice_(tAsSFA2, (None, None, None, 0))).shape),
+                    cutlass.Boolean,
+                )
+
+                scale_producer_state.reset_count()
+                peek_scale_empty_status = cutlass.Boolean(1)
+                if scale_producer_state.count < k_tile_cnt:
+                    peek_scale_empty_status = scale_pipeline.producer_try_acquire(scale_producer_state)
+
+                for k_tile in cutlass.range(0, k_tile_cnt // k_tile_same_scale_factor, 1, unroll=1):
+                    tAsSFA2_pipe = cute.filter_zeros(tAsSFA2[(None, None, None, scale_producer_state.index)])
+                    tAgSFA2_k = cute.filter_zeros(
+                        tAgSFA2_mkl[
+                            (
+                                None,
+                                None,
+                                None,
+                                tile_m_cta,
+                                scale_producer_state.count * k_tile_same_scale_factor,
+                                0,
+                            )
+                        ]
+                    )
+                    tAcSFA2_compact = cute.filter_zeros(
+                        cute.slice_(
+                            tAcSFA2,
+                            (
+                                None,
+                                None,
+                                None,
+                                tile_m_cta,
+                                scale_producer_state.count * k_tile_same_scale_factor,
+                                0,
+                            ),
+                        )
+                    )
+
+                    for i in cutlass.range_constexpr(cute.size(tApSFA2, mode=[1])):
+                        tApSFA2[((0, 0), i, (0, 0))] = cute.elem_less(tAcSFA2_compact[(i)][0], mSFA2_mkl_current.shape[0])
+
+                    scale_pipeline.producer_acquire(scale_producer_state, peek_scale_empty_status)
+                    cute.copy(tiled_copy_sfa2, tAgSFA2_k, tAsSFA2_pipe, pred=tApSFA2)
+                    scale_pipeline.producer_commit(scale_producer_state)
+
+                    scale_producer_state.advance()
+                    peek_scale_empty_status = cutlass.Boolean(1)
+                    if scale_producer_state.count < k_tile_cnt:
+                        peek_scale_empty_status = scale_pipeline.producer_try_acquire(scale_producer_state)
+
+                sched_pipeline.consumer_wait(sched_consumer_state)
+                rmem = cute.make_rmem_tensor((4,), cutlass.Int32)
+                cute.copy(
+                    sched_copy_atom,
+                    sched_buf_tensor[(None, sched_consumer_state.index)],
+                    rmem,
+                )
+                work_tile_info = MoEWorkTileInfo.from_rmem_tensor(rmem)
+                cute.arch.fence_acq_rel_cta()
+                sched_pipeline.consumer_release(sched_consumer_state)
+                sched_consumer_state.advance()
+
+        # =================================================================
+        # MMA warp (warp 8) — one clean partial accumulator per scale block
+        # =================================================================
+        if warp_idx == self.mma_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_uniform_warps)
+            tCrA = tiled_mma.make_fragment_A(sA)
+            tCrB = tiled_mma.make_fragment_B(sB)
+
+            tmem.wait_for_alloc()
+            acc_tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+
+            sfa_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            tCtSFA_layout = blockscaled_utils.make_tmem_layout_sfa(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfa_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFA = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout)
+
+            sfb_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            tCtSFB_layout = blockscaled_utils.make_tmem_layout_sfb(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfb_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFB = cute.make_tensor(sfb_tmem_ptr, tCtSFB_layout)
+
+            (
+                tiled_copy_s2t_sfa,
+                tCsSFA_compact_s2t,
+                tCtSFA_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFA, tCtSFA)
+            (
+                tiled_copy_s2t_sfb,
+                tCsSFB_compact_s2t,
+                tCtSFB_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFB, tCtSFB)
+
+            acc_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_acc_stage)
+            sched_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_sched_stages)
+
+            sched_pipeline.consumer_wait(sched_consumer_state)
+            rmem = cute.make_rmem_tensor((4,), cutlass.Int32)
+            cute.copy(
+                sched_copy_atom,
+                sched_buf_tensor[(None, sched_consumer_state.index)],
+                rmem,
+            )
+            work_tile_info = MoEWorkTileInfo.from_rmem_tensor(rmem)
+            cute.arch.fence_acq_rel_cta()
+            sched_pipeline.consumer_release(sched_consumer_state)
+            sched_consumer_state.advance()
+
+            while work_tile_info.is_valid_tile:
+                k_tile_cnt = work_tile_info.k_tile_cnt
+
+                tCtSFB_mma = tCtSFB
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
+                    offset = cutlass.Int32((work_tile_info.tile_n_idx % 2) * 2)
+                    shifted_ptr = cute.recast_ptr(
+                        acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols + offset,
+                        dtype=self.sf_dtype,
+                    )
+                    tCtSFB_mma = cute.make_tensor(shifted_ptr, tCtSFB_layout)
+
+                acc_producer_state.reset_count()
+                peek_acc_empty_status = cutlass.Boolean(1)
+                if is_leader_cta and k_tile_cnt > 0:
+                    peek_acc_empty_status = acc_pipeline.producer_try_acquire(acc_producer_state)
+
+                if is_leader_cta:
+                    ab_consumer.reset()
+                peek_ab_full_status = cutlass.Boolean(1)
+                if is_leader_cta and k_tile_cnt > 0:
+                    peek_ab_full_status = ab_consumer.try_wait()
+
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                    # Acquire a fresh accumulator stage at each scale block start
+                    if k_tile % k_tile_same_scale_factor == 0:
+                        if is_leader_cta:
+                            acc_pipeline.producer_acquire(acc_producer_state, peek_acc_empty_status)
+
+                    if is_leader_cta:
+                        tCtAcc = tCtAcc_base[(None, None, None, acc_producer_state.index)]
+
+                        handle = ab_consumer.wait_and_advance(peek_ab_full_status)
+                        peek_ab_full_status = cutlass.Boolean(1)
+                        if handle.count + 1 < k_tile_cnt:
+                            peek_ab_full_status = ab_consumer.try_wait()
+
+                        s2t_stage_coord = (None, None, None, None, handle.index)
+                        cute.copy(
+                            tiled_copy_s2t_sfa,
+                            tCsSFA_compact_s2t[s2t_stage_coord],
+                            tCtSFA_compact_s2t,
+                        )
+                        cute.copy(
+                            tiled_copy_s2t_sfb,
+                            tCsSFB_compact_s2t[s2t_stage_coord],
+                            tCtSFB_compact_s2t,
+                        )
+
+                        # Clean accumulator on the first tile of each block
+                        tiled_mma.set(
+                            tcgen05.Field.ACCUMULATE,
+                            k_tile % k_tile_same_scale_factor > 0,
+                        )
+                        tile_crd = (None, None, None, handle.index)
+                        cute.gemm(
+                            tiled_mma,
+                            tCtAcc,
+                            [tCrA[tile_crd], tCtSFA],
+                            [tCrB[tile_crd], tCtSFB_mma],
+                            tCtAcc,
+                        )
+                        handle.release()
+
+                    # Commit the block's partial accumulator to the consumers
+                    if k_tile % k_tile_same_scale_factor == k_tile_same_scale_factor - 1:
+                        if is_leader_cta:
+                            acc_pipeline.producer_commit(acc_producer_state)
+                        acc_producer_state.advance()
+                        peek_acc_empty_status = cutlass.Boolean(1)
+                        if acc_producer_state.count < k_tile_cnt:
+                            if is_leader_cta:
+                                peek_acc_empty_status = acc_pipeline.producer_try_acquire(acc_producer_state)
+
+                sched_pipeline.consumer_wait(sched_consumer_state)
+                rmem = cute.make_rmem_tensor((4,), cutlass.Int32)
+                cute.copy(
+                    sched_copy_atom,
+                    sched_buf_tensor[(None, sched_consumer_state.index)],
+                    rmem,
+                )
+                work_tile_info = MoEWorkTileInfo.from_rmem_tensor(rmem)
+                cute.arch.fence_acq_rel_cta()
+                sched_pipeline.consumer_release(sched_consumer_state)
+                sched_consumer_state.advance()
+
+            acc_pipeline.producer_tail(acc_producer_state)
+
+        # =================================================================
+        # SMEM tensor C (allocated after MMA section)
+        # =================================================================
+        sC = smem.allocate_tensor(
+            element_type=self.c_dtype,
+            layout=c_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=c_smem_layout_staged.inner,
+        )
+
+        # =================================================================
+        # Accumulator-update warps (warps 0-3): per scale block,
+        # final += partial * sfa2 in f32 registers; result -> sFinalAcc.
+        # NO empty-work early exit: k_tile_cnt == 0 tiles still zero-fill
+        # and produce the epi stage so empty experts write zeros.
+        # =================================================================
+        if warp_idx in self.accumulator_update_warp_id:
+            cute.arch.warpgroup_reg_alloc(self.num_regs_acc_update_warps)
+
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            tCtAcc_base = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+
+            # Shape-only partition on the output tensor (invariant t2r setup;
+            # never dereferenced — expert-uniform C shape)
+            gC_mnl_shape = cute.local_tile(
+                mC_mnl,
+                cute.slice_(self.mma_tiler, (None, None, 0)),
+                (None, None, None),
+            )
+            thr_mma_acc = tiled_mma.get_slice(mma_tile_coord_v)
+            tCgC_shape = thr_mma_acc.partition_C(gC_mnl_shape)
+
+            acc_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_acc_stage)
+            scale_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_scale_stage)
+            epi_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.num_epi_stage)
+
+            (
+                tiled_copy_t2r,
+                tiled_copy_r2s_acc,
+                tTR_tAcc_base,
+                tTR_rAcc,
+                tTR_rAcc_final,
+                tRS_sFinalAcc,
+                tTR_sSFA2,
+            ) = self.acc_update_tmem_copy_and_partition(
+                tidx,
+                tCtAcc_base,
+                tCgC_shape,
+                sSFA2_view_as_C,
+                sFinalAcc,
+                epi_tile,
+            )
+
+            sched_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_sched_stages)
+
+            sched_pipeline.consumer_wait(sched_consumer_state)
+            rmem = cute.make_rmem_tensor((4,), cutlass.Int32)
+            cute.copy(
+                sched_copy_atom,
+                sched_buf_tensor[(None, sched_consumer_state.index)],
+                rmem,
+            )
+            work_tile_info = MoEWorkTileInfo.from_rmem_tensor(rmem)
+            cute.arch.fence_acq_rel_cta()
+            sched_pipeline.consumer_release(sched_consumer_state)
+            sched_consumer_state.advance()
+
+            while work_tile_info.is_valid_tile:
+                k_tile_cnt = work_tile_info.k_tile_cnt
+
+                tTR_rAcc_final.fill(0.0)
+
+                tTR_rSFA2 = cute.make_rmem_tensor(
+                    cute.slice_(tTR_sSFA2, (None, None, None, 0, None, 0)).shape,
+                    self.acc_dtype,
+                )
+
+                acc_consumer_state.reset_count()
+                peek_acc_full_status = cutlass.Boolean(1)
+                if acc_consumer_state.count < k_tile_cnt:
+                    peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
+
+                scale_consumer_state.reset_count()
+                peek_scale_full_status = cutlass.Boolean(1)
+                if scale_consumer_state.count < k_tile_cnt:
+                    peek_scale_full_status = scale_pipeline.consumer_try_wait(scale_consumer_state)
+
+                for k_tile in cutlass.range(0, k_tile_cnt // k_tile_same_scale_factor, 1, unroll=1):
+                    # This scale block's per-row SFA2 from SMEM into registers
+                    scale_pipeline.consumer_wait(scale_consumer_state, peek_scale_full_status)
+                    tTR_sSFA2_slice = cute.slice_(
+                        tTR_sSFA2,
+                        (None, None, None, 0, None, scale_consumer_state.index),
+                    )
+                    scale_atom_copy = cute.make_copy_atom(
+                        cute.nvgpu.CopyUniversalOp(),
+                        self.acc_dtype,
+                        num_bits_per_copy=self.acc_dtype.width,
+                    )
+                    cute.copy(scale_atom_copy, tTR_sSFA2_slice, tTR_rSFA2)
+
+                    scale_pipeline.consumer_release(scale_consumer_state)
+                    scale_consumer_state.advance()
+
+                    # Wait for the block's partial accumulator from the MMA
+                    acc_pipeline.consumer_wait(acc_consumer_state, peek_acc_full_status)
+
+                    tTR_tAcc = tTR_tAcc_base[(None, None, None, None, None, acc_consumer_state.index)]
+                    tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+
+                    subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+                    assert cute.size(tTR_rAcc) % 2 == 0
+                    for subtile_idx in cutlass.range(subtile_cnt):
+                        tTR_tAcc_mn = tTR_tAcc[(None, None, None, subtile_idx)]
+                        cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+
+                        # final += partial * sfa2, as SEPARATELY-ROUNDED f32
+                        # mul then add: mul.rn is non-contractible (PTX), so
+                        # ptxas cannot fuse this into an FFMA — keeping the
+                        # kernel byte-exact vs the torch mul+add reference
+                        # for ARBITRARY f32 scales (the RHT producer's
+                        # amax/(6*448) descales are not powers of two).
+                        tTR_rAcc_subtile = tTR_rAcc_final[(None, None, None, subtile_idx)]
+                        tTR_rSFA2_sub = tTR_rSFA2[(None, None, None, subtile_idx)]
+                        for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
+                            s0, s1 = cute.arch.mul_packed_f32x2(
+                                (tTR_rAcc[i], tTR_rAcc[i + 1]),
+                                (tTR_rSFA2_sub[i], tTR_rSFA2_sub[i + 1]),
+                                rnd="rn",
+                                ftz=False,
+                            )
+                            tTR_rAcc_subtile[i] = tTR_rAcc_subtile[i] + s0
+                            tTR_rAcc_subtile[i + 1] = tTR_rAcc_subtile[i + 1] + s1
+
+                    with cute.arch.elect_one():
+                        acc_pipeline.consumer_release(acc_consumer_state)
+                    acc_consumer_state.advance()
+
+                    peek_acc_full_status = cutlass.Boolean(1)
+                    if acc_consumer_state.count < k_tile_cnt:
+                        peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
+                    peek_scale_full_status = cutlass.Boolean(1)
+                    if scale_consumer_state.count < k_tile_cnt:
+                        peek_scale_full_status = scale_pipeline.consumer_try_wait(scale_consumer_state)
+
+                # All scale blocks accumulated (or none: zeros) — publish the
+                # final tile to the epilogue through sFinalAcc.
+                epi_pipeline.producer_acquire(epi_producer_state)
+
+                final_subtile_cnt = cute.size(tTR_rAcc_final.shape, mode=[3])
+                slot_base = epi_producer_state.index * final_subtile_cnt
+                for subtile_idx in cutlass.range(final_subtile_cnt, unroll_full=True):
+                    tRS_rFinal = tiled_copy_r2s_acc.retile(tTR_rAcc_final[(None, None, None, subtile_idx)])
+                    cute.copy(
+                        tiled_copy_r2s_acc,
+                        tRS_rFinal,
+                        tRS_sFinalAcc[(None, None, None, slot_base + subtile_idx)],
+                    )
+
+                epi_pipeline.producer_commit(epi_producer_state)
+                epi_producer_state.advance()
+
+                sched_pipeline.consumer_wait(sched_consumer_state)
+                rmem = cute.make_rmem_tensor((4,), cutlass.Int32)
+                cute.copy(
+                    sched_copy_atom,
+                    sched_buf_tensor[(None, sched_consumer_state.index)],
+                    rmem,
+                )
+                work_tile_info = MoEWorkTileInfo.from_rmem_tensor(rmem)
+                cute.arch.fence_acq_rel_cta()
+                sched_pipeline.consumer_release(sched_consumer_state)
+                sched_consumer_state.advance()
+
+        # =================================================================
+        # Epilogue warps (warps 4-7): sFinalAcc -> alpha -> bf16 -> TMA C
+        # =================================================================
+        if warp_idx in self.epilog_warp_id:
+            cute.arch.warpgroup_reg_alloc(self.num_regs_epilogue_warps)
+            tmem.allocate(self.num_tmem_alloc_cols)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+
+            # Shape/TV-layout carrier only — the final accumulator lives in
+            # SMEM (sFinalAcc); TMEM holds just MMA partials + SF.
+            tCtAcc_base_ = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+
+            gC_mnl_shape = cute.local_tile(
+                mC_mnl,
+                cute.slice_(self.mma_tiler, (None, None, 0)),
+                (None, None, None),
+            )
+            thr_mma_epi = tiled_mma.get_slice(mma_tile_coord_v)
+            tCgC_shape = thr_mma_epi.partition_C(gC_mnl_shape)
+
+            epi_tidx = tidx % 128
+            (
+                tiled_copy_t2r,
+                tTR_tAcc_base,
+                tTR_rAcc,
+            ) = self.epilog_tmem_copy_and_partition(
+                epi_tidx,
+                tCtAcc_base_,
+                tCgC_shape,
+                epi_tile,
+                use_2cta_instrs,
+            )
+
+            tTR_rC = cute.make_rmem_tensor(tTR_rAcc.shape, self.c_dtype)
+            tiled_copy_r2s, tRS_rC, tRS_sC = self.epilog_smem_copy_and_partition(
+                tiled_copy_t2r,
+                tTR_rC,
+                epi_tidx,
+                sC,
+            )
+            tiled_copy_s2r, tSR_rAcc, tSR_sFinalAcc = self.epilog_smem_load_copy_and_partition(
+                tiled_copy_t2r,
+                tTR_rAcc,
+                epi_tidx,
+                sFinalAcc,
+            )
+
+            epi_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_epi_stage)
+            sched_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.num_sched_stages)
+            c_producer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                32 * len(self.epilog_warp_id),
+            )
+            c_pipeline = pipeline.PipelineTmaStore.create(num_stages=self.num_c_stage, producer_group=c_producer_group)
+
+            epilog_sync_barrier = pipeline.NamedBarrier(
+                barrier_id=self.epilog_sync_bar_id,
+                num_threads=32 * len(self.epilog_warp_id),
+            )
+
+            num_prev_subtiles = cutlass.Int32(0)
+
+            sched_pipeline.consumer_wait(sched_consumer_state)
+            rmem = cute.make_rmem_tensor((4,), cutlass.Int32)
+            cute.copy(
+                sched_copy_atom,
+                sched_buf_tensor[(None, sched_consumer_state.index)],
+                rmem,
+            )
+            work_tile_info = MoEWorkTileInfo.from_rmem_tensor(rmem)
+            cute.arch.fence_acq_rel_cta()
+            sched_pipeline.consumer_release(sched_consumer_state)
+            sched_consumer_state.advance()
+
+            while work_tile_info.is_valid_tile:
+                ext.update_expert_info(offs, work_tile_info.expert_idx)
+
+                real_c, desc_ptr_c = ext.get_gmem_tensor(
+                    "c",
+                    mC_mnl,
+                    offs,
+                    work_tile_info,
+                )
+
+                gC_mnl_loop = cute.local_tile(
+                    real_c,
+                    cute.slice_(self.mma_tiler, (None, None, 0)),
+                    (None, None, None),
+                )
+                tCgC_loop = thr_mma_epi.partition_C(gC_mnl_loop)
+                _, bSG_sC, bSG_gC_partitioned = epilog_gmem_copy_and_partition(
+                    epi_tidx,
+                    tma_atom_c,
+                    tCgC_loop,
+                    epi_tile,
+                    sC,
+                )
+
+                mma_tile_coord_mnl = (
+                    work_tile_info.tile_m_idx // cute.size(tiled_mma.thr_id.shape),
+                    work_tile_info.tile_n_idx,
+                    cutlass.Int32(0),
+                )
+                bSG_gC = bSG_gC_partitioned[(None, None, None, *mma_tile_coord_mnl)]
+                bSG_gC = cute.group_modes(bSG_gC, 1, cute.rank(bSG_gC))
+
+                if cutlass.const_expr(global_scale_a is not None):
+                    expert_idx = work_tile_info.expert_idx
+                    current_scale_a_iter = global_scale_a.iterator + expert_idx
+                    current_scale_b_iter = global_scale_b.iterator + expert_idx
+                    alpha = cute.arch.load(current_scale_a_iter.llvm_ptr, cutlass.Float32) * cute.arch.load(current_scale_b_iter.llvm_ptr, cutlass.Float32)
+                else:
+                    alpha = None
+
+                epi_stage_index = epi_consumer_state.index
+
+                # Wait for the final accumulator from the acc-update warps
+                epi_pipeline.consumer_wait(epi_consumer_state)
+
+                subtile_cnt = self.final_acc_subtile_cnt
+                for subtile_idx in cutlass.range(0, subtile_cnt, 1, unroll=1):
+                    final_slot = epi_stage_index * subtile_cnt + subtile_idx
+                    cute.copy(
+                        tiled_copy_s2r,
+                        tSR_sFinalAcc[(None, None, None, final_slot)],
+                        tSR_rAcc,
+                    )
+
+                    acc_vec = tiled_copy_r2s.retile(tTR_rAcc).load()
+                    if cutlass.const_expr(global_scale_a is not None):
+                        acc_vec = acc_vec * alpha
+                    acc_vec = acc_vec.to(self.c_dtype)
+                    tRS_rC.store(acc_vec)
+
+                    c_buffer = num_prev_subtiles % self.num_c_stage
+                    num_prev_subtiles = num_prev_subtiles + 1
+                    cute.copy(tiled_copy_r2s, tRS_rC, tRS_sC[(None, None, None, c_buffer)])
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    epilog_sync_barrier.arrive_and_wait()
+
+                    if warp_idx == self.epilog_warp_id[0]:
+                        cute.copy(
+                            tma_atom_c,
+                            bSG_sC[(None, c_buffer)],
+                            bSG_gC[(None, subtile_idx)],
+                            tma_desc_ptr=desc_ptr_c,
+                        )
+                        c_pipeline.producer_commit()
+                        c_pipeline.producer_acquire()
+                    epilog_sync_barrier.arrive_and_wait()
+
+                epi_pipeline.consumer_release(epi_consumer_state)
+                epi_consumer_state.advance()
+
+                sched_pipeline.consumer_wait(sched_consumer_state)
+                rmem = cute.make_rmem_tensor((4,), cutlass.Int32)
+                cute.copy(
+                    sched_copy_atom,
+                    sched_buf_tensor[(None, sched_consumer_state.index)],
+                    rmem,
+                )
+                work_tile_info = MoEWorkTileInfo.from_rmem_tensor(rmem)
+                cute.arch.fence_acq_rel_cta()
+                sched_pipeline.consumer_release(sched_consumer_state)
+                sched_consumer_state.advance()
+
+            c_pipeline.producer_tail()
+
+            tmem.relinquish_alloc_permit()
+            epilog_sync_barrier.arrive_and_wait()
+            tmem.free(tmem_ptr)
+
+    kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dswiglu_subchannel_scaled.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dswiglu_subchannel_scaled.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Tests for the Subchannel-Scaled dSwiGLU Grouped GEMM Kernel (SM100)
+Tests for the Subchannel-Scaled dSwiGLU Grouped GEMM Kernel (SM100+, Rubin dispatch)
 
 Second-level-scaled dSwiGLU-backward block-scaled grouped GEMM: NVFP4 A/B with
 per-(1, 16) e4m3 first-level scales plus f32 second-level (subchannel) scales,
@@ -13,12 +13,18 @@ BYTE-EXACT (``torch.equal``) against the ported harness references — do not
 loosen these to tolerance-based comparisons; find the real gap instead.
 dprob/dbias use tolerances only because their cross-tile atomic accumulation
 order is nondeterministic beyond two tiles.
+
+On Rubin the API dispatches to the sm107 kernel module transparently, so the
+whole suite doubles as its e2e coverage; the ``sf_e5m3`` ids additionally feed
+UE5M3-encoded first-level scales through ``sf_fp8_dtype_override="e5m3"`` (the
+e5m3 path is Rubin-only and skips elsewhere).
 """
 
 import pytest
 import torch
 
 from test_utils import torch_fork_set_rng
+from fe_api.grouped_gemm.test_grouped_gemm_wgrad_utils import _skip_unless_e5m3_supported
 from fe_api.grouped_gemm.test_grouped_gemm_dswiglu_subchannel_scaled_utils import (
     _sf_atom_unpack,
     _sf_to_mma,
@@ -58,6 +64,7 @@ def _run(problem, discrete=False, **overrides):
         dbias_dtype=problem["dbias_dtype"],
         block2_shape=problem["block2_shape"],
         d_deinterleaved=problem["d_deinterleaved"],
+        sf_fp8_dtype_override=problem["sf_fp8_dtype_override"],
     )
     if discrete:
         ptrs = build_discrete_pointers_dswiglu(problem)
@@ -76,6 +83,13 @@ def _run(problem, discrete=False, **overrides):
         )
     kwargs.update(overrides)
     return _wrapper()(**kwargs)
+
+
+# First-level scale format axis: e4m3 everywhere, e5m3 only on Rubin (skips
+# elsewhere). The e5m3 leg re-encodes the same scale values as UE5M3 bytes, so
+# the references are unchanged while the kernel must decode them as e5m3 and
+# emit e5m3-encoded d_quant_sf.
+SF_FORMATS = pytest.mark.parametrize("sf_fmt", ["e4m3", "e5m3"], ids=["sf_e4m3", "sf_e5m3"])
 
 
 def _check_outputs(out, problem):
@@ -144,18 +158,20 @@ def test_sf_atom_unpack_roundtrip():
 
 
 @pytest.mark.L0
+@SF_FORMATS
 @pytest.mark.parametrize("with_dbias", [False, True], ids=["nodbias", "dbias"])
 @torch_fork_set_rng(seed=0)
-def test_dswiglu_subchannel_wrapper_dense_bf16_interleaved(with_dbias):
-    problem = make_dswiglu_subchannel_problem(m_per_expert=256, n=128, k=512, l=2, with_dbias=with_dbias, d_deinterleaved=False, seed=0)
+def test_dswiglu_subchannel_wrapper_dense_bf16_interleaved(with_dbias, sf_fmt):
+    problem = make_dswiglu_subchannel_problem(m_per_expert=256, n=128, k=512, l=2, with_dbias=with_dbias, d_deinterleaved=False, seed=0, sf_fmt=sf_fmt)
     out = _run(problem)
     _check_outputs(out, problem)
 
 
 @pytest.mark.L0
+@SF_FORMATS
 @torch_fork_set_rng(seed=1)
-def test_dswiglu_subchannel_wrapper_dense_quant_deint():
-    problem = make_dswiglu_subchannel_problem(m_per_expert=256, n=128, k=512, l=2, d_quant=True, d_deinterleaved=True, with_dbias=True, seed=1)
+def test_dswiglu_subchannel_wrapper_dense_quant_deint(sf_fmt):
+    problem = make_dswiglu_subchannel_problem(m_per_expert=256, n=128, k=512, l=2, d_quant=True, d_deinterleaved=True, with_dbias=True, seed=1, sf_fmt=sf_fmt)
     out = _run(problem)
     _check_outputs(out, problem)
 
@@ -169,11 +185,12 @@ def test_dswiglu_subchannel_wrapper_dense_quant_interleaved():
 
 
 @pytest.mark.L0
+@SF_FORMATS
 @torch_fork_set_rng(seed=3)
-def test_dswiglu_subchannel_wrapper_discrete_quant_deint():
+def test_dswiglu_subchannel_wrapper_discrete_quant_deint(sf_fmt):
     # n=256, k=1024 with sgn=sgk=256 -> per-expert SFB2 block is 1x4 f32 =
     # 16 bytes, satisfying the 16B discrete alignment gate with l=2.
-    problem = make_dswiglu_subchannel_problem(m_per_expert=256, n=256, k=1024, l=2, d_quant=True, d_deinterleaved=True, seed=3)
+    problem = make_dswiglu_subchannel_problem(m_per_expert=256, n=256, k=1024, l=2, d_quant=True, d_deinterleaved=True, seed=3, sf_fmt=sf_fmt)
     out = _run(problem, discrete=True)
     _check_outputs(out, problem)
 
@@ -298,13 +315,14 @@ def test_dswiglu_subchannel_wrapper_cache():
 
 
 @pytest.mark.L0
+@SF_FORMATS
 @torch_fork_set_rng(seed=10)
-def test_dswiglu_subchannel_dsmem_rowwise_cluster22():
+def test_dswiglu_subchannel_dsmem_rowwise_cluster22(sf_fmt):
     """Rowwise-sfd2 DSMEM reduction (sgn=256, cluster (2,2): sgn/cta_n ==
     cluster_n) versus the gmem atomic + counter protocol at the same cluster
     shape: both must match the reference byte-exact AND each other bitwise
     (identical bit-pattern u32 max, order-independent)."""
-    problem = make_dswiglu_subchannel_problem(m_per_expert=256, n=256, k=512, l=2, with_dbias=True, d_quant=True, d_deinterleaved=True, seed=10)
+    problem = make_dswiglu_subchannel_problem(m_per_expert=256, n=256, k=512, l=2, with_dbias=True, d_quant=True, d_deinterleaved=True, seed=10, sf_fmt=sf_fmt)
     out_dsmem = _run(problem, cluster_shape_mn=(2, 2), dsmem_rowwise=True)
     _check_outputs(out_dsmem, problem)
     out_gmem = _run(problem, cluster_shape_mn=(2, 2), dsmem_rowwise=False)
@@ -350,3 +368,57 @@ def test_dswiglu_subchannel_cluster_negatives():
     # verifiable host-side on ragged inputs).
     with pytest.raises((ValueError, AssertionError)):
         _run(problem2, cluster_shape_mn=(4, 2))
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=14)
+def test_dswiglu_subchannel_e5m3_rejected_off_rubin(monkeypatch):
+    """e5m3 scale factors decode only in the sm107 MMA op; pretend to be Blackwell."""
+    import cudnn.api_base as api_base
+    from cudnn import GroupedGemmDswigluSubchannelScaledSm100
+
+    monkeypatch.setattr(api_base, "get_device_type", lambda: "blackwell")
+    problem = make_dswiglu_subchannel_problem(m_per_expert=256, n=128, k=512, l=2, d_quant=True, d_deinterleaved=True, seed=14)
+    mt, n2 = problem["valid_m"], 2 * problem["n"]
+    d_quant = torch.zeros((1, mt, n2 // 2), dtype=torch.uint8, device="cuda").view(torch.float4_e2m1fn_x2).permute(1, 2, 0)
+    d_quant_sf = torch.zeros((1, mt // 128, (n2 // 16) // 4, 32, 4, 4), dtype=torch.float8_e4m3fn, device="cuda").permute(3, 4, 1, 5, 2, 0)
+    dprob = torch.zeros((mt, 1, 1), dtype=torch.float32, device="cuda")
+    sfd2 = torch.zeros((1, 2 * problem["nd"], problem["sfd2_rows"]), dtype=torch.float32, device="cuda").permute(2, 1, 0)
+    api = GroupedGemmDswigluSubchannelScaledSm100(
+        sample_a=problem["a_tensor"],
+        sample_sfa=problem["sfa_tensor"],
+        sample_sfa2=problem["sfa2_tensor"],
+        sample_c=problem["c_tensor"],
+        sample_padded_offsets=problem["padded_offsets"],
+        sample_alpha=problem["alpha_tensor"],
+        sample_beta=problem["beta_tensor"],
+        sample_prob=problem["prob_tensor"],
+        sample_d=d_quant,
+        sample_dprob=dprob,
+        sample_sfd2=sfd2,
+        sample_d_quant_sf=d_quant_sf,
+        sample_norm_const=problem["norm_const_tensor"],
+        sample_b=problem["b_tensor"],
+        sample_sfb=problem["sfb_tensor"],
+        sample_sfb2=problem["sfb2_tensor"],
+        sf_fp8_dtype_override="e5m3",
+    )
+    with pytest.raises(ValueError, match="requires Rubin"):
+        api.check_support()
+
+    # Unknown override formats are rejected everywhere.
+    with pytest.raises(ValueError, match="sf_fp8_dtype_override must be"):
+        _run(problem, sf_fp8_dtype_override="e4m3")
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=15)
+def test_dswiglu_subchannel_e5m3_is_not_cached_as_e4m3():
+    """sf_fp8_dtype_override must take part in the compile cache key: identical
+    scale bytes decode differently under E4M3 and UE5M3."""
+    _skip_unless_e5m3_supported()
+    problem = make_dswiglu_subchannel_problem(m_per_expert=256, n=128, k=512, l=2, d_quant=False, d_deinterleaved=False, seed=15)
+    d_e4m3 = _run(problem)["d_tensor"].float().clone()
+    d_e5m3 = _run(problem, sf_fp8_dtype_override="e5m3")["d_tensor"].float().clone()
+    torch.cuda.synchronize()
+    assert not torch.equal(d_e4m3, d_e5m3), "e5m3 and e4m3 produced identical output from identical scale-factor bytes"

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dswiglu_subchannel_scaled.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dswiglu_subchannel_scaled.py
@@ -1,0 +1,352 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the Subchannel-Scaled dSwiGLU Grouped GEMM Kernel (SM100)
+
+Second-level-scaled dSwiGLU-backward block-scaled grouped GEMM: NVFP4 A/B with
+per-(1, 16) e4m3 first-level scales plus f32 second-level (subchannel) scales,
+fused dSwiGLU epilogue with dprob, optional dbias, second-level output
+descales (sfd2), and optional NVFP4 D quantization (interleaved or
+deinterleaved gate/up layout). d / d_quant / d_quant_sf / sfd2 are compared
+BYTE-EXACT (``torch.equal``) against the ported harness references — do not
+loosen these to tolerance-based comparisons; find the real gap instead.
+dprob/dbias use tolerances only because their cross-tile atomic accumulation
+order is nondeterministic beyond two tiles.
+"""
+
+import pytest
+import torch
+
+from test_utils import torch_fork_set_rng
+from fe_api.grouped_gemm.test_grouped_gemm_dswiglu_subchannel_scaled_utils import (
+    _sf_atom_unpack,
+    _sf_to_mma,
+    build_discrete_pointers_dswiglu,
+    make_dswiglu_subchannel_problem,
+)
+
+
+@pytest.fixture(autouse=True)
+def require_sm100():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 100:
+        pytest.skip("SM100 is required")
+
+
+def _wrapper():
+    from cudnn import grouped_gemm_dswiglu_subchannel_scaled_wrapper_sm100
+
+    return grouped_gemm_dswiglu_subchannel_scaled_wrapper_sm100
+
+
+def _run(problem, discrete=False, **overrides):
+    kwargs = dict(
+        a_tensor=problem["a_tensor"],
+        sfa_tensor=problem["sfa_tensor"],
+        sfa2_tensor=problem["sfa2_tensor"],
+        c_tensor=problem["c_tensor"],
+        padded_offsets=problem["padded_offsets"],
+        alpha_tensor=problem["alpha_tensor"],
+        beta_tensor=problem["beta_tensor"],
+        prob_tensor=problem["prob_tensor"],
+        d_dtype=(torch.float4_e2m1fn_x2 if problem["d_quant"] else torch.bfloat16),
+        norm_const_tensor=problem["norm_const_tensor"],
+        dbias=problem["with_dbias"],
+        dbias_dtype=problem["dbias_dtype"],
+        block2_shape=problem["block2_shape"],
+        d_deinterleaved=problem["d_deinterleaved"],
+    )
+    if discrete:
+        ptrs = build_discrete_pointers_dswiglu(problem)
+        kwargs.update(
+            b_ptrs=ptrs["b_ptrs"],
+            sfb_ptrs=ptrs["sfb_ptrs"],
+            sfb2_ptrs=ptrs["sfb2_ptrs"],
+            n=problem["n"],
+            b_dtype=torch.float4_e2m1fn_x2,
+        )
+    else:
+        kwargs.update(
+            b_tensor=problem["b_tensor"],
+            sfb_tensor=problem["sfb_tensor"],
+            sfb2_tensor=problem["sfb2_tensor"],
+        )
+    kwargs.update(overrides)
+    return _wrapper()(**kwargs)
+
+
+def _check_outputs(out, problem):
+    torch.cuda.synchronize()
+    mt, n, nd = problem["valid_m"], problem["n"], problem["nd"]
+    n2 = 2 * n
+    deint = problem["d_deinterleaved"]
+
+    # ---- d (byte-exact) ----
+    if not problem["d_quant"]:
+        got = out["d_tensor"].squeeze(-1)
+        ref = problem["ref_d"]
+        assert got.dtype == ref.dtype == torch.bfloat16
+        assert torch.equal(got, ref), (
+            f"bf16 d differs from reference: max abs diff "
+            f"{(got.float() - ref.float()).abs().max().item()}, "
+            f"mismatches {(got != ref).sum().item()}/{ref.numel()}"
+        )
+        assert out["d_quant_tensor"] is None and out["d_quant_sf_tensor"] is None
+    else:
+        assert out["d_tensor"] is None
+        got_q = out["d_quant_tensor"].view(torch.uint8).squeeze(-1)
+        ref_q = problem["ref_d_quant"]
+        assert got_q.shape == ref_q.shape == (mt, n)
+        assert torch.equal(got_q, ref_q), f"d_quant bytes differ: mismatches " f"{(got_q != ref_q).sum().item()}/{ref_q.numel()}"
+        got_sf = _sf_atom_unpack(out["d_quant_sf_tensor"].view(torch.uint8), mt, n2)
+        ref_sf = problem["ref_d_quant_sf"]
+        assert got_sf.shape == ref_sf.shape == (mt, n2 // 16)
+        assert torch.equal(got_sf, ref_sf), f"d_quant_sf bytes differ: mismatches " f"{(got_sf != ref_sf).sum().item()}/{ref_sf.numel()}"
+
+    # ---- sfd2 (byte-exact; atomic max commutes) ----
+    sfd2 = out["sfd2_tensor"]
+    if deint:
+        assert torch.equal(sfd2[:, :nd, 0], problem["ref_sfd2_gate"])
+        assert torch.equal(sfd2[:, nd:, 0], problem["ref_sfd2_up"])
+    else:
+        assert torch.equal(sfd2[:, 0::2, 0], problem["ref_sfd2_gate"])
+        assert torch.equal(sfd2[:, 1::2, 0], problem["ref_sfd2_up"])
+    assert torch.equal(out["sfd2_gate_tensor"][:, :, 0], problem["ref_sfd2_gate"])
+    assert torch.equal(out["sfd2_up_tensor"][:, :, 0], problem["ref_sfd2_up"])
+
+    # ---- dprob (atomic f32 adds across n-tiles) ----
+    torch.testing.assert_close(out["dprob_tensor"].reshape(-1, 1), problem["ref_dprob"], atol=1e-6, rtol=0)
+
+    # ---- dbias ----
+    if problem["with_dbias"]:
+        atol = 5e-2 if problem["dbias_dtype"] == torch.bfloat16 else 1e-6
+        torch.testing.assert_close(out["dbias_tensor"].squeeze(-1), problem["ref_dbias"], atol=atol, rtol=0)
+    else:
+        assert out["dbias_tensor"] is None
+
+
+@pytest.mark.L0
+def test_sf_atom_unpack_roundtrip():
+    """Validate _sf_atom_unpack independently: scatter flat scales into the
+    MMA-tiled view with the established forward converter (_sf_to_mma, the
+    same one the kernel's SFA/SFB inputs are built with) and check the unpack
+    inverts it exactly."""
+    torch.manual_seed(0)
+    mt, ksf = 256, 16  # n2 = 256
+    flat = torch.rand((1, mt, ksf), dtype=torch.float32) * 4.0 + 0.5
+    mma = _sf_to_mma(flat)  # e4m3, MMA-tiled (32, 4, mt//128, 4, rest, 1) view
+    got = _sf_atom_unpack(mma.view(torch.uint8), mt, ksf * 16)
+    expected = flat[0].to(torch.float8_e4m3fn).view(torch.uint8).cuda()
+    assert torch.equal(got, expected)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("with_dbias", [False, True], ids=["nodbias", "dbias"])
+@torch_fork_set_rng(seed=0)
+def test_dswiglu_subchannel_wrapper_dense_bf16_interleaved(with_dbias):
+    problem = make_dswiglu_subchannel_problem(m_per_expert=256, n=128, k=512, l=2, with_dbias=with_dbias, d_deinterleaved=False, seed=0)
+    out = _run(problem)
+    _check_outputs(out, problem)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=1)
+def test_dswiglu_subchannel_wrapper_dense_quant_deint():
+    problem = make_dswiglu_subchannel_problem(m_per_expert=256, n=128, k=512, l=2, d_quant=True, d_deinterleaved=True, with_dbias=True, seed=1)
+    out = _run(problem)
+    _check_outputs(out, problem)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=2)
+def test_dswiglu_subchannel_wrapper_dense_quant_interleaved():
+    problem = make_dswiglu_subchannel_problem(m_per_expert=256, n=128, k=512, l=2, d_quant=True, d_deinterleaved=False, with_dbias=True, seed=2)
+    out = _run(problem)
+    _check_outputs(out, problem)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=3)
+def test_dswiglu_subchannel_wrapper_discrete_quant_deint():
+    # n=256, k=1024 with sgn=sgk=256 -> per-expert SFB2 block is 1x4 f32 =
+    # 16 bytes, satisfying the 16B discrete alignment gate with l=2.
+    problem = make_dswiglu_subchannel_problem(m_per_expert=256, n=256, k=1024, l=2, d_quant=True, d_deinterleaved=True, seed=3)
+    out = _run(problem, discrete=True)
+    _check_outputs(out, problem)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=4)
+def test_dswiglu_subchannel_check_support_negatives():
+    quant_problem = make_dswiglu_subchannel_problem(m_per_expert=256, n=128, k=512, l=2, d_quant=True, d_deinterleaved=True, seed=4)
+    bf16_problem = make_dswiglu_subchannel_problem(m_per_expert=256, n=128, k=512, l=2, d_deinterleaved=False, seed=4)
+
+    # Deinterleaved layout requires the quantized (fp4) D output
+    with pytest.raises((ValueError, AssertionError)):
+        _run(bf16_problem, d_deinterleaved=True)
+
+    # Quantized D output requires norm_const
+    with pytest.raises((ValueError, AssertionError)):
+        _run(quant_problem, norm_const_tensor=None)
+
+    # Unsupported MMA tiler (only (256, 128))
+    with pytest.raises((ValueError, AssertionError)):
+        _run(quant_problem, mma_tiler_mn=(256, 256))
+
+    # Unsupported cluster shape (only (2, 1))
+    with pytest.raises((ValueError, AssertionError)):
+        _run(quant_problem, cluster_shape_mn=(1, 1))
+
+    # sgn must be a multiple of the MMA tile N (128)
+    with pytest.raises((ValueError, AssertionError)):
+        _run(quant_problem, block2_shape=(1, 192, 256))
+
+    # Generator gate: n % 128 != 0 (output width 2n % 256 != 0)
+    with pytest.raises(AssertionError):
+        make_dswiglu_subchannel_problem(m_per_expert=256, n=64, k=512, l=2, seed=4)
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize("discrete", [False, True], ids=["dense", "discrete"])
+@torch_fork_set_rng(seed=5)
+def test_dswiglu_subchannel_block2_512_quant_deint(discrete):
+    # sgn=512 spans 4 N work tiles -> exercises the sfd2 cross-tile arrival
+    # protocol (sfd2_n_contrib=4). k=2048 (not 1024) so the discrete per-expert
+    # SFB2 block (1x4 f32 = 16 B) passes the 16B discrete alignment gate.
+    problem = make_dswiglu_subchannel_problem(
+        m_per_expert=256,
+        n=512,
+        k=2048,
+        l=2,
+        block2_shape=(1, 512, 512),
+        d_quant=True,
+        d_deinterleaved=True,
+        seed=5,
+    )
+    out = _run(problem, discrete=discrete)
+    _check_outputs(out, problem)
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=6)
+def test_dswiglu_subchannel_partial_sfd2_block():
+    # n=128 with sgn=256: nd=1, the single sfd2 block covers only half its
+    # nominal width (partial block), and the quant fold map broadcast is
+    # clamped to the real n/16 width.
+    problem = make_dswiglu_subchannel_problem(
+        m_per_expert=256,
+        n=128,
+        k=512,
+        l=2,
+        block2_shape=(1, 256, 256),
+        d_quant=True,
+        d_deinterleaved=True,
+        seed=6,
+    )
+    assert problem["nd"] == 1
+    out = _run(problem)
+    _check_outputs(out, problem)
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=7)
+def test_dswiglu_subchannel_dbias_f32():
+    # float32 dbias: the testing-only plain-atomic path, tight tolerance.
+    problem = make_dswiglu_subchannel_problem(
+        m_per_expert=256,
+        n=128,
+        k=512,
+        l=2,
+        d_quant=True,
+        d_deinterleaved=True,
+        with_dbias=True,
+        dbias_dtype=torch.float32,
+        seed=7,
+    )
+    out = _run(problem)
+    _check_outputs(out, problem)
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=8)
+def test_dswiglu_subchannel_larger():
+    problem = make_dswiglu_subchannel_problem(m_per_expert=512, n=256, k=1024, l=4, d_quant=True, d_deinterleaved=True, seed=8)
+    out = _run(problem)
+    _check_outputs(out, problem)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=9)
+def test_dswiglu_subchannel_wrapper_cache():
+    from cudnn.gemm.cutedsl.grouped.dswiglu_subchannel_scaled.api import (
+        _cache_of_GroupedGemmDswigluSubchannelScaledSm100Objects as cache,
+    )
+
+    problem = make_dswiglu_subchannel_problem(m_per_expert=256, n=128, k=512, l=2, d_quant=True, d_deinterleaved=True, seed=9)
+    out1 = _run(problem)
+    n_cached = len(cache)
+    # Second call with the same configuration must reuse the cached object.
+    out2 = _run(problem)
+    assert len(cache) == n_cached
+    torch.cuda.synchronize()
+    assert torch.equal(out1["d_quant_tensor"].view(torch.uint8), out2["d_quant_tensor"].view(torch.uint8))
+    assert torch.equal(out1["sfd2_tensor"], out2["sfd2_tensor"])
+    _check_outputs(out2, problem)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=10)
+def test_dswiglu_subchannel_dsmem_rowwise_cluster22():
+    """Rowwise-sfd2 DSMEM reduction (sgn=256, cluster (2,2): sgn/cta_n ==
+    cluster_n) versus the gmem atomic + counter protocol at the same cluster
+    shape: both must match the reference byte-exact AND each other bitwise
+    (identical bit-pattern u32 max, order-independent)."""
+    problem = make_dswiglu_subchannel_problem(m_per_expert=256, n=256, k=512, l=2, with_dbias=True, d_quant=True, d_deinterleaved=True, seed=10)
+    out_dsmem = _run(problem, cluster_shape_mn=(2, 2), dsmem_rowwise=True)
+    _check_outputs(out_dsmem, problem)
+    out_gmem = _run(problem, cluster_shape_mn=(2, 2), dsmem_rowwise=False)
+    _check_outputs(out_gmem, problem)
+    torch.cuda.synchronize()
+    assert torch.equal(out_dsmem["d_quant_tensor"].view(torch.uint8), out_gmem["d_quant_tensor"].view(torch.uint8))
+    assert torch.equal(out_dsmem["d_quant_sf_tensor"].view(torch.uint8), out_gmem["d_quant_sf_tensor"].view(torch.uint8))
+    assert torch.equal(out_dsmem["sfd2_tensor"], out_gmem["sfd2_tensor"])
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=11)
+def test_dswiglu_subchannel_cluster22_bf16_interleaved():
+    """cluster_n=2 on the bf16-D path: row_dsmem is inert (generate_sfd off),
+    validating the plain cluster_n>1 enablement (scheduler/multicast)."""
+    problem = make_dswiglu_subchannel_problem(m_per_expert=256, n=256, k=512, l=2, d_quant=False, d_deinterleaved=False, seed=11)
+    out = _run(problem, cluster_shape_mn=(2, 2))
+    _check_outputs(out, problem)
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize("discrete", [False, True], ids=["dense", "discrete"])
+@torch_fork_set_rng(seed=12)
+def test_dswiglu_subchannel_dsmem_rowwise_sgn512_cluster24(discrete):
+    """sgn=512 with cluster (2,4): four N work tiles per sfd2 block, all
+    cluster peers — the widest rowwise DSMEM geometry."""
+    problem = make_dswiglu_subchannel_problem(
+        m_per_expert=256, n=512, k=2048, l=2, with_dbias=True, d_quant=True, d_deinterleaved=True, block2_shape=(1, 512, 512), seed=12
+    )
+    out = _run(problem, discrete=discrete, cluster_shape_mn=(2, 4), dsmem_rowwise=True)
+    _check_outputs(out, problem)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=13)
+def test_dswiglu_subchannel_cluster_negatives():
+    problem = make_dswiglu_subchannel_problem(m_per_expert=256, n=384, k=512, l=2, d_quant=True, d_deinterleaved=True, seed=13)
+    # ceil(384/128) = 3 N work tiles is not a cluster_n=2 multiple.
+    with pytest.raises((ValueError, AssertionError)):
+        _run(problem, cluster_shape_mn=(2, 2))
+    problem2 = make_dswiglu_subchannel_problem(m_per_expert=256, n=256, k=512, l=2, d_quant=True, d_deinterleaved=True, seed=13)
+    # cluster_m=4 is not supported by the FE API (per-expert-M gate not
+    # verifiable host-side on ragged inputs).
+    with pytest.raises((ValueError, AssertionError)):
+        _run(problem2, cluster_shape_mn=(4, 2))

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dswiglu_subchannel_scaled_utils.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dswiglu_subchannel_scaled_utils.py
@@ -1,0 +1,825 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for the subchannel-scaled dSwiGLU grouped GEMM tests.
+
+Builds two-level NVFP4 inputs (reusing the unfused subchannel-scaled test
+utils) plus the BYTE-EXACT torch/DSL reference of the fused kernel's op:
+
+    d2n = dSwiGLU(alpha^2 * subchannel_scaled_gemm(A, B), beta * C, prob)
+
+with fused dprob (the kernel's exact reduction tree), optional per-expert
+dbias column sums (the kernel's tilewise scheme), second-level output
+descales sfd2 (per-(sgm x sgn) block amax of the deinterleaved dy_gate /
+dy_up halves, divided by the NVFP4 two-level encode range with the DSL's
+approximate '/'), and the optional NVFP4 quantization of d (the kernel's
+quant_sfd_row op sequence, replayed by a standalone DSL kernel).
+
+The op-order-sensitive pieces (sigmoid, SFD2 divide, NVFP4 quantize) are
+ported verbatim from the bs_ggemm_harness reference modules
+(``references/activation/dglu.py``, ``references/activation/dsl.py``,
+``references/reduction/torch.py``, ``references/quantization/dsl.py``,
+``references/fc2_dgrad.py``) so the comparisons stay bit-exact — do not
+"simplify" them into plain torch ops.
+
+FE ``n`` convention: ``n`` is the GEMM/weight width (the harness reference's
+``f``); the n-axis outputs cover ``2n`` (the harness reference's ``n``).
+"""
+
+from typing import Optional, Tuple
+
+import pytest
+import torch
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import llvm, math, vector, arith
+from cutlass.cute.typing import Float32, Int32
+from cutlass.cute.runtime import from_dlpack
+from cutlass.cutlass_dsl import T
+
+from cudnn.gemm.cutedsl.grouped.moe_kernel_helpers import fmin
+
+from fe_api.test_fe_api_utils import ceil_div
+from fe_api.grouped_gemm.test_grouped_gemm_unfused_subchannel_scaled_utils import (
+    NVFP4_MAX_REPRESENTABLE,
+    _grouped_gemm_second_level_scaled,
+    _group_ranges,
+    _pack_fp4x2,
+    _quantize_two_level,
+    _second_level_block_amax,
+    _sf2_strided,
+    _sf_to_mma,
+    build_discrete_pointers,
+)
+
+# Thread-block sizes of the ported DSL reference kernels (each file's
+# module-level _THREADS: 256 in references/activation/dsl.py, 128 in
+# references/quantization/dsl.py).
+_SIGMOID_THREADS = 256
+_LOG2_E = 1.4426950408889634
+_THREADS = 128
+
+# Compile cache of the DSL test kernels (one entry per shape/config).
+_compiled: dict = {}
+
+
+def _stream():
+    return cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+
+# ---------------------------------------------------------------------------
+# Private port of the harness kernels/common/device/moe_kernel_helpers.py
+# cvt_f32_to_e4m3_byte_and_f32 (not present in the FE shared
+# cudnn.gemm.cutedsl.grouped.moe_kernel_helpers module).
+# ---------------------------------------------------------------------------
+
+
+def _cvt_f32_to_e4m3_byte_and_f32(fp32x1, loc=None, ip=None):
+    """Scalar f32 -> e4m3 (rn, satfinite), returning (encoded byte as Int32,
+    exact f32 decode). Pure PTX so it compiles on both DSL wheels — the public
+    4.5 wheel rejects scalar narrow-precision `.to()` conversions
+    (nvgpu.cvt_fptrunc/cvt_fpext require vector operands). Bit-identical to the
+    generic `.to(Float8E4M3FN)` / `.to(Float32)` pair: same cvt.rn.satfinite
+    encode, and e4m3 decodes exactly in f16."""
+    src_fp32 = Float32(fp32x1).ir_value(loc=loc, ip=ip)
+    asm_tmpl = (
+        "{\n"
+        "  .reg .b16 q;\n"
+        "  .reg .b32 up;\n"
+        "  cvt.rn.satfinite.e4m3x2.f32 q, 0f00000000, $2;\n"
+        "  cvt.rn.f16x2.e4m3x2 up, q;\n"
+        "  cvt.u32.u16 $0, q;\n"
+        "  mov.b32 $1, up;\n"
+        "}"
+    )
+    res = llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(i32, i32)>"),
+        [src_fp32],
+        asm_tmpl,
+        "=r,=r,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+    byte_i32 = llvm.extractvalue(T.i32(), res, [0], loc=loc, ip=ip)
+    f16x2_i32 = llvm.extractvalue(T.i32(), res, [1], loc=loc, ip=ip)
+    vec_f16_ty = ir.Type.parse("vector<2xf16>")
+    f16x2 = llvm.bitcast(vec_f16_ty, f16x2_i32, loc=loc, ip=ip)
+    h0 = vector.extract(f16x2, [], [0], loc=loc, ip=ip)
+    decoded = Float32(arith.extf(Float32.mlir_type, h0, loc=loc, ip=ip))
+    return Int32(byte_i32), decoded
+
+
+# ---------------------------------------------------------------------------
+# DSL sigmoid — port of references/activation/dsl.py (the fused kernels' EXACT
+# sigmoid: rcp.approx(exp2.approx(x * -log2e) + 1); the approx instructions are
+# device-generation-dependent, so the reference replays them on-device).
+# ---------------------------------------------------------------------------
+
+
+class _Sigmoid:
+    """out[i] = rcp.approx(exp2.approx(x[i] * -log2e) + 1) — the kernels' sigmoid."""
+
+    def __init__(self, n):
+        self.n = n
+
+    @cute.kernel
+    def kernel(self, x: cute.Tensor, out: cute.Tensor):
+        bidx, _, _ = cute.arch.block_idx()
+        tidx, _, _ = cute.arch.thread_idx()
+        i = bidx * _SIGMOID_THREADS + tidx
+        if i < self.n:
+            t = x[i] * cutlass.Float32(-_LOG2_E)
+            e = cute.math.exp2(t, fastmath=True)
+            out[i] = cute.arch.rcp_approx(e + cutlass.Float32(1.0))
+
+    @cute.jit
+    def __call__(self, x: cute.Tensor, out: cute.Tensor, stream: cuda.CUstream):
+        self.kernel(x, out).launch(
+            grid=((self.n + _SIGMOID_THREADS - 1) // _SIGMOID_THREADS, 1, 1),
+            block=(_SIGMOID_THREADS, 1, 1),
+            stream=stream,
+        )
+
+
+def sigmoid(x: torch.Tensor) -> torch.Tensor:
+    """The fused kernels' sigmoid over any-shape CUDA tensor; returns float32 of
+    the same shape. Compiled once per element count."""
+    assert x.is_cuda, "dsl sigmoid runs on the GPU (same device as the kernels)"
+    x32 = x.detach().to(torch.float32).contiguous().view(-1)
+    out = torch.empty_like(x32)
+    n = x32.numel()
+    key = ("sigmoid", n)
+    args = (from_dlpack(x32, assumed_align=4), from_dlpack(out, assumed_align=4), _stream())
+    if key not in _compiled:
+        _compiled[key] = cute.compile(_Sigmoid(n), *args, options="--generate-line-info")
+    _compiled[key](*args)
+    return out.view(x.shape)
+
+
+# ---------------------------------------------------------------------------
+# dGLU torch reference — port of references/activation/dglu.py (dswiglu path).
+# ---------------------------------------------------------------------------
+
+
+def _split_gate_up(c: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Deinterleave the 32-feature gate/up bands: (m, n) -> gate, up (m, n/2)."""
+    m, n2 = c.shape
+    assert n2 % 64 == 0, f"gate/up 32-feature bands need n % 64 == 0, got n={n2}"
+    bands = c.reshape(m, n2 // 64, 2, 32)
+    return bands[:, :, 0, :].reshape(m, -1), bands[:, :, 1, :].reshape(m, -1)
+
+
+def _merge_gate_up(dy1: torch.Tensor, dy2: torch.Tensor) -> torch.Tensor:
+    """Inverse of _split_gate_up: (m, n/2) x2 -> (m, n) interleaved bands."""
+    m, n = dy1.shape
+    return torch.stack((dy1.reshape(m, n // 32, 32), dy2.reshape(m, n // 32, 32)), dim=2).reshape(m, 2 * n)
+
+
+def _seq_sum(t: torch.Tensor) -> torch.Tensor:
+    """Strictly sequential f32 sum over the LAST dim (torch.sum's reduction
+    order is unspecified; the kernel's is not)."""
+    s = torch.zeros_like(t[..., 0])
+    for i in range(t.shape[-1]):
+        s = s + t[..., i]
+    return s
+
+
+def dprob_rowsum(x: torch.Tensor, tile_n: int = 128) -> torch.Tensor:
+    """Row sum replaying the dgrad_dglu kernel's dprob reduction tree exactly:
+    per 32-column chunk, sequential even-lane and odd-lane pair sums are added
+    (p0 + p1); chunk totals accumulate sequentially within each tile_n n-tile;
+    tile partials combine in ascending tile order (the kernel's per-tile f32
+    atomics). tile_n is the mma tiler N (128 — the kernel's only supported
+    tiler). Bit-exact vs the kernel for up to TWO n-tiles (two f32 adds onto
+    a zeroed buffer commute); with 3+ tiles the kernel's atomic arrival order
+    is nondeterministic and only tolerance-level agreement is possible.
+    (m, n) -> (m, 1)."""
+    m, n = x.shape
+    assert n % 32 == 0, f"32-wide dprob chunks need n % 32 == 0, got n={n}"
+    x = x.float()
+    chunks = x.reshape(m, n // 32, 32)
+    chunk_tot = _seq_sum(chunks[..., 0::2]) + _seq_sum(chunks[..., 1::2])
+    # Ragged last tile is fine: sequential accumulation per tile slice.
+    tile_tots = [_seq_sum(chunk_tot[:, t0 : t0 + tile_n // 32]) for t0 in range(0, n // 32, tile_n // 32)]
+    return _seq_sum(torch.stack(tile_tots, dim=-1)).reshape(m, 1)
+
+
+def dswiglu(
+    g: torch.Tensor,  # (m, n/2) f32, upstream gradient (gemm result, alpha applied)
+    c: torch.Tensor,  # (m, n) f32, forward pre-activations (RAW — beta applies inside)
+    prob: torch.Tensor,  # (m,) f32, per-token multiplier
+    beta: Optional[torch.Tensor] = None,  # (m,) f32, per-row C scale (applied AFTER the clamps)
+    glu_alpha: Optional[float] = None,  # extra upstream-gradient scale
+    glu_clamp_max: Optional[float] = None,  # gate/up clamps on the RAW C values,
+    glu_clamp_min: Optional[float] = None,  # gate max-only, up both sides
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """dSwiGLU: gradients through d = up * (gate * sigmoid(gate)) * prob,
+    replaying the kernel's op order: glu_alpha on the accumulator, clamps on
+    the raw C values (gate upper-only, up both sides), then beta."""
+    m = g.shape[0]
+    x1, x2 = _split_gate_up(c.float())
+    g = g.float()
+    p = prob.reshape(m, 1).float().to(g.device)
+
+    if glu_alpha is not None and float(glu_alpha) != 1.0:
+        g = g * float(glu_alpha)
+    if glu_clamp_max is not None and glu_clamp_min is not None:
+        x1 = x1.clamp(max=float(glu_clamp_max))
+        x2 = x2.clamp(max=float(glu_clamp_max)).clamp(min=float(glu_clamp_min))
+    if beta is not None:
+        b = beta.reshape(m, 1).float().to(g.device)
+        x1 = x1 * b
+        x2 = x2 * b
+
+    sig = sigmoid(x1)
+    swish = x1 * sig
+
+    dprob = dprob_rowsum(swish * x2 * g)
+    dy1 = g * p * x2 * sig * (1 + x1 * (1 - sig))
+    dy2 = g * p * swish
+    return _merge_gate_up(dy1, dy2), dprob, dy1, dy2
+
+
+# ---------------------------------------------------------------------------
+# dbias column sums — port of references/reduction/torch.py::colsum_tilewise.
+# ---------------------------------------------------------------------------
+
+
+def colsum_tilewise(x: torch.Tensor, acc_dtype: torch.dtype = torch.float32, tile: Tuple[int, int] = (128, 256)) -> torch.Tensor:
+    """Column sums with the kernel's tiling/accumulation: (rows, cols) ->
+    (cols,) in acc_dtype. Only tile[0] (rows per partial) is numeric; tile[1]
+    is the DSL kernel's column blocking, with no effect here (columns are
+    independent)."""
+    assert x.dim() == 2, f"expected 2-D input, got {tuple(x.shape)}"
+    tile_m = tile[0]
+    assert tile_m % 32 == 0, f"tile_m ({tile_m}) must be a multiple of 32 (warp chunks)"
+    rows, cols = x.shape
+    assert rows % tile_m == 0, f"rows ({rows}) must be {tile_m}-tileable"
+    x = x.float()
+    # f32 in-tile sums: (tiles, chunks, 32, cols) reduced sequentially over the
+    # 32 rows, then sequentially over the chunks.
+    chunks = x.reshape(rows // tile_m, tile_m // 32, 32, cols)
+    csum = torch.zeros(chunks.shape[0], chunks.shape[1], cols, dtype=torch.float32, device=x.device)
+    for r in range(32):
+        csum = csum + chunks[:, :, r]
+    partials = torch.zeros(chunks.shape[0], cols, dtype=torch.float32, device=x.device)
+    for c in range(csum.shape[1]):
+        partials = partials + csum[:, c]
+    # Accumulate tile partials in acc_dtype, ascending tile order.
+    acc = torch.zeros(cols, dtype=acc_dtype, device=x.device)
+    for t in range(partials.shape[0]):
+        acc = acc + partials[t].to(acc_dtype)
+    return acc
+
+
+# ---------------------------------------------------------------------------
+# Band (de)interleaving — port of references/fc2_dgrad.py lines 99-118.
+# ---------------------------------------------------------------------------
+
+
+def _interleave_bands(a: torch.Tensor, b: torch.Tensor, band: int) -> torch.Tensor:
+    """Interleave two (m, c) tensors in `band`-sized chunks -> (m, 2c):
+    a[:band], b[:band], a[band:2band], ... — the block-granularity analogue of
+    dglu._merge_gate_up (which interleaves 32-feature gate/up bands of c/d)."""
+    m, c = a.shape
+    return torch.stack((a.reshape(m, c // band, band), b.reshape(m, c // band, band)), dim=2).reshape(m, 2 * c)
+
+
+def _deinterleave_bands(x: torch.Tensor, band: int, dim: int = 1) -> torch.Tensor:
+    """Undo the gate/up interleave at `band`-sized chunks along `dim`: even
+    chunks (gate) first, odd chunks (up) second — the layout of the
+    deinterleaved kernel's n-axis outputs (interleaved 32-col band b ->
+    deinterleaved band position 32*(b//2) + (b%2)*(n/2))."""
+    x = x.movedim(dim, -1)
+    lead = x.shape[:-1]
+    c = x.shape[-1]
+    x = x.reshape(*lead, c // (2 * band), 2, band)
+    x = torch.cat((x[..., 0, :], x[..., 1, :]), dim=-2).reshape(*lead, c)
+    return x.movedim(-1, dim).contiguous()
+
+
+# ---------------------------------------------------------------------------
+# DSL NVFP4 quantize + second-level descale — port of
+# references/quantization/dsl.py (rowwise NVFP4-e4m3 path only; the e5m3 scale
+# branches are dropped — they need FloatNV8E5M3FNU, absent from this repo).
+# ---------------------------------------------------------------------------
+
+
+class _QuantNvfp4:
+    """Blockwise NVFP4 quantization at global encode scale norm_const. One
+    thread per two-block chunk, replicating the fused kernels'
+    flashinfer-derived op sequence (hadamard_utils._nvfp4_quant_row /
+    dgrad_dglu quant_sfd_row) exactly: packed f32x2 scale multiplies, satfinite
+    e4m3/e2m1 converts, rcp_approx + fmin. Input bf16 or f32 (the dgrad_dglu
+    kernel quantizes its raw f32 accumulator values). block is the format's
+    first-level vec size (a ctor param — the kernel takes one int, like the
+    fused kernels)."""
+
+    def __init__(self, m, f, norm_const=1.0, two_level=False, rowwise=True, block=None, sf_fmt="e4m3", sf_max=448.0):
+        self.m, self.f = m, f
+        self.block = int(block)
+        self.norm_const = float(norm_const)
+        # This port keeps the e4m3 scale format only (the NVFP4 recipe).
+        assert str(sf_fmt) == "e4m3", f"only e4m3 scale bytes are ported, got {sf_fmt}"
+        self.sf_fmt = str(sf_fmt)
+        self.sf_max = float(sf_max)
+        # When set, an extra per-first-level-block f32 second-level descale
+        # (sf2) is folded into the first-level scale, mirroring the dgrad_dglu
+        # kernels' quant_sfd_row / colwise-RHT quant: pvscale *=
+        # rcp_approx(sf2) BEFORE the encode cvt, while the data multiply stays
+        # on the un-prescaled values. The sf2 map shares the sf grid layout
+        # ((m, f/block) rowwise, (f, m/block) colwise).
+        self.two_level = bool(two_level)
+        # Rowwise: (1, 16) feature blocks, one CTA per token row. Colwise:
+        # (16, 1) token blocks, one CTA per 16-token slab, a thread quantizes
+        # two consecutive feature COLUMNS — identical per-block math, only the
+        # addressing differs. Scales: (m, f/16) rowwise, (f, m/16) colwise.
+        # Data bytes always land in the (m, f) orientation (a byte pairs two
+        # adjacent features of one token), like the fused kernels store them.
+        self.rowwise = bool(rowwise)
+
+    @cute.kernel
+    def kernel(self, x: cute.Tensor, q_u8: cute.Tensor, sf_u8: cute.Tensor, sf2: cute.Tensor):
+        bidx, _, _ = cute.arch.block_idx()
+        tidx, _, _ = cute.arch.thread_idx()
+        q_ptr = cute.recast_ptr(q_u8.iterator, dtype=cutlass.Float4E2M1FN)
+        q = cute.make_tensor(q_ptr, cute.make_layout((self.m, self.f), stride=(self.f, 1)))
+        if cutlass.const_expr(self.rowwise):
+            nblk = self.f // self.block
+            sf = cute.make_tensor(sf_u8.iterator, cute.make_layout((self.m, nblk), stride=(nblk, 1)))
+            nchunk = self.f // (2 * self.block)
+        else:
+            nblk = self.m // self.block
+            sf = cute.make_tensor(sf_u8.iterator, cute.make_layout((self.f, nblk), stride=(nblk, 1)))
+            nchunk = self.f // 2
+        norm_const = cutlass.Float32(self.norm_const)
+        for it in cutlass.range((nchunk + _THREADS - 1) // _THREADS, unroll_full=True):
+            cidx = it * _THREADS + tidx
+            if cidx < nchunk:
+                tCompute = cute.make_rmem_tensor((2 * self.block,), cutlass.Float32)
+                if cutlass.const_expr(self.rowwise):
+                    x_row = cute.zipped_divide(x[(bidx, None)], (2 * self.block,))
+                    x_rmem = cute.make_rmem_tensor((2 * self.block,), x.element_type)
+                    cute.autovec_copy(cute.slice_(x_row, ((None,), cidx)), x_rmem)
+                    for i in cutlass.range_constexpr(2 * self.block):
+                        tCompute[i] = x_rmem[i].to(cutlass.Float32)
+                else:
+                    # Block 0 = feature 2*cidx, block 1 = feature 2*cidx + 1,
+                    # each over this CTA's block-many tokens.
+                    for t in cutlass.range_constexpr(self.block):
+                        tCompute[t] = x[(bidx * self.block + t, 2 * cidx)].to(cutlass.Float32)
+                        tCompute[self.block + t] = x[(bidx * self.block + t, 2 * cidx + 1)].to(cutlass.Float32)
+
+                num_vecs = 2
+                tTR_rAcc_frg = cute.logical_divide(tCompute, cute.make_layout(self.block))
+                acc_frg = tTR_rAcc_frg.load()
+                abs_acc_frg_ir = math.absf(acc_frg.ir_value())
+                abs_acc_frg = type(acc_frg)(abs_acc_frg_ir, acc_frg.shape, acc_frg.dtype)
+                tCrSFC_pvscale = cute.make_rmem_tensor((num_vecs,), cutlass.Float32)
+                for vi in cutlass.range_constexpr(num_vecs):
+                    tCrSFC_pvscale[vi] = abs_acc_frg[None, vi].reduce(
+                        cute.ReductionOp.MAX,
+                        cutlass.Float32(0.0),
+                        0,
+                    )
+                for vi in cutlass.range_constexpr(0, num_vecs, 2):
+                    tCrSFC_pvscale[vi], tCrSFC_pvscale[vi + 1] = cute.arch.mul_packed_f32x2(
+                        (tCrSFC_pvscale[vi], tCrSFC_pvscale[vi + 1]),
+                        (cutlass.Float32(1 / 6.0), cutlass.Float32(1 / 6.0)),
+                    )
+                    tCrSFC_pvscale[vi], tCrSFC_pvscale[vi + 1] = cute.arch.mul_packed_f32x2(
+                        (tCrSFC_pvscale[vi], tCrSFC_pvscale[vi + 1]),
+                        (norm_const, norm_const),
+                    )
+                # Fold the second-level descale into the first-level scale
+                # (quant_sfd_row: pvscale *= rcp_approx(sfd2_descale)), so the
+                # encoded SF absorbs the second-level block magnitude exactly
+                # as the fused kernels do. The data multiply below is
+                # unchanged. sf2 is addressed exactly like the sf store below:
+                # (row, block) rowwise, (feature, token-block) colwise.
+                if cutlass.const_expr(self.two_level):
+                    for vi in cutlass.range_constexpr(num_vecs):
+                        if cutlass.const_expr(self.rowwise):
+                            sfd2_descale = sf2[(bidx, num_vecs * cidx + vi)]
+                        else:
+                            sfd2_descale = sf2[(2 * cidx + vi, bidx)]
+                        sfd2_scale = cute.arch.rcp_approx(sfd2_descale)
+                        tCrSFC_pvscale[vi] = tCrSFC_pvscale[vi] * sfd2_scale
+                # PTX e4m3 encode + exact decode in one shot — scalar f32/f8
+                # `.to()` conversions are rejected by the public 4.5 wheel.
+                # Same cvt.rn.satfinite.e4m3x2.f32 the generic conversion emits.
+                tCrSFC_up = cute.make_rmem_tensor((num_vecs,), cutlass.Float32)
+                for vi in cutlass.range_constexpr(num_vecs):
+                    sf_byte_i32, sf_up = _cvt_f32_to_e4m3_byte_and_f32(tCrSFC_pvscale[vi])
+                    sf_byte = cutlass.Uint8(sf_byte_i32)
+                    if cutlass.const_expr(self.rowwise):
+                        sf[(bidx, num_vecs * cidx + vi)] = sf_byte
+                    else:
+                        sf[(2 * cidx + vi, bidx)] = sf_byte
+                    tCrSFC_up[vi] = sf_up
+
+                fp32_max = cutlass.Float32(3.40282346638528859812e38)
+                for vi in cutlass.range_constexpr(0, num_vecs, 2):
+                    acc_scale = cute.arch.mul_packed_f32x2(
+                        (
+                            cute.arch.rcp_approx(tCrSFC_up[vi]),
+                            cute.arch.rcp_approx(tCrSFC_up[vi + 1]),
+                        ),
+                        (norm_const, norm_const),
+                    )
+                    acc_scale_min0 = fmin(acc_scale[0], fp32_max, nan=True)
+                    acc_scale_min1 = fmin(acc_scale[1], fp32_max, nan=True)
+                    vec0 = tTR_rAcc_frg[None, vi]
+                    vec1 = tTR_rAcc_frg[None, vi + 1]
+                    for ei in cutlass.range_constexpr(self.block):
+                        vec0[ei], vec1[ei] = cute.arch.mul_packed_f32x2(
+                            (vec0[ei], vec1[ei]),
+                            (acc_scale_min0, acc_scale_min1),
+                        )
+
+                if cutlass.const_expr(self.rowwise):
+                    fp4_rmem = cute.make_rmem_tensor((2 * self.block,), cutlass.Float4E2M1FN)
+                    fp4_rmem.store(tCompute.load().to(cutlass.Float4E2M1FN))
+                    q_row = cute.zipped_divide(q[(bidx, None)], (2 * self.block,))
+                    cute.autovec_copy(fp4_rmem, cute.slice_(q_row, ((None,), cidx)))
+                else:
+                    # Interleave the two feature columns so each byte packs the
+                    # (2*cidx, 2*cidx + 1) feature pair of one token, then one
+                    # byte store per token row.
+                    tInter = cute.make_rmem_tensor((2 * self.block,), cutlass.Float32)
+                    for t in cutlass.range_constexpr(self.block):
+                        tInter[2 * t] = tCompute[t]
+                        tInter[2 * t + 1] = tCompute[self.block + t]
+                    fp4_rmem = cute.make_rmem_tensor((2 * self.block,), cutlass.Float4E2M1FN)
+                    fp4_rmem.store(tInter.load().to(cutlass.Float4E2M1FN))
+                    fp4_pairs = cute.logical_divide(fp4_rmem, cute.make_layout(2))
+                    for t in cutlass.range_constexpr(self.block):
+                        q_pair_row = cute.zipped_divide(q[(bidx * self.block + t, None)], (2,))
+                        cute.autovec_copy(fp4_pairs[(None, t)], cute.slice_(q_pair_row, ((None,), cidx)))
+
+    @cute.jit
+    def __call__(self, x: cute.Tensor, q_u8: cute.Tensor, sf_u8: cute.Tensor, sf2: cute.Tensor, stream: cuda.CUstream):
+        grid_x = self.m if self.rowwise else self.m // self.block
+        self.kernel(x, q_u8, sf_u8, sf2).launch(grid=(grid_x, 1, 1), block=(_THREADS, 1, 1), stream=stream)
+
+
+class _SecondLevelDescale:
+    """Elementwise x / divisor via the DSL '/' operator — the fused dgrad_dglu
+    kernel's exact SFD2 formula (thread_tile_amax / (max(d_dtype)*max(sf_dtype))).
+    A dedicated kernel is needed because the DSL division is approximate
+    (div.full-style), not IEEE div.rn, so a torch divide/multiply does not
+    reproduce it bit-for-bit."""
+
+    def __init__(self, n, divisor):
+        self.n = n
+        self.divisor = float(divisor)
+
+    @cute.kernel
+    def kernel(self, x: cute.Tensor, o: cute.Tensor):
+        bidx, _, _ = cute.arch.block_idx()
+        tidx, _, _ = cute.arch.thread_idx()
+        i = bidx * _THREADS + tidx
+        if i < self.n:
+            o[i] = x[i] / self.divisor
+
+    @cute.jit
+    def __call__(self, x: cute.Tensor, o: cute.Tensor, stream: cuda.CUstream):
+        nblocks = (self.n + _THREADS - 1) // _THREADS
+        self.kernel(x, o).launch(grid=(nblocks, 1, 1), block=(_THREADS, 1, 1), stream=stream)
+
+
+def second_level_descale(x: torch.Tensor, divisor: float) -> torch.Tensor:
+    """x (any shape) f32 -> x / divisor, computed with the DSL '/' so it matches
+    the fused kernel's SFD2 (thread_tile_amax / (max(d_dtype)*max(sf_dtype)))
+    bit-for-bit (the DSL division is approximate, not IEEE div.rn). divisor is
+    the product of the two second-level target format maxima."""
+    assert x.is_cuda and x.dtype == torch.float32
+    flat = x.contiguous().reshape(-1)
+    n = flat.numel()
+    out = torch.empty_like(flat)
+    key = ("sldescale", n, float(divisor))
+    args = (from_dlpack(flat), from_dlpack(out), _stream())
+    if key not in _compiled:
+        _compiled[key] = cute.compile(_SecondLevelDescale(n, divisor), *args, options="--generate-line-info")
+    _compiled[key](*args)
+    torch.cuda.synchronize()
+    return out.reshape(x.shape)
+
+
+def _quant_nvfp4(
+    x: torch.Tensor, norm_const: float, rowwise: bool, block: int, sf_fmt: str = "e4m3", sf_max: float = 448.0
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Blockwise-NVFP4-quantize a bf16 or f32 (m, f) tensor (global encode
+    scale norm_const). Blocks run along the last dim rowwise ((1, block)
+    features) or along the first dim colwise ((block, 1) tokens); the packed
+    data bytes come out in the (m, f) orientation either way. Returns
+    (packed e2m1 uint8 (m, f/2), e4m3 scale uint8 — (m, f/block) rowwise,
+    (f, m/block) colwise)."""
+    assert x.is_cuda and x.dtype in (torch.bfloat16, torch.float32) and x.dim() == 2
+    assert x.is_contiguous()
+    m, f = x.shape
+    assert f % (2 * block) == 0
+    if not rowwise:
+        assert m % block == 0, f"colwise ({block}, 1) token blocks need m % {block} == 0, got m={m}"
+    q = torch.empty((m, f // 2), dtype=torch.uint8, device=x.device)
+    sf_shape = (m, f // block) if rowwise else (f, m // block)
+    sf = torch.empty(sf_shape, dtype=torch.uint8, device=x.device)
+    key = ("quant", m, f, x.dtype, float(norm_const), rowwise, block, sf_fmt)
+    # sf is passed twice: the second slot is the (unused) sf2 placeholder for the
+    # one-level path — the kernel never reads it when two_level is False.
+    args = (from_dlpack(x, assumed_align=16), from_dlpack(q, assumed_align=16), from_dlpack(sf, assumed_align=16), from_dlpack(sf, assumed_align=16), _stream())
+    if key not in _compiled:
+        _compiled[key] = cute.compile(
+            _QuantNvfp4(m, f, norm_const, rowwise=rowwise, block=block, sf_fmt=sf_fmt, sf_max=sf_max),
+            *args,
+            options="--generate-line-info",
+        )
+    _compiled[key](*args)
+    torch.cuda.synchronize()
+    return q, sf
+
+
+def _quant_nvfp4_two_level(
+    x: torch.Tensor,
+    norm_const: float,
+    sf2_descale: torch.Tensor,
+    block: int,
+    sf_fmt: str = "e4m3",
+    sf_max: float = 448.0,
+    rowwise: bool = True,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Two-level NVFP4 quant (dgrad_dglu quant_sfd_row / dgrad_dglu_rht colwise
+    quant): like _quant_nvfp4, but the first-level block scale is folded by a
+    per-block second-level descale sf2_descale (f32 on the scale grid — (m,
+    f/block) rowwise, (f, m/block) colwise — the stored SFD2 value broadcast to
+    each block), pvscale *= rcp_approx(sf2_descale) before the encode cvt. The
+    data multiply stays on the raw values, so dequant is data * SF (single
+    level); the fold only reshapes how the SF magnitude is split. Returns
+    (packed e2m1 uint8 (m, f/2), scale uint8 on the same grid as sf2)."""
+    assert x.is_cuda and x.dtype in (torch.bfloat16, torch.float32) and x.dim() == 2
+    assert x.is_contiguous()
+    m, f = x.shape
+    assert f % (2 * block) == 0
+    if not rowwise:
+        assert m % block == 0, f"colwise ({block}, 1) token blocks need m % {block} == 0, got m={m}"
+    sf_shape = (m, f // block) if rowwise else (f, m // block)
+    assert sf2_descale.shape == sf_shape, f"sf2_descale must be {sf_shape}, got {tuple(sf2_descale.shape)}"
+    assert sf2_descale.dtype == torch.float32 and sf2_descale.is_contiguous()
+    q = torch.empty((m, f // 2), dtype=torch.uint8, device=x.device)
+    sf = torch.empty(sf_shape, dtype=torch.uint8, device=x.device)
+    key = ("quant2", m, f, x.dtype, float(norm_const), rowwise, block, sf_fmt)
+    args = (
+        from_dlpack(x, assumed_align=16),
+        from_dlpack(q, assumed_align=16),
+        from_dlpack(sf, assumed_align=16),
+        from_dlpack(sf2_descale, assumed_align=16),
+        _stream(),
+    )
+    if key not in _compiled:
+        _compiled[key] = cute.compile(
+            _QuantNvfp4(m, f, norm_const, two_level=True, rowwise=rowwise, block=block, sf_fmt=sf_fmt, sf_max=sf_max),
+            *args,
+            options="--generate-line-info",
+        )
+    _compiled[key](*args)
+    torch.cuda.synchronize()
+    return q, sf
+
+
+def quantize(x: torch.Tensor, fmt=None, sf2: Optional[torch.Tensor] = None, norm_const: float = 1.0, rowwise: bool = True) -> Tuple[torch.Tensor, torch.Tensor]:
+    """THE quantization entry point (harness references/quantization/dsl.py,
+    trimmed to the rowwise NVFP4-e4m3 case — the only one these tests use).
+    Blockwise-quantize a bf16 or f32 (m, f) tensor at global encode scale
+    norm_const with (1, 16) feature blocks; data bytes come out (m, f)-packed.
+
+    sf2 (f32 on the (m, f/16) scale grid) folds a GIVEN per-block second-level
+    descale into the encoded scale — the dgrad_dglu kernel's quant_sfd_row.
+    Second-level GENERATION is not done here.
+
+    Returns (packed data bytes, scale bytes)."""
+    assert fmt is None, "only the NVFP4 (e2m1 data, e4m3 scales) format is ported"
+    assert rowwise, "only the rowwise block orientation is ported"
+    block = 16  # NVFP4 first-level vec size
+    sf_fmt = "e4m3"
+    sf_max = 448.0
+    if sf2 is not None:
+        return _quant_nvfp4_two_level(x, norm_const, sf2, block, sf_fmt, sf_max, rowwise=rowwise)
+    return _quant_nvfp4(x, norm_const, rowwise, block, sf_fmt, sf_max)
+
+
+# ---------------------------------------------------------------------------
+# SF-atom unpack (the kernel's MMA-tiled row-scale view -> flat scales).
+# ---------------------------------------------------------------------------
+
+
+def _sf_atom_unpack(sf_view: torch.Tensor, valid_m: int, n2: int) -> torch.Tensor:
+    """Gather the flat (valid_m, n2//16) row scale factors out of the kernel's
+    MMA-tiled SF view (32, 4, ceil(valid_m/128), 4, rest, 1).
+
+    Canonical SF-atom mapping (the create_sf_layout_tensor /
+    cvt_sf_MKL_to_M32x4xrm_K4xrk_L scatter used for SFA/SFB inputs):
+
+        mma[m % 32, (m // 32) % 4, m // 128, ksf % 4, ksf // 4, 0] == flat[m, ksf]
+
+    Implemented directly from that mapping with advanced indexing, so it is
+    layout-independent (works on any permuted/strided view of the backing).
+    Validated against _sf_to_mma by round-trip in the test file."""
+    assert sf_view.dim() == 6, f"expected the 6-D MMA-tiled view, got {tuple(sf_view.shape)}"
+    ksf = n2 // 16
+    dev = sf_view.device
+    m_idx = torch.arange(valid_m, device=dev).unsqueeze(1).expand(valid_m, ksf)
+    k_idx = torch.arange(ksf, device=dev).unsqueeze(0).expand(valid_m, ksf)
+    zero = torch.zeros_like(m_idx)
+    return sf_view[m_idx % 32, (m_idx // 32) % 4, m_idx // 128, k_idx % 4, k_idx // 4, zero]
+
+
+# ---------------------------------------------------------------------------
+# Problem generator.
+# ---------------------------------------------------------------------------
+
+
+def make_dswiglu_subchannel_problem(
+    m_per_expert: int,
+    n: int,
+    k: int,
+    l: int,
+    block2_shape: Tuple[int, int, int] = (1, 256, 256),
+    with_dbias: bool = False,
+    dbias_dtype: torch.dtype = torch.bfloat16,
+    d_quant: bool = False,
+    norm_const: float = 0.5,
+    d_deinterleaved: bool = True,
+    seed: int = 0,
+):
+    """Build FE-format inputs plus the byte-exact references for the dSwiGLU
+    subchannel-scaled wrapper. FE n = GEMM/weight width (harness f); the
+    n-axis outputs cover 2n. d_deinterleaved is only effective with d_quant
+    (the kernel's harness-validated combination); the returned dict's
+    "d_deinterleaved" key holds the effective value to pass to the wrapper.
+
+    Reference mirrors the harness references/fc2_dgrad.py dswiglu path exactly
+    (op order matters for byte-exactness)."""
+    if not hasattr(torch, "float4_e2m1fn_x2"):
+        pytest.skip("Current torch version does not support float4_e2m1fn_x2")
+    torch.manual_seed(seed)
+    sgm, sgn, sgk = block2_shape
+    assert m_per_expert % 256 == 0 and m_per_expert % sgm == 0
+    assert k % sgk == 0 and k % 32 == 0
+    assert n % 128 == 0 and sgn % 128 == 0
+    deint = bool(d_deinterleaved) and bool(d_quant)
+    mt = l * m_per_expert
+    n2 = 2 * n
+    group_sizes = [m_per_expert] * l
+
+    a_master = torch.randn((mt, k), dtype=torch.bfloat16, device="cuda")
+    b_master = torch.randn((l * n, k), dtype=torch.bfloat16, device="cuda")
+
+    a_vals, a_sf, a_sf2 = _quantize_two_level(a_master.float(), sgm, sgk)
+    # B second-level blocks must not straddle experts: quantize per expert.
+    b_parts = [_quantize_two_level(b_master[e * n : (e + 1) * n].float(), sgn, sgk) for e in range(l)]
+    b_vals = torch.stack([p[0] for p in b_parts])  # (l, n, k)
+    b_sf = torch.stack([p[1] for p in b_parts])  # (l, n, k/16)
+    b_sf2 = torch.stack([p[2] for p in b_parts])  # (l, ceil(n/sgn), k/sgk)
+
+    # Forward FC1 pre-activations (gate/up interleaved in 32-col bands); the
+    # harness generator's c_init_scale = 1 / harness_n with harness_n = 2n.
+    c = torch.randn((mt, n2), dtype=torch.bfloat16, device="cuda") * (1.0 / n2)
+
+    alpha = (0.75 + 0.25 * (torch.arange(l) % 4)).float().cuda()
+    beta = (0.75 + 0.25 * ((torch.arange(l) + 2) % 4)).float().cuda()
+    prob = torch.randint(-2, 2, (mt, 1, 1), dtype=torch.float32, device="cuda").float()
+
+    # ---- FE-format tensors ----
+    a_packed = _pack_fp4x2(a_vals)  # (mt, k/2)
+    a_tensor = a_packed.reshape(1, mt, k // 2).permute(1, 2, 0)
+    b_packed = torch.stack([_pack_fp4x2(p[0]) for p in b_parts])  # (l, n, k/2)
+    b_tensor = b_packed.permute(1, 2, 0)
+
+    sfa_tensor = _sf_to_mma(a_sf.reshape(1, mt, k // 16))
+    sfb_tensor = _sf_to_mma(b_sf)
+
+    sfa2_tensor = _sf2_strided(a_sf2.reshape(1, mt // sgm, k // sgk))
+    sfb2_tensor = _sf2_strided(b_sf2)
+
+    c_tensor = c.reshape(1, mt, n2).permute(1, 2, 0)  # (mt, 2n, 1) n-major
+
+    padded_offsets = torch.tensor(
+        [sum(group_sizes[: e + 1]) for e in range(l)],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    norm_const_tensor = torch.tensor([norm_const], dtype=torch.float32, device="cuda") if d_quant else None
+
+    # ---- reference (fc2_dgrad.py dswiglu path, in FE-n terms) ----
+    a_f32 = a_vals * a_sf.repeat_interleave(16, dim=-1)
+    b_f32 = b_vals * b_sf.repeat_interleave(16, dim=-1)
+    g = _grouped_gemm_second_level_scaled(a_f32, b_f32, a_sf2, b_sf2, group_sizes, sgm, sgn, sgk)
+
+    # Alpha lands on both the A and B contributions, applied as ONE multiply
+    # by the f32 pre-squared alpha — exactly as the kernel does (harness
+    # apply_alpha(g, alpha * alpha, group_sizes)).
+    alpha2 = alpha * alpha
+    for e, (r0, r1) in enumerate(_group_ranges(group_sizes)):
+        g[r0:r1] *= float(alpha2[e])
+
+    # Beta applies per row INSIDE dswiglu (after the clamps). Clamp defaults
+    # match the wrapper/API defaults (glu_clamp_max=7.0, glu_clamp_min=-7.0).
+    beta_row = beta.repeat_interleave(m_per_expert)
+    d, dprob, dy1, dy2 = dswiglu(
+        g,
+        c.float(),
+        prob.reshape(mt),
+        beta=beta_row,
+        glu_alpha=None,
+        glu_clamp_max=7.0,
+        glu_clamp_min=-7.0,
+    )
+
+    ref_dbias = None
+    if with_dbias:
+        # The kernel's exact dbias scheme: f32 per-M-tile partials,
+        # dbias_dtype-matched atomics across tiles.
+        ref_dbias = torch.stack([colsum_tilewise(d[r0:r1].contiguous(), acc_dtype=dbias_dtype) for r0, r1 in _group_ranges(group_sizes)])  # (l, 2n)
+
+    # SFD2: NVFP4 max_representable in both the quant and bf16-D modes (the
+    # d_quant_format is NVFP4 either way); the divide replays the kernel's
+    # approximate DSL '/' (not IEEE div.rn).
+    sf2_norm = NVFP4_MAX_REPRESENTABLE  # 2688.0
+    ref_sfd2_gate = second_level_descale(_second_level_block_amax(dy1, sgm, sgn), sf2_norm)
+    ref_sfd2_up = second_level_descale(_second_level_block_amax(dy2, sgm, sgn), sf2_norm)
+
+    ref_d_quant = ref_d_quant_sf = None
+    if d_quant:
+        # The kernel quantizes the bf16-rounded dGLU output (quant_sfd_row)
+        # with norm_const as the global encode scale, folding the per-block
+        # second-level descale into the e4m3 row scales. Build the fold map on
+        # d's interleaved (32-feature-band) layout: broadcast each
+        # deinterleaved gate/up sfd2 block over its sgn columns (clamped to the
+        # real n/16 width for partial blocks), then re-interleave gate/up in
+        # NVFP4-block-sized bands to match d.
+        d_src = d.to(torch.bfloat16)
+        d_sfn = 16  # D blocks run along N
+        bpb = sgn // d_sfn
+        g16 = ref_sfd2_gate.repeat_interleave(bpb, dim=1)[:, : n // d_sfn]
+        u16 = ref_sfd2_up.repeat_interleave(bpb, dim=1)[:, : n // d_sfn]
+        sf2_d = _interleave_bands(g16, u16, 2).contiguous()  # band = 32 // d_sfn
+        ref_d_quant, ref_d_quant_sf = quantize(d_src.contiguous(), sf2=sf2_d, norm_const=norm_const)
+
+    if deint:
+        # Deinterleaved layout: permute every n-axis output so gate bands come
+        # first, up bands second. The sfd2 refs are already deinterleaved.
+        if ref_dbias is not None:
+            ref_dbias = _deinterleave_bands(ref_dbias, 32, dim=1)
+        ref_d_quant = _deinterleave_bands(ref_d_quant, 16, dim=1)  # 32 e2m1 = 16 B
+        ref_d_quant_sf = _deinterleave_bands(ref_d_quant_sf, 2, dim=1)  # 2 SF/band
+
+    ref_d = None if d_quant else d.to(torch.bfloat16)
+
+    return {
+        # wrapper inputs
+        "a_tensor": a_tensor,
+        "sfa_tensor": sfa_tensor,
+        "sfa2_tensor": sfa2_tensor,
+        "c_tensor": c_tensor,
+        "b_tensor": b_tensor,
+        "b_packed": b_packed,  # (l, n, k/2) contiguous backing for discrete pointers
+        "sfb_tensor": sfb_tensor,
+        "sfb2_tensor": sfb2_tensor,
+        "padded_offsets": padded_offsets,
+        "alpha_tensor": alpha,
+        "beta_tensor": beta,
+        "prob_tensor": prob,
+        "norm_const_tensor": norm_const_tensor,
+        "block2_shape": block2_shape,
+        "d_quant": d_quant,
+        "with_dbias": with_dbias,
+        "dbias_dtype": dbias_dtype,
+        "d_deinterleaved": deint,
+        "norm_const": norm_const,
+        # geometry
+        "valid_m": mt,
+        "n": n,
+        "k": k,
+        "l": l,
+        "nd": ceil_div(n, sgn),
+        "sfd2_rows": ceil_div(mt, sgm),
+        # references
+        "ref_d": ref_d,  # bf16 (mt, 2n), bf16-D mode only
+        "ref_d_quant": ref_d_quant,  # uint8 (mt, n) packed e2m1, quant mode
+        "ref_d_quant_sf": ref_d_quant_sf,  # uint8 (mt, 2n/16), quant mode
+        "ref_dprob": dprob,  # f32 (mt, 1)
+        "ref_dbias": ref_dbias,  # (l, 2n) dbias_dtype or None
+        "ref_sfd2_gate": ref_sfd2_gate,  # f32 (sfd2_rows, nd)
+        "ref_sfd2_up": ref_sfd2_up,  # f32 (sfd2_rows, nd)
+    }
+
+
+def build_discrete_pointers_dswiglu(problem) -> dict:
+    """Per-expert int64 pointer arrays into the dense backings; the problem
+    dict provides the same "b_packed"/"sfb_tensor"/"sfb2_tensor"/"l" keys the
+    sibling helper expects, so reuse it directly."""
+    return build_discrete_pointers(problem)

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dswiglu_subchannel_scaled_utils.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dswiglu_subchannel_scaled_utils.py
@@ -42,7 +42,8 @@ from cutlass.cutlass_dsl import T
 
 from cudnn.gemm.cutedsl.grouped.moe_kernel_helpers import fmin
 
-from fe_api.test_fe_api_utils import ceil_div
+from fe_api.test_fe_api_utils import ceil_div, reencode_sf_tensor_as_ue5m3
+from fe_api.grouped_gemm.test_grouped_gemm_wgrad_utils import _skip_unless_e5m3_supported
 from fe_api.grouped_gemm.test_grouped_gemm_unfused_subchannel_scaled_utils import (
     NVFP4_MAX_REPRESENTABLE,
     _grouped_gemm_second_level_scaled,
@@ -304,8 +305,8 @@ def _deinterleave_bands(x: torch.Tensor, band: int, dim: int = 1) -> torch.Tenso
 
 # ---------------------------------------------------------------------------
 # DSL NVFP4 quantize + second-level descale — port of
-# references/quantization/dsl.py (rowwise NVFP4-e4m3 path only; the e5m3 scale
-# branches are dropped — they need FloatNV8E5M3FNU, absent from this repo).
+# references/quantization/dsl.py (rowwise NVFP4 path; e4m3 scale bytes via the
+# PTX cvt, e5m3 scale bytes via cutlass.FloatNV8E5M3FNU -- Rubin only).
 # ---------------------------------------------------------------------------
 
 
@@ -323,8 +324,10 @@ class _QuantNvfp4:
         self.m, self.f = m, f
         self.block = int(block)
         self.norm_const = float(norm_const)
-        # This port keeps the e4m3 scale format only (the NVFP4 recipe).
-        assert str(sf_fmt) == "e4m3", f"only e4m3 scale bytes are ported, got {sf_fmt}"
+        # e5m3 (FloatNV8E5M3FNU, sm107) has no satfinite cvt -- the kernel
+        # semantics are an explicit clamp to the format max (sf_max) followed
+        # by the scalar RN .to() encode.
+        assert str(sf_fmt) in ("e4m3", "e5m3"), f"unsupported scale format {sf_fmt}"
         self.sf_fmt = str(sf_fmt)
         self.sf_max = float(sf_max)
         # When set, an extra per-first-level-block f32 second-level descale
@@ -414,8 +417,15 @@ class _QuantNvfp4:
                 # Same cvt.rn.satfinite.e4m3x2.f32 the generic conversion emits.
                 tCrSFC_up = cute.make_rmem_tensor((num_vecs,), cutlass.Float32)
                 for vi in cutlass.range_constexpr(num_vecs):
-                    sf_byte_i32, sf_up = _cvt_f32_to_e4m3_byte_and_f32(tCrSFC_pvscale[vi])
-                    sf_byte = cutlass.Uint8(sf_byte_i32)
+                    if cutlass.const_expr(self.sf_fmt == "e5m3"):
+                        pv = fmin(tCrSFC_pvscale[vi], cutlass.Float32(self.sf_max), nan=True)
+                        enc_r = cute.make_rmem_tensor((1,), cutlass.FloatNV8E5M3FNU)
+                        enc_r[0] = pv.to(cutlass.FloatNV8E5M3FNU)
+                        sf_byte = cute.recast_tensor(enc_r, cutlass.Uint8)[0]
+                        sf_up = enc_r[0].to(cutlass.Float32)
+                    else:
+                        sf_byte_i32, sf_up = _cvt_f32_to_e4m3_byte_and_f32(tCrSFC_pvscale[vi])
+                        sf_byte = cutlass.Uint8(sf_byte_i32)
                     if cutlass.const_expr(self.rowwise):
                         sf[(bidx, num_vecs * cidx + vi)] = sf_byte
                     else:
@@ -590,9 +600,11 @@ def _quant_nvfp4_two_level(
     return q, sf
 
 
-def quantize(x: torch.Tensor, fmt=None, sf2: Optional[torch.Tensor] = None, norm_const: float = 1.0, rowwise: bool = True) -> Tuple[torch.Tensor, torch.Tensor]:
+def quantize(
+    x: torch.Tensor, fmt=None, sf2: Optional[torch.Tensor] = None, norm_const: float = 1.0, rowwise: bool = True, sf_fmt: str = "e4m3"
+) -> Tuple[torch.Tensor, torch.Tensor]:
     """THE quantization entry point (harness references/quantization/dsl.py,
-    trimmed to the rowwise NVFP4-e4m3 case — the only one these tests use).
+    trimmed to the rowwise NVFP4 case with e4m3 or e5m3 (Rubin) scale bytes).
     Blockwise-quantize a bf16 or f32 (m, f) tensor at global encode scale
     norm_const with (1, 16) feature blocks; data bytes come out (m, f)-packed.
 
@@ -601,11 +613,10 @@ def quantize(x: torch.Tensor, fmt=None, sf2: Optional[torch.Tensor] = None, norm
     Second-level GENERATION is not done here.
 
     Returns (packed data bytes, scale bytes)."""
-    assert fmt is None, "only the NVFP4 (e2m1 data, e4m3 scales) format is ported"
+    assert fmt is None, "only the NVFP4 (e2m1 data, e4m3/e5m3 scales) format is ported"
     assert rowwise, "only the rowwise block orientation is ported"
     block = 16  # NVFP4 first-level vec size
-    sf_fmt = "e4m3"
-    sf_max = 448.0
+    sf_max = SF_FORMAT_MAX[sf_fmt]
     if sf2 is not None:
         return _quant_nvfp4_two_level(x, norm_const, sf2, block, sf_fmt, sf_max, rowwise=rowwise)
     return _quant_nvfp4(x, norm_const, rowwise, block, sf_fmt, sf_max)
@@ -614,6 +625,11 @@ def quantize(x: torch.Tensor, fmt=None, sf2: Optional[torch.Tensor] = None, norm
 # ---------------------------------------------------------------------------
 # SF-atom unpack (the kernel's MMA-tiled row-scale view -> flat scales).
 # ---------------------------------------------------------------------------
+
+
+# Largest finite magnitude of the first-level scale formats (e5m3 = UE5M3,
+# the Rubin FloatNV8E5M3FNU scale type).
+SF_FORMAT_MAX = {"e4m3": 448.0, "e5m3": 61440.0}
 
 
 def _sf_atom_unpack(sf_view: torch.Tensor, valid_m: int, n2: int) -> torch.Tensor:
@@ -654,6 +670,7 @@ def make_dswiglu_subchannel_problem(
     norm_const: float = 0.5,
     d_deinterleaved: bool = True,
     seed: int = 0,
+    sf_fmt: str = "e4m3",
 ):
     """Build FE-format inputs plus the byte-exact references for the dSwiGLU
     subchannel-scaled wrapper. FE n = GEMM/weight width (harness f); the
@@ -661,10 +678,19 @@ def make_dswiglu_subchannel_problem(
     (the kernel's harness-validated combination); the returned dict's
     "d_deinterleaved" key holds the effective value to pass to the wrapper.
 
+    sf_fmt="e5m3" (Rubin only, skips elsewhere) re-encodes the e4m3 first-level
+    sfa/sfb bytes in place as UE5M3 (exact: every non-negative e4m3 value is
+    representable) and sets the returned "sf_fp8_dtype_override" to "e5m3"; the
+    quantized-D references then use e5m3-encoded row scales and the e5m3 sfd2
+    norm (output scale format follows the input's).
+
     Reference mirrors the harness references/fc2_dgrad.py dswiglu path exactly
     (op order matters for byte-exactness)."""
     if not hasattr(torch, "float4_e2m1fn_x2"):
         pytest.skip("Current torch version does not support float4_e2m1fn_x2")
+    assert sf_fmt in SF_FORMAT_MAX, f"unsupported sf_fmt {sf_fmt}"
+    if sf_fmt == "e5m3":
+        _skip_unless_e5m3_supported()
     torch.manual_seed(seed)
     sgm, sgn, sgk = block2_shape
     assert m_per_expert % 256 == 0 and m_per_expert % sgm == 0
@@ -701,6 +727,11 @@ def make_dswiglu_subchannel_problem(
 
     sfa_tensor = _sf_to_mma(a_sf.reshape(1, mt, k // 16))
     sfb_tensor = _sf_to_mma(b_sf)
+    if sf_fmt == "e5m3":
+        # Same scale VALUES, UE5M3 byte encoding: the f32 reference below is
+        # unchanged while the kernel must decode the bytes as e5m3.
+        reencode_sf_tensor_as_ue5m3(sfa_tensor)
+        reencode_sf_tensor_as_ue5m3(sfb_tensor)
 
     sfa2_tensor = _sf2_strided(a_sf2.reshape(1, mt // sgm, k // sgk))
     sfb2_tensor = _sf2_strided(b_sf2)
@@ -745,10 +776,12 @@ def make_dswiglu_subchannel_problem(
         # dbias_dtype-matched atomics across tiles.
         ref_dbias = torch.stack([colsum_tilewise(d[r0:r1].contiguous(), acc_dtype=dbias_dtype) for r0, r1 in _group_ranges(group_sizes)])  # (l, 2n)
 
-    # SFD2: NVFP4 max_representable in both the quant and bf16-D modes (the
-    # d_quant_format is NVFP4 either way); the divide replays the kernel's
-    # approximate DSL '/' (not IEEE div.rn).
-    sf2_norm = NVFP4_MAX_REPRESENTABLE  # 2688.0
+    # SFD2: max(e2m1) * max(sf format) in both the quant and bf16-D modes (the
+    # d_quant_format is NVFP4 either way; 2688 for e4m3 scales, 6*61440 for
+    # e5m3); the divide replays the kernel's approximate DSL '/' (not IEEE
+    # div.rn).
+    sf2_norm = 6.0 * SF_FORMAT_MAX[sf_fmt]
+    assert sf_fmt != "e4m3" or sf2_norm == NVFP4_MAX_REPRESENTABLE  # 2688.0
     ref_sfd2_gate = second_level_descale(_second_level_block_amax(dy1, sgm, sgn), sf2_norm)
     ref_sfd2_up = second_level_descale(_second_level_block_amax(dy2, sgm, sgn), sf2_norm)
 
@@ -767,7 +800,7 @@ def make_dswiglu_subchannel_problem(
         g16 = ref_sfd2_gate.repeat_interleave(bpb, dim=1)[:, : n // d_sfn]
         u16 = ref_sfd2_up.repeat_interleave(bpb, dim=1)[:, : n // d_sfn]
         sf2_d = _interleave_bands(g16, u16, 2).contiguous()  # band = 32 // d_sfn
-        ref_d_quant, ref_d_quant_sf = quantize(d_src.contiguous(), sf2=sf2_d, norm_const=norm_const)
+        ref_d_quant, ref_d_quant_sf = quantize(d_src.contiguous(), sf2=sf2_d, norm_const=norm_const, sf_fmt=sf_fmt)
 
     if deint:
         # Deinterleaved layout: permute every n-axis output so gate bands come
@@ -800,6 +833,8 @@ def make_dswiglu_subchannel_problem(
         "dbias_dtype": dbias_dtype,
         "d_deinterleaved": deint,
         "norm_const": norm_const,
+        "sf_fmt": sf_fmt,
+        "sf_fp8_dtype_override": "e5m3" if sf_fmt == "e5m3" else None,
         # geometry
         "valid_m": mt,
         "n": n,

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_unfused_subchannel_scaled.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_unfused_subchannel_scaled.py
@@ -1,0 +1,238 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the Unfused Subchannel-Scaled Grouped GEMM Kernel (SM100+)
+
+Second-level-scaled unfused block-scaled grouped GEMM for MoE workloads:
+NVFP4 A/B with per-(1, 16) e4m3 first-level scales plus f32 second-level
+(subchannel) scales, BF16 D output. The kernel output is compared BYTE-EXACT
+(``torch.equal``) against the pure-torch reference -- do not loosen this to a
+tolerance-based comparison; find the real gap instead.
+"""
+
+import pytest
+import torch
+
+from test_utils import torch_fork_set_rng
+from fe_api.grouped_gemm.test_grouped_gemm_unfused_subchannel_scaled_utils import (
+    build_discrete_pointers,
+    make_unfused_subchannel_scaled_problem,
+)
+
+
+@pytest.fixture(autouse=True)
+def require_sm100():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 100:
+        pytest.skip("SM100 is required")
+
+
+def _wrapper():
+    from cudnn import grouped_gemm_unfused_subchannel_scaled_wrapper_sm100
+
+    return grouped_gemm_unfused_subchannel_scaled_wrapper_sm100
+
+
+def _run_dense(problem, **overrides):
+    kwargs = dict(
+        a_tensor=problem["a_tensor"],
+        sfa_tensor=problem["sfa_tensor"],
+        sfa2_tensor=problem["sfa2_tensor"],
+        padded_offsets=problem["padded_offsets"],
+        alpha_tensor=problem["alpha_tensor"],
+        prob_tensor=problem["prob_tensor"],
+        b_tensor=problem["b_tensor"],
+        sfb_tensor=problem["sfb_tensor"],
+        sfb2_tensor=problem["sfb2_tensor"],
+        bias_tensor=problem["bias_tensor"],
+        block2_shape=problem["block2_shape"],
+    )
+    kwargs.update(overrides)
+    return _wrapper()(**kwargs)
+
+
+def _assert_byte_exact(out_d, ref_d):
+    got = out_d.squeeze(-1)
+    torch.cuda.synchronize()
+    assert got.dtype == ref_d.dtype == torch.bfloat16
+    assert torch.equal(got, ref_d), (
+        f"kernel output differs from reference: "
+        f"max abs diff {(got.float() - ref_d.float()).abs().max().item()}, "
+        f"mismatches {(got != ref_d).sum().item()}/{ref_d.numel()}"
+    )
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize(
+    "mma_tiler_mn,cluster_shape_mn",
+    [((256, 128), (2, 1)), ((256, 256), (2, 1)), ((256, 128), (2, 2))],
+    ids=["t256x128-c2x1", "t256x256-c2x1", "t256x128-c2x2"],
+)
+@torch_fork_set_rng(seed=0)
+def test_unfused_subchannel_scaled_wrapper_dense_fp4(mma_tiler_mn, cluster_shape_mn):
+    problem = make_unfused_subchannel_scaled_problem(m_per_expert=256, n=256, k=512, l=2)
+    out = _run_dense(problem, mma_tiler_mn=mma_tiler_mn, cluster_shape_mn=cluster_shape_mn)
+    _assert_byte_exact(out["d_tensor"], problem["ref_d"])
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=1)
+def test_unfused_subchannel_scaled_wrapper_dense_bias():
+    problem = make_unfused_subchannel_scaled_problem(m_per_expert=256, n=256, k=512, l=2, with_bias=True, seed=1)
+    out = _run_dense(problem)
+    _assert_byte_exact(out["d_tensor"], problem["ref_d"])
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=2)
+def test_unfused_subchannel_scaled_class_api_dense():
+    from cudnn import GroupedGemmUnfusedSubchannelScaledSm100
+
+    problem = make_unfused_subchannel_scaled_problem(m_per_expert=256, n=256, k=512, l=2, seed=2)
+    valid_m, n = problem["valid_m"], problem["n"]
+    d_tensor = torch.empty_strided((valid_m, n, 1), (n, 1, valid_m * n), dtype=torch.bfloat16, device="cuda")
+
+    api = GroupedGemmUnfusedSubchannelScaledSm100(
+        sample_a=problem["a_tensor"],
+        sample_sfa=problem["sfa_tensor"],
+        sample_sfa2=problem["sfa2_tensor"],
+        sample_padded_offsets=problem["padded_offsets"],
+        sample_alpha=problem["alpha_tensor"],
+        sample_prob=problem["prob_tensor"],
+        sample_d=d_tensor,
+        sample_b=problem["b_tensor"],
+        sample_sfb=problem["sfb_tensor"],
+        sample_sfb2=problem["sfb2_tensor"],
+        block2_shape=problem["block2_shape"],
+    )
+    assert api.check_support()
+    api.compile()
+    api.execute(
+        a_tensor=problem["a_tensor"],
+        sfa_tensor=problem["sfa_tensor"],
+        sfa2_tensor=problem["sfa2_tensor"],
+        padded_offsets=problem["padded_offsets"],
+        alpha_tensor=problem["alpha_tensor"],
+        prob_tensor=problem["prob_tensor"],
+        d_tensor=d_tensor,
+        b_tensor=problem["b_tensor"],
+        sfb_tensor=problem["sfb_tensor"],
+        sfb2_tensor=problem["sfb2_tensor"],
+    )
+    _assert_byte_exact(d_tensor, problem["ref_d"])
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=3)
+def test_unfused_subchannel_scaled_wrapper_discrete_fp4():
+    # n=512, k=1024 with sgn=sgk=256 -> per-expert SFB2 block is 2x4 f32 =
+    # 32 bytes, satisfying the 16B discrete alignment gate with l=2.
+    problem = make_unfused_subchannel_scaled_problem(m_per_expert=256, n=512, k=1024, l=2, seed=3)
+    ptrs = build_discrete_pointers(problem)
+    out = _wrapper()(
+        a_tensor=problem["a_tensor"],
+        sfa_tensor=problem["sfa_tensor"],
+        sfa2_tensor=problem["sfa2_tensor"],
+        padded_offsets=problem["padded_offsets"],
+        alpha_tensor=problem["alpha_tensor"],
+        prob_tensor=problem["prob_tensor"],
+        b_ptrs=ptrs["b_ptrs"],
+        sfb_ptrs=ptrs["sfb_ptrs"],
+        sfb2_ptrs=ptrs["sfb2_ptrs"],
+        n=problem["n"],
+        b_dtype=torch.float4_e2m1fn_x2,
+        block2_shape=problem["block2_shape"],
+    )
+    _assert_byte_exact(out["d_tensor"], problem["ref_d"])
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=4)
+def test_unfused_subchannel_scaled_block2_512():
+    problem = make_unfused_subchannel_scaled_problem(m_per_expert=256, n=512, k=1024, l=2, block2_shape=(1, 512, 512), seed=4)
+    out = _run_dense(problem)
+    _assert_byte_exact(out["d_tensor"], problem["ref_d"])
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=5)
+def test_unfused_subchannel_scaled_larger_shape():
+    problem = make_unfused_subchannel_scaled_problem(m_per_expert=512, n=512, k=1024, l=4, seed=5)
+    out = _run_dense(problem)
+    _assert_byte_exact(out["d_tensor"], problem["ref_d"])
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=6)
+def test_unfused_subchannel_scaled_wrapper_cache_and_preallocated_d():
+    from cudnn.gemm.cutedsl.grouped.unfused_subchannel_scaled.api import (
+        _cache_of_GroupedGemmUnfusedSubchannelScaledSm100Objects as cache,
+    )
+
+    problem = make_unfused_subchannel_scaled_problem(m_per_expert=256, n=256, k=512, l=2, seed=6)
+    out1 = _run_dense(problem)
+    n_cached = len(cache)
+    # Second call with the same configuration must reuse the cached object.
+    out2 = _run_dense(problem)
+    assert len(cache) == n_cached
+    assert torch.equal(out1["d_tensor"], out2["d_tensor"])
+    # Preallocated output path
+    valid_m, n = problem["valid_m"], problem["n"]
+    d_pre = torch.empty_strided((valid_m, n, 1), (n, 1, valid_m * n), dtype=torch.bfloat16, device="cuda")
+    out3 = _run_dense(problem, d_tensor=d_pre)
+    assert out3["d_tensor"] is d_pre
+    _assert_byte_exact(d_pre, problem["ref_d"])
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=7)
+def test_unfused_subchannel_scaled_check_support_negatives():
+    problem = make_unfused_subchannel_scaled_problem(m_per_expert=256, n=256, k=512, l=2, seed=7)
+
+    # Unsupported MMA tiler
+    with pytest.raises((ValueError, AssertionError)):
+        _run_dense(problem, mma_tiler_mn=(128, 256))
+
+    # Missing prob (the kernel always fuses the prob multiply)
+    with pytest.raises(ValueError):
+        _run_dense(problem, prob_tensor=None)
+
+    # SFA2 with the wrong (row-major) stride: shape passes, stride must not
+    rows, cols = problem["sfa2_tensor"].shape[0], problem["sfa2_tensor"].shape[1]
+    sfa2_bad = torch.zeros((rows, cols, 1), dtype=torch.float32, device="cuda")  # stride (cols, 1, 1)
+    sfa2_bad[:, :, 0] = problem["sfa2_tensor"][:, :, 0]
+    with pytest.raises((ValueError, AssertionError)):
+        _run_dense(problem, sfa2_tensor=sfa2_bad)
+
+    # e5m3 override requires Rubin
+    major, minor = torch.cuda.get_device_capability()
+    if (major, minor) != (10, 7):
+        with pytest.raises((ValueError, AssertionError)):
+            _run_dense(problem, sf_fp8_dtype_override="e5m3")
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=8)
+def test_unfused_subchannel_scaled_discrete_sfb2_alignment_gate():
+    # n=256, k=256, sgn=sgk=256 -> per-expert SFB2 block is 1x1 f32 = 4 bytes:
+    # with l=2 the second expert's base cannot be 16B-aligned -> must be rejected.
+    problem = make_unfused_subchannel_scaled_problem(m_per_expert=256, n=256, k=256, l=2, seed=8)
+    ptrs = build_discrete_pointers(problem)
+    with pytest.raises((ValueError, AssertionError)):
+        _wrapper()(
+            a_tensor=problem["a_tensor"],
+            sfa_tensor=problem["sfa_tensor"],
+            sfa2_tensor=problem["sfa2_tensor"],
+            padded_offsets=problem["padded_offsets"],
+            alpha_tensor=problem["alpha_tensor"],
+            prob_tensor=problem["prob_tensor"],
+            b_ptrs=ptrs["b_ptrs"],
+            sfb_ptrs=ptrs["sfb_ptrs"],
+            sfb2_ptrs=ptrs["sfb2_ptrs"],
+            n=problem["n"],
+            b_dtype=torch.float4_e2m1fn_x2,
+            block2_shape=problem["block2_shape"],
+        )

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_unfused_subchannel_scaled.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_unfused_subchannel_scaled.py
@@ -15,6 +15,8 @@ import pytest
 import torch
 
 from test_utils import torch_fork_set_rng
+from fe_api.test_fe_api_utils import reencode_sf_tensor_as_ue5m3
+from fe_api.grouped_gemm.test_grouped_gemm_wgrad_utils import _skip_unless_e5m3_supported
 from fe_api.grouped_gemm.test_grouped_gemm_unfused_subchannel_scaled_utils import (
     build_discrete_pointers,
     make_unfused_subchannel_scaled_problem,
@@ -54,6 +56,27 @@ def _run_dense(problem, **overrides):
     return _wrapper()(**kwargs)
 
 
+def _apply_sf_override(problem, sf_fp8_dtype_override):
+    """Prepare ``problem`` for ``sf_fp8_dtype_override`` and return the wrapper kwargs for it.
+
+    For ``"e5m3"`` the e4m3 first-level scale bytes are rewritten in place as UE5M3. Every
+    non-negative finite e4m3 value is exactly representable in UE5M3 (same 3-bit mantissa,
+    wider exponent range), so ``problem["ref_d"]`` stays valid while the bytes handed to
+    the kernel differ -- a kernel still decoding them as e4m3 would fail the byte-exact
+    comparison.
+    """
+    if sf_fp8_dtype_override is None:
+        return {}
+    assert sf_fp8_dtype_override == "e5m3"
+    _skip_unless_e5m3_supported()
+    reencode_sf_tensor_as_ue5m3(problem["sfa_tensor"])
+    reencode_sf_tensor_as_ue5m3(problem["sfb_tensor"])
+    return {"sf_fp8_dtype_override": "e5m3"}
+
+
+SF_OVERRIDES = pytest.mark.parametrize("sf_fp8_dtype_override", [None, "e5m3"], ids=["sf_e4m3", "sf_e5m3"])
+
+
 def _assert_byte_exact(out_d, ref_d):
     got = out_d.squeeze(-1)
     torch.cuda.synchronize()
@@ -71,10 +94,12 @@ def _assert_byte_exact(out_d, ref_d):
     [((256, 128), (2, 1)), ((256, 256), (2, 1)), ((256, 128), (2, 2))],
     ids=["t256x128-c2x1", "t256x256-c2x1", "t256x128-c2x2"],
 )
+@SF_OVERRIDES
 @torch_fork_set_rng(seed=0)
-def test_unfused_subchannel_scaled_wrapper_dense_fp4(mma_tiler_mn, cluster_shape_mn):
+def test_unfused_subchannel_scaled_wrapper_dense_fp4(mma_tiler_mn, cluster_shape_mn, sf_fp8_dtype_override):
     problem = make_unfused_subchannel_scaled_problem(m_per_expert=256, n=256, k=512, l=2)
-    out = _run_dense(problem, mma_tiler_mn=mma_tiler_mn, cluster_shape_mn=cluster_shape_mn)
+    sf_kwargs = _apply_sf_override(problem, sf_fp8_dtype_override)
+    out = _run_dense(problem, mma_tiler_mn=mma_tiler_mn, cluster_shape_mn=cluster_shape_mn, **sf_kwargs)
     _assert_byte_exact(out["d_tensor"], problem["ref_d"])
 
 
@@ -126,11 +151,15 @@ def test_unfused_subchannel_scaled_class_api_dense():
 
 
 @pytest.mark.L0
+@SF_OVERRIDES
 @torch_fork_set_rng(seed=3)
-def test_unfused_subchannel_scaled_wrapper_discrete_fp4():
+def test_unfused_subchannel_scaled_wrapper_discrete_fp4(sf_fp8_dtype_override):
     # n=512, k=1024 with sgn=sgk=256 -> per-expert SFB2 block is 2x4 f32 =
     # 32 bytes, satisfying the 16B discrete alignment gate with l=2.
+    # The discrete SFB pointers are typed inside the kernel from self.sf_dtype, so the
+    # e5m3 leg also covers the per-expert tensormap path (re-encode before taking ptrs).
     problem = make_unfused_subchannel_scaled_problem(m_per_expert=256, n=512, k=1024, l=2, seed=3)
+    sf_kwargs = _apply_sf_override(problem, sf_fp8_dtype_override)
     ptrs = build_discrete_pointers(problem)
     out = _wrapper()(
         a_tensor=problem["a_tensor"],
@@ -145,6 +174,7 @@ def test_unfused_subchannel_scaled_wrapper_discrete_fp4():
         n=problem["n"],
         b_dtype=torch.float4_e2m1fn_x2,
         block2_shape=problem["block2_shape"],
+        **sf_kwargs,
     )
     _assert_byte_exact(out["d_tensor"], problem["ref_d"])
 
@@ -212,6 +242,19 @@ def test_unfused_subchannel_scaled_check_support_negatives():
     if (major, minor) != (10, 7):
         with pytest.raises((ValueError, AssertionError)):
             _run_dense(problem, sf_fp8_dtype_override="e5m3")
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=9)
+def test_unfused_subchannel_scaled_e5m3_is_not_cached_as_e4m3():
+    """sf_fp8_dtype_override must take part in the compile cache key: identical scale
+    bytes decode differently under E4M3 and UE5M3."""
+    _skip_unless_e5m3_supported()
+    problem = make_unfused_subchannel_scaled_problem(m_per_expert=256, n=256, k=512, l=2, seed=9)
+    d_e4m3 = _run_dense(problem)["d_tensor"].float().clone()
+    d_e5m3 = _run_dense(problem, sf_fp8_dtype_override="e5m3")["d_tensor"].float().clone()
+    torch.cuda.synchronize()
+    assert not torch.equal(d_e4m3, d_e5m3), "e5m3 and e4m3 produced identical output from identical scale-factor bytes"
 
 
 @pytest.mark.L0

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_unfused_subchannel_scaled_utils.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_unfused_subchannel_scaled_utils.py
@@ -1,0 +1,321 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for the unfused subchannel-scaled grouped GEMM tests.
+
+Two-level NVFP4 input generation (per-(1, 16) e4m3 first-level scales plus
+power-of-two f32 second-level scales at ``block2_shape`` granularity) and the
+byte-exact torch reference of the kernel's op:
+
+    d = (sum over sgk-tiles of sfa2 * sfb2 * (A @ B^T)) * alpha * prob
+        (with bias: d = gemm * alpha + prob * bias)
+
+The second-level scales are POWERS OF TWO (exp2-ceil of block_amax /
+max_representable), so dividing by them is exact in f32 and the kernel-vs-
+reference comparison is bit-exact (with ``vector_f32=True``, the kernels'
+byte-exact-verified configuration). Ported from the bs_ggemm_harness
+``tensors/fc2_dgrad.py`` generator and ``references/fc2_dgrad.py::fc2_dgrad_gemm``.
+"""
+
+import math
+from typing import List, Optional, Tuple
+
+import torch
+import pytest
+
+from fe_api.test_fe_api_utils import (
+    ceil_div,
+    create_sf_layout_tensor,
+    cvt_sf_MKL_to_M32x4xrm_K4xrk_L,
+)
+from test_low_precision_matmul import _bfloat16_to_float4_e2m1fn_x2
+
+_E2M1_MAX = 6.0
+_E4M3_MAX = 448.0
+# NVFP4 encode range: format_max(e2m1) * format_max(e4m3)
+NVFP4_MAX_REPRESENTABLE = _E2M1_MAX * _E4M3_MAX  # 2688.0
+
+
+def _round_e2m1(x: torch.Tensor) -> torch.Tensor:
+    """Round float32 to the nearest e2m1 value (dequantized FP4), same shape."""
+    r = torch.zeros_like(x, dtype=torch.float32)
+    r[(x > 0.25) & (x < 0.75)] = 0.5
+    r[(x >= 0.75) & (x <= 1.25)] = 1.0
+    r[(x > 1.25) & (x < 1.75)] = 1.5
+    r[(x >= 1.75) & (x <= 2.5)] = 2.0
+    r[(x > 2.5) & (x < 3.5)] = 3.0
+    r[(x >= 3.5) & (x <= 5.0)] = 4.0
+    r[x > 5.0] = 6.0
+    r[(x < -0.25) & (x > -0.75)] = -0.5
+    r[(x <= -0.75) & (x >= -1.25)] = -1.0
+    r[(x < -1.25) & (x > -1.75)] = -1.5
+    r[(x <= -1.75) & (x >= -2.5)] = -2.0
+    r[(x < -2.5) & (x > -3.5)] = -3.0
+    r[(x <= -3.5) & (x >= -5.0)] = -4.0
+    r[x < -5.0] = -6.0
+    return r
+
+
+def _quantize_nvfp4_first_level(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """First-level NVFP4 quantization: f32 (rows, cols) in, (decoded fp4
+    values f32 (rows, cols), decoded e4m3 block scales f32 (rows, cols/16)) out.
+    Op sequence ported from the harness pure-torch quantizer (global encode
+    scale 1)."""
+    x = x.to(torch.float32)
+    rows, cols = x.shape
+    assert cols % 16 == 0, f"cols ({cols}) must be a multiple of the sf vec size (16)"
+    xr = x.view(rows, cols // 16, 16)
+    vec_max = torch.amax(torch.abs(xr), dim=-1, keepdim=True)
+    fmax = torch.tensor(torch.finfo(torch.float32).max, device=x.device)
+
+    dec = torch.min(vec_max * (1.0 / _E2M1_MAX), fmax)
+    dec_f = torch.clamp(dec, -_E4M3_MAX, _E4M3_MAX).to(torch.float8_e4m3fn).to(torch.float32)
+    enc = torch.min(torch.div(1.0, dec_f), fmax)
+
+    scaled = xr * enc
+    vals = _round_e2m1(torch.clamp(scaled, -_E2M1_MAX, _E2M1_MAX).reshape(rows, cols))
+    return vals, dec_f.squeeze(-1)
+
+
+def _second_level_block_amax(x: torch.Tensor, row_g: int, col_g: int) -> torch.Tensor:
+    """Per-(row_g x col_g)-block max(|x|) of a 2-D tensor, f32
+    (ceil(rows/row_g), ceil(cols/col_g))."""
+    r, c = x.shape
+    rb, cb = ceil_div(r, row_g), ceil_div(c, col_g)
+    pad_r, pad_c = rb * row_g - r, cb * col_g - c
+    xp = torch.nn.functional.pad(x.float().abs(), (0, pad_c, 0, pad_r))
+    return xp.reshape(rb, row_g, cb, col_g).amax(dim=(1, 3))
+
+
+def _quantize_two_level(x: torch.Tensor, row_g: int, col_g: int) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Two-level blockwise quantization: f32 power-of-two second-level scales at
+    (row_g x col_g) granularity, then the first-level quantizer on x / sf2.
+    Returns (decoded fp4 values f32, decoded first-level scales f32, sf2 f32)."""
+    rows, cols = x.shape
+    amax = _second_level_block_amax(x.float(), row_g, col_g)
+    # Smallest power of two making block_amax / sf2 fit the one-level encode
+    # range; amax-0 blocks get scale 1 (nothing to represent). exp2/log2 run on
+    # CPU (mirrors the harness generator).
+    amax_cpu = amax.cpu()
+    sf2 = torch.exp2(torch.ceil(torch.log2(amax_cpu / NVFP4_MAX_REPRESENTABLE)))
+    sf2 = torch.where(amax_cpu == 0.0, torch.ones_like(sf2), sf2).to(amax.device)
+    inv = (1.0 / sf2).repeat_interleave(row_g, dim=0)[:rows].repeat_interleave(col_g, dim=1)[:, :cols]
+    vals, scales = _quantize_nvfp4_first_level((x.float() * inv).to(torch.bfloat16).float())
+    return vals, scales, sf2
+
+
+def _pack_fp4x2(vals: torch.Tensor) -> torch.Tensor:
+    """Encode decoded e2m1 values f32 (rows, cols) into a packed
+    torch.float4_e2m1fn_x2 tensor (rows, cols/2). Exact: the values are on the
+    e2m1 grid."""
+    return _bfloat16_to_float4_e2m1fn_x2(vals.to(torch.bfloat16))
+
+
+def _sf_to_mma(sf: torch.Tensor, dtype: torch.dtype = torch.float8_e4m3fn) -> torch.Tensor:
+    """Scatter decoded first-level scales f32 (l, mn, sf_k) into the MMA-tiled
+    (32, 4, ceil(mn/128), 4, ceil(sf_k/4), l) cuda tensor of the given dtype."""
+    from cutlass.cute.runtime import from_dlpack
+
+    l, mn, sf_k = sf.shape
+    mma_f32_cpu, _ = create_sf_layout_tensor(l, mn, sf_k * 16, 16)
+    ref_cpu = sf.float().cpu().permute(1, 2, 0).contiguous().permute(0, 1, 2)  # (mn, sf_k, l)
+    if ref_cpu.numel() > 0:
+        cvt_sf_MKL_to_M32x4xrm_K4xrk_L(
+            from_dlpack(ref_cpu),
+            from_dlpack(mma_f32_cpu),
+        )
+    return mma_f32_cpu.to(dtype).cuda()
+
+
+def _sf2_strided(sf2: torch.Tensor) -> torch.Tensor:
+    """Lay out second-level scales f32 (l, rows, cols) as the kernels'
+    rows-contiguous (rows, cols, l) cuda view with stride (1, rows, rows*cols)."""
+    l, rows, cols = sf2.shape
+    t = torch.empty((l, cols, rows), dtype=torch.float32, device="cuda").permute(2, 1, 0)
+    t[:] = sf2.permute(1, 2, 0).to(t.device)
+    return t
+
+
+def _group_ranges(group_sizes: List[int]) -> List[Tuple[int, int]]:
+    ranges, start = [], 0
+    for rows in group_sizes:
+        ranges.append((start, start + rows))
+        start += rows
+    return ranges
+
+
+def _grouped_gemm_second_level_scaled(
+    a: torch.Tensor,  # (mt, k) f32, first-level dequantized
+    b: torch.Tensor,  # (l, n, k) f32, first-level dequantized
+    sfa2: torch.Tensor,  # (mt/sgm, k/sgk) f32
+    sfb2: torch.Tensor,  # (l, n/sgn, k/sgk) f32
+    group_sizes: List[int],
+    sgm: int,
+    sgn: int,
+    sgk: int,
+) -> torch.Tensor:
+    """c (mt, n) f32: per-expert, per-k-tile matmul with second-level scaling
+    (byte-exact op order of the harness reference)."""
+    mt, k = a.shape
+    n = b.shape[1]
+    num_k_tiles = math.ceil(k / sgk)
+
+    a = a.float()
+    b = b.float()
+    sfa2 = sfa2.float().to(a.device)
+    sfb2 = sfb2.float().to(a.device)
+
+    col_scale_idx = torch.arange(n, device=a.device) // sgn
+    c = torch.zeros((mt, n), dtype=torch.float32, device=a.device)
+    for e, (r0, r1) in enumerate(_group_ranges(group_sizes)):
+        row_scale_idx = torch.arange(r0, r1, device=a.device) // sgm
+        for t in range(num_k_tiles):
+            k0, k1 = t * sgk, min((t + 1) * sgk, k)
+            partial = a[r0:r1, k0:k1] @ b[e, :, k0:k1].t()
+            row_scale = sfa2[row_scale_idx, t]  # (rows,)
+            col_scale = sfb2[e, col_scale_idx, t]  # (n,)
+            c[r0:r1] += (partial * row_scale.unsqueeze(1)) * col_scale.unsqueeze(0)
+    return c
+
+
+def reference_unfused_subchannel_scaled(
+    a_vals: torch.Tensor,  # (mt, k) f32 decoded fp4
+    a_sf: torch.Tensor,  # (mt, k/16) f32 decoded first-level scales
+    a_sf2: torch.Tensor,  # (mt/sgm, k/sgk) f32
+    b_vals: torch.Tensor,  # (l, n, k) f32 decoded fp4
+    b_sf: torch.Tensor,  # (l, n, k/16) f32
+    b_sf2: torch.Tensor,  # (l, n/sgn, k/sgk) f32
+    prob: torch.Tensor,  # (mt,) or (mt, 1, 1) f32
+    alpha: torch.Tensor,  # (l,) f32
+    bias: Optional[torch.Tensor],  # (n, l) bf16 or None
+    group_sizes: List[int],
+    block2_shape: Tuple[int, int, int],
+) -> torch.Tensor:
+    """The kernel's op in the byte-exact reference order. Returns (mt, n) bf16."""
+    sgm, sgn, sgk = block2_shape
+    mt = a_vals.shape[0]
+    a = a_vals * a_sf.repeat_interleave(16, dim=-1)
+    b = b_vals * b_sf.repeat_interleave(16, dim=-1)
+    g = _grouped_gemm_second_level_scaled(a, b, a_sf2, b_sf2, group_sizes, sgm, sgn, sgk)
+    # alpha applies once, per expert
+    for e, (r0, r1) in enumerate(_group_ranges(group_sizes)):
+        g[r0:r1] *= float(alpha[e])
+    prob_col = prob.reshape(mt, 1).to(g.device)
+    if bias is None:
+        d = g * prob_col
+    else:
+        bias_term = torch.zeros_like(g)
+        for e, (r0, r1) in enumerate(_group_ranges(group_sizes)):
+            bias_term[r0:r1] += bias[:, e].float()
+        d = g + bias_term * prob_col
+    return d.to(torch.bfloat16)
+
+
+def make_unfused_subchannel_scaled_problem(
+    m_per_expert: int,
+    n: int,
+    k: int,
+    l: int,
+    block2_shape: Tuple[int, int, int] = (1, 256, 256),
+    with_bias: bool = False,
+    seed: int = 0,
+):
+    """Build FE-format inputs plus the byte-exact reference output.
+
+    Returns a dict with the wrapper-ready tensors (a/sfa/sfa2, b/sfb/sfb2,
+    padded_offsets/alpha/prob[/bias]) and ``ref_d`` (valid_m, n) bf16.
+    """
+    if not hasattr(torch, "float4_e2m1fn_x2"):
+        pytest.skip("Current torch version does not support float4_e2m1fn_x2")
+    torch.manual_seed(seed)
+    sgm, sgn, sgk = block2_shape
+    assert m_per_expert % 256 == 0 and m_per_expert % sgm == 0
+    assert k % sgk == 0 and k % 32 == 0 and n % 64 == 0
+    mt = l * m_per_expert
+    group_sizes = [m_per_expert] * l
+
+    a_master = torch.randn((mt, k), dtype=torch.bfloat16, device="cuda")
+    b_master = torch.randn((l * n, k), dtype=torch.bfloat16, device="cuda")
+
+    a_vals, a_sf, a_sf2 = _quantize_two_level(a_master.float(), sgm, sgk)
+    # B second-level blocks must not straddle experts: quantize per expert.
+    b_parts = [_quantize_two_level(b_master[e * n : (e + 1) * n].float(), sgn, sgk) for e in range(l)]
+    b_vals = torch.stack([p[0] for p in b_parts])  # (l, n, k)
+    b_sf = torch.stack([p[1] for p in b_parts])  # (l, n, k/16)
+    b_sf2 = torch.stack([p[2] for p in b_parts])  # (l, ceil(n/sgn), k/sgk)
+
+    # ---- FE-format tensors ----
+    # A: (valid_m, k/2, 1) fp4x2, k-major, l-outermost physical layout
+    a_packed = _pack_fp4x2(a_vals)  # (mt, k/2)
+    a_tensor = a_packed.reshape(1, mt, k // 2).permute(1, 2, 0)
+    # B: (n, k/2, l) fp4x2
+    b_packed = torch.stack([_pack_fp4x2(p[0]) for p in b_parts])  # (l, n, k/2)
+    b_tensor = b_packed.permute(1, 2, 0)
+
+    sfa_tensor = _sf_to_mma(a_sf.reshape(1, mt, k // 16))
+    sfb_tensor = _sf_to_mma(b_sf)
+
+    sfa2_tensor = _sf2_strided(a_sf2.reshape(1, mt // sgm, k // sgk))
+    sfb2_tensor = _sf2_strided(b_sf2)
+
+    padded_offsets = torch.tensor(
+        [sum(group_sizes[: e + 1]) for e in range(l)],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    alpha = (0.75 + 0.25 * (torch.arange(l) % 4)).float().cuda()
+    prob = torch.randint(-2, 2, (mt, 1, 1), dtype=torch.float32, device="cuda").float()
+
+    bias = None
+    if with_bias:
+        bias_ln = (torch.randn((l, n), device="cuda") * 0.1).to(torch.bfloat16)
+        bias = torch.empty((l, n), dtype=torch.bfloat16, device="cuda").t()  # (n, l) stride (1, n)
+        bias.copy_(bias_ln.t())
+
+    ref_d = reference_unfused_subchannel_scaled(
+        a_vals,
+        a_sf,
+        a_sf2,
+        b_vals,
+        b_sf,
+        b_sf2,
+        prob,
+        alpha,
+        bias,
+        group_sizes,
+        block2_shape,
+    )
+
+    return {
+        "a_tensor": a_tensor,
+        "sfa_tensor": sfa_tensor,
+        "sfa2_tensor": sfa2_tensor,
+        "b_tensor": b_tensor,
+        "b_packed": b_packed,  # (l, n, k/2) contiguous backing for discrete pointers
+        "sfb_tensor": sfb_tensor,
+        "sfb2_tensor": sfb2_tensor,
+        "padded_offsets": padded_offsets,
+        "alpha_tensor": alpha,
+        "prob_tensor": prob,
+        "bias_tensor": bias,
+        "valid_m": mt,
+        "n": n,
+        "k": k,
+        "l": l,
+        "block2_shape": block2_shape,
+        "ref_d": ref_d,
+    }
+
+
+def build_discrete_pointers(problem) -> dict:
+    """Per-expert int64 pointer arrays into the dense backings (uniform
+    per-expert layout, back-to-back blocks)."""
+    b_packed = problem["b_packed"]  # (l, n, k/2) contiguous
+    sfb_tensor = problem["sfb_tensor"]  # MMA-tiled, l outermost in memory
+    sfb2_tensor = problem["sfb2_tensor"]  # (rows, cols, l) stride (1, rows, rows*cols)
+    l = problem["l"]
+
+    b_ptrs = torch.tensor([b_packed[e].data_ptr() for e in range(l)], dtype=torch.int64, device="cuda")
+    sfb_ptrs = torch.tensor([sfb_tensor[..., e].data_ptr() for e in range(l)], dtype=torch.int64, device="cuda")
+    sfb2_ptrs = torch.tensor([sfb2_tensor[..., e].data_ptr() for e in range(l)], dtype=torch.int64, device="cuda")
+    return {"b_ptrs": b_ptrs, "sfb_ptrs": sfb_ptrs, "sfb2_ptrs": sfb2_ptrs}

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad_subchannel_scaled.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad_subchannel_scaled.py
@@ -15,6 +15,7 @@ import pytest
 import torch
 
 from test_utils import torch_fork_set_rng
+from fe_api.test_fe_api_utils import reencode_sf_tensor_as_ue5m3
 from fe_api.grouped_gemm.test_grouped_gemm_wgrad_utils import _skip_unless_e5m3_supported
 from fe_api.grouped_gemm.test_grouped_gemm_wgrad_subchannel_scaled_utils import (
     assert_bytes_equal,
@@ -56,6 +57,26 @@ def _run(problem, output_mode="dense", **overrides):
     return _wrapper()(**kwargs)["wgrad_tensor"]
 
 
+def _apply_sf_override(problem, sf_fp8_dtype_override):
+    """Prepare ``problem`` for ``sf_fp8_dtype_override`` and return the wrapper kwargs for it.
+
+    For ``"e5m3"`` the e4m3 first-level scale bytes are rewritten in place as UE5M3. Every
+    non-negative finite e4m3 value is exactly representable in UE5M3 (same 3-bit mantissa,
+    wider exponent range), so the dequantized reference operands are unchanged while the
+    bytes handed to the kernel differ -- a kernel still decoding them as e4m3 would fail
+    the byte-exact comparison.
+    """
+    if sf_fp8_dtype_override is None:
+        return {}
+    assert sf_fp8_dtype_override == "e5m3"
+    _skip_unless_e5m3_supported()
+    reencode_sf_tensor_as_ue5m3(problem["sfa_tensor"])
+    reencode_sf_tensor_as_ue5m3(problem["sfb_tensor"])
+    return {"sf_fp8_dtype_override": "e5m3"}
+
+
+SF_OVERRIDES = pytest.mark.parametrize("sf_fp8_dtype_override", [None, "e5m3"], ids=["sf_e4m3", "sf_e5m3"])
+
 CONFIGS = pytest.mark.parametrize(
     "mma_tiler_mn, cluster_shape_mn",
     [((128, 128), (1, 1)), ((256, 128), (2, 1))],
@@ -79,9 +100,11 @@ OUTPUT_MODES = pytest.mark.parametrize("output_mode", ["dense", "discrete"])
 @CONFIGS
 @SHAPES
 @OUTPUT_MODES
-def test_wgrad_subchannel_matches_reference(mma_tiler_mn, cluster_shape_mn, sgk, hidden, intermediate, token_counts, output_mode):
+@SF_OVERRIDES
+def test_wgrad_subchannel_matches_reference(mma_tiler_mn, cluster_shape_mn, sgk, hidden, intermediate, token_counts, output_mode, sf_fp8_dtype_override):
     problem = make_wgrad_subchannel_problem(hidden, intermediate, token_counts, sgk)
-    out = _run(problem, output_mode=output_mode, mma_tiler_mn=mma_tiler_mn, cluster_shape_mn=cluster_shape_mn)
+    sf_kwargs = _apply_sf_override(problem, sf_fp8_dtype_override)
+    out = _run(problem, output_mode=output_mode, mma_tiler_mn=mma_tiler_mn, cluster_shape_mn=cluster_shape_mn, **sf_kwargs)
     assert_bytes_equal(out, wgrad_subchannel_reference(problem))
 
 
@@ -119,14 +142,16 @@ def test_wgrad_subchannel_ones_sfa2_matches_baseline():
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
 @OUTPUT_MODES
-def test_wgrad_subchannel_accumulate(output_mode):
+@SF_OVERRIDES
+def test_wgrad_subchannel_accumulate(output_mode, sf_fp8_dtype_override):
     # accumulate_on_output TMA-reduce-adds the bf16 tile into the caller's buffer; a
     # zero-token expert must reduce-add zeros (init preserved).
     problem = make_wgrad_subchannel_problem(512, 512, (512, 0, 512, 1024), 512)
+    sf_kwargs = _apply_sf_override(problem, sf_fp8_dtype_override)
     l = len(problem["token_counts"])
     init = torch.randn((l, 512, 512), device="cuda").to(torch.bfloat16)
     out_buf = init.clone()
-    out = _run(problem, output_mode=output_mode, wgrad_tensor=out_buf, accumulate_on_output=True)
+    out = _run(problem, output_mode=output_mode, wgrad_tensor=out_buf, accumulate_on_output=True, **sf_kwargs)
     assert out is out_buf
     assert_bytes_equal(out, wgrad_subchannel_reference(problem, out_init=init, accumulate=True))
 

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad_subchannel_scaled.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad_subchannel_scaled.py
@@ -1,0 +1,250 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the Subchannel-Scaled Grouped GEMM Weight Gradient Kernel (SM100+)
+
+The 2Dx2D wgrad grouped GEMM with a second-level A scale (SFA2 only, no SFB2): NVFP4 A/B
+with per-(1, 16) e4m3 first-level scales plus one f32 SFA2 per (hidden row x sgk tokens),
+ragged per-expert token counts along K, BF16 dW. The kernel output is compared BYTE-EXACT
+(``torch.equal``) against the pure-torch reference -- do not loosen this to a
+tolerance-based comparison; find the real gap instead.
+"""
+
+import pytest
+import torch
+
+from test_utils import torch_fork_set_rng
+from fe_api.grouped_gemm.test_grouped_gemm_wgrad_utils import _skip_unless_e5m3_supported
+from fe_api.grouped_gemm.test_grouped_gemm_wgrad_subchannel_scaled_utils import (
+    assert_bytes_equal,
+    make_wgrad_subchannel_problem,
+    wgrad_baseline_reference,
+    wgrad_subchannel_reference,
+)
+
+
+@pytest.fixture(autouse=True)
+def require_sm100():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 100:
+        pytest.skip("SM100 is required")
+
+
+def _wrapper():
+    from cudnn import grouped_gemm_wgrad_subchannel_scaled_wrapper_sm100
+
+    return grouped_gemm_wgrad_subchannel_scaled_wrapper_sm100
+
+
+def _run(problem, output_mode="dense", **overrides):
+    kwargs = dict(
+        a_tensor=problem["a_tensor"],
+        b_tensor=problem["b_tensor"],
+        sfa_tensor=problem["sfa_tensor"],
+        sfb_tensor=problem["sfb_tensor"],
+        sfa2_tensor=problem["sfa2_tensor"],
+        offsets_tensor=problem["offsets_tensor"],
+        sgk=problem["sgk"],
+        output_mode=output_mode,
+        global_scale_a=problem["global_scale_a"],
+        global_scale_b=problem["global_scale_b"],
+    )
+    kwargs.update(overrides)
+    return _wrapper()(**kwargs)["wgrad_tensor"]
+
+
+CONFIGS = pytest.mark.parametrize(
+    "mma_tiler_mn, cluster_shape_mn",
+    [((128, 128), (1, 1)), ((256, 128), (2, 1))],
+    ids=["t128x128-c1x1", "t256x128-c2x1"],
+)
+
+# Each set has an empty expert and a single-block expert; token counts are sgk-aligned.
+SHAPES = pytest.mark.parametrize(
+    "sgk, hidden, intermediate, token_counts",
+    [
+        pytest.param(256, 512, 512, (256, 512, 0, 768, 256), id="sg256-ragged-l5"),
+        pytest.param(512, 512, 512, (512, 1536, 0, 512), id="sg512-ragged-l4"),
+    ],
+)
+
+OUTPUT_MODES = pytest.mark.parametrize("output_mode", ["dense", "discrete"])
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@CONFIGS
+@SHAPES
+@OUTPUT_MODES
+def test_wgrad_subchannel_matches_reference(mma_tiler_mn, cluster_shape_mn, sgk, hidden, intermediate, token_counts, output_mode):
+    problem = make_wgrad_subchannel_problem(hidden, intermediate, token_counts, sgk)
+    out = _run(problem, output_mode=output_mode, mma_tiler_mn=mma_tiler_mn, cluster_shape_mn=cluster_shape_mn)
+    assert_bytes_equal(out, wgrad_subchannel_reference(problem))
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=0)
+@CONFIGS
+def test_wgrad_subchannel_large(mma_tiler_mn, cluster_shape_mn):
+    problem = make_wgrad_subchannel_problem(1024, 1024, (2048, 512, 1024, 512), 512)
+    out = _run(problem, mma_tiler_mn=mma_tiler_mn, cluster_shape_mn=cluster_shape_mn)
+    assert_bytes_equal(out, wgrad_subchannel_reference(problem))
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@OUTPUT_MODES
+def test_wgrad_subchannel_no_global_scale(output_mode):
+    # global scales absent is a distinct compile branch (const_expr alpha off).
+    problem = make_wgrad_subchannel_problem(512, 512, (512, 1024, 512), 512, global_scales=False)
+    out = _run(problem, output_mode=output_mode)
+    assert_bytes_equal(out, wgrad_subchannel_reference(problem))
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_wgrad_subchannel_ones_sfa2_matches_baseline():
+    # sfa2 == 1 makes the kernel mathematically identical to the single-level GEMM --
+    # isolates the accumulator-splitting plumbing from the scale math (the per-block
+    # partial sums recombine exactly in f32).
+    problem = make_wgrad_subchannel_problem(512, 512, (512, 1024, 0, 512), 512)
+    ones = torch.ones_like(problem["sfa2_tensor"].T).T
+    out = _run(problem, sfa2_tensor=ones)
+    assert_bytes_equal(out, wgrad_baseline_reference(problem))
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@OUTPUT_MODES
+def test_wgrad_subchannel_accumulate(output_mode):
+    # accumulate_on_output TMA-reduce-adds the bf16 tile into the caller's buffer; a
+    # zero-token expert must reduce-add zeros (init preserved).
+    problem = make_wgrad_subchannel_problem(512, 512, (512, 0, 512, 1024), 512)
+    l = len(problem["token_counts"])
+    init = torch.randn((l, 512, 512), device="cuda").to(torch.bfloat16)
+    out_buf = init.clone()
+    out = _run(problem, output_mode=output_mode, wgrad_tensor=out_buf, accumulate_on_output=True)
+    assert out is out_buf
+    assert_bytes_equal(out, wgrad_subchannel_reference(problem, out_init=init, accumulate=True))
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_wgrad_subchannel_class_api_dense():
+    from cudnn import GroupedGemmWgradSubchannelScaledSm100
+
+    problem = make_wgrad_subchannel_problem(512, 512, (768, 256), 256)
+    out = torch.empty((2, 512, 512), dtype=torch.bfloat16, device="cuda")
+    op = GroupedGemmWgradSubchannelScaledSm100(
+        sample_a=problem["a_tensor"],
+        sample_b=problem["b_tensor"],
+        sample_sfa=problem["sfa_tensor"],
+        sample_sfb=problem["sfb_tensor"],
+        sample_sfa2=problem["sfa2_tensor"],
+        sample_offsets=problem["offsets_tensor"],
+        sgk=256,
+        sample_wgrad=out,
+        sample_global_scale_a=problem["global_scale_a"],
+        sample_global_scale_b=problem["global_scale_b"],
+    )
+    assert op.check_support()
+    op.compile()
+    op.execute(
+        a_tensor=problem["a_tensor"],
+        b_tensor=problem["b_tensor"],
+        sfa_tensor=problem["sfa_tensor"],
+        sfb_tensor=problem["sfb_tensor"],
+        sfa2_tensor=problem["sfa2_tensor"],
+        offsets_tensor=problem["offsets_tensor"],
+        wgrad_tensor=out,
+        global_scale_a=problem["global_scale_a"],
+        global_scale_b=problem["global_scale_b"],
+    )
+    assert_bytes_equal(out, wgrad_subchannel_reference(problem))
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@OUTPUT_MODES
+def test_wgrad_subchannel_dynamic_tokens_reuse_compile(output_mode):
+    # The token axis is dynamic: two token distributions with the same expert count share
+    # one compiled kernel, and both stay byte-exact.
+    from cudnn.gemm.cutedsl.grouped.wgrad_subchannel_scaled import api
+
+    p1 = make_wgrad_subchannel_problem(512, 512, (512, 1024, 512), 512, seed=1)
+    p2 = make_wgrad_subchannel_problem(512, 512, (1536, 0, 512), 512, seed=2)
+    before = len(api._cache_of_GroupedGemmWgradSubchannelScaledSm100Objects)
+    out1 = _run(p1, output_mode=output_mode)
+    assert_bytes_equal(out1, wgrad_subchannel_reference(p1))
+    after_first = len(api._cache_of_GroupedGemmWgradSubchannelScaledSm100Objects)
+    out2 = _run(p2, output_mode=output_mode)
+    assert_bytes_equal(out2, wgrad_subchannel_reference(p2))
+    assert len(api._cache_of_GroupedGemmWgradSubchannelScaledSm100Objects) == after_first
+    assert after_first >= before
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_wgrad_subchannel_rejects():
+    problem = make_wgrad_subchannel_problem(512, 512, (512, 512), 512)
+    # Token counts aligned to 256 but not to sgk=512 (tokens_sum itself is sgk-aligned).
+    bad = make_wgrad_subchannel_problem(512, 512, (256, 768), 256)
+    with pytest.raises(ValueError, match="sgk-aligned"):
+        _run(bad, sgk=512, sfa2_tensor=problem["sfa2_tensor"])
+    # sfa2 must be hidden-contiguous (the producer's view); a row-major copy is rejected.
+    with pytest.raises(ValueError, match="hidden-contiguous"):
+        _run(problem, sfa2_tensor=problem["sfa2_tensor"].contiguous())
+    # Wrong sfa2 column count.
+    with pytest.raises(ValueError):
+        _run(problem, sfa2_tensor=problem["sfa2_tensor"][:, :1])
+    # sgk must be a multiple of the 256-token MMA K tile.
+    with pytest.raises(ValueError, match="MMA K tile"):
+        _run(problem, sgk=128)
+    # Only the harness-validated tilers / clusters.
+    with pytest.raises(ValueError, match="mma_tiler_mn must be one of"):
+        _run(problem, mma_tiler_mn=(256, 256))
+    with pytest.raises(ValueError, match="cluster_shape_mn must be one of"):
+        _run(problem, mma_tiler_mn=(128, 128), cluster_shape_mn=(3, 1))
+    # Unknown override formats.
+    with pytest.raises(ValueError, match="sf_fp8_dtype_override must be"):
+        _run(problem, sf_fp8_dtype_override="e4m3")
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_wgrad_subchannel_e5m3_rejected_off_rubin(monkeypatch):
+    # e5m3 scale factors decode only in the sm107 MMA op; pretend to be Blackwell.
+    import cudnn.api_base as api_base
+    from cudnn import GroupedGemmWgradSubchannelScaledSm100
+
+    monkeypatch.setattr(api_base, "get_device_type", lambda: "blackwell")
+    problem = make_wgrad_subchannel_problem(512, 512, (512, 512), 512)
+    op = GroupedGemmWgradSubchannelScaledSm100(
+        sample_a=problem["a_tensor"],
+        sample_b=problem["b_tensor"],
+        sample_sfa=problem["sfa_tensor"],
+        sample_sfb=problem["sfb_tensor"],
+        sample_sfa2=problem["sfa2_tensor"],
+        sample_offsets=problem["offsets_tensor"],
+        sgk=512,
+        sample_wgrad=torch.empty((2, 512, 512), dtype=torch.bfloat16, device="cuda"),
+        sf_fp8_dtype_override="e5m3",
+    )
+    with pytest.raises(ValueError, match="requires Rubin"):
+        op.check_support()
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_wgrad_subchannel_e5m3_is_not_cached_as_e4m3():
+    """sf_fp8_dtype_override must take part in the compile cache key: identical scale
+    bytes decode differently under E4M3 and UE5M3."""
+    _skip_unless_e5m3_supported()
+    problem = make_wgrad_subchannel_problem(512, 512, (512, 512), 512)
+    w_e4m3 = _run(problem).float().clone()
+    w_e5m3 = _run(problem, sf_fp8_dtype_override="e5m3").float().clone()
+    torch.cuda.synchronize()
+    assert not torch.equal(w_e4m3, w_e5m3), "e5m3 and e4m3 produced identical output from identical scale-factor bytes"

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad_subchannel_scaled_utils.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad_subchannel_scaled_utils.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for the subchannel-scaled (second-level SFA2) grouped GEMM wgrad tests.
+
+Input generation and the byte-exact torch reference of the kernel's op, per expert ``e``
+with token range ``[k0, k1)`` split into ``sgk``-token scale blocks ``b`` (ascending)::
+
+    dW[e] = partial_b * sfa2[:, b_idx] + dW[e]     with partial_b = A[:, b] @ B[b, :]   (f32)
+    dW[e] = (dW[e] * gsa[e] * gsb[e]).to(bf16)
+
+``A = a_fp4 * sfa`` / ``B = b_fp4 * sfb`` are the first-level NVFP4 dequantized operands. The
+SFA2 grid is random and independent of the data: kernel and reference replay the identical
+``partial * sfa2 + acc`` f32 ops (the kernel uses a non-contractible ``mul.rn`` + add), so any
+values verify exactly. Ported from the bs_ggemm_harness ``tensors/wgrad.py`` generator and
+``references/wgrad.py::wgrad_gemm_2nd_level`` / ``wgrad_gemm_baseline``.
+"""
+
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import torch
+
+from fe_api.grouped_gemm.test_grouped_gemm_unfused_subchannel_scaled_utils import (
+    _pack_fp4x2,
+    _quantize_nvfp4_first_level,
+)
+from fe_api.grouped_gemm.test_grouped_gemm_wgrad_utils import _wgrad_assemble_scales_2d2d
+
+
+def _group_ranges(token_counts: Sequence[int]) -> List[Tuple[int, int]]:
+    ranges, start = [], 0
+    for k in token_counts:
+        ranges.append((start, start + k))
+        start += k
+    return ranges
+
+
+def _assemble_sf(scales_f32: torch.Tensor, token_counts: Sequence[int]) -> torch.Tensor:
+    """Decoded first-level scales f32 (mn, tokens_sum/16) -> the kernel's assembled
+    per-expert 128x4-atom e4m3 layout (round_up(mn, 128), round_up(tokens_sum/16, 4))."""
+    mn = scales_f32.shape[0]
+    parts = []
+    for k0, k1 in _group_ranges(token_counts):
+        if k1 > k0:
+            parts.append(scales_f32[:, k0 // 16 : k1 // 16].to(torch.float8_e4m3fn))
+    return _wgrad_assemble_scales_2d2d(parts, mn)
+
+
+def make_wgrad_subchannel_problem(
+    hidden: int,
+    intermediate: int,
+    token_counts: Sequence[int],
+    sgk: int,
+    global_scales: bool = True,
+    seed: Optional[int] = 0,
+) -> Dict:
+    """Random wgrad inputs: ``token_counts[e]`` tokens per expert (each sgk-aligned; 0 =
+    empty expert), concatenated along the token (K) axis.
+
+    Returns the kernel-facing tensors (``a_tensor`` (hidden, tokens_sum) fp4x2 K-major,
+    ``b_tensor`` (tokens_sum, intermediate) fp4x2 K-major, assembled ``sfa_tensor`` /
+    ``sfb_tensor``, ``sfa2_tensor`` (hidden, tokens_sum/sgk) f32 hidden-contiguous,
+    ``offsets_tensor`` int32 cumulative end offsets, optional {1, 2}-valued global scales)
+    plus the decoded operands the reference consumes."""
+    token_counts = tuple(int(k) for k in token_counts)
+    for k in token_counts:
+        assert k >= 0 and k % sgk == 0, f"per-expert tokens ({k}) must be sgk-aligned ({sgk})"
+    tokens_sum = sum(token_counts)
+    assert tokens_sum > 0, "at least one expert must have tokens"
+    if seed is not None:
+        torch.manual_seed(seed)
+    l = len(token_counts)
+
+    a_master = torch.randn((hidden, tokens_sum), dtype=torch.float32, device="cuda")
+    b_master = torch.randn((intermediate, tokens_sum), dtype=torch.float32, device="cuda")
+    a_vals, a_scales = _quantize_nvfp4_first_level(a_master)
+    b_vals, b_scales = _quantize_nvfp4_first_level(b_master)
+
+    a_deq = a_vals * a_scales.repeat_interleave(16, dim=1)
+    b_deq = b_vals * b_scales.repeat_interleave(16, dim=1)
+
+    a_tensor = _pack_fp4x2(a_vals).contiguous()  # (hidden, tokens_sum/2), token-innermost
+    b_tensor = _pack_fp4x2(b_vals).contiguous().t()  # (tokens_sum/2, intermediate), strides (1, tokens_sum/2)
+
+    # Feature-contiguous (strides (1, hidden)) like the live rowwise-quant sf2 view.
+    sfa2_tensor = (torch.rand((tokens_sum // sgk, hidden), dtype=torch.float32, device="cuda") + 0.5).T
+
+    offsets = torch.tensor([k1 for _, k1 in _group_ranges(token_counts)], dtype=torch.int32, device="cuda")
+    gsa = gsb = None
+    if global_scales:
+        gsa = torch.randint(1, 3, (l,), dtype=torch.float32, device="cuda")
+        gsb = torch.randint(1, 3, (l,), dtype=torch.float32, device="cuda")
+
+    return dict(
+        hidden=hidden,
+        intermediate=intermediate,
+        token_counts=token_counts,
+        tokens_sum=tokens_sum,
+        sgk=sgk,
+        a_tensor=a_tensor,
+        b_tensor=b_tensor,
+        sfa_tensor=_assemble_sf(a_scales, token_counts),
+        sfb_tensor=_assemble_sf(b_scales, token_counts),
+        sfa2_tensor=sfa2_tensor,
+        offsets_tensor=offsets,
+        global_scale_a=gsa,
+        global_scale_b=gsb,
+        a_deq=a_deq,
+        b_deq=b_deq,
+    )
+
+
+def _finish(dw: torch.Tensor, problem: Dict, out_init: Optional[torch.Tensor], accumulate: bool) -> torch.Tensor:
+    l = len(problem["token_counts"])
+    if problem["global_scale_a"] is not None:
+        alpha = (problem["global_scale_a"].float() * problem["global_scale_b"].float()).reshape(l, 1, 1)
+        dw = dw * alpha
+    dw = dw.to(torch.bfloat16)
+    if accumulate:
+        # The kernel TMA-reduce-adds the bf16 tile into gmem: one f32-exact add of two
+        # bf16 values, rounded RN back to bf16.
+        assert out_init is not None
+        dw = (out_init.float() + dw.float()).to(torch.bfloat16)
+    return dw
+
+
+def wgrad_subchannel_reference(
+    problem: Dict,
+    sfa2: Optional[torch.Tensor] = None,
+    out_init: Optional[torch.Tensor] = None,
+    accumulate: bool = False,
+) -> torch.Tensor:
+    """Port of ``references/wgrad.py::wgrad_gemm_2nd_level`` on the decoded operands:
+    partial products per sgk-token block in ascending order, folded as
+    ``dw = partial * sfa2 + dw`` (each op RN f32); alpha applied to the fully accumulated
+    f32 tile BEFORE the bf16 cast, like the epilogue."""
+    a, b = problem["a_deq"], problem["b_deq"]
+    sfa2 = problem["sfa2_tensor"] if sfa2 is None else sfa2
+    sgk = problem["sgk"]
+    l = len(problem["token_counts"])
+    dw = torch.zeros((l, problem["hidden"], problem["intermediate"]), dtype=torch.float32, device="cuda")
+    for e, (k0, k1) in enumerate(_group_ranges(problem["token_counts"])):
+        for b0 in range(k0, k1, sgk):
+            blk = b0 // sgk
+            partial = a[:, b0 : b0 + sgk] @ b[:, b0 : b0 + sgk].T
+            dw[e] = partial * sfa2[:, blk : blk + 1] + dw[e]
+    return _finish(dw, problem, out_init, accumulate)
+
+
+def wgrad_baseline_reference(problem: Dict) -> torch.Tensor:
+    """Port of ``references/wgrad.py::wgrad_gemm_baseline`` (single-level: one GEMM per
+    expert, no block splitting) -- the ``sfa2 == 1`` equivalence target."""
+    a, b = problem["a_deq"], problem["b_deq"]
+    l = len(problem["token_counts"])
+    dw = torch.zeros((l, problem["hidden"], problem["intermediate"]), dtype=torch.float32, device="cuda")
+    for e, (k0, k1) in enumerate(_group_ranges(problem["token_counts"])):
+        if k1 > k0:
+            dw[e] = a[:, k0:k1] @ b[:, k0:k1].T
+    return _finish(dw, problem, None, False)
+
+
+def assert_bytes_equal(out: torch.Tensor, ref: torch.Tensor) -> None:
+    torch.cuda.synchronize()
+    assert out.shape == ref.shape and out.dtype == ref.dtype, (out.shape, out.dtype, ref.shape, ref.dtype)
+    if not torch.equal(out, ref):
+        diff = (out.float() - ref.float()).abs()
+        raise AssertionError(f"kernel output is not byte-exact: {int((diff != 0).sum())} of {diff.numel()} elements differ, max |diff| = {diff.max().item()}")

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad_utils.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad_utils.py
@@ -13,8 +13,8 @@ from fe_api.test_fe_api_utils import ceil_div
 def _skip_unless_e5m3_supported():
     """E5M3 scales need Rubin plus an internal cutlass-dsl build.
 
-    Shared by the glu, dglu, quant and wgrad e5m3 guard tests -- those are the
-    only four APIs that expose ``sf_fp8_dtype_override``.
+    Shared by the glu, dglu, quant, wgrad, unfused_subchannel_scaled and
+    wgrad_subchannel_scaled e5m3 tests -- the APIs that expose ``sf_fp8_dtype_override``.
     """
     try:
         import cutlass

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad_utils.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad_utils.py
@@ -13,8 +13,9 @@ from fe_api.test_fe_api_utils import ceil_div
 def _skip_unless_e5m3_supported():
     """E5M3 scales need Rubin plus an internal cutlass-dsl build.
 
-    Shared by the glu, dglu, quant, wgrad, unfused_subchannel_scaled and
-    wgrad_subchannel_scaled e5m3 tests -- the APIs that expose ``sf_fp8_dtype_override``.
+    Shared by the glu, dglu, quant, wgrad, unfused_subchannel_scaled,
+    wgrad_subchannel_scaled and dswiglu_subchannel_scaled e5m3 tests -- the APIs
+    that expose ``sf_fp8_dtype_override``.
     """
     try:
         import cutlass

--- a/test/python/fe_api/test_rubin_kernel_dispatch.py
+++ b/test/python/fe_api/test_rubin_kernel_dispatch.py
@@ -62,6 +62,13 @@ RUBIN_DISPATCH_CASES = [
         "moe_blockscaled_grouped_gemm_wgrad_subchannel_scaled_rubin.py",
         id="grouped_gemm_wgrad_subchannel_scaled",
     ),
+    pytest.param(
+        "cudnn.gemm.cutedsl.grouped.dswiglu_subchannel_scaled.api",
+        "cudnn.gemm.cutedsl.grouped.dswiglu_subchannel_scaled.grouped_gemm_dswiglu_subchannel_scaled",
+        "BlockScaledSubChannelMoEGroupedGemmDgluDbiasKernel",
+        "moe_blockscaled_grouped_gemm_dswiglu_subchannel_scaled_rubin.py",
+        id="grouped_gemm_dswiglu_subchannel_scaled",
+    ),
 ]
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]

--- a/test/python/fe_api/test_rubin_kernel_dispatch.py
+++ b/test/python/fe_api/test_rubin_kernel_dispatch.py
@@ -48,6 +48,13 @@ RUBIN_DISPATCH_CASES = [
         "moe_blockscaled_grouped_gemm_wgrad_rubin.py",
         id="grouped_gemm_wgrad",
     ),
+    pytest.param(
+        "cudnn.gemm.cutedsl.grouped.unfused_subchannel_scaled.api",
+        "cudnn.gemm.cutedsl.grouped.unfused_subchannel_scaled.grouped_gemm_unfused_subchannel_scaled",
+        "BlockScaledSubChannelMoEGroupedGemmKernel",
+        "moe_blockscaled_grouped_gemm_unfused_subchannel_scaled_rubin.py",
+        id="grouped_gemm_unfused_subchannel_scaled",
+    ),
 ]
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]

--- a/test/python/fe_api/test_rubin_kernel_dispatch.py
+++ b/test/python/fe_api/test_rubin_kernel_dispatch.py
@@ -55,6 +55,13 @@ RUBIN_DISPATCH_CASES = [
         "moe_blockscaled_grouped_gemm_unfused_subchannel_scaled_rubin.py",
         id="grouped_gemm_unfused_subchannel_scaled",
     ),
+    pytest.param(
+        "cudnn.gemm.cutedsl.grouped.wgrad_subchannel_scaled.api",
+        "cudnn.gemm.cutedsl.grouped.wgrad_subchannel_scaled.grouped_gemm_wgrad_subchannel_scaled",
+        "BlockScaledSubChannelMoEGroupedGemmWgradKernel",
+        "moe_blockscaled_grouped_gemm_wgrad_subchannel_scaled_rubin.py",
+        id="grouped_gemm_wgrad_subchannel_scaled",
+    ),
 ]
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]


### PR DESCRIPTION

MR: Subchannel-scaled Grouped GEMM kernels (basic_gemm + dgrad + wgrad) for cuDNN Frontend

**Changes**
- sggemm integrated — Adds the initial grouped_gemm_unfused_subchannel_scaled kernel under python/cudnn/gemm/cutedsl/grouped/unfused_subchannel_scaled/: Blackwell + Rubin kernel implementations, API surface, moe_kernel_helpers.py/moe_sched_extension.py scheduling support, docs, and test/dispatch wiring. This is the foundational commit establishing the grouped/ subchannel-scaled kernel package layout reused by later kernels.
- sggemm + dswiglu + dquant kernel integrated — Adds grouped_gemm_dswiglu_subchannel_scaled: Blackwell kernel, API, tests/utils, and extends the shared moe_kernel_helpers.py/moe_sched_extension.py to support dswiglu/dquant scheduling; minor follow-on fix to the unfused kernel.
- sggemm wgrad kernel integrated — Adds grouped_gemm_wgrad_subchannel_scaled (weight-gradient grouped GEMM) under .../wgrad_subchannel_scaled/, including Blackwell + Rubin kernel implementations, API, shared helper/scheduling extensions, docs, and kernel-dispatch test wiring.
- numerical tests for e5m3 in wgrad and unfused kernels — Extends the wgrad and unfused subchannel-scaled test suites with e5m3 numerical coverage, plus corresponding doc updates.
- rubin version of dswiglu sggemm kernel — Adds the Rubin implementation of grouped_gemm_dswiglu_subchannel_scaled (~5.3K LOC), updates the dswiglu API and tests/utils accordingly, and registers it in the Rubin kernel dispatch test.
- Cleaning up dead code — Removes ~1.5K lines of dead/unused code across the dswiglu, unfused, and wgrad subchannel-scaled kernels (both Blackwell and Rubin variants) and their APIs/tests ([[Subchannel dead-code pass]]).
- Changing the comments — Comment-only cleanup pass on the dswiglu subchannel-scaled kernel (Blackwell + Rubin), reducing verbosity (~565 lines net removed) without functional changes.

**Test plan**

- [x] test_grouped_gemm_unfused_subchannel_scaled.py passes on Blackwell and Rubin
- [x] test_grouped_gemm_dswiglu_subchannel_scaled.py passes on Blackwell and Rubin
- [x] test_grouped_gemm_wgrad_subchannel_scaled.py passes on Blackwell and Rubin
- [x] test_rubin_kernel_dispatch.py covers all Rubin kernel registrations (unfused, dswiglu, wgrad)
- [x] e5m3 numerical tests pass for wgrad and unfused kernel

## Before submitting

- [ ] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [ ] I ran `pre-commit run` and committed any formatting changes.
- [ ] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches (see [root AGENTS.md § Reviewing a PR](https://github.com/NVIDIA/cudnn-frontend/blob/develop/AGENTS.md#reviewing-a-pr-human-or-agent)) and my changes comply, or I explain the exception below.
- [ ] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
