### PR TITLE
frost(sdpa): Rubin (SM107) prefill forward — 9 kernels, 3 engine rows, f16/FP8/MXFP8

### DIFF
--- a/python/cudnn/engines/manifest.py
+++ b/python/cudnn/engines/manifest.py
@@ -206,6 +206,8 @@ MANIFEST: Tuple[EngineFamily, ...] = (
             "sdpa_fwd_prefill_sm100_mxfp8": EngineSlot(12, opt_in=True),
             "sdpa_fwd_prefill_sm100_fp8": EngineSlot(13, opt_in=True),
             "sdpa_fwd_prefill_sm107_fp8": EngineSlot(14, opt_in=True),
+            "sdpa_fwd_prefill_sm107": EngineSlot(15, opt_in=True),
+            "sdpa_fwd_prefill_sm107_mxfp8": EngineSlot(16, opt_in=True),
         },
         analyzer=("cudnn.sdpa.graph_analyzer", "analyze"),
         heuristics=("cudnn.sdpa.fwd.heuristics", "recommend"),

--- a/python/cudnn/frost/tile_dsl/handles.py
+++ b/python/cudnn/frost/tile_dsl/handles.py
@@ -158,6 +158,9 @@ class SmemTile:
     def desc(self):
         from cutlass.experimental import primitives as prims
 
+        if self.desc_version not in (0, 1):
+            raise ValueError(f"SmemTile.desc_version must be 0 or 1 (got {self.desc_version}); there is no other tcgen05 SMEM-descriptor format")
+
         if self.desc_version == 0:
             return prims.Tcgen05SmemDesc.build(
                 self.base,
@@ -173,6 +176,15 @@ class SmemTile:
         import cutlass
         from cutlass._mlir.dialects import llvm
         from cutlass.experimental.primitives import nvvm_wrapper as _nvvm_wrap
+
+        if not hasattr(_nvvm_wrap, "_tcgen05_mma_smem_desc_v2"):
+            raise RuntimeError(
+                "desc_version=1 needs the versioned tcgen05 SMEM-descriptor intrinsic "
+                "(cutlass.experimental.primitives.nvvm_wrapper._tcgen05_mma_smem_desc_v2), "
+                "which this cutlass-dsl build does not expose.  It is required on Rubin "
+                "(SM107) for any MMA operand at or above 256 KiB; there is no kernel-side "
+                "workaround -- upgrade the DSL."
+            )
 
         addr = cutlass.Int32(llvm.ptrtoint(cutlass.Int32.mlir_type, self.base.ir_value()))
         return prims.Tcgen05SmemDesc(

--- a/python/cudnn/frost/tile_dsl/handles.py
+++ b/python/cudnn/frost/tile_dsl/handles.py
@@ -127,6 +127,24 @@ class SmemTile:
     tma_granu_elems: int = 0
     tma_subtile_stride_elems: int = 0
     stages: int = 1
+    # tcgen05 SMEM-descriptor version for :meth:`desc`.
+    #
+    # 0 = the public ``Tcgen05SmemDesc.build`` path (SM100 format).  Its
+    # ``start_address`` field is bits [0:15) with bit [14] *reserved on SM100*,
+    # i.e. only 14 usable bits = a 256 KiB addressable window.
+    #
+    # 1 = the extended format, which is what the C++ ``SmemTile::make_desc``
+    # always emitted.  REQUIRED on Rubin (SM107) for any MMA operand whose SMEM
+    # buffer sits at or above 256 KiB — the arch raises the per-CTA SMEM cap to
+    # 327 KiB, but a version-0 descriptor still truncates the address to 14 bits
+    # and silently wraps it to the bottom of SMEM.
+    #
+    # Symptom of getting this wrong: the MMA runs, both operands are provably
+    # correct in SMEM, the accumulator TMEM is the one the epilogue reads — and
+    # the accumulator is EXACTLY zero, because the wrapped address landed on an
+    # untouched buffer.  No crash, no launch error.  (Found 2026-09-04 on the
+    # d512 f16 SM107 port: sP_xfer_raw began at exactly 262144.)
+    desc_version: int = 0
 
     def __getitem__(self, stage):
         off = stage * self.elems_per_stage
@@ -140,11 +158,34 @@ class SmemTile:
     def desc(self):
         from cutlass.experimental import primitives as prims
 
-        return prims.Tcgen05SmemDesc.build(
-            self.base,
-            leading_byte_offset=self.leading_byte_offset,
-            stride_byte_offset=self.stride_byte_offset,
-            layout=self.layout,
+        if self.desc_version == 0:
+            return prims.Tcgen05SmemDesc.build(
+                self.base,
+                leading_byte_offset=self.leading_byte_offset,
+                stride_byte_offset=self.stride_byte_offset,
+                layout=self.layout,
+            )
+
+        # Hand-rolled because the public ``Tcgen05SmemDesc.build`` takes no
+        # ``version`` argument — it calls the non-versioned intrinsic.  The
+        # versioned one exists in the same wheel, just module-private, and the
+        # argument list below mirrors ``build``'s defaults exactly.
+        import cutlass
+        from cutlass._mlir.dialects import llvm
+        from cutlass.experimental.primitives import nvvm_wrapper as _nvvm_wrap
+
+        addr = cutlass.Int32(llvm.ptrtoint(cutlass.Int32.mlir_type, self.base.ir_value()))
+        return prims.Tcgen05SmemDesc(
+            _nvvm_wrap._tcgen05_mma_smem_desc_v2(
+                addr >> cutlass.Int32(4),
+                self.leading_byte_offset >> 4,
+                self.stride_byte_offset >> 4,
+                self.desc_version,
+                0,  # base_offset
+                0,  # leading_dim_mode
+                0,  # k_segment_offset
+                self.layout,
+            )
         )
 
 

--- a/python/cudnn/frost/tile_dsl/tmem.py
+++ b/python/cudnn/frost/tile_dsl/tmem.py
@@ -11,9 +11,12 @@ import cutlass.cute as cute
 def tmem_alloc(tmem_ptr_i32, num_cols: int, cta_group_kind, is_exclusive: cutlass.Constexpr[bool] = False):
     # is_exclusive is the sm_107/sm_109 >512-column mechanism (GR100's 576-col
     # TMEM; cute.arch.tmem.is_tmem_allocation_exclusive) — pass True only
-    # there.  It is fenced out of the PUBLIC cutlass-dsl tcgen05_alloc
-    # wrapper, so the kwarg is only emitted on the True branch
-    # (internal-wheel-only callers); <=512-column allocations never trace it.
+    # there.  The kwarg is emitted ONLY on the True branch because FROST's
+    # declared cutlass-dsl floor is 4.7.0, whose tcgen05_alloc wrapper does not
+    # accept it; <=512-column allocations therefore never trace it and keep
+    # working on the floor.  (Verified 2026-09-04 on 4.8.0.dev0: the PUBLIC
+    # `primitives.tcgen05_alloc` DOES take is_exclusive — the older claim that
+    # this needed an internal wheel is false.)
     if cutlass.const_expr(is_exclusive):
         nvvm.tcgen05_alloc(
             tmem_ptr_i32,

--- a/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
+++ b/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
@@ -210,9 +210,9 @@ backward) and its workspace (about one payload-equivalent of bytes).
 
 ## SM107 (Rubin, cc 10.7–11.9)
 
-Engines: `sdpa_fwd_prefill_sm107` (f16/bf16) and `sdpa_fwd_prefill_sm107_fp8`.
-**No MXFP8 forward and no backward** on the Rubin line — those graphs fall
-through to the backend.
+Engines: `sdpa_fwd_prefill_sm107` (f16/bf16), `sdpa_fwd_prefill_sm107_fp8`
+(per-tensor FP8) and `sdpa_fwd_prefill_sm107_mxfp8` (block-scale). **No
+backward** on the Rubin line — those graphs fall through to the backend.
 
 The f16/bf16 row is a separate engine from `sdpa_fwd_prefill_sm100` (which stops
 at cc 10.6) because the lowerings diverge: the Rubin kernels build **version-1
@@ -222,8 +222,13 @@ flavor's P transfer ring at exactly 256 KiB, where a version-0 descriptor wraps
 to offset 0 and the MMA multiplies the untouched O staging slab (O comes out
 exactly zero, no crash).
 
-Rubin ships a **strict subset** of the SM100 flavors: there is no d192×d128
-sibling, so a d=192 f16 graph rides the d256 envelope at that flavor's MMA cost.
+The f16/bf16 line carries all four SM100 flavors, d192×d128 included
+(`prefill_d192_d128_f16_sm107.py` — the d128 body with `make_cfg_d192`), so a
+d=192 f16 graph lands on its NATIVE kernel. The **quantized** lines are the
+strict subset: neither has a d192×d128 sibling, and (as on SM100) the
+`(256, 256)` envelope floor keeps an inexact graph off the d256 flavor's
+unvalidated padded path, so a d=192 FP8/MXFP8 graph is **declined** rather than
+zero-padded.
 
 | Feature | d64 (GPT-OSS)<br>FPROP | d128 (Llama)<br>FPROP | d256 (Qwen)<br>FPROP | d512 (DSv4)<br>FPROP | BPROP<br>no engine |
 |---|:--:|:--:|:--:|:--:|:--:|
@@ -232,7 +237,7 @@ sibling, so a d=192 f16 graph rides the d256 envelope at that flavor's MMA cost.
 | FP8 E4M3 / E5M2 (per-tensor) | ⚠️ⁱ | ✅ | ✅ | ✅ | ❌ |
 | MXFP8 | ❌ | ✅ | ✅ | ⚠️ⁱᵛ | ❌ |
 | O dtype ≠ QKV — **quantized graphs only** (fp16/bf16/fp8 out) | ✅ | ✅ | ✅ | ✅ | — |
-| Head-dim envelope | none — runs the d128 kernelⁱ | f16 ×8 · fp8 ×16 | f16 ×8 (serves d192 too) | f16 ×8 | — |
+| Head-dim envelope | none — runs the d128 kernelⁱ | f16 ×8 · fp8 ×16 | f16 ×8 · fp8 ×16 (floor 255) | f16 ×8 · fp8 ×16 (floor 256) | — |
 | **Layout** | | | | | |
 | BSHD | ✅ | ✅ | ✅ | ✅ | ❌ |
 | Arbitrary dense stride order (`dense_flex`) | ❌ | ❌ | ❌ | ❌ | ❌ |
@@ -388,9 +393,9 @@ feature-free d=64 graph.
 | Backward sink / dSink, bias / dBias | SM100, SM103 |
 | Backward deterministic, decode | SM100, SM103 — served by the MXFP8 d=256 row only |
 | MXFP8 backward: E5M2, bottom-right / band-widened / sliding-window masks, non-BSHD strides, `amax_*` outputs | SM100, SM103 |
-| f16/bf16 forward THD, split-KV, PackGQA, optional-stats, dense padded-Q trim | SM107 (Rubin) — the row serves dense f16/bf16 at d128/d256/d512; these five are the machinery its kernels lack |
-| Per-tensor FP8 forward above d=128 | SM107 — the d256/d512 kernels exist but have never produced a number |
-| MXFP8 forward | SM107 (kernels ported, never validated), SM120, SM80 |
+| f16/bf16 forward THD, split-KV, PackGQA, dense padded-Q trim | SM107 (Rubin) — the row serves dense f16/bf16 at d128/d192×d128/d256/d512; these four are the machinery its kernels lack (optional stats IS served — `lse_optional=True`) |
+| d192×d128 **quantized** forward | SM107 — no FP8 or MXFP8 sibling at that shape, and the d256 envelope floor declines the inexact ride |
+| MXFP8 forward | SM120, SM80 (SM107 is served — see the SM107 table; d512 is ⚠️ⁱᵛ, correct but with no test module) |
 | Per-tensor FP8 backward | every arch |
 | MXFP8 backward outside SM100/SM103 d = 256 | every arch |
 | THD / ragged backward | SM80, SM120, and the SM100/SM103 MXFP8 row (the SM100/SM103 f16/bf16 row serves it — see ʰ) |

--- a/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
+++ b/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
@@ -210,33 +210,90 @@ backward) and its workspace (about one payload-equivalent of bytes).
 
 ## SM107 (Rubin, cc 10.7–11.9)
 
-Engine: `sdpa_fwd_prefill_sm107_fp8` only. **No f16/bf16 and no MXFP8 forward,
-no backward** on the Rubin line — those graphs fall through to the backend.
+Engines: `sdpa_fwd_prefill_sm107` (f16/bf16) and `sdpa_fwd_prefill_sm107_fp8`.
+**No MXFP8 forward and no backward** on the Rubin line — those graphs fall
+through to the backend.
 
-| Feature | d64 (GPT-OSS)<br>FPROP | d128 (Llama)<br>FPROP | BPROP<br>no engine |
-|---|:--:|:--:|:--:|
-| FP16 / BF16 | ❌ | ❌ | ❌ |
-| FP8 E4M3 / E5M2 (per-tensor) | ⚠️ⁱ | ✅ | ❌ |
-| MXFP8 | ❌ | ❌ | ❌ |
-| O dtype ≠ QKV — **FP8 graphs only** (fp16/bf16/fp8 out) | ✅ | ✅ | — |
-| Head-dim envelope | none — runs the d128 kernelⁱ | ×16 up to 128 | — |
-| BSHD / `dense_flex` | ✅ / ❌ | ✅ / ❌ | ❌ |
-| THD + `cu_seq_len` | ❌ⁱⁱ | ✅ | ❌ |
-| Causal · bottom-right · right-band · SWA | ✅ | ✅ | ❌ |
-| Padding mask (+ stats) | ✅ | ✅ | ❌ |
-| Dense padded-Q trim | ❌ | ❌ | ❌ |
-| Attention sink | ✅ | ✅ | ❌ |
-| Bias | ❌ | ❌ | ❌ |
-| FP16 softmax accumulate (`softmax_precision=HALF`) | ❔ⁱⁱⁱ | ✅ (Rubin-only f16x2 arm) | — |
+The f16/bf16 row is a separate engine from `sdpa_fwd_prefill_sm100` (which stops
+at cc 10.6) because the lowerings diverge: the Rubin kernels build **version-1
+tcgen05 SMEM descriptors**. A version-0 descriptor's `start_address` field is 14
+bits — a 256 KiB window — and Rubin's 327 KiB per-CTA budget puts the d512
+flavor's P transfer ring at exactly 256 KiB, where a version-0 descriptor wraps
+to offset 0 and the MMA multiplies the untouched O staging slab (O comes out
+exactly zero, no crash).
 
-ⁱ Same story as SM100 footnote ⁷: no native d=64 Rubin kernel, so a d=64 FP8
-graph rides the d128 envelope (64 is a multiple of 16) at ~2× the MMA cost.
-ⁱⁱ `thd_d_shapes={(128,128)}` is exact — d=64 THD is declined.
-ⁱⁱⁱ **Accepted, not validated.** The `softmax_precision=HALF` domain is gated on
-`flavor == (128, 128)` (`fwd/api_dsl.py:1100`), and a d=64 graph's *flavor* IS
-(128,128), so the knob passes the probe and the kernel runs. What is untested is
-the f16x2 exponent arm over the zero-padded 64 → 128 region. Validate before
-relying on it; do not read ❔ as either a guarantee or a rejection.
+Rubin ships a **strict subset** of the SM100 flavors: there is no d192×d128
+sibling, so a d=192 f16 graph rides the d256 envelope at that flavor's MMA cost.
+
+| Feature | d64 (GPT-OSS)<br>FPROP | d128 (Llama)<br>FPROP | d256 (Qwen)<br>FPROP | d512 (DSv4)<br>FPROP | BPROP<br>no engine |
+|---|:--:|:--:|:--:|:--:|:--:|
+| **Data types** | | | | | |
+| FP16 / BF16 | ⚠️ⁱ | ✅ | ✅ | ✅ | ❌ |
+| FP8 E4M3 / E5M2 (per-tensor) | ⚠️ⁱ | ✅ | ✅ | ✅ | ❌ |
+| MXFP8 | ❌ | ✅ | ✅ | ⚠️ⁱᵛ | ❌ |
+| O dtype ≠ QKV — **quantized graphs only** (fp16/bf16/fp8 out) | ✅ | ✅ | ✅ | ✅ | — |
+| Head-dim envelope | none — runs the d128 kernelⁱ | f16 ×8 · fp8 ×16 | f16 ×8 (serves d192 too) | f16 ×8 | — |
+| **Layout** | | | | | |
+| BSHD | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Arbitrary dense stride order (`dense_flex`) | ❌ | ❌ | ❌ | ❌ | ❌ |
+| THD / ragged (packed varlen) | ❌ⁱⁱ | fp8 onlyᵛ | ❌ᵛ | ❌ᵛ | ❌ |
+| `cu_seq_len_q/kv` prefix sums (THD only) | ❌ⁱⁱ | fp8 only | ❌ | ❌ | ❌ |
+| **Masks / features** | | | | | |
+| Causal (top-left) | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Causal bottom-right | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Causal right-band widening | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Sliding window (left) | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Padding mask (`seq_len_kv`) | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Padding mask + stats (per-batch LSE trim) | ✅ | fp8 onlyᵛⁱ | ❌ᵛⁱ | ❌ᵛⁱ | ❌ |
+| Dense padded-Q trim (O:=0, LSE:=−inf) | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Attention sink | ✅ | ✅ | ✅ | ✅ | ❌ |
+| GQA / MQA (`H_q ≠ H_kv`) | ✅ | ✅ | ✅ | ✅ | ❌ |
+| PackGQA | fp8 only | fp8 only | ❌ | ❌ | ❌ |
+| Split-KV | fp8 only | fp8 only | ❌ᵛⁱⁱ | ❌ᵛⁱⁱ | ❌ |
+| Optional stats (LSE store compiled out) | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Bias | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Ragged `S_kv` (non-multiple of 128) | ✅ⁱˣ | ✅ⁱˣ | ✅ⁱˣ | ✅ⁱˣ | ❌ |
+| FP16 softmax accumulate (`softmax_precision=HALF`) | ❔ⁱⁱⁱ | fp8 only (Rubin f16x2 arm) | ❌ | ❌ | — |
+
+ⁱ No native d=64 Rubin kernel, so a d=64 graph rides the d128 envelope (64 is a
+multiple of 8 at f16 and of 16 at fp8) at ~2× the MMA cost.
+ⁱⁱ `thd_d_shapes={(128,128)}` on the FP8 row is exact — d=64 THD is declined.
+ⁱⁱⁱ **Accepted, not validated.** `softmax_precision=HALF` is gated on
+`flavor == (128, 128)` (`fwd/api_dsl.py`), and a d=64 graph's *flavor* IS
+(128,128), so the knob passes the probe and the kernel runs. Untested is the
+f16x2 exponent arm over the zero-padded 64 → 128 region.
+ⁱᵛ **d512 MXFP8 is CORRECT but has no test module**, so it is ⚠️ not ✅: cos =
+0.9997 / LSE exact at SQ ∈ {128, 256, 384, 512} from `frost_dev/_probe_d512_mxfp8.py`,
+but SM100 has no d512 MXFP8 sibling, so the shared suite carries no d512 case to
+widen — it needs new cases, not a widened gate. Every other quantized cell above
+is covered by `test_sdpa_fwd_{fp8,mxfp8}_sm100.py` running on Rubin.
+ᵛ THD is not ported for the f16 kernels: the setup-kernel call site still speaks
+a 7-arg contract against a 14-arg helper, and the metadata layout differs
+(3B+2 vs 4B+4). `compile()` raises rather than half-serving it.
+ᵛⁱ Needs the per-batch `seq_len_q` LSE trim, which the f16 Rubin kernels do not
+carry (`padded_stats=False`). KV-side padding itself is served.
+ᵛⁱⁱ The f16 Rubin kernels wire no SplitHelpers.
+ⁱˣ Served through the padded path with synthesized full-length KV lengths
+(`skv_tail_via_padding`). REQUIRED, not an optimization: with no mask the
+kernel's KV loop bound is a floor division, so an un-synthesized ragged `S_kv`
+would silently drop the tail tile.
+
+**Scheduler policy — NATURAL only on every Rubin row.** `SCHED_LPT_L2` was
+dropped first (the ported decode sites never thread `qh_per_kh` / `seqlen_kv`,
+so `_common_sm100._decode_initial` raises); plain `SCHED_LPT` followed on
+2026-09-08 once a heuristics fallback fix let a causal graph actually reach it —
+it is silently WRONG on the ported kernels (causal d512 FP8 → NaN, masked d128
+MXFP8 → max|O-ref| ≈ 1.9). A knob is honored or the engine is ineligible. The
+SHIPPED d128 FP8 kernel does honor both and loses them here too, because
+`sched_policies` is row-wide; recovering that needs a per-shape domain
+(`sched_policies_by_d_shape`, mirroring `cgas_by_d_shape`).
+
+**Coverage.** The Rubin cells above are exercised by the SM100 suites running on
+cc 10.7 with an arch-aware engine pin — `test_sdpa_fwd_dsl_sm100.py` (f16/bf16),
+`test_sdpa_fwd_fp8_sm100.py`, `test_sdpa_fwd_mxfp8_sm100.py` — plus the
+device-independent `test_sdpa_fwd_dsl_sm107.py` / `test_sdpa_fp8_sm107.py` row
+assertions. Every ❌ in the table is a `skipif(_SM == 107, ...)` naming the row
+field that declines it, so the skip inverts when the feature lands.
 
 ---
 
@@ -331,8 +388,9 @@ feature-free d=64 graph.
 | Backward sink / dSink, bias / dBias | SM100, SM103 |
 | Backward deterministic, decode | SM100, SM103 — served by the MXFP8 d=256 row only |
 | MXFP8 backward: E5M2, bottom-right / band-widened / sliding-window masks, non-BSHD strides, `amax_*` outputs | SM100, SM103 |
-| f16/bf16 forward | SM107 (Rubin) |
-| MXFP8 forward | SM107, SM120, SM80 |
+| f16/bf16 forward THD, split-KV, PackGQA, optional-stats, dense padded-Q trim | SM107 (Rubin) — the row serves dense f16/bf16 at d128/d256/d512; these five are the machinery its kernels lack |
+| Per-tensor FP8 forward above d=128 | SM107 — the d256/d512 kernels exist but have never produced a number |
+| MXFP8 forward | SM107 (kernels ported, never validated), SM120, SM80 |
 | Per-tensor FP8 backward | every arch |
 | MXFP8 backward outside SM100/SM103 d = 256 | every arch |
 | THD / ragged backward | SM80, SM120, and the SM100/SM103 MXFP8 row (the SM100/SM103 f16/bf16 row serves it — see ʰ) |

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -90,7 +90,26 @@ _SM100_MXFP8_KERNEL_FILES = {
     (192, 128): "prefill_d192_d128_mxfp8_sm100.py",
     (256, 256): "prefill_d256_mxfp8_sm100.py",
 }
-_SM107_FP8_KERNEL_FILE = "prefill_d128_fp8_sm107.py"
+# Rubin (SM107) siblings.  Separate maps rather than entries in the SM100
+# ones: the lowerings genuinely diverge (dense K=64 FP8 MMA, 576-column TMEM,
+# version-1 tcgen05 SMEM descriptors for operands above 256 KiB), which is the
+# same reason engines.py keeps one row per ARCH LINE.
+_SM107_KERNEL_FILES = {
+    (512, 512): "prefill_d512_f16_sm107.py",
+    (256, 256): "prefill_d256_f16_sm107.py",
+    (192, 128): "prefill_d192_d128_f16_sm107.py",
+    (128, 128): "prefill_d128_f16_sm107.py",
+}
+_SM107_FP8_KERNEL_FILES = {
+    (512, 512): "prefill_d512_fp8_sm107.py",
+    (256, 256): "prefill_d256_fp8_sm107.py",
+    (128, 128): "prefill_d128_fp8_sm107.py",
+}
+_SM107_MXFP8_KERNEL_FILES = {
+    (512, 512): "prefill_d512_mxfp8_sm107.py",
+    (256, 256): "prefill_d256_mxfp8_sm107.py",
+    (128, 128): "prefill_d128_mxfp8_sm107.py",
+}
 _SM100_FP8_KERNEL_FILES = {
     (128, 128): "prefill_d128_fp8_sm100.py",
     (192, 128): "prefill_d192_d128_fp8_sm100.py",
@@ -102,7 +121,7 @@ _SM100_FP8_KERNEL_FILES = {
 def _sm100_fp8_shapes(pertensor: bool, device_cc: tuple[int, int]) -> frozenset[tuple[int, int]]:
     """NATIVE (exact) FP8 kernel-flavor shapes for the device line."""
     if device_cc == (10, 7):
-        return frozenset({(128, 128)})
+        return frozenset(_SM107_FP8_KERNEL_FILES if pertensor else _SM107_MXFP8_KERNEL_FILES)
     kernel_files = _SM100_FP8_KERNEL_FILES if pertensor else _SM100_MXFP8_KERNEL_FILES
     return frozenset(kernel_files)
 
@@ -330,13 +349,19 @@ def _load_kernel_template(filename: str, params: Hashable, tag: str):
 
 def _load_sm100_kernel_module(flavor: tuple[int, int], params: Sm100TemplateParams, fp8: bool = False, pertensor: bool = False, rubin: bool = False):
     """Load one SM100-family module for the selected flavor and quantization
-    path.  ``rubin`` routes per-tensor FP8 to the SM107 sibling kernel (the
-    dense K=64 FP8 path baked in — see prefill_d128_fp8_sm107.py)."""
+    path.  ``rubin`` routes EVERY dtype family to its SM107 sibling kernel
+    (dense K=64 FP8 MMA and the version-1 SMEM descriptors baked in — see
+    prefill_d128_fp8_sm107.py and the d256/d512 siblings)."""
 
     tag = _flavor_tag(flavor)
-    if fp8 and pertensor and rubin and flavor == (128, 128):
-        filename = _SM107_FP8_KERNEL_FILE
-        tag = f"sdpa_fwd_sm107_fp8_{tag}"
+    if rubin:
+        # Tag spelling is load-bearing: it keys the template-module cache, and
+        # "sdpa_fwd_sm107_fp8_<flavor>" is what the shipped d128 FP8 row has
+        # always produced -- keep it byte-identical.
+        kind = ("fp8" if pertensor else "mxfp8") if fp8 else "f16"
+        files = (_SM107_FP8_KERNEL_FILES if pertensor else _SM107_MXFP8_KERNEL_FILES) if fp8 else _SM107_KERNEL_FILES
+        filename = files[flavor]
+        tag = f"sdpa_fwd_sm107_{kind}_{tag}"
     elif fp8:
         filename = _SM100_FP8_KERNEL_FILES[flavor] if pertensor else _SM100_MXFP8_KERNEL_FILES[flavor]
         tag = f"sdpa_fwd_sm100_{'fp8' if pertensor else 'mxfp8'}_{tag}"
@@ -1041,15 +1066,13 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         # cc10.0 (SM100) and cc10.3 (Blackwell-class) both run these kernels; cc10.3
         # additionally has the fused LDTM.STAT row-max, auto-enabled for MXFP8 in compile().
         self._device_cc = (major, minor)
-        # cc10.7 (Rubin) is served by the per-tensor FP8 path only, through the
-        # SM107 sibling kernel (dense K=64 FP8; the f16 and MXFP8 kernels'
-        # K=32-QMMA / f16-QMMA geometry has not been ported).
-        if self._fp8 and self._pertensor:
-            _allowed_cc = ((10, 0), (10, 3), (10, 7))
-            _allowed_msg = "cc=10.0/10.3 (Blackwell) or 10.7 (Rubin, per-tensor FP8)"
-        else:
-            _allowed_cc = ((10, 0), (10, 3))
-            _allowed_msg = "cc=10.0 or 10.3 (Blackwell; Rubin cc10.7 serves only the per-tensor FP8 d128 path)"
+        # cc10.7 (Rubin) now runs every dtype family through its own SM107
+        # sibling kernels (f16/bf16, per-tensor FP8 and MXFP8 -- the SM107 port).
+        # The per-arch-line split lives in the kernel FILES and the engine rows;
+        # this adapter serves both lines, so the gate is simply "a cc10.x line
+        # we have kernels for".
+        _allowed_cc = ((10, 0), (10, 3), (10, 7))
+        _allowed_msg = "cc=10.0/10.3 (Blackwell) or 10.7 (Rubin)"
         self._value_error_if(
             self._device_cc not in _allowed_cc,
             f"SdpaFwdDslSm100 requires {_allowed_msg}; found SM{major}{minor} on {device}",
@@ -1057,8 +1080,8 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
 
         # FP8 flavor shapes: SM100 per-tensor FP8 serves d128/d128,
         # d192/d128, and d256/d256; MXFP8 serves the shapes in its independent
-        # native map. Rubin
-        # currently serves only per-tensor FP8 d128. Per-tensor FP8 serves
+        # native map. Rubin serves d128/d256/d512 in both quantized families
+        # through its SM107 siblings. Per-tensor FP8 serves
         # the dense ENVELOPE of every flavor it has (TMA zero-padding, like
         # the f16 flavors — exact in FP8, and the descales are scalars, so
         # the envelope is arch-independent): head dims componentwise <= a
@@ -1091,24 +1114,28 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             f"(TMA 16-byte global-stride constraint at 2 bytes/elem); got "
             f"(D_QK={d_qk}, D_V={d_v})",
         )
-        # An FP8 graph must only land on a flavor that HAS an fp8 kernel: the
-        # per-tensor and block-scale families have different native maps.
-        # The FP8 walk must agree with check_support: a flavor whose envelope
-        # floor excludes (d_qk, d_v) is skipped, so the graph lands on the next
-        # covering flavor instead of the one the floor exists to keep it off.
-        self.flavor = _pick_flavor(
-            d_qk,
-            d_v,
-            (
-                tuple(
-                    f
-                    for f in _SM100_FLAVORS
-                    if f in fp8_shapes and (f == (int(d_qk), int(d_v)) or min(int(d_qk), int(d_v)) > _SM100_FP8_ENVELOPE_FLOORS.get(f, 0))
-                )
-                if self._fp8
-                else None
-            ),
-        )
+        # A graph must only land on a flavor that HAS a kernel for its
+        # quantization AND its arch line: the per-tensor and block-scale
+        # families have different native maps, and Rubin ships a strict subset
+        # of the SM100 f16 flavors (no d192xd128 sibling).  Without the Rubin
+        # narrowing a d=192 graph would pick (192, 128) and then KeyError in
+        # _load_sm100_kernel_module; with it, the graph falls to the next
+        # covering envelope exactly as it does for a missing FP8 flavor.
+        # The FP8 walk must also agree with check_support: a flavor whose
+        # envelope floor excludes (d_qk, d_v) is skipped, so the graph lands on
+        # the next covering flavor instead of the one the floor exists to keep
+        # it off.  (`fp8_shapes` is already arch-aware -- _sm100_fp8_shapes
+        # returns the SM107 maps at cc 10.7 -- so the FP8 arm needs no separate
+        # Rubin narrowing.)
+        if self._fp8:
+            _flavor_pool = tuple(
+                f for f in _SM100_FLAVORS if f in fp8_shapes and (f == (int(d_qk), int(d_v)) or min(int(d_qk), int(d_v)) > _SM100_FP8_ENVELOPE_FLOORS.get(f, 0))
+            )
+        elif self._device_cc == (10, 7):
+            _flavor_pool = tuple(f for f in _SM100_FLAVORS if f in _SM107_KERNEL_FILES)
+        else:
+            _flavor_pool = None
+        self.flavor = _pick_flavor(d_qk, d_v, _flavor_pool)
         self._value_error_if(
             self.sched_policy is not None and self.sched_policy not in (SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2),
             f"SM100 DSL SDPA sched_policy must be NATURAL/LPT/LPT_L2 (or None to derive); got {self.sched_policy}",
@@ -1198,6 +1225,22 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             self.thd and self._fp8 and (int(d_qk), int(d_v)) not in _thd_fp8_shapes,
             f"THD/varlen on this quantized path supports {sorted(_thd_fp8_shapes)}; " f"got (D_QK={d_qk}, D_V={d_v})",
         )
+        # THD on the Rubin line: only the SHIPPED d128 per-tensor FP8 kernel
+        # carries it.  Every PORTED SM107 kernel raises at compile() -- the
+        # setup-kernel call site still speaks the pre-upstream 7-arg contract
+        # against a 14-arg helper, and the metadata layout differs (3B+2 vs
+        # 4B+4).  The three SM107 engine rows already say so (`thd=False` on
+        # f16/MXFP8, `thd_d_shapes={(128,128)}` on FP8); this is the
+        # STANDALONE-wrapper twin of that decline, which the rows cannot cover
+        # because the wrapper never consults them.  Without it check_support()
+        # returns True and compile() dies with a bare TypeError on the
+        # lse_head_major kwarg -- an untyped escape, not a decline.
+        self._not_implemented_error_if(
+            self.thd and self._device_cc == (10, 7) and not (self._fp8 and self._pertensor and (int(d_qk), int(d_v)) == (128, 128)),
+            f"THD/varlen on the Rubin (SM107) line is per-tensor FP8 d128 only; "
+            f"got (D_QK={d_qk}, D_V={d_v}) on the "
+            f"{'MXFP8' if (self._fp8 and not self._pertensor) else 'FP8' if self._fp8 else 'f16/bf16'} path",
+        )
         # Dense padded-Q trim backstops (engines.lower_dsl_prefill never sets
         # these combinations; a direct caller could).
         self._value_error_if(
@@ -1265,7 +1308,21 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             # THD is excluded: the LPT decodes assume a dense rectangular
             # tile space, while a ragged batch carries its own scheduler,
             # which walks the live units through batch_remap.
-            if self.window_right is not None and not self.thd:
+            #
+            # Rubin is excluded for a different reason: the PORTED SM107
+            # kernels do not honor either LPT decode.  LPT_L2 raises outright
+            # ("SCHED_LPT_L2 decode requires qh_per_kh and seqlen_kv at every
+            # call site" -- the ported decode sites never thread them), and
+            # plain LPT is silently WRONG (measured 2026-09-08: causal d512 FP8
+            # -> NaN, masked d128 MXFP8 -> max|O-ref| ~ 1.9).  The three SM107
+            # engine rows already declare sched_policies={SCHED_NATURAL}; this
+            # is the STANDALONE-wrapper twin of that decline, which the row
+            # cannot cover because the wrapper never consults it.
+            # NOTE: the SHIPPED d128 FP8 SM107 kernel does honor both, and
+            # loses them here too -- recovering that needs a per-flavor domain
+            # (see the sched_policies_by_d_shape follow-up).
+            _rubin = self._device_cc == (10, 7)
+            if self.window_right is not None and not self.thd and not _rubin:
                 # Causal: balance the triangular load; pick the LPT variant by working set.
                 _, _, s_kv_sched, _ = self.k_desc.shape
                 _, _, _, d_qk_sched = self.q_desc.shape

--- a/python/cudnn/sdpa/fwd/config_sm107.py
+++ b/python/cudnn/sdpa/fwd/config_sm107.py
@@ -249,8 +249,13 @@ def _validate_params(flavor: str, k: TemplateParams) -> None:
         raise ValueError(f"{flavor}: qh_per_kh ({k.qh_per_kh}) must be >= 1")
     if k.split_kv and k.split_kv > 1:
         raise ValueError(f"{flavor}: split_kv > 1 is not wired in the SM107 kernels (no SplitHelpers)")
-    if k.thd_varlen and k.dtype_qkv not in (_DTYPE_E4M3, _DTYPE_E5M2, _DTYPE_BF16, _DTYPE_FP16):
-        raise ValueError(f"{flavor}: THD/varlen supports f16/bf16/fp8 only (got dtype_qkv={k.dtype_qkv})")
+    # FP8/MXFP8 only.  The f16/bf16 Rubin kernels carry no varlen plumbing --
+    # their setup-kernel call site still speaks the pre-upstream 7-arg contract
+    # against a 14-arg helper, and the metadata layout differs (3B+2 vs 4B+4).
+    # (This guard used to repeat the same dtype set the check above already
+    # enforces, so it declined nothing.)
+    if k.thd_varlen and k.dtype_qkv not in (_DTYPE_E4M3, _DTYPE_E5M2):
+        raise ValueError(f"{flavor}: THD/varlen is FP8/MXFP8 only on SM107 (got dtype_qkv={k.dtype_qkv}); the f16/bf16 kernels carry no varlen plumbing")
 
 
 def _band_fields(params: TemplateParams) -> Tuple[int, int, int, int, int]:

--- a/python/cudnn/sdpa/fwd/config_sm107.py
+++ b/python/cudnn/sdpa/fwd/config_sm107.py
@@ -1,0 +1,883 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Kernel configuration for the Frost SM107 (Rubin) DSL SDPA-forward flavors.
+
+**Why this is a separate module from** :mod:`cudnn.sdpa.fwd.config_sm100`, and
+not a widening of it: the Rubin kernels are a different kernel *lineage*, not
+the Blackwell kernels recompiled. They implement different pipelines, so they
+need different warp populations, stage depths and MMA k-steps. The two module's
+flavors overlap in NAME (``d128`` / ``d256`` / ``d512``) and in almost nothing
+else, and the overlap is what makes sharing dangerous rather than economical.
+
+That is not a theoretical concern — it cost a debugging session. The SM107
+``d256`` per-tensor FP8 kernel was routed through ``make_cfg_d256`` (Blackwell),
+which derives its whole warp layout from a *split-P* switch that only the
+Blackwell d256 kernel implements::
+
+    SOFTMAX_WARPGROUPS   rubin-body=1     blackwell-cfg=2
+    TOTAL_WARPS          rubin-body=12    blackwell-cfg=16
+    THREADS_PER_CTA      rubin-body=384   blackwell-cfg=512
+    MMA_WARP_ID          rubin-body=8     blackwell-cfg=12
+    READ_TILE_ARRIVERS   rubin-body=11    blackwell-cfg=15
+
+The last line is the fatal one: ``READ_TILE_ARRIVERS`` is the init count of the
+scheduler's tile-handoff mbarrier, so a count of 15 against 11 actual arrivers
+can never be reached and the *first* tile handoff never completes. The kernel
+hung at every shape, down to ``B=1 H=1 S=128`` — 100 % GPU, no fault, no wrong
+number, nothing for a sanitizer to find. Keeping Rubin's geometry in its own
+module is what makes that class of mismatch impossible rather than merely
+unlikely.
+
+Provenance: every value here is the one the Rubin kernel BODIES were written and
+validated against (the pre-upstream ``sdpa_config_{llama,dsv3,qwen,
+dsv4}`` flavors, keyed here by op geometry per the engine contract, not by model
+name). ``test_sdpa_fwd_config_sm107.py`` pins the ones a kernel body would
+deadlock or corrupt on if they drifted.
+
+Shared with SM100 by design: :class:`TemplateParams` (the engine-contract record
+the loader injects) and the mask / dtype / scheduler vocabulary. Those are the
+interface; everything below is the Rubin geometry behind it.
+
+All configuration errors raise :class:`ValueError`. Anything a *user-built
+graph* could trip must be rejected earlier, by ``graph_analyzer.probe`` /
+``api_dsl.SdpaFwdDslSm100.check_support`` — a ``ValueError`` from here means
+those support checks have a gap.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+from cudnn.frost.tile_dsl.constants import (
+    MASK_CAUSAL,
+    MASK_NONE,
+    MASK_PADDED,
+    MASK_SWA,
+    SCHED_LPT,
+    SCHED_LPT_L2,
+    SCHED_NATURAL,
+)
+
+# The engine-contract record is deliberately SHARED: one lowering builds it, and
+# an arch-specific copy would let the two drift in ways the loader cannot see.
+from cudnn.sdpa.fwd.config_sm100 import TemplateParams
+
+__all__ = [
+    "TemplateParams",
+    "resolve_dtype_o",
+    "TmaIters",
+    "CfgD128",
+    "CfgD192",
+    "CfgD256",
+    "CfgD512",
+    "make_cfg_d128",
+    "make_cfg_d128_mxfp8",
+    "make_cfg_d192",
+    "make_cfg_d256",
+    "make_cfg_d256_mxfp8",
+    "make_cfg_d512",
+    "make_cfg_d512_mxfp8",
+    "SMEM_CAP_BYTES",
+]
+
+
+# ---------------------------------------------------------------------------
+# Rubin architecture constants
+# ---------------------------------------------------------------------------
+
+# Rubin SM10.7 oversized SMEM cap.  Reaching past the standard 227 KiB requires
+# the launcher to set ALLOW_OVERSIZED_SHARED_MEMORY; the d128 FP8 9-stage ring
+# and the d256/d512 flavors all depend on it.
+SMEM_CAP_BYTES = 327 * 1024
+
+# ...but the CAPACITY is not the budget. The shipped prefill_d128_fp8_sm107.py
+# sizes its own guard against 320 KiB ("327 KiB capacity minus reserves"), and
+# the kernels additionally spend ~2 KiB on barriers, the scheduler ring and the
+# TMEM pointer. Validating Q/K/V/O against the raw 327 KiB waves through an
+# allocation that silently overflows: d192 f16 at STAGES_KV=4 sums to exactly
+# 320 KiB of Q/K/V/O, passed a 327 KiB check, and produced an output that was
+# 50 % ZEROS with a numerically EXACT LSE (BMM1 and the softmax are fine; only
+# the clobbered O half is wrong). Check against this, not the capacity.
+SMEM_USABLE_BYTES = 320 * 1024
+_SMEM_FIXED_OVERHEAD = 2 * 1024  # barriers + scheduler + tmem-ptr slack
+
+# TMEM columns.  Rubin raises the Blackwell 512 to 576, which needs
+# `tmem_alloc(..., is_exclusive=True)` (see tile_dsl/tmem.py).
+TMEM_TOTAL_COLS = 576
+
+_DTYPE_E4M3, _DTYPE_E5M2, _DTYPE_BF16, _DTYPE_FP16 = 0, 1, 2, 3
+
+
+# ---------------------------------------------------------------------------
+# Derivation helpers (Rubin values — several differ from the SM100 twins)
+# ---------------------------------------------------------------------------
+
+
+def bpe(dtype: int) -> int:
+    """Bytes per element. FP8/MXFP8 = 1, BF16/FP16 = 2."""
+    return 1 if dtype <= _DTYPE_E5M2 else 2
+
+
+def resolve_dtype_o(params: TemplateParams) -> int:
+    """``TemplateParams.dtype_o`` uses -1 as "inherit dtype_qkv"; every consumer
+    must resolve it before use. Passing the raw -1 into ``bpe()`` would silently
+    yield BPE_O=1 (an FP8-sized O buffer) for a half-precision output."""
+    return params.dtype_qkv if params.dtype_o < 0 else params.dtype_o
+
+
+def tile_k_hw(dtype_qkv: int) -> int:
+    """HW k-step in elements.
+
+    **This is the single most arch-sensitive value in the file.** Rubin runs the
+    dense 2xFP8 MMA at K=64 per instruction and pairs it with idesc ``k_dim=1``;
+    Blackwell has no K=64 FP8 path and uses K=32 with ``k_dim=0``. The pairing is
+    arch-OPPOSITE, and a mismatch does not fail — it silently scrambles rows of
+    the accumulator (see rules/mma-tma-matrix.md S1). The kernel bodies here
+    hardcode ``k_dim=1``, so FP8/MXFP8 must be 64.
+
+    BF16/FP16 use 16 on both arches: the 2-chunk (K=32) f16 path is silently
+    wrong on SM10x.
+    """
+    return 64 if dtype_qkv <= _DTYPE_E5M2 else 16
+
+
+def q_swz_bytes(tile_k: int, bpe_val: int) -> int:
+    return 128 if (tile_k * bpe_val) % 128 == 0 else 64
+
+
+def v_swz_bytes(tile_o: int, cta_mma: int, bpe_val: int) -> int:
+    """V is split along d_v under cga2, so its swizzle follows the PER-CTA inner
+    stride; Q/K/O use the full-tile inner extent."""
+    inner = (tile_o // cta_mma) * bpe_val
+    if inner % 128 == 0:
+        return 128
+    if inner % 64 == 0:
+        return 64
+    if inner % 32 == 0:
+        return 32
+    raise ValueError(f"V inner bytes {inner} is not a multiple of 32/64/128")
+
+
+def o_swz_bytes(tile_o: int, bpe_o: int) -> int:
+    return 128 if (tile_o * bpe_o) % 128 == 0 else 64
+
+
+def rescale_threshold(dtype_qkv: int) -> float:
+    """4.0 for FP8/MXFP8 (low precision, rescale aggressively); 8.0 for
+    BF16/FP16 (defer rescale to amortize the alpha == 1 fast path)."""
+    return 4.0 if dtype_qkv <= _DTYPE_E5M2 else 8.0
+
+
+def sdpa_smem_bytes(
+    tile_m: int,
+    tile_n: int,
+    tile_k: int,
+    tile_o: int,
+    tiles_q: int,
+    stages_kv: int,
+    cta_mma: int,
+    bpe_qkv: int,
+    bpe_o: int,
+    qo_alias: bool = False,
+) -> int:
+    """Q/K/V/O SMEM footprint for the classic prefill pipeline.
+
+    K (seq rows) and V (d_v cols) shrink by CTA_MMA; Q/O are per-CTA full.
+    ``qo_alias`` = O reuses Q's slab in the epilogue (max instead of sum).
+    """
+    s_q = tiles_q * (tile_m * tile_k) * bpe_qkv
+    s_o = tiles_q * (tile_m * tile_o) * bpe_o
+    s_k = stages_kv * (tile_n * tile_k // cta_mma) * bpe_qkv
+    s_v = stages_kv * (tile_o * tile_n // cta_mma) * bpe_qkv
+    return (max(s_q, s_o) if qo_alias else s_q + s_o) + s_k + s_v
+
+
+@dataclass(frozen=True)
+class TmaIters:
+    """TMA inner-loop iteration counts and per-iteration element granularity."""
+
+    QK_ITERS: int
+    VO_ITERS: int
+    QK_GRANU_ELEMS: int
+    VO_GRANU_ELEMS: int
+
+
+def _tma_iters_for(d_elems: int, bpe_val: int, swz_b: int) -> int:
+    """TMA inner-loop iters when d*BPE exceeds the swizzle atom: each TMA-tile
+    load expands into inner_bytes/swz_b sub-loads stepped by swz_b/BPE elems."""
+    inner_bytes = d_elems * bpe_val
+    if inner_bytes % swz_b != 0:
+        raise ValueError(f"TMA inner bytes {inner_bytes} is not a multiple of swizzle {swz_b}")
+    return inner_bytes // swz_b
+
+
+def _tma_iters(cfg) -> TmaIters:
+    qk = _tma_iters_for(cfg.TILE_K, cfg.BPE, cfg.Q_SWZ_BYTES)
+    vo = _tma_iters_for(cfg.TILE_O, cfg.BPE, cfg.V_SWZ_BYTES)
+    return TmaIters(QK_ITERS=qk, VO_ITERS=vo, QK_GRANU_ELEMS=cfg.TILE_K // qk, VO_GRANU_ELEMS=cfg.TILE_O // vo)
+
+
+def _mask_flags_from(params: TemplateParams) -> int:
+    """Kernel-facing MASK bits, derived from the band + padding. The kernels fold
+    trace-time branches on these bits; the band VALUES ride WINDOW_LEFT /
+    WINDOW_RIGHT (0 when the corresponding bit is unset)."""
+    flags = MASK_NONE
+    if params.window_right is not None:
+        flags |= MASK_CAUSAL
+    if params.window_left is not None:
+        flags |= MASK_SWA
+    if params.thd_varlen or params.seq_kv_lens_present:
+        flags |= MASK_PADDED
+    return flags
+
+
+def _validate_params(flavor: str, k: TemplateParams) -> None:
+    """Guard the TemplateParams a Rubin flavor can express. Every rejection here
+    must also be a Capabilities decline — reaching this is an engine-row bug."""
+    if k.dtype_qkv not in (_DTYPE_E4M3, _DTYPE_E5M2, _DTYPE_BF16, _DTYPE_FP16):
+        raise ValueError(f"{flavor}: dtype_qkv must be 0=E4M3/1=E5M2/2=BF16/3=FP16 (got {k.dtype_qkv}); Rubin has no TF32 prefill kernel")
+    dtype_o = resolve_dtype_o(k)
+    if dtype_o not in (_DTYPE_E4M3, _DTYPE_E5M2, _DTYPE_BF16, _DTYPE_FP16):
+        raise ValueError(f"{flavor}: dtype_o must be 0..3 (got {k.dtype_o})")
+    if k.dtype_qkv > _DTYPE_E5M2 and dtype_o != k.dtype_qkv:
+        raise ValueError(f"{flavor}: half input (BF16/FP16) requires dtype_o == dtype_qkv; got dtype_o={dtype_o}")
+    if k.sched_policy not in (None, SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2):
+        raise ValueError(f"{flavor}: sched_policy must be NATURAL/LPT/LPT_L2 or None (got {k.sched_policy})")
+    if k.qh_per_kh < 1:
+        raise ValueError(f"{flavor}: qh_per_kh ({k.qh_per_kh}) must be >= 1")
+    if k.split_kv and k.split_kv > 1:
+        raise ValueError(f"{flavor}: split_kv > 1 is not wired in the SM107 kernels (no SplitHelpers)")
+    if k.thd_varlen and k.dtype_qkv not in (_DTYPE_E4M3, _DTYPE_E5M2, _DTYPE_BF16, _DTYPE_FP16):
+        raise ValueError(f"{flavor}: THD/varlen supports f16/bf16/fp8 only (got dtype_qkv={k.dtype_qkv})")
+
+
+def _band_fields(params: TemplateParams) -> Tuple[int, int, int, int, int]:
+    """(MASK_FLAGS, WINDOW_LEFT, WINDOW_RIGHT, BOTTOM_RIGHT, HAS_SINK).
+
+    WINDOW_* are 0 when their mask bit is unset. Passing window_left without
+    window_right is silently wrong rather than partial — the KV-tile trim already
+    uses WINDOW_RIGHT, so the element-level mask must receive it too."""
+    return (
+        _mask_flags_from(params),
+        params.window_left or 0,
+        params.window_right or 0,
+        int(params.bottom_right),
+        int(params.has_sink),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared field surface
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _CfgSm107:
+    """Fields every Rubin prefill flavor carries.
+
+    Per-flavor factories set every field explicitly; the defaults exist so the
+    dataclass is constructible in a doc/test context, not as a fallback.
+    """
+
+    # --- tile geometry
+    TILE_M: int = 128
+    TILE_N: int = 128
+    TILE_K: int = 128  # d_qk
+    TILE_O: int = 128  # d_v
+
+    # --- dtypes
+    DTYPE_QKV: int = _DTYPE_FP16  # 0=E4M3 1=E5M2 2=BF16 3=FP16
+    DTYPE_O: int = _DTYPE_FP16
+    BPE: int = 2
+    BPE_O: int = 2
+
+    # --- cluster
+    CGA_M: int = 2
+    CGA_N: int = 1
+    CTA_MMA: int = 2
+    SPLIT_PIPELINE: int = 0
+
+    # --- swizzles
+    Q_SWZ_BYTES: int = 128
+    K_SWZ_BYTES: int = 128
+    V_SWZ_BYTES: int = 128
+    O_SWZ_BYTES: int = 128
+
+    # --- MMA k-step (arch-sensitive; see tile_k_hw)
+    TILE_K_HW_BMM1: int = 16
+    TILE_K_HW_BMM2: int = 16
+
+    # --- pipeline depth
+    TILES_Q: int = 2
+    SCHEDULER_STAGES: int = 2
+    STAGES_KV: int = 4
+
+    # --- warp roles
+    SOFTMAX_WARPGROUPS: int = 2
+    CORRECTION_WARPS: int = 4
+    SOFTMAX_REGS: int = 192
+    CORRECTION_REGS: int = 88
+    MMA_REGS: int = 40
+    TMALDG_REGS: int = 40
+    TMASTG_REGS: int = 40
+    SCHEDULER_REGS: int = 40
+    OTHER_REGS: int = 40
+
+    RESCALE_THRESHOLD: float = 8.0
+
+    # --- graph-derived features
+    MASK_FLAGS: int = MASK_NONE
+    WINDOW_LEFT: int = 0
+    WINDOW_RIGHT: int = 0
+    BOTTOM_RIGHT: int = 0
+    HAS_SINK: int = 0
+    PACK_GQA: int = 0
+    QH_PER_KH: int = 1
+    SPLIT_KV: int = 1
+    SEQ_KV_LENS_PRESENT: int = 0
+    SEQ_Q_LENS_PRESENT: int = 0
+    THD_VARLEN: int = 0
+
+    L2_SIZE_MIB: int = 60
+    SCHEDULER_POLICY: int = SCHED_NATURAL
+
+    N_BMM2_CHUNKS: int = 2
+    BMM2_CHUNK_SIZE: int = 64
+
+    # --- warp population (READ_TILE_ARRIVERS must equal the number of warps that
+    # actually call read_tile_id_arrive; a mismatch is an unreachable mbarrier
+    # count, i.e. a hang at every shape)
+    TOTAL_WARPS: int = 16
+    THREADS_PER_CTA: int = 16 * 32
+    SOFTMAX_WG_WARPS: int = 4
+    OTHER_WARPS: int = 4
+    SOFTMAX_WG0_BASE: int = 0
+    SOFTMAX_WG1_BASE: int = 4
+    CORR_WARP_BASE: int = 8
+    MMA_WARP_ID: int = 12
+    TMALDG_WARP_ID: int = 13
+    TMASTG_WARP_ID: int = 14
+    SCHED_WARP_ID: int = 15
+
+    # --- mbarrier lane constants
+    ONE_LANE: int = 1
+    ONE_WARP: int = 32
+    SOFTMAX_LANES: int = 128
+    CORR_LANES: int = 128
+    SOFTMAX_PLUS_CORR: int = 256
+    READ_TILE_ARRIVERS: int = 15
+
+
+@dataclass(frozen=True)
+class CfgD128(_CfgSm107):
+    """d_qk = d_v = 128 (the classic 2-warpgroup pipeline)."""
+
+    QO_ALIAS: int = 0
+
+
+@dataclass(frozen=True)
+class CfgD192(CfgD128):
+    """d_qk = 192, d_v = 128. Same pipeline as d128; Q/K swizzle drops to 64 B at
+    FP8 because TILE_K * 1 = 192 is not a multiple of 128."""
+
+
+@dataclass(frozen=True)
+class CfgD256(_CfgSm107):
+    """d_qk = d_v = 256. Q-union-O SMEM alias, single softmax warpgroup, a
+    Q.K(i+1) -> S.V(i) lookahead MMA stream with two parity S_acc TMEM slots."""
+
+
+@dataclass(frozen=True)
+class CfgD512(_CfgSm107):
+    """d_qk = d_v = 512, cga4x1 role-split: the cluster's 4 CTAs form two 2-CTA
+    sub-groups (sg0 = BMM1 + softmax + ship, sg1 = recv + correction + BMM2)."""
+
+    XFER_STAGES: int = 2
+    BMM2_N_PER_CALL: int = 256
+    BMM2_LOOP_N_BLOCKS: int = 2
+
+
+# ---------------------------------------------------------------------------
+# Shared validators
+# ---------------------------------------------------------------------------
+
+
+def _check(preds) -> None:
+    for ok, msg in preds:
+        if not ok:
+            raise ValueError(msg)
+
+
+def _validate_regs(cfg, flavor: str) -> None:
+    """The four hardware register constraints. Equality and alignment are HW
+    requirements, not style: violating them gives wrong results or a crash, with
+    no diagnostic."""
+    _check(
+        [
+            (
+                cfg.MMA_REGS == cfg.TMALDG_REGS == cfg.TMASTG_REGS == cfg.SCHEDULER_REGS,
+                f"{flavor}: MMA/TMALDG/TMASTG/SCHEDULER regs must be equal",
+            ),
+            (
+                cfg.MMA_REGS + cfg.CORRECTION_REGS + cfg.SOFTMAX_WARPGROUPS * cfg.SOFTMAX_REGS <= 512,
+                f"{flavor}: register budget over 512",
+            ),
+            (
+                all(r % 8 == 0 for r in (cfg.MMA_REGS, cfg.CORRECTION_REGS, cfg.SOFTMAX_REGS, cfg.OTHER_REGS)),
+                f"{flavor}: every per-role register count must be a multiple of 8",
+            ),
+            (
+                all(24 <= r <= 256 for r in (cfg.MMA_REGS, cfg.SOFTMAX_REGS) if r),
+                f"{flavor}: per-warp register counts must be within 24..256",
+            ),
+        ]
+    )
+
+
+def _validate_warp_layout(cfg, flavor: str, *, expect_total: int, expect_arrivers: int) -> None:
+    """Pin the warp population against the count the kernel BODY implements.
+
+    This is the check whose absence hung the d256 FP8 port: the body's role
+    dispatch and its ``read_tile_id_arrive`` call sites are fixed, so a config
+    that disagrees produces an mbarrier init count nothing can reach."""
+    _check(
+        [
+            (cfg.TOTAL_WARPS == expect_total, f"{flavor}: kernel body has {expect_total} warps, config says {cfg.TOTAL_WARPS}"),
+            (cfg.THREADS_PER_CTA == cfg.TOTAL_WARPS * 32, f"{flavor}: THREADS_PER_CTA must be TOTAL_WARPS*32"),
+            (
+                cfg.READ_TILE_ARRIVERS == expect_arrivers,
+                f"{flavor}: READ_TILE_ARRIVERS must be {expect_arrivers} for this body (got {cfg.READ_TILE_ARRIVERS}); "
+                f"a wrong count is an unreachable scheduler mbarrier, i.e. a hang at EVERY shape",
+            ),
+        ]
+    )
+
+
+def _validate_dtype_k_step(cfg, flavor: str) -> None:
+    """FP8/MXFP8 must ride Rubin's K=64 dense path (the bodies hardcode idesc
+    k_dim=1); f16/bf16 must stay 1-chunk at 16."""
+    want = tile_k_hw(cfg.DTYPE_QKV)
+    _check(
+        [
+            (
+                cfg.TILE_K_HW_BMM1 == want and cfg.TILE_K_HW_BMM2 == want,
+                f"{flavor}: TILE_K_HW must be {want} at DTYPE_QKV={cfg.DTYPE_QKV} on Rubin "
+                f"(got {cfg.TILE_K_HW_BMM1}/{cfg.TILE_K_HW_BMM2}); a mismatch against the body's "
+                f"idesc k_dim silently scrambles accumulator rows",
+            ),
+        ]
+    )
+
+
+def _validate_smem(cfg, flavor: str, *, qo_alias: bool) -> None:
+    used = (
+        sdpa_smem_bytes(cfg.TILE_M, cfg.TILE_N, cfg.TILE_K, cfg.TILE_O, cfg.TILES_Q, cfg.STAGES_KV, cfg.CTA_MMA, cfg.BPE, cfg.BPE_O, qo_alias=qo_alias)
+        + _SMEM_FIXED_OVERHEAD
+    )
+    if used > SMEM_USABLE_BYTES:
+        raise ValueError(
+            f"{flavor}: SMEM {used // 1024} KiB (Q/K/V/O + {_SMEM_FIXED_OVERHEAD // 1024} KiB fixed) exceeds the "
+            f"{SMEM_USABLE_BYTES // 1024} KiB usable Rubin carveout at STAGES_KV={cfg.STAGES_KV}, CTA_MMA={cfg.CTA_MMA}. "
+            f"Overflowing it does NOT fail the launch -- it clobbers the last buffer allocated (measured: O came back "
+            f"50 % zeros with an exact LSE), so this must raise here"
+        )
+
+
+def _validate_swizzles(cfg, flavor: str) -> None:
+    _check(
+        [
+            (cfg.Q_SWZ_BYTES in (64, 128), f"{flavor}: Q swizzle must be 64/128 B"),
+            (cfg.K_SWZ_BYTES in (64, 128), f"{flavor}: K swizzle must be 64/128 B"),
+            (cfg.V_SWZ_BYTES in (32, 64, 128), f"{flavor}: V swizzle must be 32/64/128 B"),
+            (cfg.O_SWZ_BYTES in (64, 128), f"{flavor}: O swizzle must be 64/128 B"),
+        ]
+    )
+
+
+def _validate_masks(cfg, flavor: str) -> None:
+    _check(
+        [
+            (
+                not (cfg.BOTTOM_RIGHT and not (cfg.MASK_FLAGS & MASK_CAUSAL)),
+                f"{flavor}: bottom-right alignment requires a causal band",
+            ),
+            (
+                not (cfg.THD_VARLEN and not (cfg.MASK_FLAGS & MASK_PADDED)),
+                f"{flavor}: THD/varlen implies per-sequence padded masking",
+            ),
+            (
+                not (cfg.THD_VARLEN and not cfg.SEQ_KV_LENS_PRESENT),
+                f"{flavor}: THD/varlen must force SEQ_KV_LENS_PRESENT=1, or every sequence attends the whole pack",
+            ),
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# d128 / d192 -- the classic 2-warpgroup pipeline (16 warps)
+# ---------------------------------------------------------------------------
+#
+# Warp map: 8 softmax (2 warpgroups) + 4 correction + MMA + TMALDG + TMASTG +
+# scheduler.  15 of the 16 warps arrive on the scheduler ring (all but the
+# scheduler warp itself).
+
+
+_D128_TOTAL_WARPS = 16
+_D128_READ_TILE_ARRIVERS = 15
+
+
+def _stages_kv_d128(dtype_qkv: int, cta_mma: int, *, mxfp8: bool, tile_k: int) -> int:
+    """Rubin d128-family ring depth.
+
+    Per-tensor FP8 at d128/cga2 runs a **9-stage** ring: a Rubin-specific tuning
+    carried by the shipped ``prefill_d128_fp8_sm107.py`` (which previously spelled
+    it as a post-hoc ``dataclasses.replace``), and the reason that kernel needs
+    the oversized-SMEM launch mode.
+
+    It is deliberately narrow. At cga1 the per-CTA K/V slabs double and 9 stages
+    need 352 KiB, past the 327 KiB cap; at d192 (``tile_k=192``) the Q/K slabs
+    grow and the tuning was never measured. Both fall back to 4, which is what
+    the kernel bodies were validated with.
+    """
+    if dtype_qkv <= _DTYPE_E5M2:
+        if not mxfp8 and tile_k == 128 and cta_mma == 2:
+            return 9
+        return 4
+    # d192's wider Q/K slabs do not leave room for a 4-deep ring: Q/K/V/O alone
+    # sum to exactly 320 KiB, which overflows the usable carveout once barriers
+    # are counted. Measured on Rubin at n_kv=2: depth 4 -> 50 % of O zeroed,
+    # cos = 0.0015; depth 2 -> cos = 1.000000. d128 at depth 4 sums to 256 KiB
+    # and passes every n_kv, so this is a d192 constraint, not a family one.
+    if tile_k == 192:
+        return 2
+    return 2 * cta_mma
+
+
+def _make_cfg_d128_family(params: TemplateParams, *, flavor: str, tile_k: int, tile_o: int, mxfp8: bool):
+    _validate_params(flavor, params)
+    cta_mma = params.cta_mma
+    dtype_o = resolve_dtype_o(params)
+    b, b_o = bpe(params.dtype_qkv), bpe(dtype_o)
+    tile_n = 128
+    stages_kv = _stages_kv_d128(params.dtype_qkv, cta_mma, mxfp8=mxfp8, tile_k=tile_k)
+    mask_flags, win_l, win_r, bottom_right, has_sink = _band_fields(params)
+    cls = CfgD192 if tile_k == 192 else CfgD128
+
+    cfg = cls(
+        TILE_M=128,
+        TILE_N=tile_n,
+        TILE_K=tile_k,
+        TILE_O=tile_o,
+        DTYPE_QKV=params.dtype_qkv,
+        DTYPE_O=dtype_o,
+        BPE=b,
+        BPE_O=b_o,
+        CGA_M=cta_mma,
+        CGA_N=1,
+        CTA_MMA=cta_mma,
+        SPLIT_PIPELINE=0,
+        QO_ALIAS=0,
+        Q_SWZ_BYTES=q_swz_bytes(tile_k, b),
+        K_SWZ_BYTES=q_swz_bytes(tile_k, b),
+        V_SWZ_BYTES=v_swz_bytes(tile_o, cta_mma, b),
+        O_SWZ_BYTES=o_swz_bytes(tile_o, b_o),
+        TILE_K_HW_BMM1=tile_k_hw(params.dtype_qkv),
+        TILE_K_HW_BMM2=tile_k_hw(params.dtype_qkv),
+        TILES_Q=2,
+        SCHEDULER_STAGES=2,
+        STAGES_KV=stages_kv,
+        SOFTMAX_WARPGROUPS=2,
+        CORRECTION_WARPS=4,
+        SOFTMAX_REGS=192,
+        CORRECTION_REGS=88,
+        RESCALE_THRESHOLD=rescale_threshold(params.dtype_qkv),
+        MASK_FLAGS=mask_flags,
+        WINDOW_LEFT=win_l,
+        WINDOW_RIGHT=win_r,
+        BOTTOM_RIGHT=bottom_right,
+        HAS_SINK=has_sink,
+        PACK_GQA=int(params.pack_gqa),
+        QH_PER_KH=params.qh_per_kh,
+        SPLIT_KV=params.split_kv or 1,
+        SEQ_KV_LENS_PRESENT=1 if params.thd_varlen else int(params.seq_kv_lens_present),
+        SEQ_Q_LENS_PRESENT=int(params.seq_q_lens_present),
+        THD_VARLEN=int(params.thd_varlen),
+        SCHEDULER_POLICY=params.sched_policy if params.sched_policy is not None else SCHED_NATURAL,
+        N_BMM2_CHUNKS=tile_n // 64,
+        BMM2_CHUNK_SIZE=64,
+        TOTAL_WARPS=_D128_TOTAL_WARPS,
+        THREADS_PER_CTA=_D128_TOTAL_WARPS * 32,
+        SOFTMAX_WG0_BASE=0,
+        SOFTMAX_WG1_BASE=4,
+        CORR_WARP_BASE=8,
+        MMA_WARP_ID=12,
+        TMALDG_WARP_ID=13,
+        TMASTG_WARP_ID=14,
+        SCHED_WARP_ID=15,
+        READ_TILE_ARRIVERS=_D128_READ_TILE_ARRIVERS,
+    )
+
+    _validate_regs(cfg, flavor)
+    _validate_warp_layout(cfg, flavor, expect_total=_D128_TOTAL_WARPS, expect_arrivers=_D128_READ_TILE_ARRIVERS)
+    _validate_dtype_k_step(cfg, flavor)
+    _validate_swizzles(cfg, flavor)
+    _validate_masks(cfg, flavor)
+    _validate_smem(cfg, flavor, qo_alias=bool(cfg.QO_ALIAS))
+    return cfg, _tma_iters(cfg)
+
+
+def make_cfg_d128(params: TemplateParams) -> Tuple[CfgD128, TmaIters]:
+    return _make_cfg_d128_family(params, flavor="sm107 d128", tile_k=128, tile_o=128, mxfp8=False)
+
+
+def make_cfg_d128_mxfp8(params: TemplateParams) -> Tuple[CfgD128, TmaIters]:
+    return _make_cfg_d128_family(params, flavor="sm107 d128 mxfp8", tile_k=128, tile_o=128, mxfp8=True)
+
+
+def make_cfg_d192(params: TemplateParams) -> Tuple[CfgD192, TmaIters]:
+    return _make_cfg_d128_family(params, flavor="sm107 d192xd128", tile_k=192, tile_o=128, mxfp8=False)
+
+
+# ---------------------------------------------------------------------------
+# d256 -- Q-union-O alias, ONE softmax warpgroup (12 warps)
+# ---------------------------------------------------------------------------
+#
+# Warp map: 4 softmax + 4 correction + MMA + TMALDG + TMASTG + scheduler.
+# The arriver count is per-CTA-group: ((SOFTMAX_WG*4) + CORR + 2) * CGA_SIZE
+# + (CGA_M / CTA_MMA).
+
+_D256_TOTAL_WARPS = 12
+
+
+def _d256_read_tile_arrivers(cta_mma: int) -> int:
+    return ((1 * 4) + 4 + 2) * (cta_mma * 1) + (cta_mma // cta_mma)
+
+
+def _make_cfg_d256_family(params: TemplateParams, *, flavor: str, mxfp8: bool):
+    _validate_params(flavor, params)
+    cta_mma = params.cta_mma
+    dtype_o = resolve_dtype_o(params)
+    b, b_o = bpe(params.dtype_qkv), bpe(dtype_o)
+    tile_k = tile_o = 256
+    tile_n = 128
+    # STAGES_KV is a BODY CONSTRAINT here, not a tuning knob -- pin it to 2.
+    #
+    # This pipeline runs a Q.K(i+1) -> S.V(i) lookahead against TWO parity
+    # S_acc TMEM slots, and the body conflates the KV ring index with that
+    # parity.  At depth 2 the two coincide and everything is consistent; at
+    # depth 4 they diverge and the MMA consumes the wrong K/V tile from the
+    # third KV iteration onward -- the first time parity slot 0 is REUSED.
+    #
+    # Measured on Rubin (d256 FP8 e4m3, cos vs an fp32 reference), n_kv =
+    # 2/3/4/8:  depth 4 -> 0.9996 / 0.6493 / 0.5448 / --  ;
+    #           depth 2 -> 0.9996 / 0.9996 / 0.9996 / 0.9997.
+    # The f16 sibling breaks identically at depth 4, which is how this was
+    # caught: it had been green at depth 2 and regressed when the SM107 config
+    # first adopted the pre-upstream value of 4 wholesale.
+    #
+    # So do NOT "restore" 4 to match the pre-upstream config or to deepen the
+    # ring for latency -- that is a silent-wrong-answer change, and it only
+    # shows up at S_kv > 256.  Deepening it needs the body's parity indexing
+    # decoupled from the ring index first.
+    stages_kv = 2
+    mask_flags, win_l, win_r, bottom_right, has_sink = _band_fields(params)
+    arrivers = _d256_read_tile_arrivers(cta_mma)
+
+    cfg = CfgD256(
+        TILE_M=128,
+        TILE_N=tile_n,
+        TILE_K=tile_k,
+        TILE_O=tile_o,
+        DTYPE_QKV=params.dtype_qkv,
+        DTYPE_O=dtype_o,
+        BPE=b,
+        BPE_O=b_o,
+        CGA_M=cta_mma,
+        CGA_N=1,
+        CTA_MMA=cta_mma,
+        SPLIT_PIPELINE=0,
+        Q_SWZ_BYTES=q_swz_bytes(tile_k, b),
+        K_SWZ_BYTES=q_swz_bytes(tile_k, b),
+        V_SWZ_BYTES=v_swz_bytes(tile_o, cta_mma, b),
+        O_SWZ_BYTES=o_swz_bytes(tile_o, b_o),
+        TILE_K_HW_BMM1=tile_k_hw(params.dtype_qkv),
+        TILE_K_HW_BMM2=tile_k_hw(params.dtype_qkv),
+        TILES_Q=1,
+        SCHEDULER_STAGES=2,
+        STAGES_KV=stages_kv,
+        # The body is a SINGLE-warpgroup pipeline. Two warpgroups is the
+        # Blackwell d256 split-P design and does not exist here.
+        SOFTMAX_WARPGROUPS=1,
+        CORRECTION_WARPS=4,
+        SOFTMAX_REGS=240,
+        CORRECTION_REGS=96,
+        RESCALE_THRESHOLD=rescale_threshold(params.dtype_qkv),
+        MASK_FLAGS=mask_flags,
+        WINDOW_LEFT=win_l,
+        WINDOW_RIGHT=win_r,
+        BOTTOM_RIGHT=bottom_right,
+        HAS_SINK=has_sink,
+        PACK_GQA=int(params.pack_gqa),
+        QH_PER_KH=params.qh_per_kh,
+        SPLIT_KV=params.split_kv or 1,
+        SEQ_KV_LENS_PRESENT=1 if params.thd_varlen else int(params.seq_kv_lens_present),
+        SEQ_Q_LENS_PRESENT=int(params.seq_q_lens_present),
+        THD_VARLEN=int(params.thd_varlen),
+        SCHEDULER_POLICY=params.sched_policy if params.sched_policy is not None else SCHED_NATURAL,
+        N_BMM2_CHUNKS=tile_n // 64,
+        BMM2_CHUNK_SIZE=64,
+        TOTAL_WARPS=_D256_TOTAL_WARPS,
+        THREADS_PER_CTA=_D256_TOTAL_WARPS * 32,
+        SOFTMAX_WG0_BASE=0,
+        SOFTMAX_WG1_BASE=0,  # unused at SOFTMAX_WARPGROUPS=1
+        CORR_WARP_BASE=4,
+        MMA_WARP_ID=8,
+        TMALDG_WARP_ID=9,
+        TMASTG_WARP_ID=10,
+        SCHED_WARP_ID=11,
+        READ_TILE_ARRIVERS=arrivers,
+    )
+
+    _validate_regs(cfg, flavor)
+    _validate_warp_layout(cfg, flavor, expect_total=_D256_TOTAL_WARPS, expect_arrivers=arrivers)
+    _validate_dtype_k_step(cfg, flavor)
+    _validate_swizzles(cfg, flavor)
+    _validate_masks(cfg, flavor)
+    _check(
+        [
+            (cfg.TILES_Q == 1, f"{flavor}: the d256 pipeline mandates TILES_Q == 1"),
+            (cfg.SOFTMAX_WARPGROUPS == 1, f"{flavor}: the d256 pipeline mandates SOFTMAX_WARPGROUPS == 1"),
+            (
+                cfg.STAGES_KV == 2,
+                f"{flavor}: the d256 body ties its KV ring index to the 2-slot S_acc parity, so "
+                f"STAGES_KV must be 2 (got {cfg.STAGES_KV}); a deeper ring returns WRONG RESULTS "
+                f"from the third KV iteration on, silently, and only at S_kv > 256",
+            ),
+        ]
+    )
+    # d256 always Q-union-O aliases.
+    _validate_smem(cfg, flavor, qo_alias=True)
+    return cfg, _tma_iters(cfg)
+
+
+def make_cfg_d256(params: TemplateParams) -> Tuple[CfgD256, TmaIters]:
+    return _make_cfg_d256_family(params, flavor="sm107 d256", mxfp8=False)
+
+
+def make_cfg_d256_mxfp8(params: TemplateParams) -> Tuple[CfgD256, TmaIters]:
+    return _make_cfg_d256_family(params, flavor="sm107 d256 mxfp8", mxfp8=True)
+
+
+# ---------------------------------------------------------------------------
+# d512 -- cga4x1 role split (8 warps)
+# ---------------------------------------------------------------------------
+#
+# Warp map: 4 compute (softmax on sg0 / correction on sg1) + MMA + TMALDG +
+# TMASTG + scheduler.  READ_TILE_ARRIVERS counts across the whole cluster:
+#   compute warps (4/CTA, both sgs)          = 4 * CGA_M * CGA_N          = 16
+#   TMALDG        (1/CTA, both sgs)          = 1 * CGA_M * CGA_N          =  4
+#   sg0 MMA leader (lead CTA only)           = (CGA_M*CGA_N)/(2*CTA_MMA)  =  1
+#   sg1 MMA all   (P12 forwarder + leader)   = (CGA_M*CGA_N)/2            =  2
+#   sg1 TMASTG    (sg1 CTAs only)            = CTA_MMA * CGA_N            =  2
+#                                                                   total = 25
+
+_D512_TOTAL_WARPS = 8
+_D512_CGA_M, _D512_CGA_N, _D512_CTA_MMA = 4, 1, 2
+_D512_READ_TILE_ARRIVERS = (
+    ((1 * 4) + 1) * (_D512_CGA_M * _D512_CGA_N)
+    + (_D512_CGA_M * _D512_CGA_N) // (2 * _D512_CTA_MMA)
+    + (_D512_CGA_M * _D512_CGA_N) // 2
+    + _D512_CTA_MMA * _D512_CGA_N
+)
+
+
+def _make_cfg_d512_family(params: TemplateParams, *, flavor: str, mxfp8: bool):
+    _validate_params(flavor, params)
+    if params.cta_mma != _D512_CTA_MMA:
+        raise ValueError(f"{flavor}: the role-split pipeline is cga4x1 / CTA_MMA=2 only (got cta_mma={params.cta_mma})")
+    dtype_o = resolve_dtype_o(params)
+    b, b_o = bpe(params.dtype_qkv), bpe(dtype_o)
+    tile_k = tile_o = 512
+    tile_n = 128
+    is_fp8 = params.dtype_qkv <= _DTYPE_E5M2
+    # FP8 (BPE=1) fits a deeper K/V ring and a 4-deep cross-sg P ring; f16/bf16
+    # (BPE=2) are SMEM-cap driven down to 2/2.
+    stages_kv = 3 if is_fp8 else 2
+    xfer_stages = 4 if is_fp8 else 2
+    mask_flags, win_l, win_r, bottom_right, has_sink = _band_fields(params)
+
+    cfg = CfgD512(
+        TILE_M=128,
+        TILE_N=tile_n,
+        TILE_K=tile_k,
+        TILE_O=tile_o,
+        DTYPE_QKV=params.dtype_qkv,
+        DTYPE_O=dtype_o,
+        BPE=b,
+        BPE_O=b_o,
+        CGA_M=_D512_CGA_M,
+        CGA_N=_D512_CGA_N,
+        CTA_MMA=_D512_CTA_MMA,
+        SPLIT_PIPELINE=1,
+        Q_SWZ_BYTES=q_swz_bytes(tile_k, b),
+        K_SWZ_BYTES=q_swz_bytes(tile_k, b),
+        V_SWZ_BYTES=v_swz_bytes(tile_o, _D512_CTA_MMA, b),
+        O_SWZ_BYTES=o_swz_bytes(tile_o, b_o),
+        TILE_K_HW_BMM1=tile_k_hw(params.dtype_qkv),
+        TILE_K_HW_BMM2=tile_k_hw(params.dtype_qkv),
+        TILES_Q=1,
+        SCHEDULER_STAGES=2,
+        STAGES_KV=stages_kv,
+        XFER_STAGES=xfer_stages,
+        # One 4-warp compute group; correction is fused into it, sub-group
+        # conditional, so there are no separate correction warps or registers.
+        SOFTMAX_WARPGROUPS=1,
+        CORRECTION_WARPS=0,
+        SOFTMAX_REGS=240,
+        CORRECTION_REGS=0,
+        RESCALE_THRESHOLD=rescale_threshold(params.dtype_qkv),
+        MASK_FLAGS=mask_flags,
+        WINDOW_LEFT=win_l,
+        WINDOW_RIGHT=win_r,
+        BOTTOM_RIGHT=bottom_right,
+        HAS_SINK=has_sink,
+        PACK_GQA=int(params.pack_gqa),
+        QH_PER_KH=params.qh_per_kh,
+        SPLIT_KV=params.split_kv or 1,
+        SEQ_KV_LENS_PRESENT=1 if params.thd_varlen else int(params.seq_kv_lens_present),
+        SEQ_Q_LENS_PRESENT=int(params.seq_q_lens_present),
+        THD_VARLEN=int(params.thd_varlen),
+        SCHEDULER_POLICY=params.sched_policy if params.sched_policy is not None else SCHED_NATURAL,
+        BMM2_N_PER_CALL=256,
+        BMM2_LOOP_N_BLOCKS=tile_o // 256,
+        N_BMM2_CHUNKS=2,
+        BMM2_CHUNK_SIZE=256,
+        TOTAL_WARPS=_D512_TOTAL_WARPS,
+        THREADS_PER_CTA=_D512_TOTAL_WARPS * 32,
+        SOFTMAX_WG0_BASE=0,
+        SOFTMAX_WG1_BASE=0,  # unused under the role split
+        CORR_WARP_BASE=0,  # correction fused with the compute group
+        MMA_WARP_ID=4,
+        TMALDG_WARP_ID=5,
+        TMASTG_WARP_ID=6,
+        SCHED_WARP_ID=7,
+        READ_TILE_ARRIVERS=_D512_READ_TILE_ARRIVERS,
+    )
+
+    _validate_regs(cfg, flavor)
+    _validate_warp_layout(cfg, flavor, expect_total=_D512_TOTAL_WARPS, expect_arrivers=_D512_READ_TILE_ARRIVERS)
+    _validate_dtype_k_step(cfg, flavor)
+    _validate_swizzles(cfg, flavor)
+    _validate_masks(cfg, flavor)
+    _check([(cfg.SPLIT_PIPELINE == 1, f"{flavor}: the d512 flavor is role-split (SPLIT_PIPELINE=1)")])
+    return cfg, _tma_iters(cfg)
+
+
+def make_cfg_d512(params: TemplateParams) -> Tuple[CfgD512, TmaIters]:
+    return _make_cfg_d512_family(params, flavor="sm107 d512", mxfp8=False)
+
+
+def make_cfg_d512_mxfp8(params: TemplateParams) -> Tuple[CfgD512, TmaIters]:
+    return _make_cfg_d512_family(params, flavor="sm107 d512 mxfp8", mxfp8=True)

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -265,6 +265,10 @@ class Capabilities:
     # a row that accepts split_kv > 1 without the plumbing leaves untouched
     # partial slots at lse_partial = 0, which corrupt the combine's
     # log-sum-exp rather than raising.
+    # PackGQA, like split-KV, can be wired per FLAVOR rather than per row: the
+    # SM107 line ships it only in the d128 per-tensor FP8 kernel, while the
+    # ported d256/d512 siblings skip it.  None = every shape the row serves.
+    pack_gqa_d_shapes: Optional[frozenset] = None
     split_kv_supported: bool = False
     # Shapes whose kernel flavors wire SplitHelpers. None = every flavor in
     # d_shapes does (f16/SM120). A set = split_kv > 1 is honored only when
@@ -389,6 +393,9 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
                 return (
                     f"split_kv > 1 is wired only in the {sorted(capabilities.split_d_shapes)} kernel " f"flavors; graph has D_QK={facts.d_qk}/D_V={facts.d_v}"
                 )
+        if knobs.pack_gqa and capabilities.pack_gqa_d_shapes is not None:
+            if (facts.d_qk, facts.d_v) not in capabilities.pack_gqa_d_shapes:
+                return f"pack_gqa is wired only in the {sorted(capabilities.pack_gqa_d_shapes)} kernel " f"flavors; graph has D_QK={facts.d_qk}/D_V={facts.d_v}"
         if knobs.pack_gqa:
             if facts.thd:
                 return "PackGQA is currently not supported for THD/ragged graphs"
@@ -614,6 +621,89 @@ def _sm100_spec() -> EngineSpec:
     )
 
 
+def _sm107_spec() -> EngineSpec:
+    """f16/bf16 Rubin (SM107) engine — the per-arch-line sibling of
+    ``sdpa_fwd_prefill_sm100``, which stops at cc 10.6.
+
+    The lowerings diverge enough to need their own row rather than a widened
+    SM100 one: the Rubin kernels build **version-1 tcgen05 SMEM descriptors**
+    (a version-0 descriptor addresses only 256 KiB, and Rubin's 327 KiB budget
+    puts the d512 flavor's P ring at exactly that boundary), and Rubin ships a
+    strict SUBSET of the SM100 flavors — there is no d192xd128 sibling, so a
+    d=192 graph rides the d256 envelope here.
+
+    Every capability below was MEASURED on Rubin (`w2u1g-lc-0030`) against an
+    explicit fp32 reference, not inherited from the SM100 row:
+
+    - causal / bottom-right / right-band / SWA: validated on all three flavors,
+      cos = 1.000000. ``window_right`` is load-bearing rather than decorative —
+      ``bounds_for_tile`` already trims KV *tiles* by it, so a right-banded
+      graph is silently wrong unless the element-level mask gets it too.
+    - padded: per-batch ``seq_len_kv``, deliberately ragged and NOT tile
+      aligned, so a tail tile is partly masked.
+    - sink, and GQA 4:1.
+
+    Deliberately NOT claimed, each because the kernels lack the machinery
+    rather than because it went untested:
+
+    - ``thd``: the setup-kernel call site still speaks the pre-upstream 7-arg
+      contract against a 14-arg helper, and the metadata layout differs
+      (3B+2 vs 4B+4). ``compile()`` raises rather than half-serving it.
+    - ``split_kv_supported``: these kernels wire no SplitHelpers.
+    - ``pack_gqas``: no PackGQA path.
+    - ``padded_stats`` / ``dense_seq_q_trim``: both need the per-batch
+      ``seq_len_q`` LSE trim, which these kernels do not carry.
+    - ``softmax_precisions``: the f16x2 exponent arm lives only in the d128 FP8
+      sibling.
+    """
+    return EngineSpec(
+        name="sdpa_fwd_prefill_sm107",
+        capabilities=Capabilities(
+            sm_lo=107,
+            sm_hi=_BLACKWELL[1],
+            phase="prefill",
+            # No (192, 128): Rubin has no native d192xd128 kernel.
+            d_shapes=frozenset({(128, 128), (256, 256), (512, 512)}),
+            dtypes=frozenset({cudnn.data_type.HALF, cudnn.data_type.BFLOAT16}),
+            causal=True,
+            bottom_right=True,
+            right_band_widening=True,
+            swa=True,
+            padded=True,
+            sink=True,
+            stats=True,
+            # The LSE store is const_expr'd out on a None lse_tensor, and
+            # compile(has_lse=False) binds no dummy buffer at any level -- so a
+            # stats-less graph reports get_workspace_size() == 0.
+            lse_optional=True,
+            # Ragged S_kv with an uncovered tail rides the padded path with
+            # synthesized full-length per-batch KV lengths (lower_dsl_prefill's
+            # synth_kv_padding).  It is REQUIRED, not an optimization: at
+            # MASK_FLAGS == 0 the kernel's kv_right is a floor division, so an
+            # un-synthesized ragged S_kv would silently drop the tail tile.
+            skv_tail_via_padding=True,
+            # NATURAL and LPT only -- NOT LPT_L2.  The SM107 kernels import the
+            # SCHED_LPT_L2 constant but never pass qh_per_kh / seqlen_kv to their
+            # decode call sites, so _common_sm100._decode_initial raises
+            # "SCHED_LPT_L2 decode requires qh_per_kh and seqlen_kv at every call
+            # site" the moment heuristics proposes it.  A knob is honored or the
+            # engine is ineligible -- so the row must not claim it.  This was
+            # latent on the f16/FP8 rows too (their suites never hit a shape the
+            # heuristic sends down the L2 path); MXFP8 surfaced it.
+            # NATURAL ONLY -- same finding as the FP8 and MXFP8 Rubin rows:
+            # every kernel this row serves is a PORT, and the ported decode
+            # sites do not honor SCHED_LPT (measured on the d512 FP8 and d128
+            # MXFP8 siblings; no SM107 f16 numerics suite exists yet to measure
+            # this one, so the row claims the conservative domain).
+            sched_policies=frozenset({SCHED_NATURAL}),
+            tile_ms=frozenset({128}),
+            tile_ns=frozenset({128}),
+            cgas=frozenset({2}),
+        ),
+        lower=partial(lower_dsl_prefill, api_type=_SM100),
+    )
+
+
 def _sm100_mxfp8_spec() -> EngineSpec:
     """Block-scale MXFP8 engine (E4M3/E5M2 + per-32-block E8M0 SF).
 
@@ -720,7 +810,7 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
             sm_lo=107 if rubin_row else _BLACKWELL[0],
             sm_hi=_BLACKWELL[1] if rubin_row else 106,
             phase="prefill",
-            d_shapes=frozenset({(128, 128)}) if rubin_row else frozenset({(128, 128), (192, 128), (256, 256), (512, 512)}),
+            d_shapes=frozenset({(128, 128), (256, 256), (512, 512)}) if rubin_row else frozenset({(128, 128), (192, 128), (256, 256), (512, 512)}),
             d_pad_multiple=16,
             # The d512 flavor serves the (256, 512] band on BOTH head dims —
             # the range no smaller FP8 flavor reaches, at most 2x zero-padding.
@@ -768,11 +858,33 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
             # figure the remap blocks against (CFG.L2_SIZE_MIB) is a tuning
             # hint for the grouping, not a chip capacity, so the SM100 number
             # carries to Rubin unchanged.
-            sched_policies=frozenset({SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2}),
+            # LPT_L2 needs qh_per_kh + seqlen_kv threaded through EVERY decode
+            # call site (_common_sm100._decode_initial raises otherwise).  On the
+            # Rubin line only the shipped d128 kernel does that -- d256 and d512
+            # have 0/10 sites threaded -- so the row cannot claim the policy for
+            # the flavors it now serves.  Heuristics derives its proposals from
+            # this domain (heuristics.py:329), so narrowing means those graphs
+            # get LPT instead of going unserved: a scheduling trade, not a
+            # correctness one.  Re-widen once the args are threaded everywhere.
+            # Rubin: NATURAL ONLY.  SCHED_LPT is not honored by the PORTED
+            # SM107 kernels (d256 / d512 here) -- a causal d512 FP8 graph under
+            # LPT returns NaN, and all 12 masked d512 cases go green the moment
+            # the row stops claiming it.  Session 6 had already dropped
+            # SCHED_LPT_L2 for the same reason; LPT survived only because
+            # heuristics could not REACH it (the causal primary is LPT_L2, and
+            # the old out-of-domain fallback dropped to NATURAL -- fixed in
+            # heuristics._sched_points, which is what surfaced this).
+            # KNOWN COST: the SHIPPED d128 FP8 kernel *does* honor LPT and loses
+            # that plan here, because sched_policies is row-wide.  Recovering it
+            # needs a per-d-shape domain (a `sched_policies_by_d_shape` mirroring
+            # `cgas_by_d_shape`), or the ported decode sites threaded and
+            # validated.  Correctness first: a knob is honored or the engine is
+            # ineligible, and a user could already request LPT explicitly.
+            sched_policies=(frozenset({SCHED_NATURAL}) if rubin_row else frozenset({SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2})),
             tile_ms=frozenset({128}),
             tile_ns=frozenset({128}),
             cgas=frozenset({2}),
-            cgas_by_d_shape=(() if rubin_row else (((192, 128), frozenset({1, 2})), ((256, 256), frozenset({1})))),
+            cgas_by_d_shape=((((256, 256), frozenset({1})),) if rubin_row else (((192, 128), frozenset({1, 2})), ((256, 256), frozenset({1})))),
             split_cgas_by_d_shape=(() if rubin_row else (((192, 128), frozenset({2})),)),
             # f16x2-softmax arm: only the SM107 sibling kernel carries the
             # path (MUFU EX2.F16x2 exists below cc10.7 but no other file wires
@@ -783,6 +895,78 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
             split_kv_supported=True,
             split_d_shapes=(frozenset({(128, 128)}) if rubin_row else frozenset({(128, 128), (192, 128), (256, 256)})),
             pack_gqas=frozenset({False, True}),
+            # SM107: only the shipped d128 sibling wires PackGQA; the ported
+            # d256/d512 kernels skip it, as they skip split-KV.
+            pack_gqa_d_shapes=(frozenset({(128, 128)}) if rubin_row else None),
+        ),
+        lower=partial(lower_dsl_prefill, api_type=_SM100),
+    )
+
+
+def _sm107_mxfp8_spec() -> EngineSpec:
+    """Block-scale MXFP8 on Rubin (E4M3/E5M2 + per-32-block E8M0 SF).
+
+    Rubin's own row rather than a widened SM100 one, for the same reason the
+    f16 and FP8 rows split at the arch line: these are the SM107 sibling
+    kernels (dense K=64 MMA, version-1 SMEM descriptors).  Rubin also carries a
+    d512 MXFP8 flavor, which SM100 does NOT -- so this row is WIDER than its
+    Blackwell counterpart at the top end and narrower at d192xd128, which has
+    no Rubin MXFP8 sibling.
+
+    Declined deliberately, because the ported kernels lack the machinery (not
+    because it went untested): THD, split-KV, PackGQA, optional stats, and the
+    dense padded-Q trim.  See _sm107_spec for the same list on f16.
+    """
+    return EngineSpec(
+        name="sdpa_fwd_prefill_sm107_mxfp8",
+        capabilities=Capabilities(
+            sm_lo=107,
+            sm_hi=_BLACKWELL[1],
+            phase="prefill",
+            # Exact native shapes only -- the SF tensors are not zero-padded.
+            d_shapes=frozenset({(128, 128), (256, 256), (512, 512)}),
+            d_pad_multiple=0,
+            dtypes=frozenset({cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2}),
+            out_dtypes=frozenset({cudnn.data_type.HALF, cudnn.data_type.BFLOAT16, cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2}),
+            is_mxfp8=True,
+            causal=True,
+            bottom_right=True,
+            right_band_widening=True,
+            swa=True,
+            padded=True,
+            sink=True,
+            stats=True,
+            # See the f16 SM107 row: has_lse=False is a real specialization on
+            # every Rubin kernel, not an accepted-and-ignored flag.
+            lse_optional=True,
+            skv_tail_via_padding=True,
+            # NATURAL and LPT only -- NOT LPT_L2.  The SM107 kernels import the
+            # SCHED_LPT_L2 constant but never pass qh_per_kh / seqlen_kv to their
+            # decode call sites, so _common_sm100._decode_initial raises
+            # "SCHED_LPT_L2 decode requires qh_per_kh and seqlen_kv at every call
+            # site" the moment heuristics proposes it.  A knob is honored or the
+            # engine is ineligible -- so the row must not claim it.  This was
+            # latent on the f16/FP8 rows too (their suites never hit a shape the
+            # heuristic sends down the L2 path); MXFP8 surfaced it.
+            # NATURAL ONLY.  Session 6 dropped SCHED_LPT_L2 from this row
+            # (the ported decode sites never thread qh_per_kh / seqlen_kv);
+            # SCHED_LPT is ALSO not honored, and that stayed hidden because
+            # heuristics could not reach it: its causal primary is LPT_L2, and
+            # the old out-of-domain fallback dropped straight to NATURAL.  Fixing
+            # that fallback (heuristics._sched_points) made causal graphs pick
+            # LPT here for the first time and turned 23 green MXFP8 tests red
+            # with max|O-ref| ~ 1.9-4.1 -- dense stayed correct, every masked
+            # shape did not.  A knob is honored or the engine is ineligible, so
+            # the row claims only what its kernels serve.  INVERTS-WHEN the LPT
+            # decode is threaded and validated on the ported Rubin kernels.
+            sched_policies=frozenset({SCHED_NATURAL}),
+            tile_ms=frozenset({128}),
+            tile_ns=frozenset({128}),
+            cgas=frozenset({2}),
+            # d256 MXFP8 runs cga1 (FROST rule: d256 quantized requires cta_mma=1;
+            # heuristics.py:492 enforces it, so the row cannot declare otherwise).
+            cgas_by_d_shape=((((256, 256), frozenset({1})),)),
+            pack_gqas=frozenset({False}),
         ),
         lower=partial(lower_dsl_prefill, api_type=_SM100),
     )
@@ -1252,6 +1436,8 @@ ENGINE_SPECS = (
     _sm100_mxfp8_spec(),
     _sm100_fp8_spec(),
     _sm100_fp8_spec(arch="sm107"),
+    _sm107_spec(),
+    _sm107_mxfp8_spec(),
     _sm120_spec(),
     _sm120_fp8_spec(),
     _sm80_spec(),

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -265,10 +265,6 @@ class Capabilities:
     # a row that accepts split_kv > 1 without the plumbing leaves untouched
     # partial slots at lse_partial = 0, which corrupt the combine's
     # log-sum-exp rather than raising.
-    # PackGQA, like split-KV, can be wired per FLAVOR rather than per row: the
-    # SM107 line ships it only in the d128 per-tensor FP8 kernel, while the
-    # ported d256/d512 siblings skip it.  None = every shape the row serves.
-    pack_gqa_d_shapes: Optional[frozenset] = None
     split_kv_supported: bool = False
     # Shapes whose kernel flavors wire SplitHelpers. None = every flavor in
     # d_shapes does (f16/SM120). A set = split_kv > 1 is honored only when
@@ -281,6 +277,12 @@ class Capabilities:
     # each row declares exactly what its own lowering carries — not by a
     # knob x arch notch here.
     softmax_precisions: frozenset[int] = frozenset()
+    # PackGQA, like split-KV, can be wired per FLAVOR rather than per row: the
+    # SM107 line ships it only in the d128 per-tensor FP8 kernel, while the
+    # ported d256/d512 siblings skip it.  None = every shape the row serves.
+    # APPENDED at the end deliberately: Capabilities evolves append-only, so a
+    # positional construction of an older field never silently rebinds.
+    pack_gqa_d_shapes: Optional[frozenset] = None
 
 
 def _band_covers_kv_tail(facts: "ga.SdpaGraphFacts") -> bool:
@@ -394,7 +396,11 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
                     f"split_kv > 1 is wired only in the {sorted(capabilities.split_d_shapes)} kernel " f"flavors; graph has D_QK={facts.d_qk}/D_V={facts.d_v}"
                 )
         if knobs.pack_gqa and capabilities.pack_gqa_d_shapes is not None:
-            if (facts.d_qk, facts.d_v) not in capabilities.pack_gqa_d_shapes:
+            # _selected_d_shape, not the raw dims: the FP8 rows carry
+            # d_pad_multiple=16, so an inexact graph (D=112) lowers onto the
+            # smallest covering NATIVE flavor (d128) -- which is the kernel
+            # whose PackGQA wiring the set is describing.
+            if _selected_d_shape(capabilities, facts) not in capabilities.pack_gqa_d_shapes:
                 return f"pack_gqa is wired only in the {sorted(capabilities.pack_gqa_d_shapes)} kernel " f"flavors; graph has D_QK={facts.d_qk}/D_V={facts.d_v}"
         if knobs.pack_gqa:
             if facts.thd:
@@ -628,9 +634,10 @@ def _sm107_spec() -> EngineSpec:
     The lowerings diverge enough to need their own row rather than a widened
     SM100 one: the Rubin kernels build **version-1 tcgen05 SMEM descriptors**
     (a version-0 descriptor addresses only 256 KiB, and Rubin's 327 KiB budget
-    puts the d512 flavor's P ring at exactly that boundary), and Rubin ships a
-    strict SUBSET of the SM100 flavors — there is no d192xd128 sibling, so a
-    d=192 graph rides the d256 envelope here.
+    puts the d512 flavor's P ring at exactly that boundary).  The f16 line
+    carries all four SM100 flavors, d192xd128 included
+    (``prefill_d192_d128_f16_sm107.py`` — the d128 body with ``make_cfg_d192``);
+    the QUANTIZED Rubin rows are the ones that ship a strict subset.
 
     Every capability below was MEASURED on Rubin (`w2u1g-lc-0030`) against an
     explicit fp32 reference, not inherited from the SM100 row:
@@ -662,8 +669,10 @@ def _sm107_spec() -> EngineSpec:
             sm_lo=107,
             sm_hi=_BLACKWELL[1],
             phase="prefill",
-            # No (192, 128): Rubin has no native d192xd128 kernel.
-            d_shapes=frozenset({(128, 128), (256, 256), (512, 512)}),
+            # All four f16 flavors have a Rubin module -- api_dsl._SM107_KERNEL_FILES
+            # is the other half of this claim, and _pick_flavor lands a d=192
+            # graph on the NATIVE kernel rather than the d256 envelope.
+            d_shapes=frozenset({(128, 128), (192, 128), (256, 256), (512, 512)}),
             dtypes=frozenset({cudnn.data_type.HALF, cudnn.data_type.BFLOAT16}),
             causal=True,
             bottom_right=True,
@@ -682,14 +691,6 @@ def _sm107_spec() -> EngineSpec:
             # MASK_FLAGS == 0 the kernel's kv_right is a floor division, so an
             # un-synthesized ragged S_kv would silently drop the tail tile.
             skv_tail_via_padding=True,
-            # NATURAL and LPT only -- NOT LPT_L2.  The SM107 kernels import the
-            # SCHED_LPT_L2 constant but never pass qh_per_kh / seqlen_kv to their
-            # decode call sites, so _common_sm100._decode_initial raises
-            # "SCHED_LPT_L2 decode requires qh_per_kh and seqlen_kv at every call
-            # site" the moment heuristics proposes it.  A knob is honored or the
-            # engine is ineligible -- so the row must not claim it.  This was
-            # latent on the f16/FP8 rows too (their suites never hit a shape the
-            # heuristic sends down the L2 path); MXFP8 surfaced it.
             # NATURAL ONLY -- same finding as the FP8 and MXFP8 Rubin rows:
             # every kernel this row serves is a PORT, and the ported decode
             # sites do not honor SCHED_LPT (measured on the d512 FP8 and d128
@@ -828,7 +829,16 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
             # shows run-to-run nondeterminism on long causal e5m2/GQA/sink graphs;
             # min(d_qk, d_v) > 255 admits nothing inexact. Lift both floors once the
             # kernels' padded paths are validated through test_mhas_v2.
-            d_envelope_floors=() if rubin_row else (((192, 128), 128), ((256, 256), 255), ((512, 512), 256)),
+            # The Rubin row carries the SAME floors, minus the (192, 128) entry
+            # it has no flavor for.  It previously declared () -- which made
+            # mismatch() ADMIT e.g. (512, 256) and (192, 128) that
+            # api_dsl._SM100_FP8_ENVELOPE_FLOORS then rejected with a bare
+            # ValueError inside check_support: a plan that enters the ranked
+            # list only to die in the lowering (contract rule 1).  The floors'
+            # rationale transfers unchanged -- the Rubin d512 kernel is the same
+            # cga4x1 role-split geometry, and the d256 padded envelope is no
+            # more validated here than on Blackwell.
+            d_envelope_floors=(((256, 256), 255), ((512, 512), 256)) if rubin_row else (((192, 128), 128), ((256, 256), 255), ((512, 512), 256)),
             thd_d_shapes=frozenset({(128, 128)}) if rubin_row else frozenset({(128, 128), (192, 128), (256, 256), (512, 512)}),
             dtypes=frozenset({cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2}),
             out_dtypes=frozenset({cudnn.data_type.HALF, cudnn.data_type.BFLOAT16, cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2}),
@@ -914,8 +924,10 @@ def _sm107_mxfp8_spec() -> EngineSpec:
     no Rubin MXFP8 sibling.
 
     Declined deliberately, because the ported kernels lack the machinery (not
-    because it went untested): THD, split-KV, PackGQA, optional stats, and the
-    dense padded-Q trim.  See _sm107_spec for the same list on f16.
+    because it went untested): THD, split-KV, PackGQA, and the dense padded-Q
+    trim.  Optional stats IS served (``lse_optional=True`` below -- has_lse=False
+    is a real specialization on every Rubin kernel, not an accepted-and-ignored
+    flag).  See _sm107_spec for the same list on f16.
     """
     return EngineSpec(
         name="sdpa_fwd_prefill_sm107_mxfp8",
@@ -940,14 +952,6 @@ def _sm107_mxfp8_spec() -> EngineSpec:
             # every Rubin kernel, not an accepted-and-ignored flag.
             lse_optional=True,
             skv_tail_via_padding=True,
-            # NATURAL and LPT only -- NOT LPT_L2.  The SM107 kernels import the
-            # SCHED_LPT_L2 constant but never pass qh_per_kh / seqlen_kv to their
-            # decode call sites, so _common_sm100._decode_initial raises
-            # "SCHED_LPT_L2 decode requires qh_per_kh and seqlen_kv at every call
-            # site" the moment heuristics proposes it.  A knob is honored or the
-            # engine is ineligible -- so the row must not claim it.  This was
-            # latent on the f16/FP8 rows too (their suites never hit a shape the
-            # heuristic sends down the L2 path); MXFP8 surfaced it.
             # NATURAL ONLY.  Session 6 dropped SCHED_LPT_L2 from this row
             # (the ported decode sites never thread qh_per_kh / seqlen_kv);
             # SCHED_LPT is ALSO not honored, and that stayed hidden because

--- a/python/cudnn/sdpa/fwd/heuristics.py
+++ b/python/cudnn/sdpa/fwd/heuristics.py
@@ -370,7 +370,7 @@ def _sched_points(caps: Capabilities, facts) -> List[Optional[int]]:
     # already balanced — so don't spend autotune slots on them.
     if not causal_ish and facts.window_left is None:
         runners = []
-    return [chosen] + runners
+    return [chosen, *runners]
 
 
 def select_d192_auto_knobs(

--- a/python/cudnn/sdpa/fwd/heuristics.py
+++ b/python/cudnn/sdpa/fwd/heuristics.py
@@ -357,12 +357,20 @@ def _sched_points(caps: Capabilities, facts) -> List[Optional[int]]:
     else:
         primary = SCHED_NATURAL
     order = {SCHED_LPT_L2: (SCHED_LPT, SCHED_NATURAL), SCHED_LPT: (SCHED_LPT_L2, SCHED_NATURAL), SCHED_NATURAL: (SCHED_LPT, SCHED_LPT_L2)}
-    runners = [p for p in order[primary] if p in domain]
+    # The primary may be outside a row's DOMAIN (the SM107 rows do not carry
+    # SCHED_LPT_L2 — their kernels raise on the L2 decode).  Fall back along the
+    # SAME preference order rather than to NATURAL: dropping straight to NATURAL
+    # cost a causal Rubin FP8 graph the LPT load-balancing win, and listed
+    # NATURAL twice ([0, 1, 0]), burning an autotune slot on a duplicate plan.
+    # When the primary IS in domain this is byte-identical to the old form
+    # (order[primary] never contains primary).
+    chosen = next((p for p in (primary, *order[primary]) if p in domain), SCHED_NATURAL)
+    runners = [p for p in order[primary] if p in domain and p != chosen]
     # A mask-free graph gains nothing from either LPT remap — the grid is
     # already balanced — so don't spend autotune slots on them.
     if not causal_ish and facts.window_left is None:
         runners = []
-    return [primary if primary in domain else _sole(domain) or SCHED_NATURAL] + runners
+    return [chosen] + runners
 
 
 def select_d192_auto_knobs(

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_f16_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_f16_sm107.py
@@ -1,0 +1,2055 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""
+DSL prefill SDPA kernel — classic pipeline, f16/bf16, d=128, SM107 (Rubin).
+
+Ported from the pre-upstream CTM kernel ``prefill_sdpa_f16.py``
+(CTM DSL) by frost_dev/port_ctm_kernel.py. The kernel BODY is the pre-upstream one,
+unchanged — only the DSL surface moved (ctm.* -> public cutlass/nvvm/cute, and
+tile_ctm -> cudnn.frost.tile_dsl). Two things are NOT mechanical and were done
+by hand:
+
+  1. **Config.** The pre-upstream kernels picked a flavor with an env var;
+     FROST forbids env-var configuration, so this reads TemplateParams via the
+     FROST_TEMPLATE_PARAMS global (engine contract §5/§6).
+  2. **TMA descriptors.** ``create_tensor_map_tiled_from_tensor`` became
+     ``..._from_view`` — a signature change, not a rename.
+
+Geometry is FROST's ``make_cfg_d128`` as-is. the pre-upstream helper would give
+STAGES_KV = 2*CTA_MMA (4 at cga2) where FROST gives 2; the deeper ring is a
+PERF lever and this port is for FUNCTIONAL coverage first, so it is deliberately
+not taken here.
+
+Original pre-upstream header follows.
+
+CTM-DSL port of the pre-upstream prefill SDPA kernel
+(llama flavor: FP16, d_qk = d_v = 128, TILES_Q = 2, two softmax
+warpgroups, four correction warps, persistent try_cancel scheduler).
+
+Same kernel shape as the C++ source: pipeline, TMEM/SMEM layout,
+barrier inventory + init counts, scheduler, warp dispatch, register
+split match.  Canonical reference port; reaches ~0.99x C++ TFLOPS.
+
+THD / varlen (``CFG.THD_VARLEN=1``, the pre-upstream packed-varlen entry point)
+is supported (f16/bf16) for all three d=128 flavors (llama / dsv3 / gptoss) at
+cga1 and cga2: packed ``[1,T,H,D]`` + ``cu_seqlens`` coord offset (applied to
+both Q slabs under TILES_Q=2), per-batch O TMA-descriptor array (shared
+``kernels/ctm/common/sdpa/thd.py``), packed ``[1,QH,T]`` LSE.  The dense
+``[B,S,H,D]`` path is byte-identical.
+"""
+
+import os
+import sys
+from functools import lru_cache
+from typing import Callable, Optional, Tuple
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO_DIR = os.path.normpath(os.path.join(_HERE, "..", "..", "..", "..", ".."))
+_PYTHON_DIR = os.path.join(_REPO_DIR, "python")
+_CONFIGS_DIR = os.path.normpath(os.path.join(_HERE, "..", "configs"))
+# Shared THD / varlen device helpers (build_o_descs_kernel + TENSOR_MAP_QWORDS).
+_COMMON_SDPA_DIR = os.path.normpath(os.path.join(_HERE, "..", "..", "..", "common", "sdpa"))
+for _p in (_PYTHON_DIR, _CONFIGS_DIR, _COMMON_SDPA_DIR):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from cutlass.base_dsl.typing import Pointer
+from cutlass.experimental import primitives as nvvm
+from cutlass.experimental.primitives import vote_sync, VoteSync
+from cutlass.experimental.cuda import tensor_map as tmap
+from cutlass._mlir.dialects import arith
+
+import cutlass
+from cutlass.experimental import primitives as prims
+import cutlass.cute as cute
+import cuda.bindings.driver as _cuda_driver  # noqa: F401  (cute.compile pulls cuda)
+
+from dataclasses import dataclass
+
+# Config comes from the FROST template loader, NOT an env var: the pre-upstream
+# kernels picked a flavor with an env var + a sdpa_config_<flavor> module, which the
+# FROST engine contract forbids ("no environment variables for configuration" —
+# parameters travel as typed dataclasses). The loader injects
+# FROST_TEMPLATE_PARAMS before this body runs; the default keeps a direct
+# `import` usable as a standalone driver.
+from cudnn.sdpa.fwd.config_sm107 import TemplateParams, make_cfg_d128
+
+PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
+CFG, _TMA = make_cfg_d128(PARAMS)
+Cfg = type(CFG)
+TMA_QK_ITERS = _TMA.QK_ITERS
+TMA_VO_ITERS = _TMA.VO_ITERS
+TMA_QK_GRANU_ELEMS = _TMA.QK_GRANU_ELEMS
+TMA_VO_GRANU_ELEMS = _TMA.VO_GRANU_ELEMS
+
+# O TMA box / store params follow O's swizzle, not V's (under cga2 V may drop to a narrower swizzle while O stays Swz128B).
+TMA_O_GRANU_ELEMS_HOST = CFG.O_SWZ_BYTES // CFG.BPE
+TMA_O_ITERS_HOST = (CFG.TILE_O * CFG.BPE) // CFG.O_SWZ_BYTES
+
+from typing import NamedTuple
+
+from cudnn.frost.tile_dsl.barrier import (
+    PipelineState,
+    advance,
+    cga_arrive,
+    cga_wait,
+    # `wait` (free fn) — still used for sched.mb_* (Sched is not in Bars yet;
+    # only the per-kernel Bars NamedTuple was migrated to MBarrier in this step).
+    wait,
+)
+from cudnn.frost.tile_dsl.scheduler import (
+    Sched,
+    scheduler_warp_loop,
+    read_tile_id_arrive,
+    SCHED_NATURAL,
+    SCHED_LPT,
+    SCHED_LPT_L2,
+)
+from cudnn.frost.tile_dsl.pointwise import (
+    tmem_load_max_reduction_tile,
+    row_reduction_pair,
+    row_max_reduction,
+    vec_scale_pair,
+)
+from cudnn.frost.tile_dsl.regtile import RegTile, vec_concat
+from cudnn.frost.tile_dsl.mma import mma_ss, mma_ts_step
+from cudnn.frost.tile_dsl.tma import tma_load_tile, tma_store_tile, tma_store_commit, tma_store_wait
+from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, tma_slice_runtime_desc
+from cudnn.frost.tile_dsl.tmem import tmem_alloc, tmem_dealloc
+from cudnn.frost.tile_dsl.mask import (
+    apply_mask_chunk,
+    MASK_NONE,
+    MASK_PADDED,
+    MASK_CAUSAL,
+    MASK_SWA,
+)
+
+# Storage dtype + MMA kind dispatch — folded at trace time on CFG.DTYPE_QKV.
+if CFG.DTYPE_QKV == 2:
+    STORAGE_DTYPE = cutlass.BFloat16
+    P_STORAGE_DTYPE = cutlass.BFloat16
+    MMA_KIND = nvvm.Tcgen05MMAKind.F16
+    IS_TF32 = False
+elif CFG.DTYPE_QKV == 3:
+    STORAGE_DTYPE = cutlass.Float16
+    P_STORAGE_DTYPE = cutlass.Float16
+    MMA_KIND = nvvm.Tcgen05MMAKind.F16
+    IS_TF32 = False
+elif CFG.DTYPE_QKV == 4:
+    # TF32: 4-byte FP32 storage, kind::tf32 MMA (HW rounds operands to a
+    # 10-bit mantissa).  Mirrors the C++ prefill_sdpa_f16.cu IS_TF32 path.
+    # Three TF32-specific deltas vs BF16/FP16 (all folded on IS_TF32 below):
+    #   1. V (the transposed BMM2 operand) SmemDesc + TMA use
+    #      SWIZZLE_128B_ATOM_32B (enc=1, leading=TILE_N*128, stride=512).
+    #      Standard Swz128B with kind::tf32 + b_trans silently returns all-0.
+    #   2. P TMEM packing is 1:1 (one FP32 cell per prob) vs 2:1 for
+    #      fp16/bf16, so P aliases the FULL S_acc slot, not just its tail.
+    #   3. BPE=4 doubles every SMEM/TMA byte count (sized off CFG.BPE).
+    STORAGE_DTYPE = cutlass.Float32
+    P_STORAGE_DTYPE = cutlass.Float32
+    MMA_KIND = nvvm.Tcgen05MMAKind.TF32
+    IS_TF32 = True
+else:
+    raise ValueError(f"prefill_sdpa_f16: DTYPE_QKV={CFG.DTYPE_QKV} not supported " f"(expected 2=BF16, 3=FP16, or 4=TF32)")
+
+
+from cudnn.sdpa.fwd.kernels._common_sm100 import (
+    Bars,
+    KvLoopBounds,
+    make_classic_bars,
+    compute_kv_loop_bounds,
+    lpt_tile_coords,
+    make_sdpa_helpers,
+)
+
+CGA_SIZE = CFG.CGA_M * CFG.CGA_N
+
+CTA_GROUP_KIND = nvvm.CTAGroup.CTA_2 if CFG.CTA_MMA == 2 else nvvm.CTAGroup.CTA_1
+
+# Per-CTA buffer element counts + collective TMA transaction byte counts.
+# K (seq rows) and V (d_v cols) shrink by CTA_MMA; Q / O are per-CTA full.
+# At cga2 leader's expect_tx = per-CTA elems * BPE * CTA_MMA (collective bytes).
+qBufferElems = CFG.TILE_M * CFG.TILE_K
+kBufferElems = CFG.TILE_N * CFG.TILE_K // CFG.CTA_MMA
+vBufferElems = CFG.TILE_O * CFG.TILE_N // CFG.CTA_MMA
+oBufferElems = CFG.TILE_M * CFG.TILE_O
+
+# Q∪O alias (dsv3 TF32): O reuses Q's SMEM slab once BMM1 has consumed Q.
+# Each of the TILES_Q slabs is sized to max(Q,O) so sQ[qs] and sO[qs] coincide;
+# for the classic flavors d_qk >= d_v so the slab is qBufferElems.  TMA-STG
+# arrives mb_q_o_alias after O drains; TMA-LDG waits it before reloading Q.
+IS_QO_ALIAS = bool(CFG.QO_ALIAS)
+QO_SLAB_ELEMS = max(qBufferElems, oBufferElems)
+
+qTmaTransactionBytes = qBufferElems * CFG.BPE * CFG.CTA_MMA
+kTmaTransactionBytes = kBufferElems * CFG.BPE * CFG.CTA_MMA
+vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
+
+
+CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+
+
+_sdpa_h = make_sdpa_helpers(CFG)
+_decode_initial = _sdpa_h.decode_initial
+_decode_payload = _sdpa_h.decode_payload
+_bounds_for_tile = _sdpa_h.bounds_for_tile
+_resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+
+# THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
+# factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
+# kernels/ctm/common/sdpa/thd.py.  Gated by CFG.THD_VARLEN (folds out otherwise).
+# Supported at cga1 and cga2 (TILES_Q=2 → two Q slabs / O stores per tile).
+# seq_kv_lens overloaded as the THD metadata buffer (int32 len 3B+2):
+#   [0..B-1]=seq_kv_lens  [B..2B]=cu_q(B+1)  [2B+1..3B+1]=cu_k(B+1)
+# THD: FROST's builder is NOT the pre-upstream one, which was 7-arg, O-descriptors-
+# only build_o_descs_kernel; FROST does per-execute meta + O (+ K/V base descs)
+# in one elected-thread kernel with a 14-arg contract, and ships a dedicated
+# f16/bf16 entry point. The import is corrected here; the CALL SITE still speaks
+# the pre-upstream contract and is taken from the shipped fp8 SM107 sibling when THD
+# is wired (dense path first — see the module header).
+from cudnn.sdpa.fwd.kernels.thd_helpers import build_thd_meta_o_descs_kernel as _build_o_descs_kernel, TENSOR_MAP_QWORDS
+
+_TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
+_dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
+_dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
+_thd_tma_offsets = _sdpa_h.thd_tma_offsets
+
+
+# P (BMM2 operand) aliases the TAIL of each 128-col S_acc slot since BMM1
+# finishes (and softmax loads S into registers) before P is written.
+# fp16/bf16 pack 2 probs per FP32 cell → P width = TILE_N/2 ≤ 64 cols → P
+# sits at slot offset 64.  TF32 is 1:1 → P width = TILE_N, so P aliases the
+# FULL slot (offset 0 / 128).  Mirrors C++ S_bmm2_0 = S_acc_cols - S_bmm2_cols.
+_P0_OFF = 0 if IS_TF32 else 64
+_P1_OFF = 128 if IS_TF32 else 192
+
+
+@dataclass(frozen=True)
+class KernelTmemLayout:
+    """Column offsets for the classic 2-sub-tile SDPA pipeline.
+
+    Stats deliberately sit outside S_acc/O ranges so BMM1's next-iter
+    write doesn't clobber them.  P aliases the tail of S_acc[qs] since
+    BMM1 finishes before P is written.
+    """
+
+    # Rubin SM10.7 cap; requires is_exclusive=True on tcgen05_alloc.
+    TOTAL_COLS: int = 576
+
+    S0_OFF: int = 0
+    S1_OFF: int = 128
+
+    O0_OFF: int = 256
+    O1_OFF: int = 384
+
+    P0_OFF: int = _P0_OFF
+    P1_OFF: int = _P1_OFF
+
+    # qs stride = 8 cols.
+    STATS_OFF: int = 544
+
+
+LAYOUT = KernelTmemLayout()
+
+
+# === Kernel ===
+
+
+@cute.kernel
+def _kernel(
+    tma_q_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_k_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_v_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_o_desc: cutlass.GridConstant[tmap.TensorMap],
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    seqlen_q: cutlass.Int32,
+    seqlen_kv: cutlass.Int32,
+    n_q_supers: cutlass.Int32,
+    n_qh: cutlass.Int32,
+    n_batch: cutlass.Int32,
+    qh_per_kh: cutlass.Int32,
+    scale_softmax_log2: cutlass.Float32,
+) -> None:
+
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    tidx, _, _ = cute.arch.thread_idx()
+
+    bidx = cute.arch.block_idx()[0]
+    bidy = cute.arch.block_idx()[1]
+    bidz = cute.arch.block_idx()[2]
+
+    # SMEM allocations in natural Q/K/V/O order — CTM Tcgen05SmemDesc.build truncates
+    # start_address past ~256 KiB so this order keeps the data buffers in low SMEM.
+    # QO_ALIAS: one Q∪O slab (TILES_Q × max(Q,O) elems); sO points into it and
+    # strides by QO_SLAB_ELEMS so sO[qs] coincides with sQ[qs].  Else: separate
+    # Q and O buffers (the classic layout).
+    if cutlass.const_expr(IS_QO_ALIAS):
+        sQ_raw = cutlass.Array(STORAGE_DTYPE, CFG.TILES_Q * QO_SLAB_ELEMS, alignment=1024, space=cutlass.AddressSpace.smem)
+        sO_raw = sQ_raw
+        _SO_STAGE_ELEMS = QO_SLAB_ELEMS
+    else:
+        sQ_raw = cutlass.Array(STORAGE_DTYPE, CFG.TILES_Q * qBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+        sO_raw = cutlass.Array(STORAGE_DTYPE, CFG.TILES_Q * oBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+        _SO_STAGE_ELEMS = oBufferElems
+    sK_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * kBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    sV_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * vBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+
+    sQ = SmemTile(
+        base=sQ_raw,
+        elems_per_stage=qBufferElems,
+        stages=CFG.TILES_Q,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+    )
+    sK = SmemTile(
+        base=sK_raw,
+        elems_per_stage=kBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+    )
+    sV = SmemTile(
+        base=sV_raw,
+        elems_per_stage=vBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_PV,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_PV,
+        layout=SMEM_LAYOUT_V,
+        # V is split along d_v under cga2 → tma_loads_per_tile = TMA_VO_ITERS / CTA_MMA.
+        tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
+        tma_granu_elems=TMA_VO_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+    )
+    sO = SmemTile(
+        base=sO_raw,
+        elems_per_stage=_SO_STAGE_ELEMS,
+        stages=CFG.TILES_Q,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_O_ITERS_HOST,
+        tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+    )
+
+    bars = make_classic_bars(CFG)
+
+    tmem_ptr_i32 = cutlass.Array(cutlass.Int32, 1, alignment=16, space=cutlass.AddressSpace.smem)
+
+    # tile_id_smem stride 8 Int32/stage (32 B) = 16 B try_cancel payload + 16 B padding.
+    sched = Sched(
+        **{
+            "mb_scheduler": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "mb_read_tile_id": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "tile_id_smem": cutlass.Array(cutlass.Int32, CFG.SCHEDULER_STAGES * 8, alignment=16, space=cutlass.AddressSpace.smem),
+            "bidx_init": bidx,
+            "bidy_init": bidy,
+            "bidz_init": bidz,
+        }
+    )
+
+    # Scheduler mbar arrive count — stays kernel-local (sched is NOT in Bars).
+    READ_TILE_ARRIVERS_TOTAL = ((CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS) + CFG.CORRECTION_WARPS + 1 + 1) * CGA_SIZE + (CFG.CGA_M // CFG.CTA_MMA)
+
+    if warp_idx == 0:
+        if nvvm.elect_sync():
+            # range_constexpr → Python-int loop variable so bars.mb_X[qs].init()
+            # can index the per-stage init_count tuple (mb_bmm2_ready) at trace
+            # time.  Loop bounds are small (TILES_Q=2, STAGES_KV=2-4) — unroll
+            # is free.
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                bars.mb_q_full[qs].init()
+                bars.mb_q_empty[qs].init()
+                bars.mb_bmm1_done[qs].init()
+                bars.mb_bmm2_done[qs].init()
+                bars.mb_stat_full[qs].init()
+                bars.mb_stat_empty[qs].init()
+                bars.mb_o_full[qs].init()
+                bars.mb_o_empty[qs].init()
+                if cutlass.const_expr(IS_QO_ALIAS):
+                    bars.mb_q_o_alias[qs].init()
+                for c in cutlass.range_constexpr(CFG.N_BMM2_CHUNKS):
+                    bars.mb_bmm2_ready[qs * CFG.N_BMM2_CHUNKS + c].init()
+            for ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_k_full[ks].init()
+                bars.mb_k_empty[ks].init()
+                bars.mb_v_full[ks].init()
+                bars.mb_v_empty[ks].init()
+            for s in range(CFG.SCHEDULER_STAGES):
+                nvvm.mbarrier_init(sched.mb_scheduler.subview(s), CFG.ONE_LANE)
+                nvvm.mbarrier_init(sched.mb_read_tile_id.subview(s), READ_TILE_ARRIVERS_TOTAL)
+            bars.mb_tmem_dealloc.init()
+            bars.mb_empty_mainloop.init()
+
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync()
+
+    # P4: cluster fence gates cga2 cross-CTA arrive_on_peer on peer init.
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        cga_arrive()
+        cga_wait()
+
+    # CTM @cute.kernel stages if/else — use Python ternaries so the chosen
+    # expression flows into the trace (variables in branches aren't visible outside).
+    cta_id_x = cute.arch.block_idx_in_cluster() if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    cta_in_pair = (cta_id_x & cutlass.Int32(1)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    leader_cta_id = (cta_id_x & cutlass.Int32(~1 & 0xFFFFFFFF)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    mcast_mask = (cutlass.Int32(3) << leader_cta_id) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    # TMA-load self-bit mask: each peer's cta_group::2 TMA targets its own bit;
+    # cga2 routing strips bit-24 so bytes land on leader's mbar.
+    tma_mcast_mask = (cutlass.Int16(1) << cta_in_pair) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
+    is_leader = cta_in_pair == cutlass.Int32(0)
+
+    # === Per-warp role dispatch ===
+    if warp_idx >= CFG.SOFTMAX_WG0_BASE and warp_idx < CFG.SOFTMAX_WG0_BASE + CFG.SOFTMAX_WG_WARPS:
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        _softmax_warp_group(
+            sub_tile_id=0,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_softmax_log2,
+            tmem_ptr_i32=tmem_ptr_i32,
+            sQ=sQ,
+            bars=bars,
+            sched=sched,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+        )
+
+    elif warp_idx >= CFG.SOFTMAX_WG1_BASE and warp_idx < CFG.SOFTMAX_WG1_BASE + CFG.SOFTMAX_WG_WARPS:
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        _softmax_warp_group(
+            sub_tile_id=1,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_softmax_log2,
+            tmem_ptr_i32=tmem_ptr_i32,
+            sQ=sQ,
+            bars=bars,
+            sched=sched,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+        )
+
+    elif warp_idx >= CFG.CORR_WARP_BASE and warp_idx < CFG.CORR_WARP_BASE + CFG.CORRECTION_WARPS:
+        nvvm.setmaxregister(CFG.CORRECTION_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _correction_warp_group(
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            sO=sO,
+            tmem_ptr_i32=tmem_ptr_i32,
+            tidx=tidx,
+            bars=bars,
+            sched=sched,
+            lse_tensor=lse_tensor,
+            sinks_tensor=sinks_tensor,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+            cta_id_x=cta_id_x,
+        )
+
+    elif warp_idx == CFG.MMA_WARP_ID:
+        # Under cga2 the non-leader CTA runs the quiet body (alloc + dealloc only).
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        if cutlass.const_expr(CFG.CTA_MMA == 2):
+            if is_leader:
+                _mma_warp_group(
+                    seqlen_q=seqlen_q,
+                    seqlen_kv=seqlen_kv,
+                    sQ=sQ,
+                    sK=sK,
+                    sV=sV,
+                    tmem_ptr_i32=tmem_ptr_i32,
+                    bars=bars,
+                    sched=sched,
+                    seq_kv_lens_tensor=seq_kv_lens_tensor,
+                    n_q_supers=n_q_supers,
+                    n_qh=n_qh,
+                    n_batch=n_batch,
+                    mcast_mask=mcast_mask,
+                    cta_in_pair=cta_in_pair,
+                )
+            else:
+                _mma_warp_quiet(tmem_ptr_i32, bars)
+        else:
+            _mma_warp_group(
+                seqlen_q=seqlen_q,
+                seqlen_kv=seqlen_kv,
+                sQ=sQ,
+                sK=sK,
+                sV=sV,
+                tmem_ptr_i32=tmem_ptr_i32,
+                bars=bars,
+                sched=sched,
+                seq_kv_lens_tensor=seq_kv_lens_tensor,
+                n_q_supers=n_q_supers,
+                n_qh=n_qh,
+                n_batch=n_batch,
+                mcast_mask=mcast_mask,
+                cta_in_pair=cta_in_pair,
+            )
+
+    elif warp_idx == CFG.TMALDG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        nvvm.prefetch_tensormap(tma_q_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_k_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_v_desc.get_ptr())
+        _tmaldg_warp_group(
+            tma_q_desc=tma_q_desc,
+            tma_k_desc=tma_k_desc,
+            tma_v_desc=tma_v_desc,
+            sQ=sQ,
+            sK=sK,
+            sV=sV,
+            bars=bars,
+            sched=sched,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            qh_per_kh=qh_per_kh,
+            is_leader=is_leader,
+            cta_in_pair=cta_in_pair,
+            tma_mcast_mask=tma_mcast_mask,
+        )
+
+    elif warp_idx == CFG.TMASTG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _tmastg_warp_group(
+            tma_o_desc=tma_o_desc,
+            sO=sO,
+            bars=bars,
+            sched=sched,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            cta_in_pair=cta_in_pair,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
+        )
+
+    else:  # warp_idx == CFG.SCHED_WARP_ID
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        # try_cancel.multicast::cluster::all — only (0,0,0) CTA issues; at cga1
+        # cta_id_x == 0 always, so flag is 1 unconditionally.
+        is_cga_first_cta = cta_id_x == cutlass.Int32(0)
+        scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
+
+
+# === TMA-LDG warp ===
+
+
+@cute.jit
+def _tmaldg_warp_group(
+    tma_q_desc,
+    tma_k_desc,
+    tma_v_desc,
+    sQ,
+    sK,
+    sV,
+    bars,
+    sched,
+    seqlen_q,
+    seqlen_kv,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    qh_per_kh,
+    is_leader,
+    cta_in_pair,
+    tma_mcast_mask,
+):
+    """Unified TMA-LDG warp — cga1 / cga2 x MASK_NONE / PADDED / CAUSAL / SWA.
+
+    Spill-free in CFG.OTHER_REGS via q_row_base pre-multiplied after each
+    scheduler decode (gives ptxas a live use of nxt_q before the loop
+    back-edge, keeping the LDS.128 result in uniform registers).
+    """
+    q_empty_phase = cutlass.Int32(1)
+    kv_state = PipelineState.start(phase=1)
+
+    # Q-reload gate: under QO_ALIAS the next tile's Q-load must wait for the
+    # prior tile's O (sharing the slab) to drain — TMA-STG fires mb_q_o_alias
+    # (strictly after MMA consumed Q).  Else gate on mb_q_empty (MMA commit).
+    # Both bootstrap consumer-side via q_empty_phase=1.
+    mb_q_reload = bars.mb_q_o_alias if cutlass.const_expr(IS_QO_ALIAS) else bars.mb_q_empty
+
+    tma_q = GmemTileTma(tma_q_desc)
+    tma_k = GmemTileTma(tma_k_desc)
+    tma_v = GmemTileTma(tma_v_desc)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    # GQA: K/V are indexed by kv-head, not Q-head.
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+    q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    # CTM TMA descriptor is element-typed; contiguous coord is in ELEMENTS not bytes.
+    K_ROW_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_N // CFG.CTA_MMA)
+    V_COL_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_O // CFG.CTA_MMA)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+            pass
+        else:
+            # Prologue interleave Q[0] -> K[first] -> Q[1] -> V[first] -> mainloop —
+            # K load starts before Q[1] is issued and V before kv mainloop.
+            kv_row_base = kv_left * CFG.TILE_N
+
+            mb_q_reload[0].wait(q_empty_phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_q_full[0].arrive(n_bytes=qTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_q_full[0].arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sQ[0],
+                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(0 * CFG.TILE_M) + q_seq_off, tma_batch),
+                bars.mb_q_full[0].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+
+            bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sK[kv_state.idx],
+                tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER, batch_idx),
+                bars.mb_k_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+
+            mb_q_reload[1].wait(q_empty_phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_q_full[1].arrive(n_bytes=qTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_q_full[1].arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sQ[1],
+                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(1 * CFG.TILE_M) + q_seq_off, tma_batch),
+                bars.mb_q_full[1].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+            q_empty_phase = q_empty_phase ^ 1
+
+            bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sV[kv_state.idx],
+                tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
+                bars.mb_v_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+
+            for kv_loop in cutlass.range(kv_left + cutlass.Int32(1), kv_right, 1, unroll=1):
+                kv_row_base = kv_loop * CFG.TILE_N
+
+                bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sK[kv_state.idx],
+                    tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
+                    bars.mb_k_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+
+                bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sV[kv_state.idx],
+                    tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
+                    bars.mb_v_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+        nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+        nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+        # q_row_base compute right after decode drives ptxas R2UR.
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+        q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+
+    # cga2: drain trailing empty mbar arrives so SMEM isn't torn down while
+    # leader's multicast commits are still in-flight.
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        for _qs in cutlass.range_constexpr(CFG.TILES_Q):
+            mb_q_reload[_qs].wait(q_empty_phase)
+        q_empty_phase = q_empty_phase ^ cutlass.Int32(1)
+        for _ks in cutlass.range_constexpr(CFG.STAGES_KV):
+            bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+            bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+
+# === TMA-STG warp ===
+
+
+@cute.jit
+def _tmastg_warp_group(
+    tma_o_desc,
+    sO,
+    bars,
+    sched,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    cta_in_pair,
+    seq_kv_lens_tensor,
+    o_desc_words,
+):
+    """Persistent O-store warp.  First tile from blockIdx; subsequent tiles
+    via scheduler warp's clusterlaunchcontrol.try_cancel.async.
+    """
+    o_full_phase = cutlass.Int32(0)  # consumer waits — first-arrive flips 0 → 1
+
+    tma_o = GmemTileTma(tma_o_desc)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        q_row_base = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+
+        for qs in cutlass.range_constexpr(CFG.TILES_Q):
+            bars.mb_o_full[qs].wait(o_full_phase)
+
+            # O TMA params follow O's swizzle (NOT V's) — under gptoss cga2 V drops to Swz64B while O stays Swz128B.
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: store each Q slab through this batch's pre-built descriptor
+                # (base at the sequence's packed row, seq extent = S_q_b → a box
+                # past S_q_b is OOB-clipped).  q_row coord is sequence-local; the
+                # batch coord collapses to 0.  Both slabs share one descriptor.
+                o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), cutlass.Int32(0))
+                tma_store_tile(sO[qs], o_slice)
+            else:
+                tma_store_tile(
+                    sO[qs],
+                    tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), batch_idx),
+                )
+
+            tma_store_commit()
+            tma_store_wait(0)
+
+            bars.mb_o_empty[qs].arrive()
+            # QO_ALIAS: O[qs] has drained to GMEM → the shared Q∪O slab is free
+            # for TMA-LDG to clobber with the next tile's Q[qs].
+            if cutlass.const_expr(IS_QO_ALIAS):
+                bars.mb_q_o_alias[qs].arrive()
+
+        o_full_phase = o_full_phase ^ 1
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+
+# === BMM1 / BMM2 SMEM + idesc constants ===
+
+# Per-tensor swizzle layout enum: SWIZZLE_128B_ATOM_32B=1, Swz128B=2,
+# Swz64B=4, Swz32B=6.
+_SWZ_ENUM = {128: 2, 64: 4, 32: 6}
+_SWZ_ATOM_32B = 1  # required on the transposed BMM2 operand (V) under kind::tf32
+SMEM_LAYOUT_Q = _SWZ_ENUM[CFG.Q_SWZ_BYTES]
+SMEM_LAYOUT_K = _SWZ_ENUM[CFG.K_SWZ_BYTES]
+# V is the B-transposed BMM2 operand → TF32 needs SWIZZLE_128B_ATOM_32B.
+# Q/K (BMM1, non-transposed) and O keep standard swizzle for all dtypes.
+SMEM_LAYOUT_V = _SWZ_ATOM_32B if IS_TF32 else _SWZ_ENUM[CFG.V_SWZ_BYTES]
+SMEM_LAYOUT_O = _SWZ_ENUM[CFG.O_SWZ_BYTES]
+SMEM_LAYOUT_QKO = SMEM_LAYOUT_Q
+
+# O SMEM swizzle: third param is the XOR shift offset (=3 across all widths), NOT the B value.
+_O_SWZ_B = {128: 3, 64: 2, 32: 1}[CFG.O_SWZ_BYTES]
+_O_SMEM_SWIZZLE = cutlass.Swizzle(_O_SWZ_B, 4, 3)
+
+LEADING_BYTE_OFFSET_QK = 0
+STRIDE_BYTE_OFFSET_QK = 8 * CFG.Q_SWZ_BYTES
+
+# leading_byte_offset = 0 when (TILE_O/CTA_MMA)/8 <= 8 else TILE_N*V_SWZ_BYTES
+# TF32 ATOM32 override (mirrors C++ prefill_sdpa_f16.cu:803-806): the
+# SWIZZLE_128B_ATOM_32B mode pins leading = TILE_N*128, stride = 512 (NOT
+# the standard 8*V_SWZ).  Standard formulas with kind::tf32 silently zero C.
+_CORE_MATRIX_ROWS = 8
+_V_PC_COLS = CFG.TILE_O // CFG.CTA_MMA
+_LEADING_PV_STD = 0 if (_V_PC_COLS // _CORE_MATRIX_ROWS) <= 8 else CFG.TILE_N * CFG.V_SWZ_BYTES
+LEADING_BYTE_OFFSET_PV = (CFG.TILE_N * 128) if IS_TF32 else _LEADING_PV_STD
+STRIDE_BYTE_OFFSET_PV = 512 if IS_TF32 else (8 * CFG.V_SWZ_BYTES)
+
+NUM_KPHASES_PV = CFG.TILE_N // CFG.TILE_K_HW_BMM2
+NUM_KPHASES_PV_PER_CHUNK = NUM_KPHASES_PV // CFG.N_BMM2_CHUNKS
+
+
+@cute.jit
+def _mma_warp_quiet(tmem_ptr_i32, bars):
+    """Minimal quiet body for the non-leader CTA's MMA-warp slot under cga2.
+
+    Non-leader still participates in TMEM alloc / release lock (warp-collective
+    .sync.aligned ops) and TMEM-publish named barriers — leader's MMA reads
+    through the cluster crossbar from peer's TMEM during cga2 collective MMA.
+    """
+    # All-lanes warp-collective ops — NO elect_sync gating.
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND, is_exclusive=True)
+    # Match lead MMA's named-barrier arrive count (lead is +1 on both publish barriers).
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _mma_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    sQ,
+    sK,
+    sV,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    mcast_mask,
+    cta_in_pair,
+):
+    """Unified MMA warp — cga1 / cga2-leader x MASK_NONE / PADDED / CAUSAL / SWA,
+    spill-free in CFG.OTHER_REGS (40).  Non-leader under cga2 uses _mma_warp_quiet.
+    """
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND, is_exclusive=True)
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    tmem_raw = nvvm.make_tmem_ptr(tmem_ptr_i32.load(), cutlass.Int8)
+
+    # idesc M is COLLECTIVE (per-CTA M * CTA_MMA): cga2 tcgen05.mma.cta_group::2
+    # reads both peers' A and produces 2*LOCAL_M output rows.
+    idesc_qk = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_N,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+    )
+    idesc_pv = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_O,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        b_major=1,
+    )
+    bmm1_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_N,
+        K=CFG.TILE_K,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=CFG.TILE_K_HW_BMM1,
+        btranspose=False,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_qk,
+        kind=MMA_KIND,
+    )
+    # BMM2 V uses non-default K_SUBTILE = V_SWZ_BYTES/BPE (cga2 V Swz64B on dsv3/gptoss).
+    bmm2_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_O,
+        K=CFG.TILE_N,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=CFG.TILE_K_HW_BMM2,
+        btranspose=True,
+        k_subtile=CFG.V_SWZ_BYTES // CFG.BPE,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_pv,
+        kind=MMA_KIND,
+    )
+
+    desc_Q0 = sQ[0].desc()
+    desc_Q1 = sQ[1].desc()
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        q_super_idx, _hd, batch_idx = _dispatch_decode_initial(
+            sched.bidx_init,
+            sched.bidy_init,
+            sched.bidz_init,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    q_full_phase = cutlass.Int32(0)
+    kv_state = PipelineState.start(phase=0)
+    bmm2_ready_phase = cutlass.Int32(0)
+    # Initialised unconditionally so type is stable across const_expr branches.
+    empty_mainloop_phase = cutlass.Int32(0)
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+            # Empty mainloop: fire both bmm2_done so softmax/correction phase trackers stay in lockstep.
+            bars.mb_empty_mainloop.wait(empty_mainloop_phase)
+            empty_mainloop_phase = empty_mainloop_phase ^ cutlass.Int32(1)
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bars.mb_bmm2_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+        else:
+            # Prologue: BMM1[sub0], BMM1[sub1] for kv=kv_left
+            bars.mb_q_full[0].wait(q_full_phase)
+            bars.mb_k_full[kv_state.idx].wait(kv_state.phase)
+            desc_K = sK[kv_state.idx].desc()
+            mma_ss(bmm1_desc, desc_Q0, desc_K, (tmem_raw.subview(LAYOUT.S0_OFF)))
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm1_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+            bars.mb_q_full[1].wait(q_full_phase)
+            mma_ss(bmm1_desc, desc_Q1, desc_K, (tmem_raw.subview(LAYOUT.S1_OFF)))
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm1_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bars.mb_k_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+            q_full_phase = q_full_phase ^ 1
+
+            # Mainloop kv = kv_left+1 .. kv_right-1 (empty when n_kv == 1)
+            for kv_loop in cutlass.range(kv_left + cutlass.Int32(1), kv_right, 1, unroll=1):
+                old_state = kv_state
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+
+                bars.mb_v_full[old_state.idx].wait(old_state.phase)
+                desc_V = sV[old_state.idx].desc()
+                is_not_first_bmm2 = cutlass.Boolean(kv_loop != (kv_left + cutlass.Int32(1)))
+
+                # BMM2 sub-tile 0
+                bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
+                accum_b2 = is_not_first_bmm2
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P0_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O0_OFF)), local_k, accum_b2)
+                    accum_b2 = cutlass.Boolean(True)
+                # Chunk 1 folds out at TILE_N=64 (N_BMM2_CHUNKS=1).
+                if cutlass.const_expr(CFG.N_BMM2_CHUNKS == 2):
+                    bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 1].wait(bmm2_ready_phase)
+                    for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                        mma_ts_step(
+                            bmm2_desc,
+                            (tmem_raw.subview(LAYOUT.P0_OFF)),
+                            desc_V,
+                            (tmem_raw.subview(LAYOUT.O0_OFF)),
+                            NUM_KPHASES_PV_PER_CHUNK + local_k,
+                            cutlass.Boolean(True),
+                        )
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+                # BMM1 sub 0 for next kv
+                bars.mb_k_full[kv_state.idx].wait(kv_state.phase)
+                desc_K = sK[kv_state.idx].desc()
+                mma_ss(bmm1_desc, desc_Q0, desc_K, (tmem_raw.subview(LAYOUT.S0_OFF)))
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm1_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+                # BMM2 sub-tile 1
+                bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
+                accum_b2 = is_not_first_bmm2
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P1_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O1_OFF)), local_k, accum_b2)
+                    accum_b2 = cutlass.Boolean(True)
+                if cutlass.const_expr(CFG.N_BMM2_CHUNKS == 2):
+                    bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 1].wait(bmm2_ready_phase)
+                    for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                        mma_ts_step(
+                            bmm2_desc,
+                            (tmem_raw.subview(LAYOUT.P1_OFF)),
+                            desc_V,
+                            (tmem_raw.subview(LAYOUT.O1_OFF)),
+                            NUM_KPHASES_PV_PER_CHUNK + local_k,
+                            cutlass.Boolean(True),
+                        )
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm2_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                bars.mb_v_empty[old_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+                # BMM1 sub 1 for next kv
+                mma_ss(bmm1_desc, desc_Q1, desc_K, (tmem_raw.subview(LAYOUT.S1_OFF)))
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm1_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                bars.mb_k_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+                bmm2_ready_phase = bmm2_ready_phase ^ 1
+
+            # Epilogue: BMM2 for last kv (always runs — n_kv >= 1).
+            # Under QO_ALIAS the TMA-LDG Q-reload gate is mb_q_o_alias (fired by
+            # TMA-STG after O drains), so MMA does NOT fire mb_q_empty.
+            if cutlass.const_expr(not IS_QO_ALIAS):
+                elect_p = nvvm.elect_sync()
+                for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                    bars.mb_q_empty[qs].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+            bars.mb_v_full[kv_state.idx].wait(kv_state.phase)
+            desc_V = sV[kv_state.idx].desc()
+            is_not_first_bmm2_epi = cutlass.Boolean((kv_right - kv_left) != cutlass.Int32(1))
+
+            bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
+            accum_b2 = is_not_first_bmm2_epi
+            for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P0_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O0_OFF)), local_k, accum_b2)
+                accum_b2 = cutlass.Boolean(True)
+            if cutlass.const_expr(CFG.N_BMM2_CHUNKS == 2):
+                bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 1].wait(bmm2_ready_phase)
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(
+                        bmm2_desc,
+                        (tmem_raw.subview(LAYOUT.P0_OFF)),
+                        desc_V,
+                        (tmem_raw.subview(LAYOUT.O0_OFF)),
+                        NUM_KPHASES_PV_PER_CHUNK + local_k,
+                        cutlass.Boolean(True),
+                    )
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+            bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
+            accum_b2 = is_not_first_bmm2_epi
+            for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P1_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O1_OFF)), local_k, accum_b2)
+                accum_b2 = cutlass.Boolean(True)
+            if cutlass.const_expr(CFG.N_BMM2_CHUNKS == 2):
+                bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 1].wait(bmm2_ready_phase)
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(
+                        bmm2_desc,
+                        (tmem_raw.subview(LAYOUT.P1_OFF)),
+                        desc_V,
+                        (tmem_raw.subview(LAYOUT.O1_OFF)),
+                        NUM_KPHASES_PV_PER_CHUNK + local_k,
+                        cutlass.Boolean(True),
+                    )
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm2_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bars.mb_v_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+            bmm2_ready_phase = bmm2_ready_phase ^ 1
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+            nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+        else:
+            nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+            nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+            nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+            q_super_idx, _hd, batch_idx = _dispatch_decode_payload(
+                nxt_q,
+                nxt_hb,
+                cta_in_pair,
+                n_q_supers,
+                n_qh,
+                n_batch,
+                seq_kv_lens_tensor,
+            )
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _softmax_kv_body(
+    apply_mask: bool,
+    sub_tile_id: int,
+    kv_loop,
+    tmem_ptr_i32,
+    bars,
+    q_abs,
+    eff_seqlen_kv,
+    seqlen_q,
+    scale_log2,
+    total_max,
+    total_sum,
+    bmm1_phase,
+    stat_empty_phase,
+    leader_cta_id,
+):
+    """Per-iter kv body for the softmax warp group.
+
+    Compile-time apply_mask (Python bool) picks the load+max strategy:
+    apply_mask=False uses fused tcgen05.ld.red.f32.max (HW row-max);
+    apply_mask=True uses tcgen05.ld + apply_mask_chunk + software row-max
+    (HW max can't observe NEG_INFINITY written after the load).
+
+    Returns updated (total_max, total_sum, bmm1_phase, stat_empty_phase).
+    """
+    tmem_S_off = LAYOUT.S0_OFF if sub_tile_id == 0 else LAYOUT.S1_OFF
+    tmem_P_off = LAYOUT.P0_OFF if sub_tile_id == 0 else LAYOUT.P1_OFF
+    stats_off = LAYOUT.STATS_OFF + sub_tile_id * 8
+    CHUNK = 64
+    # fp16/bf16 pack 2 probs per FP32 TMEM cell (CHUNK//2); TF32 is 1:1 (CHUNK).
+    P_COLS_PER_CHUNK = CHUNK if IS_TF32 else CHUNK // 2
+    N_CHUNKS = CFG.N_BMM2_CHUNKS
+    NEG_INF = cutlass.Float32(-3.4028235e38)
+    RESCALE_THRESHOLD = cutlass.Float32(CFG.RESCALE_THRESHOLD)
+
+    bars.mb_bmm1_done[sub_tile_id].wait(bmm1_phase)
+    bmm1_phase = bmm1_phase ^ 1
+
+    # Hoist all TMEM address math to a single base load — Rubin tcgen05.ld/st
+    # auto-derives row from warp_id_in_warpgroup; address only needs the column.
+    tmem_base = tmem_ptr_i32.load()
+    s_addr_base = tmem_base + cutlass.Int32(tmem_S_off)
+    p_addr_base = tmem_base + cutlass.Int32(tmem_P_off)
+    stats_addr = tmem_base + cutlass.Int32(stats_off)
+
+    # apply_mask is a Python bool — wrap in cutlass.const_expr so CTM folds
+    # at trace time instead of staging cf.if (the two arms produce Vectors
+    # built via different MLIR op sequences and the tracer would error).
+    if cutlass.const_expr(apply_mask):
+        kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+        # Python comprehensions (not for+append) so the tracer sees fully-formed lists.
+        raw_chunks = [
+            nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32),
+                num=CHUNK,
+            )
+            for c in range(N_CHUNKS)
+        ]
+        # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
+        # CFG.BOTTOM_RIGHT is 0 — top-left masking is unchanged).
+        causal_diag = eff_seqlen_kv - seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+        chunks_S = [
+            apply_mask_chunk(
+                raw_chunks[c],
+                q_abs,
+                kv_col_base + cutlass.Int32(c * CHUNK),
+                eff_seqlen_kv,
+                CFG.WINDOW_LEFT,
+                CFG.MASK_FLAGS,
+                N=CHUNK,
+                bottom_right=CFG.BOTTOM_RIGHT,
+                causal_diag=causal_diag,
+                window_right=CFG.WINDOW_RIGHT,
+            )
+            for c in range(N_CHUNKS)
+        ]
+        chunks_max = [row_max_reduction(chunks_S[c]) for c in range(N_CHUNKS)]
+        # vec_concat handles single-element lists too; keeps tracer Vector type uniform across N_CHUNKS.
+        reg_S_vec = vec_concat(chunks_S)
+        current_max_unscaled = chunks_max[0]
+        for m in chunks_max[1:]:
+            current_max_unscaled = cute.math.max(current_max_unscaled, m)
+    else:
+        reg_S_tile, current_max_unscaled = tmem_load_max_reduction_tile(
+            s_addr_base,
+            num_elems=CFG.TILE_N,
+        )
+        reg_S_vec = reg_S_tile.vec
+
+    # Pass size=CFG.TILE_N explicitly — Vector.shape[0] is an MLIR value
+    # (not Python int) for vec_concat-built vectors, so auto-detect can't recover the length.
+    reg_S = RegTile(reg_S_vec, size=CFG.TILE_N)
+    current_max = current_max_unscaled * scale_log2
+
+    # Named-barrier wg0/wg1 sync: sub_tile_id==1 waits at TOP for sub_tile_id==0's bottom arrive.
+    if sub_tile_id == 1:
+        nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
+
+    # Online softmax with RESCALE_THRESHOLD skip.
+    old_total_max = total_max
+    is_first = total_max == NEG_INF
+    update_cond = is_first | ((current_max - total_max) > RESCALE_THRESHOLD)
+    total_max = cutlass.Float32(
+        arith.select(
+            update_cond.ir_value(),
+            current_max.ir_value(),
+            total_max.ir_value(),
+        )
+    )
+    exp_input = cutlass.Float32(
+        arith.select(
+            is_first.ir_value(),
+            NEG_INF.ir_value(),
+            (old_total_max - total_max).ir_value(),
+        )
+    )
+    alpha = cute.math.exp2(exp_input, fastmath=True)
+    new_total_max = total_max
+
+    alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+    bars.mb_stat_full[sub_tile_id].arrive()
+
+    # Rescale full reg_S in one vector op — emits same FFMA2 sequence as explicit half-tile rescales.
+    reg_S = reg_S * scale_log2 - new_total_max
+
+    # Chunk 0 manual unroll — CTM's @cute.jit tracer makes the loop iter an
+    # MLIR value, breaking Python slice.indices() math inside RegTile[].
+    chunk_S_0 = reg_S[0:CHUNK].vec
+    chunk_P_0 = cute.math.exp2(chunk_S_0, fastmath=True)
+    # Hoist chunk 0's sum before the cast to overlap with the cast's FFMA chain.
+    hoisted_sum = row_reduction_pair(chunk_P_0)
+    chunk_P_0_fp16 = chunk_P_0.to(STORAGE_DTYPE)
+    nvvm.tcgen05_st(
+        "32x32b",
+        nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32),
+        chunk_P_0_fp16,
+    )
+    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+    bars.mb_bmm2_ready[sub_tile_id * N_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+    # Chunk 1 folds out at TILE_N=64 (N_CHUNKS=1).
+    deferred_P_1 = None
+    if cutlass.const_expr(N_CHUNKS == 2):
+        chunk_S_1 = reg_S[CHUNK : 2 * CHUNK].vec
+        deferred_P_1 = cute.math.exp2(chunk_S_1, fastmath=True)
+        chunk_P_1_fp16 = deferred_P_1.to(STORAGE_DTYPE)
+        nvvm.tcgen05_st(
+            "32x32b",
+            nvvm.make_tmem_ptr(
+                p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK),
+                cutlass.Float32,
+            ),
+            chunk_P_1_fp16,
+        )
+        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+        bars.mb_bmm2_ready[sub_tile_id * N_CHUNKS + 1].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+    # wg0 fires bottom sync to release wg1 spinning at TOP barrier.
+    if sub_tile_id == 0:
+        nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
+
+    new_p_sum_pair = hoisted_sum
+    if cutlass.const_expr(N_CHUNKS == 2):
+        new_p_sum_pair = new_p_sum_pair + row_reduction_pair(deferred_P_1)
+    alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+    total_sum = total_sum * alpha_pair + new_p_sum_pair
+
+    bars.mb_stat_empty[sub_tile_id].wait(stat_empty_phase)
+    stat_empty_phase = stat_empty_phase ^ 1
+
+    return total_max, total_sum, bmm1_phase, stat_empty_phase
+
+
+@cute.jit
+def _softmax_warp_group(
+    sub_tile_id: int,
+    seqlen_q,
+    seqlen_kv,
+    scale_log2: cutlass.Float32,
+    tmem_ptr_i32,
+    sQ,
+    bars,
+    sched,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+):
+    """Softmax warp group (one of two): online softmax per kv iter.
+
+    Each lane owns one row of the 128 x 128 S_acc tile, loads its 128 fp32
+    cols with a single tcgen05.ld.red.max, runs online softmax (total_max +
+    total_sum tracking with RESCALE_THRESHOLD skip), publishes alpha to
+    corr, writes P to TMEM cols at S_acc tail, fires bmm2_ready[sub][chunk].
+    """
+    # Wait on MMA's TMEM-publish named barrier BEFORE any tmem_ptr_i32.load() —
+    # without it softmax can race MMA's tcgen05_alloc and read a stale base.
+    nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+
+    tmem_S_off = LAYOUT.S0_OFF if sub_tile_id == 0 else LAYOUT.S1_OFF
+    tmem_P_off = LAYOUT.P0_OFF if sub_tile_id == 0 else LAYOUT.P1_OFF
+
+    NEG_INF = cutlass.Float32(-3.4028235e38)
+
+    CHUNK = 64
+    P_COLS_PER_CHUNK = CHUNK // 2
+    stats_off = LAYOUT.STATS_OFF + sub_tile_id * 8
+
+    # Phase trackers persist across tile boundaries (barriers don't reset).
+    bmm1_phase = cutlass.Int32(0)
+    stat_empty_phase = cutlass.Int32(1)  # bootstrap pre-armed at phase 1 so first wait passes immediately
+    # init phase=1; both softmax wgs wait on slot [0] not [SoftmaxGid].
+    epilogue_state = cutlass.Int32(1)
+
+    # total_sum kept as Vector[Float32, 2] (even/odd partials) so per-iter update lowers to packed FMUL2 + FADD2.
+    total_max = NEG_INF
+    total_sum = cutlass.Vector.from_elements(
+        (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+        cutlass.Float32,
+    )
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    softmax_wg_base_const = CFG.SOFTMAX_WG0_BASE if sub_tile_id == 0 else CFG.SOFTMAX_WG1_BASE
+    tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(softmax_wg_base_const * 32)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        # Top-of-tile mb_o_empty[0] wait: without it softmax can race into the
+        # next tile while TMA-STG is still draining the prior tile's O slot.
+        bars.mb_o_empty[0].wait(epilogue_state)
+        epilogue_state = epilogue_state ^ cutlass.Int32(1)
+
+        total_max = NEG_INF
+        total_sum = cutlass.Vector.from_elements(
+            (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+            cutlass.Float32,
+        )
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+        q_abs = q_row_coord + cutlass.Int32(sub_tile_id * CFG.TILE_M) + tid_in_wg
+        # Bootstrap stat_empty wait BEFORE kv loop — lifts wait off per-iter
+        # critical path so alpha publish + stat_full fire happen back-to-back.
+        bars.mb_stat_empty[sub_tile_id].wait(stat_empty_phase)
+        stat_empty_phase = stat_empty_phase ^ 1
+        # 3-segment kv loop: LEFT-masked / fully-unmasked / RIGHT-masked.
+        # At MASK_NONE bounds collapse so the two masked sub-loops have empty range and fold out.
+        if cutlass.const_expr(CFG.MASK_FLAGS == MASK_NONE):
+            for kv_loop in cutlass.range(bounds.left, bounds.right, 1, unroll=1):
+                total_max, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                    False,
+                    sub_tile_id,
+                    kv_loop,
+                    tmem_ptr_i32,
+                    bars,
+                    q_abs,
+                    eff_seqlen_kv,
+                    seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_sum,
+                    bmm1_phase,
+                    stat_empty_phase,
+                    leader_cta_id,
+                )
+        else:
+            for kv_loop in cutlass.range(bounds.left, bounds.unmasked_lo, 1, unroll=1):
+                total_max, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                    True,
+                    sub_tile_id,
+                    kv_loop,
+                    tmem_ptr_i32,
+                    bars,
+                    q_abs,
+                    eff_seqlen_kv,
+                    seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_sum,
+                    bmm1_phase,
+                    stat_empty_phase,
+                    leader_cta_id,
+                )
+            for kv_loop in cutlass.range(bounds.unmasked_lo, bounds.unmasked_hi, 1, unroll=1):
+                total_max, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                    False,
+                    sub_tile_id,
+                    kv_loop,
+                    tmem_ptr_i32,
+                    bars,
+                    q_abs,
+                    eff_seqlen_kv,
+                    seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_sum,
+                    bmm1_phase,
+                    stat_empty_phase,
+                    leader_cta_id,
+                )
+            for kv_loop in cutlass.range(bounds.unmasked_hi, bounds.right, 1, unroll=1):
+                total_max, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                    True,
+                    sub_tile_id,
+                    kv_loop,
+                    tmem_ptr_i32,
+                    bars,
+                    q_abs,
+                    eff_seqlen_kv,
+                    seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_sum,
+                    bmm1_phase,
+                    stat_empty_phase,
+                    leader_cta_id,
+                )
+
+        # End-of-kv: publish (total_max, total_sum_final) to TMEM Stats — corr reads it for LSE.
+        total_sum_scalar = total_sum[0] + total_sum[1]
+
+        stats_addr_epi = tmem_ptr_i32.load() + cutlass.Int32(stats_off)
+        stats_vec_epi = cutlass.Vector.from_elements((total_max, total_sum_scalar), cutlass.Float32)
+        nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr_epi, cutlass.Float32), stats_vec_epi)
+        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+        bars.mb_stat_full[sub_tile_id].arrive()
+
+        # make_warp_uniform on scheduler-payload loads keeps nxt_* in uniform
+        # registers across the back-edge so ptxas doesn't STL them.
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+        nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+        nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+
+@cute.jit
+def _correction_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    sO,
+    tmem_ptr_i32,
+    tidx,
+    bars,
+    sched,
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+    cta_id_x,
+):
+    """Correction warp group: 4 warps x 32 lanes = 128 lanes, 1 lane per O row.
+
+    Per kv iter rescales O by alpha (skipped when all_alpha_one warp ballot
+    fires); per-tile epilogue normalizes O by 1/total_sum, casts to fp16,
+    swizzled-stores to sO, fires o_full for TMA-STG.  Holds the P14
+    end-of-tile catch-up flip on bmm2_done_phase (needed at n_kv=1 multi-wave).
+    """
+    # Wait on MMA's TMEM-publish named barrier BEFORE any tmem_ptr_i32.load() —
+    # without it correction can race MMA's tcgen05_alloc and read a stale base.
+    nvvm.barrier_cta_sync(barrier_id=2, thread_count=32 * (CFG.CORRECTION_WARPS + 1))
+
+    # Read tidx directly from PTX sreg — cute.arch.thread_idx() in @cute.jit may yield warp-uniform via folding.
+    tid_raw = cute.arch.thread_idx()[0]
+    tid_in_wg = tid_raw - cutlass.Int32(CFG.CORR_WARP_BASE * 32)
+
+    # O_CHUNK=16 (halved from 32) shortens the alpha-rescale live range —
+    # at 32, CTM regalloc spilled correction-warp regs to the stack.
+    O_CHUNK = 16
+    N_CHUNKS_O = CFG.TILE_O // O_CHUNK
+    # Use O_SWZ_B (NOT V_SWZ_B): under cga2 V is split along d_v and may drop
+    # to a narrower swizzle while O is full-row.  V-based stride here silently
+    # produces correct TMEM but garbled SMEM → wrong O after TMA-STG.
+    TMA_O_ITERS = (CFG.TILE_O * CFG.BPE) // CFG.O_SWZ_BYTES
+    D_BLOCK_SIZE = CFG.TILE_O // TMA_O_ITERS
+    TMA_O_GRANU_ELEMS = CFG.TILE_M * D_BLOCK_SIZE
+
+    stat_full_phase = cutlass.Int32(0)
+    # bmm2_done starts at phase=0; iter 0 is skipped, first wait at kv_loop=1.
+    bmm2_done_phase = cutlass.Int32(0)
+    o_empty_phase = cutlass.Int32(1)  # bootstrap
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+        # Iter-0 lifted out of kv loop: MMA's iter-0 BMM2 uses init_d=False
+        # to overwrite O garbage, so alpha-rescale is unnecessary in iter 0.
+        if bounds.right > bounds.left:
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                bars.mb_bmm2_ready[qs * CFG.N_BMM2_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                bars.mb_stat_full[qs].wait(stat_full_phase)
+                bars.mb_stat_empty[qs].arrive()
+            stat_full_phase = stat_full_phase ^ 1
+        else:
+            # Empty-mainloop: corr fires (DSMEM-arrive on leader at cga2); MMA fires bmm2_done[0/1] via multicast.
+            bars.mb_empty_mainloop.arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+        for kv_loop in cutlass.range(bounds.left + cutlass.Int32(1), bounds.right, 1, unroll=1):
+            tmem_base_iter = tmem_ptr_i32.load()
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                stats_off = LAYOUT.STATS_OFF + qs * 8
+                tmem_O_off = LAYOUT.O0_OFF if qs == 0 else LAYOUT.O1_OFF
+
+                bars.mb_stat_full[qs].wait(stat_full_phase)
+
+                stats_addr = tmem_base_iter + cutlass.Int32(stats_off)
+                stats_vec = nvvm.tcgen05_ld(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(stats_addr, cutlass.Float32),
+                    num=2,
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                alpha = stats_vec[0]
+
+                # all_alpha_one ballot: when every lane has alpha==1.0 the entire rescale loop skips.
+                alpha_is_one = alpha == cutlass.Float32(1.0)
+                all_alpha_one = vote_sync(0xFFFFFFFF, alpha_is_one, VoteSync.ALL)
+
+                bars.mb_stat_empty[qs].arrive()
+
+                bars.mb_bmm2_done[qs].wait(bmm2_done_phase)
+
+                # vec_scale_pair emits nvvm.mul_packed_f32x2 → FMUL2.  Without it
+                # plain o_chunk*alpha lowers to scalar FMUL inside the runtime-if
+                # (downstream fp32 tcgen05_st doesn't force packed regs).
+                # Per-chunk cfence keeps ptxas from sinking the next chunk's
+                # tcgen05_ld ahead of the prior tcgen05_st (TMEM-col anti-dep).
+                if ~all_alpha_one:
+                    for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                        o_addr = tmem_base_iter + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
+                        o_chunk = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                            num=O_CHUNK,
+                        )
+                        o_scaled = vec_scale_pair(o_chunk, alpha, O_CHUNK)
+                        nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(o_addr, cutlass.Float32), o_scaled)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+
+                bars.mb_bmm2_ready[qs * CFG.N_BMM2_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+            stat_full_phase = stat_full_phase ^ 1
+            bmm2_done_phase = bmm2_done_phase ^ 1
+
+        # === End-of-kv epilogue ===
+        tmem_base_epi = tmem_ptr_i32.load()
+        for qs in cutlass.range_constexpr(CFG.TILES_Q):
+            stats_off = LAYOUT.STATS_OFF + qs * 8
+            tmem_O_off = LAYOUT.O0_OFF if qs == 0 else LAYOUT.O1_OFF
+
+            bars.mb_bmm2_done[qs].wait(bmm2_done_phase)
+
+            # Wait the (total_max, total_sum_final) publish from softmax's epilogue.
+            bars.mb_stat_full[qs].wait(stat_full_phase)
+
+            stats_addr = tmem_base_epi + cutlass.Int32(stats_off)
+            stats_vec = nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(stats_addr, cutlass.Float32),
+                num=2,
+            )
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+            total_max_scaled = stats_vec[0]  # log2-units (softmax stores it scaled)
+            total_sum = stats_vec[1]
+
+            # Fire stat_empty so softmax's NEXT-tile iter 0 wait can pass.
+            bars.mb_stat_empty[qs].arrive()
+
+            inv_sum = cutlass.Float32(0.0)  # pre-declare for CTM if-staging
+            lse_val = cutlass.Float32(0.0)
+            # With sinks: fold the lift-the-max rescale into threshold_beta so O is scaled by scale/new_sum in one FMUL.
+            LN2 = cutlass.Float32(0.6931471805599453)
+            total_max_nat = total_max_scaled * LN2
+            if cutlass.const_expr(CFG.HAS_SINK):
+                sinks_arr = cutlass.make_array_view(sinks_tensor)
+                sink_logit = sinks_arr[head_idx]
+                new_max = cute.math.max(total_max_nat, sink_logit)
+                scale = cute.math.exp(total_max_nat - new_max, fastmath=True)
+                new_sum = total_sum * scale + cute.math.exp(sink_logit - new_max, fastmath=True)
+                lse_val = new_max + cute.math.log(new_sum, fastmath=True)
+                inv_sum = scale / new_sum
+            else:
+                lse_val = total_max_nat + cute.math.log(total_sum, fastmath=True)
+                # Safe inverse: avoid div by 0 on fully-masked rows.
+                inv_sum = cutlass.Float32(1.0) / cute.math.max(total_sum, cutlass.Float32(1e-30))
+
+            # OOB-row guard: under cga2 the cluster's Q rows can exceed seqlen_q;
+            # without the guard the write aliases the next head's LSE slot.
+            q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: q_row_global is sequence-local; LSE is packed [1,QH,T] →
+                # index [0, head, cu_q[b] + local], bound by per-sequence Q len S_q_b.
+                _cu = cutlass.make_array_view(seq_kv_lens_tensor)
+                _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
+                _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
+                if cutlass.const_expr(lse_tensor is not None):
+                    if q_row_global < _s_q_b:
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
+                        lse_row[_cu_q_b + q_row_global] = lse_val
+            else:
+                if cutlass.const_expr(lse_tensor is not None):
+                    if q_row_global < seqlen_q:
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        lse_row = lse_arr[batch_idx, head_idx, :]
+                        lse_row[q_row_global] = lse_val
+
+            sO_sub_base = sO[qs].base
+
+            for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                o_addr = tmem_base_epi + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
+                o_chunk = nvvm.tcgen05_ld(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                    num=O_CHUNK,
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                o_scaled = o_chunk * inv_sum
+                o_fp16 = o_scaled.to(STORAGE_DTYPE)
+
+                col_offset_const = (chunk_idx * O_CHUNK) % D_BLOCK_SIZE
+                block_idx_const = (chunk_idx * O_CHUNK) // D_BLOCK_SIZE
+                block_offset_const = block_idx_const * TMA_O_GRANU_ELEMS
+                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
+
+                smem_ptr = sO_sub_base.subview(smem_offset).data_ptr()
+                # mb_o_empty[qs] wait gates the FIRST SMEM store (not the
+                # earlier TMEM-load loop), keeping TMEM-load/FFMA/cast overlapped
+                # with TMA-STG draining the prior persistent tile.
+                if chunk_idx == 0:
+                    bars.mb_o_empty[qs].wait(o_empty_phase)
+                smem_ptr.store_swizzled(o_fp16, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+
+            # fence_proxy needed before TMA reads SMEM written by tcgen05_st (via store_swizzled).
+            nvvm.fence_proxy("async.shared", space="cta")
+
+            bars.mb_o_full[qs].arrive()
+
+        stat_full_phase = stat_full_phase ^ 1
+        o_empty_phase = o_empty_phase ^ 1
+        # P14 catch-up flip — bmm2_done_phase ^= 1 AFTER epilogue wait
+        # (mainloop flips n_kv-1 times, MMA fires n_kv times; +1 here matches —
+        # without this, n_kv=1 multi-wave deadlocks on the 2nd tile).
+        bmm2_done_phase = bmm2_done_phase ^ 1
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    # End-of-warp tmem_dealloc: under cga2 each corr lane ALSO DSMEM-arrives
+    # on the peer so the peer's local mbar accumulates the full CGA-total count.
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        peer_cta = cta_id_x ^ cutlass.Int32(1)
+        bars.mb_tmem_dealloc.arrive_on_peer(peer_cta)
+    bars.mb_tmem_dealloc.arrive()
+
+
+# === Host launcher ===
+
+
+@cute.jit
+def _host(
+    q_tensor: cute.Tensor,
+    k_tensor: cute.Tensor,
+    v_tensor: cute.Tensor,
+    o_tensor: cute.Tensor,
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    problem_size: Tuple[int, int, int, int, int, int],
+    scale_softmax_log2: cutlass.Float32,
+    n_thd_units: cutlass.Int32,
+    # FROST passes the dense padded-Q trim tensor POSITIONALLY on every call.
+    # These kernels have no Q-trim epilogue (Capabilities.dense_seq_q_trim=False)
+    # so it is accepted and unused -- but the SLOT is mandatory: without it the
+    # adapter's 12th positional lands on `stream` and execute dies with
+    # "got multiple values for argument 'stream'".
+    seq_q_lens_tensor: Optional[cute.Tensor] = None,
+    # FROST plans must run on the caller's stream (engine contract; there is a
+    # dedicated stream-respect test).  Threaded exactly as the shipped
+    # prefill_d128_fp8_sm107.py sibling does.
+    stream: _cuda_driver.CUstream = None,
+) -> None:
+    B, QH, KH, SQ, SKV, _ = problem_size
+
+    # Tensors are [B, S, H, D] with stride_order=(3, 2, 1, 0); D is fastest.
+    # K is split along seq under cga2 — box rows are per-CTA.  V is split along d_v
+    # (plumbed via num_iters//CTA_MMA).  O's TMA box inner dim follows O's swizzle, NOT V's.
+    _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE
+    qk_box_q = (1, CFG.TILE_M, 1, TMA_QK_GRANU_ELEMS)
+    qk_box_k = (1, CFG.TILE_N // CFG.CTA_MMA, 1, TMA_QK_GRANU_ELEMS)
+    vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M, 1, _O_GRANU_ELEMS)
+    stride_order = (3, 2, 1, 0)
+
+    # Per-tensor TMA swizzle tracks per-CTA inner bytes (derived from CFG.*_SWZ_BYTES).
+    def _tma_swz(byte_w: int):
+        return tmap.TensorMapSwizzle.s128b if byte_w == 128 else tmap.TensorMapSwizzle.s64b if byte_w == 64 else tmap.TensorMapSwizzle.s32b
+
+    tma_q_desc = tmap.create_tensor_map_tiled_from_view(
+        q_tensor,
+        box_dims=qk_box_q,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.Q_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_k_desc = tmap.create_tensor_map_tiled_from_view(
+        k_tensor,
+        box_dims=qk_box_k,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.K_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    # V TMA: TF32 needs SWIZZLE_128B_ATOM_32B (transposed BMM2 operand) — same
+    # 128-B swizzle line / box geometry as standard Swz128B, just the atom mode.
+    # Standard Swz128B with kind::tf32 + b_trans silently returns all-zero O.
+    _v_tma_swz = tmap.TensorMapSwizzle.s128b_atom_32b if IS_TF32 else _tma_swz(CFG.V_SWZ_BYTES)
+    tma_v_desc = tmap.create_tensor_map_tiled_from_view(
+        v_tensor,
+        box_dims=vo_box_v,
+        stride_order=stride_order,
+        swizzle=_v_tma_swz,
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_o_desc = tmap.create_tensor_map_tiled_from_view(
+        o_tensor,
+        box_dims=vo_box_o,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.O_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+
+    # Each cluster pair (CTA_MMA CTAs) collectively covers TILE_M*TILES_Q*CTA_MMA Q rows;
+    # without the cluster-wide divisor cga2 over-launches and OOB clusters collide in GMEM.
+    rows_per_cluster = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+    q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
+    grid_q_supers = q_clusters * CFG.CTA_MMA
+    q_supers = grid_q_supers
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD: build the per-batch O descriptor array (reuse tma_o_desc over the
+        # packed [1,T,QH,D_v] O as base), then launch the exact flat
+        # batch-outermost grid (n_thd_units = Σ_b ceil(S_q_b/CGA_TILE_M)*QH,
+        # host-computed); grid_x = n_thd_units * CGA_M.  Works at cga1 (CGA_M=1).
+        _build_o_descs_kernel(
+            o_tensor,
+            tma_o_desc,
+            o_desc_words,
+            seq_kv_lens_tensor,
+            cutlass.Int32(QH),
+            cutlass.Int32(B),
+            cutlass.Int32(CFG.TILE_O),
+        ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
+        grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
+    else:
+        # Grid Python-folds on Cfg constant (avoids CTM if staging).
+        grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
+    _kernel(
+        tma_q_desc,
+        tma_k_desc,
+        tma_v_desc,
+        tma_o_desc,
+        lse_tensor,
+        sinks_tensor,
+        seq_kv_lens_tensor,
+        o_desc_words,
+        cutlass.Int32(SQ),
+        cutlass.Int32(SKV),
+        cutlass.Int32(q_supers),
+        cutlass.Int32(QH),
+        cutlass.Int32(B),
+        cutlass.Int32(QH // KH),
+        scale_softmax_log2,
+    ).launch(
+        grid=grid_shape,
+        block=[CFG.THREADS_PER_CTA, 1, 1],
+        cluster=(CFG.CTA_MMA, 1, 1),
+        stream=stream,
+    )
+
+
+@lru_cache(maxsize=None)
+def compile(  # noqa: A001
+    b: int = 1,
+    qh: int = 1,
+    kh: int = 1,
+    sq: int = 256,
+    skv: int = 128,
+    d_qk: int = CFG.TILE_K,
+    d_v: int = CFG.TILE_O,
+    has_lse: bool = True,
+    lse_stride: Optional[tuple] = None,
+) -> Callable:
+    """Compile a kernel with ALL dims concrete to pin TMA descriptor strides at compile time.
+
+    THD/varlen: q/k/v/o/lse are PACKED with batch dim 1 ([1,T,H,D]); ``b`` is the
+    LOGICAL batch (sequence count) driving n_batch / metadata + O-desc sizes."""
+    # THD/varlen is NOT ported for this kernel yet.  The setup-kernel call site
+    # below still speaks the pre-upstream 7-arg contract, while FROST's
+    # thd_helpers.build_thd_meta_o_descs_kernel takes 14 args and a different
+    # metadata layout (4B+4 with batch_remap + a claim counter, vs the 3B+2
+    # here), and the scheduler decode differs to match.  Raise here rather than
+    # let it fail as an arity error deep in the trace -- and so no engine row
+    # can advertise thd=True for this kernel and appear to work.  The dense
+    # path is unaffected: CFG.THD_VARLEN is 0 and every THD branch folds out.
+    if CFG.THD_VARLEN:
+        raise NotImplementedError(f"{__name__}: THD/varlen not ported to the FROST setup-kernel contract")
+    # ---- FROST adapter ABI ------------------------------------------------
+    # lower_dsl_prefill calls EVERY kernel with the full forward signature.
+    # This body carries only what the port brought over, so anything
+    # it cannot honor RAISES rather than being silently ignored: a raise here
+    # means the engine's Capabilities row is lying, which is the failure we
+    # want loud.  (Capabilities: lse_optional=False, no strided Stats.)
+    if lse_stride is not None:
+        raise NotImplementedError(f"{__name__}: strided Stats not ported (contiguous [B, H, S] only)")
+    if d_qk > CFG.TILE_K or d_v > CFG.TILE_O or d_qk <= 0 or d_v <= 0:
+        raise ValueError(f"{__name__}: envelope is 0 < d_qk <= {CFG.TILE_K}, 0 < d_v <= {CFG.TILE_O}; " f"got ({d_qk}, {d_v})")
+    _fake_batch = 1 if CFG.THD_VARLEN else b
+    fake_q = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, sq, qh, d_qk),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_k = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, d_qk),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_v = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, d_v),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_o = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, sq, qh, d_v),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    # has_lse=False (no Stats output): the LSE argument is None-specialized and
+    # the store is compiled out entirely -- no dummy buffer exists at any level,
+    # which is what lets the dense graph report get_workspace_size() == 0.
+    # Mirrors the shipped prefill_d128_fp8_sm107.py.
+    fake_lse = (
+        cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (_fake_batch, qh, sq),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
+        if has_lse
+        else None
+    )
+    # Sinks tensor always part of the ABI; read only when CFG.HAS_SINK == 1 (compile-time fold).
+    fake_sinks = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (qh,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # seq_kv_lens always part of the ABI; read only when CFG.SEQ_KV_LENS_PRESENT == 1
+    # (compile-time fold).  THD overloads it as the [seq_kv_lens(B)|cu_q(B+1)|
+    # cu_k(B+1)] metadata buffer (length 3B+2).
+    _skv_len = (3 * b + 2) if CFG.THD_VARLEN else b
+    fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (_skv_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # Per-batch O TMA-descriptor array (16 int64 = 128 B each) + 1 pad slot;
+    # dummy 1-elem when THD off (kernel never reads it).
+    _odesc_len = (b * _TENSOR_MAP_QWORDS + _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
+    fake_o_desc = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int64,
+        (_odesc_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    return cute.compile(
+        _host,
+        fake_q,
+        fake_k,
+        fake_v,
+        fake_o,
+        fake_lse,
+        fake_sinks,
+        fake_seq_kv_lens,
+        fake_o_desc,
+        (b, qh, kh, sq, skv, 0),
+        cutlass.Float32(0.0),
+        cutlass.Int32(0),
+        stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
+        options="--enable-tvm-ffi",
+    )

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_f16_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_f16_sm107.py
@@ -31,12 +31,14 @@ Same kernel shape as the C++ source: pipeline, TMEM/SMEM layout,
 barrier inventory + init counts, scheduler, warp dispatch, register
 split match.  Canonical reference port; reaches ~0.99x C++ TFLOPS.
 
-THD / varlen (``CFG.THD_VARLEN=1``, the pre-upstream packed-varlen entry point)
-is supported (f16/bf16) for all three d=128 flavors (llama / dsv3 / gptoss) at
-cga1 and cga2: packed ``[1,T,H,D]`` + ``cu_seqlens`` coord offset (applied to
-both Q slabs under TILES_Q=2), per-batch O TMA-descriptor array (shared
-``kernels/ctm/common/sdpa/thd.py``), packed ``[1,QH,T]`` LSE.  The dense
-``[B,S,H,D]`` path is byte-identical.
+THD / varlen is **NOT** ported.  The pre-upstream body carried a packed-varlen
+entry point (``CFG.THD_VARLEN=1``: packed ``[1,T,H,D]`` + ``cu_seqlens`` coord
+offset, per-batch O TMA-descriptor array, packed ``[1,QH,T]`` LSE), but its
+setup-kernel call site still speaks the pre-upstream 7-arg contract against a
+14-arg helper and the metadata layout differs (3B+2 vs 4B+4).  ``compile()``
+raises on ``CFG.THD_VARLEN`` rather than half-serving it, ``config_sm107``
+rejects THD for f16/bf16, and no engine row advertises it.  Only the dense
+``[B,S,H,D]`` path is served.
 """
 
 import os
@@ -77,6 +79,20 @@ from cudnn.sdpa.fwd.config_sm107 import TemplateParams, make_cfg_d128
 
 PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
 CFG, _TMA = make_cfg_d128(PARAMS)
+
+# tcgen05 SMEM-descriptor version for EVERY SmemTile in this module -- ONE
+# decision point, wired into every construction below rather than repeated as a
+# per-tile literal.  A version-0 descriptor's ``start_address`` is 14 bits = a
+# 256 KiB window; Rubin raises the per-CTA SMEM cap to 327 KiB, so an operand
+# buffer at or above 256 KiB wraps to offset 0 and the MMA multiplies whatever
+# sits at the bottom of SMEM.  This flavor's buffers all stay below the line.
+#
+# Do NOT re-literal this at a call site: the d512 MXFP8 sibling shipped NaN on
+# 100% of cells because its scale-factor tiles were declared UNDER a comment
+# claiming "every operand tile here carries desc_version=1" -- without the
+# kwarg.  A single constant makes that class of drift impossible, and
+# test_sm107_descriptor_version_matches_the_smem_budget asserts it.
+DESC_VERSION: int = 0
 Cfg = type(CFG)
 TMA_QK_ITERS = _TMA.QK_ITERS
 TMA_VO_ITERS = _TMA.VO_ITERS
@@ -308,6 +324,7 @@ def _kernel(
         tma_loads_per_tile=TMA_QK_ITERS,
         tma_granu_elems=TMA_QK_GRANU_ELEMS,
         tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+        desc_version=DESC_VERSION,
     )
     sK = SmemTile(
         base=sK_raw,
@@ -319,6 +336,7 @@ def _kernel(
         tma_loads_per_tile=TMA_QK_ITERS,
         tma_granu_elems=TMA_QK_GRANU_ELEMS,
         tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+        desc_version=DESC_VERSION,
     )
     sV = SmemTile(
         base=sV_raw,
@@ -331,6 +349,7 @@ def _kernel(
         tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
         tma_granu_elems=TMA_VO_GRANU_ELEMS,
         tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+        desc_version=DESC_VERSION,
     )
     sO = SmemTile(
         base=sO_raw,
@@ -342,6 +361,7 @@ def _kernel(
         tma_loads_per_tile=TMA_O_ITERS_HOST,
         tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
         tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+        desc_version=DESC_VERSION,
     )
 
     bars = make_classic_bars(CFG)
@@ -1726,6 +1746,24 @@ def _correction_warp_group(
                 lse_val = total_max_nat + cute.math.log(total_sum, fastmath=True)
                 # Safe inverse: avoid div by 0 on fully-masked rows.
                 inv_sum = cutlass.Float32(1.0) / cute.math.max(total_sum, cutlass.Float32(1e-30))
+            # --- empty KV range (fully-masked / zero-length KV for this tile) ---
+            # Same guard as prefill_d256_{f16,fp8,mxfp8}_sm107.py.  With
+            # bounds.right <= bounds.left the kv loop ran ZERO iterations, so
+            # BMM2 never overwrote the O accumulator (mma_ss overwrites only on
+            # its first k-step) and TMEM still holds the PREVIOUS persistent
+            # tile's O -- residue, possibly a NaN bit pattern.
+            #
+            # The softmax warp still publishes (total_max = -inf, total_sum = 0)
+            # for an empty range, so LSE is already right on both arms: no-sink
+            # gives -inf + log(0) = -inf (this kernel puts NO 1e-30 floor on the
+            # log -- if one is ever added, the select below must cover lse_val
+            # too, or it leaks log(1e-30) = -69.08), and the sink arm folds to
+            # exactly sink_logit.  inv_sum, however, is 1/max(0, 1e-30) = 1e30
+            # (no sink) or 0 (sink), so O = residue * 1e30 -> +-inf/NaN, or
+            # residue * 0 -> NaN.  Zero O with a SELECT, never a multiply.
+            _kv_empty = bounds.right <= bounds.left
+            if cutlass.const_expr(not CFG.HAS_SINK):
+                lse_val = cutlass.Float32(arith.select(_kv_empty.ir_value(), cutlass.Float32(float("-inf")).ir_value(), lse_val.ir_value()))
 
             # OOB-row guard: under cga2 the cluster's Q rows can exceed seqlen_q;
             # without the guard the write aliases the next head's LSE slot.
@@ -1759,6 +1797,14 @@ def _correction_warp_group(
                 )
                 nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                 o_scaled = o_chunk * inv_sum
+                # SELECT the zero for an empty KV range -- see _kv_empty above.
+                # NB: a plain `for` statement, not a comprehension -- the DSL
+                # preprocessor only rewrites statement-level range_constexpr
+                # loops ("range_constexpr should be preprocessed by preprocessor").
+                _o_elems = []
+                for _i in cutlass.range_constexpr(O_CHUNK):
+                    _o_elems.append(cutlass.Float32(arith.select(_kv_empty.ir_value(), cutlass.Float32(0.0).ir_value(), o_scaled[_i].ir_value())))
+                o_scaled = cutlass.Vector.from_elements(tuple(_o_elems), cutlass.Float32)
                 o_fp16 = o_scaled.to(STORAGE_DTYPE)
 
                 col_offset_const = (chunk_idx * O_CHUNK) % D_BLOCK_SIZE

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_f16_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_f16_sm107.py
@@ -4,10 +4,10 @@
 """
 DSL prefill SDPA kernel — classic pipeline, f16/bf16, d=128, SM107 (Rubin).
 
-Ported from the pre-upstream CTM kernel ``prefill_sdpa_f16.py``
-(CTM DSL) by frost_dev/port_ctm_kernel.py. The kernel BODY is the pre-upstream one,
-unchanged — only the DSL surface moved (ctm.* -> public cutlass/nvvm/cute, and
-tile_ctm -> cudnn.frost.tile_dsl). Two things are NOT mechanical and were done
+Ported from the pre-upstream kernel ``prefill_sdpa_f16.py``
+by the port script. The kernel BODY is the pre-upstream one,
+unchanged — only the DSL surface moved (the pre-upstream ops -> public cutlass/nvvm/cute, and
+the pre-upstream tile library -> cudnn.frost.tile_dsl). Two things are NOT mechanical and were done
 by hand:
 
   1. **Config.** The pre-upstream kernels picked a flavor with an env var;
@@ -23,7 +23,7 @@ not taken here.
 
 Original pre-upstream header follows.
 
-CTM-DSL port of the pre-upstream prefill SDPA kernel
+Port (from the pre-upstream DSL) of the pre-upstream prefill SDPA kernel
 (llama flavor: FP16, d_qk = d_v = 128, TILES_Q = 2, two softmax
 warpgroups, four correction warps, persistent try_cancel scheduler).
 
@@ -214,7 +214,7 @@ _resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
 
 # THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
 # factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
-# kernels/ctm/common/sdpa/thd.py.  Gated by CFG.THD_VARLEN (folds out otherwise).
+# the shared pre-upstream THD helper.  Gated by CFG.THD_VARLEN (folds out otherwise).
 # Supported at cga1 and cga2 (TILES_Q=2 → two Q slabs / O stores per tile).
 # seq_kv_lens overloaded as the THD metadata buffer (int32 len 3B+2):
 #   [0..B-1]=seq_kv_lens  [B..2B]=cu_q(B+1)  [2B+1..3B+1]=cu_k(B+1)
@@ -298,7 +298,7 @@ def _kernel(
     bidy = cute.arch.block_idx()[1]
     bidz = cute.arch.block_idx()[2]
 
-    # SMEM allocations in natural Q/K/V/O order — CTM Tcgen05SmemDesc.build truncates
+    # SMEM allocations in natural Q/K/V/O order — Tcgen05SmemDesc.build truncates
     # start_address past ~256 KiB so this order keeps the data buffers in low SMEM.
     # QO_ALIAS: one Q∪O slab (TILES_Q × max(Q,O) elems); sO points into it and
     # strides by QO_SLAB_ELEMS so sO[qs] coincides with sQ[qs].  Else: separate
@@ -421,7 +421,7 @@ def _kernel(
         cga_arrive()
         cga_wait()
 
-    # CTM @cute.kernel stages if/else — use Python ternaries so the chosen
+    # @cute.kernel stages if/else — use Python ternaries so the chosen
     # expression flows into the trace (variables in branches aren't visible outside).
     cta_id_x = cute.arch.block_idx_in_cluster() if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
     cta_in_pair = (cta_id_x & cutlass.Int32(1)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
@@ -652,7 +652,7 @@ def _tmaldg_warp_group(
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
 
-    # CTM TMA descriptor is element-typed; contiguous coord is in ELEMENTS not bytes.
+    # the DSL's TMA descriptors is element-typed; contiguous coord is in ELEMENTS not bytes.
     K_ROW_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_N // CFG.CTA_MMA)
     V_COL_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_O // CFG.CTA_MMA)
 
@@ -1255,7 +1255,7 @@ def _softmax_kv_body(
     p_addr_base = tmem_base + cutlass.Int32(tmem_P_off)
     stats_addr = tmem_base + cutlass.Int32(stats_off)
 
-    # apply_mask is a Python bool — wrap in cutlass.const_expr so CTM folds
+    # apply_mask is a Python bool — wrap in cutlass.const_expr so the DSL folds
     # at trace time instead of staging cf.if (the two arms produce Vectors
     # built via different MLIR op sequences and the tracer would error).
     if cutlass.const_expr(apply_mask):
@@ -1338,7 +1338,7 @@ def _softmax_kv_body(
     # Rescale full reg_S in one vector op — emits same FFMA2 sequence as explicit half-tile rescales.
     reg_S = reg_S * scale_log2 - new_total_max
 
-    # Chunk 0 manual unroll — CTM's @cute.jit tracer makes the loop iter an
+    # Chunk 0 manual unroll — the DSL's @cute.jit tracer makes the loop iter an
     # MLIR value, breaking Python slice.indices() math inside RegTile[].
     chunk_S_0 = reg_S[0:CHUNK].vec
     chunk_P_0 = cute.math.exp2(chunk_S_0, fastmath=True)
@@ -1612,7 +1612,7 @@ def _correction_warp_group(
     tid_in_wg = tid_raw - cutlass.Int32(CFG.CORR_WARP_BASE * 32)
 
     # O_CHUNK=16 (halved from 32) shortens the alpha-rescale live range —
-    # at 32, CTM regalloc spilled correction-warp regs to the stack.
+    # at 32, the DSL's register allocator spilled correction-warp regs to the stack.
     O_CHUNK = 16
     N_CHUNKS_O = CFG.TILE_O // O_CHUNK
     # Use O_SWZ_B (NOT V_SWZ_B): under cga2 V is split along d_v and may drop
@@ -1729,7 +1729,7 @@ def _correction_warp_group(
             # Fire stat_empty so softmax's NEXT-tile iter 0 wait can pass.
             bars.mb_stat_empty[qs].arrive()
 
-            inv_sum = cutlass.Float32(0.0)  # pre-declare for CTM if-staging
+            inv_sum = cutlass.Float32(0.0)  # pre-declare for DSL if-staging
             lse_val = cutlass.Float32(0.0)
             # With sinks: fold the lift-the-max rescale into threshold_beta so O is scaled by scale/new_sum in one FMUL.
             LN2 = cutlass.Float32(0.6931471805599453)
@@ -1956,7 +1956,7 @@ def _host(
         ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
         grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
     else:
-        # Grid Python-folds on Cfg constant (avoids CTM if staging).
+        # Grid Python-folds on Cfg constant (avoids DSL if-staging).
         grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
     _kernel(
         tma_q_desc,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
@@ -67,22 +67,23 @@ import cuda.bindings.driver as _cuda_driver  # noqa: F401  (cute.compile pulls c
 
 from dataclasses import dataclass
 
-from cudnn.sdpa.fwd.config_sm100 import TemplateParams, make_cfg_d128
+from cudnn.sdpa.fwd.config_sm107 import TemplateParams, make_cfg_d128
 
 # The template loader (api_dsl._load_kernel_module) injects FROST_TEMPLATE_PARAMS
 # as a module global before this body runs; the default keeps direct import usable.
 PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
 CFG, _TMA = make_cfg_d128(PARAMS)
-# Rubin geometry, baked post-validation (this module is only ever loaded for
-# cc10.7 by the adapter): dense-FP8 K=64 steps and the 9-stage KV ring. The
-# TMA iteration constants depend only on TILE_K/TILE_O/BPE/swizzle, so _TMA
-# is unaffected.
-import dataclasses as _dc
-
-CFG = _dc.replace(CFG, TILE_K_HW_BMM1=64, TILE_K_HW_BMM2=64, STAGES_KV=9)
+# Rubin's dense-FP8 MMA runs K=64 per instruction, and every
+# ``Tcgen05InstrDesc.build`` site in this body hardcodes the matching idesc
+# ``k_dim=1``.  ``config_sm107.tile_k_hw()`` derives the 64; this guard is the
+# tripwire for the pairing, which is arch-OPPOSITE (Blackwell wants k_dim=0 with
+# TILE_K_HW=32) and fails SILENTLY -- a mismatch scrambles rows of the
+# accumulator rather than raising (rules/mma-tma-matrix.md S1).
+if CFG.TILE_K_HW_BMM1 != 64 or CFG.TILE_K_HW_BMM2 != 64:
+    raise ValueError(f"{__name__}: this body's idesc k_dim=1 requires TILE_K_HW=64 on Rubin; " f"got BMM1={CFG.TILE_K_HW_BMM1} BMM2={CFG.TILE_K_HW_BMM2}")
 Cfg = type(CFG)
 
-# Static SMEM accounting for the post-override geometry.  The 9-stage ring
+# Static SMEM accounting for the Rubin geometry.  The 9-stage ring
 # with BF16/FP16 O (~241 KiB) exceeds the STANDARD sm_10x 227 KiB per-CTA
 # opt-in, and is legal on GR100 only through the sm107 oversized-SMEM
 # launch mode (function attribute 16), which the required internal
@@ -172,7 +173,7 @@ else:
 # P -> fp8 cast bias (BAKED constant — NOT cuDNN's Scale_S; that pair is
 # accepted and ignored). P is quantized as P * 2**P_CAST_LOG2_SCALE: the
 # lazy-rescale skip bounds P by 2**RESCALE_THRESHOLD (4.0 for fp8, see
-# config_sm100.rescale_threshold), so the cast peaks at 2^(4+4) = 256 < 448
+# config_sm107.rescale_threshold), so the cast peaks at 2^(4+4) = 256 < 448
 # (e4m3 max) — no saturation — while flat-row entries (P ~ 1/S) sit four
 # binades above e4m3's subnormal cliff (quantization stays normal out to
 # S ~ 2^13). The bias rides the exp2 argument, so total_sum accumulates in

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
@@ -73,6 +73,20 @@ from cudnn.sdpa.fwd.config_sm107 import TemplateParams, make_cfg_d128
 # as a module global before this body runs; the default keeps direct import usable.
 PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
 CFG, _TMA = make_cfg_d128(PARAMS)
+
+# tcgen05 SMEM-descriptor version for EVERY SmemTile in this module -- ONE
+# decision point, wired into every construction below rather than repeated as a
+# per-tile literal.  A version-0 descriptor's ``start_address`` is 14 bits = a
+# 256 KiB window; Rubin raises the per-CTA SMEM cap to 327 KiB, so an operand
+# buffer at or above 256 KiB wraps to offset 0 and the MMA multiplies whatever
+# sits at the bottom of SMEM.  This flavor's buffers all stay below the line.
+#
+# Do NOT re-literal this at a call site: the d512 MXFP8 sibling shipped NaN on
+# 100% of cells because its scale-factor tiles were declared UNDER a comment
+# claiming "every operand tile here carries desc_version=1" -- without the
+# kwarg.  A single constant makes that class of drift impossible, and
+# test_sm107_descriptor_version_matches_the_smem_budget asserts it.
+DESC_VERSION: int = 0
 # Rubin's dense-FP8 MMA runs K=64 per instruction, and every
 # ``Tcgen05InstrDesc.build`` site in this body hardcodes the matching idesc
 # ``k_dim=1``.  ``config_sm107.tile_k_hw()`` derives the 64; this guard is the
@@ -419,6 +433,7 @@ def _kernel(
         tma_loads_per_tile=TMA_QK_ITERS,
         tma_granu_elems=TMA_QK_GRANU_ELEMS,
         tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+        desc_version=DESC_VERSION,
     )
     sK = SmemTile(
         base=sK_raw,
@@ -430,6 +445,7 @@ def _kernel(
         tma_loads_per_tile=TMA_QK_ITERS,
         tma_granu_elems=TMA_QK_GRANU_ELEMS,
         tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+        desc_version=DESC_VERSION,
     )
     sV = SmemTile(
         base=sV_raw,
@@ -442,6 +458,7 @@ def _kernel(
         tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
         tma_granu_elems=TMA_VO_GRANU_ELEMS,
         tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+        desc_version=DESC_VERSION,
     )
     sO = SmemTile(
         base=sO_raw,
@@ -453,6 +470,7 @@ def _kernel(
         tma_loads_per_tile=TMA_O_ITERS_HOST,
         tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
         tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+        desc_version=DESC_VERSION,
     )
 
     bars = make_classic_bars(CFG)
@@ -1226,6 +1244,7 @@ def _mma_warp_group(
         leading_byte_offset=LEADING_BYTE_OFFSET_QK,
         stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
         layout=SMEM_LAYOUT_QKO,
+        desc_version=DESC_VERSION,
     )
     desc_ones = sOnes[0].desc()
     idesc_sum = prims.Tcgen05InstrDesc.build(

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm107.py
@@ -1,0 +1,2402 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""CTM-DSL port of the pre-upstream prefill SDPA MXFP8 kernel
+(dsv3 / llama / gptoss: block-scale MXFP8 inputs, TILES_Q = 2,
+2 softmax warpgroups, 4 correction warps, persistent try_cancel
+scheduler).  Same pipeline structure as the FP8 CTM twin.
+"""
+
+import os
+import sys
+from functools import lru_cache
+from typing import Callable, Optional, Tuple
+
+
+from cutlass.experimental import primitives as nvvm
+from cutlass.experimental.primitives import vote_sync, VoteSync
+from cutlass._mlir.dialects import arith
+
+import cutlass
+from cutlass.experimental import primitives as prims
+import cutlass.cute as cute
+from cutlass.base_dsl.typing import Pointer
+from cutlass.experimental.cuda import tensor_map as tmap
+import cuda.bindings.driver as _cuda_driver  # noqa: F401
+
+from dataclasses import dataclass, replace
+from typing import NamedTuple
+
+# Config comes from the FROST template loader, NOT an env var: the pre-upstream
+# kernels picked a flavor with an env var + a sdpa_config_<flavor> module, which the
+# FROST engine contract forbids ("no environment variables for configuration" --
+# parameters travel as typed dataclasses). The loader injects
+# FROST_TEMPLATE_PARAMS before this body runs; the default keeps a plain
+# `import` usable as a standalone driver.
+from cudnn.sdpa.fwd.config_sm107 import TemplateParams, make_cfg_d128_mxfp8
+
+PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
+CFG, _TMA = make_cfg_d128_mxfp8(PARAMS)
+Cfg = type(CFG)
+TMA_QK_ITERS = _TMA.QK_ITERS
+TMA_VO_ITERS = _TMA.VO_ITERS
+TMA_QK_GRANU_ELEMS = _TMA.QK_GRANU_ELEMS
+TMA_VO_GRANU_ELEMS = _TMA.VO_GRANU_ELEMS
+
+# MXFP8 K-step pin -- k_dim=1 selects 64-element K chunks, halving the
+# tcgen05.mma.block_scale issue count versus k_dim=0.  ``config_sm107`` derives
+# TILE_K_HW from the dtype; this guard pins the two together, because the
+# pairing is arch-OPPOSITE (Blackwell wants k_dim=0 with 32) and a mismatch
+# scrambles accumulator rows SILENTLY (rules/mma-tma-matrix.md S1).
+_MXFP8_K_DIM = 1
+_MXFP8_TILE_K_HW = 32 if _MXFP8_K_DIM == 0 else 64
+if CFG.TILE_K_HW_BMM1 != _MXFP8_TILE_K_HW or CFG.TILE_K_HW_BMM2 != _MXFP8_TILE_K_HW:
+    raise ValueError(
+        f"{__name__}: idesc k_dim={_MXFP8_K_DIM} requires TILE_K_HW={_MXFP8_TILE_K_HW}; " f"got BMM1={CFG.TILE_K_HW_BMM1} BMM2={CFG.TILE_K_HW_BMM2}"
+    )
+
+# O TMA box params follow O's swizzle, not V's — required when V_SWZ_B != O_SWZ_B (gptoss cga2).
+# Sized in BPE_O — O may be written at BF16/FP16 when DTYPE_O != DTYPE_QKV.
+TMA_O_GRANU_ELEMS_HOST = CFG.O_SWZ_BYTES // CFG.BPE_O
+TMA_O_ITERS_HOST = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
+
+from cudnn.frost.tile_dsl.barrier import (
+    PipelineState,
+    advance,
+    cga_arrive,
+    cga_wait,
+    # `wait` (free fn) — still used for sched.mb_* (Sched not in Bars).
+    wait,
+)
+from cudnn.frost.tile_dsl.scheduler import (
+    Sched,
+    scheduler_warp_loop,
+    read_tile_id_arrive,
+    SCHED_NATURAL,
+    SCHED_LPT,
+    SCHED_LPT_L2,
+)
+from cudnn.frost.tile_dsl.pointwise import (
+    tmem_load_max_reduction_x64,
+    row_reduction_pair_64,
+    row_max_reduction_64,
+    vec_scale_pair,
+)
+from cudnn.frost.tile_dsl.mma import mma_ss, mma_ts_step
+from cudnn.frost.tile_dsl.tma import (
+    tma_load_tile,
+    tma_store_tile,
+    tma_store_commit,
+    tma_store_wait,
+    bulk_copy,
+    bulk_copy_multicast,
+)
+from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, GmemTileLinear, tma_slice_runtime_desc
+from cudnn.frost.tile_dsl.tmem import tmem_alloc, tmem_dealloc
+from cudnn.frost.tile_dsl.mask import (
+    apply_mask_chunk,
+    MASK_NONE,
+    MASK_PADDED,
+    MASK_CAUSAL,
+    MASK_SWA,
+)
+
+# MXFP8 storage dtype dispatch — keyed off CFG.DTYPE_QKV (0=E4M3, 1=E5M2).
+if CFG.DTYPE_QKV == 0:
+    STORAGE_DTYPE = cutlass.Float8E4M3FN
+    P_STORAGE_DTYPE = cutlass.Float8E4M3FN
+elif CFG.DTYPE_QKV == 1:
+    STORAGE_DTYPE = cutlass.Float8E5M2
+    P_STORAGE_DTYPE = cutlass.Float8E5M2
+else:
+    raise ValueError(f"prefill_sdpa_mxfp8: DTYPE_QKV={CFG.DTYPE_QKV} not supported " f"(expected 0=E4M3 or 1=E5M2)")
+
+MMA_KIND = nvvm.MMABlockScaleKind.MXF8F6F4
+SCALE_VEC_SIZE = nvvm.Tcgen05MMAScaleVecSize.BLOCK32
+
+
+# DTYPE_O is independent of DTYPE_QKV — MXFP8 input may write BF16/FP16 O so a
+# downstream consumer skips a dequant.  BPE_O ∈ {1, 2}; the epilogue already
+# casts via .to(OUT_STORAGE_DTYPE) + store_swizzled (dtype-generic), so only the
+# O-buffer / TMA-box sizing needs to follow BPE_O.
+if CFG.DTYPE_O == 0:
+    OUT_STORAGE_DTYPE = cutlass.Float8E4M3FN
+elif CFG.DTYPE_O == 1:
+    OUT_STORAGE_DTYPE = cutlass.Float8E5M2
+elif CFG.DTYPE_O == 2:
+    OUT_STORAGE_DTYPE = cutlass.BFloat16
+elif CFG.DTYPE_O == 3:
+    OUT_STORAGE_DTYPE = cutlass.Float16
+else:
+    raise ValueError(f"prefill_sdpa_mxfp8 CTM: DTYPE_O={CFG.DTYPE_O} not supported " f"(expected 0=E4M3 / 1=E5M2 / 2=BF16 / 3=FP16)")
+
+
+# MXFP8 SF constants — E8M0 scale factor, 32 elems share one SF.
+BITS_PER_SF_ELEMENT = 8
+BLOCK_SCALE_BLOCK_SIZE = 32
+SF_BLOCK_DIM_NON_K = 128
+SF_BLOCK_DIM_K = 4
+SF_SWIZZLED_BLOCK_DIM_K = 16
+SF_BYTES_PER_BLOCK = SF_BLOCK_DIM_NON_K * SF_BLOCK_DIM_K * BITS_PER_SF_ELEMENT // 8
+
+
+def _round_up(a: int, b: int) -> int:
+    return (a + b - 1) // b * b
+
+
+# SF_NUM_BLOCKS_K: 1 (llama TILE_K=128), 2 (dsv3 TILE_K=192 → round_up 256).
+SF_NUM_BLOCKS_M = CFG.TILE_M // SF_BLOCK_DIM_NON_K
+SF_NUM_BLOCKS_N = CFG.TILE_N // SF_BLOCK_DIM_NON_K
+SF_NUM_BLOCKS_K = _round_up(CFG.TILE_K, 128) // BLOCK_SCALE_BLOCK_SIZE // SF_BLOCK_DIM_K
+
+SF_REGISTERS_PER_BLOCK = SF_SWIZZLED_BLOCK_DIM_K * BITS_PER_SF_ELEMENT // 32
+
+SF_TMEM_COLS_Q = SF_NUM_BLOCKS_M * SF_NUM_BLOCKS_K * SF_REGISTERS_PER_BLOCK
+SF_TMEM_COLS_K = SF_NUM_BLOCKS_N * SF_NUM_BLOCKS_K * SF_REGISTERS_PER_BLOCK
+
+SF_SMEM_SIZE_Q = CFG.TILE_M * _round_up(CFG.TILE_K, 128) // BLOCK_SCALE_BLOCK_SIZE
+SF_SMEM_SIZE_K = CFG.TILE_N * _round_up(CFG.TILE_K, 128) // BLOCK_SCALE_BLOCK_SIZE
+
+# BMM2 SF: P is constant 1.0 (softmax doesn't scale P); V comes from GMEM.
+SF_NUM_BLOCKS_P = CFG.TILE_M // SF_BLOCK_DIM_NON_K
+SF_NUM_BLOCKS_V = _round_up(CFG.TILE_O, 128) // SF_BLOCK_DIM_NON_K
+SF_NUM_BLOCKS_K_BMM2 = CFG.TILE_N // BLOCK_SCALE_BLOCK_SIZE // SF_BLOCK_DIM_K
+SF_TMEM_COLS_P = SF_NUM_BLOCKS_P * SF_NUM_BLOCKS_K_BMM2 * SF_REGISTERS_PER_BLOCK
+SF_SMEM_SIZE_P = _round_up(CFG.TILE_M, 128) * CFG.TILE_N // BLOCK_SCALE_BLOCK_SIZE
+SF_SMEM_SIZE_V = _round_up(CFG.TILE_O, 128) * CFG.TILE_N // BLOCK_SCALE_BLOCK_SIZE
+
+# 0x7F = E8M0 representation of 2^0 = 1.0.
+SF_CONST_VALUE = 0x7F
+
+
+from cudnn.sdpa.fwd.kernels._common_sm100 import (
+    Bars,
+    KvLoopBounds,
+    make_classic_bars,
+    compute_kv_loop_bounds,
+    lpt_tile_coords,
+    make_sdpa_helpers,
+    assert_tile_n_supported,
+)
+
+assert_tile_n_supported(CFG)
+
+
+CGA_SIZE = CFG.CGA_M * CFG.CGA_N
+CTA_GROUP_KIND = nvvm.CTAGroup.CTA_2 if CFG.CTA_MMA == 2 else nvvm.CTAGroup.CTA_1
+
+qBufferElems = CFG.TILE_M * CFG.TILE_K
+kBufferElems = CFG.TILE_N * CFG.TILE_K // CFG.CTA_MMA
+vBufferElems = CFG.TILE_O * CFG.TILE_N // CFG.CTA_MMA
+oBufferElems = CFG.TILE_M * CFG.TILE_O
+
+qTmaTransactionBytes = qBufferElems * CFG.BPE * CFG.CTA_MMA
+kTmaTransactionBytes = kBufferElems * CFG.BPE * CFG.CTA_MMA
+vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
+
+CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+
+
+_sdpa_h = make_sdpa_helpers(CFG)
+_decode_initial = _sdpa_h.decode_initial
+_decode_payload = _sdpa_h.decode_payload
+_bounds_for_tile = _sdpa_h.bounds_for_tile
+_resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+
+# THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
+# factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
+# kernels/ctm/common/sdpa/thd.py.  Gated by CFG.THD_VARLEN (folds out otherwise).
+# Supported at cga1 and cga2 (TILES_Q=2 → two Q slabs / O stores per tile).
+# seq_kv_lens overloaded as the THD metadata buffer (int32 len 3B+2):
+#   [0..B-1]=seq_kv_lens  [B..2B]=cu_q(B+1)  [2B+1..3B+1]=cu_k(B+1)
+# MXFP8-only: _thd_sf_tile_bases returns the per-sequence SF-tile prefix bases
+# (cu_sf_q_base / cu_sf_k_base) for the packed scale-factor layout.
+from cudnn.sdpa.fwd.kernels.thd_helpers import build_thd_meta_o_descs_kernel as _build_thd_meta_o_descs_kernel, TENSOR_MAP_QWORDS
+
+_TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
+_dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
+_dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
+_thd_tma_offsets = _sdpa_h.thd_tma_offsets
+_thd_sf_tile_bases = _sdpa_h.thd_sf_tile_bases
+
+
+# Kernel TMEM layout — P aliases S_acc tail (4:1 fp8 pack); SF tiles cols 512..543; Stats outside S/O range.
+@dataclass(frozen=True)
+class KernelTmemLayout:
+    TOTAL_COLS: int = 576  # Rubin SM10.7 cap, is_exclusive=True
+
+    S0_OFF: int = 0
+    S1_OFF: int = 128
+
+    O0_OFF: int = 256
+    O1_OFF: int = 384
+
+    P0_OFF: int = 96
+    P1_OFF: int = 224
+
+    SF_Q0_OFF: int = 512
+    SF_K_OFF: int = 512 + SF_TMEM_COLS_Q
+    SF_Q1_OFF: int = 512 + SF_TMEM_COLS_Q + SF_TMEM_COLS_K
+    SF_P_OFF: int = 536
+    SF_V_OFF: int = 536 + SF_TMEM_COLS_P
+
+    STATS_OFF: int = 544
+
+
+LAYOUT = KernelTmemLayout()
+
+
+_SWZ_ENUM = {128: 2, 64: 4, 32: 6}
+SMEM_LAYOUT_Q = _SWZ_ENUM[CFG.Q_SWZ_BYTES]
+SMEM_LAYOUT_K = _SWZ_ENUM[CFG.K_SWZ_BYTES]
+SMEM_LAYOUT_V = _SWZ_ENUM[CFG.V_SWZ_BYTES]
+SMEM_LAYOUT_O = _SWZ_ENUM[CFG.O_SWZ_BYTES]
+SMEM_LAYOUT_QKO = SMEM_LAYOUT_Q
+
+# SF SmemDesc layout: NONE=0 is real no-swizzle (NOT value 1 which is SWIZZLE_128B_ATOM_32B).
+SMEM_LAYOUT_SF = 0
+SF_LEADING_BYTE_OFFSET = 16
+SF_STRIDE_BYTE_OFFSET = 128
+
+_O_SWZ_B = {128: 3, 64: 2, 32: 1}[CFG.O_SWZ_BYTES]
+_O_SMEM_SWIZZLE = cutlass.Swizzle(_O_SWZ_B, 4, 3)
+LEADING_BYTE_OFFSET_QK = 0
+
+_CTM_MMA_K_FP8 = _MXFP8_TILE_K_HW
+STRIDE_BYTE_OFFSET_QK = 8 * CFG.Q_SWZ_BYTES
+
+# leading_byte_offset = 0 when (TILE_O/CTA_MMA)/8 <= 8 else TILE_N*V_SWZ_BYTES
+_CORE_MATRIX_ROWS = 8
+_V_PC_COLS = CFG.TILE_O // CFG.CTA_MMA
+LEADING_BYTE_OFFSET_PV = 0 if (_V_PC_COLS // _CORE_MATRIX_ROWS) <= 8 else CFG.TILE_N * CFG.V_SWZ_BYTES
+STRIDE_BYTE_OFFSET_PV = 8 * CFG.V_SWZ_BYTES
+
+NUM_KPHASES_PV = CFG.TILE_N // _CTM_MMA_K_FP8
+NUM_KPHASES_PV_PER_CHUNK = NUM_KPHASES_PV // CFG.N_BMM2_CHUNKS
+
+
+# === Kernel ===
+
+
+@cute.kernel
+def _kernel(
+    tma_q_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_k_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_v_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_o_desc: cutlass.GridConstant[tmap.TensorMap],
+    # SF rides cta_group=CFG.CTA_MMA TMA → bytes route through mb_q/k/v_full like Q/K/V; no peer Q_SF DSMEM forward.
+    tma_q_sf_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_k_sf_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_v_sf_desc: cutlass.GridConstant[tmap.TensorMap],
+    lse_tensor: Optional[cute.Tensor],
+    amax_o_tensor: cute.Tensor,
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    seqlen_q: cutlass.Int32,
+    seqlen_kv: cutlass.Int32,
+    n_q_supers: cutlass.Int32,
+    n_qh: cutlass.Int32,
+    n_batch: cutlass.Int32,
+    qh_per_kh: cutlass.Int32,  # GQA group size = n_qh / n_kh.
+    scale_softmax_log2: cutlass.Float32,
+) -> None:
+
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    tidx, _, _ = cute.arch.thread_idx()
+
+    bidx = cute.arch.block_idx()[0]
+    bidy = cute.arch.block_idx()[1]
+    bidz = cute.arch.block_idx()[2]
+
+    sQ_raw = cutlass.Array(STORAGE_DTYPE, CFG.TILES_Q * qBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    sK_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * kBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    sV_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * vBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    sO_raw = cutlass.Array(OUT_STORAGE_DTYPE, CFG.TILES_Q * oBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+
+    # SF buffers sized in BYTES (uint8 storage).
+    sQ_SF_raw = cutlass.Array(cutlass.Int8, CFG.TILES_Q * SF_SMEM_SIZE_Q, alignment=1024, space=cutlass.AddressSpace.smem)
+    sK_SF_raw = cutlass.Array(cutlass.Int8, CFG.STAGES_KV * SF_SMEM_SIZE_K, alignment=1024, space=cutlass.AddressSpace.smem)
+    sP_SF_raw = cutlass.Array(cutlass.Int8, CFG.STAGES_KV * SF_SMEM_SIZE_P, alignment=1024, space=cutlass.AddressSpace.smem)
+    sV_SF_raw = cutlass.Array(cutlass.Int8, CFG.STAGES_KV * SF_SMEM_SIZE_V, alignment=1024, space=cutlass.AddressSpace.smem)
+
+    sQ = SmemTile(
+        base=sQ_raw,
+        elems_per_stage=qBufferElems,
+        stages=CFG.TILES_Q,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+    )
+    sK = SmemTile(
+        base=sK_raw,
+        elems_per_stage=kBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+    )
+    sV = SmemTile(
+        base=sV_raw,
+        elems_per_stage=vBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_PV,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_PV,
+        layout=SMEM_LAYOUT_V,
+        tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
+        tma_granu_elems=TMA_VO_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+    )
+    sO = SmemTile(
+        base=sO_raw,
+        elems_per_stage=oBufferElems,
+        stages=CFG.TILES_Q,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_O_ITERS_HOST,
+        tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+    )
+
+    # SF SmemTiles: no-swizzle, leading=16, stride=128. TMA-LDG warp issues one 5-D bulk.tensor per slab.
+    K_SF_BYTES_PER_PEER = SF_SMEM_SIZE_K // CFG.CTA_MMA
+    V_SF_BYTES_PER_PEER = SF_SMEM_SIZE_V // CFG.CTA_MMA
+    sQ_SF = SmemTile(
+        base=sQ_SF_raw,
+        elems_per_stage=SF_SMEM_SIZE_Q,
+        stages=CFG.TILES_Q,
+        leading_byte_offset=SF_LEADING_BYTE_OFFSET,
+        stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
+        layout=SMEM_LAYOUT_SF,
+    )
+    sK_SF = SmemTile(
+        base=sK_SF_raw,
+        elems_per_stage=SF_SMEM_SIZE_K,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=SF_LEADING_BYTE_OFFSET,
+        stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
+        layout=SMEM_LAYOUT_SF,
+    )
+    sP_SF = SmemTile(
+        base=sP_SF_raw,
+        elems_per_stage=SF_SMEM_SIZE_P,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=SF_LEADING_BYTE_OFFSET,
+        stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
+        layout=SMEM_LAYOUT_SF,
+    )
+    sV_SF = SmemTile(
+        base=sV_SF_raw,
+        elems_per_stage=SF_SMEM_SIZE_V,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=SF_LEADING_BYTE_OFFSET,
+        stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
+        layout=SMEM_LAYOUT_SF,
+    )
+
+    bars = make_classic_bars(CFG)
+
+    tmem_ptr_i32 = cutlass.Array(cutlass.Int32, 1, alignment=16, space=cutlass.AddressSpace.smem)
+
+    sched = Sched(
+        **{
+            "mb_scheduler": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "mb_read_tile_id": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "tile_id_smem": cutlass.Array(cutlass.Int32, CFG.SCHEDULER_STAGES * 8, alignment=16, space=cutlass.AddressSpace.smem),
+            "bidx_init": bidx,
+            "bidy_init": bidy,
+            "bidz_init": bidz,
+        }
+    )
+
+    # READ_TILE_ARRIVERS = 15 × CGA_M × CGA_N (softmax(8) + corr(4) + MMA + TMALDG + TMASTG).
+    READ_TILE_ARRIVERS_TOTAL = ((CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS) + CFG.CORRECTION_WARPS + 1 + 1 + 1) * CGA_SIZE
+
+    if warp_idx == 0:
+        if nvvm.elect_sync():
+            # mb_q_full init=1: leader's arrive_expect_tx covers Q TMA + both peers' Q_SF TMA via cta_group::2.
+            # range_constexpr → Python-int loop var (required for the
+            # mb_bmm2_ready tuple-init lookup).  Bounds are small —
+            # unroll is free.
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                bars.mb_q_full[qs].init()
+                bars.mb_q_empty[qs].init()
+                bars.mb_bmm1_done[qs].init()
+                bars.mb_bmm2_done[qs].init()
+                bars.mb_stat_full[qs].init()
+                bars.mb_stat_empty[qs].init()
+                bars.mb_o_full[qs].init()
+                bars.mb_o_empty[qs].init()
+                for c in cutlass.range_constexpr(CFG.N_BMM2_CHUNKS):
+                    bars.mb_bmm2_ready[qs * CFG.N_BMM2_CHUNKS + c].init()
+            for ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_k_full[ks].init()
+                bars.mb_k_empty[ks].init()
+                bars.mb_v_full[ks].init()
+                bars.mb_v_empty[ks].init()
+            for s in range(CFG.SCHEDULER_STAGES):
+                nvvm.mbarrier_init(sched.mb_scheduler.subview(s), CFG.ONE_LANE)
+                nvvm.mbarrier_init(sched.mb_read_tile_id.subview(s), READ_TILE_ARRIVERS_TOTAL)
+            bars.mb_tmem_dealloc.init()
+            bars.mb_empty_mainloop.init()
+
+    # P_SF SMEM fill 0x7F (constant 1.0); MUST happen BEFORE cga_arrive so both peers see filled SMEM.
+    SF_TOTAL_BYTES_P = SF_SMEM_SIZE_P * CFG.STAGES_KV
+    _SF_P_ITERS = (SF_TOTAL_BYTES_P + CFG.THREADS_PER_CTA - 1) // CFG.THREADS_PER_CTA
+    for _i in cutlass.range_constexpr(_SF_P_ITERS):
+        _off = tidx + cutlass.Int32(_i * CFG.THREADS_PER_CTA)
+        if _off < cutlass.Int32(SF_TOTAL_BYTES_P):
+            sP_SF_raw.subview(_off).store(cutlass.Int8(0x7F))
+
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync()
+
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        cga_arrive()
+        cga_wait()
+
+    cta_id_x = cute.arch.block_idx_in_cluster() if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    cta_in_pair = (cta_id_x & cutlass.Int32(1)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    leader_cta_id = (cta_id_x & cutlass.Int32(~1 & 0xFFFFFFFF)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    mcast_mask = (cutlass.Int32(3) << leader_cta_id) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    tma_mcast_mask = (cutlass.Int16(1) << cta_in_pair) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
+    # 0b11 delivers each peer's K_SF/V_SF half to BOTH peers' SMEM.
+    sf_mcast_mask = cutlass.Int16(3) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
+    is_leader = cta_in_pair == cutlass.Int32(0)
+
+    if warp_idx >= CFG.SOFTMAX_WG0_BASE and warp_idx < CFG.SOFTMAX_WG0_BASE + CFG.SOFTMAX_WG_WARPS:
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        _softmax_warp_group(
+            sub_tile_id=0,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_softmax_log2,
+            tmem_ptr_i32=tmem_ptr_i32,
+            sQ=sQ,
+            bars=bars,
+            sched=sched,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+        )
+
+    elif warp_idx >= CFG.SOFTMAX_WG1_BASE and warp_idx < CFG.SOFTMAX_WG1_BASE + CFG.SOFTMAX_WG_WARPS:
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        _softmax_warp_group(
+            sub_tile_id=1,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_softmax_log2,
+            tmem_ptr_i32=tmem_ptr_i32,
+            sQ=sQ,
+            bars=bars,
+            sched=sched,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+        )
+
+    elif warp_idx >= CFG.CORR_WARP_BASE and warp_idx < CFG.CORR_WARP_BASE + CFG.CORRECTION_WARPS:
+        nvvm.setmaxregister(CFG.CORRECTION_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _correction_warp_group(
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            sO=sO,
+            tmem_ptr_i32=tmem_ptr_i32,
+            tidx=tidx,
+            bars=bars,
+            sched=sched,
+            lse_tensor=lse_tensor,
+            amax_o_tensor=amax_o_tensor,
+            sinks_tensor=sinks_tensor,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+            cta_id_x=cta_id_x,
+        )
+
+    elif warp_idx == CFG.MMA_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        if cutlass.const_expr(CFG.CTA_MMA == 2):
+            if is_leader:
+                _mma_warp_group(
+                    seqlen_q=seqlen_q,
+                    seqlen_kv=seqlen_kv,
+                    sQ=sQ,
+                    sK=sK,
+                    sV=sV,
+                    sQ_SF=sQ_SF,
+                    sK_SF=sK_SF,
+                    sP_SF=sP_SF,
+                    sV_SF=sV_SF,
+                    tmem_ptr_i32=tmem_ptr_i32,
+                    bars=bars,
+                    sched=sched,
+                    seq_kv_lens_tensor=seq_kv_lens_tensor,
+                    n_q_supers=n_q_supers,
+                    n_qh=n_qh,
+                    n_batch=n_batch,
+                    mcast_mask=mcast_mask,
+                    cta_in_pair=cta_in_pair,
+                )
+            else:
+                _mma_warp_quiet(
+                    tmem_ptr_i32=tmem_ptr_i32,
+                    bars=bars,
+                    sched=sched,
+                    seqlen_q=seqlen_q,
+                    seqlen_kv=seqlen_kv,
+                    seq_kv_lens_tensor=seq_kv_lens_tensor,
+                    n_q_supers=n_q_supers,
+                    n_qh=n_qh,
+                    n_batch=n_batch,
+                    cta_in_pair=cta_in_pair,
+                    cta_id_x=cta_id_x,
+                )
+        else:
+            _mma_warp_group(
+                seqlen_q=seqlen_q,
+                seqlen_kv=seqlen_kv,
+                sQ=sQ,
+                sK=sK,
+                sV=sV,
+                sQ_SF=sQ_SF,
+                sK_SF=sK_SF,
+                sP_SF=sP_SF,
+                sV_SF=sV_SF,
+                tmem_ptr_i32=tmem_ptr_i32,
+                bars=bars,
+                sched=sched,
+                seq_kv_lens_tensor=seq_kv_lens_tensor,
+                n_q_supers=n_q_supers,
+                n_qh=n_qh,
+                n_batch=n_batch,
+                mcast_mask=mcast_mask,
+                cta_in_pair=cta_in_pair,
+            )
+
+    elif warp_idx == CFG.TMALDG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        nvvm.prefetch_tensormap(tma_q_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_k_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_v_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_q_sf_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_k_sf_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_v_sf_desc.get_ptr())
+        _tmaldg_warp_group(
+            tma_q_desc=tma_q_desc,
+            tma_k_desc=tma_k_desc,
+            tma_v_desc=tma_v_desc,
+            tma_q_sf_desc=tma_q_sf_desc,
+            tma_k_sf_desc=tma_k_sf_desc,
+            tma_v_sf_desc=tma_v_sf_desc,
+            sQ=sQ,
+            sK=sK,
+            sV=sV,
+            sQ_SF=sQ_SF,
+            sK_SF=sK_SF,
+            sV_SF=sV_SF,
+            bars=bars,
+            sched=sched,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            qh_per_kh=qh_per_kh,
+            is_leader=is_leader,
+            cta_in_pair=cta_in_pair,
+            tma_mcast_mask=tma_mcast_mask,
+            sf_mcast_mask=sf_mcast_mask,
+        )
+
+    elif warp_idx == CFG.TMASTG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _tmastg_warp_group(
+            tma_o_desc=tma_o_desc,
+            sO=sO,
+            bars=bars,
+            sched=sched,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            cta_in_pair=cta_in_pair,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
+        )
+
+    else:  # warp_idx == CFG.SCHED_WARP_ID
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        is_cga_first_cta = cta_id_x == cutlass.Int32(0)
+        scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
+
+
+# === Warp-group functions ===
+
+
+@cute.jit
+def _tmaldg_warp_group(
+    tma_q_desc,
+    tma_k_desc,
+    tma_v_desc,
+    tma_q_sf_desc,
+    tma_k_sf_desc,
+    tma_v_sf_desc,
+    sQ,
+    sK,
+    sV,
+    sQ_SF,
+    sK_SF,
+    sV_SF,
+    bars,
+    sched,
+    seqlen_q,
+    seqlen_kv,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    qh_per_kh,
+    is_leader,
+    cta_in_pair,
+    tma_mcast_mask,
+    sf_mcast_mask,
+):
+    """TMA-LDG warp — Q/K/V TMA loads + per-iter SF TMA loads.
+
+    Under cga2: Q_SF — each peer pulls its own M-half (one peer in mcast),
+    bytes route to leader via cta_group::2.  K_SF/V_SF — both peers
+    cooperatively load HALF the slab each at peer-offset with sf_mcast_mask=3.
+    """
+    q_empty_phase = cutlass.Int32(1)
+    kv_state = PipelineState.start(phase=1)
+
+    # SF TMA handles 5-D (innermost = 128-B row); tma_load_tile auto-selects on coord_0.
+    tma_q = GmemTileTma(tma_q_desc)
+    tma_k = GmemTileTma(tma_k_desc)
+    tma_v = GmemTileTma(tma_v_desc)
+    tma_q_sf = GmemTileTma(tma_q_sf_desc)
+    tma_k_sf = GmemTileTma(tma_k_sf_desc)
+    tma_v_sf = GmemTileTma(tma_v_sf_desc)
+
+    # cga2 split-half offsets fold to 0 under cga1.
+    SF_TMA_ROW_BYTES = 128
+    K_SF_BYTES_PER_PEER = SF_SMEM_SIZE_K // CFG.CTA_MMA
+    V_SF_BYTES_PER_PEER = SF_SMEM_SIZE_V // CFG.CTA_MMA
+    K_SF_ROWS_PER_PEER = K_SF_BYTES_PER_PEER // SF_TMA_ROW_BYTES
+    V_SF_ROWS_PER_PEER = V_SF_BYTES_PER_PEER // SF_TMA_ROW_BYTES
+    k_sf_peer_off = cta_in_pair * cutlass.Int32(K_SF_BYTES_PER_PEER)
+    v_sf_peer_off = cta_in_pair * cutlass.Int32(V_SF_BYTES_PER_PEER)
+    k_sf_peer_row = cta_in_pair * cutlass.Int32(K_SF_ROWS_PER_PEER)
+    v_sf_peer_row = cta_in_pair * cutlass.Int32(V_SF_ROWS_PER_PEER)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    # GQA: K/V indexed by kv-head.
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+    # THD packed-tensor seq offsets (fold to (0,0,batch_idx) dense); SF-tile bases
+    # fold to (0,0) dense.
+    q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+    cu_sf_q_base, cu_sf_k_base = _thd_sf_tile_bases(seq_kv_lens_tensor, batch_idx, n_batch)
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    K_ROW_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_N // CFG.CTA_MMA)
+    V_COL_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_O // CFG.CTA_MMA)
+
+    # SF expect_tx scales by CTA_MMA under cga2 (2× SMEM size on leader); cga1 → SF_SMEM_SIZE.
+    Q_SF_EXPECT_BYTES = SF_SMEM_SIZE_Q * CFG.CTA_MMA
+    K_SF_EXPECT_BYTES = SF_SMEM_SIZE_K * CFG.CTA_MMA
+    V_SF_EXPECT_BYTES = SF_SMEM_SIZE_V * CFG.CTA_MMA
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        # Empty-kv tile: MMA's empty-mainloop branch handles the matching mbar phases.
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+            pass
+        else:
+            q_sf_tile_base = q_row_base // cutlass.Int32(CFG.TILE_M)
+            kv_row_base = kv_left * CFG.TILE_N
+
+            # Prologue: Q[0] / K[first] / Q[1] / V[first] interleaved.
+            bars.mb_q_empty[0].wait(q_empty_phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                if is_leader:
+                    if nvvm.elect_sync():
+                        bars.mb_q_full[0].arrive(n_bytes=qTmaTransactionBytes + Q_SF_EXPECT_BYTES)
+            else:
+                if nvvm.elect_sync():
+                    bars.mb_q_full[0].arrive(n_bytes=qTmaTransactionBytes + Q_SF_EXPECT_BYTES)
+            tma_load_tile(
+                sQ[0],
+                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(0 * CFG.TILE_M) + q_seq_off, tma_batch),
+                bars.mb_q_full[0].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+            tma_load_tile(
+                sQ_SF[0],
+                tma_q_sf(cutlass.Int32(0), cu_sf_q_base + q_sf_tile_base + cutlass.Int32(0), head_idx, tma_batch, coord_0=cutlass.Int32(0)),
+                bars.mb_q_full[0].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+
+            bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                if is_leader:
+                    if nvvm.elect_sync():
+                        bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES)
+            else:
+                if nvvm.elect_sync():
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES)
+            tma_load_tile(
+                sK[kv_state.idx],
+                tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
+                bars.mb_k_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+            tma_load_tile(
+                sK_SF[kv_state.idx].shifted(k_sf_peer_off),
+                tma_k_sf(k_sf_peer_row, cu_sf_k_base + kv_left, kv_head_idx, tma_batch, coord_0=cutlass.Int32(0)),
+                bars.mb_k_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=sf_mcast_mask,
+            )
+
+            bars.mb_q_empty[1].wait(q_empty_phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                if is_leader:
+                    if nvvm.elect_sync():
+                        bars.mb_q_full[1].arrive(n_bytes=qTmaTransactionBytes + Q_SF_EXPECT_BYTES)
+            else:
+                if nvvm.elect_sync():
+                    bars.mb_q_full[1].arrive(n_bytes=qTmaTransactionBytes + Q_SF_EXPECT_BYTES)
+            tma_load_tile(
+                sQ[1],
+                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(1 * CFG.TILE_M) + q_seq_off, tma_batch),
+                bars.mb_q_full[1].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+            tma_load_tile(
+                sQ_SF[1],
+                tma_q_sf(cutlass.Int32(0), cu_sf_q_base + q_sf_tile_base + cutlass.Int32(1), head_idx, tma_batch, coord_0=cutlass.Int32(0)),
+                bars.mb_q_full[1].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+            q_empty_phase = q_empty_phase ^ 1
+
+            bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                if is_leader:
+                    if nvvm.elect_sync():
+                        bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes + V_SF_EXPECT_BYTES)
+            else:
+                if nvvm.elect_sync():
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes + V_SF_EXPECT_BYTES)
+            tma_load_tile(
+                sV[kv_state.idx],
+                tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
+                bars.mb_v_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+            tma_load_tile(
+                sV_SF[kv_state.idx].shifted(v_sf_peer_off),
+                tma_v_sf(v_sf_peer_row, cu_sf_k_base + kv_left, kv_head_idx, tma_batch, coord_0=cutlass.Int32(0)),
+                bars.mb_v_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=sf_mcast_mask,
+            )
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+
+            for kv_loop in cutlass.range(kv_left + cutlass.Int32(1), kv_right, 1, unroll=1):
+                kv_row_base_iter = kv_loop * CFG.TILE_N
+
+                bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    if is_leader:
+                        if nvvm.elect_sync():
+                            bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES)
+                else:
+                    if nvvm.elect_sync():
+                        bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES)
+                tma_load_tile(
+                    sK[kv_state.idx],
+                    tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base_iter + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
+                    bars.mb_k_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+                tma_load_tile(
+                    sK_SF[kv_state.idx].shifted(k_sf_peer_off),
+                    tma_k_sf(k_sf_peer_row, cu_sf_k_base + kv_loop, kv_head_idx, tma_batch, coord_0=cutlass.Int32(0)),
+                    bars.mb_k_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=sf_mcast_mask,
+                )
+
+                bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    if is_leader:
+                        if nvvm.elect_sync():
+                            bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes + V_SF_EXPECT_BYTES)
+                else:
+                    if nvvm.elect_sync():
+                        bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes + V_SF_EXPECT_BYTES)
+                tma_load_tile(
+                    sV[kv_state.idx],
+                    tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base_iter + kv_seq_off, tma_batch),
+                    bars.mb_v_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+                tma_load_tile(
+                    sV_SF[kv_state.idx].shifted(v_sf_peer_off),
+                    tma_v_sf(v_sf_peer_row, cu_sf_k_base + kv_loop, kv_head_idx, tma_batch, coord_0=cutlass.Int32(0)),
+                    bars.mb_v_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=sf_mcast_mask,
+                )
+
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+        nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+        nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+        q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+        cu_sf_q_base, cu_sf_k_base = _thd_sf_tile_bases(seq_kv_lens_tensor, batch_idx, n_batch)
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+
+    # cga2 drain — TMA warp cga2 drain at kernel exit (cga2-mma.md).
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        for _qs in cutlass.range_constexpr(CFG.TILES_Q):
+            bars.mb_q_empty[_qs].wait(q_empty_phase)
+        q_empty_phase = q_empty_phase ^ cutlass.Int32(1)
+        for _ks in cutlass.range_constexpr(CFG.STAGES_KV):
+            bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+            bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+
+@cute.jit
+def _tmastg_warp_group(
+    tma_o_desc,
+    sO,
+    bars,
+    sched,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    cta_in_pair,
+    seq_kv_lens_tensor,
+    o_desc_words,
+):
+    """TMA-STG warp — O SMEM→GMEM store."""
+    o_full_phase = cutlass.Int32(0)
+
+    tma_o = GmemTileTma(tma_o_desc)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        q_row_base = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+
+        for qs in cutlass.range_constexpr(CFG.TILES_Q):
+            bars.mb_o_full[qs].wait(o_full_phase)
+
+            # O TMA params follow O's swizzle, NOT V's — required when V_SWZ_B != O_SWZ_B (gptoss cga2).
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: store each Q slab through this batch's pre-built descriptor
+                # (base at the sequence's packed row, seq extent = S_q_b → a box
+                # past S_q_b is OOB-clipped).  q_row coord is sequence-local; the
+                # batch coord collapses to 0.  Both slabs share one descriptor.
+                o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), cutlass.Int32(0))
+                tma_store_tile(sO[qs], o_slice)
+            else:
+                tma_store_tile(
+                    sO[qs],
+                    tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), batch_idx),
+                )
+
+            tma_store_commit()
+            tma_store_wait(0)
+
+            bars.mb_o_empty[qs].arrive()
+
+        o_full_phase = o_full_phase ^ 1
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+
+@cute.jit
+def _mma_warp_quiet(
+    tmem_ptr_i32,
+    bars,
+    sched,
+    seqlen_q,
+    seqlen_kv,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    cta_in_pair,
+    cta_id_x,
+):
+    """Quiet MMA warp — non-leader CTA's MMA slot under cga2.
+
+    Persistent loop keeps peer's mb_read_tile_id contribution + scheduler
+    advance in lockstep with leader (MXFP8 quiet warp counts in
+    READ_TILE_ARRIVERS=15×CGA, unlike FP8).
+    """
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND, is_exclusive=True)
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _mma_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    sQ,
+    sK,
+    sV,
+    sQ_SF,
+    sK_SF,
+    sP_SF,
+    sV_SF,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    mcast_mask,
+    cta_in_pair,
+):
+    """Leader MMA warp — block-scale MMA stream for BMM1 + BMM2.
+
+    Per-iter copy_sf into SF TMEM tiles ahead of each mma; P_SF tile is
+    populated once at warp start (constant 1.0).  For dsv3
+    SF_NUM_BLOCKS_K=2 the inner loop covers both K-blocks.
+    """
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND, is_exclusive=True)
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    tmem_raw = nvvm.make_tmem_ptr(tmem_ptr_i32.load(), cutlass.Int8)
+
+    idesc_qk_bs = prims.Tcgen05MxInstrDesc.build(
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_N,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        k_dim=_MXFP8_K_DIM,
+    )
+    idesc_pv_bs = prims.Tcgen05MxInstrDesc.build(
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_O,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        b_major=1,
+        k_dim=_MXFP8_K_DIM,
+    )
+    # sf_blocks_per_step = TILE_K_HW/32 (SF cols per MMA k-step); NOT SF_NUM_BLOCKS_K (total across K-tile).
+    _MXFP8_SF_BLOCKS_PER_STEP = _MXFP8_TILE_K_HW // 32
+    bmm1_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_N,
+        K=CFG.TILE_K,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=_MXFP8_TILE_K_HW,
+        btranspose=False,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_qk_bs,
+        kind=MMA_KIND,
+        is_block_scale=True,
+        sf_blocks_per_step=_MXFP8_SF_BLOCKS_PER_STEP,
+        scale_vec_size=SCALE_VEC_SIZE,
+    )
+    bmm2_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_O,
+        K=CFG.TILE_N,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=_MXFP8_TILE_K_HW,
+        btranspose=True,
+        k_subtile=CFG.V_SWZ_BYTES // CFG.BPE,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_pv_bs,
+        kind=MMA_KIND,
+        is_block_scale=True,
+        sf_blocks_per_step=_MXFP8_SF_BLOCKS_PER_STEP,
+        scale_vec_size=SCALE_VEC_SIZE,
+    )
+
+    desc_Q0 = sQ[0].desc()
+    desc_Q1 = sQ[1].desc()
+
+    desc_Q_SF_0 = sQ_SF[0].desc()
+    desc_Q_SF_1 = sQ_SF[1].desc()
+    desc_P_SF_0 = sP_SF[0].desc()
+
+    tmem_SF_Q0 = tmem_raw.subview(LAYOUT.SF_Q0_OFF)
+    tmem_SF_Q1 = tmem_raw.subview(LAYOUT.SF_Q1_OFF)
+    tmem_SF_K = tmem_raw.subview(LAYOUT.SF_K_OFF)
+    tmem_SF_P = tmem_raw.subview(LAYOUT.SF_P_OFF)
+    tmem_SF_V = tmem_raw.subview(LAYOUT.SF_V_OFF)
+
+    # One-shot SMEM(P_SF) → TMEM(SF_P); reused every kv-iter (P_SF is constant 1.0).
+    if nvvm.elect_sync():
+        nvvm.tcgen05_cp(
+            nvvm.Tcgen05CpShape.SHAPE_32X128B,
+            tmem_SF_P,
+            desc_P_SF_0,
+            group=CTA_GROUP_KIND,
+            multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+        )
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        q_super_idx, _hd, batch_idx = _dispatch_decode_initial(
+            sched.bidx_init,
+            sched.bidy_init,
+            sched.bidz_init,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    q_full_phase = cutlass.Int32(0)
+    kv_state = PipelineState.start(phase=0)
+    bmm2_ready_phase = cutlass.Int32(0)
+    empty_mainloop_phase = cutlass.Int32(0)
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+            # Empty mainloop — keep softmax/correction phase trackers in lockstep with non-empty path.
+            bars.mb_empty_mainloop.wait(empty_mainloop_phase)
+            empty_mainloop_phase = empty_mainloop_phase ^ cutlass.Int32(1)
+            if nvvm.elect_sync():
+                bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+                bars.mb_bmm2_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+        else:
+            # Prologue: BMM1[sub0] + BMM1[sub1] for kv=kv_left.
+            bars.mb_q_full[0].wait(q_full_phase)
+            bars.mb_k_full[kv_state.idx].wait(kv_state.phase)
+            desc_K = sK[kv_state.idx].desc()
+            desc_K_SF = sK_SF[kv_state.idx].desc()
+            if nvvm.elect_sync():
+                # SF_NUM_BLOCKS_K: 1 (llama), 2 (dsv3 TILE_K=192); inner loop folds to single call for llama.
+                for _sf_k in cutlass.range_constexpr(SF_NUM_BLOCKS_K):
+                    nvvm.tcgen05_cp(
+                        nvvm.Tcgen05CpShape.SHAPE_32X128B,
+                        tmem_SF_Q0.subview(_sf_k * SF_REGISTERS_PER_BLOCK),
+                        desc_Q_SF_0 + _sf_k * (SF_BYTES_PER_BLOCK // 16),
+                        group=CTA_GROUP_KIND,
+                        multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+                    )
+                    nvvm.tcgen05_cp(
+                        nvvm.Tcgen05CpShape.SHAPE_32X128B,
+                        tmem_SF_K.subview(_sf_k * SF_REGISTERS_PER_BLOCK),
+                        desc_K_SF + _sf_k * (SF_BYTES_PER_BLOCK // 16),
+                        group=CTA_GROUP_KIND,
+                        multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+                    )
+            mma_ss(bmm1_desc, desc_Q0, desc_K, (tmem_raw.subview(LAYOUT.S0_OFF)), tmem_sf_a=tmem_SF_Q0, tmem_sf_b=tmem_SF_K)
+            if nvvm.elect_sync():
+                bars.mb_bmm1_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+
+            bars.mb_q_full[1].wait(q_full_phase)
+            if nvvm.elect_sync():
+                for _sf_k in cutlass.range_constexpr(SF_NUM_BLOCKS_K):
+                    nvvm.tcgen05_cp(
+                        nvvm.Tcgen05CpShape.SHAPE_32X128B,
+                        tmem_SF_Q1.subview(_sf_k * SF_REGISTERS_PER_BLOCK),
+                        desc_Q_SF_1 + _sf_k * (SF_BYTES_PER_BLOCK // 16),
+                        group=CTA_GROUP_KIND,
+                        multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+                    )
+            mma_ss(bmm1_desc, desc_Q1, desc_K, (tmem_raw.subview(LAYOUT.S1_OFF)), tmem_sf_a=tmem_SF_Q1, tmem_sf_b=tmem_SF_K)
+            if nvvm.elect_sync():
+                bars.mb_bmm1_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+                bars.mb_k_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+
+            q_full_phase = q_full_phase ^ 1
+
+            for kv_loop in cutlass.range(kv_left + cutlass.Int32(1), kv_right, 1, unroll=1):
+                old_state = kv_state
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+
+                bars.mb_v_full[old_state.idx].wait(old_state.phase)
+                desc_V = sV[old_state.idx].desc()
+                desc_V_SF = sV_SF[old_state.idx].desc()
+                if nvvm.elect_sync():
+                    nvvm.tcgen05_cp(nvvm.Tcgen05CpShape.SHAPE_32X128B, tmem_SF_V, desc_V_SF, group=CTA_GROUP_KIND, multicast=nvvm.Tcgen05CpMulticast.WARPX4)
+                is_not_first_bmm2 = cutlass.Boolean(kv_loop != (kv_left + cutlass.Int32(1)))
+
+                bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
+                accum_b2 = is_not_first_bmm2
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(
+                        bmm2_desc,
+                        (tmem_raw.subview(LAYOUT.P0_OFF)),
+                        desc_V,
+                        (tmem_raw.subview(LAYOUT.O0_OFF)),
+                        local_k,
+                        accum_b2,
+                        tmem_sf_a=tmem_SF_P,
+                        tmem_sf_b=tmem_SF_V,
+                    )
+                    accum_b2 = cutlass.Boolean(True)
+                bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 1].wait(bmm2_ready_phase)
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(
+                        bmm2_desc,
+                        (tmem_raw.subview(LAYOUT.P0_OFF)),
+                        desc_V,
+                        (tmem_raw.subview(LAYOUT.O0_OFF)),
+                        NUM_KPHASES_PV_PER_CHUNK + local_k,
+                        cutlass.Boolean(True),
+                        tmem_sf_a=tmem_SF_P,
+                        tmem_sf_b=tmem_SF_V,
+                    )
+                if nvvm.elect_sync():
+                    bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+
+                bars.mb_k_full[kv_state.idx].wait(kv_state.phase)
+                desc_K = sK[kv_state.idx].desc()
+                desc_K_SF = sK_SF[kv_state.idx].desc()
+                if nvvm.elect_sync():
+                    for _sf_k in cutlass.range_constexpr(SF_NUM_BLOCKS_K):
+                        nvvm.tcgen05_cp(
+                            shape=nvvm.Tcgen05CpShape.SHAPE_32X128B,
+                            taddr=tmem_SF_K.subview(_sf_k * SF_REGISTERS_PER_BLOCK),
+                            smem_desc=desc_K_SF + _sf_k * (SF_BYTES_PER_BLOCK // 16),
+                            group=CTA_GROUP_KIND,
+                            multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+                        )
+                mma_ss(bmm1_desc, desc_Q0, desc_K, (tmem_raw.subview(LAYOUT.S0_OFF)), tmem_sf_a=tmem_SF_Q0, tmem_sf_b=tmem_SF_K)
+                if nvvm.elect_sync():
+                    bars.mb_bmm1_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+
+                bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
+                accum_b2 = is_not_first_bmm2
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(
+                        bmm2_desc,
+                        (tmem_raw.subview(LAYOUT.P1_OFF)),
+                        desc_V,
+                        (tmem_raw.subview(LAYOUT.O1_OFF)),
+                        local_k,
+                        accum_b2,
+                        tmem_sf_a=tmem_SF_P,
+                        tmem_sf_b=tmem_SF_V,
+                    )
+                    accum_b2 = cutlass.Boolean(True)
+                bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 1].wait(bmm2_ready_phase)
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(
+                        bmm2_desc,
+                        (tmem_raw.subview(LAYOUT.P1_OFF)),
+                        desc_V,
+                        (tmem_raw.subview(LAYOUT.O1_OFF)),
+                        NUM_KPHASES_PV_PER_CHUNK + local_k,
+                        cutlass.Boolean(True),
+                        tmem_sf_a=tmem_SF_P,
+                        tmem_sf_b=tmem_SF_V,
+                    )
+                if nvvm.elect_sync():
+                    bars.mb_bmm2_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+                    bars.mb_v_empty[old_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+
+                # BMM1 sub 1 for next kv — SF_K already in TMEM from above.
+                mma_ss(bmm1_desc, desc_Q1, desc_K, (tmem_raw.subview(LAYOUT.S1_OFF)), tmem_sf_a=tmem_SF_Q1, tmem_sf_b=tmem_SF_K)
+                if nvvm.elect_sync():
+                    bars.mb_bmm1_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+                    bars.mb_k_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+
+                bmm2_ready_phase = bmm2_ready_phase ^ 1
+
+            # Epilogue: BMM2 for last kv (always runs — n_kv >= 1).
+            if nvvm.elect_sync():
+                for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                    bars.mb_q_empty[qs].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+
+            bars.mb_v_full[kv_state.idx].wait(kv_state.phase)
+            desc_V = sV[kv_state.idx].desc()
+            desc_V_SF = sV_SF[kv_state.idx].desc()
+            if nvvm.elect_sync():
+                nvvm.tcgen05_cp(
+                    shape=nvvm.Tcgen05CpShape.SHAPE_32X128B,
+                    taddr=tmem_SF_V,
+                    smem_desc=desc_V_SF,
+                    group=CTA_GROUP_KIND,
+                    multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+                )
+            is_not_first_bmm2_epi = cutlass.Boolean((kv_right - kv_left) != cutlass.Int32(1))
+
+            bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
+            accum_b2 = is_not_first_bmm2_epi
+            for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                mma_ts_step(
+                    bmm2_desc,
+                    (tmem_raw.subview(LAYOUT.P0_OFF)),
+                    desc_V,
+                    (tmem_raw.subview(LAYOUT.O0_OFF)),
+                    local_k,
+                    accum_b2,
+                    tmem_sf_a=tmem_SF_P,
+                    tmem_sf_b=tmem_SF_V,
+                )
+                accum_b2 = cutlass.Boolean(True)
+            bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 1].wait(bmm2_ready_phase)
+            for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                mma_ts_step(
+                    bmm2_desc,
+                    (tmem_raw.subview(LAYOUT.P0_OFF)),
+                    desc_V,
+                    (tmem_raw.subview(LAYOUT.O0_OFF)),
+                    NUM_KPHASES_PV_PER_CHUNK + local_k,
+                    cutlass.Boolean(True),
+                    tmem_sf_a=tmem_SF_P,
+                    tmem_sf_b=tmem_SF_V,
+                )
+            if nvvm.elect_sync():
+                bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+
+            bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
+            accum_b2 = is_not_first_bmm2_epi
+            for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                mma_ts_step(
+                    bmm2_desc,
+                    (tmem_raw.subview(LAYOUT.P1_OFF)),
+                    desc_V,
+                    (tmem_raw.subview(LAYOUT.O1_OFF)),
+                    local_k,
+                    accum_b2,
+                    tmem_sf_a=tmem_SF_P,
+                    tmem_sf_b=tmem_SF_V,
+                )
+                accum_b2 = cutlass.Boolean(True)
+            bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 1].wait(bmm2_ready_phase)
+            for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                mma_ts_step(
+                    bmm2_desc,
+                    (tmem_raw.subview(LAYOUT.P1_OFF)),
+                    desc_V,
+                    (tmem_raw.subview(LAYOUT.O1_OFF)),
+                    NUM_KPHASES_PV_PER_CHUNK + local_k,
+                    cutlass.Boolean(True),
+                    tmem_sf_a=tmem_SF_P,
+                    tmem_sf_b=tmem_SF_V,
+                )
+            if nvvm.elect_sync():
+                bars.mb_bmm2_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+                bars.mb_v_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+
+            bmm2_ready_phase = bmm2_ready_phase ^ 1
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+            nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+        else:
+            nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+            nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+            nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+            q_super_idx, _hd, batch_idx = _dispatch_decode_payload(
+                nxt_q,
+                nxt_hb,
+                cta_in_pair,
+                n_q_supers,
+                n_qh,
+                n_batch,
+                seq_kv_lens_tensor,
+            )
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _softmax_kv_body(
+    apply_mask: bool,
+    sub_tile_id: int,
+    kv_loop,
+    tmem_ptr_i32,
+    bars,
+    q_abs,
+    eff_seqlen_kv,
+    seqlen_q,
+    scale_log2,
+    total_max,
+    total_sum,
+    bmm1_phase,
+    stat_empty_phase,
+    leader_cta_id,
+):
+    """Per-iter softmax body — returns (total_max, total_sum, bmm1_phase, stat_empty_phase).
+
+    Compile-time apply_mask picks fast HW max (tcgen05.ld.red.f32.max)
+    vs slow path (load → apply_mask_chunk → software row_max).  The HW
+    max can't observe NEG_INF written after load, so the kv-loop is
+    split into LEFT/unmasked/RIGHT segments to keep the fast path on
+    every interior iter.
+    """
+    tmem_S_off = LAYOUT.S0_OFF if sub_tile_id == 0 else LAYOUT.S1_OFF
+    tmem_P_off = LAYOUT.P0_OFF if sub_tile_id == 0 else LAYOUT.P1_OFF
+    stats_off = LAYOUT.STATS_OFF + sub_tile_id * 8
+    CHUNK = 64
+    P_COLS_PER_CHUNK = CHUNK // 4
+    NEG_INF = cutlass.Float32(-3.4028235e38)
+    RESCALE_THRESHOLD = cutlass.Float32(CFG.RESCALE_THRESHOLD)
+
+    bars.mb_bmm1_done[sub_tile_id].wait(bmm1_phase)
+    bmm1_phase = bmm1_phase ^ 1
+
+    # Hoist TMEM address math to a single base load per kv-iter.
+    tmem_base = tmem_ptr_i32.load()
+    s_addr_a = tmem_base + cutlass.Int32(tmem_S_off + 0)
+    s_addr_b = tmem_base + cutlass.Int32(tmem_S_off + CHUNK)
+    p_addr_a = tmem_base + cutlass.Int32(tmem_P_off + 0)
+    p_addr_b = tmem_base + cutlass.Int32(tmem_P_off + P_COLS_PER_CHUNK)
+    stats_addr = tmem_base + cutlass.Int32(stats_off)
+
+    # Pre-declare reg_S_*/max_* — without it MLIR cf.if NameErrors the tracer post-branch.
+    reg_S_a = cutlass.Vector.from_elements(
+        tuple(cutlass.Float32(0.0) for _ in range(CHUNK)),
+        cutlass.Float32,
+    )
+    reg_S_b = reg_S_a
+    max_a = cutlass.Float32(0.0)
+    max_b = cutlass.Float32(0.0)
+
+    if apply_mask:
+        # Masked slow path — load, mask, software row-max.
+        reg_S_a = nvvm.tcgen05_ld(
+            "32x32b",
+            nvvm.make_tmem_ptr(s_addr_a, cutlass.Float32),
+            num=CHUNK,
+        )
+        reg_S_b = nvvm.tcgen05_ld(
+            "32x32b",
+            nvvm.make_tmem_ptr(s_addr_b, cutlass.Float32),
+            num=CHUNK,
+        )
+        # No tcgen05_wait(LOAD) — reg consumers chain through deps; no downstream mbar arrive depends on it.
+
+        kv_col_base_a = kv_loop * cutlass.Int32(CFG.TILE_N)
+        kv_col_base_b = kv_col_base_a + cutlass.Int32(CHUNK)
+        # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
+        # CFG.BOTTOM_RIGHT is 0 — top-left masking is unchanged).
+        causal_diag = eff_seqlen_kv - seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+        reg_S_a = apply_mask_chunk(
+            reg_S_a,
+            q_abs,
+            kv_col_base_a,
+            eff_seqlen_kv,
+            CFG.WINDOW_LEFT,
+            CFG.MASK_FLAGS,
+            N=CHUNK,
+            bottom_right=CFG.BOTTOM_RIGHT,
+            causal_diag=causal_diag,
+            window_right=CFG.WINDOW_RIGHT,
+        )
+        reg_S_b = apply_mask_chunk(
+            reg_S_b,
+            q_abs,
+            kv_col_base_b,
+            eff_seqlen_kv,
+            CFG.WINDOW_LEFT,
+            CFG.MASK_FLAGS,
+            N=CHUNK,
+            bottom_right=CFG.BOTTOM_RIGHT,
+            causal_diag=causal_diag,
+            window_right=CFG.WINDOW_RIGHT,
+        )
+
+        max_a = row_max_reduction_64(reg_S_a)
+        max_b = row_max_reduction_64(reg_S_b)
+    else:
+        # Fast path — fused HW row-max (tcgen05.ld.red.f32.max).
+        res_a = tmem_load_max_reduction_x64(s_addr_a)
+        res_b = tmem_load_max_reduction_x64(s_addr_b)
+
+        reg_S_a = cutlass.Vector.from_elements(
+            tuple(res_a[:CHUNK]),
+            cutlass.Int32,
+        ).bitcast(cutlass.Float32)
+        reg_S_b = cutlass.Vector.from_elements(
+            tuple(res_b[:CHUNK]),
+            cutlass.Int32,
+        ).bitcast(cutlass.Float32)
+
+        max_a_vec = cutlass.Vector.from_elements(
+            (res_a[CHUNK],),
+            cutlass.Int32,
+        ).bitcast(cutlass.Float32)
+        max_b_vec = cutlass.Vector.from_elements(
+            (res_b[CHUNK],),
+            cutlass.Int32,
+        ).bitcast(cutlass.Float32)
+        max_a = max_a_vec[0]
+        max_b = max_b_vec[0]
+
+    current_max = cute.math.max(max_a, max_b) * scale_log2
+
+    # cfence pins ptxas from hoisting stat-store work across the wg0/wg1 sync.
+    if sub_tile_id == 1:
+        nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
+
+    old_total_max = total_max
+    is_first = total_max == NEG_INF
+    update_cond = is_first | ((current_max - total_max) > RESCALE_THRESHOLD)
+    total_max = cutlass.Float32(
+        arith.select(
+            update_cond.ir_value(),
+            current_max.ir_value(),
+            total_max.ir_value(),
+        )
+    )
+    exp_input = cutlass.Float32(
+        arith.select(
+            is_first.ir_value(),
+            NEG_INF.ir_value(),
+            (old_total_max - total_max).ir_value(),
+        )
+    )
+    alpha = cute.math.exp2(exp_input, fastmath=True)
+    new_total_max = total_max
+
+    alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+    bars.mb_stat_full[sub_tile_id].arrive()
+
+    # SchedResBusyXU64 around exp2 biases ptxas to keep MUFU/exp pipe busy across dependent FFMA chain.
+    reg_S_a = reg_S_a * scale_log2 - new_total_max
+    reg_S_b = reg_S_b * scale_log2 - new_total_max
+    reg_P_a = cute.math.exp2(reg_S_a, fastmath=True)
+    sum_a_pair = row_reduction_pair_64(reg_P_a)
+    p_a_fp16 = reg_P_a.to(STORAGE_DTYPE)
+    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_a, cutlass.Float32), p_a_fp16)
+    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+    bars.mb_bmm2_ready[sub_tile_id * CFG.N_BMM2_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+    reg_P_b = cute.math.exp2(reg_S_b, fastmath=True)
+    p_b_fp16 = reg_P_b.to(STORAGE_DTYPE)
+    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_b, cutlass.Float32), p_b_fp16)
+    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+    bars.mb_bmm2_ready[sub_tile_id * CFG.N_BMM2_CHUNKS + 1].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+    if sub_tile_id == 0:
+        nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
+
+    sum_b_pair = row_reduction_pair_64(reg_P_b)
+    new_p_sum_pair = sum_a_pair + sum_b_pair
+    alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+    total_sum = total_sum * alpha_pair + new_p_sum_pair
+
+    bars.mb_stat_empty[sub_tile_id].wait(stat_empty_phase)
+    stat_empty_phase = stat_empty_phase ^ 1
+
+    return total_max, total_sum, bmm1_phase, stat_empty_phase
+
+
+@cute.jit
+def _softmax_warp_group(
+    sub_tile_id: int,
+    seqlen_q,
+    seqlen_kv,
+    scale_log2: cutlass.Float32,
+    tmem_ptr_i32,
+    sQ,
+    bars,
+    sched,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+):
+    """Softmax warp group — online softmax + α publish (LSE write owned by correction)."""
+    # Wait on MMA's TMEM-publish named barrier BEFORE tmem_ptr_i32.load() — else stale base pointer.
+    nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+
+    tmem_S_off = LAYOUT.S0_OFF if sub_tile_id == 0 else LAYOUT.S1_OFF
+    tmem_P_off = LAYOUT.P0_OFF if sub_tile_id == 0 else LAYOUT.P1_OFF
+
+    NEG_INF = cutlass.Float32(-3.4028235e38)
+
+    CHUNK = 64
+    P_COLS_PER_CHUNK = CHUNK // 4
+    stats_off = LAYOUT.STATS_OFF + sub_tile_id * 8
+
+    bmm1_phase = cutlass.Int32(0)
+    stat_empty_phase = cutlass.Int32(1)  # bootstrap pre-armed at phase 1 so first wait passes immediately
+    epilogue_state = cutlass.Int32(1)  # bootstrap pre-armed at phase 1 so first wait passes immediately
+
+    # total_sum kept as Vector[Float32,2] so per-iter update lowers to packed FMUL2 + FADD2.
+    total_max = NEG_INF
+    total_sum = cutlass.Vector.from_elements(
+        (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+        cutlass.Float32,
+    )
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    softmax_wg_base_const = CFG.SOFTMAX_WG0_BASE if sub_tile_id == 0 else CFG.SOFTMAX_WG1_BASE
+    tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(softmax_wg_base_const * 32)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        # Both softmax wgs wait on slot [0]; without this softmax races ahead while TMA-STG drains prior tile.
+        bars.mb_o_empty[0].wait(epilogue_state)
+        epilogue_state = epilogue_state ^ cutlass.Int32(1)
+
+        total_max = NEG_INF
+        total_sum = cutlass.Vector.from_elements(
+            (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+            cutlass.Float32,
+        )
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+        q_abs = q_row_coord + cutlass.Int32(sub_tile_id * CFG.TILE_M) + tid_in_wg
+        # Bootstrap stat_empty wait lifts the wait out of per-iter critical path.
+        bars.mb_stat_empty[sub_tile_id].wait(stat_empty_phase)
+        stat_empty_phase = stat_empty_phase ^ 1
+        # 3-segment kv loop: LEFT-masked / unmasked (fast HW max) / RIGHT-masked.
+        # MASK_NONE: bounds collapse so masked sub-loops fold out at trace time.
+        if cutlass.const_expr(CFG.MASK_FLAGS == MASK_NONE):
+            for kv_loop in cutlass.range(bounds.left, bounds.right, 1, unroll=1):
+                total_max, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                    False,
+                    sub_tile_id,
+                    kv_loop,
+                    tmem_ptr_i32,
+                    bars,
+                    q_abs,
+                    eff_seqlen_kv,
+                    seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_sum,
+                    bmm1_phase,
+                    stat_empty_phase,
+                    leader_cta_id,
+                )
+        else:
+            for kv_loop in cutlass.range(bounds.left, bounds.unmasked_lo, 1, unroll=1):
+                total_max, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                    True,
+                    sub_tile_id,
+                    kv_loop,
+                    tmem_ptr_i32,
+                    bars,
+                    q_abs,
+                    eff_seqlen_kv,
+                    seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_sum,
+                    bmm1_phase,
+                    stat_empty_phase,
+                    leader_cta_id,
+                )
+            for kv_loop in cutlass.range(bounds.unmasked_lo, bounds.unmasked_hi, 1, unroll=1):
+                total_max, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                    False,
+                    sub_tile_id,
+                    kv_loop,
+                    tmem_ptr_i32,
+                    bars,
+                    q_abs,
+                    eff_seqlen_kv,
+                    seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_sum,
+                    bmm1_phase,
+                    stat_empty_phase,
+                    leader_cta_id,
+                )
+            for kv_loop in cutlass.range(bounds.unmasked_hi, bounds.right, 1, unroll=1):
+                total_max, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                    True,
+                    sub_tile_id,
+                    kv_loop,
+                    tmem_ptr_i32,
+                    bars,
+                    q_abs,
+                    eff_seqlen_kv,
+                    seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_sum,
+                    bmm1_phase,
+                    stat_empty_phase,
+                    leader_cta_id,
+                )
+
+        # Per-tile balance: softmax 1 bootstrap + n_kv end-of-body waits = n_kv+1 = corr fires.
+        total_sum_scalar = total_sum[0] + total_sum[1]
+
+        stats_addr_epi = tmem_ptr_i32.load() + cutlass.Int32(stats_off)
+        stats_vec_epi = cutlass.Vector.from_elements((total_max, total_sum_scalar), cutlass.Float32)
+        nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr_epi, cutlass.Float32), stats_vec_epi)
+        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+        bars.mb_stat_full[sub_tile_id].arrive()
+
+        # make_warp_uniform on scheduler loads keeps payload in uniform regs across back-edge (no STL spill).
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+        nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+        nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+
+@cute.jit
+def _correction_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    sO,
+    tmem_ptr_i32,
+    tidx,
+    bars,
+    sched,
+    lse_tensor: Optional[cute.Tensor],
+    amax_o_tensor: cute.Tensor,
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+    cta_id_x,
+):
+    """Correction warp group — α-rescale O + epilogue cast/store + LSE.
+
+    P14 catch-up flip on bmm2_done_phase at end of tile is REQUIRED for
+    multi-wave at n_kv=1.
+    """
+    # Wait on MMA's TMEM-publish named barrier BEFORE tmem_ptr_i32.load() — else stale base pointer.
+    nvvm.barrier_cta_sync(barrier_id=2, thread_count=32 * (CFG.CORRECTION_WARPS + 1))
+
+    tid_raw = cute.arch.thread_idx()[0]
+    tid_in_wg = tid_raw - cutlass.Int32(CFG.CORR_WARP_BASE * 32)
+
+    # O_CHUNK=16 keeps live range short enough to avoid spilling (O_CHUNK=32 spilled correction regs).
+    O_CHUNK = 16
+    N_CHUNKS_O = CFG.TILE_O // O_CHUNK
+    # D_BLOCK_SIZE must use O_SWZ_B not V_SWZ_B — gptoss cga2 V drops to Swz64B while O stays Swz128B.
+    # Sized in BPE_O so it stays consistent with the BPE_O-derived O_SWZ_BYTES (BF16/FP16 O).
+    TMA_O_ITERS = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
+    D_BLOCK_SIZE = CFG.TILE_O // TMA_O_ITERS
+    TMA_O_GRANU_ELEMS = CFG.TILE_M * D_BLOCK_SIZE
+
+    stat_full_phase = cutlass.Int32(0)
+    bmm2_done_phase = cutlass.Int32(0)
+    o_empty_phase = cutlass.Int32(1)  # bootstrap pre-armed at phase 1 so first wait passes immediately
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+        # Iter-0 skip — MMA's iter-0 BMM2 uses init_d=False to overwrite O, no α-rescale needed.
+        if bounds.right > bounds.left:
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                bars.mb_bmm2_ready[qs * CFG.N_BMM2_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                bars.mb_stat_full[qs].wait(stat_full_phase)
+                bars.mb_stat_empty[qs].arrive()
+            stat_full_phase = stat_full_phase ^ 1
+        else:
+            bars.mb_empty_mainloop.arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+        for kv_loop in cutlass.range(bounds.left + cutlass.Int32(1), bounds.right, 1, unroll=1):
+            tmem_base_iter = tmem_ptr_i32.load()
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                stats_off = LAYOUT.STATS_OFF + qs * 8
+                tmem_O_off = LAYOUT.O0_OFF if qs == 0 else LAYOUT.O1_OFF
+
+                bars.mb_stat_full[qs].wait(stat_full_phase)
+
+                stats_addr = tmem_base_iter + cutlass.Int32(stats_off)
+                stats_vec = nvvm.tcgen05_ld(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(stats_addr, cutlass.Float32),
+                    num=2,
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                alpha = stats_vec[0]
+
+                # all_alpha_one ballot skips α-rescale once softmax stops bumping total_max.
+                alpha_is_one = alpha == cutlass.Float32(1.0)
+                all_alpha_one = vote_sync(0xFFFFFFFF, alpha_is_one, VoteSync.ALL)
+
+                bars.mb_stat_empty[qs].arrive()
+
+                bars.mb_bmm2_done[qs].wait(bmm2_done_phase)
+
+                # vec_scale_pair emits mul_packed_f32x2; without it CTM lowers to scalar FMUL inside this runtime-if.
+                # cfence after each chunk keeps ptxas from sinking next tcgen05_ld ahead of prior tcgen05_st (TMEM anti-dep).
+                if ~all_alpha_one:
+                    for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                        o_addr = tmem_base_iter + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
+                        o_chunk = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                            num=O_CHUNK,
+                        )
+                        o_scaled = vec_scale_pair(o_chunk, alpha, O_CHUNK)
+                        nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(o_addr, cutlass.Float32), o_scaled)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+
+                bars.mb_bmm2_ready[qs * CFG.N_BMM2_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+            stat_full_phase = stat_full_phase ^ 1
+            bmm2_done_phase = bmm2_done_phase ^ 1
+
+        tmem_base_epi = tmem_ptr_i32.load()
+        for qs in cutlass.range_constexpr(CFG.TILES_Q):
+            stats_off = LAYOUT.STATS_OFF + qs * 8
+            tmem_O_off = LAYOUT.O0_OFF if qs == 0 else LAYOUT.O1_OFF
+
+            bars.mb_bmm2_done[qs].wait(bmm2_done_phase)
+
+            bars.mb_stat_full[qs].wait(stat_full_phase)
+
+            stats_addr = tmem_base_epi + cutlass.Int32(stats_off)
+            stats_vec = nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(stats_addr, cutlass.Float32),
+                num=2,
+            )
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+            total_max_scaled = stats_vec[0]
+            total_sum = stats_vec[1]
+
+            bars.mb_stat_empty[qs].arrive()
+
+            # Pre-declare inv_sum/lse_val — without it MLIR cf.if NameErrors the tracer post-branch.
+            inv_sum = cutlass.Float32(0.0)
+            lse_val = cutlass.Float32(0.0)
+            LN2 = cutlass.Float32(0.6931471805599453)
+            total_max_nat = total_max_scaled * LN2
+            if cutlass.const_expr(CFG.HAS_SINK):
+                sinks_arr = cutlass.make_array_view(sinks_tensor)
+                sink_logit = sinks_arr[head_idx]
+                new_max = cute.math.max(total_max_nat, sink_logit)
+                scale = cute.math.exp(total_max_nat - new_max, fastmath=True)
+                new_sum = total_sum * scale + cute.math.exp(sink_logit - new_max, fastmath=True)
+                lse_val = new_max + cute.math.log(new_sum, fastmath=True)
+                inv_sum = scale / new_sum
+            else:
+                lse_val = total_max_nat + cute.math.log(total_sum, fastmath=True)
+                # Safe inverse: avoid div by 0 (rows fully masked).
+                inv_sum = cutlass.Float32(1.0) / cute.math.max(total_sum, cutlass.Float32(1e-30))
+
+            # OOB-row guard: under cga2 cluster Q rows can exceed seqlen_q (else write aliases next head's LSE slot).
+            q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: q_row_global is sequence-local; LSE is packed [1,QH,T] →
+                # index [0, head, cu_q[b] + local], bound by per-sequence Q len S_q_b.
+                _cu = cutlass.make_array_view(seq_kv_lens_tensor)
+                _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
+                _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
+                if cutlass.const_expr(lse_tensor is not None):
+                    if q_row_global < _s_q_b:
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
+                        lse_row[_cu_q_b + q_row_global] = lse_val
+            else:
+                if cutlass.const_expr(lse_tensor is not None):
+                    if q_row_global < seqlen_q:
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        lse_row = lse_arr[batch_idx, head_idx, :]
+                        lse_row[q_row_global] = lse_val
+
+            sO_sub_base = sO[qs].base
+
+            # amax_o over VALID rows of |o| (fp32, pre-cast).  atomicMax only
+            # grows, so a padded row would permanently inflate the graph's
+            # Amax_O -- gate it exactly like the LSE write above.
+            _amax_o_ptr = Pointer(amax_o_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
+            _amax_o_local = cutlass.Float32(0.0)
+
+            for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                o_addr = tmem_base_epi + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
+                o_chunk = nvvm.tcgen05_ld(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                    num=O_CHUNK,
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                o_scaled = o_chunk * inv_sum
+                for _i in cutlass.range_constexpr(O_CHUNK):
+                    _e = o_scaled[_i]
+                    _amax_o_local = cute.math.max(_amax_o_local, cute.math.max(_e, -_e))
+                o_out = o_scaled.to(OUT_STORAGE_DTYPE)
+
+                col_offset_const = (chunk_idx * O_CHUNK) % D_BLOCK_SIZE
+                block_idx_const = (chunk_idx * O_CHUNK) // D_BLOCK_SIZE
+                block_offset_const = block_idx_const * TMA_O_GRANU_ELEMS
+                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
+
+                smem_ptr = sO_sub_base.subview(smem_offset).data_ptr()
+                # Gate FIRST SMEM store (not earlier TMEM-load loop) — keeps load/FFMA/cast overlapped with prior TMA-STG drain.
+                if chunk_idx == 0:
+                    bars.mb_o_empty[qs].wait(o_empty_phase)
+                smem_ptr.store_swizzled(o_out, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+
+            if q_row_global < seqlen_q:
+                nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
+
+            # fence_proxy needed before TMA reads SMEM written by tcgen05_st.
+            nvvm.fence_proxy("async.shared", space="cta")
+
+            bars.mb_o_full[qs].arrive()
+
+        stat_full_phase = stat_full_phase ^ 1
+        o_empty_phase = o_empty_phase ^ 1
+        # P14 catch-up flip — bmm2_done_phase ^= 1 AFTER epilogue wait (else n_kv=1 multi-wave deadlocks on tile 2).
+        bmm2_done_phase = bmm2_done_phase ^ 1
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    # mb_tmem_dealloc fan-out — all-lanes arrive + DSMEM-arrive on cross-pair peer under cga2.
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        peer_cta = cta_id_x ^ cutlass.Int32(1)
+        bars.mb_tmem_dealloc.arrive_on_peer(peer_cta)
+    bars.mb_tmem_dealloc.arrive()
+
+
+# === Host launcher ===
+
+
+@cute.jit
+def _host(
+    q_tensor: cute.Tensor,
+    k_tensor: cute.Tensor,
+    v_tensor: cute.Tensor,
+    o_tensor: cute.Tensor,
+    sf_q_tensor: cute.Tensor,
+    sf_k_tensor: cute.Tensor,
+    sf_v_tensor: cute.Tensor,
+    lse_tensor: Optional[cute.Tensor],
+    # FROST's MXFP8 ABI puts amax_o RIGHT AFTER lse (position 9) and does NOT
+    # pass the SF-tile counts positionally -- those are compile-time there.
+    amax_o_tensor: cute.Tensor,
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    problem_size: Tuple[int, int, int, int, int, int],
+    scale_softmax_log2: cutlass.Float32,
+    n_thd_units: cutlass.Int32,
+    # FROST passes the dense padded-Q trim tensor POSITIONALLY on every call.
+    # These kernels have no Q-trim epilogue (Capabilities.dense_seq_q_trim=False)
+    # so it is accepted and unused -- but the SLOT is mandatory: without it the
+    # adapter's 12th positional lands on `stream` and execute dies with
+    # "got multiple values for argument 'stream'".
+    seq_q_lens_tensor: Optional[cute.Tensor] = None,
+    # Keyword-only in effect: FROST never passes these positionally (its SF
+    # extents are compile-time), and they are read only on the THD path, which
+    # this kernel declines.
+    total_q_sf_tiles: cutlass.Int32 = 0,
+    total_kv_sf_tiles: cutlass.Int32 = 0,
+    # FROST plans must run on the caller's stream (engine contract; there is a
+    # dedicated stream-respect test).  Threaded exactly as the shipped
+    # prefill_d128_fp8_sm107.py sibling does.
+    stream: _cuda_driver.CUstream = None,
+) -> None:
+    """MXFP8 host launcher — builds TMA descriptors for Q/K/V/O + SF tensors.
+
+    THD/varlen: q/k/v/o/lse/SF are PACKED with batch dim 1; the SF descriptors use
+    B=1 + total_*_sf_tiles (per-sequence-TILE-padded SF layout); O uses a per-batch
+    descriptor array (build_thd_meta_o_descs_kernel)."""
+    B, QH, KH, SQ, SKV, _ = problem_size
+
+    _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE_O  # O box sized in BPE_O (BF16/FP16 O)
+    qk_box_q = (1, CFG.TILE_M, 1, TMA_QK_GRANU_ELEMS)
+    qk_box_k = (1, CFG.TILE_N // CFG.CTA_MMA, 1, TMA_QK_GRANU_ELEMS)
+    vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M, 1, _O_GRANU_ELEMS)
+    stride_order = (3, 2, 1, 0)
+
+    # SF TMA: 5-D, box=(128, num_rows, 1, 1, 1); cga2 K_SF/V_SF narrows to (128, num_rows//CTA_MMA, ...).
+    # 5-D layout assumes SF SMEM flat-contiguous (single block-K); Qwen d=256 (SF_NUM_BLOCKS_V=2) needs split TMA or 6-D.
+    SF_TMA_ROW_BYTES = 128
+    SF_NUM_ROWS_Q = SF_SMEM_SIZE_Q // SF_TMA_ROW_BYTES
+    SF_NUM_ROWS_K = SF_SMEM_SIZE_K // SF_TMA_ROW_BYTES
+    SF_NUM_ROWS_V = SF_SMEM_SIZE_V // SF_TMA_ROW_BYTES
+
+    def _tma_swz(byte_w: int):
+        return tmap.TensorMapSwizzle.s128b if byte_w == 128 else tmap.TensorMapSwizzle.s64b if byte_w == 64 else tmap.TensorMapSwizzle.s32b
+
+    tma_q_desc = tmap.create_tensor_map_tiled_from_view(
+        q_tensor,
+        box_dims=qk_box_q,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.Q_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_k_desc = tmap.create_tensor_map_tiled_from_view(
+        k_tensor,
+        box_dims=qk_box_k,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.K_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_v_desc = tmap.create_tensor_map_tiled_from_view(
+        v_tensor,
+        box_dims=vo_box_v,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.V_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_o_desc = tmap.create_tensor_map_tiled_from_view(
+        o_tensor,
+        box_dims=vo_box_o,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.O_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    # SF TMA strides in 16-B units (TMA convention); reinterpret 4-D runner SF tensor as 5-D split-byte view.
+    # Dense: per-batch tile counts (SQ/TILE_M, SKV/TILE_N), B-extent = B.  THD:
+    # the SF tensor is PACKED (batch dim 1) and per-sequence-TILE-padded, so the
+    # descriptor uses num_tiles = total_*_sf_tiles (Σ_b ceil(S/TILE)) and B = 1.
+    # _B_SF folds to the const 1 under THD so the descriptor's batch extent is correct.
+    sq_sf_tiles = (SQ + CFG.TILE_M - 1) // CFG.TILE_M
+    skv_sf_tiles = (SKV + CFG.TILE_N - 1) // CFG.TILE_N
+    _B_SF = 1 if cutlass.const_expr(CFG.THD_VARLEN) else B
+    _q_sf_num_tiles = total_q_sf_tiles if cutlass.const_expr(CFG.THD_VARLEN) else sq_sf_tiles
+    _kv_sf_num_tiles = total_kv_sf_tiles if cutlass.const_expr(CFG.THD_VARLEN) else skv_sf_tiles
+
+    def _build_sf_desc(sf_tensor, num_tiles, sf_smem_size, num_rows_box, num_heads):
+        sf_base = cutlass.Int64(sf_tensor.iterator.toint())
+        tile_stride_16 = sf_smem_size // 16
+        return tmap.create_tensor_map_tiled(
+            global_address=sf_base,
+            dtype=cutlass.Uint8,
+            global_dims=[
+                SF_TMA_ROW_BYTES,
+                sf_smem_size // SF_TMA_ROW_BYTES,
+                num_tiles,
+                num_heads,
+                _B_SF,
+            ],
+            global_strides=[
+                SF_TMA_ROW_BYTES // 16,
+                tile_stride_16,
+                num_tiles * tile_stride_16,
+                num_heads * num_tiles * tile_stride_16,
+            ],
+            box_dims=[SF_TMA_ROW_BYTES, num_rows_box, 1, 1, 1],
+            swizzle=tmap.TensorMapSwizzle.none,
+            l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+        )
+
+    tma_q_sf_desc = _build_sf_desc(sf_q_tensor, _q_sf_num_tiles, SF_SMEM_SIZE_Q, SF_NUM_ROWS_Q, QH)
+    tma_k_sf_desc = _build_sf_desc(sf_k_tensor, _kv_sf_num_tiles, SF_SMEM_SIZE_K, SF_NUM_ROWS_K // CFG.CTA_MMA, KH)
+    tma_v_sf_desc = _build_sf_desc(sf_v_tensor, _kv_sf_num_tiles, SF_SMEM_SIZE_V, SF_NUM_ROWS_V // CFG.CTA_MMA, KH)
+
+    rows_per_cluster = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+    q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
+    grid_q_supers = q_clusters * CFG.CTA_MMA
+    q_supers = grid_q_supers
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD: build the per-batch O descriptor array (reuse tma_o_desc over the
+        # packed [1,T,QH,D_v] O as base), then launch the exact flat
+        # batch-outermost grid (n_thd_units = Σ_b ceil(S_q_b/CGA_TILE_M)*QH,
+        # host-computed); grid_x = n_thd_units * CGA_M.  Works at cga1 (CGA_M=1).
+        _build_thd_meta_o_descs_kernel(
+            o_tensor,
+            tma_o_desc,
+            o_desc_words,
+            seq_kv_lens_tensor,
+            cutlass.Int32(QH),
+            cutlass.Int32(B),
+            cutlass.Int32(CFG.TILE_O),
+        ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
+        grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
+    else:
+        grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
+    _kernel(
+        tma_q_desc,
+        tma_k_desc,
+        tma_v_desc,
+        tma_o_desc,
+        tma_q_sf_desc,
+        tma_k_sf_desc,
+        tma_v_sf_desc,
+        lse_tensor,
+        amax_o_tensor,
+        sinks_tensor,
+        seq_kv_lens_tensor,
+        o_desc_words,
+        cutlass.Int32(SQ),
+        cutlass.Int32(SKV),
+        cutlass.Int32(q_supers),
+        cutlass.Int32(QH),
+        cutlass.Int32(B),
+        cutlass.Int32(QH // KH),
+        scale_softmax_log2,
+    ).launch(
+        grid=grid_shape,
+        block=[CFG.THREADS_PER_CTA, 1, 1],
+        cluster=(CFG.CTA_MMA, 1, 1),
+        stream=stream,
+    )
+
+
+@lru_cache(maxsize=None)
+def compile(  # noqa: A001
+    b: int = 1,
+    qh: int = 1,
+    kh: int = 1,
+    sq: int = 256,
+    skv: int = 128,
+    total_q_sf_tiles: int = 0,
+    total_kv_sf_tiles: int = 0,
+    d_qk: int = CFG.TILE_K,
+    d_v: int = CFG.TILE_O,
+    has_lse: bool = True,
+    lse_stride: Optional[tuple] = None,
+) -> Callable:
+    """Compile a kernel with concrete dims; 3 SF tensors layout [B, H, num_seq_tiles, SF_SMEM_SIZE_*].
+
+    THD/varlen: q/k/v/o/lse + SF tensors are PACKED with batch dim 1; ``b`` is the
+    LOGICAL batch (sequence count).  The SF tensors are per-sequence-TILE-padded so
+    their packed tile extent is ``total_q_sf_tiles`` / ``total_kv_sf_tiles`` (=
+    Σ_b ceil(S/TILE)); pass those (they vary with the cu_seqlens partition, hence
+    part of the lru_cache key).  Default 0 → fall back to the dense per-batch
+    tile counts so the dense path is unaffected."""
+    # THD/varlen is NOT ported for this kernel yet.  The setup-kernel call site
+    # below still speaks the pre-upstream 7-arg contract, while FROST's
+    # thd_helpers.build_thd_meta_o_descs_kernel takes 14 args and a different
+    # metadata layout (4B+4 with batch_remap + a claim counter, vs the 3B+2
+    # here), and the scheduler decode differs to match.  Raise here rather than
+    # let it fail as an arity error deep in the trace -- and so no engine row
+    # can advertise thd=True for this kernel and appear to work.  The dense
+    # path is unaffected: CFG.THD_VARLEN is 0 and every THD branch folds out.
+    if CFG.THD_VARLEN:
+        raise NotImplementedError(f"{__name__}: THD/varlen not ported to the FROST setup-kernel contract")
+    # ---- FROST adapter ABI ------------------------------------------------
+    # lower_dsl_prefill calls EVERY kernel with the full forward signature.
+    # This body carries only what the port brought over, so anything
+    # it cannot honor RAISES rather than being silently ignored: a raise here
+    # means the engine's Capabilities row is lying, which is the failure we
+    # want loud.  (Capabilities: lse_optional=False, no strided Stats.)
+    if lse_stride is not None:
+        raise NotImplementedError(f"{__name__}: strided Stats not ported (contiguous [B, H, S] only)")
+    if d_qk > CFG.TILE_K or d_v > CFG.TILE_O or d_qk <= 0 or d_v <= 0:
+        raise ValueError(f"{__name__}: envelope is 0 < d_qk <= {CFG.TILE_K}, 0 < d_v <= {CFG.TILE_O}; " f"got ({d_qk}, {d_v})")
+    _fake_batch = 1 if CFG.THD_VARLEN else b
+
+    # Q SF tiles TILE_M-row wide → num_tiles = SQ/TILE_M; K/V SF TILE_N-row wide → num_tiles = SKV/TILE_N.
+    # THD: packed (batch dim 1) + per-sequence-TILE-padded → total_*_sf_tiles tiles.
+    sq_tiles = (sq + CFG.TILE_M - 1) // CFG.TILE_M
+    skv_tiles = (skv + CFG.TILE_N - 1) // CFG.TILE_N
+    if CFG.THD_VARLEN:
+        _q_sf_tiles = total_q_sf_tiles if total_q_sf_tiles > 0 else b * sq_tiles
+        _kv_sf_tiles = total_kv_sf_tiles if total_kv_sf_tiles > 0 else b * skv_tiles
+    else:
+        _q_sf_tiles = sq_tiles
+        _kv_sf_tiles = skv_tiles
+
+    fake_q = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, sq, qh, d_qk),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_k = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, d_qk),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_v = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, d_v),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_o = cute.runtime.make_fake_compact_tensor(
+        OUT_STORAGE_DTYPE,
+        (_fake_batch, sq, qh, d_v),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+
+    fake_sf_q = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int8,
+        (_fake_batch, qh, _q_sf_tiles, SF_SMEM_SIZE_Q),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_sf_k = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int8,
+        (_fake_batch, kh, _kv_sf_tiles, SF_SMEM_SIZE_K),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_sf_v = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int8,
+        (_fake_batch, kh, _kv_sf_tiles, SF_SMEM_SIZE_V),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+
+    # has_lse=False (no Stats output): the LSE argument is None-specialized and
+    # the store is compiled out entirely -- no dummy buffer exists at any level,
+    # which is what lets the dense graph report get_workspace_size() == 0.
+    # Mirrors the shipped prefill_d128_fp8_sm107.py.
+    fake_lse = (
+        cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (_fake_batch, qh, sq),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
+        if has_lse
+        else None
+    )
+    fake_sinks = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (qh,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # seq_kv_lens always part of the ABI; THD overloads it as the
+    # [seq_kv_lens(B)|cu_q(B+1)|cu_k(B+1)] metadata buffer (length 3B+2).
+    _skv_len = (3 * b + 2) if CFG.THD_VARLEN else b
+    fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (_skv_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # Per-batch O TMA-descriptor array (TENSOR_MAP_QWORDS int64 = 128 B each) + 1
+    # pad slot; dummy 1-elem when THD off (kernel never reads it).
+    _odesc_len = (b * _TENSOR_MAP_QWORDS + _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
+    fake_o_desc = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int64,
+        (_odesc_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    fake_amax_o = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (1,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    return cute.compile(
+        _host,
+        fake_q,
+        fake_k,
+        fake_v,
+        fake_o,
+        fake_sf_q,
+        fake_sf_k,
+        fake_sf_v,
+        fake_lse,
+        fake_amax_o,
+        fake_sinks,
+        fake_seq_kv_lens,
+        fake_o_desc,
+        (b, qh, kh, sq, skv, 0),
+        cutlass.Float32(0.0),
+        cutlass.Int32(0),
+        None,
+        cutlass.Int32(_q_sf_tiles),
+        cutlass.Int32(_kv_sf_tiles),
+        stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
+        options="--enable-tvm-ffi",
+    )

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm107.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-"""CTM-DSL port of the pre-upstream prefill SDPA MXFP8 kernel
+"""Port (from the pre-upstream DSL) of the pre-upstream prefill SDPA MXFP8 kernel
 (dsv3 / llama / gptoss: block-scale MXFP8 inputs, TILES_Q = 2,
 2 softmax warpgroups, 4 correction warps, persistent try_cancel
-scheduler).  Same pipeline structure as the FP8 CTM twin.
+scheduler).  Same pipeline structure as the FP8 twin.
 """
 
 import os
@@ -142,7 +142,7 @@ elif CFG.DTYPE_O == 2:
 elif CFG.DTYPE_O == 3:
     OUT_STORAGE_DTYPE = cutlass.Float16
 else:
-    raise ValueError(f"prefill_sdpa_mxfp8 CTM: DTYPE_O={CFG.DTYPE_O} not supported " f"(expected 0=E4M3 / 1=E5M2 / 2=BF16 / 3=FP16)")
+    raise ValueError(f"prefill_sdpa_mxfp8: DTYPE_O={CFG.DTYPE_O} not supported " f"(expected 0=E4M3 / 1=E5M2 / 2=BF16 / 3=FP16)")
 
 
 # MXFP8 SF constants — E8M0 scale factor, 32 elems share one SF.
@@ -219,7 +219,7 @@ _resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
 
 # THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
 # factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
-# kernels/ctm/common/sdpa/thd.py.  Gated by CFG.THD_VARLEN (folds out otherwise).
+# the shared pre-upstream THD helper.  Gated by CFG.THD_VARLEN (folds out otherwise).
 # Supported at cga1 and cga2 (TILES_Q=2 → two Q slabs / O stores per tile).
 # seq_kv_lens overloaded as the THD metadata buffer (int32 len 3B+2):
 #   [0..B-1]=seq_kv_lens  [B..2B]=cu_q(B+1)  [2B+1..3B+1]=cu_k(B+1)
@@ -276,7 +276,7 @@ _O_SWZ_B = {128: 3, 64: 2, 32: 1}[CFG.O_SWZ_BYTES]
 _O_SMEM_SWIZZLE = cutlass.Swizzle(_O_SWZ_B, 4, 3)
 LEADING_BYTE_OFFSET_QK = 0
 
-_CTM_MMA_K_FP8 = _MXFP8_TILE_K_HW
+_MMA_K_FP8 = _MXFP8_TILE_K_HW
 STRIDE_BYTE_OFFSET_QK = 8 * CFG.Q_SWZ_BYTES
 
 # leading_byte_offset = 0 when (TILE_O/CTA_MMA)/8 <= 8 else TILE_N*V_SWZ_BYTES
@@ -285,7 +285,7 @@ _V_PC_COLS = CFG.TILE_O // CFG.CTA_MMA
 LEADING_BYTE_OFFSET_PV = 0 if (_V_PC_COLS // _CORE_MATRIX_ROWS) <= 8 else CFG.TILE_N * CFG.V_SWZ_BYTES
 STRIDE_BYTE_OFFSET_PV = 8 * CFG.V_SWZ_BYTES
 
-NUM_KPHASES_PV = CFG.TILE_N // _CTM_MMA_K_FP8
+NUM_KPHASES_PV = CFG.TILE_N // _MMA_K_FP8
 NUM_KPHASES_PV_PER_CHUNK = NUM_KPHASES_PV // CFG.N_BMM2_CHUNKS
 
 
@@ -1929,7 +1929,7 @@ def _correction_warp_group(
 
                 bars.mb_bmm2_done[qs].wait(bmm2_done_phase)
 
-                # vec_scale_pair emits mul_packed_f32x2; without it CTM lowers to scalar FMUL inside this runtime-if.
+                # vec_scale_pair emits mul_packed_f32x2; without it the DSL lowers to scalar FMUL inside this runtime-if.
                 # cfence after each chunk keeps ptxas from sinking next tcgen05_ld ahead of prior tcgen05_st (TMEM anti-dep).
                 if ~all_alpha_one:
                     for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm107.py
@@ -37,6 +37,20 @@ from cudnn.sdpa.fwd.config_sm107 import TemplateParams, make_cfg_d128_mxfp8
 
 PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
 CFG, _TMA = make_cfg_d128_mxfp8(PARAMS)
+
+# tcgen05 SMEM-descriptor version for EVERY SmemTile in this module -- ONE
+# decision point, wired into every construction below rather than repeated as a
+# per-tile literal.  A version-0 descriptor's ``start_address`` is 14 bits = a
+# 256 KiB window; Rubin raises the per-CTA SMEM cap to 327 KiB, so an operand
+# buffer at or above 256 KiB wraps to offset 0 and the MMA multiplies whatever
+# sits at the bottom of SMEM.  This flavor's buffers all stay below the line.
+#
+# Do NOT re-literal this at a call site: the d512 MXFP8 sibling shipped NaN on
+# 100% of cells because its scale-factor tiles were declared UNDER a comment
+# claiming "every operand tile here carries desc_version=1" -- without the
+# kwarg.  A single constant makes that class of drift impossible, and
+# test_sm107_descriptor_version_matches_the_smem_budget asserts it.
+DESC_VERSION: int = 0
 Cfg = type(CFG)
 TMA_QK_ITERS = _TMA.QK_ITERS
 TMA_VO_ITERS = _TMA.VO_ITERS
@@ -330,6 +344,7 @@ def _kernel(
         tma_loads_per_tile=TMA_QK_ITERS,
         tma_granu_elems=TMA_QK_GRANU_ELEMS,
         tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+        desc_version=DESC_VERSION,
     )
     sK = SmemTile(
         base=sK_raw,
@@ -341,6 +356,7 @@ def _kernel(
         tma_loads_per_tile=TMA_QK_ITERS,
         tma_granu_elems=TMA_QK_GRANU_ELEMS,
         tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+        desc_version=DESC_VERSION,
     )
     sV = SmemTile(
         base=sV_raw,
@@ -352,6 +368,7 @@ def _kernel(
         tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
         tma_granu_elems=TMA_VO_GRANU_ELEMS,
         tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+        desc_version=DESC_VERSION,
     )
     sO = SmemTile(
         base=sO_raw,
@@ -363,6 +380,7 @@ def _kernel(
         tma_loads_per_tile=TMA_O_ITERS_HOST,
         tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
         tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+        desc_version=DESC_VERSION,
     )
 
     # SF SmemTiles: no-swizzle, leading=16, stride=128. TMA-LDG warp issues one 5-D bulk.tensor per slab.
@@ -375,6 +393,7 @@ def _kernel(
         leading_byte_offset=SF_LEADING_BYTE_OFFSET,
         stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
         layout=SMEM_LAYOUT_SF,
+        desc_version=DESC_VERSION,
     )
     sK_SF = SmemTile(
         base=sK_SF_raw,
@@ -383,6 +402,7 @@ def _kernel(
         leading_byte_offset=SF_LEADING_BYTE_OFFSET,
         stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
         layout=SMEM_LAYOUT_SF,
+        desc_version=DESC_VERSION,
     )
     sP_SF = SmemTile(
         base=sP_SF_raw,
@@ -391,6 +411,7 @@ def _kernel(
         leading_byte_offset=SF_LEADING_BYTE_OFFSET,
         stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
         layout=SMEM_LAYOUT_SF,
+        desc_version=DESC_VERSION,
     )
     sV_SF = SmemTile(
         base=sV_SF_raw,
@@ -399,6 +420,7 @@ def _kernel(
         leading_byte_offset=SF_LEADING_BYTE_OFFSET,
         stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
         layout=SMEM_LAYOUT_SF,
+        desc_version=DESC_VERSION,
     )
 
     bars = make_classic_bars(CFG)
@@ -1964,23 +1986,51 @@ def _correction_warp_group(
                 lse_val = total_max_nat + cute.math.log(total_sum, fastmath=True)
                 # Safe inverse: avoid div by 0 (rows fully masked).
                 inv_sum = cutlass.Float32(1.0) / cute.math.max(total_sum, cutlass.Float32(1e-30))
+            # --- empty KV range (fully-masked / zero-length KV for this tile) ---
+            # Same guard as prefill_d256_mxfp8_sm107.py.  With bounds.right <=
+            # bounds.left the kv loop ran ZERO iterations, so BMM2 never
+            # overwrote the O accumulator (mma_ss overwrites only on its first
+            # k-step) and TMEM still holds the PREVIOUS persistent tile's O --
+            # residue, possibly a NaN bit pattern.
+            #
+            # The softmax warp still publishes (total_max = -inf, total_sum = 0)
+            # for an empty range, so LSE is already right on both arms: no-sink
+            # gives -inf + log(0) = -inf (this kernel puts NO 1e-30 floor on the
+            # log -- if one is ever added, the select below must cover lse_val
+            # too, or it leaks log(1e-30) = -69.08), and the sink arm folds to
+            # exactly sink_logit.  inv_sum, however, is 1/max(0, 1e-30) = 1e30
+            # (no sink) or 0 (sink), so O = residue * 1e30 -> +-inf/NaN, or
+            # residue * 0 -> NaN.  Zero O with a SELECT, never a multiply -- and
+            # BEFORE the amax fold below, or one dead row's NaN permanently
+            # inflates the graph's Amax_O for every live row (atomicMax only grows).
+            _kv_empty = bounds.right <= bounds.left
+            if cutlass.const_expr(not CFG.HAS_SINK):
+                lse_val = cutlass.Float32(arith.select(_kv_empty.ir_value(), cutlass.Float32(float("-inf")).ir_value(), lse_val.ir_value()))
 
             # OOB-row guard: under cga2 cluster Q rows can exceed seqlen_q (else write aliases next head's LSE slot).
             q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
+            # ONE row bound for BOTH the LSE write and the amax atomic below.
+            # They must stay tied: amax is an atomicMax, which only GROWS, so a
+            # single padded row folded in permanently inflates the graph's
+            # Amax_O for the whole tensor and no per-row check ever shows it.
+            # Dense-only today (compile() rejects THD on this kernel), but the
+            # THD arm is written out so a future port cannot diverge the two.
+            q_row_limit = seqlen_q
             if cutlass.const_expr(CFG.THD_VARLEN):
                 # THD: q_row_global is sequence-local; LSE is packed [1,QH,T] →
                 # index [0, head, cu_q[b] + local], bound by per-sequence Q len S_q_b.
                 _cu = cutlass.make_array_view(seq_kv_lens_tensor)
                 _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
                 _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
+                q_row_limit = _s_q_b
                 if cutlass.const_expr(lse_tensor is not None):
-                    if q_row_global < _s_q_b:
+                    if q_row_global < q_row_limit:
                         lse_arr = cutlass.make_array_view(lse_tensor)
                         lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
                         lse_row[_cu_q_b + q_row_global] = lse_val
             else:
                 if cutlass.const_expr(lse_tensor is not None):
-                    if q_row_global < seqlen_q:
+                    if q_row_global < q_row_limit:
                         lse_arr = cutlass.make_array_view(lse_tensor)
                         lse_row = lse_arr[batch_idx, head_idx, :]
                         lse_row[q_row_global] = lse_val
@@ -2002,6 +2052,14 @@ def _correction_warp_group(
                 )
                 nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                 o_scaled = o_chunk * inv_sum
+                # SELECT the zero for an empty KV range -- see _kv_empty above.
+                # NB: a plain `for` statement, not a comprehension -- the DSL
+                # preprocessor only rewrites statement-level range_constexpr
+                # loops ("range_constexpr should be preprocessed by preprocessor").
+                _o_elems = []
+                for _i in cutlass.range_constexpr(O_CHUNK):
+                    _o_elems.append(cutlass.Float32(arith.select(_kv_empty.ir_value(), cutlass.Float32(0.0).ir_value(), o_scaled[_i].ir_value())))
+                o_scaled = cutlass.Vector.from_elements(tuple(_o_elems), cutlass.Float32)
                 for _i in cutlass.range_constexpr(O_CHUNK):
                     _e = o_scaled[_i]
                     _amax_o_local = cute.math.max(_amax_o_local, cute.math.max(_e, -_e))
@@ -2018,7 +2076,7 @@ def _correction_warp_group(
                     bars.mb_o_empty[qs].wait(o_empty_phase)
                 smem_ptr.store_swizzled(o_out, alignment=64, swizzle=_O_SMEM_SWIZZLE)
 
-            if q_row_global < seqlen_q:
+            if q_row_global < q_row_limit:
                 nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
 
             # fence_proxy needed before TMA reads SMEM written by tcgen05_st.

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm107.py
@@ -4,10 +4,10 @@
 """
 DSL prefill SDPA kernel — classic pipeline, f16/bf16, d_qk=192 / d_v=128, SM107 (Rubin).
 
-Ported from the pre-upstream CTM kernel ``prefill_sdpa_f16.py``
-(CTM DSL) by frost_dev/port_ctm_kernel.py. The kernel BODY is the pre-upstream one,
-unchanged — only the DSL surface moved (ctm.* -> public cutlass/nvvm/cute, and
-tile_ctm -> cudnn.frost.tile_dsl). Two things are NOT mechanical and were done
+Ported from the pre-upstream kernel ``prefill_sdpa_f16.py``
+by the port script. The kernel BODY is the pre-upstream one,
+unchanged — only the DSL surface moved (the pre-upstream ops -> public cutlass/nvvm/cute, and
+the pre-upstream tile library -> cudnn.frost.tile_dsl). Two things are NOT mechanical and were done
 by hand:
 
   1. **Config.** The pre-upstream kernels picked a flavor with an env var;
@@ -27,7 +27,7 @@ not taken here.
 
 Original pre-upstream header follows.
 
-CTM-DSL port of the pre-upstream prefill SDPA kernel
+Port (from the pre-upstream DSL) of the pre-upstream prefill SDPA kernel
 (FP16, d_qk = 192 / d_v = 128 via ``make_cfg_d192``, TILES_Q = 2, two softmax
 warpgroups, four correction warps, persistent try_cancel scheduler).
 
@@ -218,7 +218,7 @@ _resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
 
 # THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
 # factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
-# kernels/ctm/common/sdpa/thd.py.  Gated by CFG.THD_VARLEN (folds out otherwise).
+# the shared pre-upstream THD helper.  Gated by CFG.THD_VARLEN (folds out otherwise).
 # Supported at cga1 and cga2 (TILES_Q=2 → two Q slabs / O stores per tile).
 # seq_kv_lens overloaded as the THD metadata buffer (int32 len 3B+2):
 #   [0..B-1]=seq_kv_lens  [B..2B]=cu_q(B+1)  [2B+1..3B+1]=cu_k(B+1)
@@ -302,7 +302,7 @@ def _kernel(
     bidy = cute.arch.block_idx()[1]
     bidz = cute.arch.block_idx()[2]
 
-    # SMEM allocations in natural Q/K/V/O order — CTM Tcgen05SmemDesc.build truncates
+    # SMEM allocations in natural Q/K/V/O order — Tcgen05SmemDesc.build truncates
     # start_address past ~256 KiB so this order keeps the data buffers in low SMEM.
     # QO_ALIAS: one Q∪O slab (TILES_Q × max(Q,O) elems); sO points into it and
     # strides by QO_SLAB_ELEMS so sO[qs] coincides with sQ[qs].  Else: separate
@@ -425,7 +425,7 @@ def _kernel(
         cga_arrive()
         cga_wait()
 
-    # CTM @cute.kernel stages if/else — use Python ternaries so the chosen
+    # @cute.kernel stages if/else — use Python ternaries so the chosen
     # expression flows into the trace (variables in branches aren't visible outside).
     cta_id_x = cute.arch.block_idx_in_cluster() if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
     cta_in_pair = (cta_id_x & cutlass.Int32(1)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
@@ -656,7 +656,7 @@ def _tmaldg_warp_group(
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
 
-    # CTM TMA descriptor is element-typed; contiguous coord is in ELEMENTS not bytes.
+    # the DSL's TMA descriptors is element-typed; contiguous coord is in ELEMENTS not bytes.
     K_ROW_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_N // CFG.CTA_MMA)
     V_COL_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_O // CFG.CTA_MMA)
 
@@ -1259,7 +1259,7 @@ def _softmax_kv_body(
     p_addr_base = tmem_base + cutlass.Int32(tmem_P_off)
     stats_addr = tmem_base + cutlass.Int32(stats_off)
 
-    # apply_mask is a Python bool — wrap in cutlass.const_expr so CTM folds
+    # apply_mask is a Python bool — wrap in cutlass.const_expr so the DSL folds
     # at trace time instead of staging cf.if (the two arms produce Vectors
     # built via different MLIR op sequences and the tracer would error).
     if cutlass.const_expr(apply_mask):
@@ -1342,7 +1342,7 @@ def _softmax_kv_body(
     # Rescale full reg_S in one vector op — emits same FFMA2 sequence as explicit half-tile rescales.
     reg_S = reg_S * scale_log2 - new_total_max
 
-    # Chunk 0 manual unroll — CTM's @cute.jit tracer makes the loop iter an
+    # Chunk 0 manual unroll — the DSL's @cute.jit tracer makes the loop iter an
     # MLIR value, breaking Python slice.indices() math inside RegTile[].
     chunk_S_0 = reg_S[0:CHUNK].vec
     chunk_P_0 = cute.math.exp2(chunk_S_0, fastmath=True)
@@ -1616,7 +1616,7 @@ def _correction_warp_group(
     tid_in_wg = tid_raw - cutlass.Int32(CFG.CORR_WARP_BASE * 32)
 
     # O_CHUNK=16 (halved from 32) shortens the alpha-rescale live range —
-    # at 32, CTM regalloc spilled correction-warp regs to the stack.
+    # at 32, the DSL's register allocator spilled correction-warp regs to the stack.
     O_CHUNK = 16
     N_CHUNKS_O = CFG.TILE_O // O_CHUNK
     # Use O_SWZ_B (NOT V_SWZ_B): under cga2 V is split along d_v and may drop
@@ -1733,7 +1733,7 @@ def _correction_warp_group(
             # Fire stat_empty so softmax's NEXT-tile iter 0 wait can pass.
             bars.mb_stat_empty[qs].arrive()
 
-            inv_sum = cutlass.Float32(0.0)  # pre-declare for CTM if-staging
+            inv_sum = cutlass.Float32(0.0)  # pre-declare for DSL if-staging
             lse_val = cutlass.Float32(0.0)
             # With sinks: fold the lift-the-max rescale into threshold_beta so O is scaled by scale/new_sum in one FMUL.
             LN2 = cutlass.Float32(0.6931471805599453)
@@ -1960,7 +1960,7 @@ def _host(
         ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
         grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
     else:
-        # Grid Python-folds on Cfg constant (avoids CTM if staging).
+        # Grid Python-folds on Cfg constant (avoids DSL if-staging).
         grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
     _kernel(
         tma_q_desc,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm107.py
@@ -1,0 +1,2059 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""
+DSL prefill SDPA kernel — classic pipeline, f16/bf16, d=128, SM107 (Rubin).
+
+Ported from the pre-upstream CTM kernel ``prefill_sdpa_f16.py``
+(CTM DSL) by frost_dev/port_ctm_kernel.py. The kernel BODY is the pre-upstream one,
+unchanged — only the DSL surface moved (ctm.* -> public cutlass/nvvm/cute, and
+tile_ctm -> cudnn.frost.tile_dsl). Two things are NOT mechanical and were done
+by hand:
+
+  1. **Config.** The pre-upstream kernels picked a flavor with an env var;
+     FROST forbids env-var configuration, so this reads TemplateParams via the
+     FROST_TEMPLATE_PARAMS global (engine contract §5/§6).
+  2. **TMA descriptors.** ``create_tensor_map_tiled_from_tensor`` became
+     ``..._from_view`` — a signature change, not a rename.
+
+Geometry is FROST's ``make_cfg_d192`` (d_qk=192, d_v=128) as-is.
+Same body as ``prefill_d128_f16_sm107.py`` -- the pre-upstream base kernel is
+flavor-generic (it served llama/dsv3/gptoss off one file by swapping
+sdpa_config_<flavor>), and CfgD192/CfgD128 have identical field sets, so
+the ONLY difference is the config factory. the pre-upstream helper would give
+STAGES_KV = 2*CTA_MMA (4 at cga2) where FROST gives 2; the deeper ring is a
+PERF lever and this port is for FUNCTIONAL coverage first, so it is deliberately
+not taken here.
+
+Original pre-upstream header follows.
+
+CTM-DSL port of the pre-upstream prefill SDPA kernel
+(llama flavor: FP16, d_qk = d_v = 128, TILES_Q = 2, two softmax
+warpgroups, four correction warps, persistent try_cancel scheduler).
+
+Same kernel shape as the C++ source: pipeline, TMEM/SMEM layout,
+barrier inventory + init counts, scheduler, warp dispatch, register
+split match.  Canonical reference port; reaches ~0.99x C++ TFLOPS.
+
+THD / varlen (``CFG.THD_VARLEN=1``, the pre-upstream packed-varlen entry point)
+is supported (f16/bf16) for all three d=128 flavors (llama / dsv3 / gptoss) at
+cga1 and cga2: packed ``[1,T,H,D]`` + ``cu_seqlens`` coord offset (applied to
+both Q slabs under TILES_Q=2), per-batch O TMA-descriptor array (shared
+``kernels/ctm/common/sdpa/thd.py``), packed ``[1,QH,T]`` LSE.  The dense
+``[B,S,H,D]`` path is byte-identical.
+"""
+
+import os
+import sys
+from functools import lru_cache
+from typing import Callable, Optional, Tuple
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO_DIR = os.path.normpath(os.path.join(_HERE, "..", "..", "..", "..", ".."))
+_PYTHON_DIR = os.path.join(_REPO_DIR, "python")
+_CONFIGS_DIR = os.path.normpath(os.path.join(_HERE, "..", "configs"))
+# Shared THD / varlen device helpers (build_o_descs_kernel + TENSOR_MAP_QWORDS).
+_COMMON_SDPA_DIR = os.path.normpath(os.path.join(_HERE, "..", "..", "..", "common", "sdpa"))
+for _p in (_PYTHON_DIR, _CONFIGS_DIR, _COMMON_SDPA_DIR):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from cutlass.base_dsl.typing import Pointer
+from cutlass.experimental import primitives as nvvm
+from cutlass.experimental.primitives import vote_sync, VoteSync
+from cutlass.experimental.cuda import tensor_map as tmap
+from cutlass._mlir.dialects import arith
+
+import cutlass
+from cutlass.experimental import primitives as prims
+import cutlass.cute as cute
+import cuda.bindings.driver as _cuda_driver  # noqa: F401  (cute.compile pulls cuda)
+
+from dataclasses import dataclass
+
+# Config comes from the FROST template loader, NOT an env var: the pre-upstream
+# kernels picked a flavor with an env var + a sdpa_config_<flavor> module, which the
+# FROST engine contract forbids ("no environment variables for configuration" —
+# parameters travel as typed dataclasses). The loader injects
+# FROST_TEMPLATE_PARAMS before this body runs; the default keeps a direct
+# `import` usable as a standalone driver.
+from cudnn.sdpa.fwd.config_sm107 import TemplateParams, make_cfg_d192
+
+PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
+CFG, _TMA = make_cfg_d192(PARAMS)
+Cfg = type(CFG)
+TMA_QK_ITERS = _TMA.QK_ITERS
+TMA_VO_ITERS = _TMA.VO_ITERS
+TMA_QK_GRANU_ELEMS = _TMA.QK_GRANU_ELEMS
+TMA_VO_GRANU_ELEMS = _TMA.VO_GRANU_ELEMS
+
+# O TMA box / store params follow O's swizzle, not V's (under cga2 V may drop to a narrower swizzle while O stays Swz128B).
+TMA_O_GRANU_ELEMS_HOST = CFG.O_SWZ_BYTES // CFG.BPE
+TMA_O_ITERS_HOST = (CFG.TILE_O * CFG.BPE) // CFG.O_SWZ_BYTES
+
+from typing import NamedTuple
+
+from cudnn.frost.tile_dsl.barrier import (
+    PipelineState,
+    advance,
+    cga_arrive,
+    cga_wait,
+    # `wait` (free fn) — still used for sched.mb_* (Sched is not in Bars yet;
+    # only the per-kernel Bars NamedTuple was migrated to MBarrier in this step).
+    wait,
+)
+from cudnn.frost.tile_dsl.scheduler import (
+    Sched,
+    scheduler_warp_loop,
+    read_tile_id_arrive,
+    SCHED_NATURAL,
+    SCHED_LPT,
+    SCHED_LPT_L2,
+)
+from cudnn.frost.tile_dsl.pointwise import (
+    tmem_load_max_reduction_tile,
+    row_reduction_pair,
+    row_max_reduction,
+    vec_scale_pair,
+)
+from cudnn.frost.tile_dsl.regtile import RegTile, vec_concat
+from cudnn.frost.tile_dsl.mma import mma_ss, mma_ts_step
+from cudnn.frost.tile_dsl.tma import tma_load_tile, tma_store_tile, tma_store_commit, tma_store_wait
+from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, tma_slice_runtime_desc
+from cudnn.frost.tile_dsl.tmem import tmem_alloc, tmem_dealloc
+from cudnn.frost.tile_dsl.mask import (
+    apply_mask_chunk,
+    MASK_NONE,
+    MASK_PADDED,
+    MASK_CAUSAL,
+    MASK_SWA,
+)
+
+# Storage dtype + MMA kind dispatch — folded at trace time on CFG.DTYPE_QKV.
+if CFG.DTYPE_QKV == 2:
+    STORAGE_DTYPE = cutlass.BFloat16
+    P_STORAGE_DTYPE = cutlass.BFloat16
+    MMA_KIND = nvvm.Tcgen05MMAKind.F16
+    IS_TF32 = False
+elif CFG.DTYPE_QKV == 3:
+    STORAGE_DTYPE = cutlass.Float16
+    P_STORAGE_DTYPE = cutlass.Float16
+    MMA_KIND = nvvm.Tcgen05MMAKind.F16
+    IS_TF32 = False
+elif CFG.DTYPE_QKV == 4:
+    # TF32: 4-byte FP32 storage, kind::tf32 MMA (HW rounds operands to a
+    # 10-bit mantissa).  Mirrors the C++ prefill_sdpa_f16.cu IS_TF32 path.
+    # Three TF32-specific deltas vs BF16/FP16 (all folded on IS_TF32 below):
+    #   1. V (the transposed BMM2 operand) SmemDesc + TMA use
+    #      SWIZZLE_128B_ATOM_32B (enc=1, leading=TILE_N*128, stride=512).
+    #      Standard Swz128B with kind::tf32 + b_trans silently returns all-0.
+    #   2. P TMEM packing is 1:1 (one FP32 cell per prob) vs 2:1 for
+    #      fp16/bf16, so P aliases the FULL S_acc slot, not just its tail.
+    #   3. BPE=4 doubles every SMEM/TMA byte count (sized off CFG.BPE).
+    STORAGE_DTYPE = cutlass.Float32
+    P_STORAGE_DTYPE = cutlass.Float32
+    MMA_KIND = nvvm.Tcgen05MMAKind.TF32
+    IS_TF32 = True
+else:
+    raise ValueError(f"prefill_sdpa_f16: DTYPE_QKV={CFG.DTYPE_QKV} not supported " f"(expected 2=BF16, 3=FP16, or 4=TF32)")
+
+
+from cudnn.sdpa.fwd.kernels._common_sm100 import (
+    Bars,
+    KvLoopBounds,
+    make_classic_bars,
+    compute_kv_loop_bounds,
+    lpt_tile_coords,
+    make_sdpa_helpers,
+)
+
+CGA_SIZE = CFG.CGA_M * CFG.CGA_N
+
+CTA_GROUP_KIND = nvvm.CTAGroup.CTA_2 if CFG.CTA_MMA == 2 else nvvm.CTAGroup.CTA_1
+
+# Per-CTA buffer element counts + collective TMA transaction byte counts.
+# K (seq rows) and V (d_v cols) shrink by CTA_MMA; Q / O are per-CTA full.
+# At cga2 leader's expect_tx = per-CTA elems * BPE * CTA_MMA (collective bytes).
+qBufferElems = CFG.TILE_M * CFG.TILE_K
+kBufferElems = CFG.TILE_N * CFG.TILE_K // CFG.CTA_MMA
+vBufferElems = CFG.TILE_O * CFG.TILE_N // CFG.CTA_MMA
+oBufferElems = CFG.TILE_M * CFG.TILE_O
+
+# Q∪O alias (dsv3 TF32): O reuses Q's SMEM slab once BMM1 has consumed Q.
+# Each of the TILES_Q slabs is sized to max(Q,O) so sQ[qs] and sO[qs] coincide;
+# for the classic flavors d_qk >= d_v so the slab is qBufferElems.  TMA-STG
+# arrives mb_q_o_alias after O drains; TMA-LDG waits it before reloading Q.
+IS_QO_ALIAS = bool(CFG.QO_ALIAS)
+QO_SLAB_ELEMS = max(qBufferElems, oBufferElems)
+
+qTmaTransactionBytes = qBufferElems * CFG.BPE * CFG.CTA_MMA
+kTmaTransactionBytes = kBufferElems * CFG.BPE * CFG.CTA_MMA
+vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
+
+
+CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+
+
+_sdpa_h = make_sdpa_helpers(CFG)
+_decode_initial = _sdpa_h.decode_initial
+_decode_payload = _sdpa_h.decode_payload
+_bounds_for_tile = _sdpa_h.bounds_for_tile
+_resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+
+# THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
+# factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
+# kernels/ctm/common/sdpa/thd.py.  Gated by CFG.THD_VARLEN (folds out otherwise).
+# Supported at cga1 and cga2 (TILES_Q=2 → two Q slabs / O stores per tile).
+# seq_kv_lens overloaded as the THD metadata buffer (int32 len 3B+2):
+#   [0..B-1]=seq_kv_lens  [B..2B]=cu_q(B+1)  [2B+1..3B+1]=cu_k(B+1)
+# THD: FROST's builder is NOT the pre-upstream one, which was 7-arg, O-descriptors-
+# only build_o_descs_kernel; FROST does per-execute meta + O (+ K/V base descs)
+# in one elected-thread kernel with a 14-arg contract, and ships a dedicated
+# f16/bf16 entry point. The import is corrected here; the CALL SITE still speaks
+# the pre-upstream contract and is taken from the shipped fp8 SM107 sibling when THD
+# is wired (dense path first — see the module header).
+from cudnn.sdpa.fwd.kernels.thd_helpers import build_thd_meta_o_descs_kernel as _build_o_descs_kernel, TENSOR_MAP_QWORDS
+
+_TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
+_dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
+_dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
+_thd_tma_offsets = _sdpa_h.thd_tma_offsets
+
+
+# P (BMM2 operand) aliases the TAIL of each 128-col S_acc slot since BMM1
+# finishes (and softmax loads S into registers) before P is written.
+# fp16/bf16 pack 2 probs per FP32 cell → P width = TILE_N/2 ≤ 64 cols → P
+# sits at slot offset 64.  TF32 is 1:1 → P width = TILE_N, so P aliases the
+# FULL slot (offset 0 / 128).  Mirrors C++ S_bmm2_0 = S_acc_cols - S_bmm2_cols.
+_P0_OFF = 0 if IS_TF32 else 64
+_P1_OFF = 128 if IS_TF32 else 192
+
+
+@dataclass(frozen=True)
+class KernelTmemLayout:
+    """Column offsets for the classic 2-sub-tile SDPA pipeline.
+
+    Stats deliberately sit outside S_acc/O ranges so BMM1's next-iter
+    write doesn't clobber them.  P aliases the tail of S_acc[qs] since
+    BMM1 finishes before P is written.
+    """
+
+    # Rubin SM10.7 cap; requires is_exclusive=True on tcgen05_alloc.
+    TOTAL_COLS: int = 576
+
+    S0_OFF: int = 0
+    S1_OFF: int = 128
+
+    O0_OFF: int = 256
+    O1_OFF: int = 384
+
+    P0_OFF: int = _P0_OFF
+    P1_OFF: int = _P1_OFF
+
+    # qs stride = 8 cols.
+    STATS_OFF: int = 544
+
+
+LAYOUT = KernelTmemLayout()
+
+
+# === Kernel ===
+
+
+@cute.kernel
+def _kernel(
+    tma_q_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_k_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_v_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_o_desc: cutlass.GridConstant[tmap.TensorMap],
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    seqlen_q: cutlass.Int32,
+    seqlen_kv: cutlass.Int32,
+    n_q_supers: cutlass.Int32,
+    n_qh: cutlass.Int32,
+    n_batch: cutlass.Int32,
+    qh_per_kh: cutlass.Int32,
+    scale_softmax_log2: cutlass.Float32,
+) -> None:
+
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    tidx, _, _ = cute.arch.thread_idx()
+
+    bidx = cute.arch.block_idx()[0]
+    bidy = cute.arch.block_idx()[1]
+    bidz = cute.arch.block_idx()[2]
+
+    # SMEM allocations in natural Q/K/V/O order — CTM Tcgen05SmemDesc.build truncates
+    # start_address past ~256 KiB so this order keeps the data buffers in low SMEM.
+    # QO_ALIAS: one Q∪O slab (TILES_Q × max(Q,O) elems); sO points into it and
+    # strides by QO_SLAB_ELEMS so sO[qs] coincides with sQ[qs].  Else: separate
+    # Q and O buffers (the classic layout).
+    if cutlass.const_expr(IS_QO_ALIAS):
+        sQ_raw = cutlass.Array(STORAGE_DTYPE, CFG.TILES_Q * QO_SLAB_ELEMS, alignment=1024, space=cutlass.AddressSpace.smem)
+        sO_raw = sQ_raw
+        _SO_STAGE_ELEMS = QO_SLAB_ELEMS
+    else:
+        sQ_raw = cutlass.Array(STORAGE_DTYPE, CFG.TILES_Q * qBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+        sO_raw = cutlass.Array(STORAGE_DTYPE, CFG.TILES_Q * oBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+        _SO_STAGE_ELEMS = oBufferElems
+    sK_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * kBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    sV_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * vBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+
+    sQ = SmemTile(
+        base=sQ_raw,
+        elems_per_stage=qBufferElems,
+        stages=CFG.TILES_Q,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+    )
+    sK = SmemTile(
+        base=sK_raw,
+        elems_per_stage=kBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+    )
+    sV = SmemTile(
+        base=sV_raw,
+        elems_per_stage=vBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_PV,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_PV,
+        layout=SMEM_LAYOUT_V,
+        # V is split along d_v under cga2 → tma_loads_per_tile = TMA_VO_ITERS / CTA_MMA.
+        tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
+        tma_granu_elems=TMA_VO_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+    )
+    sO = SmemTile(
+        base=sO_raw,
+        elems_per_stage=_SO_STAGE_ELEMS,
+        stages=CFG.TILES_Q,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_O_ITERS_HOST,
+        tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+    )
+
+    bars = make_classic_bars(CFG)
+
+    tmem_ptr_i32 = cutlass.Array(cutlass.Int32, 1, alignment=16, space=cutlass.AddressSpace.smem)
+
+    # tile_id_smem stride 8 Int32/stage (32 B) = 16 B try_cancel payload + 16 B padding.
+    sched = Sched(
+        **{
+            "mb_scheduler": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "mb_read_tile_id": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "tile_id_smem": cutlass.Array(cutlass.Int32, CFG.SCHEDULER_STAGES * 8, alignment=16, space=cutlass.AddressSpace.smem),
+            "bidx_init": bidx,
+            "bidy_init": bidy,
+            "bidz_init": bidz,
+        }
+    )
+
+    # Scheduler mbar arrive count — stays kernel-local (sched is NOT in Bars).
+    READ_TILE_ARRIVERS_TOTAL = ((CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS) + CFG.CORRECTION_WARPS + 1 + 1) * CGA_SIZE + (CFG.CGA_M // CFG.CTA_MMA)
+
+    if warp_idx == 0:
+        if nvvm.elect_sync():
+            # range_constexpr → Python-int loop variable so bars.mb_X[qs].init()
+            # can index the per-stage init_count tuple (mb_bmm2_ready) at trace
+            # time.  Loop bounds are small (TILES_Q=2, STAGES_KV=2-4) — unroll
+            # is free.
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                bars.mb_q_full[qs].init()
+                bars.mb_q_empty[qs].init()
+                bars.mb_bmm1_done[qs].init()
+                bars.mb_bmm2_done[qs].init()
+                bars.mb_stat_full[qs].init()
+                bars.mb_stat_empty[qs].init()
+                bars.mb_o_full[qs].init()
+                bars.mb_o_empty[qs].init()
+                if cutlass.const_expr(IS_QO_ALIAS):
+                    bars.mb_q_o_alias[qs].init()
+                for c in cutlass.range_constexpr(CFG.N_BMM2_CHUNKS):
+                    bars.mb_bmm2_ready[qs * CFG.N_BMM2_CHUNKS + c].init()
+            for ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_k_full[ks].init()
+                bars.mb_k_empty[ks].init()
+                bars.mb_v_full[ks].init()
+                bars.mb_v_empty[ks].init()
+            for s in range(CFG.SCHEDULER_STAGES):
+                nvvm.mbarrier_init(sched.mb_scheduler.subview(s), CFG.ONE_LANE)
+                nvvm.mbarrier_init(sched.mb_read_tile_id.subview(s), READ_TILE_ARRIVERS_TOTAL)
+            bars.mb_tmem_dealloc.init()
+            bars.mb_empty_mainloop.init()
+
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync()
+
+    # P4: cluster fence gates cga2 cross-CTA arrive_on_peer on peer init.
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        cga_arrive()
+        cga_wait()
+
+    # CTM @cute.kernel stages if/else — use Python ternaries so the chosen
+    # expression flows into the trace (variables in branches aren't visible outside).
+    cta_id_x = cute.arch.block_idx_in_cluster() if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    cta_in_pair = (cta_id_x & cutlass.Int32(1)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    leader_cta_id = (cta_id_x & cutlass.Int32(~1 & 0xFFFFFFFF)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    mcast_mask = (cutlass.Int32(3) << leader_cta_id) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    # TMA-load self-bit mask: each peer's cta_group::2 TMA targets its own bit;
+    # cga2 routing strips bit-24 so bytes land on leader's mbar.
+    tma_mcast_mask = (cutlass.Int16(1) << cta_in_pair) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
+    is_leader = cta_in_pair == cutlass.Int32(0)
+
+    # === Per-warp role dispatch ===
+    if warp_idx >= CFG.SOFTMAX_WG0_BASE and warp_idx < CFG.SOFTMAX_WG0_BASE + CFG.SOFTMAX_WG_WARPS:
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        _softmax_warp_group(
+            sub_tile_id=0,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_softmax_log2,
+            tmem_ptr_i32=tmem_ptr_i32,
+            sQ=sQ,
+            bars=bars,
+            sched=sched,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+        )
+
+    elif warp_idx >= CFG.SOFTMAX_WG1_BASE and warp_idx < CFG.SOFTMAX_WG1_BASE + CFG.SOFTMAX_WG_WARPS:
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        _softmax_warp_group(
+            sub_tile_id=1,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_softmax_log2,
+            tmem_ptr_i32=tmem_ptr_i32,
+            sQ=sQ,
+            bars=bars,
+            sched=sched,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+        )
+
+    elif warp_idx >= CFG.CORR_WARP_BASE and warp_idx < CFG.CORR_WARP_BASE + CFG.CORRECTION_WARPS:
+        nvvm.setmaxregister(CFG.CORRECTION_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _correction_warp_group(
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            sO=sO,
+            tmem_ptr_i32=tmem_ptr_i32,
+            tidx=tidx,
+            bars=bars,
+            sched=sched,
+            lse_tensor=lse_tensor,
+            sinks_tensor=sinks_tensor,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+            cta_id_x=cta_id_x,
+        )
+
+    elif warp_idx == CFG.MMA_WARP_ID:
+        # Under cga2 the non-leader CTA runs the quiet body (alloc + dealloc only).
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        if cutlass.const_expr(CFG.CTA_MMA == 2):
+            if is_leader:
+                _mma_warp_group(
+                    seqlen_q=seqlen_q,
+                    seqlen_kv=seqlen_kv,
+                    sQ=sQ,
+                    sK=sK,
+                    sV=sV,
+                    tmem_ptr_i32=tmem_ptr_i32,
+                    bars=bars,
+                    sched=sched,
+                    seq_kv_lens_tensor=seq_kv_lens_tensor,
+                    n_q_supers=n_q_supers,
+                    n_qh=n_qh,
+                    n_batch=n_batch,
+                    mcast_mask=mcast_mask,
+                    cta_in_pair=cta_in_pair,
+                )
+            else:
+                _mma_warp_quiet(tmem_ptr_i32, bars)
+        else:
+            _mma_warp_group(
+                seqlen_q=seqlen_q,
+                seqlen_kv=seqlen_kv,
+                sQ=sQ,
+                sK=sK,
+                sV=sV,
+                tmem_ptr_i32=tmem_ptr_i32,
+                bars=bars,
+                sched=sched,
+                seq_kv_lens_tensor=seq_kv_lens_tensor,
+                n_q_supers=n_q_supers,
+                n_qh=n_qh,
+                n_batch=n_batch,
+                mcast_mask=mcast_mask,
+                cta_in_pair=cta_in_pair,
+            )
+
+    elif warp_idx == CFG.TMALDG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        nvvm.prefetch_tensormap(tma_q_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_k_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_v_desc.get_ptr())
+        _tmaldg_warp_group(
+            tma_q_desc=tma_q_desc,
+            tma_k_desc=tma_k_desc,
+            tma_v_desc=tma_v_desc,
+            sQ=sQ,
+            sK=sK,
+            sV=sV,
+            bars=bars,
+            sched=sched,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            qh_per_kh=qh_per_kh,
+            is_leader=is_leader,
+            cta_in_pair=cta_in_pair,
+            tma_mcast_mask=tma_mcast_mask,
+        )
+
+    elif warp_idx == CFG.TMASTG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _tmastg_warp_group(
+            tma_o_desc=tma_o_desc,
+            sO=sO,
+            bars=bars,
+            sched=sched,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            cta_in_pair=cta_in_pair,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
+        )
+
+    else:  # warp_idx == CFG.SCHED_WARP_ID
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        # try_cancel.multicast::cluster::all — only (0,0,0) CTA issues; at cga1
+        # cta_id_x == 0 always, so flag is 1 unconditionally.
+        is_cga_first_cta = cta_id_x == cutlass.Int32(0)
+        scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
+
+
+# === TMA-LDG warp ===
+
+
+@cute.jit
+def _tmaldg_warp_group(
+    tma_q_desc,
+    tma_k_desc,
+    tma_v_desc,
+    sQ,
+    sK,
+    sV,
+    bars,
+    sched,
+    seqlen_q,
+    seqlen_kv,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    qh_per_kh,
+    is_leader,
+    cta_in_pair,
+    tma_mcast_mask,
+):
+    """Unified TMA-LDG warp — cga1 / cga2 x MASK_NONE / PADDED / CAUSAL / SWA.
+
+    Spill-free in CFG.OTHER_REGS via q_row_base pre-multiplied after each
+    scheduler decode (gives ptxas a live use of nxt_q before the loop
+    back-edge, keeping the LDS.128 result in uniform registers).
+    """
+    q_empty_phase = cutlass.Int32(1)
+    kv_state = PipelineState.start(phase=1)
+
+    # Q-reload gate: under QO_ALIAS the next tile's Q-load must wait for the
+    # prior tile's O (sharing the slab) to drain — TMA-STG fires mb_q_o_alias
+    # (strictly after MMA consumed Q).  Else gate on mb_q_empty (MMA commit).
+    # Both bootstrap consumer-side via q_empty_phase=1.
+    mb_q_reload = bars.mb_q_o_alias if cutlass.const_expr(IS_QO_ALIAS) else bars.mb_q_empty
+
+    tma_q = GmemTileTma(tma_q_desc)
+    tma_k = GmemTileTma(tma_k_desc)
+    tma_v = GmemTileTma(tma_v_desc)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    # GQA: K/V are indexed by kv-head, not Q-head.
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+    q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    # CTM TMA descriptor is element-typed; contiguous coord is in ELEMENTS not bytes.
+    K_ROW_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_N // CFG.CTA_MMA)
+    V_COL_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_O // CFG.CTA_MMA)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+            pass
+        else:
+            # Prologue interleave Q[0] -> K[first] -> Q[1] -> V[first] -> mainloop —
+            # K load starts before Q[1] is issued and V before kv mainloop.
+            kv_row_base = kv_left * CFG.TILE_N
+
+            mb_q_reload[0].wait(q_empty_phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_q_full[0].arrive(n_bytes=qTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_q_full[0].arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sQ[0],
+                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(0 * CFG.TILE_M) + q_seq_off, tma_batch),
+                bars.mb_q_full[0].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+
+            bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sK[kv_state.idx],
+                tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER, batch_idx),
+                bars.mb_k_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+
+            mb_q_reload[1].wait(q_empty_phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_q_full[1].arrive(n_bytes=qTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_q_full[1].arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sQ[1],
+                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(1 * CFG.TILE_M) + q_seq_off, tma_batch),
+                bars.mb_q_full[1].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+            q_empty_phase = q_empty_phase ^ 1
+
+            bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sV[kv_state.idx],
+                tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
+                bars.mb_v_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+
+            for kv_loop in cutlass.range(kv_left + cutlass.Int32(1), kv_right, 1, unroll=1):
+                kv_row_base = kv_loop * CFG.TILE_N
+
+                bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sK[kv_state.idx],
+                    tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
+                    bars.mb_k_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+
+                bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sV[kv_state.idx],
+                    tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
+                    bars.mb_v_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+        nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+        nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+        # q_row_base compute right after decode drives ptxas R2UR.
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+        q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+
+    # cga2: drain trailing empty mbar arrives so SMEM isn't torn down while
+    # leader's multicast commits are still in-flight.
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        for _qs in cutlass.range_constexpr(CFG.TILES_Q):
+            mb_q_reload[_qs].wait(q_empty_phase)
+        q_empty_phase = q_empty_phase ^ cutlass.Int32(1)
+        for _ks in cutlass.range_constexpr(CFG.STAGES_KV):
+            bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+            bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+
+# === TMA-STG warp ===
+
+
+@cute.jit
+def _tmastg_warp_group(
+    tma_o_desc,
+    sO,
+    bars,
+    sched,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    cta_in_pair,
+    seq_kv_lens_tensor,
+    o_desc_words,
+):
+    """Persistent O-store warp.  First tile from blockIdx; subsequent tiles
+    via scheduler warp's clusterlaunchcontrol.try_cancel.async.
+    """
+    o_full_phase = cutlass.Int32(0)  # consumer waits — first-arrive flips 0 → 1
+
+    tma_o = GmemTileTma(tma_o_desc)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        q_row_base = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+
+        for qs in cutlass.range_constexpr(CFG.TILES_Q):
+            bars.mb_o_full[qs].wait(o_full_phase)
+
+            # O TMA params follow O's swizzle (NOT V's) — under gptoss cga2 V drops to Swz64B while O stays Swz128B.
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: store each Q slab through this batch's pre-built descriptor
+                # (base at the sequence's packed row, seq extent = S_q_b → a box
+                # past S_q_b is OOB-clipped).  q_row coord is sequence-local; the
+                # batch coord collapses to 0.  Both slabs share one descriptor.
+                o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), cutlass.Int32(0))
+                tma_store_tile(sO[qs], o_slice)
+            else:
+                tma_store_tile(
+                    sO[qs],
+                    tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), batch_idx),
+                )
+
+            tma_store_commit()
+            tma_store_wait(0)
+
+            bars.mb_o_empty[qs].arrive()
+            # QO_ALIAS: O[qs] has drained to GMEM → the shared Q∪O slab is free
+            # for TMA-LDG to clobber with the next tile's Q[qs].
+            if cutlass.const_expr(IS_QO_ALIAS):
+                bars.mb_q_o_alias[qs].arrive()
+
+        o_full_phase = o_full_phase ^ 1
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+
+# === BMM1 / BMM2 SMEM + idesc constants ===
+
+# Per-tensor swizzle layout enum: SWIZZLE_128B_ATOM_32B=1, Swz128B=2,
+# Swz64B=4, Swz32B=6.
+_SWZ_ENUM = {128: 2, 64: 4, 32: 6}
+_SWZ_ATOM_32B = 1  # required on the transposed BMM2 operand (V) under kind::tf32
+SMEM_LAYOUT_Q = _SWZ_ENUM[CFG.Q_SWZ_BYTES]
+SMEM_LAYOUT_K = _SWZ_ENUM[CFG.K_SWZ_BYTES]
+# V is the B-transposed BMM2 operand → TF32 needs SWIZZLE_128B_ATOM_32B.
+# Q/K (BMM1, non-transposed) and O keep standard swizzle for all dtypes.
+SMEM_LAYOUT_V = _SWZ_ATOM_32B if IS_TF32 else _SWZ_ENUM[CFG.V_SWZ_BYTES]
+SMEM_LAYOUT_O = _SWZ_ENUM[CFG.O_SWZ_BYTES]
+SMEM_LAYOUT_QKO = SMEM_LAYOUT_Q
+
+# O SMEM swizzle: third param is the XOR shift offset (=3 across all widths), NOT the B value.
+_O_SWZ_B = {128: 3, 64: 2, 32: 1}[CFG.O_SWZ_BYTES]
+_O_SMEM_SWIZZLE = cutlass.Swizzle(_O_SWZ_B, 4, 3)
+
+LEADING_BYTE_OFFSET_QK = 0
+STRIDE_BYTE_OFFSET_QK = 8 * CFG.Q_SWZ_BYTES
+
+# leading_byte_offset = 0 when (TILE_O/CTA_MMA)/8 <= 8 else TILE_N*V_SWZ_BYTES
+# TF32 ATOM32 override (mirrors C++ prefill_sdpa_f16.cu:803-806): the
+# SWIZZLE_128B_ATOM_32B mode pins leading = TILE_N*128, stride = 512 (NOT
+# the standard 8*V_SWZ).  Standard formulas with kind::tf32 silently zero C.
+_CORE_MATRIX_ROWS = 8
+_V_PC_COLS = CFG.TILE_O // CFG.CTA_MMA
+_LEADING_PV_STD = 0 if (_V_PC_COLS // _CORE_MATRIX_ROWS) <= 8 else CFG.TILE_N * CFG.V_SWZ_BYTES
+LEADING_BYTE_OFFSET_PV = (CFG.TILE_N * 128) if IS_TF32 else _LEADING_PV_STD
+STRIDE_BYTE_OFFSET_PV = 512 if IS_TF32 else (8 * CFG.V_SWZ_BYTES)
+
+NUM_KPHASES_PV = CFG.TILE_N // CFG.TILE_K_HW_BMM2
+NUM_KPHASES_PV_PER_CHUNK = NUM_KPHASES_PV // CFG.N_BMM2_CHUNKS
+
+
+@cute.jit
+def _mma_warp_quiet(tmem_ptr_i32, bars):
+    """Minimal quiet body for the non-leader CTA's MMA-warp slot under cga2.
+
+    Non-leader still participates in TMEM alloc / release lock (warp-collective
+    .sync.aligned ops) and TMEM-publish named barriers — leader's MMA reads
+    through the cluster crossbar from peer's TMEM during cga2 collective MMA.
+    """
+    # All-lanes warp-collective ops — NO elect_sync gating.
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND, is_exclusive=True)
+    # Match lead MMA's named-barrier arrive count (lead is +1 on both publish barriers).
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _mma_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    sQ,
+    sK,
+    sV,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    mcast_mask,
+    cta_in_pair,
+):
+    """Unified MMA warp — cga1 / cga2-leader x MASK_NONE / PADDED / CAUSAL / SWA,
+    spill-free in CFG.OTHER_REGS (40).  Non-leader under cga2 uses _mma_warp_quiet.
+    """
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND, is_exclusive=True)
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    tmem_raw = nvvm.make_tmem_ptr(tmem_ptr_i32.load(), cutlass.Int8)
+
+    # idesc M is COLLECTIVE (per-CTA M * CTA_MMA): cga2 tcgen05.mma.cta_group::2
+    # reads both peers' A and produces 2*LOCAL_M output rows.
+    idesc_qk = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_N,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+    )
+    idesc_pv = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_O,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        b_major=1,
+    )
+    bmm1_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_N,
+        K=CFG.TILE_K,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=CFG.TILE_K_HW_BMM1,
+        btranspose=False,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_qk,
+        kind=MMA_KIND,
+    )
+    # BMM2 V uses non-default K_SUBTILE = V_SWZ_BYTES/BPE (cga2 V Swz64B on dsv3/gptoss).
+    bmm2_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_O,
+        K=CFG.TILE_N,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=CFG.TILE_K_HW_BMM2,
+        btranspose=True,
+        k_subtile=CFG.V_SWZ_BYTES // CFG.BPE,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_pv,
+        kind=MMA_KIND,
+    )
+
+    desc_Q0 = sQ[0].desc()
+    desc_Q1 = sQ[1].desc()
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        q_super_idx, _hd, batch_idx = _dispatch_decode_initial(
+            sched.bidx_init,
+            sched.bidy_init,
+            sched.bidz_init,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    q_full_phase = cutlass.Int32(0)
+    kv_state = PipelineState.start(phase=0)
+    bmm2_ready_phase = cutlass.Int32(0)
+    # Initialised unconditionally so type is stable across const_expr branches.
+    empty_mainloop_phase = cutlass.Int32(0)
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+            # Empty mainloop: fire both bmm2_done so softmax/correction phase trackers stay in lockstep.
+            bars.mb_empty_mainloop.wait(empty_mainloop_phase)
+            empty_mainloop_phase = empty_mainloop_phase ^ cutlass.Int32(1)
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bars.mb_bmm2_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+        else:
+            # Prologue: BMM1[sub0], BMM1[sub1] for kv=kv_left
+            bars.mb_q_full[0].wait(q_full_phase)
+            bars.mb_k_full[kv_state.idx].wait(kv_state.phase)
+            desc_K = sK[kv_state.idx].desc()
+            mma_ss(bmm1_desc, desc_Q0, desc_K, (tmem_raw.subview(LAYOUT.S0_OFF)))
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm1_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+            bars.mb_q_full[1].wait(q_full_phase)
+            mma_ss(bmm1_desc, desc_Q1, desc_K, (tmem_raw.subview(LAYOUT.S1_OFF)))
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm1_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bars.mb_k_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+            q_full_phase = q_full_phase ^ 1
+
+            # Mainloop kv = kv_left+1 .. kv_right-1 (empty when n_kv == 1)
+            for kv_loop in cutlass.range(kv_left + cutlass.Int32(1), kv_right, 1, unroll=1):
+                old_state = kv_state
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+
+                bars.mb_v_full[old_state.idx].wait(old_state.phase)
+                desc_V = sV[old_state.idx].desc()
+                is_not_first_bmm2 = cutlass.Boolean(kv_loop != (kv_left + cutlass.Int32(1)))
+
+                # BMM2 sub-tile 0
+                bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
+                accum_b2 = is_not_first_bmm2
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P0_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O0_OFF)), local_k, accum_b2)
+                    accum_b2 = cutlass.Boolean(True)
+                # Chunk 1 folds out at TILE_N=64 (N_BMM2_CHUNKS=1).
+                if cutlass.const_expr(CFG.N_BMM2_CHUNKS == 2):
+                    bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 1].wait(bmm2_ready_phase)
+                    for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                        mma_ts_step(
+                            bmm2_desc,
+                            (tmem_raw.subview(LAYOUT.P0_OFF)),
+                            desc_V,
+                            (tmem_raw.subview(LAYOUT.O0_OFF)),
+                            NUM_KPHASES_PV_PER_CHUNK + local_k,
+                            cutlass.Boolean(True),
+                        )
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+                # BMM1 sub 0 for next kv
+                bars.mb_k_full[kv_state.idx].wait(kv_state.phase)
+                desc_K = sK[kv_state.idx].desc()
+                mma_ss(bmm1_desc, desc_Q0, desc_K, (tmem_raw.subview(LAYOUT.S0_OFF)))
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm1_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+                # BMM2 sub-tile 1
+                bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
+                accum_b2 = is_not_first_bmm2
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P1_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O1_OFF)), local_k, accum_b2)
+                    accum_b2 = cutlass.Boolean(True)
+                if cutlass.const_expr(CFG.N_BMM2_CHUNKS == 2):
+                    bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 1].wait(bmm2_ready_phase)
+                    for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                        mma_ts_step(
+                            bmm2_desc,
+                            (tmem_raw.subview(LAYOUT.P1_OFF)),
+                            desc_V,
+                            (tmem_raw.subview(LAYOUT.O1_OFF)),
+                            NUM_KPHASES_PV_PER_CHUNK + local_k,
+                            cutlass.Boolean(True),
+                        )
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm2_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                bars.mb_v_empty[old_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+                # BMM1 sub 1 for next kv
+                mma_ss(bmm1_desc, desc_Q1, desc_K, (tmem_raw.subview(LAYOUT.S1_OFF)))
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm1_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                bars.mb_k_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+                bmm2_ready_phase = bmm2_ready_phase ^ 1
+
+            # Epilogue: BMM2 for last kv (always runs — n_kv >= 1).
+            # Under QO_ALIAS the TMA-LDG Q-reload gate is mb_q_o_alias (fired by
+            # TMA-STG after O drains), so MMA does NOT fire mb_q_empty.
+            if cutlass.const_expr(not IS_QO_ALIAS):
+                elect_p = nvvm.elect_sync()
+                for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                    bars.mb_q_empty[qs].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+            bars.mb_v_full[kv_state.idx].wait(kv_state.phase)
+            desc_V = sV[kv_state.idx].desc()
+            is_not_first_bmm2_epi = cutlass.Boolean((kv_right - kv_left) != cutlass.Int32(1))
+
+            bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
+            accum_b2 = is_not_first_bmm2_epi
+            for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P0_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O0_OFF)), local_k, accum_b2)
+                accum_b2 = cutlass.Boolean(True)
+            if cutlass.const_expr(CFG.N_BMM2_CHUNKS == 2):
+                bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 1].wait(bmm2_ready_phase)
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(
+                        bmm2_desc,
+                        (tmem_raw.subview(LAYOUT.P0_OFF)),
+                        desc_V,
+                        (tmem_raw.subview(LAYOUT.O0_OFF)),
+                        NUM_KPHASES_PV_PER_CHUNK + local_k,
+                        cutlass.Boolean(True),
+                    )
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+            bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
+            accum_b2 = is_not_first_bmm2_epi
+            for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P1_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O1_OFF)), local_k, accum_b2)
+                accum_b2 = cutlass.Boolean(True)
+            if cutlass.const_expr(CFG.N_BMM2_CHUNKS == 2):
+                bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 1].wait(bmm2_ready_phase)
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(
+                        bmm2_desc,
+                        (tmem_raw.subview(LAYOUT.P1_OFF)),
+                        desc_V,
+                        (tmem_raw.subview(LAYOUT.O1_OFF)),
+                        NUM_KPHASES_PV_PER_CHUNK + local_k,
+                        cutlass.Boolean(True),
+                    )
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm2_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bars.mb_v_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+            bmm2_ready_phase = bmm2_ready_phase ^ 1
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+            nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+        else:
+            nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+            nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+            nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+            q_super_idx, _hd, batch_idx = _dispatch_decode_payload(
+                nxt_q,
+                nxt_hb,
+                cta_in_pair,
+                n_q_supers,
+                n_qh,
+                n_batch,
+                seq_kv_lens_tensor,
+            )
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _softmax_kv_body(
+    apply_mask: bool,
+    sub_tile_id: int,
+    kv_loop,
+    tmem_ptr_i32,
+    bars,
+    q_abs,
+    eff_seqlen_kv,
+    seqlen_q,
+    scale_log2,
+    total_max,
+    total_sum,
+    bmm1_phase,
+    stat_empty_phase,
+    leader_cta_id,
+):
+    """Per-iter kv body for the softmax warp group.
+
+    Compile-time apply_mask (Python bool) picks the load+max strategy:
+    apply_mask=False uses fused tcgen05.ld.red.f32.max (HW row-max);
+    apply_mask=True uses tcgen05.ld + apply_mask_chunk + software row-max
+    (HW max can't observe NEG_INFINITY written after the load).
+
+    Returns updated (total_max, total_sum, bmm1_phase, stat_empty_phase).
+    """
+    tmem_S_off = LAYOUT.S0_OFF if sub_tile_id == 0 else LAYOUT.S1_OFF
+    tmem_P_off = LAYOUT.P0_OFF if sub_tile_id == 0 else LAYOUT.P1_OFF
+    stats_off = LAYOUT.STATS_OFF + sub_tile_id * 8
+    CHUNK = 64
+    # fp16/bf16 pack 2 probs per FP32 TMEM cell (CHUNK//2); TF32 is 1:1 (CHUNK).
+    P_COLS_PER_CHUNK = CHUNK if IS_TF32 else CHUNK // 2
+    N_CHUNKS = CFG.N_BMM2_CHUNKS
+    NEG_INF = cutlass.Float32(-3.4028235e38)
+    RESCALE_THRESHOLD = cutlass.Float32(CFG.RESCALE_THRESHOLD)
+
+    bars.mb_bmm1_done[sub_tile_id].wait(bmm1_phase)
+    bmm1_phase = bmm1_phase ^ 1
+
+    # Hoist all TMEM address math to a single base load — Rubin tcgen05.ld/st
+    # auto-derives row from warp_id_in_warpgroup; address only needs the column.
+    tmem_base = tmem_ptr_i32.load()
+    s_addr_base = tmem_base + cutlass.Int32(tmem_S_off)
+    p_addr_base = tmem_base + cutlass.Int32(tmem_P_off)
+    stats_addr = tmem_base + cutlass.Int32(stats_off)
+
+    # apply_mask is a Python bool — wrap in cutlass.const_expr so CTM folds
+    # at trace time instead of staging cf.if (the two arms produce Vectors
+    # built via different MLIR op sequences and the tracer would error).
+    if cutlass.const_expr(apply_mask):
+        kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+        # Python comprehensions (not for+append) so the tracer sees fully-formed lists.
+        raw_chunks = [
+            nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32),
+                num=CHUNK,
+            )
+            for c in range(N_CHUNKS)
+        ]
+        # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
+        # CFG.BOTTOM_RIGHT is 0 — top-left masking is unchanged).
+        causal_diag = eff_seqlen_kv - seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+        chunks_S = [
+            apply_mask_chunk(
+                raw_chunks[c],
+                q_abs,
+                kv_col_base + cutlass.Int32(c * CHUNK),
+                eff_seqlen_kv,
+                CFG.WINDOW_LEFT,
+                CFG.MASK_FLAGS,
+                N=CHUNK,
+                bottom_right=CFG.BOTTOM_RIGHT,
+                causal_diag=causal_diag,
+                window_right=CFG.WINDOW_RIGHT,
+            )
+            for c in range(N_CHUNKS)
+        ]
+        chunks_max = [row_max_reduction(chunks_S[c]) for c in range(N_CHUNKS)]
+        # vec_concat handles single-element lists too; keeps tracer Vector type uniform across N_CHUNKS.
+        reg_S_vec = vec_concat(chunks_S)
+        current_max_unscaled = chunks_max[0]
+        for m in chunks_max[1:]:
+            current_max_unscaled = cute.math.max(current_max_unscaled, m)
+    else:
+        reg_S_tile, current_max_unscaled = tmem_load_max_reduction_tile(
+            s_addr_base,
+            num_elems=CFG.TILE_N,
+        )
+        reg_S_vec = reg_S_tile.vec
+
+    # Pass size=CFG.TILE_N explicitly — Vector.shape[0] is an MLIR value
+    # (not Python int) for vec_concat-built vectors, so auto-detect can't recover the length.
+    reg_S = RegTile(reg_S_vec, size=CFG.TILE_N)
+    current_max = current_max_unscaled * scale_log2
+
+    # Named-barrier wg0/wg1 sync: sub_tile_id==1 waits at TOP for sub_tile_id==0's bottom arrive.
+    if sub_tile_id == 1:
+        nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
+
+    # Online softmax with RESCALE_THRESHOLD skip.
+    old_total_max = total_max
+    is_first = total_max == NEG_INF
+    update_cond = is_first | ((current_max - total_max) > RESCALE_THRESHOLD)
+    total_max = cutlass.Float32(
+        arith.select(
+            update_cond.ir_value(),
+            current_max.ir_value(),
+            total_max.ir_value(),
+        )
+    )
+    exp_input = cutlass.Float32(
+        arith.select(
+            is_first.ir_value(),
+            NEG_INF.ir_value(),
+            (old_total_max - total_max).ir_value(),
+        )
+    )
+    alpha = cute.math.exp2(exp_input, fastmath=True)
+    new_total_max = total_max
+
+    alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+    bars.mb_stat_full[sub_tile_id].arrive()
+
+    # Rescale full reg_S in one vector op — emits same FFMA2 sequence as explicit half-tile rescales.
+    reg_S = reg_S * scale_log2 - new_total_max
+
+    # Chunk 0 manual unroll — CTM's @cute.jit tracer makes the loop iter an
+    # MLIR value, breaking Python slice.indices() math inside RegTile[].
+    chunk_S_0 = reg_S[0:CHUNK].vec
+    chunk_P_0 = cute.math.exp2(chunk_S_0, fastmath=True)
+    # Hoist chunk 0's sum before the cast to overlap with the cast's FFMA chain.
+    hoisted_sum = row_reduction_pair(chunk_P_0)
+    chunk_P_0_fp16 = chunk_P_0.to(STORAGE_DTYPE)
+    nvvm.tcgen05_st(
+        "32x32b",
+        nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32),
+        chunk_P_0_fp16,
+    )
+    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+    bars.mb_bmm2_ready[sub_tile_id * N_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+    # Chunk 1 folds out at TILE_N=64 (N_CHUNKS=1).
+    deferred_P_1 = None
+    if cutlass.const_expr(N_CHUNKS == 2):
+        chunk_S_1 = reg_S[CHUNK : 2 * CHUNK].vec
+        deferred_P_1 = cute.math.exp2(chunk_S_1, fastmath=True)
+        chunk_P_1_fp16 = deferred_P_1.to(STORAGE_DTYPE)
+        nvvm.tcgen05_st(
+            "32x32b",
+            nvvm.make_tmem_ptr(
+                p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK),
+                cutlass.Float32,
+            ),
+            chunk_P_1_fp16,
+        )
+        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+        bars.mb_bmm2_ready[sub_tile_id * N_CHUNKS + 1].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+    # wg0 fires bottom sync to release wg1 spinning at TOP barrier.
+    if sub_tile_id == 0:
+        nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
+
+    new_p_sum_pair = hoisted_sum
+    if cutlass.const_expr(N_CHUNKS == 2):
+        new_p_sum_pair = new_p_sum_pair + row_reduction_pair(deferred_P_1)
+    alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+    total_sum = total_sum * alpha_pair + new_p_sum_pair
+
+    bars.mb_stat_empty[sub_tile_id].wait(stat_empty_phase)
+    stat_empty_phase = stat_empty_phase ^ 1
+
+    return total_max, total_sum, bmm1_phase, stat_empty_phase
+
+
+@cute.jit
+def _softmax_warp_group(
+    sub_tile_id: int,
+    seqlen_q,
+    seqlen_kv,
+    scale_log2: cutlass.Float32,
+    tmem_ptr_i32,
+    sQ,
+    bars,
+    sched,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+):
+    """Softmax warp group (one of two): online softmax per kv iter.
+
+    Each lane owns one row of the 128 x 128 S_acc tile, loads its 128 fp32
+    cols with a single tcgen05.ld.red.max, runs online softmax (total_max +
+    total_sum tracking with RESCALE_THRESHOLD skip), publishes alpha to
+    corr, writes P to TMEM cols at S_acc tail, fires bmm2_ready[sub][chunk].
+    """
+    # Wait on MMA's TMEM-publish named barrier BEFORE any tmem_ptr_i32.load() —
+    # without it softmax can race MMA's tcgen05_alloc and read a stale base.
+    nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+
+    tmem_S_off = LAYOUT.S0_OFF if sub_tile_id == 0 else LAYOUT.S1_OFF
+    tmem_P_off = LAYOUT.P0_OFF if sub_tile_id == 0 else LAYOUT.P1_OFF
+
+    NEG_INF = cutlass.Float32(-3.4028235e38)
+
+    CHUNK = 64
+    P_COLS_PER_CHUNK = CHUNK // 2
+    stats_off = LAYOUT.STATS_OFF + sub_tile_id * 8
+
+    # Phase trackers persist across tile boundaries (barriers don't reset).
+    bmm1_phase = cutlass.Int32(0)
+    stat_empty_phase = cutlass.Int32(1)  # bootstrap pre-armed at phase 1 so first wait passes immediately
+    # init phase=1; both softmax wgs wait on slot [0] not [SoftmaxGid].
+    epilogue_state = cutlass.Int32(1)
+
+    # total_sum kept as Vector[Float32, 2] (even/odd partials) so per-iter update lowers to packed FMUL2 + FADD2.
+    total_max = NEG_INF
+    total_sum = cutlass.Vector.from_elements(
+        (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+        cutlass.Float32,
+    )
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    softmax_wg_base_const = CFG.SOFTMAX_WG0_BASE if sub_tile_id == 0 else CFG.SOFTMAX_WG1_BASE
+    tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(softmax_wg_base_const * 32)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        # Top-of-tile mb_o_empty[0] wait: without it softmax can race into the
+        # next tile while TMA-STG is still draining the prior tile's O slot.
+        bars.mb_o_empty[0].wait(epilogue_state)
+        epilogue_state = epilogue_state ^ cutlass.Int32(1)
+
+        total_max = NEG_INF
+        total_sum = cutlass.Vector.from_elements(
+            (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+            cutlass.Float32,
+        )
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+        q_abs = q_row_coord + cutlass.Int32(sub_tile_id * CFG.TILE_M) + tid_in_wg
+        # Bootstrap stat_empty wait BEFORE kv loop — lifts wait off per-iter
+        # critical path so alpha publish + stat_full fire happen back-to-back.
+        bars.mb_stat_empty[sub_tile_id].wait(stat_empty_phase)
+        stat_empty_phase = stat_empty_phase ^ 1
+        # 3-segment kv loop: LEFT-masked / fully-unmasked / RIGHT-masked.
+        # At MASK_NONE bounds collapse so the two masked sub-loops have empty range and fold out.
+        if cutlass.const_expr(CFG.MASK_FLAGS == MASK_NONE):
+            for kv_loop in cutlass.range(bounds.left, bounds.right, 1, unroll=1):
+                total_max, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                    False,
+                    sub_tile_id,
+                    kv_loop,
+                    tmem_ptr_i32,
+                    bars,
+                    q_abs,
+                    eff_seqlen_kv,
+                    seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_sum,
+                    bmm1_phase,
+                    stat_empty_phase,
+                    leader_cta_id,
+                )
+        else:
+            for kv_loop in cutlass.range(bounds.left, bounds.unmasked_lo, 1, unroll=1):
+                total_max, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                    True,
+                    sub_tile_id,
+                    kv_loop,
+                    tmem_ptr_i32,
+                    bars,
+                    q_abs,
+                    eff_seqlen_kv,
+                    seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_sum,
+                    bmm1_phase,
+                    stat_empty_phase,
+                    leader_cta_id,
+                )
+            for kv_loop in cutlass.range(bounds.unmasked_lo, bounds.unmasked_hi, 1, unroll=1):
+                total_max, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                    False,
+                    sub_tile_id,
+                    kv_loop,
+                    tmem_ptr_i32,
+                    bars,
+                    q_abs,
+                    eff_seqlen_kv,
+                    seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_sum,
+                    bmm1_phase,
+                    stat_empty_phase,
+                    leader_cta_id,
+                )
+            for kv_loop in cutlass.range(bounds.unmasked_hi, bounds.right, 1, unroll=1):
+                total_max, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                    True,
+                    sub_tile_id,
+                    kv_loop,
+                    tmem_ptr_i32,
+                    bars,
+                    q_abs,
+                    eff_seqlen_kv,
+                    seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_sum,
+                    bmm1_phase,
+                    stat_empty_phase,
+                    leader_cta_id,
+                )
+
+        # End-of-kv: publish (total_max, total_sum_final) to TMEM Stats — corr reads it for LSE.
+        total_sum_scalar = total_sum[0] + total_sum[1]
+
+        stats_addr_epi = tmem_ptr_i32.load() + cutlass.Int32(stats_off)
+        stats_vec_epi = cutlass.Vector.from_elements((total_max, total_sum_scalar), cutlass.Float32)
+        nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr_epi, cutlass.Float32), stats_vec_epi)
+        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+        bars.mb_stat_full[sub_tile_id].arrive()
+
+        # make_warp_uniform on scheduler-payload loads keeps nxt_* in uniform
+        # registers across the back-edge so ptxas doesn't STL them.
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+        nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+        nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+
+@cute.jit
+def _correction_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    sO,
+    tmem_ptr_i32,
+    tidx,
+    bars,
+    sched,
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+    cta_id_x,
+):
+    """Correction warp group: 4 warps x 32 lanes = 128 lanes, 1 lane per O row.
+
+    Per kv iter rescales O by alpha (skipped when all_alpha_one warp ballot
+    fires); per-tile epilogue normalizes O by 1/total_sum, casts to fp16,
+    swizzled-stores to sO, fires o_full for TMA-STG.  Holds the P14
+    end-of-tile catch-up flip on bmm2_done_phase (needed at n_kv=1 multi-wave).
+    """
+    # Wait on MMA's TMEM-publish named barrier BEFORE any tmem_ptr_i32.load() —
+    # without it correction can race MMA's tcgen05_alloc and read a stale base.
+    nvvm.barrier_cta_sync(barrier_id=2, thread_count=32 * (CFG.CORRECTION_WARPS + 1))
+
+    # Read tidx directly from PTX sreg — cute.arch.thread_idx() in @cute.jit may yield warp-uniform via folding.
+    tid_raw = cute.arch.thread_idx()[0]
+    tid_in_wg = tid_raw - cutlass.Int32(CFG.CORR_WARP_BASE * 32)
+
+    # O_CHUNK=16 (halved from 32) shortens the alpha-rescale live range —
+    # at 32, CTM regalloc spilled correction-warp regs to the stack.
+    O_CHUNK = 16
+    N_CHUNKS_O = CFG.TILE_O // O_CHUNK
+    # Use O_SWZ_B (NOT V_SWZ_B): under cga2 V is split along d_v and may drop
+    # to a narrower swizzle while O is full-row.  V-based stride here silently
+    # produces correct TMEM but garbled SMEM → wrong O after TMA-STG.
+    TMA_O_ITERS = (CFG.TILE_O * CFG.BPE) // CFG.O_SWZ_BYTES
+    D_BLOCK_SIZE = CFG.TILE_O // TMA_O_ITERS
+    TMA_O_GRANU_ELEMS = CFG.TILE_M * D_BLOCK_SIZE
+
+    stat_full_phase = cutlass.Int32(0)
+    # bmm2_done starts at phase=0; iter 0 is skipped, first wait at kv_loop=1.
+    bmm2_done_phase = cutlass.Int32(0)
+    o_empty_phase = cutlass.Int32(1)  # bootstrap
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+        # Iter-0 lifted out of kv loop: MMA's iter-0 BMM2 uses init_d=False
+        # to overwrite O garbage, so alpha-rescale is unnecessary in iter 0.
+        if bounds.right > bounds.left:
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                bars.mb_bmm2_ready[qs * CFG.N_BMM2_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                bars.mb_stat_full[qs].wait(stat_full_phase)
+                bars.mb_stat_empty[qs].arrive()
+            stat_full_phase = stat_full_phase ^ 1
+        else:
+            # Empty-mainloop: corr fires (DSMEM-arrive on leader at cga2); MMA fires bmm2_done[0/1] via multicast.
+            bars.mb_empty_mainloop.arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+        for kv_loop in cutlass.range(bounds.left + cutlass.Int32(1), bounds.right, 1, unroll=1):
+            tmem_base_iter = tmem_ptr_i32.load()
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                stats_off = LAYOUT.STATS_OFF + qs * 8
+                tmem_O_off = LAYOUT.O0_OFF if qs == 0 else LAYOUT.O1_OFF
+
+                bars.mb_stat_full[qs].wait(stat_full_phase)
+
+                stats_addr = tmem_base_iter + cutlass.Int32(stats_off)
+                stats_vec = nvvm.tcgen05_ld(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(stats_addr, cutlass.Float32),
+                    num=2,
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                alpha = stats_vec[0]
+
+                # all_alpha_one ballot: when every lane has alpha==1.0 the entire rescale loop skips.
+                alpha_is_one = alpha == cutlass.Float32(1.0)
+                all_alpha_one = vote_sync(0xFFFFFFFF, alpha_is_one, VoteSync.ALL)
+
+                bars.mb_stat_empty[qs].arrive()
+
+                bars.mb_bmm2_done[qs].wait(bmm2_done_phase)
+
+                # vec_scale_pair emits nvvm.mul_packed_f32x2 → FMUL2.  Without it
+                # plain o_chunk*alpha lowers to scalar FMUL inside the runtime-if
+                # (downstream fp32 tcgen05_st doesn't force packed regs).
+                # Per-chunk cfence keeps ptxas from sinking the next chunk's
+                # tcgen05_ld ahead of the prior tcgen05_st (TMEM-col anti-dep).
+                if ~all_alpha_one:
+                    for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                        o_addr = tmem_base_iter + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
+                        o_chunk = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                            num=O_CHUNK,
+                        )
+                        o_scaled = vec_scale_pair(o_chunk, alpha, O_CHUNK)
+                        nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(o_addr, cutlass.Float32), o_scaled)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+
+                bars.mb_bmm2_ready[qs * CFG.N_BMM2_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+            stat_full_phase = stat_full_phase ^ 1
+            bmm2_done_phase = bmm2_done_phase ^ 1
+
+        # === End-of-kv epilogue ===
+        tmem_base_epi = tmem_ptr_i32.load()
+        for qs in cutlass.range_constexpr(CFG.TILES_Q):
+            stats_off = LAYOUT.STATS_OFF + qs * 8
+            tmem_O_off = LAYOUT.O0_OFF if qs == 0 else LAYOUT.O1_OFF
+
+            bars.mb_bmm2_done[qs].wait(bmm2_done_phase)
+
+            # Wait the (total_max, total_sum_final) publish from softmax's epilogue.
+            bars.mb_stat_full[qs].wait(stat_full_phase)
+
+            stats_addr = tmem_base_epi + cutlass.Int32(stats_off)
+            stats_vec = nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(stats_addr, cutlass.Float32),
+                num=2,
+            )
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+            total_max_scaled = stats_vec[0]  # log2-units (softmax stores it scaled)
+            total_sum = stats_vec[1]
+
+            # Fire stat_empty so softmax's NEXT-tile iter 0 wait can pass.
+            bars.mb_stat_empty[qs].arrive()
+
+            inv_sum = cutlass.Float32(0.0)  # pre-declare for CTM if-staging
+            lse_val = cutlass.Float32(0.0)
+            # With sinks: fold the lift-the-max rescale into threshold_beta so O is scaled by scale/new_sum in one FMUL.
+            LN2 = cutlass.Float32(0.6931471805599453)
+            total_max_nat = total_max_scaled * LN2
+            if cutlass.const_expr(CFG.HAS_SINK):
+                sinks_arr = cutlass.make_array_view(sinks_tensor)
+                sink_logit = sinks_arr[head_idx]
+                new_max = cute.math.max(total_max_nat, sink_logit)
+                scale = cute.math.exp(total_max_nat - new_max, fastmath=True)
+                new_sum = total_sum * scale + cute.math.exp(sink_logit - new_max, fastmath=True)
+                lse_val = new_max + cute.math.log(new_sum, fastmath=True)
+                inv_sum = scale / new_sum
+            else:
+                lse_val = total_max_nat + cute.math.log(total_sum, fastmath=True)
+                # Safe inverse: avoid div by 0 on fully-masked rows.
+                inv_sum = cutlass.Float32(1.0) / cute.math.max(total_sum, cutlass.Float32(1e-30))
+
+            # OOB-row guard: under cga2 the cluster's Q rows can exceed seqlen_q;
+            # without the guard the write aliases the next head's LSE slot.
+            q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: q_row_global is sequence-local; LSE is packed [1,QH,T] →
+                # index [0, head, cu_q[b] + local], bound by per-sequence Q len S_q_b.
+                _cu = cutlass.make_array_view(seq_kv_lens_tensor)
+                _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
+                _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
+                if cutlass.const_expr(lse_tensor is not None):
+                    if q_row_global < _s_q_b:
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
+                        lse_row[_cu_q_b + q_row_global] = lse_val
+            else:
+                if cutlass.const_expr(lse_tensor is not None):
+                    if q_row_global < seqlen_q:
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        lse_row = lse_arr[batch_idx, head_idx, :]
+                        lse_row[q_row_global] = lse_val
+
+            sO_sub_base = sO[qs].base
+
+            for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                o_addr = tmem_base_epi + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
+                o_chunk = nvvm.tcgen05_ld(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                    num=O_CHUNK,
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                o_scaled = o_chunk * inv_sum
+                o_fp16 = o_scaled.to(STORAGE_DTYPE)
+
+                col_offset_const = (chunk_idx * O_CHUNK) % D_BLOCK_SIZE
+                block_idx_const = (chunk_idx * O_CHUNK) // D_BLOCK_SIZE
+                block_offset_const = block_idx_const * TMA_O_GRANU_ELEMS
+                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
+
+                smem_ptr = sO_sub_base.subview(smem_offset).data_ptr()
+                # mb_o_empty[qs] wait gates the FIRST SMEM store (not the
+                # earlier TMEM-load loop), keeping TMEM-load/FFMA/cast overlapped
+                # with TMA-STG draining the prior persistent tile.
+                if chunk_idx == 0:
+                    bars.mb_o_empty[qs].wait(o_empty_phase)
+                smem_ptr.store_swizzled(o_fp16, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+
+            # fence_proxy needed before TMA reads SMEM written by tcgen05_st (via store_swizzled).
+            nvvm.fence_proxy("async.shared", space="cta")
+
+            bars.mb_o_full[qs].arrive()
+
+        stat_full_phase = stat_full_phase ^ 1
+        o_empty_phase = o_empty_phase ^ 1
+        # P14 catch-up flip — bmm2_done_phase ^= 1 AFTER epilogue wait
+        # (mainloop flips n_kv-1 times, MMA fires n_kv times; +1 here matches —
+        # without this, n_kv=1 multi-wave deadlocks on the 2nd tile).
+        bmm2_done_phase = bmm2_done_phase ^ 1
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    # End-of-warp tmem_dealloc: under cga2 each corr lane ALSO DSMEM-arrives
+    # on the peer so the peer's local mbar accumulates the full CGA-total count.
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        peer_cta = cta_id_x ^ cutlass.Int32(1)
+        bars.mb_tmem_dealloc.arrive_on_peer(peer_cta)
+    bars.mb_tmem_dealloc.arrive()
+
+
+# === Host launcher ===
+
+
+@cute.jit
+def _host(
+    q_tensor: cute.Tensor,
+    k_tensor: cute.Tensor,
+    v_tensor: cute.Tensor,
+    o_tensor: cute.Tensor,
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    problem_size: Tuple[int, int, int, int, int, int],
+    scale_softmax_log2: cutlass.Float32,
+    n_thd_units: cutlass.Int32,
+    # FROST passes the dense padded-Q trim tensor POSITIONALLY on every call.
+    # These kernels have no Q-trim epilogue (Capabilities.dense_seq_q_trim=False)
+    # so it is accepted and unused -- but the SLOT is mandatory: without it the
+    # adapter's 12th positional lands on `stream` and execute dies with
+    # "got multiple values for argument 'stream'".
+    seq_q_lens_tensor: Optional[cute.Tensor] = None,
+    # FROST plans must run on the caller's stream (engine contract; there is a
+    # dedicated stream-respect test).  Threaded exactly as the shipped
+    # prefill_d128_fp8_sm107.py sibling does.
+    stream: _cuda_driver.CUstream = None,
+) -> None:
+    B, QH, KH, SQ, SKV, _ = problem_size
+
+    # Tensors are [B, S, H, D] with stride_order=(3, 2, 1, 0); D is fastest.
+    # K is split along seq under cga2 — box rows are per-CTA.  V is split along d_v
+    # (plumbed via num_iters//CTA_MMA).  O's TMA box inner dim follows O's swizzle, NOT V's.
+    _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE
+    qk_box_q = (1, CFG.TILE_M, 1, TMA_QK_GRANU_ELEMS)
+    qk_box_k = (1, CFG.TILE_N // CFG.CTA_MMA, 1, TMA_QK_GRANU_ELEMS)
+    vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M, 1, _O_GRANU_ELEMS)
+    stride_order = (3, 2, 1, 0)
+
+    # Per-tensor TMA swizzle tracks per-CTA inner bytes (derived from CFG.*_SWZ_BYTES).
+    def _tma_swz(byte_w: int):
+        return tmap.TensorMapSwizzle.s128b if byte_w == 128 else tmap.TensorMapSwizzle.s64b if byte_w == 64 else tmap.TensorMapSwizzle.s32b
+
+    tma_q_desc = tmap.create_tensor_map_tiled_from_view(
+        q_tensor,
+        box_dims=qk_box_q,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.Q_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_k_desc = tmap.create_tensor_map_tiled_from_view(
+        k_tensor,
+        box_dims=qk_box_k,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.K_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    # V TMA: TF32 needs SWIZZLE_128B_ATOM_32B (transposed BMM2 operand) — same
+    # 128-B swizzle line / box geometry as standard Swz128B, just the atom mode.
+    # Standard Swz128B with kind::tf32 + b_trans silently returns all-zero O.
+    _v_tma_swz = tmap.TensorMapSwizzle.s128b_atom_32b if IS_TF32 else _tma_swz(CFG.V_SWZ_BYTES)
+    tma_v_desc = tmap.create_tensor_map_tiled_from_view(
+        v_tensor,
+        box_dims=vo_box_v,
+        stride_order=stride_order,
+        swizzle=_v_tma_swz,
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_o_desc = tmap.create_tensor_map_tiled_from_view(
+        o_tensor,
+        box_dims=vo_box_o,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.O_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+
+    # Each cluster pair (CTA_MMA CTAs) collectively covers TILE_M*TILES_Q*CTA_MMA Q rows;
+    # without the cluster-wide divisor cga2 over-launches and OOB clusters collide in GMEM.
+    rows_per_cluster = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+    q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
+    grid_q_supers = q_clusters * CFG.CTA_MMA
+    q_supers = grid_q_supers
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD: build the per-batch O descriptor array (reuse tma_o_desc over the
+        # packed [1,T,QH,D_v] O as base), then launch the exact flat
+        # batch-outermost grid (n_thd_units = Σ_b ceil(S_q_b/CGA_TILE_M)*QH,
+        # host-computed); grid_x = n_thd_units * CGA_M.  Works at cga1 (CGA_M=1).
+        _build_o_descs_kernel(
+            o_tensor,
+            tma_o_desc,
+            o_desc_words,
+            seq_kv_lens_tensor,
+            cutlass.Int32(QH),
+            cutlass.Int32(B),
+            cutlass.Int32(CFG.TILE_O),
+        ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
+        grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
+    else:
+        # Grid Python-folds on Cfg constant (avoids CTM if staging).
+        grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
+    _kernel(
+        tma_q_desc,
+        tma_k_desc,
+        tma_v_desc,
+        tma_o_desc,
+        lse_tensor,
+        sinks_tensor,
+        seq_kv_lens_tensor,
+        o_desc_words,
+        cutlass.Int32(SQ),
+        cutlass.Int32(SKV),
+        cutlass.Int32(q_supers),
+        cutlass.Int32(QH),
+        cutlass.Int32(B),
+        cutlass.Int32(QH // KH),
+        scale_softmax_log2,
+    ).launch(
+        grid=grid_shape,
+        block=[CFG.THREADS_PER_CTA, 1, 1],
+        cluster=(CFG.CTA_MMA, 1, 1),
+        stream=stream,
+    )
+
+
+@lru_cache(maxsize=None)
+def compile(  # noqa: A001
+    b: int = 1,
+    qh: int = 1,
+    kh: int = 1,
+    sq: int = 256,
+    skv: int = 128,
+    d_qk: int = CFG.TILE_K,
+    d_v: int = CFG.TILE_O,
+    has_lse: bool = True,
+    lse_stride: Optional[tuple] = None,
+) -> Callable:
+    """Compile a kernel with ALL dims concrete to pin TMA descriptor strides at compile time.
+
+    THD/varlen: q/k/v/o/lse are PACKED with batch dim 1 ([1,T,H,D]); ``b`` is the
+    LOGICAL batch (sequence count) driving n_batch / metadata + O-desc sizes."""
+    # THD/varlen is NOT ported for this kernel yet.  The setup-kernel call site
+    # below still speaks the pre-upstream 7-arg contract, while FROST's
+    # thd_helpers.build_thd_meta_o_descs_kernel takes 14 args and a different
+    # metadata layout (4B+4 with batch_remap + a claim counter, vs the 3B+2
+    # here), and the scheduler decode differs to match.  Raise here rather than
+    # let it fail as an arity error deep in the trace -- and so no engine row
+    # can advertise thd=True for this kernel and appear to work.  The dense
+    # path is unaffected: CFG.THD_VARLEN is 0 and every THD branch folds out.
+    if CFG.THD_VARLEN:
+        raise NotImplementedError(f"{__name__}: THD/varlen not ported to the FROST setup-kernel contract")
+    # ---- FROST adapter ABI ------------------------------------------------
+    # lower_dsl_prefill calls EVERY kernel with the full forward signature.
+    # This body carries only what the port brought over, so anything
+    # it cannot honor RAISES rather than being silently ignored: a raise here
+    # means the engine's Capabilities row is lying, which is the failure we
+    # want loud.  (Capabilities: lse_optional=False, no strided Stats.)
+    if lse_stride is not None:
+        raise NotImplementedError(f"{__name__}: strided Stats not ported (contiguous [B, H, S] only)")
+    if d_qk > CFG.TILE_K or d_v > CFG.TILE_O or d_qk <= 0 or d_v <= 0:
+        raise ValueError(f"{__name__}: envelope is 0 < d_qk <= {CFG.TILE_K}, 0 < d_v <= {CFG.TILE_O}; " f"got ({d_qk}, {d_v})")
+    _fake_batch = 1 if CFG.THD_VARLEN else b
+    fake_q = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, sq, qh, d_qk),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_k = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, d_qk),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_v = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, d_v),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_o = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, sq, qh, d_v),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    # has_lse=False (no Stats output): the LSE argument is None-specialized and
+    # the store is compiled out entirely -- no dummy buffer exists at any level,
+    # which is what lets the dense graph report get_workspace_size() == 0.
+    # Mirrors the shipped prefill_d128_fp8_sm107.py.
+    fake_lse = (
+        cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (_fake_batch, qh, sq),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
+        if has_lse
+        else None
+    )
+    # Sinks tensor always part of the ABI; read only when CFG.HAS_SINK == 1 (compile-time fold).
+    fake_sinks = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (qh,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # seq_kv_lens always part of the ABI; read only when CFG.SEQ_KV_LENS_PRESENT == 1
+    # (compile-time fold).  THD overloads it as the [seq_kv_lens(B)|cu_q(B+1)|
+    # cu_k(B+1)] metadata buffer (length 3B+2).
+    _skv_len = (3 * b + 2) if CFG.THD_VARLEN else b
+    fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (_skv_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # Per-batch O TMA-descriptor array (16 int64 = 128 B each) + 1 pad slot;
+    # dummy 1-elem when THD off (kernel never reads it).
+    _odesc_len = (b * _TENSOR_MAP_QWORDS + _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
+    fake_o_desc = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int64,
+        (_odesc_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    return cute.compile(
+        _host,
+        fake_q,
+        fake_k,
+        fake_v,
+        fake_o,
+        fake_lse,
+        fake_sinks,
+        fake_seq_kv_lens,
+        fake_o_desc,
+        (b, qh, kh, sq, skv, 0),
+        cutlass.Float32(0.0),
+        cutlass.Int32(0),
+        stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
+        options="--enable-tvm-ffi",
+    )

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm107.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 """
-DSL prefill SDPA kernel — classic pipeline, f16/bf16, d=128, SM107 (Rubin).
+DSL prefill SDPA kernel — classic pipeline, f16/bf16, d_qk=192 / d_v=128, SM107 (Rubin).
 
 Ported from the pre-upstream CTM kernel ``prefill_sdpa_f16.py``
 (CTM DSL) by frost_dev/port_ctm_kernel.py. The kernel BODY is the pre-upstream one,
@@ -28,19 +28,21 @@ not taken here.
 Original pre-upstream header follows.
 
 CTM-DSL port of the pre-upstream prefill SDPA kernel
-(llama flavor: FP16, d_qk = d_v = 128, TILES_Q = 2, two softmax
+(FP16, d_qk = 192 / d_v = 128 via ``make_cfg_d192``, TILES_Q = 2, two softmax
 warpgroups, four correction warps, persistent try_cancel scheduler).
 
 Same kernel shape as the C++ source: pipeline, TMEM/SMEM layout,
 barrier inventory + init counts, scheduler, warp dispatch, register
 split match.  Canonical reference port; reaches ~0.99x C++ TFLOPS.
 
-THD / varlen (``CFG.THD_VARLEN=1``, the pre-upstream packed-varlen entry point)
-is supported (f16/bf16) for all three d=128 flavors (llama / dsv3 / gptoss) at
-cga1 and cga2: packed ``[1,T,H,D]`` + ``cu_seqlens`` coord offset (applied to
-both Q slabs under TILES_Q=2), per-batch O TMA-descriptor array (shared
-``kernels/ctm/common/sdpa/thd.py``), packed ``[1,QH,T]`` LSE.  The dense
-``[B,S,H,D]`` path is byte-identical.
+THD / varlen is **NOT** ported.  The pre-upstream body carried a packed-varlen
+entry point (``CFG.THD_VARLEN=1``: packed ``[1,T,H,D]`` + ``cu_seqlens`` coord
+offset, per-batch O TMA-descriptor array, packed ``[1,QH,T]`` LSE), but its
+setup-kernel call site still speaks the pre-upstream 7-arg contract against a
+14-arg helper and the metadata layout differs (3B+2 vs 4B+4).  ``compile()``
+raises on ``CFG.THD_VARLEN`` rather than half-serving it, ``config_sm107``
+rejects THD for f16/bf16, and no engine row advertises it.  Only the dense
+``[B,S,H,D]`` path is served.
 """
 
 import os
@@ -81,6 +83,20 @@ from cudnn.sdpa.fwd.config_sm107 import TemplateParams, make_cfg_d192
 
 PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
 CFG, _TMA = make_cfg_d192(PARAMS)
+
+# tcgen05 SMEM-descriptor version for EVERY SmemTile in this module -- ONE
+# decision point, wired into every construction below rather than repeated as a
+# per-tile literal.  A version-0 descriptor's ``start_address`` is 14 bits = a
+# 256 KiB window; Rubin raises the per-CTA SMEM cap to 327 KiB, so an operand
+# buffer at or above 256 KiB wraps to offset 0 and the MMA multiplies whatever
+# sits at the bottom of SMEM.  This flavor's buffers all stay below the line.
+#
+# Do NOT re-literal this at a call site: the d512 MXFP8 sibling shipped NaN on
+# 100% of cells because its scale-factor tiles were declared UNDER a comment
+# claiming "every operand tile here carries desc_version=1" -- without the
+# kwarg.  A single constant makes that class of drift impossible, and
+# test_sm107_descriptor_version_matches_the_smem_budget asserts it.
+DESC_VERSION: int = 0
 Cfg = type(CFG)
 TMA_QK_ITERS = _TMA.QK_ITERS
 TMA_VO_ITERS = _TMA.VO_ITERS
@@ -312,6 +328,7 @@ def _kernel(
         tma_loads_per_tile=TMA_QK_ITERS,
         tma_granu_elems=TMA_QK_GRANU_ELEMS,
         tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+        desc_version=DESC_VERSION,
     )
     sK = SmemTile(
         base=sK_raw,
@@ -323,6 +340,7 @@ def _kernel(
         tma_loads_per_tile=TMA_QK_ITERS,
         tma_granu_elems=TMA_QK_GRANU_ELEMS,
         tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+        desc_version=DESC_VERSION,
     )
     sV = SmemTile(
         base=sV_raw,
@@ -335,6 +353,7 @@ def _kernel(
         tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
         tma_granu_elems=TMA_VO_GRANU_ELEMS,
         tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+        desc_version=DESC_VERSION,
     )
     sO = SmemTile(
         base=sO_raw,
@@ -346,6 +365,7 @@ def _kernel(
         tma_loads_per_tile=TMA_O_ITERS_HOST,
         tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
         tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+        desc_version=DESC_VERSION,
     )
 
     bars = make_classic_bars(CFG)
@@ -1730,6 +1750,24 @@ def _correction_warp_group(
                 lse_val = total_max_nat + cute.math.log(total_sum, fastmath=True)
                 # Safe inverse: avoid div by 0 on fully-masked rows.
                 inv_sum = cutlass.Float32(1.0) / cute.math.max(total_sum, cutlass.Float32(1e-30))
+            # --- empty KV range (fully-masked / zero-length KV for this tile) ---
+            # Same guard as prefill_d256_{f16,fp8,mxfp8}_sm107.py.  With
+            # bounds.right <= bounds.left the kv loop ran ZERO iterations, so
+            # BMM2 never overwrote the O accumulator (mma_ss overwrites only on
+            # its first k-step) and TMEM still holds the PREVIOUS persistent
+            # tile's O -- residue, possibly a NaN bit pattern.
+            #
+            # The softmax warp still publishes (total_max = -inf, total_sum = 0)
+            # for an empty range, so LSE is already right on both arms: no-sink
+            # gives -inf + log(0) = -inf (this kernel puts NO 1e-30 floor on the
+            # log -- if one is ever added, the select below must cover lse_val
+            # too, or it leaks log(1e-30) = -69.08), and the sink arm folds to
+            # exactly sink_logit.  inv_sum, however, is 1/max(0, 1e-30) = 1e30
+            # (no sink) or 0 (sink), so O = residue * 1e30 -> +-inf/NaN, or
+            # residue * 0 -> NaN.  Zero O with a SELECT, never a multiply.
+            _kv_empty = bounds.right <= bounds.left
+            if cutlass.const_expr(not CFG.HAS_SINK):
+                lse_val = cutlass.Float32(arith.select(_kv_empty.ir_value(), cutlass.Float32(float("-inf")).ir_value(), lse_val.ir_value()))
 
             # OOB-row guard: under cga2 the cluster's Q rows can exceed seqlen_q;
             # without the guard the write aliases the next head's LSE slot.
@@ -1763,6 +1801,14 @@ def _correction_warp_group(
                 )
                 nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                 o_scaled = o_chunk * inv_sum
+                # SELECT the zero for an empty KV range -- see _kv_empty above.
+                # NB: a plain `for` statement, not a comprehension -- the DSL
+                # preprocessor only rewrites statement-level range_constexpr
+                # loops ("range_constexpr should be preprocessed by preprocessor").
+                _o_elems = []
+                for _i in cutlass.range_constexpr(O_CHUNK):
+                    _o_elems.append(cutlass.Float32(arith.select(_kv_empty.ir_value(), cutlass.Float32(0.0).ir_value(), o_scaled[_i].ir_value())))
+                o_scaled = cutlass.Vector.from_elements(tuple(_o_elems), cutlass.Float32)
                 o_fp16 = o_scaled.to(STORAGE_DTYPE)
 
                 col_offset_const = (chunk_idx * O_CHUNK) % D_BLOCK_SIZE

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm107.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-"""CTM-DSL qwen prefill SDPA kernel — d_qk = d_v = 256, FP16/BF16.
+"""pre-upstream DSL qwen prefill SDPA kernel — d_qk = d_v = 256, FP16/BF16.
 
 TILES_Q=1, SOFTMAX_WARPGROUPS=1, 12 warps total.  Q∪O SMEM alias with
 extra barriers ``mb_q_o_alias`` and ``mb_tmastg_go``.  Q·K(i+1) → S·V(i)
@@ -130,7 +130,7 @@ else:
     raise ValueError(f"prefill_sdpa_d256_f16: DTYPE_QKV={CFG.DTYPE_QKV} not supported " f"(expected 2=BF16, 3=FP16, or 4=TF32)")
 
 if CFG.DTYPE_O != CFG.DTYPE_QKV:
-    raise NotImplementedError(f"prefill_sdpa_d256_f16 CTM: DTYPE_O={CFG.DTYPE_O} != DTYPE_QKV=" f"{CFG.DTYPE_QKV} not yet supported.")
+    raise NotImplementedError(f"prefill_sdpa_d256_f16: DTYPE_O={CFG.DTYPE_O} != DTYPE_QKV=" f"{CFG.DTYPE_QKV} not yet supported.")
 OUT_STORAGE_DTYPE = STORAGE_DTYPE
 
 
@@ -169,7 +169,7 @@ _resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
 
 # THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
 # factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
-# kernels/ctm/common/sdpa/thd.py.  Gated by CFG.THD_VARLEN (folds out otherwise).
+# the shared pre-upstream THD helper.  Gated by CFG.THD_VARLEN (folds out otherwise).
 # seq_kv_lens overloaded as the THD metadata buffer (int32 len 3B+2):
 #   [0..B-1]=seq_kv_lens  [B..2B]=cu_q(B+1)  [2B+1..3B+1]=cu_k(B+1)
 from cudnn.sdpa.fwd.kernels.thd_helpers import build_thd_meta_o_descs_kernel as _build_thd_meta_o_descs_kernel, TENSOR_MAP_QWORDS
@@ -195,7 +195,7 @@ class KernelTmemLayout:
 
     O_OFF: int = 256
 
-    # Stats parked at 544 (outside S_acc/O range — CTM-only vs C++ col 512).
+    # Stats parked at 544 (outside S_acc/O range — DSL-only vs C++ col 512).
     STATS_OFF: int = 544
 
 
@@ -1075,7 +1075,7 @@ def _softmax_warp_group(
         N_CHUNKS = CFG.N_BMM2_CHUNKS
         RESCALE_THRESHOLD = cutlass.Float32(CFG.RESCALE_THRESHOLD)
 
-        # 3-segment dispatch — body inlined so the CTM tracer can dispatch
+        # 3-segment dispatch — body inlined so the DSL tracer can dispatch
         # through cutlass.range without tripping the closure check.
         if cutlass.const_expr(CFG.MASK_FLAGS == MASK_NONE):
             for kv_loop in cutlass.range(bounds.left, bounds.right, 1, unroll=1):
@@ -1515,7 +1515,7 @@ def _correction_warp_group(
 
         tmem_base_epi = tmem_ptr_i32.load()
 
-        # CTM if-staging requires names used after the conditional to be bound on every path
+        # DSL if-staging requires names used after the conditional to be bound on every path
         total_max_scaled = cutlass.Float32(0.0)
         total_sum = cutlass.Float32(0.0)
         if bounds.right > bounds.left:

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm107.py
@@ -1,0 +1,1900 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""CTM-DSL qwen prefill SDPA kernel — d_qk = d_v = 256, FP16/BF16.
+
+TILES_Q=1, SOFTMAX_WARPGROUPS=1, 12 warps total.  Q∪O SMEM alias with
+extra barriers ``mb_q_o_alias`` and ``mb_tmastg_go``.  Q·K(i+1) → S·V(i)
+lookahead stream order with two parity-keyed S_acc TMEM slots; P_cast
+aliases the tail of each.  Stats parked at col 544 (outside S_acc/O).
+
+THD / varlen (``CFG.THD_VARLEN=1``, the pre-upstream packed-varlen entry point)
+is supported (f16/bf16) via the shared mechanism (packed ``[1,T,H,D]`` +
+``cu_seqlens`` coord offset, per-batch O descriptor array, packed ``[1,QH,T]``
+LSE); the dense ``[B,S,H,D]`` path is byte-identical.
+"""
+
+import os
+import sys
+from functools import lru_cache
+from typing import Callable, Optional, Tuple
+
+
+from cutlass.experimental import primitives as nvvm
+from cutlass.experimental.primitives import vote_sync, VoteSync
+from cutlass._mlir.dialects import arith
+
+import cutlass
+from cutlass.experimental import primitives as prims
+import cutlass.cute as cute
+from cutlass.base_dsl.typing import Pointer
+from cutlass.experimental.cuda import tensor_map as tmap
+import cuda.bindings.driver as _cuda_driver  # noqa: F401
+
+from dataclasses import dataclass
+from typing import NamedTuple
+
+# Config comes from the FROST template loader, NOT an env var: the pre-upstream
+# kernels picked a flavor with an env var + a sdpa_config_<flavor> module, which the
+# FROST engine contract forbids ("no environment variables for configuration" --
+# parameters travel as typed dataclasses). The loader injects
+# FROST_TEMPLATE_PARAMS before this body runs; the default keeps a plain
+# `import` usable as a standalone driver.
+from cudnn.sdpa.fwd.config_sm107 import TemplateParams, make_cfg_d256
+
+PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
+CFG, _TMA = make_cfg_d256(PARAMS)
+Cfg = type(CFG)
+TMA_QK_ITERS = _TMA.QK_ITERS
+TMA_VO_ITERS = _TMA.VO_ITERS
+TMA_QK_GRANU_ELEMS = _TMA.QK_GRANU_ELEMS
+TMA_VO_GRANU_ELEMS = _TMA.VO_GRANU_ELEMS
+
+# DTYPE_QKV ∈ {2: BF16, 3: FP16, 4: TF32} — FP8 lives in the d256_fp8 kernel.
+if CFG.DTYPE_QKV not in (2, 3, 4):
+    raise ValueError(
+        f"prefill_sdpa_d256_f16: DTYPE_QKV must be 2 (BF16), 3 (FP16), or " f"4 (TF32); got {CFG.DTYPE_QKV}.  Use prefill_sdpa_d256_fp8.py for FP8/E5M2."
+    )
+
+TMA_O_GRANU_ELEMS_HOST = CFG.O_SWZ_BYTES // CFG.BPE_O
+TMA_O_ITERS_HOST = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
+
+from cudnn.frost.tile_dsl.barrier import (
+    PipelineState,
+    advance,
+    cga_arrive,
+    cga_wait,
+    # `wait` (free fn) — still used for sched.mb_* (Sched not in Bars).
+    wait,
+)
+from cudnn.frost.tile_dsl.scheduler import (
+    Sched,
+    scheduler_warp_loop,
+    read_tile_id_arrive,
+    SCHED_NATURAL,
+    SCHED_LPT,
+    SCHED_LPT_L2,
+)
+from cudnn.frost.tile_dsl.pointwise import (
+    tmem_load_max_reduction_tile,
+    row_reduction_pair,
+    row_max_reduction,
+    vec_scale_pair,
+)
+from cudnn.frost.tile_dsl.regtile import RegTile, vec_concat
+from cudnn.frost.tile_dsl.mma import mma_ss, mma_ts_step
+from cudnn.frost.tile_dsl.tma import tma_load_tile, tma_store_tile, tma_store_commit, tma_store_wait
+from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, tma_slice_runtime_desc
+from cudnn.frost.tile_dsl.tmem import tmem_alloc, tmem_dealloc
+from cudnn.frost.tile_dsl.mask import (
+    apply_mask_chunk,
+    MASK_NONE,
+    MASK_PADDED,
+    MASK_CAUSAL,
+    MASK_SWA,
+)
+
+if CFG.DTYPE_QKV == 2:
+    STORAGE_DTYPE = cutlass.BFloat16
+    P_STORAGE_DTYPE = cutlass.BFloat16
+    MMA_KIND = nvvm.Tcgen05MMAKind.F16
+    IS_TF32 = False
+elif CFG.DTYPE_QKV == 3:
+    STORAGE_DTYPE = cutlass.Float16
+    P_STORAGE_DTYPE = cutlass.Float16
+    MMA_KIND = nvvm.Tcgen05MMAKind.F16
+    IS_TF32 = False
+elif CFG.DTYPE_QKV == 4:
+    # TF32 — see prefill_sdpa_f16.py for the three deltas (V SWIZZLE_128B_ATOM_32B
+    # SmemDesc+TMA, 1:1 P TMEM packing, BPE=4).  qwen already Q∪O-aliases, so
+    # the only flavor-specific bits here are STAGES_KV=2 + TILE_N=64 (config).
+    STORAGE_DTYPE = cutlass.Float32
+    P_STORAGE_DTYPE = cutlass.Float32
+    MMA_KIND = nvvm.Tcgen05MMAKind.TF32
+    IS_TF32 = True
+else:
+    raise ValueError(f"prefill_sdpa_d256_f16: DTYPE_QKV={CFG.DTYPE_QKV} not supported " f"(expected 2=BF16, 3=FP16, or 4=TF32)")
+
+if CFG.DTYPE_O != CFG.DTYPE_QKV:
+    raise NotImplementedError(f"prefill_sdpa_d256_f16 CTM: DTYPE_O={CFG.DTYPE_O} != DTYPE_QKV=" f"{CFG.DTYPE_QKV} not yet supported.")
+OUT_STORAGE_DTYPE = STORAGE_DTYPE
+
+
+from cudnn.sdpa.fwd.kernels._common_sm100 import (
+    D256Bars as Bars,
+    KvLoopBounds,
+    make_d256_bars,
+    compute_kv_loop_bounds,
+    lpt_tile_coords,
+    make_sdpa_helpers,
+)
+
+CGA_SIZE = CFG.CGA_M * CFG.CGA_N
+
+CTA_GROUP_KIND = nvvm.CTAGroup.CTA_2 if CFG.CTA_MMA == 2 else nvvm.CTAGroup.CTA_1
+
+qBufferElems = CFG.TILE_M * CFG.TILE_K
+kBufferElems = CFG.TILE_N * CFG.TILE_K // CFG.CTA_MMA
+vBufferElems = CFG.TILE_O * CFG.TILE_N // CFG.CTA_MMA
+oBufferElems = CFG.TILE_M * CFG.TILE_O
+qoAliasBytes = max(qBufferElems * CFG.BPE, oBufferElems * CFG.BPE_O)
+
+qTmaTransactionBytes = qBufferElems * CFG.BPE * CFG.CTA_MMA
+kTmaTransactionBytes = kBufferElems * CFG.BPE * CFG.CTA_MMA
+vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
+
+N_O_CHUNKS = (CFG.TILE_O * CFG.BPE_O + 127) // 128
+
+CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+
+_sdpa_h = make_sdpa_helpers(CFG)
+_decode_initial = _sdpa_h.decode_initial
+_decode_payload = _sdpa_h.decode_payload
+_bounds_for_tile = _sdpa_h.bounds_for_tile
+_resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+
+# THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
+# factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
+# kernels/ctm/common/sdpa/thd.py.  Gated by CFG.THD_VARLEN (folds out otherwise).
+# seq_kv_lens overloaded as the THD metadata buffer (int32 len 3B+2):
+#   [0..B-1]=seq_kv_lens  [B..2B]=cu_q(B+1)  [2B+1..3B+1]=cu_k(B+1)
+from cudnn.sdpa.fwd.kernels.thd_helpers import build_thd_meta_o_descs_kernel as _build_thd_meta_o_descs_kernel, TENSOR_MAP_QWORDS
+
+_TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
+_dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
+_dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
+_thd_tma_offsets = _sdpa_h.thd_tma_offsets
+
+
+@dataclass(frozen=True)
+class KernelTmemLayout:
+    """Column offsets for the qwen 2-parity-slot SDPA pipeline (FP16 d=256)."""
+
+    TOTAL_COLS: int = 576
+
+    S_ACC_EVEN_OFF: int = 0
+    S_ACC_ODD_OFF: int = 128
+
+    # P_cast aliases tail of same-parity S_acc (FP16 2:1 packing).
+    P_EVEN_OFF: int = 64
+    P_ODD_OFF: int = 192
+
+    O_OFF: int = 256
+
+    # Stats parked at 544 (outside S_acc/O range — CTM-only vs C++ col 512).
+    STATS_OFF: int = 544
+
+
+LAYOUT = KernelTmemLayout()
+
+
+_SWZ_ENUM = {128: 2, 64: 4, 32: 6}
+_SWZ_ATOM_32B = 1  # SWIZZLE_128B_ATOM_32B — TF32 transposed BMM2 operand (V)
+SMEM_LAYOUT_Q = _SWZ_ENUM[CFG.Q_SWZ_BYTES]
+SMEM_LAYOUT_K = _SWZ_ENUM[CFG.K_SWZ_BYTES]
+# V is the B-transposed BMM2 operand → TF32 needs SWIZZLE_128B_ATOM_32B.
+SMEM_LAYOUT_V = _SWZ_ATOM_32B if IS_TF32 else _SWZ_ENUM[CFG.V_SWZ_BYTES]
+SMEM_LAYOUT_O = _SWZ_ENUM[CFG.O_SWZ_BYTES]
+SMEM_LAYOUT_QKO = SMEM_LAYOUT_Q
+
+_O_SWZ_B = {128: 3, 64: 2, 32: 1}[CFG.O_SWZ_BYTES]
+_O_SMEM_SWIZZLE = cutlass.Swizzle(_O_SWZ_B, 4, 3)
+
+LEADING_BYTE_OFFSET_QK = 0
+STRIDE_BYTE_OFFSET_QK = 8 * CFG.Q_SWZ_BYTES
+
+# leading_byte_offset = 0 when (TILE_O/CTA_MMA)/8 <= 8 else TILE_N * V_SWZ_BYTES
+# TF32 ATOM32 override (see prefill_sdpa_f16.py): leading = TILE_N*128, stride = 512.
+_CORE_MATRIX_ROWS = 8
+_V_PC_COLS = CFG.TILE_O // CFG.CTA_MMA
+_LEADING_PV_STD = 0 if (_V_PC_COLS // _CORE_MATRIX_ROWS) <= 8 else CFG.TILE_N * CFG.V_SWZ_BYTES
+LEADING_BYTE_OFFSET_PV = (CFG.TILE_N * 128) if IS_TF32 else _LEADING_PV_STD
+STRIDE_BYTE_OFFSET_PV = 512 if IS_TF32 else (8 * CFG.V_SWZ_BYTES)
+
+NUM_KPHASES_PV = CFG.TILE_N // CFG.TILE_K_HW_BMM2
+NUM_KPHASES_PV_PER_CHUNK = NUM_KPHASES_PV // CFG.N_BMM2_CHUNKS
+
+
+# === Kernel entry ===
+
+
+@cute.kernel
+def _kernel(
+    tma_q_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_k_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_v_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_o_desc: cutlass.GridConstant[tmap.TensorMap],
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    seqlen_q: cutlass.Int32,
+    seqlen_kv: cutlass.Int32,
+    n_q_supers: cutlass.Int32,
+    n_qh: cutlass.Int32,
+    n_batch: cutlass.Int32,
+    qh_per_kh: cutlass.Int32,
+    scale_softmax_log2: cutlass.Float32,
+) -> None:
+
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    tidx, _, _ = cute.arch.thread_idx()
+
+    bidx = cute.arch.block_idx()[0]
+    bidy = cute.arch.block_idx()[1]
+    bidz = cute.arch.block_idx()[2]
+
+    # Q∪O alias — single buffer (DTYPE_O == DTYPE_QKV).
+    sQO_raw = cutlass.Array(STORAGE_DTYPE, qBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    sK_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * kBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    sV_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * vBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+
+    sQ = SmemTile(
+        base=sQO_raw,
+        elems_per_stage=qBufferElems,
+        stages=1,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+    )
+    sK = SmemTile(
+        base=sK_raw,
+        elems_per_stage=kBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+    )
+    sV = SmemTile(
+        base=sV_raw,
+        elems_per_stage=vBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_PV,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_PV,
+        layout=SMEM_LAYOUT_V,
+        tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
+        tma_granu_elems=TMA_VO_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+    )
+    # sO shares backing with sQ (Q∪O alias).
+    sO = SmemTile(
+        base=sQO_raw,
+        elems_per_stage=oBufferElems,
+        stages=1,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=SMEM_LAYOUT_O,
+        tma_loads_per_tile=TMA_O_ITERS_HOST,
+        tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+    )
+
+    bars = make_d256_bars(CFG, N_O_CHUNKS=N_O_CHUNKS)
+
+    tmem_ptr_i32 = cutlass.Array(cutlass.Int32, 1, alignment=16, space=cutlass.AddressSpace.smem)
+
+    sched = Sched(
+        **{
+            "mb_scheduler": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "mb_read_tile_id": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "tile_id_smem": cutlass.Array(cutlass.Int32, CFG.SCHEDULER_STAGES * 8, alignment=16, space=cutlass.AddressSpace.smem),
+            "bidx_init": bidx,
+            "bidy_init": bidy,
+            "bidz_init": bidz,
+        }
+    )
+
+    READ_TILE_ARRIVERS_TOTAL = CFG.READ_TILE_ARRIVERS
+
+    if warp_idx == 0:
+        if nvvm.elect_sync():
+            # Init counts baked into make_d256_bars(...); kernel calls .init()
+            # per stage.  range_constexpr keeps loop vars Python int (required
+            # for mb_bmm2_ready tuple-init lookup).
+            bars.mb_q_full.init()
+            bars.mb_q_o_alias.init()
+            bars.mb_tmastg_go.init()
+            for p in cutlass.range_constexpr(2):
+                bars.mb_bmm1_done[p].init()
+                bars.mb_bmm2_done[p].init()
+                for c in cutlass.range_constexpr(CFG.N_BMM2_CHUNKS):
+                    bars.mb_bmm2_ready[p * CFG.N_BMM2_CHUNKS + c].init()
+            bars.mb_stat_full.init()
+            bars.mb_stat_empty.init()
+            for chunk in cutlass.range_constexpr(N_O_CHUNKS):
+                bars.mb_o_full[chunk].init()
+            bars.mb_o_empty.init()
+            for ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_k_full[ks].init()
+                bars.mb_k_empty[ks].init()
+                bars.mb_v_full[ks].init()
+                bars.mb_v_empty[ks].init()
+            for s in range(CFG.SCHEDULER_STAGES):
+                nvvm.mbarrier_init(sched.mb_scheduler.subview(s), CFG.ONE_LANE)
+                nvvm.mbarrier_init(sched.mb_read_tile_id.subview(s), READ_TILE_ARRIVERS_TOTAL)
+            bars.mb_empty_mainloop.init()
+            bars.mb_tmem_dealloc.init()
+
+            # bootstrap mb_q_o_alias so first TMA wait passes (no prior O to flush)
+            bars.mb_q_o_alias.arrive()
+
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync()
+
+    # P4 cluster fence after mbar init — required before any cga2 cross-CTA arrive
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        cga_arrive()
+        cga_wait()
+
+    cta_id_x = cute.arch.block_idx_in_cluster() if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    cta_in_pair = (cta_id_x & cutlass.Int32(1)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    leader_cta_id = (cta_id_x & cutlass.Int32(~1 & 0xFFFFFFFF)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    mcast_mask = (cutlass.Int32(3) << leader_cta_id) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    tma_mcast_mask = (cutlass.Int16(1) << cta_in_pair) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
+    is_leader = cta_in_pair == cutlass.Int32(0)
+
+    # Warp layout: 0-3 softmax wg / 4-7 correction / 8 MMA / 9 TMALDG / 10 TMASTG / 11 scheduler
+    if warp_idx >= CFG.SOFTMAX_WG0_BASE and warp_idx < CFG.SOFTMAX_WG0_BASE + CFG.SOFTMAX_WG_WARPS:
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        _softmax_warp_group(
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_softmax_log2,
+            tmem_ptr_i32=tmem_ptr_i32,
+            bars=bars,
+            sched=sched,
+            lse_tensor=lse_tensor,
+            sinks_tensor=sinks_tensor,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+        )
+
+    elif warp_idx >= CFG.CORR_WARP_BASE and warp_idx < CFG.CORR_WARP_BASE + CFG.CORRECTION_WARPS:
+        nvvm.setmaxregister(CFG.CORRECTION_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _correction_warp_group(
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            sO=sO,
+            tmem_ptr_i32=tmem_ptr_i32,
+            tidx=tidx,
+            bars=bars,
+            sched=sched,
+            lse_tensor=lse_tensor,
+            sinks_tensor=sinks_tensor,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+            cta_id_x=cta_id_x,
+        )
+
+    elif warp_idx == CFG.MMA_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        if cutlass.const_expr(CFG.CTA_MMA == 2):
+            if is_leader:
+                _mma_warp_group(
+                    seqlen_q=seqlen_q,
+                    seqlen_kv=seqlen_kv,
+                    sQ=sQ,
+                    sK=sK,
+                    sV=sV,
+                    tmem_ptr_i32=tmem_ptr_i32,
+                    bars=bars,
+                    sched=sched,
+                    seq_kv_lens_tensor=seq_kv_lens_tensor,
+                    n_q_supers=n_q_supers,
+                    n_qh=n_qh,
+                    n_batch=n_batch,
+                    mcast_mask=mcast_mask,
+                    cta_in_pair=cta_in_pair,
+                )
+            else:
+                _mma_warp_quiet(tmem_ptr_i32, bars)
+        else:
+            _mma_warp_group(
+                seqlen_q=seqlen_q,
+                seqlen_kv=seqlen_kv,
+                sQ=sQ,
+                sK=sK,
+                sV=sV,
+                tmem_ptr_i32=tmem_ptr_i32,
+                bars=bars,
+                sched=sched,
+                seq_kv_lens_tensor=seq_kv_lens_tensor,
+                n_q_supers=n_q_supers,
+                n_qh=n_qh,
+                n_batch=n_batch,
+                mcast_mask=mcast_mask,
+                cta_in_pair=cta_in_pair,
+            )
+
+    elif warp_idx == CFG.TMALDG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        nvvm.prefetch_tensormap(tma_q_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_k_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_v_desc.get_ptr())
+        _tmaldg_warp_group(
+            tma_q_desc=tma_q_desc,
+            tma_k_desc=tma_k_desc,
+            tma_v_desc=tma_v_desc,
+            sQ=sQ,
+            sK=sK,
+            sV=sV,
+            bars=bars,
+            sched=sched,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            qh_per_kh=qh_per_kh,
+            is_leader=is_leader,
+            cta_in_pair=cta_in_pair,
+            tma_mcast_mask=tma_mcast_mask,
+        )
+
+    elif warp_idx == CFG.TMASTG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _tmastg_warp_group(
+            tma_o_desc=tma_o_desc,
+            sO=sO,
+            bars=bars,
+            sched=sched,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            cta_in_pair=cta_in_pair,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
+        )
+
+    else:  # warp_idx == CFG.SCHED_WARP_ID
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        is_cga_first_cta = cta_id_x == cutlass.Int32(0)
+        scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
+
+
+# === TMA-LDG warp group ===
+
+
+@cute.jit
+def _tmaldg_warp_group(
+    tma_q_desc,
+    tma_k_desc,
+    tma_v_desc,
+    sQ,
+    sK,
+    sV,
+    bars,
+    sched,
+    seqlen_q,
+    seqlen_kv,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    qh_per_kh,
+    is_leader,
+    cta_in_pair,
+    tma_mcast_mask,
+):
+    """Qwen TMA-LDG warp — single Q load gated on mb_q_o_alias; fires
+    mb_tmastg_go each tile (covers empty-mainloop branch)."""
+
+    q_o_alias_phase = cutlass.Int32(0)
+    kv_state = PipelineState.start(phase=1)  # bootstrap pre-armed at phase 1
+
+    tma_q = GmemTileTma(tma_q_desc)
+    tma_k = GmemTileTma(tma_k_desc)
+    tma_v = GmemTileTma(tma_v_desc)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+    q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    K_ROW_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_N // CFG.CTA_MMA)
+    V_COL_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_O // CFG.CTA_MMA)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        # Wait prior tile's O drained before any potential Q∪O clobber.
+        bars.mb_q_o_alias.wait(q_o_alias_phase)
+        q_o_alias_phase = q_o_alias_phase ^ cutlass.Int32(1)
+
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+            # Empty mainloop — skip Q/K/V loads; mb_tmastg_go still fires below
+            pass
+        else:
+            # P9 — leader-only arrive_expect_tx (TMA byte routing delivers all bytes to leader under cga2)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_q_full.arrive(n_bytes=qTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_q_full.arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sQ[0],
+                tma_q(cutlass.Int32(0), head_idx, q_row_base + q_seq_off, tma_batch),
+                bars.mb_q_full.smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+
+            for kv_loop in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                kv_row_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+
+                bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sK[kv_state.idx],
+                    tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
+                    bars.mb_k_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+
+                bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sV[kv_state.idx],
+                    tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
+                    bars.mb_v_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        # Both arms fire mb_tmastg_go (covers empty-mainloop too)
+        if nvvm.elect_sync():
+            bars.mb_tmastg_go.arrive()
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+        nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+        nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+        q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+
+    # cga2 drain — trailing empty mbar arrives from leader's multicast commits
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        for _ks in cutlass.range_constexpr(CFG.STAGES_KV):
+            bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+            bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+
+# === TMA-STG warp group ===
+
+
+@cute.jit
+def _tmastg_warp_group(
+    tma_o_desc,
+    sO,
+    bars,
+    sched,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    cta_in_pair,
+    seq_kv_lens_tensor,
+    o_desc_words,
+):
+    """Qwen TMA-STG warp — waits mb_tmastg_go then per-chunk mb_o_full;
+    fires mb_q_o_alias at end of tile so TMA can clobber Q∪O."""
+
+    tmastg_go_phase = cutlass.Int32(0)
+    o_full_phase = cutlass.Int32(0)
+
+    tma_o = GmemTileTma(tma_o_desc)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        bars.mb_tmastg_go.wait(tmastg_go_phase)
+        tmastg_go_phase = tmastg_go_phase ^ cutlass.Int32(1)
+
+        for chunk in cutlass.range_constexpr(N_O_CHUNKS):
+            bars.mb_o_full[chunk].wait(o_full_phase)
+
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+
+        if cutlass.const_expr(CFG.THD_VARLEN):
+            # THD: store through this batch's pre-built descriptor (base already
+            # at the sequence's packed row, seq extent = S_q_b → box past S_q_b
+            # OOB-clipped).  q_row_coord is sequence-local; batch coord → 0.
+            o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+            o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_coord, cutlass.Int32(0))
+            tma_store_tile(sO[0], o_slice)
+        else:
+            tma_store_tile(
+                sO[0],
+                tma_o(cutlass.Int32(0), head_idx, q_row_coord, batch_idx),
+            )
+        tma_store_commit()
+        tma_store_wait(0)
+
+        bars.mb_o_empty.arrive()
+        if nvvm.elect_sync():
+            bars.mb_q_o_alias.arrive()
+
+        o_full_phase = o_full_phase ^ cutlass.Int32(1)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+
+# === MMA warp group (+ quiet warp for cga2 non-leader) ===
+
+
+@cute.jit
+def _mma_warp_quiet(tmem_ptr_i32, bars):
+    """Quiet MMA-warp body for cga2 non-leader CTA — alloc then dealloc."""
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND, is_exclusive=True)
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _mma_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    sQ,
+    sK,
+    sV,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    mcast_mask,
+    cta_in_pair,
+):
+    """Qwen MMA warp — Q*K(i+1) → S*V(i) lookahead stream order with
+    prologue / mainloop (kv = lo..hi-2) / epilogue split."""
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND, is_exclusive=True)
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    tmem_raw = nvvm.make_tmem_ptr(tmem_ptr_i32.load(), cutlass.Int8)
+
+    idesc_qk = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_N,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        k_dim=1,
+    )
+    idesc_pv = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_O,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        b_major=1,
+        k_dim=1,
+    )
+    bmm1_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_N,
+        K=CFG.TILE_K,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=CFG.TILE_K_HW_BMM1,
+        btranspose=False,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_qk,
+        kind=MMA_KIND,
+    )
+    bmm2_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_O,
+        K=CFG.TILE_N,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=CFG.TILE_K_HW_BMM2,
+        btranspose=True,
+        k_subtile=CFG.V_SWZ_BYTES // CFG.BPE,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_pv,
+        kind=MMA_KIND,
+    )
+
+    desc_Q = sQ[0].desc()
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        q_super_idx, _hd, batch_idx = _dispatch_decode_initial(
+            sched.bidx_init,
+            sched.bidy_init,
+            sched.bidz_init,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    q_full_phase = cutlass.Int32(0)
+    kv_state_K = PipelineState.start(phase=0)
+    kv_state_V = PipelineState.start(phase=0)
+    # bit p of bmm2_ready_phase_pair holds parity-p's next-wait phase
+    bmm2_ready_phase_pair = cutlass.Int32(0)
+    empty_mainloop_phase = cutlass.Int32(0)
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+            bars.mb_empty_mainloop.wait(empty_mainloop_phase)
+            empty_mainloop_phase = empty_mainloop_phase ^ cutlass.Int32(1)
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+        else:
+            bars.mb_q_full.wait(q_full_phase)
+            q_full_phase = q_full_phase ^ cutlass.Int32(1)
+
+            # Prologue: Q*K(lo) → S_acc[lo&1]
+            lo_parity_runtime = kv_left & cutlass.Int32(1)
+            parity_lo_is_even = lo_parity_runtime == cutlass.Int32(0)
+            tmem_S_acc_lo_addr = cutlass.Int32(
+                arith.select(
+                    parity_lo_is_even.ir_value(),
+                    cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(),
+                    cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value(),
+                )
+            )
+
+            bars.mb_k_full[kv_state_K.idx].wait(kv_state_K.phase)
+            desc_K = sK[kv_state_K.idx].desc()
+            mma_ss(bmm1_desc, desc_Q, desc_K, (tmem_raw.subview(tmem_S_acc_lo_addr)))
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm1_done[lo_parity_runtime].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bars.mb_k_empty[kv_state_K.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            kv_state_K = advance(kv_state_K, CFG.STAGES_KV)
+
+            # Mainloop: kv = lo..hi-2 — Q*K(kv+1) then S*V(kv)
+            k_per_chunk = NUM_KPHASES_PV_PER_CHUNK
+
+            for kv_loop in cutlass.range(kv_left, kv_right - cutlass.Int32(1), 1, unroll=1):
+                parity_cur_rt = kv_loop & cutlass.Int32(1)
+                parity_next_rt = (kv_loop + cutlass.Int32(1)) & cutlass.Int32(1)
+                cur_is_even = parity_cur_rt == cutlass.Int32(0)
+                next_is_even = parity_next_rt == cutlass.Int32(0)
+
+                tmem_S_acc_next_addr = cutlass.Int32(
+                    arith.select(
+                        next_is_even.ir_value(),
+                        cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(),
+                        cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value(),
+                    )
+                )
+                tmem_P_cur_addr = cutlass.Int32(
+                    arith.select(
+                        cur_is_even.ir_value(),
+                        cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(),
+                        cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value(),
+                    )
+                )
+                bmm2_ready_phase_cur = (bmm2_ready_phase_pair >> parity_cur_rt) & cutlass.Int32(1)
+
+                # Q*K(kv+1) → S_acc[parity_next]
+                bars.mb_k_full[kv_state_K.idx].wait(kv_state_K.phase)
+                desc_K = sK[kv_state_K.idx].desc()
+                mma_ss(bmm1_desc, desc_Q, desc_K, (tmem_raw.subview(tmem_S_acc_next_addr)))
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm1_done[parity_next_rt].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                bars.mb_k_empty[kv_state_K.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                kv_state_K = advance(kv_state_K, CFG.STAGES_KV)
+
+                # S*V(kv) — chunked manual k-loop with bmm2_ready gates
+                bars.mb_v_full[kv_state_V.idx].wait(kv_state_V.phase)
+                desc_V = sV[kv_state_V.idx].desc()
+
+                # scaleC=False on kv_lo first k-step overwrites O acc; True after
+                scaleC = cutlass.Boolean(kv_loop != kv_left)
+                accum_b2 = scaleC
+                for k in cutlass.range_constexpr(NUM_KPHASES_PV):
+                    if k % k_per_chunk == 0:
+                        chunk_id = k // k_per_chunk
+                        bars.mb_bmm2_ready[parity_cur_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(chunk_id)].wait(bmm2_ready_phase_cur)
+                    mma_ts_step(bmm2_desc, (tmem_raw.subview(tmem_P_cur_addr)), desc_V, (tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF))), k, accum_b2)
+                    accum_b2 = cutlass.Boolean(True)
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm2_done[parity_cur_rt].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                bars.mb_v_empty[kv_state_V.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                bmm2_ready_phase_pair = bmm2_ready_phase_pair ^ (cutlass.Int32(1) << parity_cur_rt)
+                kv_state_V = advance(kv_state_V, CFG.STAGES_KV)
+
+            # Epilogue: S*V(hi-1) → O
+            kv_last = kv_right - cutlass.Int32(1)
+            parity_last_rt = kv_last & cutlass.Int32(1)
+            last_is_even = parity_last_rt == cutlass.Int32(0)
+            tmem_P_last_addr = cutlass.Int32(
+                arith.select(
+                    last_is_even.ir_value(),
+                    cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(),
+                    cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value(),
+                )
+            )
+            bmm2_ready_phase_last = (bmm2_ready_phase_pair >> parity_last_rt) & cutlass.Int32(1)
+
+            bars.mb_v_full[kv_state_V.idx].wait(kv_state_V.phase)
+            desc_V = sV[kv_state_V.idx].desc()
+            n_kv_eff = kv_right - kv_left
+            scaleC_epi = cutlass.Boolean(n_kv_eff != cutlass.Int32(1))
+            accum_b2 = scaleC_epi
+            for k in cutlass.range_constexpr(NUM_KPHASES_PV):
+                if k % k_per_chunk == 0:
+                    chunk_id = k // k_per_chunk
+                    bars.mb_bmm2_ready[parity_last_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(chunk_id)].wait(bmm2_ready_phase_last)
+                mma_ts_step(bmm2_desc, (tmem_raw.subview(tmem_P_last_addr)), desc_V, (tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF))), k, accum_b2)
+                accum_b2 = cutlass.Boolean(True)
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm2_done[parity_last_rt].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bars.mb_v_empty[kv_state_V.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bmm2_ready_phase_pair = bmm2_ready_phase_pair ^ (cutlass.Int32(1) << parity_last_rt)
+            kv_state_V = advance(kv_state_V, CFG.STAGES_KV)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+            nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+        else:
+            nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+            nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+            nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+            q_super_idx, _hd, batch_idx = _dispatch_decode_payload(
+                nxt_q,
+                nxt_hb,
+                cta_in_pair,
+                n_q_supers,
+                n_qh,
+                n_batch,
+                seq_kv_lens_tensor,
+            )
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+# === Softmax warp group (single wg — qwen TILES_Q=1) ===
+
+
+@cute.jit
+def _softmax_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    scale_log2: cutlass.Float32,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+):
+    """Qwen softmax — single warpgroup, parity-keyed (kv & 1) S_acc/P
+    selectors; epilogue publishes (total_max, total_sum) and fires
+    one extra mb_stat_full to balance correction's epilogue wait."""
+    nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+
+    bmm1_done_phase_pair = cutlass.Int32(0)  # bit p = next-wait phase for bmm1_done[p]
+    stat_empty_phase = cutlass.Int32(1)  # bootstrap pre-armed so first wait passes
+    epilogue_state = cutlass.Int32(1)
+
+    NEG_INF = cutlass.Float32(-3.4028235e38)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(CFG.SOFTMAX_WG0_BASE * 32)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        total_max = NEG_INF
+        total_sum = cutlass.Vector.from_elements(
+            (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+            cutlass.Float32,
+        )
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+        q_abs = q_row_coord + tid_in_wg
+
+        bars.mb_o_empty.wait(epilogue_state)
+        bars.mb_stat_empty.wait(stat_empty_phase)
+        stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+        epilogue_state = epilogue_state ^ cutlass.Int32(1)
+
+        CHUNK = 64
+        # fp16/bf16 pack 2 probs per FP32 TMEM cell; TF32 is 1:1.
+        P_COLS_PER_CHUNK = CHUNK if IS_TF32 else CHUNK // 2
+        N_CHUNKS = CFG.N_BMM2_CHUNKS
+        RESCALE_THRESHOLD = cutlass.Float32(CFG.RESCALE_THRESHOLD)
+
+        # 3-segment dispatch — body inlined so the CTM tracer can dispatch
+        # through cutlass.range without tripping the closure check.
+        if cutlass.const_expr(CFG.MASK_FLAGS == MASK_NONE):
+            for kv_loop in cutlass.range(bounds.left, bounds.right, 1, unroll=1):
+                parity_rt = kv_loop & cutlass.Int32(1)
+                parity_is_even = parity_rt == cutlass.Int32(0)
+                s_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value())
+                )
+                p_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value())
+                )
+                bmm1_phase = (bmm1_done_phase_pair >> parity_rt) & cutlass.Int32(1)
+                bars.mb_bmm1_done[parity_rt].wait(bmm1_phase)
+                bmm1_done_phase_pair = bmm1_done_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+
+                tmem_base = tmem_ptr_i32.load()
+                s_addr_base = tmem_base + s_off_rt
+                p_addr_base = tmem_base + p_off_rt
+                stats_addr = tmem_base + cutlass.Int32(LAYOUT.STATS_OFF)
+
+                reg_S_tile, current_max_unscaled = tmem_load_max_reduction_tile(
+                    s_addr_base,
+                    num_elems=CFG.TILE_N,
+                )
+                reg_S = RegTile(reg_S_tile.vec, size=CFG.TILE_N)
+                current_max = current_max_unscaled * scale_log2
+
+                old_total_max = total_max
+                is_first = total_max == NEG_INF
+                update_cond = is_first | ((current_max - total_max) > RESCALE_THRESHOLD)
+                total_max = cutlass.Float32(arith.select(update_cond.ir_value(), current_max.ir_value(), total_max.ir_value()))
+                exp_input = cutlass.Float32(arith.select(is_first.ir_value(), NEG_INF.ir_value(), (old_total_max - total_max).ir_value()))
+                alpha = cute.math.exp2(exp_input, fastmath=True)
+                new_total_max = total_max
+                alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_stat_full.arrive()
+
+                reg_S = reg_S * scale_log2 - new_total_max
+
+                # Chunk 1 cast/store/sum folds out at trace time when N_CHUNKS == 1
+                chunk_S_0 = reg_S[0:CHUNK].vec
+                chunk_P_0 = cute.math.exp2(chunk_S_0, fastmath=True)
+                hoisted_sum = row_reduction_pair(chunk_P_0)
+                chunk_P_0_fp16 = chunk_P_0.to(STORAGE_DTYPE)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32), chunk_P_0_fp16)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(0)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                deferred_P_1 = None
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    chunk_S_1 = reg_S[CHUNK : 2 * CHUNK].vec
+                    deferred_P_1 = cute.math.exp2(chunk_S_1, fastmath=True)
+                    chunk_P_1_fp16 = deferred_P_1.to(STORAGE_DTYPE)
+                    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK), cutlass.Float32), chunk_P_1_fp16)
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                    bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(1)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                new_p_sum_pair = hoisted_sum
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    new_p_sum_pair = new_p_sum_pair + row_reduction_pair(deferred_P_1)
+                alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+                total_sum = total_sum * alpha_pair + new_p_sum_pair
+
+                bars.mb_stat_empty.wait(stat_empty_phase)
+                stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+        else:
+            # LEFT-masked
+            for kv_loop in cutlass.range(bounds.left, bounds.unmasked_lo, 1, unroll=1):
+                parity_rt = kv_loop & cutlass.Int32(1)
+                parity_is_even = parity_rt == cutlass.Int32(0)
+                s_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value())
+                )
+                p_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value())
+                )
+                bmm1_phase = (bmm1_done_phase_pair >> parity_rt) & cutlass.Int32(1)
+                bars.mb_bmm1_done[parity_rt].wait(bmm1_phase)
+                bmm1_done_phase_pair = bmm1_done_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+                tmem_base = tmem_ptr_i32.load()
+                s_addr_base = tmem_base + s_off_rt
+                p_addr_base = tmem_base + p_off_rt
+                stats_addr = tmem_base + cutlass.Int32(LAYOUT.STATS_OFF)
+                kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+                raw_chunks = [
+                    nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32), num=CHUNK) for c in range(N_CHUNKS)
+                ]
+                # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
+                # CFG.BOTTOM_RIGHT is 0 — top-left masking is unchanged).
+                causal_diag = eff_seqlen_kv - seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+                chunks_S = [
+                    apply_mask_chunk(
+                        raw_chunks[c],
+                        q_abs,
+                        kv_col_base + cutlass.Int32(c * CHUNK),
+                        eff_seqlen_kv,
+                        CFG.WINDOW_LEFT,
+                        CFG.MASK_FLAGS,
+                        N=CHUNK,
+                        bottom_right=CFG.BOTTOM_RIGHT,
+                        causal_diag=causal_diag,
+                        window_right=CFG.WINDOW_RIGHT,
+                    )
+                    for c in range(N_CHUNKS)
+                ]
+                chunks_max = [row_max_reduction(chunks_S[c]) for c in range(N_CHUNKS)]
+                reg_S_vec = vec_concat(chunks_S)
+                current_max_unscaled = chunks_max[0]
+                for m in chunks_max[1:]:
+                    current_max_unscaled = cute.math.max(current_max_unscaled, m)
+                reg_S = RegTile(reg_S_vec, size=CFG.TILE_N)
+                current_max = current_max_unscaled * scale_log2
+
+                old_total_max = total_max
+                is_first = total_max == NEG_INF
+                update_cond = is_first | ((current_max - total_max) > RESCALE_THRESHOLD)
+                total_max = cutlass.Float32(arith.select(update_cond.ir_value(), current_max.ir_value(), total_max.ir_value()))
+                exp_input = cutlass.Float32(arith.select(is_first.ir_value(), NEG_INF.ir_value(), (old_total_max - total_max).ir_value()))
+                alpha = cute.math.exp2(exp_input, fastmath=True)
+                new_total_max = total_max
+                alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_stat_full.arrive()
+                reg_S = reg_S * scale_log2 - new_total_max
+
+                chunk_S_0 = reg_S[0:CHUNK].vec
+                chunk_P_0 = cute.math.exp2(chunk_S_0, fastmath=True)
+                hoisted_sum = row_reduction_pair(chunk_P_0)
+                chunk_P_0_fp16 = chunk_P_0.to(STORAGE_DTYPE)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32), chunk_P_0_fp16)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(0)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                deferred_P_1 = None
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    chunk_S_1 = reg_S[CHUNK : 2 * CHUNK].vec
+                    deferred_P_1 = cute.math.exp2(chunk_S_1, fastmath=True)
+                    chunk_P_1_fp16 = deferred_P_1.to(STORAGE_DTYPE)
+                    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK), cutlass.Float32), chunk_P_1_fp16)
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                    bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(1)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                new_p_sum_pair = hoisted_sum
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    new_p_sum_pair = new_p_sum_pair + row_reduction_pair(deferred_P_1)
+                alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+                total_sum = total_sum * alpha_pair + new_p_sum_pair
+                bars.mb_stat_empty.wait(stat_empty_phase)
+                stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+            # UNMASKED interior
+            for kv_loop in cutlass.range(bounds.unmasked_lo, bounds.unmasked_hi, 1, unroll=1):
+                parity_rt = kv_loop & cutlass.Int32(1)
+                parity_is_even = parity_rt == cutlass.Int32(0)
+                s_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value())
+                )
+                p_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value())
+                )
+                bmm1_phase = (bmm1_done_phase_pair >> parity_rt) & cutlass.Int32(1)
+                bars.mb_bmm1_done[parity_rt].wait(bmm1_phase)
+                bmm1_done_phase_pair = bmm1_done_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+                tmem_base = tmem_ptr_i32.load()
+                s_addr_base = tmem_base + s_off_rt
+                p_addr_base = tmem_base + p_off_rt
+                stats_addr = tmem_base + cutlass.Int32(LAYOUT.STATS_OFF)
+                reg_S_tile, current_max_unscaled = tmem_load_max_reduction_tile(
+                    s_addr_base,
+                    num_elems=CFG.TILE_N,
+                )
+                reg_S = RegTile(reg_S_tile.vec, size=CFG.TILE_N)
+                current_max = current_max_unscaled * scale_log2
+
+                old_total_max = total_max
+                is_first = total_max == NEG_INF
+                update_cond = is_first | ((current_max - total_max) > RESCALE_THRESHOLD)
+                total_max = cutlass.Float32(arith.select(update_cond.ir_value(), current_max.ir_value(), total_max.ir_value()))
+                exp_input = cutlass.Float32(arith.select(is_first.ir_value(), NEG_INF.ir_value(), (old_total_max - total_max).ir_value()))
+                alpha = cute.math.exp2(exp_input, fastmath=True)
+                new_total_max = total_max
+                alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_stat_full.arrive()
+                reg_S = reg_S * scale_log2 - new_total_max
+
+                chunk_S_0 = reg_S[0:CHUNK].vec
+                chunk_P_0 = cute.math.exp2(chunk_S_0, fastmath=True)
+                hoisted_sum = row_reduction_pair(chunk_P_0)
+                chunk_P_0_fp16 = chunk_P_0.to(STORAGE_DTYPE)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32), chunk_P_0_fp16)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(0)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                deferred_P_1 = None
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    chunk_S_1 = reg_S[CHUNK : 2 * CHUNK].vec
+                    deferred_P_1 = cute.math.exp2(chunk_S_1, fastmath=True)
+                    chunk_P_1_fp16 = deferred_P_1.to(STORAGE_DTYPE)
+                    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK), cutlass.Float32), chunk_P_1_fp16)
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                    bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(1)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                new_p_sum_pair = hoisted_sum
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    new_p_sum_pair = new_p_sum_pair + row_reduction_pair(deferred_P_1)
+                alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+                total_sum = total_sum * alpha_pair + new_p_sum_pair
+                bars.mb_stat_empty.wait(stat_empty_phase)
+                stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+            # RIGHT-masked
+            for kv_loop in cutlass.range(bounds.unmasked_hi, bounds.right, 1, unroll=1):
+                parity_rt = kv_loop & cutlass.Int32(1)
+                parity_is_even = parity_rt == cutlass.Int32(0)
+                s_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value())
+                )
+                p_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value())
+                )
+                bmm1_phase = (bmm1_done_phase_pair >> parity_rt) & cutlass.Int32(1)
+                bars.mb_bmm1_done[parity_rt].wait(bmm1_phase)
+                bmm1_done_phase_pair = bmm1_done_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+                tmem_base = tmem_ptr_i32.load()
+                s_addr_base = tmem_base + s_off_rt
+                p_addr_base = tmem_base + p_off_rt
+                stats_addr = tmem_base + cutlass.Int32(LAYOUT.STATS_OFF)
+                kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+                raw_chunks = [
+                    nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32), num=CHUNK) for c in range(N_CHUNKS)
+                ]
+                # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
+                # CFG.BOTTOM_RIGHT is 0 — top-left masking is unchanged).
+                causal_diag = eff_seqlen_kv - seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+                chunks_S = [
+                    apply_mask_chunk(
+                        raw_chunks[c],
+                        q_abs,
+                        kv_col_base + cutlass.Int32(c * CHUNK),
+                        eff_seqlen_kv,
+                        CFG.WINDOW_LEFT,
+                        CFG.MASK_FLAGS,
+                        N=CHUNK,
+                        bottom_right=CFG.BOTTOM_RIGHT,
+                        causal_diag=causal_diag,
+                        window_right=CFG.WINDOW_RIGHT,
+                    )
+                    for c in range(N_CHUNKS)
+                ]
+                chunks_max = [row_max_reduction(chunks_S[c]) for c in range(N_CHUNKS)]
+                reg_S_vec = vec_concat(chunks_S)
+                current_max_unscaled = chunks_max[0]
+                for m in chunks_max[1:]:
+                    current_max_unscaled = cute.math.max(current_max_unscaled, m)
+                reg_S = RegTile(reg_S_vec, size=CFG.TILE_N)
+                current_max = current_max_unscaled * scale_log2
+
+                old_total_max = total_max
+                is_first = total_max == NEG_INF
+                update_cond = is_first | ((current_max - total_max) > RESCALE_THRESHOLD)
+                total_max = cutlass.Float32(arith.select(update_cond.ir_value(), current_max.ir_value(), total_max.ir_value()))
+                exp_input = cutlass.Float32(arith.select(is_first.ir_value(), NEG_INF.ir_value(), (old_total_max - total_max).ir_value()))
+                alpha = cute.math.exp2(exp_input, fastmath=True)
+                new_total_max = total_max
+                alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_stat_full.arrive()
+                reg_S = reg_S * scale_log2 - new_total_max
+
+                chunk_S_0 = reg_S[0:CHUNK].vec
+                chunk_P_0 = cute.math.exp2(chunk_S_0, fastmath=True)
+                hoisted_sum = row_reduction_pair(chunk_P_0)
+                chunk_P_0_fp16 = chunk_P_0.to(STORAGE_DTYPE)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32), chunk_P_0_fp16)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(0)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                deferred_P_1 = None
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    chunk_S_1 = reg_S[CHUNK : 2 * CHUNK].vec
+                    deferred_P_1 = cute.math.exp2(chunk_S_1, fastmath=True)
+                    chunk_P_1_fp16 = deferred_P_1.to(STORAGE_DTYPE)
+                    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK), cutlass.Float32), chunk_P_1_fp16)
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                    bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(1)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                new_p_sum_pair = hoisted_sum
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    new_p_sum_pair = new_p_sum_pair + row_reduction_pair(deferred_P_1)
+                alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+                total_sum = total_sum * alpha_pair + new_p_sum_pair
+                bars.mb_stat_empty.wait(stat_empty_phase)
+                stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+
+        # Publish final (total_max, total_sum) — correction reads for LSE / inv_sum
+        total_sum_scalar = total_sum[0] + total_sum[1]
+        stats_addr_epi = tmem_ptr_i32.load() + cutlass.Int32(LAYOUT.STATS_OFF)
+        stats_vec_epi = cutlass.Vector.from_elements((total_max, total_sum_scalar), cutlass.Float32)
+        nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr_epi, cutlass.Float32), stats_vec_epi)
+        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+        bars.mb_stat_full.arrive()
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+        nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+        nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+
+# === Correction warp group ===
+
+
+@cute.jit
+def _correction_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    sO,
+    tmem_ptr_i32,
+    tidx,
+    bars,
+    sched,
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+    cta_id_x,
+):
+    """Qwen correction warp — bootstrap-only-lo-parity bmm2_ready arrive,
+    per-parity bmm2_done phases, LSE / sink fold + write in epilogue."""
+    nvvm.barrier_cta_sync(barrier_id=2, thread_count=32 * (CFG.CORRECTION_WARPS + 1))
+
+    tid_raw = cute.arch.thread_idx()[0]
+    tid_in_wg = tid_raw - cutlass.Int32(CFG.CORR_WARP_BASE * 32)
+
+    bmm2_done_phase_pair = cutlass.Int32(0)  # bit p = next-wait phase for bmm2_done[p]
+    stat_mbar_state = cutlass.Int32(0)
+    epilogue_state = cutlass.Int32(1)  # bootstrap pre-armed so first wait passes
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    O_CHUNK = 16
+    N_CHUNKS_O = CFG.TILE_O // O_CHUNK
+    TMA_O_ITERS_LOCAL = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
+    D_BLOCK_SIZE = CFG.TILE_O // TMA_O_ITERS_LOCAL
+    TMA_O_GRANU_ELEMS_LOCAL = CFG.TILE_M * D_BLOCK_SIZE
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if bounds.right > bounds.left:
+            # Bootstrap-only-lo-parity — fire ONE parity = lo & 1
+            lo_parity_rt = bounds.left & cutlass.Int32(1)
+            bars.mb_bmm2_ready[lo_parity_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+            # Iter-0: consume start-of-tile stat_full (no rescale)
+            bars.mb_stat_full.wait(stat_mbar_state)
+            bars.mb_stat_empty.arrive()
+            stat_mbar_state = stat_mbar_state ^ cutlass.Int32(1)
+        else:
+            # Empty mainloop — corr arms MMA's mb_empty_mainloop wait
+            bars.mb_empty_mainloop.arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+        for kv_loop in cutlass.range(bounds.left + cutlass.Int32(1), bounds.right, 1, unroll=1):
+            parity_prev_rt = (kv_loop - cutlass.Int32(1)) & cutlass.Int32(1)
+            parity_cur_rt = kv_loop & cutlass.Int32(1)
+            tmem_base_iter = tmem_ptr_i32.load()
+
+            bars.mb_stat_full.wait(stat_mbar_state)
+
+            stats_addr = tmem_base_iter + cutlass.Int32(LAYOUT.STATS_OFF)
+            stats_vec = nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(stats_addr, cutlass.Float32),
+                num=2,
+            )
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+            alpha = stats_vec[0]
+
+            alpha_is_one = alpha == cutlass.Float32(1.0)
+            all_alpha_one = vote_sync(0xFFFFFFFF, alpha_is_one, VoteSync.ALL)
+
+            bars.mb_stat_empty.arrive()
+
+            bmm2_done_phase_prev = (bmm2_done_phase_pair >> parity_prev_rt) & cutlass.Int32(1)
+            bars.mb_bmm2_done[parity_prev_rt].wait(bmm2_done_phase_prev)
+            bmm2_done_phase_pair = bmm2_done_phase_pair ^ (cutlass.Int32(1) << parity_prev_rt)
+
+            if ~all_alpha_one:
+                for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                    o_addr = tmem_base_iter + cutlass.Int32(LAYOUT.O_OFF + chunk_idx * O_CHUNK)
+                    o_chunk = nvvm.tcgen05_ld(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                        num=O_CHUNK,
+                    )
+                    o_scaled = vec_scale_pair(o_chunk, alpha, O_CHUNK)
+                    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(o_addr, cutlass.Float32), o_scaled)
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+
+            bars.mb_bmm2_ready[parity_cur_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+            stat_mbar_state = stat_mbar_state ^ cutlass.Int32(1)
+
+        tmem_base_epi = tmem_ptr_i32.load()
+
+        # CTM if-staging requires names used after the conditional to be bound on every path
+        total_max_scaled = cutlass.Float32(0.0)
+        total_sum = cutlass.Float32(0.0)
+        if bounds.right > bounds.left:
+            bars.mb_stat_full.wait(stat_mbar_state)
+            stats_addr_epi = tmem_base_epi + cutlass.Int32(LAYOUT.STATS_OFF)
+            stats_vec_epi = nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(stats_addr_epi, cutlass.Float32),
+                num=2,
+            )
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+            total_max_scaled = stats_vec_epi[0]
+            total_sum = stats_vec_epi[1]
+            bars.mb_stat_empty.arrive()
+            stat_mbar_state = stat_mbar_state ^ cutlass.Int32(1)
+
+        LN2 = cutlass.Float32(0.6931471805599453)
+        total_max_nat = total_max_scaled * LN2
+        lse_val = cutlass.Float32(0.0)
+        inv_sum = cutlass.Float32(0.0)
+        if cutlass.const_expr(CFG.HAS_SINK):
+            sinks_arr = cutlass.make_array_view(sinks_tensor)
+            sink_logit = sinks_arr[head_idx]
+            new_max = cute.math.max(total_max_nat, sink_logit)
+            scale = cute.math.exp(total_max_nat - new_max, fastmath=True)
+            new_sum = total_sum * scale + cute.math.exp(sink_logit - new_max, fastmath=True)
+            lse_val = new_max + cute.math.log(new_sum, fastmath=True)
+            inv_sum = scale / new_sum
+        else:
+            lse_val = total_max_nat + cute.math.log(cute.math.max(total_sum, cutlass.Float32(1e-30)), fastmath=True)
+            inv_sum = cutlass.Float32(1.0) / cute.math.max(total_sum, cutlass.Float32(1e-30))
+
+        # --- empty KV range (zero-length sequence under the padding mask) ---
+        # Same guard as prefill_d256_fp8_sm107.py: with bounds.right <=
+        # bounds.left the mainloop never ran, so total_max/total_sum are still 0
+        # and the 1e-30 denominator floor yields LSE = log(1e-30) = -69.08 and
+        # inv_sum = 1/1e-30 -> +inf, making O = (TMEM residue) * inf.
+        #
+        # O looks fine in a casual test only because the residue happens to be
+        # zero; with a poisoned accumulator it is NaN, so zero it with a SELECT
+        # rather than a multiply (NaN * 0 = NaN).
+        _kv_empty = bounds.right <= bounds.left
+        if cutlass.const_expr(not CFG.HAS_SINK):
+            # A sink leaves the row with mass, and the branch above already
+            # gives LSE = sink_logit there; without one, LSE is -inf.
+            lse_val = cutlass.Float32(arith.select(_kv_empty.ir_value(), cutlass.Float32(float("-inf")).ir_value(), lse_val.ir_value()))
+
+        q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + tid_in_wg
+        if cutlass.const_expr(CFG.THD_VARLEN):
+            # THD: q_row_global is sequence-local; LSE is packed [1,QH,T] →
+            # index [0, head, cu_q[b] + local], bound by per-sequence Q len S_q_b.
+            _cu = cutlass.make_array_view(seq_kv_lens_tensor)
+            _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
+            _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
+            if cutlass.const_expr(lse_tensor is not None):
+                if q_row_global < _s_q_b:
+                    lse_arr = cutlass.make_array_view(lse_tensor)
+                    lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
+                    lse_row[_cu_q_b + q_row_global] = lse_val
+        else:
+            if cutlass.const_expr(lse_tensor is not None):
+                if q_row_global < seqlen_q:
+                    lse_arr = cutlass.make_array_view(lse_tensor)
+                    lse_row = lse_arr[batch_idx, head_idx, :]
+                    lse_row[q_row_global] = lse_val
+
+        # n_kv > 0 → parity_last = (right - 1) & 1; n_kv == 0 → parity_last = 0
+        parity_last_rt = cutlass.Int32(0)
+        if bounds.right > bounds.left:
+            parity_last_rt = (bounds.right - cutlass.Int32(1)) & cutlass.Int32(1)
+        bmm2_done_phase_last = (bmm2_done_phase_pair >> parity_last_rt) & cutlass.Int32(1)
+        bars.mb_bmm2_done[parity_last_rt].wait(bmm2_done_phase_last)
+        # P14 catch-up flip — bmm2_done_phase_pair ^= (1u << parity_last) AFTER epilogue wait
+        bmm2_done_phase_pair = bmm2_done_phase_pair ^ (cutlass.Int32(1) << parity_last_rt)
+
+        # "block" = 64/sizeof(ElementO) elems; mb_o_full fires every 2 blocks
+        O_EPI_BLK = 64 // CFG.BPE_O
+        N_BLOCKS_EPI = CFG.TILE_O // O_EPI_BLK
+        CHUNKS_PER_BLK = O_EPI_BLK // O_CHUNK
+
+        sO_base = sO[0].base
+        epi_o_full_block_idx = 0
+
+        for block_idx in cutlass.range_constexpr(N_BLOCKS_EPI):
+            for sub in cutlass.range_constexpr(CHUNKS_PER_BLK):
+                chunk_idx_total = block_idx * CHUNKS_PER_BLK + sub
+                o_addr = tmem_base_epi + cutlass.Int32(LAYOUT.O_OFF + chunk_idx_total * O_CHUNK)
+                o_chunk = nvvm.tcgen05_ld(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                    num=O_CHUNK,
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                o_scaled = o_chunk * inv_sum
+                # SELECT the zero for an empty KV range -- see _kv_empty above.
+                # NB: a plain `for` statement, not a comprehension -- the DSL
+                # preprocessor only rewrites statement-level range_constexpr
+                # loops ("range_constexpr should be preprocessed by preprocessor").
+                _o_elems = []
+                for _i in cutlass.range_constexpr(O_CHUNK):
+                    _o_elems.append(cutlass.Float32(arith.select(_kv_empty.ir_value(), cutlass.Float32(0.0).ir_value(), o_scaled[_i].ir_value())))
+                o_out = cutlass.Vector.from_elements(tuple(_o_elems), cutlass.Float32).to(OUT_STORAGE_DTYPE)
+
+                col_offset_const = (chunk_idx_total * O_CHUNK) % D_BLOCK_SIZE
+                block_offset_const = ((chunk_idx_total * O_CHUNK) // D_BLOCK_SIZE) * TMA_O_GRANU_ELEMS_LOCAL
+                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
+                smem_ptr = sO_base.subview(smem_offset).data_ptr()
+
+                # Gate first sub-chunk on mb_o_empty so sO is reusable
+                if block_idx == 0 and sub == 0:
+                    bars.mb_o_empty.wait(epilogue_state)
+                smem_ptr.store_swizzled(o_out, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+
+            fire_now = (block_idx % 2 == 1) or (CFG.TILE_O == O_EPI_BLK)
+            if cutlass.const_expr(fire_now):
+                # fence_proxy needed before TMASTG reads SMEM written by store_swizzled
+                nvvm.fence_proxy("async.shared", space="cta")
+                bars.mb_o_full[(block_idx // 2)].arrive()
+
+        epilogue_state = epilogue_state ^ cutlass.Int32(1)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        peer_cta = cta_id_x ^ cutlass.Int32(1)
+        bars.mb_tmem_dealloc.arrive_on_peer(peer_cta)
+    bars.mb_tmem_dealloc.arrive()
+
+
+# === Host launcher ===
+
+
+@cute.jit
+def _host(
+    q_tensor: cute.Tensor,
+    k_tensor: cute.Tensor,
+    v_tensor: cute.Tensor,
+    o_tensor: cute.Tensor,
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    problem_size: Tuple[int, int, int, int, int, int],
+    scale_softmax_log2: cutlass.Float32,
+    n_thd_units: cutlass.Int32,
+    # FROST passes the dense padded-Q trim tensor POSITIONALLY on every call.
+    # These kernels have no Q-trim epilogue (Capabilities.dense_seq_q_trim=False)
+    # so it is accepted and unused -- but the SLOT is mandatory: without it the
+    # adapter's 12th positional lands on `stream` and execute dies with
+    # "got multiple values for argument 'stream'".
+    seq_q_lens_tensor: Optional[cute.Tensor] = None,
+    # FROST plans must run on the caller's stream (engine contract; there is a
+    # dedicated stream-respect test).  Threaded exactly as the shipped
+    # prefill_d128_fp8_sm107.py sibling does.
+    stream: _cuda_driver.CUstream = None,
+) -> None:
+    B, QH, KH, SQ, SKV, _ = problem_size
+
+    _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE_O
+    qk_box_q = (1, CFG.TILE_M, 1, TMA_QK_GRANU_ELEMS)
+    qk_box_k = (1, CFG.TILE_N // CFG.CTA_MMA, 1, TMA_QK_GRANU_ELEMS)
+    vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M, 1, _O_GRANU_ELEMS)
+    stride_order = (3, 2, 1, 0)
+
+    def _tma_swz(byte_w: int):
+        return tmap.TensorMapSwizzle.s128b if byte_w == 128 else tmap.TensorMapSwizzle.s64b if byte_w == 64 else tmap.TensorMapSwizzle.s32b
+
+    tma_q_desc = tmap.create_tensor_map_tiled_from_view(
+        q_tensor,
+        box_dims=qk_box_q,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.Q_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_k_desc = tmap.create_tensor_map_tiled_from_view(
+        k_tensor,
+        box_dims=qk_box_k,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.K_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    # V TMA: TF32 transposed BMM2 operand needs SWIZZLE_128B_ATOM_32B (same box).
+    _v_tma_swz = tmap.TensorMapSwizzle.s128b_atom_32b if IS_TF32 else _tma_swz(CFG.V_SWZ_BYTES)
+    tma_v_desc = tmap.create_tensor_map_tiled_from_view(
+        v_tensor,
+        box_dims=vo_box_v,
+        stride_order=stride_order,
+        swizzle=_v_tma_swz,
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_o_desc = tmap.create_tensor_map_tiled_from_view(
+        o_tensor,
+        box_dims=vo_box_o,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.O_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+
+    rows_per_cluster = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+    q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
+    grid_q_supers = q_clusters * CFG.CTA_MMA
+    q_supers = grid_q_supers
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD: build the per-batch O descriptor array (reuse tma_o_desc over the
+        # packed [1,T,QH,D_v] O as base), then launch the exact flat
+        # batch-outermost grid (n_thd_units = Σ_b ceil(S_q_b/CGA_TILE_M)*QH,
+        # host-computed); grid_x = n_thd_units * CGA_M.
+        _build_thd_meta_o_descs_kernel(
+            o_tensor,
+            tma_o_desc,
+            o_desc_words,
+            seq_kv_lens_tensor,
+            cutlass.Int32(QH),
+            cutlass.Int32(B),
+            cutlass.Int32(CFG.TILE_O),
+        ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
+        grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
+    else:
+        grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
+    _kernel(
+        tma_q_desc,
+        tma_k_desc,
+        tma_v_desc,
+        tma_o_desc,
+        lse_tensor,
+        sinks_tensor,
+        seq_kv_lens_tensor,
+        o_desc_words,
+        cutlass.Int32(SQ),
+        cutlass.Int32(SKV),
+        cutlass.Int32(q_supers),
+        cutlass.Int32(QH),
+        cutlass.Int32(B),
+        cutlass.Int32(QH // KH),
+        scale_softmax_log2,
+    ).launch(
+        grid=grid_shape,
+        block=[CFG.THREADS_PER_CTA, 1, 1],
+        cluster=(CFG.CTA_MMA, 1, 1),
+        stream=stream,
+    )
+
+
+@lru_cache(maxsize=None)
+def compile(  # noqa: A001
+    b: int = 1,
+    qh: int = 1,
+    kh: int = 1,
+    sq: int = 256,
+    skv: int = 128,
+    d_qk: int = CFG.TILE_K,
+    d_v: int = CFG.TILE_O,
+    has_lse: bool = True,
+    lse_stride: Optional[tuple] = None,
+) -> Callable:
+    """Compile a kernel with ALL dims concrete (pins TMA descriptor strides).
+
+    THD/varlen: q/k/v/o/lse are PACKED with batch dim 1 ([1,T,H,D]); ``b`` is the
+    LOGICAL batch (sequence count) driving n_batch / metadata + O-desc sizes."""
+    # THD/varlen is NOT ported for this kernel yet.  The setup-kernel call site
+    # below still speaks the pre-upstream 7-arg contract, while FROST's
+    # thd_helpers.build_thd_meta_o_descs_kernel takes 14 args and a different
+    # metadata layout (4B+4 with batch_remap + a claim counter, vs the 3B+2
+    # here), and the scheduler decode differs to match.  Raise here rather than
+    # let it fail as an arity error deep in the trace -- and so no engine row
+    # can advertise thd=True for this kernel and appear to work.  The dense
+    # path is unaffected: CFG.THD_VARLEN is 0 and every THD branch folds out.
+    if CFG.THD_VARLEN:
+        raise NotImplementedError(f"{__name__}: THD/varlen not ported to the FROST setup-kernel contract")
+    # ---- FROST adapter ABI ------------------------------------------------
+    # lower_dsl_prefill calls EVERY kernel with the full forward signature.
+    # This body carries only what the port brought over, so anything
+    # it cannot honor RAISES rather than being silently ignored: a raise here
+    # means the engine's Capabilities row is lying, which is the failure we
+    # want loud.  (Capabilities: lse_optional=False, no strided Stats.)
+    if lse_stride is not None:
+        raise NotImplementedError(f"{__name__}: strided Stats not ported (contiguous [B, H, S] only)")
+    if d_qk > CFG.TILE_K or d_v > CFG.TILE_O or d_qk <= 0 or d_v <= 0:
+        raise ValueError(f"{__name__}: envelope is 0 < d_qk <= {CFG.TILE_K}, 0 < d_v <= {CFG.TILE_O}; " f"got ({d_qk}, {d_v})")
+    _fake_batch = 1 if CFG.THD_VARLEN else b
+    fake_q = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, sq, qh, d_qk),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_k = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, d_qk),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_v = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, d_v),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_o = cute.runtime.make_fake_compact_tensor(
+        OUT_STORAGE_DTYPE,
+        (_fake_batch, sq, qh, d_v),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    # has_lse=False (no Stats output): the LSE argument is None-specialized and
+    # the store is compiled out entirely -- no dummy buffer exists at any level,
+    # which is what lets the dense graph report get_workspace_size() == 0.
+    # Mirrors the shipped prefill_d128_fp8_sm107.py.
+    fake_lse = (
+        cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (_fake_batch, qh, sq),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
+        if has_lse
+        else None
+    )
+    fake_sinks = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (qh,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # THD overloads seq_kv_lens as the [seq_kv_lens(B)|cu_q(B+1)|cu_k(B+1)]
+    # metadata buffer (length 3B+2); non-THD keeps the [B] per-batch-lens slot.
+    _skv_len = (3 * b + 2) if CFG.THD_VARLEN else b
+    fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (_skv_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # Per-batch O TMA-descriptor array (16 int64 = 128 B each) + 1 pad slot.
+    _odesc_len = (b * _TENSOR_MAP_QWORDS + _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
+    fake_o_desc = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int64,
+        (_odesc_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    return cute.compile(
+        _host,
+        fake_q,
+        fake_k,
+        fake_v,
+        fake_o,
+        fake_lse,
+        fake_sinks,
+        fake_seq_kv_lens,
+        fake_o_desc,
+        (b, qh, kh, sq, skv, 0),
+        cutlass.Float32(0.0),
+        cutlass.Int32(0),
+        stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
+        options="--enable-tvm-ffi",
+    )
+
+
+def _main():
+    """Minimal compile-check / perf CLI."""
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--b", type=int, default=1)
+    parser.add_argument("--hq", type=int, default=1)
+    parser.add_argument("--hk", type=int, default=1)
+    parser.add_argument("--sq", type=int, default=256)
+    parser.add_argument("--skv", type=int, default=128)
+    parser.add_argument("--validate", action="store_true")
+    parser.add_argument("--iters", type=int, default=0)
+    args = parser.parse_args()
+
+    print(f"[d256_f16] compile b={args.b} qh={args.hq} kh={args.hk} " f"sq={args.sq} skv={args.skv}", flush=True)
+    fn = compile(args.b, args.hq, args.hk, args.sq, args.skv)
+    print(f"[d256_f16] compile OK: {fn}", flush=True)
+    if args.validate:
+        print("[d256_f16] --validate is not implemented in this CLI; use the FE test suite.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm107.py
@@ -44,6 +44,20 @@ from cudnn.sdpa.fwd.config_sm107 import TemplateParams, make_cfg_d256
 
 PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
 CFG, _TMA = make_cfg_d256(PARAMS)
+
+# tcgen05 SMEM-descriptor version for EVERY SmemTile in this module -- ONE
+# decision point, wired into every construction below rather than repeated as a
+# per-tile literal.  A version-0 descriptor's ``start_address`` is 14 bits = a
+# 256 KiB window; Rubin raises the per-CTA SMEM cap to 327 KiB, so an operand
+# buffer at or above 256 KiB wraps to offset 0 and the MMA multiplies whatever
+# sits at the bottom of SMEM.  This flavor's buffers all stay below the line.
+#
+# Do NOT re-literal this at a call site: the d512 MXFP8 sibling shipped NaN on
+# 100% of cells because its scale-factor tiles were declared UNDER a comment
+# claiming "every operand tile here carries desc_version=1" -- without the
+# kwarg.  A single constant makes that class of drift impossible, and
+# test_sm107_descriptor_version_matches_the_smem_budget asserts it.
+DESC_VERSION: int = 0
 Cfg = type(CFG)
 TMA_QK_ITERS = _TMA.QK_ITERS
 TMA_VO_ITERS = _TMA.VO_ITERS
@@ -259,6 +273,7 @@ def _kernel(
         tma_loads_per_tile=TMA_QK_ITERS,
         tma_granu_elems=TMA_QK_GRANU_ELEMS,
         tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+        desc_version=DESC_VERSION,
     )
     sK = SmemTile(
         base=sK_raw,
@@ -270,6 +285,7 @@ def _kernel(
         tma_loads_per_tile=TMA_QK_ITERS,
         tma_granu_elems=TMA_QK_GRANU_ELEMS,
         tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+        desc_version=DESC_VERSION,
     )
     sV = SmemTile(
         base=sV_raw,
@@ -281,6 +297,7 @@ def _kernel(
         tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
         tma_granu_elems=TMA_VO_GRANU_ELEMS,
         tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+        desc_version=DESC_VERSION,
     )
     # sO shares backing with sQ (Q∪O alias).
     sO = SmemTile(
@@ -293,6 +310,7 @@ def _kernel(
         tma_loads_per_tile=TMA_O_ITERS_HOST,
         tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
         tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+        desc_version=DESC_VERSION,
     )
 
     bars = make_d256_bars(CFG, N_O_CHUNKS=N_O_CHUNKS)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_fp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_fp8_sm107.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-"""CTM-DSL qwen prefill SDPA kernel (d_qk=d_v=256, FP8 E4M3/E5M2).
+"""pre-upstream DSL qwen prefill SDPA kernel (d_qk=d_v=256, FP8 E4M3/E5M2).
 
 Qwen pipeline: TILES_Q=1, single softmax wg, Q∪O SMEM alias with two
 extra barriers (mb_q_o_alias TMASTG→TMA bootstrap-armed; mb_tmastg_go
@@ -136,7 +136,7 @@ elif CFG.DTYPE_O == 2:
 elif CFG.DTYPE_O == 3:
     OUT_STORAGE_DTYPE = cutlass.Float16
 else:
-    raise ValueError(f"prefill_sdpa_d256_fp8 CTM: DTYPE_O={CFG.DTYPE_O} not supported " f"(expected 0=E4M3 / 1=E5M2 / 2=BF16 / 3=FP16)")
+    raise ValueError(f"prefill_sdpa_d256_fp8: DTYPE_O={CFG.DTYPE_O} not supported " f"(expected 0=E4M3 / 1=E5M2 / 2=BF16 / 3=FP16)")
 
 
 from cudnn.sdpa.fwd.kernels._common_sm100 import (
@@ -187,7 +187,7 @@ class KernelTmemLayout:
     """Column offsets for the qwen 2-parity-slot SDPA pipeline (FP8 d=256).
 
     P aliases the TAIL of each parity's S_acc slot.  Stats parked at col
-    544 (CTM-only — outside S_acc/O range) vs C++ col 512.
+    544 (DSL-only — outside S_acc/O range) vs C++ col 512.
     """
 
     TOTAL_COLS: int = 576
@@ -228,8 +228,8 @@ STRIDE_BYTE_OFFSET_PV = 8 * CFG.V_SWZ_BYTES
 # Derived, never a literal: NUM_KPHASES_PV must track the SAME k-step size
 # the MmaDesc below is built with, or the BMM2 k-loop and the descriptor's
 # num_k_steps disagree and half of V's K is silently dropped.
-_CTM_MMA_K_FP8 = CFG.TILE_K_HW_BMM2
-NUM_KPHASES_PV = CFG.TILE_N // _CTM_MMA_K_FP8
+_MMA_K_FP8 = CFG.TILE_K_HW_BMM2
+NUM_KPHASES_PV = CFG.TILE_N // _MMA_K_FP8
 NUM_KPHASES_PV_PER_CHUNK = NUM_KPHASES_PV // CFG.N_BMM2_CHUNKS
 
 
@@ -1103,7 +1103,7 @@ def _softmax_warp_group(
         stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
         epilogue_state = epilogue_state ^ cutlass.Int32(1)
 
-        # Body inlined per-segment so the CTM tracer can dispatch through
+        # Body inlined per-segment so the DSL tracer can dispatch through
         # cutlass.range without hitting the closure check.
         CHUNK = 64
         P_COLS_PER_CHUNK = CHUNK // 4  # fp8 packed 4:1 into FP32 cells
@@ -1552,7 +1552,7 @@ def _correction_warp_group(
         # Epilogue: always run (stores garbage on empty-mainloop — TMASTG ignores)
         tmem_base_epi = tmem_ptr_i32.load()
 
-        # Pre-declare for CTM if-staging — names used after conditional must
+        # Pre-declare for DSL if-staging — names used after conditional must
         # be bound on every path
         total_max_scaled = cutlass.Float32(0.0)
         total_sum = cutlass.Float32(0.0)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_fp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_fp8_sm107.py
@@ -1,0 +1,1990 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""CTM-DSL qwen prefill SDPA kernel (d_qk=d_v=256, FP8 E4M3/E5M2).
+
+Qwen pipeline: TILES_Q=1, single softmax wg, Q∪O SMEM alias with two
+extra barriers (mb_q_o_alias TMASTG→TMA bootstrap-armed; mb_tmastg_go
+TMA→TMASTG empty-mainloop cover).  Q·K(i+1) → S·V(i) lookahead MMA
+stream with two parity S_acc TMEM slots; P_cast aliases each slot's
+tail.  Bootstrap-only-lo-parity correction arrive on mb_bmm2_ready.
+
+THD / varlen (``CFG.THD_VARLEN=1``) supported (E4M3/E5M2) via the shared
+mechanism (FP8 element-addressed, no block-scale SF; same path as f16); dense
+byte-identical.  Public-API fp8 THD glue is a follow-up (THD-aware quantizer).
+"""
+
+import os
+import sys
+from functools import lru_cache
+from typing import Callable, Optional, Tuple
+
+
+from cutlass.experimental import primitives as nvvm
+from cutlass.experimental.primitives import vote_sync, VoteSync
+from cutlass._mlir.dialects import arith
+
+import cutlass
+from cutlass.experimental import primitives as prims
+import cutlass.cute as cute
+from cutlass.base_dsl.typing import Pointer
+from cutlass.experimental.cuda import tensor_map as tmap
+import cuda.bindings.driver as _cuda_driver  # noqa: F401
+
+from dataclasses import dataclass
+from typing import NamedTuple
+
+# Config comes from the FROST template loader, NOT an env var: the pre-upstream
+# kernels picked a flavor with an env var + a sdpa_config_<flavor> module, which the
+# FROST engine contract forbids ("no environment variables for configuration" --
+# parameters travel as typed dataclasses). The loader injects
+# FROST_TEMPLATE_PARAMS before this body runs; the default keeps a plain
+# `import` usable as a standalone driver.
+from cudnn.sdpa.fwd.config_sm107 import TemplateParams, make_cfg_d256
+
+PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
+CFG, _TMA = make_cfg_d256(PARAMS)
+Cfg = type(CFG)
+TMA_QK_ITERS = _TMA.QK_ITERS
+TMA_VO_ITERS = _TMA.VO_ITERS
+TMA_QK_GRANU_ELEMS = _TMA.QK_GRANU_ELEMS
+TMA_VO_GRANU_ELEMS = _TMA.VO_GRANU_ELEMS
+
+# Rubin's dense-FP8 MMA runs K=64 per instruction, and every
+# ``Tcgen05InstrDesc.build`` site in this body hardcodes the matching idesc
+# ``k_dim=1``.  ``config_sm107.tile_k_hw()`` derives the 64; this guard is the
+# tripwire for the pairing, which is arch-OPPOSITE (Blackwell wants k_dim=0 with
+# TILE_K_HW=32) and fails SILENTLY -- a mismatch scrambles rows of the
+# accumulator rather than raising (rules/mma-tma-matrix.md S1).
+if CFG.TILE_K_HW_BMM1 != 64 or CFG.TILE_K_HW_BMM2 != 64:
+    raise ValueError(f"{__name__}: this body's idesc k_dim=1 requires TILE_K_HW=64 on Rubin; " f"got BMM1={CFG.TILE_K_HW_BMM1} BMM2={CFG.TILE_K_HW_BMM2}")
+
+if CFG.DTYPE_QKV not in (0, 1):
+    raise ValueError(f"prefill_sdpa_d256_fp8: DTYPE_QKV must be 0 (E4M3) or 1 (E5M2); " f"got {CFG.DTYPE_QKV}.  Use prefill_sdpa_d256_f16.py for BF16/FP16.")
+
+TMA_O_GRANU_ELEMS_HOST = CFG.O_SWZ_BYTES // CFG.BPE_O
+TMA_O_ITERS_HOST = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
+
+from cudnn.frost.tile_dsl.barrier import (
+    PipelineState,
+    advance,
+    cga_arrive,
+    cga_wait,
+    # `wait` (free fn) — still used for sched.mb_* (Sched not in Bars).
+    wait,
+)
+from cudnn.frost.tile_dsl.scheduler import (
+    Sched,
+    scheduler_warp_loop,
+    read_tile_id_arrive,
+    SCHED_NATURAL,
+    SCHED_LPT,
+    SCHED_LPT_L2,
+)
+from cudnn.frost.tile_dsl.pointwise import (
+    tmem_load_max_reduction_tile,
+    row_reduction_pair,
+    row_max_reduction,
+    vec_scale_pair,
+)
+from cudnn.frost.tile_dsl.regtile import RegTile, vec_concat
+from cudnn.frost.tile_dsl.mma import mma_ss, mma_ts_step
+from cudnn.frost.tile_dsl.tma import tma_load_tile, tma_store_tile, tma_store_commit, tma_store_wait
+from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, tma_slice_runtime_desc
+from cudnn.frost.tile_dsl.tmem import tmem_alloc, tmem_dealloc
+from cudnn.frost.tile_dsl.mask import (
+    apply_mask_chunk,
+    MASK_NONE,
+    MASK_PADDED,
+    MASK_CAUSAL,
+    MASK_SWA,
+)
+
+if CFG.DTYPE_QKV == 0:
+    STORAGE_DTYPE = cutlass.Float8E4M3FN
+    P_STORAGE_DTYPE = cutlass.Float8E4M3FN
+    MMA_KIND = nvvm.Tcgen05MMAKind.F8F6F4
+elif CFG.DTYPE_QKV == 1:
+    STORAGE_DTYPE = cutlass.Float8E5M2
+    P_STORAGE_DTYPE = cutlass.Float8E5M2
+    MMA_KIND = nvvm.Tcgen05MMAKind.F8F6F4
+
+# DTYPE_O independent of DTYPE_QKV — FP8 input may write BF16/FP16 O so a
+# downstream consumer skips a dequant.  BPE_O ∈ {1, 2}; epilogue already casts
+# via .to(OUT_STORAGE_DTYPE) + store_swizzled (dtype-generic).  The Q∪O SMEM
+# alias is byte-sized for max(Q@BPE, O@BPE_O) so BF16 O doesn't overflow it.
+if CFG.DTYPE_O == 0:
+    OUT_STORAGE_DTYPE = cutlass.Float8E4M3FN
+elif CFG.DTYPE_O == 1:
+    OUT_STORAGE_DTYPE = cutlass.Float8E5M2
+elif CFG.DTYPE_O == 2:
+    OUT_STORAGE_DTYPE = cutlass.BFloat16
+elif CFG.DTYPE_O == 3:
+    OUT_STORAGE_DTYPE = cutlass.Float16
+else:
+    raise ValueError(f"prefill_sdpa_d256_fp8 CTM: DTYPE_O={CFG.DTYPE_O} not supported " f"(expected 0=E4M3 / 1=E5M2 / 2=BF16 / 3=FP16)")
+
+
+from cudnn.sdpa.fwd.kernels._common_sm100 import (
+    D256Bars as Bars,
+    KvLoopBounds,
+    make_d256_bars,
+    compute_kv_loop_bounds,
+    lpt_tile_coords,
+    make_sdpa_helpers,
+)
+
+CGA_SIZE = CFG.CGA_M * CFG.CGA_N
+
+CTA_GROUP_KIND = nvvm.CTAGroup.CTA_2 if CFG.CTA_MMA == 2 else nvvm.CTAGroup.CTA_1
+
+qBufferElems = CFG.TILE_M * CFG.TILE_K
+kBufferElems = CFG.TILE_N * CFG.TILE_K // CFG.CTA_MMA
+vBufferElems = CFG.TILE_O * CFG.TILE_N // CFG.CTA_MMA
+oBufferElems = CFG.TILE_M * CFG.TILE_O
+qoAliasBytes = max(qBufferElems * CFG.BPE, oBufferElems * CFG.BPE_O)
+
+qTmaTransactionBytes = qBufferElems * CFG.BPE * CFG.CTA_MMA
+kTmaTransactionBytes = kBufferElems * CFG.BPE * CFG.CTA_MMA
+vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
+
+N_O_CHUNKS = (CFG.TILE_O * CFG.BPE_O + 127) // 128
+
+CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+
+_sdpa_h = make_sdpa_helpers(CFG)
+_decode_initial = _sdpa_h.decode_initial
+_decode_payload = _sdpa_h.decode_payload
+_bounds_for_tile = _sdpa_h.bounds_for_tile
+_resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+
+# THD / varlen — shared helpers (FP8 is element-addressed like f16; per-tensor
+# dequant scalars, no block-scale SF).  Gated by CFG.THD_VARLEN (folds out).
+from cudnn.sdpa.fwd.kernels.thd_helpers import build_thd_meta_o_descs_kernel as _build_thd_meta_o_descs_kernel, TENSOR_MAP_QWORDS
+
+_TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
+_dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
+_dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
+_thd_tma_offsets = _sdpa_h.thd_tma_offsets
+
+
+@dataclass(frozen=True)
+class KernelTmemLayout:
+    """Column offsets for the qwen 2-parity-slot SDPA pipeline (FP8 d=256).
+
+    P aliases the TAIL of each parity's S_acc slot.  Stats parked at col
+    544 (CTM-only — outside S_acc/O range) vs C++ col 512.
+    """
+
+    TOTAL_COLS: int = 576
+
+    S_ACC_EVEN_OFF: int = 0
+    S_ACC_ODD_OFF: int = 128
+
+    P_EVEN_OFF: int = 96
+    P_ODD_OFF: int = 224
+
+    O_OFF: int = 256
+
+    STATS_OFF: int = 544
+
+
+LAYOUT = KernelTmemLayout()
+
+
+_SWZ_ENUM = {128: 2, 64: 4, 32: 6}
+SMEM_LAYOUT_Q = _SWZ_ENUM[CFG.Q_SWZ_BYTES]
+SMEM_LAYOUT_K = _SWZ_ENUM[CFG.K_SWZ_BYTES]
+SMEM_LAYOUT_V = _SWZ_ENUM[CFG.V_SWZ_BYTES]
+SMEM_LAYOUT_O = _SWZ_ENUM[CFG.O_SWZ_BYTES]
+SMEM_LAYOUT_QKO = SMEM_LAYOUT_Q
+
+_O_SWZ_B = {128: 3, 64: 2, 32: 1}[CFG.O_SWZ_BYTES]
+_O_SMEM_SWIZZLE = cutlass.Swizzle(_O_SWZ_B, 4, 3)
+
+LEADING_BYTE_OFFSET_QK = 0
+STRIDE_BYTE_OFFSET_QK = 8 * CFG.Q_SWZ_BYTES
+
+# leading_byte_offset = 0 when (TILE_O/CTA_MMA)/8 <= 8 else TILE_N*V_SWZ_BYTES
+_CORE_MATRIX_ROWS = 8
+_V_PC_COLS = CFG.TILE_O // CFG.CTA_MMA
+LEADING_BYTE_OFFSET_PV = 0 if (_V_PC_COLS // _CORE_MATRIX_ROWS) <= 8 else CFG.TILE_N * CFG.V_SWZ_BYTES
+STRIDE_BYTE_OFFSET_PV = 8 * CFG.V_SWZ_BYTES
+
+# Derived, never a literal: NUM_KPHASES_PV must track the SAME k-step size
+# the MmaDesc below is built with, or the BMM2 k-loop and the descriptor's
+# num_k_steps disagree and half of V's K is silently dropped.
+_CTM_MMA_K_FP8 = CFG.TILE_K_HW_BMM2
+NUM_KPHASES_PV = CFG.TILE_N // _CTM_MMA_K_FP8
+NUM_KPHASES_PV_PER_CHUNK = NUM_KPHASES_PV // CFG.N_BMM2_CHUNKS
+
+
+# === Kernel entry ===
+
+
+@cute.kernel
+def _kernel(
+    tma_q_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_k_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_v_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_o_desc: cutlass.GridConstant[tmap.TensorMap],
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    seqlen_q: cutlass.Int32,
+    seqlen_kv: cutlass.Int32,
+    n_q_supers: cutlass.Int32,
+    n_qh: cutlass.Int32,
+    n_batch: cutlass.Int32,
+    qh_per_kh: cutlass.Int32,
+    scale_softmax_log2: cutlass.Float32,
+    o_scale_fused: cutlass.Float32,
+    # FROST's quantized ABI: the four 1-element fp32 scales arrive as DEVICE
+    # TENSORS and the amax of O is an OUTPUT.  The pre-upstream contract pre-folded the scales on
+    # the host and produced no amax -- that gap is what this closes.  Template:
+    # the shipped prefill_d128_fp8_sm107.py sibling (same lineage).
+    descale_q_t: cute.Tensor,
+    descale_k_t: cute.Tensor,
+    descale_v_t: cute.Tensor,
+    scale_o_t: cute.Tensor,
+    amax_o_tensor: cute.Tensor,
+) -> None:
+
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    tidx, _, _ = cute.arch.thread_idx()
+
+    bidx = cute.arch.block_idx()[0]
+    bidy = cute.arch.block_idx()[1]
+    bidz = cute.arch.block_idx()[2]
+
+    # Device-scale fold: every thread loads the same four 1-element fp32 scales
+    # (identical addresses -> L2 broadcast, negligible) and folds them into the
+    # softmax scale and the output scale, exactly as the shipped d128 sibling.
+    _dsc_q = cutlass.Float32(cutlass.make_array_view(descale_q_t)[0])
+    _dsc_k = cutlass.Float32(cutlass.make_array_view(descale_k_t)[0])
+    _dsc_v = cutlass.Float32(cutlass.make_array_view(descale_v_t)[0])
+    _scl_o = cutlass.Float32(cutlass.make_array_view(scale_o_t)[0])
+    scale_softmax_log2 = scale_softmax_log2 * _dsc_q * _dsc_k
+    o_scale_fused = o_scale_fused * _dsc_v * _scl_o
+
+    # Q∪O alias byte-sized to max(Q@BPE, O@BPE_O) — STORAGE_DTYPE is FP8 (1 B)
+    # so the element count == byte count.  BF16/FP16 O (BPE_O=2) would overflow
+    # a qBufferElems-only allocation, so size for the larger of the two views.
+    _QO_ALIAS_ELEMS = max(qBufferElems * CFG.BPE, oBufferElems * CFG.BPE_O)
+    sQO_raw = cutlass.Array(STORAGE_DTYPE, _QO_ALIAS_ELEMS, alignment=1024, space=cutlass.AddressSpace.smem)
+    sK_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * kBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    sV_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * vBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    # OUT_STORAGE_DTYPE view of the Q∪O backing — element offsets in the
+    # epilogue store then advance in BPE_O units (BF16/FP16 O).  No-op recast
+    # for FP8 output (same dtype).
+    sO_raw = cutlass.Array(sQO_raw.data_ptr(), shape=oBufferElems, dtype=OUT_STORAGE_DTYPE)
+
+    # sQ / sO share Q∪O backing; separate SmemTile wrappers for per-site TMA params
+    sQ = SmemTile(
+        base=sQO_raw,
+        elems_per_stage=qBufferElems,
+        stages=1,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+    )
+    sK = SmemTile(
+        base=sK_raw,
+        elems_per_stage=kBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+    )
+    sV = SmemTile(
+        base=sV_raw,
+        elems_per_stage=vBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_PV,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_PV,
+        layout=SMEM_LAYOUT_V,
+        tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
+        tma_granu_elems=TMA_VO_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+    )
+    sO = SmemTile(
+        base=sO_raw,
+        elems_per_stage=oBufferElems,
+        stages=1,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=SMEM_LAYOUT_O,
+        tma_loads_per_tile=TMA_O_ITERS_HOST,
+        tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+    )
+
+    bars = make_d256_bars(CFG, N_O_CHUNKS=N_O_CHUNKS)
+
+    tmem_ptr_i32 = cutlass.Array(cutlass.Int32, 1, alignment=16, space=cutlass.AddressSpace.smem)
+
+    sched = Sched(
+        **{
+            "mb_scheduler": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "mb_read_tile_id": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "tile_id_smem": cutlass.Array(cutlass.Int32, CFG.SCHEDULER_STAGES * 8, alignment=16, space=cutlass.AddressSpace.smem),
+            "bidx_init": bidx,
+            "bidy_init": bidy,
+            "bidz_init": bidz,
+        }
+    )
+
+    READ_TILE_ARRIVERS_TOTAL = CFG.READ_TILE_ARRIVERS
+
+    if warp_idx == 0:
+        if nvvm.elect_sync():
+            # Init counts baked into make_d256_bars(...); kernel calls .init()
+            # per stage.  range_constexpr keeps loop vars Python int.
+            bars.mb_q_full.init()
+            bars.mb_q_o_alias.init()
+            bars.mb_tmastg_go.init()
+            for p in cutlass.range_constexpr(2):
+                bars.mb_bmm1_done[p].init()
+                bars.mb_bmm2_done[p].init()
+                for c in cutlass.range_constexpr(CFG.N_BMM2_CHUNKS):
+                    bars.mb_bmm2_ready[p * CFG.N_BMM2_CHUNKS + c].init()
+            bars.mb_stat_full.init()
+            bars.mb_stat_empty.init()
+            for chunk in cutlass.range_constexpr(N_O_CHUNKS):
+                bars.mb_o_full[chunk].init()
+            bars.mb_o_empty.init()
+            for ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_k_full[ks].init()
+                bars.mb_k_empty[ks].init()
+                bars.mb_v_full[ks].init()
+                bars.mb_v_empty[ks].init()
+            for s in range(CFG.SCHEDULER_STAGES):
+                nvvm.mbarrier_init(sched.mb_scheduler.subview(s), CFG.ONE_LANE)
+                nvvm.mbarrier_init(sched.mb_read_tile_id.subview(s), READ_TILE_ARRIVERS_TOTAL)
+            bars.mb_empty_mainloop.init()
+            bars.mb_tmem_dealloc.init()
+
+            # bootstrap mb_q_o_alias so first TMA wait passes
+            bars.mb_q_o_alias.arrive()
+
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync()
+
+    # P4 cluster fence after mbar init for cga2 cross-CTA arrives
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        cga_arrive()
+        cga_wait()
+
+    cta_id_x = cute.arch.block_idx_in_cluster() if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    cta_in_pair = (cta_id_x & cutlass.Int32(1)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    leader_cta_id = (cta_id_x & cutlass.Int32(~1 & 0xFFFFFFFF)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    mcast_mask = (cutlass.Int32(3) << leader_cta_id) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    tma_mcast_mask = (cutlass.Int16(1) << cta_in_pair) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
+    is_leader = cta_in_pair == cutlass.Int32(0)
+
+    # Warp layout: 0..3 softmax wg, 4..7 correction, 8 MMA, 9 TMALDG, 10 TMASTG, 11 sched.
+    if warp_idx >= CFG.SOFTMAX_WG0_BASE and warp_idx < CFG.SOFTMAX_WG0_BASE + CFG.SOFTMAX_WG_WARPS:
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        _softmax_warp_group(
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_softmax_log2,
+            tmem_ptr_i32=tmem_ptr_i32,
+            bars=bars,
+            sched=sched,
+            lse_tensor=lse_tensor,
+            sinks_tensor=sinks_tensor,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+        )
+
+    elif warp_idx >= CFG.CORR_WARP_BASE and warp_idx < CFG.CORR_WARP_BASE + CFG.CORRECTION_WARPS:
+        nvvm.setmaxregister(CFG.CORRECTION_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _correction_warp_group(
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            sO=sO,
+            tmem_ptr_i32=tmem_ptr_i32,
+            tidx=tidx,
+            bars=bars,
+            sched=sched,
+            lse_tensor=lse_tensor,
+            sinks_tensor=sinks_tensor,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+            cta_id_x=cta_id_x,
+            o_scale_fused=o_scale_fused,
+            amax_o_tensor=amax_o_tensor,
+        )
+
+    elif warp_idx == CFG.MMA_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        if cutlass.const_expr(CFG.CTA_MMA == 2):
+            if is_leader:
+                _mma_warp_group(
+                    seqlen_q=seqlen_q,
+                    seqlen_kv=seqlen_kv,
+                    sQ=sQ,
+                    sK=sK,
+                    sV=sV,
+                    tmem_ptr_i32=tmem_ptr_i32,
+                    bars=bars,
+                    sched=sched,
+                    seq_kv_lens_tensor=seq_kv_lens_tensor,
+                    n_q_supers=n_q_supers,
+                    n_qh=n_qh,
+                    n_batch=n_batch,
+                    mcast_mask=mcast_mask,
+                    cta_in_pair=cta_in_pair,
+                )
+            else:
+                _mma_warp_quiet(tmem_ptr_i32, bars)
+        else:
+            _mma_warp_group(
+                seqlen_q=seqlen_q,
+                seqlen_kv=seqlen_kv,
+                sQ=sQ,
+                sK=sK,
+                sV=sV,
+                tmem_ptr_i32=tmem_ptr_i32,
+                bars=bars,
+                sched=sched,
+                seq_kv_lens_tensor=seq_kv_lens_tensor,
+                n_q_supers=n_q_supers,
+                n_qh=n_qh,
+                n_batch=n_batch,
+                mcast_mask=mcast_mask,
+                cta_in_pair=cta_in_pair,
+            )
+
+    elif warp_idx == CFG.TMALDG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        nvvm.prefetch_tensormap(tma_q_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_k_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_v_desc.get_ptr())
+        _tmaldg_warp_group(
+            tma_q_desc=tma_q_desc,
+            tma_k_desc=tma_k_desc,
+            tma_v_desc=tma_v_desc,
+            sQ=sQ,
+            sK=sK,
+            sV=sV,
+            bars=bars,
+            sched=sched,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            qh_per_kh=qh_per_kh,
+            is_leader=is_leader,
+            cta_in_pair=cta_in_pair,
+            tma_mcast_mask=tma_mcast_mask,
+        )
+
+    elif warp_idx == CFG.TMASTG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _tmastg_warp_group(
+            tma_o_desc=tma_o_desc,
+            sO=sO,
+            bars=bars,
+            sched=sched,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            cta_in_pair=cta_in_pair,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
+        )
+
+    else:  # warp_idx == CFG.SCHED_WARP_ID
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        is_cga_first_cta = cta_id_x == cutlass.Int32(0)
+        scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
+
+
+# === TMA-LDG warp group ===
+
+
+@cute.jit
+def _tmaldg_warp_group(
+    tma_q_desc,
+    tma_k_desc,
+    tma_v_desc,
+    sQ,
+    sK,
+    sV,
+    bars,
+    sched,
+    seqlen_q,
+    seqlen_kv,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    qh_per_kh,
+    is_leader,
+    cta_in_pair,
+    tma_mcast_mask,
+):
+    """Qwen TMA-LDG warp: single Q load gated on mb_q_o_alias, fires
+    mb_tmastg_go each tile end (covers empty-mainloop branch)."""
+
+    q_o_alias_phase = cutlass.Int32(0)
+    kv_state = PipelineState.start(phase=1)  # bootstrap pre-armed at phase 1
+
+    tma_q = GmemTileTma(tma_q_desc)
+    tma_k = GmemTileTma(tma_k_desc)
+    tma_v = GmemTileTma(tma_v_desc)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+    q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    K_ROW_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_N // CFG.CTA_MMA)
+    V_COL_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_O // CFG.CTA_MMA)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        # Run unconditionally — covers both normal and empty-mainloop branches
+        bars.mb_q_o_alias.wait(q_o_alias_phase)
+        q_o_alias_phase = q_o_alias_phase ^ cutlass.Int32(1)
+
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+            # Empty mainloop — skip Q/K/V loads; mb_tmastg_go still fires at end-of-iter
+            pass
+        else:
+            # P9 — leader-only arrive_expect_tx under cga2 (TMA bytes routed to leader mbar)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_q_full.arrive(n_bytes=qTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_q_full.arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sQ[0],
+                tma_q(cutlass.Int32(0), head_idx, q_row_base + q_seq_off, tma_batch),
+                bars.mb_q_full.smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+
+            for kv_loop in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                kv_row_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+
+                bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sK[kv_state.idx],
+                    tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
+                    bars.mb_k_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+
+                # V split along d_v under cga2 via V_COL_OFFSET_PEER
+                bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sV[kv_state.idx],
+                    tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
+                    bars.mb_v_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        # mb_tmastg_go fires on both normal and empty-mainloop tiles
+        if nvvm.elect_sync():
+            bars.mb_tmastg_go.arrive()
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+        nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+        nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+        q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+
+    # cga2 drain — trailing empty mbar arrives from leader's multicast commits
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        for _ks in cutlass.range_constexpr(CFG.STAGES_KV):
+            bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+            bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+
+# === TMA-STG warp group ===
+
+
+@cute.jit
+def _tmastg_warp_group(
+    tma_o_desc,
+    sO,
+    bars,
+    sched,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    cta_in_pair,
+    seq_kv_lens_tensor,
+    o_desc_words,
+):
+    """Qwen TMA-STG warp: waits mb_tmastg_go before per-chunk mb_o_full
+    (covers empty-mainloop); fires mb_q_o_alias at end-of-tile to release
+    Q∪O for the next persistent tile."""
+
+    tmastg_go_phase = cutlass.Int32(0)
+    o_full_phase = cutlass.Int32(0)
+
+    tma_o = GmemTileTma(tma_o_desc)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        bars.mb_tmastg_go.wait(tmastg_go_phase)
+        tmastg_go_phase = tmastg_go_phase ^ cutlass.Int32(1)
+
+        for chunk in cutlass.range_constexpr(N_O_CHUNKS):
+            bars.mb_o_full[chunk].wait(o_full_phase)
+
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+
+        if cutlass.const_expr(CFG.THD_VARLEN):
+            # THD: store through this batch's pre-built descriptor (seq extent
+            # = S_q_b → box past S_q_b OOB-clipped).  q_row_coord seq-local; batch→0.
+            o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+            o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_coord, cutlass.Int32(0))
+            tma_store_tile(sO[0], o_slice)
+        else:
+            tma_store_tile(
+                sO[0],
+                tma_o(cutlass.Int32(0), head_idx, q_row_coord, batch_idx),
+            )
+        tma_store_commit()
+        tma_store_wait(0)
+
+        bars.mb_o_empty.arrive()
+        if nvvm.elect_sync():
+            bars.mb_q_o_alias.arrive()
+
+        o_full_phase = o_full_phase ^ cutlass.Int32(1)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+
+# === MMA warp group (+ quiet warp for cga2 non-leader) ===
+
+
+@cute.jit
+def _mma_warp_quiet(tmem_ptr_i32, bars):
+    """Quiet MMA-warp body for cga2 non-leader: alloc TMEM, no MMA, dealloc."""
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND, is_exclusive=True)
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _mma_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    sQ,
+    sK,
+    sV,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    mcast_mask,
+    cta_in_pair,
+):
+    """Qwen MMA warp: Q*K(i+1) → S*V(i) lookahead stream.
+    Prologue Q*K(lo); mainloop kv=lo..hi-2 runs Q*K(kv+1) then chunked
+    S*V(kv) gated on bmm2_ready; epilogue S*V(hi-1).
+    """
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND, is_exclusive=True)
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    tmem_raw = nvvm.make_tmem_ptr(tmem_ptr_i32.load(), cutlass.Int8)
+
+    idesc_qk = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_N,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        k_dim=1,
+    )
+    idesc_pv = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_O,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        b_major=1,
+        k_dim=1,
+    )
+    bmm1_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_N,
+        K=CFG.TILE_K,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=CFG.TILE_K_HW_BMM1,
+        btranspose=False,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_qk,
+        kind=MMA_KIND,
+    )
+    bmm2_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_O,
+        K=CFG.TILE_N,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=CFG.TILE_K_HW_BMM2,
+        btranspose=True,
+        k_subtile=CFG.V_SWZ_BYTES // CFG.BPE,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_pv,
+        kind=MMA_KIND,
+    )
+
+    desc_Q = sQ[0].desc()
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        q_super_idx, _hd, batch_idx = _dispatch_decode_initial(
+            sched.bidx_init,
+            sched.bidy_init,
+            sched.bidz_init,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    q_full_phase = cutlass.Int32(0)
+    kv_state_K = PipelineState.start(phase=0)
+    kv_state_V = PipelineState.start(phase=0)
+    # bit p = next-wait phase for that parity
+    bmm2_ready_phase_pair = cutlass.Int32(0)
+    empty_mainloop_phase = cutlass.Int32(0)
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+            bars.mb_empty_mainloop.wait(empty_mainloop_phase)
+            empty_mainloop_phase = empty_mainloop_phase ^ cutlass.Int32(1)
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+        else:
+            bars.mb_q_full.wait(q_full_phase)
+            q_full_phase = q_full_phase ^ cutlass.Int32(1)
+
+            # Prologue: Q*K(lo) → S_acc[lo&1]
+            lo_parity_runtime = kv_left & cutlass.Int32(1)
+            parity_lo_is_even = lo_parity_runtime == cutlass.Int32(0)
+            tmem_S_acc_lo_addr = cutlass.Int32(
+                arith.select(
+                    parity_lo_is_even.ir_value(),
+                    cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(),
+                    cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value(),
+                )
+            )
+
+            bars.mb_k_full[kv_state_K.idx].wait(kv_state_K.phase)
+            desc_K = sK[kv_state_K.idx].desc()
+            mma_ss(bmm1_desc, desc_Q, desc_K, (tmem_raw.subview(tmem_S_acc_lo_addr)))
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm1_done[lo_parity_runtime].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bars.mb_k_empty[kv_state_K.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            kv_state_K = advance(kv_state_K, CFG.STAGES_KV)
+
+            # Mainloop kv=lo..hi-2: Q*K(kv+1) then S*V(kv)
+            k_per_chunk = NUM_KPHASES_PV_PER_CHUNK
+
+            for kv_loop in cutlass.range(kv_left, kv_right - cutlass.Int32(1), 1, unroll=1):
+                parity_cur_rt = kv_loop & cutlass.Int32(1)
+                parity_next_rt = (kv_loop + cutlass.Int32(1)) & cutlass.Int32(1)
+                cur_is_even = parity_cur_rt == cutlass.Int32(0)
+                next_is_even = parity_next_rt == cutlass.Int32(0)
+
+                tmem_S_acc_next_addr = cutlass.Int32(
+                    arith.select(
+                        next_is_even.ir_value(),
+                        cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(),
+                        cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value(),
+                    )
+                )
+                tmem_P_cur_addr = cutlass.Int32(
+                    arith.select(
+                        cur_is_even.ir_value(),
+                        cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(),
+                        cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value(),
+                    )
+                )
+                bmm2_ready_phase_cur = (bmm2_ready_phase_pair >> parity_cur_rt) & cutlass.Int32(1)
+
+                # Q*K(kv+1) → S_acc[parity_next]
+                bars.mb_k_full[kv_state_K.idx].wait(kv_state_K.phase)
+                desc_K = sK[kv_state_K.idx].desc()
+                mma_ss(bmm1_desc, desc_Q, desc_K, (tmem_raw.subview(tmem_S_acc_next_addr)))
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm1_done[parity_next_rt].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                bars.mb_k_empty[kv_state_K.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                kv_state_K = advance(kv_state_K, CFG.STAGES_KV)
+
+                # S*V(kv) — chunked k-loop with bmm2_ready gates
+                bars.mb_v_full[kv_state_V.idx].wait(kv_state_V.phase)
+                desc_V = sV[kv_state_V.idx].desc()
+
+                # scaleC=False on iter lo (first k-step overwrites O), else accumulate
+                scaleC = cutlass.Boolean(kv_loop != kv_left)
+                accum_b2 = scaleC
+                for k in cutlass.range_constexpr(NUM_KPHASES_PV):
+                    if k % k_per_chunk == 0:
+                        chunk_id = k // k_per_chunk
+                        bars.mb_bmm2_ready[parity_cur_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(chunk_id)].wait(bmm2_ready_phase_cur)
+                    mma_ts_step(bmm2_desc, (tmem_raw.subview(tmem_P_cur_addr)), desc_V, (tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF))), k, accum_b2)
+                    accum_b2 = cutlass.Boolean(True)
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm2_done[parity_cur_rt].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                bars.mb_v_empty[kv_state_V.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                bmm2_ready_phase_pair = bmm2_ready_phase_pair ^ (cutlass.Int32(1) << parity_cur_rt)
+                kv_state_V = advance(kv_state_V, CFG.STAGES_KV)
+
+            # Epilogue: S*V(hi-1) → O
+            kv_last = kv_right - cutlass.Int32(1)
+            parity_last_rt = kv_last & cutlass.Int32(1)
+            last_is_even = parity_last_rt == cutlass.Int32(0)
+            tmem_P_last_addr = cutlass.Int32(
+                arith.select(
+                    last_is_even.ir_value(),
+                    cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(),
+                    cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value(),
+                )
+            )
+            bmm2_ready_phase_last = (bmm2_ready_phase_pair >> parity_last_rt) & cutlass.Int32(1)
+
+            bars.mb_v_full[kv_state_V.idx].wait(kv_state_V.phase)
+            desc_V = sV[kv_state_V.idx].desc()
+            n_kv_eff = kv_right - kv_left
+            scaleC_epi = cutlass.Boolean(n_kv_eff != cutlass.Int32(1))
+            accum_b2 = scaleC_epi
+            for k in cutlass.range_constexpr(NUM_KPHASES_PV):
+                if k % k_per_chunk == 0:
+                    chunk_id = k // k_per_chunk
+                    bars.mb_bmm2_ready[parity_last_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(chunk_id)].wait(bmm2_ready_phase_last)
+                mma_ts_step(bmm2_desc, (tmem_raw.subview(tmem_P_last_addr)), desc_V, (tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF))), k, accum_b2)
+                accum_b2 = cutlass.Boolean(True)
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm2_done[parity_last_rt].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bars.mb_v_empty[kv_state_V.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bmm2_ready_phase_pair = bmm2_ready_phase_pair ^ (cutlass.Int32(1) << parity_last_rt)
+            kv_state_V = advance(kv_state_V, CFG.STAGES_KV)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+            nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+        else:
+            nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+            nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+            nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+            q_super_idx, _hd, batch_idx = _dispatch_decode_payload(
+                nxt_q,
+                nxt_hb,
+                cta_in_pair,
+                n_q_supers,
+                n_qh,
+                n_batch,
+                seq_kv_lens_tensor,
+            )
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+# === Softmax warp group (single wg — qwen TILES_Q=1) ===
+
+
+@cute.jit
+def _softmax_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    scale_log2: cutlass.Float32,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+):
+    """Qwen softmax warp: single wg, parity-keyed (kv&1) S_acc/P selectors,
+    publishes (total_max, total_sum) in end-of-tile epilogue."""
+    nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+
+    bmm1_done_phase_pair = cutlass.Int32(0)  # bit p = next-wait phase for parity p
+    stat_empty_phase = cutlass.Int32(1)  # bootstrap pre-armed at phase 1
+    epilogue_state = cutlass.Int32(1)
+
+    NEG_INF = cutlass.Float32(-3.4028235e38)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(CFG.SOFTMAX_WG0_BASE * 32)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        total_max = NEG_INF
+        total_sum = cutlass.Vector.from_elements(
+            (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+            cutlass.Float32,
+        )
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+        q_abs = q_row_coord + tid_in_wg
+
+        bars.mb_o_empty.wait(epilogue_state)
+        bars.mb_stat_empty.wait(stat_empty_phase)
+        stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+        epilogue_state = epilogue_state ^ cutlass.Int32(1)
+
+        # Body inlined per-segment so the CTM tracer can dispatch through
+        # cutlass.range without hitting the closure check.
+        CHUNK = 64
+        P_COLS_PER_CHUNK = CHUNK // 4  # fp8 packed 4:1 into FP32 cells
+        N_CHUNKS = CFG.N_BMM2_CHUNKS  # 2 at TILE_N=128, 1 at TILE_N=64
+        RESCALE_THRESHOLD = cutlass.Float32(CFG.RESCALE_THRESHOLD)
+
+        if cutlass.const_expr(CFG.MASK_FLAGS == MASK_NONE):
+            for kv_loop in cutlass.range(bounds.left, bounds.right, 1, unroll=1):
+                parity_rt = kv_loop & cutlass.Int32(1)
+                parity_is_even = parity_rt == cutlass.Int32(0)
+                s_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value())
+                )
+                p_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value())
+                )
+                bmm1_phase = (bmm1_done_phase_pair >> parity_rt) & cutlass.Int32(1)
+                bars.mb_bmm1_done[parity_rt].wait(bmm1_phase)
+                bmm1_done_phase_pair = bmm1_done_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+
+                tmem_base = tmem_ptr_i32.load()
+                s_addr_base = tmem_base + s_off_rt
+                p_addr_base = tmem_base + p_off_rt
+                stats_addr = tmem_base + cutlass.Int32(LAYOUT.STATS_OFF)
+
+                # Fast path: fused TMEM load + HW row-max
+                reg_S_tile, current_max_unscaled = tmem_load_max_reduction_tile(
+                    s_addr_base,
+                    num_elems=CFG.TILE_N,
+                )
+                reg_S = RegTile(reg_S_tile.vec, size=CFG.TILE_N)
+                current_max = current_max_unscaled * scale_log2
+
+                old_total_max = total_max
+                is_first = total_max == NEG_INF
+                update_cond = is_first | ((current_max - total_max) > RESCALE_THRESHOLD)
+                total_max = cutlass.Float32(arith.select(update_cond.ir_value(), current_max.ir_value(), total_max.ir_value()))
+                exp_input = cutlass.Float32(arith.select(is_first.ir_value(), NEG_INF.ir_value(), (old_total_max - total_max).ir_value()))
+                alpha = cute.math.exp2(exp_input, fastmath=True)
+                new_total_max = total_max
+                alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_stat_full.arrive()
+
+                reg_S = reg_S * scale_log2 - new_total_max
+
+                # Chunk 0 (always emitted); chunk 1 N_CHUNKS==2 only (TILE_N=128)
+                chunk_S_0 = reg_S[0:CHUNK].vec
+                chunk_P_0 = cute.math.exp2(chunk_S_0, fastmath=True)
+                hoisted_sum = row_reduction_pair(chunk_P_0)
+                chunk_P_0_pack = chunk_P_0.to(STORAGE_DTYPE)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32), chunk_P_0_pack)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(0)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                deferred_P_1 = None
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    chunk_S_1 = reg_S[CHUNK : 2 * CHUNK].vec
+                    deferred_P_1 = cute.math.exp2(chunk_S_1, fastmath=True)
+                    chunk_P_1_pack = deferred_P_1.to(STORAGE_DTYPE)
+                    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK), cutlass.Float32), chunk_P_1_pack)
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                    bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(1)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                new_p_sum_pair = hoisted_sum
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    new_p_sum_pair = new_p_sum_pair + row_reduction_pair(deferred_P_1)
+                alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+                total_sum = total_sum * alpha_pair + new_p_sum_pair
+
+                bars.mb_stat_empty.wait(stat_empty_phase)
+                stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+        else:
+            for kv_loop in cutlass.range(bounds.left, bounds.unmasked_lo, 1, unroll=1):
+                parity_rt = kv_loop & cutlass.Int32(1)
+                parity_is_even = parity_rt == cutlass.Int32(0)
+                s_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value())
+                )
+                p_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value())
+                )
+                bmm1_phase = (bmm1_done_phase_pair >> parity_rt) & cutlass.Int32(1)
+                bars.mb_bmm1_done[parity_rt].wait(bmm1_phase)
+                bmm1_done_phase_pair = bmm1_done_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+                tmem_base = tmem_ptr_i32.load()
+                s_addr_base = tmem_base + s_off_rt
+                p_addr_base = tmem_base + p_off_rt
+                stats_addr = tmem_base + cutlass.Int32(LAYOUT.STATS_OFF)
+                kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+                raw_chunks = [
+                    nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32), num=CHUNK) for c in range(N_CHUNKS)
+                ]
+                # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
+                # CFG.BOTTOM_RIGHT is 0 — top-left masking is unchanged).
+                causal_diag = eff_seqlen_kv - seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+                chunks_S = [
+                    apply_mask_chunk(
+                        raw_chunks[c],
+                        q_abs,
+                        kv_col_base + cutlass.Int32(c * CHUNK),
+                        eff_seqlen_kv,
+                        CFG.WINDOW_LEFT,
+                        CFG.MASK_FLAGS,
+                        N=CHUNK,
+                        bottom_right=CFG.BOTTOM_RIGHT,
+                        causal_diag=causal_diag,
+                        window_right=CFG.WINDOW_RIGHT,
+                    )
+                    for c in range(N_CHUNKS)
+                ]
+                chunks_max = [row_max_reduction(chunks_S[c]) for c in range(N_CHUNKS)]
+                reg_S_vec = vec_concat(chunks_S)
+                current_max_unscaled = chunks_max[0]
+                for m in chunks_max[1:]:
+                    current_max_unscaled = cute.math.max(current_max_unscaled, m)
+                reg_S = RegTile(reg_S_vec, size=CFG.TILE_N)
+                current_max = current_max_unscaled * scale_log2
+
+                old_total_max = total_max
+                is_first = total_max == NEG_INF
+                update_cond = is_first | ((current_max - total_max) > RESCALE_THRESHOLD)
+                total_max = cutlass.Float32(arith.select(update_cond.ir_value(), current_max.ir_value(), total_max.ir_value()))
+                exp_input = cutlass.Float32(arith.select(is_first.ir_value(), NEG_INF.ir_value(), (old_total_max - total_max).ir_value()))
+                alpha = cute.math.exp2(exp_input, fastmath=True)
+                new_total_max = total_max
+                alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_stat_full.arrive()
+                reg_S = reg_S * scale_log2 - new_total_max
+
+                chunk_S_0 = reg_S[0:CHUNK].vec
+                chunk_P_0 = cute.math.exp2(chunk_S_0, fastmath=True)
+                hoisted_sum = row_reduction_pair(chunk_P_0)
+                chunk_P_0_pack = chunk_P_0.to(STORAGE_DTYPE)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32), chunk_P_0_pack)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(0)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                deferred_P_1 = None
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    chunk_S_1 = reg_S[CHUNK : 2 * CHUNK].vec
+                    deferred_P_1 = cute.math.exp2(chunk_S_1, fastmath=True)
+                    chunk_P_1_pack = deferred_P_1.to(STORAGE_DTYPE)
+                    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK), cutlass.Float32), chunk_P_1_pack)
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                    bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(1)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                new_p_sum_pair = hoisted_sum
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    new_p_sum_pair = new_p_sum_pair + row_reduction_pair(deferred_P_1)
+                alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+                total_sum = total_sum * alpha_pair + new_p_sum_pair
+                bars.mb_stat_empty.wait(stat_empty_phase)
+                stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+            for kv_loop in cutlass.range(bounds.unmasked_lo, bounds.unmasked_hi, 1, unroll=1):
+                parity_rt = kv_loop & cutlass.Int32(1)
+                parity_is_even = parity_rt == cutlass.Int32(0)
+                s_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value())
+                )
+                p_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value())
+                )
+                bmm1_phase = (bmm1_done_phase_pair >> parity_rt) & cutlass.Int32(1)
+                bars.mb_bmm1_done[parity_rt].wait(bmm1_phase)
+                bmm1_done_phase_pair = bmm1_done_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+                tmem_base = tmem_ptr_i32.load()
+                s_addr_base = tmem_base + s_off_rt
+                p_addr_base = tmem_base + p_off_rt
+                stats_addr = tmem_base + cutlass.Int32(LAYOUT.STATS_OFF)
+                reg_S_tile, current_max_unscaled = tmem_load_max_reduction_tile(
+                    s_addr_base,
+                    num_elems=CFG.TILE_N,
+                )
+                reg_S = RegTile(reg_S_tile.vec, size=CFG.TILE_N)
+                current_max = current_max_unscaled * scale_log2
+
+                old_total_max = total_max
+                is_first = total_max == NEG_INF
+                update_cond = is_first | ((current_max - total_max) > RESCALE_THRESHOLD)
+                total_max = cutlass.Float32(arith.select(update_cond.ir_value(), current_max.ir_value(), total_max.ir_value()))
+                exp_input = cutlass.Float32(arith.select(is_first.ir_value(), NEG_INF.ir_value(), (old_total_max - total_max).ir_value()))
+                alpha = cute.math.exp2(exp_input, fastmath=True)
+                new_total_max = total_max
+                alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_stat_full.arrive()
+                reg_S = reg_S * scale_log2 - new_total_max
+
+                chunk_S_0 = reg_S[0:CHUNK].vec
+                chunk_P_0 = cute.math.exp2(chunk_S_0, fastmath=True)
+                hoisted_sum = row_reduction_pair(chunk_P_0)
+                chunk_P_0_pack = chunk_P_0.to(STORAGE_DTYPE)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32), chunk_P_0_pack)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(0)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                deferred_P_1 = None
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    chunk_S_1 = reg_S[CHUNK : 2 * CHUNK].vec
+                    deferred_P_1 = cute.math.exp2(chunk_S_1, fastmath=True)
+                    chunk_P_1_pack = deferred_P_1.to(STORAGE_DTYPE)
+                    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK), cutlass.Float32), chunk_P_1_pack)
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                    bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(1)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                new_p_sum_pair = hoisted_sum
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    new_p_sum_pair = new_p_sum_pair + row_reduction_pair(deferred_P_1)
+                alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+                total_sum = total_sum * alpha_pair + new_p_sum_pair
+                bars.mb_stat_empty.wait(stat_empty_phase)
+                stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+            for kv_loop in cutlass.range(bounds.unmasked_hi, bounds.right, 1, unroll=1):
+                parity_rt = kv_loop & cutlass.Int32(1)
+                parity_is_even = parity_rt == cutlass.Int32(0)
+                s_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value())
+                )
+                p_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value())
+                )
+                bmm1_phase = (bmm1_done_phase_pair >> parity_rt) & cutlass.Int32(1)
+                bars.mb_bmm1_done[parity_rt].wait(bmm1_phase)
+                bmm1_done_phase_pair = bmm1_done_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+                tmem_base = tmem_ptr_i32.load()
+                s_addr_base = tmem_base + s_off_rt
+                p_addr_base = tmem_base + p_off_rt
+                stats_addr = tmem_base + cutlass.Int32(LAYOUT.STATS_OFF)
+                kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+                raw_chunks = [
+                    nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32), num=CHUNK) for c in range(N_CHUNKS)
+                ]
+                # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
+                # CFG.BOTTOM_RIGHT is 0 — top-left masking is unchanged).
+                causal_diag = eff_seqlen_kv - seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+                chunks_S = [
+                    apply_mask_chunk(
+                        raw_chunks[c],
+                        q_abs,
+                        kv_col_base + cutlass.Int32(c * CHUNK),
+                        eff_seqlen_kv,
+                        CFG.WINDOW_LEFT,
+                        CFG.MASK_FLAGS,
+                        N=CHUNK,
+                        bottom_right=CFG.BOTTOM_RIGHT,
+                        causal_diag=causal_diag,
+                        window_right=CFG.WINDOW_RIGHT,
+                    )
+                    for c in range(N_CHUNKS)
+                ]
+                chunks_max = [row_max_reduction(chunks_S[c]) for c in range(N_CHUNKS)]
+                reg_S_vec = vec_concat(chunks_S)
+                current_max_unscaled = chunks_max[0]
+                for m in chunks_max[1:]:
+                    current_max_unscaled = cute.math.max(current_max_unscaled, m)
+                reg_S = RegTile(reg_S_vec, size=CFG.TILE_N)
+                current_max = current_max_unscaled * scale_log2
+
+                old_total_max = total_max
+                is_first = total_max == NEG_INF
+                update_cond = is_first | ((current_max - total_max) > RESCALE_THRESHOLD)
+                total_max = cutlass.Float32(arith.select(update_cond.ir_value(), current_max.ir_value(), total_max.ir_value()))
+                exp_input = cutlass.Float32(arith.select(is_first.ir_value(), NEG_INF.ir_value(), (old_total_max - total_max).ir_value()))
+                alpha = cute.math.exp2(exp_input, fastmath=True)
+                new_total_max = total_max
+                alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_stat_full.arrive()
+                reg_S = reg_S * scale_log2 - new_total_max
+
+                chunk_S_0 = reg_S[0:CHUNK].vec
+                chunk_P_0 = cute.math.exp2(chunk_S_0, fastmath=True)
+                hoisted_sum = row_reduction_pair(chunk_P_0)
+                chunk_P_0_pack = chunk_P_0.to(STORAGE_DTYPE)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32), chunk_P_0_pack)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(0)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                deferred_P_1 = None
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    chunk_S_1 = reg_S[CHUNK : 2 * CHUNK].vec
+                    deferred_P_1 = cute.math.exp2(chunk_S_1, fastmath=True)
+                    chunk_P_1_pack = deferred_P_1.to(STORAGE_DTYPE)
+                    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK), cutlass.Float32), chunk_P_1_pack)
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                    bars.mb_bmm2_ready[parity_rt * cutlass.Int32(N_CHUNKS) + cutlass.Int32(1)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                new_p_sum_pair = hoisted_sum
+                if cutlass.const_expr(N_CHUNKS == 2):
+                    new_p_sum_pair = new_p_sum_pair + row_reduction_pair(deferred_P_1)
+                alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+                total_sum = total_sum * alpha_pair + new_p_sum_pair
+                bars.mb_stat_empty.wait(stat_empty_phase)
+                stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+
+        # End-of-tile: publish final (total_max, total_sum)
+        total_sum_scalar = total_sum[0] + total_sum[1]
+        stats_addr_epi = tmem_ptr_i32.load() + cutlass.Int32(LAYOUT.STATS_OFF)
+        stats_vec_epi = cutlass.Vector.from_elements((total_max, total_sum_scalar), cutlass.Float32)
+        nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr_epi, cutlass.Float32), stats_vec_epi)
+        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+        bars.mb_stat_full.arrive()
+
+        # LSE write deferred to correction warp epilogue (qwen-specific)
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+        nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+        nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+
+# === Correction warp group ===
+
+
+@cute.jit
+def _correction_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    sO,
+    tmem_ptr_i32,
+    tidx,
+    bars,
+    sched,
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+    cta_id_x,
+    o_scale_fused,
+    amax_o_tensor,
+):
+    """Qwen correction warp: bootstrap-only-lo-parity bmm2_ready arrive,
+    per-parity bmm2_done_phase_pair, LSE+sink fold lives here (not softmax),
+    P14 catch-up flip on bmm2_done_phase_pair after the epilogue wait."""
+    nvvm.barrier_cta_sync(barrier_id=2, thread_count=32 * (CFG.CORRECTION_WARPS + 1))
+
+    tid_raw = cute.arch.thread_idx()[0]
+    tid_in_wg = tid_raw - cutlass.Int32(CFG.CORR_WARP_BASE * 32)
+
+    bmm2_done_phase_pair = cutlass.Int32(0)  # bit p = next-wait phase for parity p
+    stat_mbar_state = cutlass.Int32(0)
+    # bootstrap pre-armed at phase 1 so first wait passes immediately
+    epilogue_state = cutlass.Int32(1)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    O_CHUNK = 16
+    N_CHUNKS_O = CFG.TILE_O // O_CHUNK
+    TMA_O_ITERS_LOCAL = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
+    D_BLOCK_SIZE = CFG.TILE_O // TMA_O_ITERS_LOCAL
+    TMA_O_GRANU_ELEMS_LOCAL = CFG.TILE_M * D_BLOCK_SIZE
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if bounds.right > bounds.left:
+            # Bootstrap arrive on ONE parity (qwen-specific — NOT both)
+            lo_parity_rt = bounds.left & cutlass.Int32(1)
+            bars.mb_bmm2_ready[lo_parity_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+            # Iter-0 stat_full consume (no rescale — softmax(lo) just signaled)
+            bars.mb_stat_full.wait(stat_mbar_state)
+            bars.mb_stat_empty.arrive()
+            stat_mbar_state = stat_mbar_state ^ cutlass.Int32(1)
+        else:
+            # Empty-mainloop: MMA waits mb_empty_mainloop then fires bmm2_done[0]
+            bars.mb_empty_mainloop.arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+        for kv_loop in cutlass.range(bounds.left + cutlass.Int32(1), bounds.right, 1, unroll=1):
+            parity_prev_rt = (kv_loop - cutlass.Int32(1)) & cutlass.Int32(1)
+            parity_cur_rt = kv_loop & cutlass.Int32(1)
+            tmem_base_iter = tmem_ptr_i32.load()
+
+            bars.mb_stat_full.wait(stat_mbar_state)
+
+            stats_addr = tmem_base_iter + cutlass.Int32(LAYOUT.STATS_OFF)
+            stats_vec = nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(stats_addr, cutlass.Float32),
+                num=2,
+            )
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+            alpha = stats_vec[0]
+
+            alpha_is_one = alpha == cutlass.Float32(1.0)
+            all_alpha_one = vote_sync(0xFFFFFFFF, alpha_is_one, VoteSync.ALL)
+
+            bars.mb_stat_empty.arrive()
+
+            bmm2_done_phase_prev = (bmm2_done_phase_pair >> parity_prev_rt) & cutlass.Int32(1)
+            bars.mb_bmm2_done[parity_prev_rt].wait(bmm2_done_phase_prev)
+            bmm2_done_phase_pair = bmm2_done_phase_pair ^ (cutlass.Int32(1) << parity_prev_rt)
+
+            if ~all_alpha_one:
+                for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                    o_addr = tmem_base_iter + cutlass.Int32(LAYOUT.O_OFF + chunk_idx * O_CHUNK)
+                    o_chunk = nvvm.tcgen05_ld(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                        num=O_CHUNK,
+                    )
+                    o_scaled = vec_scale_pair(o_chunk, alpha, O_CHUNK)
+                    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(o_addr, cutlass.Float32), o_scaled)
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+
+            bars.mb_bmm2_ready[parity_cur_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+            stat_mbar_state = stat_mbar_state ^ cutlass.Int32(1)
+
+        # Epilogue: always run (stores garbage on empty-mainloop — TMASTG ignores)
+        tmem_base_epi = tmem_ptr_i32.load()
+
+        # Pre-declare for CTM if-staging — names used after conditional must
+        # be bound on every path
+        total_max_scaled = cutlass.Float32(0.0)
+        total_sum = cutlass.Float32(0.0)
+        if bounds.right > bounds.left:
+            bars.mb_stat_full.wait(stat_mbar_state)
+            stats_addr_epi = tmem_base_epi + cutlass.Int32(LAYOUT.STATS_OFF)
+            stats_vec_epi = nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(stats_addr_epi, cutlass.Float32),
+                num=2,
+            )
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+            total_max_scaled = stats_vec_epi[0]
+            total_sum = stats_vec_epi[1]
+            bars.mb_stat_empty.arrive()
+            stat_mbar_state = stat_mbar_state ^ cutlass.Int32(1)
+
+        # Sink fold + LSE compute (qwen: corr writes LSE)
+        LN2 = cutlass.Float32(0.6931471805599453)
+        total_max_nat = total_max_scaled * LN2
+        lse_val = cutlass.Float32(0.0)
+        inv_sum = cutlass.Float32(0.0)
+        if cutlass.const_expr(CFG.HAS_SINK):
+            sinks_arr = cutlass.make_array_view(sinks_tensor)
+            sink_logit = sinks_arr[head_idx]
+            new_max = cute.math.max(total_max_nat, sink_logit)
+            scale = cute.math.exp(total_max_nat - new_max, fastmath=True)
+            new_sum = total_sum * scale + cute.math.exp(sink_logit - new_max, fastmath=True)
+            lse_val = new_max + cute.math.log(new_sum, fastmath=True)
+            inv_sum = (scale * o_scale_fused) / new_sum
+        else:
+            lse_val = total_max_nat + cute.math.log(cute.math.max(total_sum, cutlass.Float32(1e-30)), fastmath=True)
+            inv_sum = o_scale_fused / cute.math.max(total_sum, cutlass.Float32(1e-30))
+
+        # --- empty KV range (zero-length sequence under the padding mask) ---
+        # bounds.right <= bounds.left means the mainloop never ran, so
+        # total_max/total_sum are still 0 and the 1e-30 denominator floor above
+        # turns LSE into log(1e-30) = -69.08 and inv_sum into o_scale/1e-30,
+        # which overflows to +inf.  O is then (TMEM residue) * inf.
+        #
+        # The residue is genuinely NaN, not merely stale: the suite poisons TMEM
+        # before execute on purpose (poison_tmem_before_execute), so O must be
+        # zeroed with a SELECT and never with a multiply by zero -- NaN * 0 is
+        # NaN (rules/frost-gotchas.md, the empty-reduction-axis row).
+        _kv_empty = bounds.right <= bounds.left
+        if cutlass.const_expr(not CFG.HAS_SINK):
+            # With a sink the row still has mass (the sink logit itself), and the
+            # branch above already yields LSE = sink_logit correctly because
+            # total_sum == 0 kills its other term.  Without one, an empty row has
+            # no mass at all and LSE is -inf.
+            lse_val = cutlass.Float32(arith.select(_kv_empty.ir_value(), cutlass.Float32(float("-inf")).ir_value(), lse_val.ir_value()))
+
+        q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + tid_in_wg
+        if cutlass.const_expr(CFG.THD_VARLEN):
+            # THD: sequence-local row; LSE packed [1,QH,T] → [0, head, cu_q[b]+local].
+            _cu = cutlass.make_array_view(seq_kv_lens_tensor)
+            _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
+            _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
+            if cutlass.const_expr(lse_tensor is not None):
+                if q_row_global < _s_q_b:
+                    lse_arr = cutlass.make_array_view(lse_tensor)
+                    lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
+                    lse_row[_cu_q_b + q_row_global] = lse_val
+        else:
+            if cutlass.const_expr(lse_tensor is not None):
+                if q_row_global < seqlen_q:
+                    lse_arr = cutlass.make_array_view(lse_tensor)
+                    lse_row = lse_arr[batch_idx, head_idx, :]
+                    lse_row[q_row_global] = lse_val
+
+        parity_last_rt = cutlass.Int32(0)
+        if bounds.right > bounds.left:
+            parity_last_rt = (bounds.right - cutlass.Int32(1)) & cutlass.Int32(1)
+        bmm2_done_phase_last = (bmm2_done_phase_pair >> parity_last_rt) & cutlass.Int32(1)
+        bars.mb_bmm2_done[parity_last_rt].wait(bmm2_done_phase_last)
+        # P14 catch-up flip — bmm2_done_phase_pair ^= (1u<<parity_last) AFTER epilogue wait
+        bmm2_done_phase_pair = bmm2_done_phase_pair ^ (cutlass.Int32(1) << parity_last_rt)
+
+        # Epilogue store: block granularity = 64 elems (4 × O_CHUNK) so we
+        # can fire mb_o_full[block/2] every 2 blocks
+        O_EPI_BLK = 64
+        N_BLOCKS_EPI = CFG.TILE_O // O_EPI_BLK
+        CHUNKS_PER_BLK = O_EPI_BLK // O_CHUNK
+
+        sO_base = sO[0].base
+        epi_o_full_block_idx = 0
+
+        # amax_o = max over VALID rows of |o| (the fp32 pre-cast output).  A
+        # padded/dead row holds garbage, so the atomic is gated the same way
+        # the LSE write above is -- an ungated max would silently inflate the
+        # graph's Amax_O output.
+        _amax_o_ptr = Pointer(amax_o_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
+        _amax_o_local = cutlass.Float32(0.0)
+        _row_valid = q_row_global < seqlen_q
+
+        for block_idx in cutlass.range_constexpr(N_BLOCKS_EPI):
+            for sub in cutlass.range_constexpr(CHUNKS_PER_BLK):
+                chunk_idx_total = block_idx * CHUNKS_PER_BLK + sub
+                o_addr = tmem_base_epi + cutlass.Int32(LAYOUT.O_OFF + chunk_idx_total * O_CHUNK)
+                o_chunk = nvvm.tcgen05_ld(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                    num=O_CHUNK,
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                o_scaled = o_chunk * inv_sum
+                # SELECT the zero for an empty KV range -- see _kv_empty above.
+                # This also keeps the NaN out of the amax fold, which would
+                # otherwise poison the graph's Amax_O for every other row.
+                _o_elems = []
+                for _i in cutlass.range_constexpr(O_CHUNK):
+                    _e = cutlass.Float32(arith.select(_kv_empty.ir_value(), cutlass.Float32(0.0).ir_value(), o_scaled[_i].ir_value()))
+                    _amax_o_local = cute.math.max(_amax_o_local, cute.math.max(_e, -_e))
+                    _o_elems.append(_e)
+                o_out = cutlass.Vector.from_elements(tuple(_o_elems), cutlass.Float32).to(OUT_STORAGE_DTYPE)
+
+                col_offset_const = (chunk_idx_total * O_CHUNK) % D_BLOCK_SIZE
+                block_offset_const = ((chunk_idx_total * O_CHUNK) // D_BLOCK_SIZE) * TMA_O_GRANU_ELEMS_LOCAL
+                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
+                smem_ptr = sO_base.subview(smem_offset).data_ptr()
+
+                if block_idx == 0 and sub == 0:
+                    bars.mb_o_empty.wait(epilogue_state)
+                smem_ptr.store_swizzled(o_out, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+
+            # Fire one mb_o_full per TMA-O store chunk.  There are N_O_CHUNKS
+            # chunks across N_BLOCKS_EPI epilogue blocks; BF16/FP16 O doubles
+            # the chunk count (BPE_O=2) so _BLOCKS_PER_OCHUNK drops 2→1 and we
+            # fire every block instead of every other one — keeps the TMA-STG
+            # consumer's N_O_CHUNKS waits balanced (FP8 path unchanged).
+            _BLOCKS_PER_OCHUNK = N_BLOCKS_EPI // N_O_CHUNKS
+            fire_now = (block_idx + 1) % _BLOCKS_PER_OCHUNK == 0
+            if cutlass.const_expr(fire_now):
+                # fence_proxy needed before TMA reads SMEM written by store_swizzled
+                nvvm.fence_proxy("async.shared", space="cta")
+                bars.mb_o_full[block_idx // _BLOCKS_PER_OCHUNK].arrive()
+
+        if _row_valid:
+            nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
+
+        epilogue_state = epilogue_state ^ cutlass.Int32(1)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        peer_cta = cta_id_x ^ cutlass.Int32(1)
+        bars.mb_tmem_dealloc.arrive_on_peer(peer_cta)
+    bars.mb_tmem_dealloc.arrive()
+
+
+# === Host launcher ===
+
+
+@cute.jit
+def _host(
+    q_tensor: cute.Tensor,
+    k_tensor: cute.Tensor,
+    v_tensor: cute.Tensor,
+    o_tensor: cute.Tensor,
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    problem_size: Tuple[int, int, int, int, int, int],
+    scale_softmax_log2: cutlass.Float32,
+    o_scale_fused: cutlass.Float32,
+    n_thd_units: cutlass.Int32,
+    # FROST's quantized ABI: the four 1-element fp32 scales arrive as DEVICE
+    # TENSORS and the amax of O is an OUTPUT.  The pre-upstream contract pre-folded the scales on
+    # the host and produced no amax -- that gap is what this closes.  Template:
+    # the shipped prefill_d128_fp8_sm107.py sibling (same lineage).
+    descale_q_t: cute.Tensor,
+    descale_k_t: cute.Tensor,
+    descale_v_t: cute.Tensor,
+    scale_o_t: cute.Tensor,
+    amax_o_tensor: cute.Tensor,
+    # FROST passes the dense padded-Q trim tensor POSITIONALLY on every call.
+    # These kernels have no Q-trim epilogue (Capabilities.dense_seq_q_trim=False)
+    # so it is accepted and unused -- but the SLOT is mandatory: without it the
+    # adapter's 12th positional lands on `stream` and execute dies with
+    # "got multiple values for argument 'stream'".
+    seq_q_lens_tensor: Optional[cute.Tensor] = None,
+    # FROST plans must run on the caller's stream (engine contract; there is a
+    # dedicated stream-respect test).  Threaded exactly as the shipped
+    # prefill_d128_fp8_sm107.py sibling does.
+    stream: _cuda_driver.CUstream = None,
+) -> None:
+    B, QH, KH, SQ, SKV, _ = problem_size
+
+    _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE_O
+    qk_box_q = (1, CFG.TILE_M, 1, TMA_QK_GRANU_ELEMS)
+    qk_box_k = (1, CFG.TILE_N // CFG.CTA_MMA, 1, TMA_QK_GRANU_ELEMS)
+    vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M, 1, _O_GRANU_ELEMS)
+    stride_order = (3, 2, 1, 0)
+
+    def _tma_swz(byte_w: int):
+        return tmap.TensorMapSwizzle.s128b if byte_w == 128 else tmap.TensorMapSwizzle.s64b if byte_w == 64 else tmap.TensorMapSwizzle.s32b
+
+    tma_q_desc = tmap.create_tensor_map_tiled_from_view(
+        q_tensor,
+        box_dims=qk_box_q,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.Q_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_k_desc = tmap.create_tensor_map_tiled_from_view(
+        k_tensor,
+        box_dims=qk_box_k,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.K_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_v_desc = tmap.create_tensor_map_tiled_from_view(
+        v_tensor,
+        box_dims=vo_box_v,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.V_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_o_desc = tmap.create_tensor_map_tiled_from_view(
+        o_tensor,
+        box_dims=vo_box_o,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.O_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+
+    rows_per_cluster = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+    q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
+    grid_q_supers = q_clusters * CFG.CTA_MMA
+    q_supers = grid_q_supers
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD: build the per-batch O descriptor array, then launch the exact
+        # flat batch-outermost grid (n_thd_units host-computed); grid_x = units*CGA_M.
+        _build_thd_meta_o_descs_kernel(
+            o_tensor,
+            tma_o_desc,
+            o_desc_words,
+            seq_kv_lens_tensor,
+            cutlass.Int32(QH),
+            cutlass.Int32(B),
+            cutlass.Int32(CFG.TILE_O),
+        ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
+        grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
+    else:
+        grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
+    _kernel(
+        tma_q_desc,
+        tma_k_desc,
+        tma_v_desc,
+        tma_o_desc,
+        lse_tensor,
+        sinks_tensor,
+        seq_kv_lens_tensor,
+        o_desc_words,
+        cutlass.Int32(SQ),
+        cutlass.Int32(SKV),
+        cutlass.Int32(q_supers),
+        cutlass.Int32(QH),
+        cutlass.Int32(B),
+        cutlass.Int32(QH // KH),
+        scale_softmax_log2,
+        o_scale_fused,
+        descale_q_t,
+        descale_k_t,
+        descale_v_t,
+        scale_o_t,
+        amax_o_tensor,
+    ).launch(
+        grid=grid_shape,
+        block=[CFG.THREADS_PER_CTA, 1, 1],
+        cluster=(CFG.CTA_MMA, 1, 1),
+        stream=stream,
+    )
+
+
+@lru_cache(maxsize=None)
+def compile(  # noqa: A001
+    b: int = 1,
+    qh: int = 1,
+    kh: int = 1,
+    sq: int = 256,
+    skv: int = 128,
+    d_qk: int = CFG.TILE_K,
+    d_v: int = CFG.TILE_O,
+    has_lse: bool = True,
+    lse_stride: Optional[tuple] = None,
+) -> Callable:
+    """Compile a kernel with ALL dims concrete (pins TMA descriptor strides).
+
+    THD/varlen: q/k/v/o/lse PACKED with batch dim 1; ``b`` = logical batch."""
+    # THD/varlen is NOT ported for this kernel yet.  The setup-kernel call site
+    # below still speaks the pre-upstream 7-arg contract, while FROST's
+    # thd_helpers.build_thd_meta_o_descs_kernel takes 14 args and a different
+    # metadata layout (4B+4 with batch_remap + a claim counter, vs the 3B+2
+    # here), and the scheduler decode differs to match.  Raise here rather than
+    # let it fail as an arity error deep in the trace -- and so no engine row
+    # can advertise thd=True for this kernel and appear to work.  The dense
+    # path is unaffected: CFG.THD_VARLEN is 0 and every THD branch folds out.
+    if CFG.THD_VARLEN:
+        raise NotImplementedError(f"{__name__}: THD/varlen not ported to the FROST setup-kernel contract")
+    # ---- FROST adapter ABI ------------------------------------------------
+    # lower_dsl_prefill calls EVERY kernel with the full forward signature.
+    # This body carries only what the port brought over, so anything
+    # it cannot honor RAISES rather than being silently ignored: a raise here
+    # means the engine's Capabilities row is lying, which is the failure we
+    # want loud.  (Capabilities: lse_optional=False, no strided Stats.)
+    if lse_stride is not None:
+        raise NotImplementedError(f"{__name__}: strided Stats not ported (contiguous [B, H, S] only)")
+    if d_qk > CFG.TILE_K or d_v > CFG.TILE_O or d_qk <= 0 or d_v <= 0:
+        raise ValueError(f"{__name__}: envelope is 0 < d_qk <= {CFG.TILE_K}, 0 < d_v <= {CFG.TILE_O}; " f"got ({d_qk}, {d_v})")
+    _fake_batch = 1 if CFG.THD_VARLEN else b
+    fake_q = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, sq, qh, d_qk),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_k = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, d_qk),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_v = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, d_v),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_o = cute.runtime.make_fake_compact_tensor(
+        OUT_STORAGE_DTYPE,
+        (_fake_batch, sq, qh, d_v),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    # has_lse=False (no Stats output): the LSE argument is None-specialized and
+    # the store is compiled out entirely -- no dummy buffer exists at any level,
+    # which is what lets the dense graph report get_workspace_size() == 0.
+    # Mirrors the shipped prefill_d128_fp8_sm107.py.
+    fake_lse = (
+        cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (_fake_batch, qh, sq),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
+        if has_lse
+        else None
+    )
+    fake_sinks = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (qh,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    _skv_len = (3 * b + 2) if CFG.THD_VARLEN else b
+    fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (_skv_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    _odesc_len = (b * _TENSOR_MAP_QWORDS + _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
+    fake_o_desc = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int64,
+        (_odesc_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+
+    # The four 1-element fp32 device scales + the amax_o output slot; the
+    # compiled artifact must declare them or the adapter's positional call
+    # cannot bind (FROST quantized ABI).
+    def _fake_scale():
+        return cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (1,),
+            stride_order=(0,),
+            assumed_align=4,
+        )
+
+    fake_amax_o = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (1,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    return cute.compile(
+        _host,
+        fake_q,
+        fake_k,
+        fake_v,
+        fake_o,
+        fake_lse,
+        fake_sinks,
+        fake_seq_kv_lens,
+        fake_o_desc,
+        (b, qh, kh, sq, skv, 0),
+        cutlass.Float32(0.0),
+        cutlass.Float32(0.0),
+        cutlass.Int32(0),
+        _fake_scale(),
+        _fake_scale(),
+        _fake_scale(),
+        _fake_scale(),
+        fake_amax_o,
+        stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
+        options="--enable-tvm-ffi",
+    )
+
+
+def _main():
+    """Minimal CLI for compile-check / perf bring-up."""
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--b", type=int, default=1)
+    parser.add_argument("--hq", type=int, default=1)
+    parser.add_argument("--hk", type=int, default=1)
+    parser.add_argument("--sq", type=int, default=256)
+    parser.add_argument("--skv", type=int, default=128)
+    parser.add_argument("--validate", action="store_true")
+    parser.add_argument("--iters", type=int, default=0)
+    args = parser.parse_args()
+
+    print(f"[d256_fp8] compile b={args.b} qh={args.hq} kh={args.hk} " f"sq={args.sq} skv={args.skv}", flush=True)
+    fn = compile(args.b, args.hq, args.hk, args.sq, args.skv)
+    print(f"[d256_fp8] compile OK: {fn}", flush=True)
+    if args.validate:
+        print("[d256_fp8] --validate: run via the test driver, not this CLI.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_fp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_fp8_sm107.py
@@ -44,6 +44,20 @@ from cudnn.sdpa.fwd.config_sm107 import TemplateParams, make_cfg_d256
 
 PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
 CFG, _TMA = make_cfg_d256(PARAMS)
+
+# tcgen05 SMEM-descriptor version for EVERY SmemTile in this module -- ONE
+# decision point, wired into every construction below rather than repeated as a
+# per-tile literal.  A version-0 descriptor's ``start_address`` is 14 bits = a
+# 256 KiB window; Rubin raises the per-CTA SMEM cap to 327 KiB, so an operand
+# buffer at or above 256 KiB wraps to offset 0 and the MMA multiplies whatever
+# sits at the bottom of SMEM.  This flavor's buffers all stay below the line.
+#
+# Do NOT re-literal this at a call site: the d512 MXFP8 sibling shipped NaN on
+# 100% of cells because its scale-factor tiles were declared UNDER a comment
+# claiming "every operand tile here carries desc_version=1" -- without the
+# kwarg.  A single constant makes that class of drift impossible, and
+# test_sm107_descriptor_version_matches_the_smem_budget asserts it.
+DESC_VERSION: int = 0
 Cfg = type(CFG)
 TMA_QK_ITERS = _TMA.QK_ITERS
 TMA_VO_ITERS = _TMA.VO_ITERS
@@ -291,6 +305,7 @@ def _kernel(
         tma_loads_per_tile=TMA_QK_ITERS,
         tma_granu_elems=TMA_QK_GRANU_ELEMS,
         tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+        desc_version=DESC_VERSION,
     )
     sK = SmemTile(
         base=sK_raw,
@@ -302,6 +317,7 @@ def _kernel(
         tma_loads_per_tile=TMA_QK_ITERS,
         tma_granu_elems=TMA_QK_GRANU_ELEMS,
         tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+        desc_version=DESC_VERSION,
     )
     sV = SmemTile(
         base=sV_raw,
@@ -313,6 +329,7 @@ def _kernel(
         tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
         tma_granu_elems=TMA_VO_GRANU_ELEMS,
         tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+        desc_version=DESC_VERSION,
     )
     sO = SmemTile(
         base=sO_raw,
@@ -324,6 +341,7 @@ def _kernel(
         tma_loads_per_tile=TMA_O_ITERS_HOST,
         tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
         tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+        desc_version=DESC_VERSION,
     )
 
     bars = make_d256_bars(CFG, N_O_CHUNKS=N_O_CHUNKS)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_mxfp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_mxfp8_sm107.py
@@ -1,0 +1,2428 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""CTM-DSL qwen prefill SDPA MXFP8 kernel (d_qk = d_v = 256).
+
+Qwen pipeline: TILES_Q=1, single softmax wg, Q∪O SMEM alias, Q*K(i+1)→S*V(i)
+lookahead, parity-keyed S_acc/P, bootstrap-only-lo-parity bmm2_ready in
+correction, P14 end-of-tile catch-up flip on bmm2_done_phase, LSE written in
+correction.
+
+MXFP8 layer: 4 SF SMEM buffers (Q/K/P/V Int8, alignment=1024); SF TMEM cols
+parked after O accumulator and before Stats; SF TMA rides the same
+cta_group=CTA_MMA collective TMA as Q/K/V; block-scale mma_ss / mma_ts_step
+with is_block_scale=True; MMA kind MXF8F6F4; only DTYPE_QKV ∈ {0,1} accepted.
+
+d=256 BMM2 N-block split: under cga1 issues TWO mma_ts_step calls per kv iter
+(one per 128 N-rows of O with shifted tmem_O / tmem_SF_V views + shifted
+desc_V); under cga2 the collective MMA covers full d_v in one call.
+
+READ_TILE_ARRIVERS overridden here: ((SOFTMAX_WG*4)+CORR+3)*CGA_M*CGA_N —
+the qwen flavor config's value is correct only for F16/FP8.
+
+THD / varlen (CFG.THD_VARLEN=1) supported (E4M3/E5M2) at cga2 via the shared
+thd helpers: Q/K/V data ride the packed [1,T,H,D] + cu_seqlens coord path;
+the MXFP8 SF tensors use B=1 + total_*_sf_tiles descriptors with a per-sequence
+SF-tile prefix base (cu_sf_q/k from _thd_sf_tile_bases) added to the SF tile
+coord.  cga2 within-tile peer SF byte offsets are orthogonal and unchanged.
+Dense path (THD_VARLEN=0) folds to identity (cu_sf=0, tma_batch=batch_idx) —
+byte-identical.  Public-API MXFP8 THD glue is a follow-up (THD-aware quantizer).
+"""
+
+import os
+import sys
+from functools import lru_cache
+from typing import Callable, Optional, Tuple
+
+
+from cutlass.experimental import primitives as nvvm
+from cutlass.experimental.primitives import vote_sync, VoteSync
+from cutlass._mlir.dialects import arith
+
+import cutlass
+from cutlass.experimental import primitives as prims
+import cutlass.cute as cute
+from cutlass.base_dsl.typing import Pointer
+from cutlass.experimental.cuda import tensor_map as tmap
+import cuda.bindings.driver as _cuda_driver  # noqa: F401
+
+from dataclasses import dataclass
+from typing import NamedTuple
+
+# Config comes from the FROST template loader, NOT an env var: the pre-upstream
+# kernels picked a flavor with an env var + a sdpa_config_<flavor> module, which the
+# FROST engine contract forbids ("no environment variables for configuration" --
+# parameters travel as typed dataclasses). The loader injects
+# FROST_TEMPLATE_PARAMS before this body runs; the default keeps a plain
+# `import` usable as a standalone driver.
+from cudnn.sdpa.fwd.config_sm107 import TemplateParams, make_cfg_d256_mxfp8
+
+PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
+CFG, _TMA = make_cfg_d256_mxfp8(PARAMS)
+Cfg = type(CFG)
+TMA_QK_ITERS = _TMA.QK_ITERS
+TMA_VO_ITERS = _TMA.VO_ITERS
+TMA_QK_GRANU_ELEMS = _TMA.QK_GRANU_ELEMS
+TMA_VO_GRANU_ELEMS = _TMA.VO_GRANU_ELEMS
+
+# MXFP8 K-step pin -- k_dim=1 selects 64-element K chunks, halving the
+# tcgen05.mma.block_scale issue count versus k_dim=0.  ``config_sm107`` derives
+# TILE_K_HW from the dtype; this guard pins the two together, because the
+# pairing is arch-OPPOSITE (Blackwell wants k_dim=0 with 32) and a mismatch
+# scrambles accumulator rows SILENTLY (rules/mma-tma-matrix.md S1).
+_MXFP8_K_DIM = 1
+_MXFP8_TILE_K_HW = 32 if _MXFP8_K_DIM == 0 else 64
+if CFG.TILE_K_HW_BMM1 != _MXFP8_TILE_K_HW or CFG.TILE_K_HW_BMM2 != _MXFP8_TILE_K_HW:
+    raise ValueError(
+        f"{__name__}: idesc k_dim={_MXFP8_K_DIM} requires TILE_K_HW={_MXFP8_TILE_K_HW}; " f"got BMM1={CFG.TILE_K_HW_BMM1} BMM2={CFG.TILE_K_HW_BMM2}"
+    )
+
+# MXFP8 inputs are FP8 storage with E8M0 SF — only E4M3 (0) / E5M2 (1) valid.
+if CFG.DTYPE_QKV not in (0, 1):
+    raise ValueError(f"prefill_sdpa_d256_mxfp8: DTYPE_QKV must be 0 (E4M3) or 1 (E5M2); " f"got {CFG.DTYPE_QKV}.  Use prefill_sdpa_d256_f16.py for BF16/FP16.")
+
+# O TMA box follows O swizzle, not V.
+TMA_O_GRANU_ELEMS_HOST = CFG.O_SWZ_BYTES // CFG.BPE_O
+TMA_O_ITERS_HOST = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
+
+from cudnn.frost.tile_dsl.barrier import (
+    PipelineState,
+    advance,
+    cga_arrive,
+    cga_wait,
+    # `wait` (free fn) — still used for sched.mb_* (Sched not in Bars).
+    wait,
+)
+from cudnn.frost.tile_dsl.scheduler import (
+    Sched,
+    scheduler_warp_loop,
+    read_tile_id_arrive,
+    SCHED_NATURAL,
+    SCHED_LPT,
+    SCHED_LPT_L2,
+)
+from cudnn.frost.tile_dsl.pointwise import (
+    tmem_load_max_reduction_x64,
+    row_reduction_pair_64,
+    row_max_reduction_64,
+    vec_scale_pair,
+)
+from cudnn.frost.tile_dsl.mma import mma_ss, mma_ts_step
+from cudnn.frost.tile_dsl.tma import (
+    tma_load_tile,
+    tma_store_tile,
+    tma_store_commit,
+    tma_store_wait,
+    bulk_copy,
+    bulk_copy_multicast,
+)
+from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, tma_slice_runtime_desc
+from cudnn.frost.tile_dsl.tmem import tmem_alloc, tmem_dealloc
+from cudnn.frost.tile_dsl.mask import (
+    apply_mask_chunk,
+    MASK_NONE,
+    MASK_PADDED,
+    MASK_CAUSAL,
+    MASK_SWA,
+)
+
+if CFG.DTYPE_QKV == 0:
+    STORAGE_DTYPE = cutlass.Float8E4M3FN
+    P_STORAGE_DTYPE = cutlass.Float8E4M3FN
+elif CFG.DTYPE_QKV == 1:
+    STORAGE_DTYPE = cutlass.Float8E5M2
+    P_STORAGE_DTYPE = cutlass.Float8E5M2
+
+MMA_KIND = nvvm.MMABlockScaleKind.MXF8F6F4
+SCALE_VEC_SIZE = nvvm.Tcgen05MMAScaleVecSize.BLOCK32
+
+
+# DTYPE_O independent of DTYPE_QKV — MXFP8 input may write BF16/FP16 O so a
+# downstream consumer skips a dequant.  BPE_O ∈ {1, 2}; epilogue already casts
+# via .to(OUT_STORAGE_DTYPE) + store_swizzled (dtype-generic).  The Q∪O SMEM
+# alias is byte-sized for max(Q@BPE, O@BPE_O) so BF16 O doesn't overflow it.
+if CFG.DTYPE_O == 0:
+    OUT_STORAGE_DTYPE = cutlass.Float8E4M3FN
+elif CFG.DTYPE_O == 1:
+    OUT_STORAGE_DTYPE = cutlass.Float8E5M2
+elif CFG.DTYPE_O == 2:
+    OUT_STORAGE_DTYPE = cutlass.BFloat16
+elif CFG.DTYPE_O == 3:
+    OUT_STORAGE_DTYPE = cutlass.Float16
+else:
+    raise ValueError(f"prefill_sdpa_d256_mxfp8 CTM: DTYPE_O={CFG.DTYPE_O} not supported " f"(expected 0=E4M3 / 1=E5M2 / 2=BF16 / 3=FP16)")
+
+
+# === MXFP8 SF constants (trace-time folded) ===
+BITS_PER_SF_ELEMENT = 8  # E8M0
+BLOCK_SCALE_BLOCK_SIZE = 32  # 32 elems share one SF byte
+SF_BLOCK_DIM_NON_K = 128
+SF_BLOCK_DIM_K = 4
+SF_SWIZZLED_BLOCK_DIM_K = 16
+SF_BYTES_PER_BLOCK = SF_BLOCK_DIM_NON_K * SF_BLOCK_DIM_K * BITS_PER_SF_ELEMENT // 8  # 512
+
+
+def _round_up(a: int, b: int) -> int:
+    return (a + b - 1) // b * b
+
+
+SF_NUM_BLOCKS_M = CFG.TILE_M // SF_BLOCK_DIM_NON_K
+SF_NUM_BLOCKS_N = CFG.TILE_N // SF_BLOCK_DIM_NON_K
+SF_NUM_BLOCKS_K = _round_up(CFG.TILE_K, 128) // BLOCK_SCALE_BLOCK_SIZE // SF_BLOCK_DIM_K
+
+SF_REGISTERS_PER_BLOCK = SF_SWIZZLED_BLOCK_DIM_K * BITS_PER_SF_ELEMENT // 32
+
+SF_TMEM_COLS_Q = SF_NUM_BLOCKS_M * SF_NUM_BLOCKS_K * SF_REGISTERS_PER_BLOCK
+SF_TMEM_COLS_K = SF_NUM_BLOCKS_N * SF_NUM_BLOCKS_K * SF_REGISTERS_PER_BLOCK
+
+SF_SMEM_SIZE_Q = CFG.TILE_M * _round_up(CFG.TILE_K, 128) // BLOCK_SCALE_BLOCK_SIZE
+SF_SMEM_SIZE_K = CFG.TILE_N * _round_up(CFG.TILE_K, 128) // BLOCK_SCALE_BLOCK_SIZE
+
+# BMM2 SF: P softmax-filled with constant 1.0; V from GMEM.
+SF_NUM_BLOCKS_P = CFG.TILE_M // SF_BLOCK_DIM_NON_K
+SF_NUM_BLOCKS_V = _round_up(CFG.TILE_O, 128) // SF_BLOCK_DIM_NON_K
+SF_NUM_BLOCKS_K_BMM2 = CFG.TILE_N // BLOCK_SCALE_BLOCK_SIZE // SF_BLOCK_DIM_K
+SF_TMEM_COLS_P = SF_NUM_BLOCKS_P * SF_NUM_BLOCKS_K_BMM2 * SF_REGISTERS_PER_BLOCK
+SF_TMEM_COLS_V = SF_NUM_BLOCKS_V * SF_NUM_BLOCKS_K_BMM2 * SF_REGISTERS_PER_BLOCK
+SF_SMEM_SIZE_P = _round_up(CFG.TILE_M, 128) * CFG.TILE_N // BLOCK_SCALE_BLOCK_SIZE
+SF_SMEM_SIZE_V = _round_up(CFG.TILE_O, 128) * CFG.TILE_N // BLOCK_SCALE_BLOCK_SIZE
+
+# V's SF D-planes are the cga peer split unit (see the V SF descriptor in
+# _host): each CTA of the pair owns a contiguous run of D-planes, matching the
+# V data columns it holds.
+if SF_NUM_BLOCKS_V % CFG.CTA_MMA != 0:
+    raise ValueError(
+        f"prefill_sdpa_d256_mxfp8: V SF D-plane count {SF_NUM_BLOCKS_V} is not " f"divisible by CTA_MMA={CFG.CTA_MMA}; the cga peer split walks whole D-planes"
+    )
+V_SF_PLANES_PER_PEER = SF_NUM_BLOCKS_V // CFG.CTA_MMA
+
+# E8M0 1.0 (=2^0) — fills P_SF SMEM.
+SF_CONST_VALUE = 0x7F
+
+
+# === d=256 BMM2 N-block split ===
+# Block-scale mma_ts_step cycles SF B only along K, so V's d_v > 128 needs one
+# MMA per V SF N-block (cga1 d_v=256 → 2 calls; cga2 collective covers full).
+SF_BMM2_N_BLOCKS = _round_up(CFG.TILE_O, 128) // 128
+BMM2_LOOP_N_BLOCKS = SF_BMM2_N_BLOCKS // CFG.CTA_MMA
+BMM2_N_PER_CALL = CFG.TILE_O // BMM2_LOOP_N_BLOCKS
+BMM2_N_PER_CALL_PER_CTA = BMM2_N_PER_CALL // CFG.CTA_MMA
+BMM2_N_BLOCK_BYTE_STRIDE = CFG.TILE_N * CFG.V_SWZ_BYTES
+
+
+from cudnn.sdpa.fwd.kernels._common_sm100 import (
+    D256Bars as Bars,
+    KvLoopBounds,
+    make_d256_bars,
+    compute_kv_loop_bounds,
+    lpt_tile_coords,
+    make_sdpa_helpers,
+    assert_tile_n_supported,
+)
+
+assert_tile_n_supported(CFG)
+
+CGA_SIZE = CFG.CGA_M * CFG.CGA_N
+CTA_GROUP_KIND = nvvm.CTAGroup.CTA_2 if CFG.CTA_MMA == 2 else nvvm.CTAGroup.CTA_1
+
+qBufferElems = CFG.TILE_M * CFG.TILE_K
+kBufferElems = CFG.TILE_N * CFG.TILE_K // CFG.CTA_MMA
+vBufferElems = CFG.TILE_O * CFG.TILE_N // CFG.CTA_MMA
+oBufferElems = CFG.TILE_M * CFG.TILE_O
+qoAliasBytes = max(qBufferElems * CFG.BPE, oBufferElems * CFG.BPE_O)
+
+qTmaTransactionBytes = qBufferElems * CFG.BPE * CFG.CTA_MMA
+kTmaTransactionBytes = kBufferElems * CFG.BPE * CFG.CTA_MMA
+vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
+
+# SF expect_tx bytes per TMA call.
+Q_SF_EXPECT_BYTES = SF_SMEM_SIZE_Q * CFG.CTA_MMA
+K_SF_EXPECT_BYTES = SF_SMEM_SIZE_K * CFG.CTA_MMA
+V_SF_EXPECT_BYTES = SF_SMEM_SIZE_V * CFG.CTA_MMA
+
+N_O_CHUNKS = (CFG.TILE_O * CFG.BPE_O + 127) // 128
+
+CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+
+_sdpa_h = make_sdpa_helpers(CFG)
+_decode_initial = _sdpa_h.decode_initial
+_decode_payload = _sdpa_h.decode_payload
+_bounds_for_tile = _sdpa_h.bounds_for_tile
+_resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+
+# THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
+# factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
+# kernels/ctm/common/sdpa/thd.py.  Gated by CFG.THD_VARLEN (folds out otherwise).
+# Supported at cga1 and cga2 (the per-batch O descriptor's seq extent OOB-clips
+# the 256-row cga2 store box).  seq_kv_lens overloaded as the THD metadata buffer
+# (int32 len 3B+2): [0..B-1]=seq_kv_lens [B..2B]=cu_q(B+1) [2B+1..3B+1]=cu_k(B+1).
+# MXFP8-only: _thd_sf_tile_bases returns the per-sequence SF-tile prefix bases
+# (cu_sf_q_base / cu_sf_k_base) for the packed scale-factor layout.
+from cudnn.sdpa.fwd.kernels.thd_helpers import build_thd_meta_o_descs_kernel as _build_thd_meta_o_descs_kernel, TENSOR_MAP_QWORDS
+
+_TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
+_dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
+_dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
+_thd_tma_offsets = _sdpa_h.thd_tma_offsets
+_thd_sf_tile_bases = _sdpa_h.thd_sf_tile_bases
+
+
+# Kernel TMEM layout (TOTAL=576 Rubin cap; Stats parked outside S_acc/O range,
+# P aliases S_acc tail, SF cols between O accumulator and Stats).
+@dataclass(frozen=True)
+class KernelTmemLayout:
+    TOTAL_COLS: int = 576
+
+    S_ACC_EVEN_OFF: int = 0
+    S_ACC_ODD_OFF: int = 128
+
+    P_EVEN_OFF: int = 96
+    P_ODD_OFF: int = 224
+
+    O_OFF: int = 256
+
+    SF_Q_OFF: int = 512
+    SF_K_OFF: int = 512 + SF_TMEM_COLS_Q
+    SF_P_OFF: int = 512 + SF_TMEM_COLS_Q + SF_TMEM_COLS_K
+    SF_V_OFF: int = 512 + SF_TMEM_COLS_Q + SF_TMEM_COLS_K + SF_TMEM_COLS_P
+
+    STATS_OFF: int = 544
+
+
+LAYOUT = KernelTmemLayout()
+assert LAYOUT.SF_V_OFF + SF_TMEM_COLS_V <= LAYOUT.STATS_OFF, "TMEM SF region collides with Stats — re-check SF_*_TMEM_COLS"
+
+
+# Overrides CFG.READ_TILE_ARRIVERS (which is the F16/FP8 qwen-quiet-minimal
+# formula).  Qwen MXFP8 quiet warp keeps the persistent loop so every CTA
+# contributes the full per-CTA arriver count.
+READ_TILE_ARRIVERS_MXFP8 = (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + CFG.CORRECTION_WARPS + 3) * CFG.CGA_M * CFG.CGA_N
+
+
+_SWZ_ENUM = {128: 2, 64: 4, 32: 6}
+SMEM_LAYOUT_Q = _SWZ_ENUM[CFG.Q_SWZ_BYTES]
+SMEM_LAYOUT_K = _SWZ_ENUM[CFG.K_SWZ_BYTES]
+SMEM_LAYOUT_V = _SWZ_ENUM[CFG.V_SWZ_BYTES]
+SMEM_LAYOUT_O = _SWZ_ENUM[CFG.O_SWZ_BYTES]
+SMEM_LAYOUT_QKO = SMEM_LAYOUT_Q
+
+# SF SmemDesc — no swizzle, leading=16, stride=128 (utccp_32x128b_warpx4).
+SMEM_LAYOUT_SF = 0
+SF_LEADING_BYTE_OFFSET = 16
+SF_STRIDE_BYTE_OFFSET = 128
+
+_O_SWZ_B = {128: 3, 64: 2, 32: 1}[CFG.O_SWZ_BYTES]
+_O_SMEM_SWIZZLE = cutlass.Swizzle(_O_SWZ_B, 4, 3)
+
+LEADING_BYTE_OFFSET_QK = 0
+STRIDE_BYTE_OFFSET_QK = 8 * CFG.Q_SWZ_BYTES
+
+_CORE_MATRIX_ROWS = 8
+_V_PC_COLS = CFG.TILE_O // CFG.CTA_MMA
+# leading_byte_offset = 0 when (TILE_O/CTA_MMA)/8 <= 8 else TILE_N*V_SWZ_BYTES
+LEADING_BYTE_OFFSET_PV = 0 if (_V_PC_COLS // _CORE_MATRIX_ROWS) <= 8 else CFG.TILE_N * CFG.V_SWZ_BYTES
+STRIDE_BYTE_OFFSET_PV = 8 * CFG.V_SWZ_BYTES
+
+NUM_KPHASES_PV = CFG.TILE_N // _MXFP8_TILE_K_HW
+NUM_KPHASES_PV_PER_CHUNK = NUM_KPHASES_PV // CFG.N_BMM2_CHUNKS
+
+SF_V_COLS_PER_NBLOCK = SF_NUM_BLOCKS_K_BMM2 * SF_REGISTERS_PER_BLOCK
+
+
+# === Kernel entry ===
+
+
+@cute.kernel
+def _kernel(
+    tma_q_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_k_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_v_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_o_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_q_sf_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_k_sf_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_v_sf_desc: cutlass.GridConstant[tmap.TensorMap],
+    lse_tensor: Optional[cute.Tensor],
+    # FROST's MXFP8 ABI puts amax_o RIGHT AFTER lse (position 9).
+    amax_o_tensor: cute.Tensor,
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    seqlen_q: cutlass.Int32,
+    seqlen_kv: cutlass.Int32,
+    n_q_supers: cutlass.Int32,
+    n_qh: cutlass.Int32,
+    n_batch: cutlass.Int32,
+    qh_per_kh: cutlass.Int32,
+    scale_softmax_log2: cutlass.Float32,
+) -> None:
+
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    tidx, _, _ = cute.arch.thread_idx()
+
+    bidx = cute.arch.block_idx()[0]
+    bidy = cute.arch.block_idx()[1]
+    bidz = cute.arch.block_idx()[2]
+
+    # Q∪O alias byte-sized to max(Q@BPE, O@BPE_O) — STORAGE_DTYPE is FP8 (1 B)
+    # so element count == byte count; BF16/FP16 O (BPE_O=2) would otherwise
+    # overflow a qBufferElems-only allocation.
+    _QO_ALIAS_ELEMS = max(qBufferElems * CFG.BPE, oBufferElems * CFG.BPE_O)
+    sQO_raw = cutlass.Array(STORAGE_DTYPE, _QO_ALIAS_ELEMS, alignment=1024, space=cutlass.AddressSpace.smem)
+    sK_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * kBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    sV_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * vBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    # OUT_STORAGE_DTYPE view of the Q∪O backing — epilogue store offsets then
+    # advance in BPE_O units (no-op recast for FP8 output).
+    sO_raw = cutlass.Array(sQO_raw.data_ptr(), shape=oBufferElems, dtype=OUT_STORAGE_DTYPE)
+
+    # SF buffers Int8 alignment=1024; Q_SF/P_SF single-stage.
+    sQ_SF_raw = cutlass.Array(cutlass.Int8, SF_SMEM_SIZE_Q, alignment=1024, space=cutlass.AddressSpace.smem)
+    sK_SF_raw = cutlass.Array(cutlass.Int8, CFG.STAGES_KV * SF_SMEM_SIZE_K, alignment=1024, space=cutlass.AddressSpace.smem)
+    sP_SF_raw = cutlass.Array(cutlass.Int8, SF_SMEM_SIZE_P, alignment=1024, space=cutlass.AddressSpace.smem)
+    sV_SF_raw = cutlass.Array(cutlass.Int8, CFG.STAGES_KV * SF_SMEM_SIZE_V, alignment=1024, space=cutlass.AddressSpace.smem)
+
+    sQ = SmemTile(
+        base=sQO_raw,
+        elems_per_stage=qBufferElems,
+        stages=1,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+    )
+    sK = SmemTile(
+        base=sK_raw,
+        elems_per_stage=kBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+    )
+    sV = SmemTile(
+        base=sV_raw,
+        elems_per_stage=vBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_PV,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_PV,
+        layout=SMEM_LAYOUT_V,
+        tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
+        tma_granu_elems=TMA_VO_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+    )
+    # sO shares backing with sQ (Q∪O alias) — OUT_STORAGE_DTYPE view for BPE_O offsets.
+    sO = SmemTile(
+        base=sO_raw,
+        elems_per_stage=oBufferElems,
+        stages=1,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=SMEM_LAYOUT_O,
+        tma_loads_per_tile=TMA_O_ITERS_HOST,
+        tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+    )
+
+    sQ_SF = SmemTile(
+        base=sQ_SF_raw,
+        elems_per_stage=SF_SMEM_SIZE_Q,
+        stages=1,
+        leading_byte_offset=SF_LEADING_BYTE_OFFSET,
+        stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
+        layout=SMEM_LAYOUT_SF,
+    )
+    sK_SF = SmemTile(
+        base=sK_SF_raw,
+        elems_per_stage=SF_SMEM_SIZE_K,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=SF_LEADING_BYTE_OFFSET,
+        stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
+        layout=SMEM_LAYOUT_SF,
+    )
+    sP_SF = SmemTile(
+        base=sP_SF_raw,
+        elems_per_stage=SF_SMEM_SIZE_P,
+        stages=1,
+        leading_byte_offset=SF_LEADING_BYTE_OFFSET,
+        stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
+        layout=SMEM_LAYOUT_SF,
+    )
+    sV_SF = SmemTile(
+        base=sV_SF_raw,
+        elems_per_stage=SF_SMEM_SIZE_V,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=SF_LEADING_BYTE_OFFSET,
+        stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
+        layout=SMEM_LAYOUT_SF,
+    )
+
+    bars = make_d256_bars(CFG, N_O_CHUNKS=N_O_CHUNKS)
+
+    tmem_ptr_i32 = cutlass.Array(cutlass.Int32, 1, alignment=16, space=cutlass.AddressSpace.smem)
+
+    sched = Sched(
+        **{
+            "mb_scheduler": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "mb_read_tile_id": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "tile_id_smem": cutlass.Array(cutlass.Int32, CFG.SCHEDULER_STAGES * 8, alignment=16, space=cutlass.AddressSpace.smem),
+            "bidx_init": bidx,
+            "bidy_init": bidy,
+            "bidz_init": bidz,
+        }
+    )
+
+    if warp_idx == 0:
+        if nvvm.elect_sync():
+            # Init counts baked into make_d256_bars(...); kernel calls .init()
+            # per stage.  range_constexpr keeps loop vars Python int.
+            bars.mb_q_full.init()
+            bars.mb_q_o_alias.init()
+            bars.mb_tmastg_go.init()
+            for p in cutlass.range_constexpr(2):
+                bars.mb_bmm1_done[p].init()
+                bars.mb_bmm2_done[p].init()
+                for c in cutlass.range_constexpr(CFG.N_BMM2_CHUNKS):
+                    bars.mb_bmm2_ready[p * CFG.N_BMM2_CHUNKS + c].init()
+            bars.mb_stat_full.init()
+            bars.mb_stat_empty.init()
+            for chunk in cutlass.range_constexpr(N_O_CHUNKS):
+                bars.mb_o_full[chunk].init()
+            bars.mb_o_empty.init()
+            for ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_k_full[ks].init()
+                bars.mb_k_empty[ks].init()
+                bars.mb_v_full[ks].init()
+                bars.mb_v_empty[ks].init()
+            for s in range(CFG.SCHEDULER_STAGES):
+                nvvm.mbarrier_init(sched.mb_scheduler.subview(s), CFG.ONE_LANE)
+                # MXFP8 quiet warp matches FP8 minimal — keep CFG arriver count.
+                nvvm.mbarrier_init(sched.mb_read_tile_id.subview(s), CFG.READ_TILE_ARRIVERS)
+            bars.mb_empty_mainloop.init()
+            bars.mb_tmem_dealloc.init()
+
+            # Bootstrap pre-armed so first wait passes immediately (no prior O).
+            bars.mb_q_o_alias.arrive()
+
+    # P_SF SMEM fill with 0x7F (E8M0 1.0) — MUST precede cga_arrive/cga_wait
+    # so both cga2 peers see filled SMEM before any cta_group::2 MMA.
+    _SF_P_ITERS = (SF_SMEM_SIZE_P + CFG.THREADS_PER_CTA - 1) // CFG.THREADS_PER_CTA
+    for _i in cutlass.range_constexpr(_SF_P_ITERS):
+        _off = tidx + cutlass.Int32(_i * CFG.THREADS_PER_CTA)
+        if _off < cutlass.Int32(SF_SMEM_SIZE_P):
+            sP_SF_raw.subview(_off).store(cutlass.Int8(0x7F))
+
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync()
+
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        cga_arrive()
+        cga_wait()
+
+    cta_id_x = cute.arch.block_idx_in_cluster() if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    cta_in_pair = (cta_id_x & cutlass.Int32(1)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    leader_cta_id = (cta_id_x & cutlass.Int32(~1 & 0xFFFFFFFF)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    mcast_mask = (cutlass.Int32(3) << leader_cta_id) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    tma_mcast_mask = (cutlass.Int16(1) << cta_in_pair) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
+    sf_mcast_mask = cutlass.Int16(3) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
+    is_leader = cta_in_pair == cutlass.Int32(0)
+
+    # Warp layout: 0..3 softmax wg, 4..7 correction, 8 MMA, 9 TMALDG,
+    # 10 TMASTG, 11 scheduler.
+    if warp_idx >= CFG.SOFTMAX_WG0_BASE and warp_idx < CFG.SOFTMAX_WG0_BASE + CFG.SOFTMAX_WG_WARPS:
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        _softmax_warp_group(
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_softmax_log2,
+            tmem_ptr_i32=tmem_ptr_i32,
+            bars=bars,
+            sched=sched,
+            lse_tensor=lse_tensor,
+            amax_o_tensor=amax_o_tensor,
+            sinks_tensor=sinks_tensor,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+        )
+
+    elif warp_idx >= CFG.CORR_WARP_BASE and warp_idx < CFG.CORR_WARP_BASE + CFG.CORRECTION_WARPS:
+        nvvm.setmaxregister(CFG.CORRECTION_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _correction_warp_group(
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            sO=sO,
+            tmem_ptr_i32=tmem_ptr_i32,
+            tidx=tidx,
+            bars=bars,
+            sched=sched,
+            lse_tensor=lse_tensor,
+            amax_o_tensor=amax_o_tensor,
+            sinks_tensor=sinks_tensor,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+            cta_id_x=cta_id_x,
+        )
+
+    elif warp_idx == CFG.MMA_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        if cutlass.const_expr(CFG.CTA_MMA == 2):
+            if is_leader:
+                _mma_warp_group(
+                    seqlen_q=seqlen_q,
+                    seqlen_kv=seqlen_kv,
+                    sQ=sQ,
+                    sK=sK,
+                    sV=sV,
+                    sQ_SF=sQ_SF,
+                    sK_SF=sK_SF,
+                    sP_SF=sP_SF,
+                    sV_SF=sV_SF,
+                    tmem_ptr_i32=tmem_ptr_i32,
+                    bars=bars,
+                    sched=sched,
+                    seq_kv_lens_tensor=seq_kv_lens_tensor,
+                    n_q_supers=n_q_supers,
+                    n_qh=n_qh,
+                    n_batch=n_batch,
+                    mcast_mask=mcast_mask,
+                    cta_in_pair=cta_in_pair,
+                )
+            else:
+                _mma_warp_quiet(
+                    tmem_ptr_i32=tmem_ptr_i32,
+                    bars=bars,
+                    sched=sched,
+                    seqlen_q=seqlen_q,
+                    seqlen_kv=seqlen_kv,
+                    seq_kv_lens_tensor=seq_kv_lens_tensor,
+                    n_q_supers=n_q_supers,
+                    n_qh=n_qh,
+                    n_batch=n_batch,
+                    cta_in_pair=cta_in_pair,
+                    cta_id_x=cta_id_x,
+                )
+        else:
+            _mma_warp_group(
+                seqlen_q=seqlen_q,
+                seqlen_kv=seqlen_kv,
+                sQ=sQ,
+                sK=sK,
+                sV=sV,
+                sQ_SF=sQ_SF,
+                sK_SF=sK_SF,
+                sP_SF=sP_SF,
+                sV_SF=sV_SF,
+                tmem_ptr_i32=tmem_ptr_i32,
+                bars=bars,
+                sched=sched,
+                seq_kv_lens_tensor=seq_kv_lens_tensor,
+                n_q_supers=n_q_supers,
+                n_qh=n_qh,
+                n_batch=n_batch,
+                mcast_mask=mcast_mask,
+                cta_in_pair=cta_in_pair,
+            )
+
+    elif warp_idx == CFG.TMALDG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        nvvm.prefetch_tensormap(tma_q_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_k_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_v_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_q_sf_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_k_sf_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_v_sf_desc.get_ptr())
+        _tmaldg_warp_group(
+            tma_q_desc=tma_q_desc,
+            tma_k_desc=tma_k_desc,
+            tma_v_desc=tma_v_desc,
+            tma_q_sf_desc=tma_q_sf_desc,
+            tma_k_sf_desc=tma_k_sf_desc,
+            tma_v_sf_desc=tma_v_sf_desc,
+            sQ=sQ,
+            sK=sK,
+            sV=sV,
+            sQ_SF=sQ_SF,
+            sK_SF=sK_SF,
+            sV_SF=sV_SF,
+            bars=bars,
+            sched=sched,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            qh_per_kh=qh_per_kh,
+            is_leader=is_leader,
+            cta_in_pair=cta_in_pair,
+            tma_mcast_mask=tma_mcast_mask,
+            sf_mcast_mask=sf_mcast_mask,
+        )
+
+    elif warp_idx == CFG.TMASTG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _tmastg_warp_group(
+            tma_o_desc=tma_o_desc,
+            sO=sO,
+            bars=bars,
+            sched=sched,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            cta_in_pair=cta_in_pair,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
+        )
+
+    else:  # warp_idx == CFG.SCHED_WARP_ID
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        is_cga_first_cta = cta_id_x == cutlass.Int32(0)
+        scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
+
+
+# === TMA-LDG warp group ===
+
+
+@cute.jit
+def _tmaldg_warp_group(
+    tma_q_desc,
+    tma_k_desc,
+    tma_v_desc,
+    tma_q_sf_desc,
+    tma_k_sf_desc,
+    tma_v_sf_desc,
+    sQ,
+    sK,
+    sV,
+    sQ_SF,
+    sK_SF,
+    sV_SF,
+    bars,
+    sched,
+    seqlen_q,
+    seqlen_kv,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    qh_per_kh,
+    is_leader,
+    cta_in_pair,
+    tma_mcast_mask,
+    sf_mcast_mask,
+):
+    """Q/K/V/SF TMA loads with cga2 SF split-half multicast.
+
+    Per-tile SF TMA loads ride the SAME mb_q/k/v_full mbar — SF expect_tx
+    adds Q_SF_EXPECT_BYTES / K_SF_EXPECT_BYTES / V_SF_EXPECT_BYTES.  Under
+    cga2 each peer pulls HALF of K_SF / V_SF via bulk_copy_multicast
+    (mcast=Int16(3) distributes the half to both peers).
+    """
+    q_o_alias_phase = cutlass.Int32(0)
+    kv_state = PipelineState.start(phase=1)
+
+    tma_q = GmemTileTma(tma_q_desc)
+    tma_k = GmemTileTma(tma_k_desc)
+    tma_v = GmemTileTma(tma_v_desc)
+    tma_q_sf = GmemTileTma(tma_q_sf_desc)
+    tma_k_sf = GmemTileTma(tma_k_sf_desc)
+    tma_v_sf = GmemTileTma(tma_v_sf_desc)
+
+    SF_TMA_ROW_BYTES = 128
+    K_SF_BYTES_PER_PEER = SF_SMEM_SIZE_K // CFG.CTA_MMA
+    V_SF_BYTES_PER_PEER = SF_SMEM_SIZE_V // CFG.CTA_MMA
+    K_SF_ROWS_PER_PEER = K_SF_BYTES_PER_PEER // SF_TMA_ROW_BYTES
+    k_sf_peer_off = cta_in_pair * cutlass.Int32(K_SF_BYTES_PER_PEER)
+    v_sf_peer_off = cta_in_pair * cutlass.Int32(V_SF_BYTES_PER_PEER)
+    k_sf_peer_row = cta_in_pair * cutlass.Int32(K_SF_ROWS_PER_PEER)
+    # V's SF descriptor is D-plane-major (host), so the peer split is a plane
+    # coord, not a row offset (K, being rowwise, keeps the row form).
+    v_sf_peer_plane = cta_in_pair * cutlass.Int32(V_SF_PLANES_PER_PEER)
+    n_kh = n_qh // qh_per_kh
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+    # THD packed-tensor seq offsets (fold to (0,0,batch_idx) dense); SF-tile bases
+    # fold to (0,0) dense.
+    q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+    cu_sf_q_base, cu_sf_k_base = _thd_sf_tile_bases(seq_kv_lens_tensor, batch_idx, n_batch)
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    K_ROW_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_N // CFG.CTA_MMA)
+    V_COL_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_O // CFG.CTA_MMA)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        # Wait q_o_alias before clobbering Q∪O with next tile's Q.
+        bars.mb_q_o_alias.wait(q_o_alias_phase)
+        q_o_alias_phase = q_o_alias_phase ^ cutlass.Int32(1)
+
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+            pass
+        else:
+            q_sf_tile_base = q_row_base // cutlass.Int32(CFG.TILE_M)
+
+            # P9 — cga2 collective TMA routes mbar arrives to leader.
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_q_full.arrive(n_bytes=qTmaTransactionBytes + Q_SF_EXPECT_BYTES, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_q_full.arrive(n_bytes=qTmaTransactionBytes + Q_SF_EXPECT_BYTES, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sQ[0],
+                tma_q(cutlass.Int32(0), head_idx, q_row_base + q_seq_off, tma_batch),
+                bars.mb_q_full.smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+            tma_load_tile(
+                sQ_SF[0],
+                tma_q_sf(cutlass.Int32(0), cu_sf_q_base + q_sf_tile_base, head_idx, tma_batch, coord_0=cutlass.Int32(0)),
+                bars.mb_q_full.smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+
+            for kv_loop in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                kv_row_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+
+                bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sK[kv_state.idx],
+                    tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
+                    bars.mb_k_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+                tma_load_tile(
+                    sK_SF[kv_state.idx].shifted(k_sf_peer_off),
+                    tma_k_sf(k_sf_peer_row, cu_sf_k_base + kv_loop, kv_head_idx, tma_batch, coord_0=cutlass.Int32(0)),
+                    bars.mb_k_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=sf_mcast_mask,
+                )
+
+                bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes + V_SF_EXPECT_BYTES, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes + V_SF_EXPECT_BYTES, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sV[kv_state.idx],
+                    tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
+                    bars.mb_v_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+                tma_load_tile(
+                    sV_SF[kv_state.idx].shifted(v_sf_peer_off),
+                    tma_v_sf(cutlass.Int32(0), v_sf_peer_plane, cu_sf_k_base + kv_loop, tma_batch * n_kh + kv_head_idx, coord_0=cutlass.Int32(0)),
+                    bars.mb_v_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=sf_mcast_mask,
+                )
+
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        if nvvm.elect_sync():
+            bars.mb_tmastg_go.arrive()
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+        nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+        nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+        q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+        cu_sf_q_base, cu_sf_k_base = _thd_sf_tile_bases(seq_kv_lens_tensor, batch_idx, n_batch)
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        for _ks in cutlass.range_constexpr(CFG.STAGES_KV):
+            bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+            bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+
+# === TMA-STG warp group ===
+
+
+@cute.jit
+def _tmastg_warp_group(
+    tma_o_desc,
+    sO,
+    bars,
+    sched,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    cta_in_pair,
+    seq_kv_lens_tensor,
+    o_desc_words,
+):
+    """TMA-STG warp — no SF channel on the O store path."""
+    tmastg_go_phase = cutlass.Int32(0)
+    o_full_phase = cutlass.Int32(0)
+    tma_o = GmemTileTma(tma_o_desc)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        bars.mb_tmastg_go.wait(tmastg_go_phase)
+        tmastg_go_phase = tmastg_go_phase ^ cutlass.Int32(1)
+
+        for chunk in cutlass.range_constexpr(N_O_CHUNKS):
+            bars.mb_o_full[chunk].wait(o_full_phase)
+
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+
+        if cutlass.const_expr(CFG.THD_VARLEN):
+            # THD: store through this batch's pre-built descriptor (seq extent
+            # = S_q_b → box past S_q_b OOB-clipped).  q_row_coord seq-local; batch→0.
+            o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+            o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_coord, cutlass.Int32(0))
+            tma_store_tile(sO[0], o_slice)
+        else:
+            tma_store_tile(
+                sO[0],
+                tma_o(cutlass.Int32(0), head_idx, q_row_coord, batch_idx),
+            )
+        tma_store_commit()
+        tma_store_wait(0)
+
+        bars.mb_o_empty.arrive()
+        if nvvm.elect_sync():
+            bars.mb_q_o_alias.arrive()
+
+        o_full_phase = o_full_phase ^ cutlass.Int32(1)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+
+# === MMA warp group (+ quiet warp for cga2 non-leader) ===
+
+
+@cute.jit
+def _mma_warp_quiet(
+    tmem_ptr_i32,
+    bars,
+    sched,
+    seqlen_q,
+    seqlen_kv,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    cta_in_pair,
+    cta_id_x,
+):
+    """Quiet MMA warp (cga2 non-leader).
+
+    P9 — cga2 collective TMA routes ALL byte arrives to the leader's mbar,
+    so peer's mb_q_full never receives bytes.  SF split-half multicast
+    (sf_mcast_mask=Int16(3)) delivers SF to both peers, so no peer DSMEM
+    forward needed.  Minimal: tmem_alloc → 2× barrier_arrive → wait dealloc
+    → tmem_dealloc.
+    """
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND, is_exclusive=True)
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _mma_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    sQ,
+    sK,
+    sV,
+    sQ_SF,
+    sK_SF,
+    sP_SF,
+    sV_SF,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    mcast_mask,
+    cta_in_pair,
+):
+    """Block-scale MMA stream for BMM1 + BMM2 (Q*K(i+1) → S*V(i) lookahead).
+
+    Prologue: copy_sf(SF_Q,SF_K) → Q*K(lo) → bmm1_done[lo&1].
+    Mainloop: copy_sf(SF_K) → Q*K(kv+1); copy_sf(SF_V) → BMM2 N-block loop
+    with bmm2_ready[parity_cur][chunk] gates.
+    Epilogue: copy_sf(SF_V) → S*V(hi-1) BMM2 N-block loop.
+    """
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND, is_exclusive=True)
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    # Int8 pointer typing — Float16 typing strides in fp16 elems not cols.
+    tmem_raw = nvvm.make_tmem_ptr(tmem_ptr_i32.load(), cutlass.Int8)
+
+    idesc_qk_bs = prims.Tcgen05MxInstrDesc.build(
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_N,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        k_dim=_MXFP8_K_DIM,
+    )
+    # BMM2 N = BMM2_N_PER_CALL (per N-block).
+    idesc_pv_bs = prims.Tcgen05MxInstrDesc.build(
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=BMM2_N_PER_CALL,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        b_major=1,
+        k_dim=_MXFP8_K_DIM,
+    )
+
+    _MXFP8_SF_BLOCKS_PER_STEP = _MXFP8_TILE_K_HW // 32
+
+    bmm1_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_N,
+        K=CFG.TILE_K,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=_MXFP8_TILE_K_HW,
+        btranspose=False,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_qk_bs,
+        kind=MMA_KIND,
+        is_block_scale=True,
+        sf_blocks_per_step=_MXFP8_SF_BLOCKS_PER_STEP,
+        scale_vec_size=SCALE_VEC_SIZE,
+    )
+    bmm2_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=BMM2_N_PER_CALL,
+        K=CFG.TILE_N,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=_MXFP8_TILE_K_HW,
+        btranspose=True,
+        k_subtile=CFG.V_SWZ_BYTES // CFG.BPE,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_pv_bs,
+        kind=MMA_KIND,
+        is_block_scale=True,
+        sf_blocks_per_step=_MXFP8_SF_BLOCKS_PER_STEP,
+        scale_vec_size=SCALE_VEC_SIZE,
+    )
+
+    desc_Q = sQ[0].desc()
+    desc_Q_SF = sQ_SF[0].desc()
+    desc_P_SF = sP_SF[0].desc()
+
+    tmem_SF_Q = tmem_raw.subview(LAYOUT.SF_Q_OFF)
+    tmem_SF_K = tmem_raw.subview(LAYOUT.SF_K_OFF)
+    tmem_SF_P = tmem_raw.subview(LAYOUT.SF_P_OFF)
+    tmem_SF_V = tmem_raw.subview(LAYOUT.SF_V_OFF)
+
+    # One-shot copy_sf SMEM(P_SF) → TMEM(SF_P) — P_SF constant 1.0.
+    if nvvm.elect_sync():
+        nvvm.tcgen05_cp(
+            nvvm.Tcgen05CpShape.SHAPE_32X128B,
+            tmem_SF_P,
+            desc_P_SF,
+            group=CTA_GROUP_KIND,
+            multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+        )
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        q_super_idx, _hd, batch_idx = _dispatch_decode_initial(
+            sched.bidx_init,
+            sched.bidy_init,
+            sched.bidz_init,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    q_full_phase = cutlass.Int32(0)
+    kv_state_K = PipelineState.start(phase=0)
+    kv_state_V = PipelineState.start(phase=0)
+    bmm2_ready_phase_pair = cutlass.Int32(0)
+    empty_mainloop_phase = cutlass.Int32(0)
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+            bars.mb_empty_mainloop.wait(empty_mainloop_phase)
+            empty_mainloop_phase = empty_mainloop_phase ^ cutlass.Int32(1)
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+        else:
+            bars.mb_q_full.wait(q_full_phase)
+            q_full_phase = q_full_phase ^ cutlass.Int32(1)
+
+            lo_parity_runtime = kv_left & cutlass.Int32(1)
+            parity_lo_is_even = lo_parity_runtime == cutlass.Int32(0)
+            tmem_S_acc_lo_addr = cutlass.Int32(
+                arith.select(
+                    parity_lo_is_even.ir_value(),
+                    cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(),
+                    cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value(),
+                )
+            )
+
+            bars.mb_k_full[kv_state_K.idx].wait(kv_state_K.phase)
+            desc_K = sK[kv_state_K.idx].desc()
+            desc_K_SF = sK_SF[kv_state_K.idx].desc()
+            if nvvm.elect_sync():
+                for _sf_k in cutlass.range_constexpr(SF_NUM_BLOCKS_K):
+                    nvvm.tcgen05_cp(
+                        nvvm.Tcgen05CpShape.SHAPE_32X128B,
+                        tmem_SF_Q.subview(_sf_k * SF_REGISTERS_PER_BLOCK),
+                        desc_Q_SF + _sf_k * (SF_BYTES_PER_BLOCK // 16),
+                        group=CTA_GROUP_KIND,
+                        multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+                    )
+                    nvvm.tcgen05_cp(
+                        nvvm.Tcgen05CpShape.SHAPE_32X128B,
+                        tmem_SF_K.subview(_sf_k * SF_REGISTERS_PER_BLOCK),
+                        desc_K_SF + _sf_k * (SF_BYTES_PER_BLOCK // 16),
+                        group=CTA_GROUP_KIND,
+                        multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+                    )
+            mma_ss(bmm1_desc, desc_Q, desc_K, (tmem_raw.subview(tmem_S_acc_lo_addr)), tmem_sf_a=tmem_SF_Q, tmem_sf_b=tmem_SF_K)
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm1_done[lo_parity_runtime].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bars.mb_k_empty[kv_state_K.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            kv_state_K = advance(kv_state_K, CFG.STAGES_KV)
+
+            k_per_chunk = NUM_KPHASES_PV_PER_CHUNK
+
+            for kv_loop in cutlass.range(kv_left, kv_right - cutlass.Int32(1), 1, unroll=1):
+                parity_cur_rt = kv_loop & cutlass.Int32(1)
+                parity_next_rt = (kv_loop + cutlass.Int32(1)) & cutlass.Int32(1)
+                cur_is_even = parity_cur_rt == cutlass.Int32(0)
+                next_is_even = parity_next_rt == cutlass.Int32(0)
+
+                tmem_S_acc_next_addr = cutlass.Int32(
+                    arith.select(
+                        next_is_even.ir_value(),
+                        cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(),
+                        cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value(),
+                    )
+                )
+                tmem_P_cur_addr = cutlass.Int32(
+                    arith.select(
+                        cur_is_even.ir_value(),
+                        cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(),
+                        cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value(),
+                    )
+                )
+                bmm2_ready_phase_cur = (bmm2_ready_phase_pair >> parity_cur_rt) & cutlass.Int32(1)
+
+                bars.mb_k_full[kv_state_K.idx].wait(kv_state_K.phase)
+                desc_K = sK[kv_state_K.idx].desc()
+                desc_K_SF = sK_SF[kv_state_K.idx].desc()
+                if nvvm.elect_sync():
+                    for _sf_k in cutlass.range_constexpr(SF_NUM_BLOCKS_K):
+                        nvvm.tcgen05_cp(
+                            nvvm.Tcgen05CpShape.SHAPE_32X128B,
+                            tmem_SF_K.subview(_sf_k * SF_REGISTERS_PER_BLOCK),
+                            desc_K_SF + _sf_k * (SF_BYTES_PER_BLOCK // 16),
+                            group=CTA_GROUP_KIND,
+                            multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+                        )
+                mma_ss(bmm1_desc, desc_Q, desc_K, (tmem_raw.subview(tmem_S_acc_next_addr)), tmem_sf_a=tmem_SF_Q, tmem_sf_b=tmem_SF_K)
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm1_done[parity_next_rt].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                bars.mb_k_empty[kv_state_K.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                kv_state_K = advance(kv_state_K, CFG.STAGES_KV)
+
+                bars.mb_v_full[kv_state_V.idx].wait(kv_state_V.phase)
+                desc_V = sV[kv_state_V.idx].desc()
+                desc_V_SF = sV_SF[kv_state_V.idx].desc()
+                if nvvm.elect_sync():
+                    # SF V SMEM→TMEM needs per-N-block loop when SF_NUM_BLOCKS_V>1.
+                    for _sf_n in cutlass.range_constexpr(SF_NUM_BLOCKS_V):
+                        nvvm.tcgen05_cp(
+                            nvvm.Tcgen05CpShape.SHAPE_32X128B,
+                            tmem_SF_V.subview(_sf_n * SF_REGISTERS_PER_BLOCK),
+                            desc_V_SF + _sf_n * (SF_BYTES_PER_BLOCK // 16),
+                            group=CTA_GROUP_KIND,
+                            multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+                        )
+
+                scaleC = cutlass.Boolean(kv_loop != kv_left)
+                for nblk in cutlass.range_constexpr(BMM2_LOOP_N_BLOCKS):
+                    tmem_O_n = tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF + nblk * BMM2_N_PER_CALL))
+                    tmem_SF_V_n = tmem_SF_V.subview(cutlass.Int32(nblk * SF_V_COLS_PER_NBLOCK))
+                    accum_b2 = scaleC
+                    for k in cutlass.range_constexpr(NUM_KPHASES_PV):
+                        if nblk == 0 and k % k_per_chunk == 0:
+                            chunk_id = k // k_per_chunk
+                            bars.mb_bmm2_ready[parity_cur_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(chunk_id)].wait(bmm2_ready_phase_cur)
+                        mma_ts_step(bmm2_desc, (tmem_raw.subview(tmem_P_cur_addr)), desc_V, tmem_O_n, k, accum_b2, tmem_sf_a=tmem_SF_P, tmem_sf_b=tmem_SF_V_n)
+                        accum_b2 = cutlass.Boolean(True)
+                    if cutlass.const_expr(BMM2_LOOP_N_BLOCKS > 1):
+                        if nblk + 1 < BMM2_LOOP_N_BLOCKS:
+                            desc_V = desc_V + cutlass.Int32(BMM2_N_BLOCK_BYTE_STRIDE // 16)
+                if cutlass.const_expr(BMM2_LOOP_N_BLOCKS > 1):
+                    desc_V = desc_V - cutlass.Int32((BMM2_LOOP_N_BLOCKS - 1) * BMM2_N_BLOCK_BYTE_STRIDE // 16)
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm2_done[parity_cur_rt].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                bars.mb_v_empty[kv_state_V.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                bmm2_ready_phase_pair = bmm2_ready_phase_pair ^ (cutlass.Int32(1) << parity_cur_rt)
+                kv_state_V = advance(kv_state_V, CFG.STAGES_KV)
+
+            kv_last = kv_right - cutlass.Int32(1)
+            parity_last_rt = kv_last & cutlass.Int32(1)
+            last_is_even = parity_last_rt == cutlass.Int32(0)
+            tmem_P_last_addr = cutlass.Int32(
+                arith.select(
+                    last_is_even.ir_value(),
+                    cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(),
+                    cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value(),
+                )
+            )
+            bmm2_ready_phase_last = (bmm2_ready_phase_pair >> parity_last_rt) & cutlass.Int32(1)
+
+            bars.mb_v_full[kv_state_V.idx].wait(kv_state_V.phase)
+            desc_V = sV[kv_state_V.idx].desc()
+            desc_V_SF = sV_SF[kv_state_V.idx].desc()
+            if nvvm.elect_sync():
+                for _sf_n in cutlass.range_constexpr(SF_NUM_BLOCKS_V):
+                    nvvm.tcgen05_cp(
+                        nvvm.Tcgen05CpShape.SHAPE_32X128B,
+                        tmem_SF_V.subview(_sf_n * SF_REGISTERS_PER_BLOCK),
+                        desc_V_SF + _sf_n * (SF_BYTES_PER_BLOCK // 16),
+                        group=CTA_GROUP_KIND,
+                        multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+                    )
+
+            n_kv_eff = kv_right - kv_left
+            scaleC_epi = cutlass.Boolean(n_kv_eff != cutlass.Int32(1))
+            for nblk in cutlass.range_constexpr(BMM2_LOOP_N_BLOCKS):
+                tmem_O_n = tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF + nblk * BMM2_N_PER_CALL))
+                tmem_SF_V_n = tmem_SF_V.subview(cutlass.Int32(nblk * SF_V_COLS_PER_NBLOCK))
+                accum_b2 = scaleC_epi
+                for k in cutlass.range_constexpr(NUM_KPHASES_PV):
+                    if nblk == 0 and k % k_per_chunk == 0:
+                        chunk_id = k // k_per_chunk
+                        bars.mb_bmm2_ready[parity_last_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(chunk_id)].wait(bmm2_ready_phase_last)
+                    mma_ts_step(bmm2_desc, (tmem_raw.subview(tmem_P_last_addr)), desc_V, tmem_O_n, k, accum_b2, tmem_sf_a=tmem_SF_P, tmem_sf_b=tmem_SF_V_n)
+                    accum_b2 = cutlass.Boolean(True)
+                if cutlass.const_expr(BMM2_LOOP_N_BLOCKS > 1):
+                    if nblk + 1 < BMM2_LOOP_N_BLOCKS:
+                        desc_V = desc_V + cutlass.Int32(BMM2_N_BLOCK_BYTE_STRIDE // 16)
+            if cutlass.const_expr(BMM2_LOOP_N_BLOCKS > 1):
+                desc_V = desc_V - cutlass.Int32((BMM2_LOOP_N_BLOCKS - 1) * BMM2_N_BLOCK_BYTE_STRIDE // 16)
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm2_done[parity_last_rt].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bars.mb_v_empty[kv_state_V.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bmm2_ready_phase_pair = bmm2_ready_phase_pair ^ (cutlass.Int32(1) << parity_last_rt)
+            kv_state_V = advance(kv_state_V, CFG.STAGES_KV)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+            nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+        else:
+            nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+            nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+            nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+            q_super_idx, _hd, batch_idx = _dispatch_decode_payload(
+                nxt_q,
+                nxt_hb,
+                cta_in_pair,
+                n_q_supers,
+                n_qh,
+                n_batch,
+                seq_kv_lens_tensor,
+            )
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+# === Softmax warp group (single wg — TILES_Q=1) ===
+
+
+@cute.jit
+def _softmax_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    scale_log2: cutlass.Float32,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    lse_tensor: Optional[cute.Tensor],
+    # FROST's MXFP8 ABI puts amax_o RIGHT AFTER lse (position 9).
+    amax_o_tensor: cute.Tensor,
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+):
+    """Softmax: reads S_acc, writes P (FP8 cast).
+
+    SF_P is the constant 1.0 already in tmem.SF_P (filled once at MMA
+    warp start).  3-segment kv loop: LEFT-masked / unmasked / RIGHT-masked.
+    """
+    nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+
+    bmm1_done_phase_pair = cutlass.Int32(0)
+    stat_empty_phase = cutlass.Int32(1)
+    epilogue_state = cutlass.Int32(1)
+
+    NEG_INF = cutlass.Float32(-3.4028235e38)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(CFG.SOFTMAX_WG0_BASE * 32)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        total_max = NEG_INF
+        total_sum = cutlass.Vector.from_elements(
+            (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+            cutlass.Float32,
+        )
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+        q_abs = q_row_coord + tid_in_wg
+
+        bars.mb_o_empty.wait(epilogue_state)
+        bars.mb_stat_empty.wait(stat_empty_phase)
+        stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+        epilogue_state = epilogue_state ^ cutlass.Int32(1)
+
+        # Body inlined (no nested @cute.jit helper) so the CTM tracer can
+        # dispatch through cutlass.range without hitting the closure check.
+        CHUNK = 64
+        P_COLS_PER_CHUNK = CHUNK // 4  # fp8 packed 4:1 into FP32 cells
+        RESCALE_THRESHOLD = cutlass.Float32(CFG.RESCALE_THRESHOLD)
+
+        if cutlass.const_expr(CFG.MASK_FLAGS == MASK_NONE):
+            for kv_loop in cutlass.range(bounds.left, bounds.right, 1, unroll=1):
+                parity_rt = kv_loop & cutlass.Int32(1)
+                parity_is_even = parity_rt == cutlass.Int32(0)
+                s_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value())
+                )
+                p_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value())
+                )
+                bmm1_phase = (bmm1_done_phase_pair >> parity_rt) & cutlass.Int32(1)
+                bars.mb_bmm1_done[parity_rt].wait(bmm1_phase)
+                bmm1_done_phase_pair = bmm1_done_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+
+                tmem_base = tmem_ptr_i32.load()
+                s_addr_a = tmem_base + s_off_rt
+                s_addr_b = tmem_base + s_off_rt + cutlass.Int32(CHUNK)
+                p_addr_a = tmem_base + p_off_rt
+                p_addr_b = tmem_base + p_off_rt + cutlass.Int32(P_COLS_PER_CHUNK)
+                stats_addr = tmem_base + cutlass.Int32(LAYOUT.STATS_OFF)
+
+                res_a = tmem_load_max_reduction_x64(s_addr_a)
+                res_b = tmem_load_max_reduction_x64(s_addr_b)
+                reg_S_a = cutlass.Vector.from_elements(tuple(res_a[:CHUNK]), cutlass.Int32).bitcast(cutlass.Float32)
+                reg_S_b = cutlass.Vector.from_elements(tuple(res_b[:CHUNK]), cutlass.Int32).bitcast(cutlass.Float32)
+                max_a = cutlass.Vector.from_elements((res_a[CHUNK],), cutlass.Int32).bitcast(cutlass.Float32)[0]
+                max_b = cutlass.Vector.from_elements((res_b[CHUNK],), cutlass.Int32).bitcast(cutlass.Float32)[0]
+                current_max = cute.math.max(max_a, max_b) * scale_log2
+
+                old_total_max = total_max
+                is_first = total_max == NEG_INF
+                update_cond = is_first | ((current_max - total_max) > RESCALE_THRESHOLD)
+                total_max = cutlass.Float32(arith.select(update_cond.ir_value(), current_max.ir_value(), total_max.ir_value()))
+                exp_input = cutlass.Float32(arith.select(is_first.ir_value(), NEG_INF.ir_value(), (old_total_max - total_max).ir_value()))
+                alpha = cute.math.exp2(exp_input, fastmath=True)
+                new_total_max = total_max
+                alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_stat_full.arrive()
+
+                reg_S_a = reg_S_a * scale_log2 - new_total_max
+                reg_P_a = cute.math.exp2(reg_S_a, fastmath=True)
+                p_a_fp8 = reg_P_a.to(STORAGE_DTYPE)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_a, cutlass.Float32), p_a_fp8)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(0)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                reg_S_b = reg_S_b * scale_log2 - new_total_max
+                reg_P_b = cute.math.exp2(reg_S_b, fastmath=True)
+                p_b_fp8 = reg_P_b.to(STORAGE_DTYPE)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_b, cutlass.Float32), p_b_fp8)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(1)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                sum_a_pair = row_reduction_pair_64(reg_P_a)
+                sum_b_pair = row_reduction_pair_64(reg_P_b)
+                new_p_sum_pair = sum_a_pair + sum_b_pair
+                alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+                total_sum = total_sum * alpha_pair + new_p_sum_pair
+
+                bars.mb_stat_empty.wait(stat_empty_phase)
+                stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+        else:
+            for kv_loop in cutlass.range(bounds.left, bounds.unmasked_lo, 1, unroll=1):
+                parity_rt = kv_loop & cutlass.Int32(1)
+                parity_is_even = parity_rt == cutlass.Int32(0)
+                s_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value())
+                )
+                p_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value())
+                )
+                bmm1_phase = (bmm1_done_phase_pair >> parity_rt) & cutlass.Int32(1)
+                bars.mb_bmm1_done[parity_rt].wait(bmm1_phase)
+                bmm1_done_phase_pair = bmm1_done_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+                tmem_base = tmem_ptr_i32.load()
+                s_addr_a = tmem_base + s_off_rt
+                s_addr_b = tmem_base + s_off_rt + cutlass.Int32(CHUNK)
+                p_addr_a = tmem_base + p_off_rt
+                p_addr_b = tmem_base + p_off_rt + cutlass.Int32(P_COLS_PER_CHUNK)
+                stats_addr = tmem_base + cutlass.Int32(LAYOUT.STATS_OFF)
+                reg_S_a = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_a, cutlass.Float32), num=CHUNK)
+                reg_S_b = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_b, cutlass.Float32), num=CHUNK)
+                kv_col_base_a = kv_loop * cutlass.Int32(CFG.TILE_N)
+                kv_col_base_b = kv_col_base_a + cutlass.Int32(CHUNK)
+                # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
+                # CFG.BOTTOM_RIGHT is 0 — top-left masking is unchanged).
+                causal_diag = eff_seqlen_kv - seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+                reg_S_a = apply_mask_chunk(
+                    reg_S_a,
+                    q_abs,
+                    kv_col_base_a,
+                    eff_seqlen_kv,
+                    CFG.WINDOW_LEFT,
+                    CFG.MASK_FLAGS,
+                    N=CHUNK,
+                    bottom_right=CFG.BOTTOM_RIGHT,
+                    causal_diag=causal_diag,
+                    window_right=CFG.WINDOW_RIGHT,
+                )
+                reg_S_b = apply_mask_chunk(
+                    reg_S_b,
+                    q_abs,
+                    kv_col_base_b,
+                    eff_seqlen_kv,
+                    CFG.WINDOW_LEFT,
+                    CFG.MASK_FLAGS,
+                    N=CHUNK,
+                    bottom_right=CFG.BOTTOM_RIGHT,
+                    causal_diag=causal_diag,
+                    window_right=CFG.WINDOW_RIGHT,
+                )
+                max_a = row_max_reduction_64(reg_S_a)
+                max_b = row_max_reduction_64(reg_S_b)
+                current_max = cute.math.max(max_a, max_b) * scale_log2
+
+                old_total_max = total_max
+                is_first = total_max == NEG_INF
+                update_cond = is_first | ((current_max - total_max) > RESCALE_THRESHOLD)
+                total_max = cutlass.Float32(arith.select(update_cond.ir_value(), current_max.ir_value(), total_max.ir_value()))
+                exp_input = cutlass.Float32(arith.select(is_first.ir_value(), NEG_INF.ir_value(), (old_total_max - total_max).ir_value()))
+                alpha = cute.math.exp2(exp_input, fastmath=True)
+                new_total_max = total_max
+                alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_stat_full.arrive()
+                reg_S_a = reg_S_a * scale_log2 - new_total_max
+                reg_P_a = cute.math.exp2(reg_S_a, fastmath=True)
+                p_a_fp8 = reg_P_a.to(STORAGE_DTYPE)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_a, cutlass.Float32), p_a_fp8)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(0)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+                reg_S_b = reg_S_b * scale_log2 - new_total_max
+                reg_P_b = cute.math.exp2(reg_S_b, fastmath=True)
+                p_b_fp8 = reg_P_b.to(STORAGE_DTYPE)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_b, cutlass.Float32), p_b_fp8)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(1)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+                sum_a_pair = row_reduction_pair_64(reg_P_a)
+                sum_b_pair = row_reduction_pair_64(reg_P_b)
+                alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+                total_sum = total_sum * alpha_pair + (sum_a_pair + sum_b_pair)
+                bars.mb_stat_empty.wait(stat_empty_phase)
+                stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+            for kv_loop in cutlass.range(bounds.unmasked_lo, bounds.unmasked_hi, 1, unroll=1):
+                parity_rt = kv_loop & cutlass.Int32(1)
+                parity_is_even = parity_rt == cutlass.Int32(0)
+                s_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value())
+                )
+                p_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value())
+                )
+                bmm1_phase = (bmm1_done_phase_pair >> parity_rt) & cutlass.Int32(1)
+                bars.mb_bmm1_done[parity_rt].wait(bmm1_phase)
+                bmm1_done_phase_pair = bmm1_done_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+                tmem_base = tmem_ptr_i32.load()
+                s_addr_a = tmem_base + s_off_rt
+                s_addr_b = tmem_base + s_off_rt + cutlass.Int32(CHUNK)
+                p_addr_a = tmem_base + p_off_rt
+                p_addr_b = tmem_base + p_off_rt + cutlass.Int32(P_COLS_PER_CHUNK)
+                stats_addr = tmem_base + cutlass.Int32(LAYOUT.STATS_OFF)
+                res_a = tmem_load_max_reduction_x64(s_addr_a)
+                res_b = tmem_load_max_reduction_x64(s_addr_b)
+                reg_S_a = cutlass.Vector.from_elements(tuple(res_a[:CHUNK]), cutlass.Int32).bitcast(cutlass.Float32)
+                reg_S_b = cutlass.Vector.from_elements(tuple(res_b[:CHUNK]), cutlass.Int32).bitcast(cutlass.Float32)
+                max_a = cutlass.Vector.from_elements((res_a[CHUNK],), cutlass.Int32).bitcast(cutlass.Float32)[0]
+                max_b = cutlass.Vector.from_elements((res_b[CHUNK],), cutlass.Int32).bitcast(cutlass.Float32)[0]
+                current_max = cute.math.max(max_a, max_b) * scale_log2
+
+                old_total_max = total_max
+                is_first = total_max == NEG_INF
+                update_cond = is_first | ((current_max - total_max) > RESCALE_THRESHOLD)
+                total_max = cutlass.Float32(arith.select(update_cond.ir_value(), current_max.ir_value(), total_max.ir_value()))
+                exp_input = cutlass.Float32(arith.select(is_first.ir_value(), NEG_INF.ir_value(), (old_total_max - total_max).ir_value()))
+                alpha = cute.math.exp2(exp_input, fastmath=True)
+                new_total_max = total_max
+                alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_stat_full.arrive()
+                reg_S_a = reg_S_a * scale_log2 - new_total_max
+                reg_P_a = cute.math.exp2(reg_S_a, fastmath=True)
+                p_a_fp8 = reg_P_a.to(STORAGE_DTYPE)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_a, cutlass.Float32), p_a_fp8)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(0)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+                reg_S_b = reg_S_b * scale_log2 - new_total_max
+                reg_P_b = cute.math.exp2(reg_S_b, fastmath=True)
+                p_b_fp8 = reg_P_b.to(STORAGE_DTYPE)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_b, cutlass.Float32), p_b_fp8)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(1)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+                sum_a_pair = row_reduction_pair_64(reg_P_a)
+                sum_b_pair = row_reduction_pair_64(reg_P_b)
+                alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+                total_sum = total_sum * alpha_pair + (sum_a_pair + sum_b_pair)
+                bars.mb_stat_empty.wait(stat_empty_phase)
+                stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+            for kv_loop in cutlass.range(bounds.unmasked_hi, bounds.right, 1, unroll=1):
+                parity_rt = kv_loop & cutlass.Int32(1)
+                parity_is_even = parity_rt == cutlass.Int32(0)
+                s_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.S_ACC_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.S_ACC_ODD_OFF).ir_value())
+                )
+                p_off_rt = cutlass.Int32(
+                    arith.select(parity_is_even.ir_value(), cutlass.Int32(LAYOUT.P_EVEN_OFF).ir_value(), cutlass.Int32(LAYOUT.P_ODD_OFF).ir_value())
+                )
+                bmm1_phase = (bmm1_done_phase_pair >> parity_rt) & cutlass.Int32(1)
+                bars.mb_bmm1_done[parity_rt].wait(bmm1_phase)
+                bmm1_done_phase_pair = bmm1_done_phase_pair ^ (cutlass.Int32(1) << parity_rt)
+                tmem_base = tmem_ptr_i32.load()
+                s_addr_a = tmem_base + s_off_rt
+                s_addr_b = tmem_base + s_off_rt + cutlass.Int32(CHUNK)
+                p_addr_a = tmem_base + p_off_rt
+                p_addr_b = tmem_base + p_off_rt + cutlass.Int32(P_COLS_PER_CHUNK)
+                stats_addr = tmem_base + cutlass.Int32(LAYOUT.STATS_OFF)
+                reg_S_a = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_a, cutlass.Float32), num=CHUNK)
+                reg_S_b = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_b, cutlass.Float32), num=CHUNK)
+                kv_col_base_a = kv_loop * cutlass.Int32(CFG.TILE_N)
+                kv_col_base_b = kv_col_base_a + cutlass.Int32(CHUNK)
+                # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
+                # CFG.BOTTOM_RIGHT is 0 — top-left masking is unchanged).
+                causal_diag = eff_seqlen_kv - seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+                reg_S_a = apply_mask_chunk(
+                    reg_S_a,
+                    q_abs,
+                    kv_col_base_a,
+                    eff_seqlen_kv,
+                    CFG.WINDOW_LEFT,
+                    CFG.MASK_FLAGS,
+                    N=CHUNK,
+                    bottom_right=CFG.BOTTOM_RIGHT,
+                    causal_diag=causal_diag,
+                    window_right=CFG.WINDOW_RIGHT,
+                )
+                reg_S_b = apply_mask_chunk(
+                    reg_S_b,
+                    q_abs,
+                    kv_col_base_b,
+                    eff_seqlen_kv,
+                    CFG.WINDOW_LEFT,
+                    CFG.MASK_FLAGS,
+                    N=CHUNK,
+                    bottom_right=CFG.BOTTOM_RIGHT,
+                    causal_diag=causal_diag,
+                    window_right=CFG.WINDOW_RIGHT,
+                )
+                max_a = row_max_reduction_64(reg_S_a)
+                max_b = row_max_reduction_64(reg_S_b)
+                current_max = cute.math.max(max_a, max_b) * scale_log2
+
+                old_total_max = total_max
+                is_first = total_max == NEG_INF
+                update_cond = is_first | ((current_max - total_max) > RESCALE_THRESHOLD)
+                total_max = cutlass.Float32(arith.select(update_cond.ir_value(), current_max.ir_value(), total_max.ir_value()))
+                exp_input = cutlass.Float32(arith.select(is_first.ir_value(), NEG_INF.ir_value(), (old_total_max - total_max).ir_value()))
+                alpha = cute.math.exp2(exp_input, fastmath=True)
+                new_total_max = total_max
+                alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_stat_full.arrive()
+                reg_S_a = reg_S_a * scale_log2 - new_total_max
+                reg_P_a = cute.math.exp2(reg_S_a, fastmath=True)
+                p_a_fp8 = reg_P_a.to(STORAGE_DTYPE)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_a, cutlass.Float32), p_a_fp8)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(0)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+                reg_S_b = reg_S_b * scale_log2 - new_total_max
+                reg_P_b = cute.math.exp2(reg_S_b, fastmath=True)
+                p_b_fp8 = reg_P_b.to(STORAGE_DTYPE)
+                nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_b, cutlass.Float32), p_b_fp8)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                bars.mb_bmm2_ready[parity_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(1)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+                sum_a_pair = row_reduction_pair_64(reg_P_a)
+                sum_b_pair = row_reduction_pair_64(reg_P_b)
+                alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+                total_sum = total_sum * alpha_pair + (sum_a_pair + sum_b_pair)
+                bars.mb_stat_empty.wait(stat_empty_phase)
+                stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+
+        total_sum_scalar = total_sum[0] + total_sum[1]
+        stats_addr_epi = tmem_ptr_i32.load() + cutlass.Int32(LAYOUT.STATS_OFF)
+        stats_vec_epi = cutlass.Vector.from_elements((total_max, total_sum_scalar), cutlass.Float32)
+        nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr_epi, cutlass.Float32), stats_vec_epi)
+        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+        bars.mb_stat_full.arrive()
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+        nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+        nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+
+# === Correction warp group ===
+
+
+@cute.jit
+def _correction_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    sO,
+    tmem_ptr_i32,
+    tidx,
+    bars,
+    sched,
+    lse_tensor: Optional[cute.Tensor],
+    # FROST's MXFP8 ABI puts amax_o RIGHT AFTER lse (position 9).
+    amax_o_tensor: cute.Tensor,
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+    cta_id_x,
+):
+    """Correction: α-rescale O, sink-aware LSE, cast→store_swizzled.
+
+    MXFP8 inv_sum drops o_scale_fused (per-block SF replaces per-tensor
+    scale).  P14 catch-up flip on bmm2_done_phase_pair at end-of-tile is
+    REQUIRED for multi-wave n_kv=1.
+    """
+    nvvm.barrier_cta_sync(barrier_id=2, thread_count=32 * (CFG.CORRECTION_WARPS + 1))
+
+    tid_raw = cute.arch.thread_idx()[0]
+    tid_in_wg = tid_raw - cutlass.Int32(CFG.CORR_WARP_BASE * 32)
+
+    bmm2_done_phase_pair = cutlass.Int32(0)
+    stat_mbar_state = cutlass.Int32(0)
+    epilogue_state = cutlass.Int32(1)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    O_CHUNK = 16
+    N_CHUNKS_O = CFG.TILE_O // O_CHUNK
+    TMA_O_ITERS_LOCAL = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
+    D_BLOCK_SIZE = CFG.TILE_O // TMA_O_ITERS_LOCAL
+    TMA_O_GRANU_ELEMS_LOCAL = CFG.TILE_M * D_BLOCK_SIZE
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if bounds.right > bounds.left:
+            # Bootstrap-only-lo-parity: arm bmm2_ready[lo_parity * N_CHUNKS + 0]
+            # (NOT both parities).
+            lo_parity_rt = bounds.left & cutlass.Int32(1)
+            bars.mb_bmm2_ready[lo_parity_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+            bars.mb_stat_full.wait(stat_mbar_state)
+            bars.mb_stat_empty.arrive()
+            stat_mbar_state = stat_mbar_state ^ cutlass.Int32(1)
+        else:
+            # Empty-mainloop — MMA waits then fires bmm2_done[0] via multicast.
+            bars.mb_empty_mainloop.arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+        for kv_loop in cutlass.range(bounds.left + cutlass.Int32(1), bounds.right, 1, unroll=1):
+            parity_prev_rt = (kv_loop - cutlass.Int32(1)) & cutlass.Int32(1)
+            parity_cur_rt = kv_loop & cutlass.Int32(1)
+            tmem_base_iter = tmem_ptr_i32.load()
+
+            bars.mb_stat_full.wait(stat_mbar_state)
+
+            stats_addr = tmem_base_iter + cutlass.Int32(LAYOUT.STATS_OFF)
+            stats_vec = nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(stats_addr, cutlass.Float32),
+                num=2,
+            )
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+            alpha = stats_vec[0]
+
+            alpha_is_one = alpha == cutlass.Float32(1.0)
+            all_alpha_one = vote_sync(0xFFFFFFFF, alpha_is_one, VoteSync.ALL)
+
+            bars.mb_stat_empty.arrive()
+
+            bmm2_done_phase_prev = (bmm2_done_phase_pair >> parity_prev_rt) & cutlass.Int32(1)
+            bars.mb_bmm2_done[parity_prev_rt].wait(bmm2_done_phase_prev)
+            bmm2_done_phase_pair = bmm2_done_phase_pair ^ (cutlass.Int32(1) << parity_prev_rt)
+
+            if ~all_alpha_one:
+                for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                    o_addr = tmem_base_iter + cutlass.Int32(LAYOUT.O_OFF + chunk_idx * O_CHUNK)
+                    o_chunk = nvvm.tcgen05_ld(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                        num=O_CHUNK,
+                    )
+                    o_scaled = vec_scale_pair(o_chunk, alpha, O_CHUNK)
+                    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(o_addr, cutlass.Float32), o_scaled)
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+
+            bars.mb_bmm2_ready[parity_cur_rt * cutlass.Int32(CFG.N_BMM2_CHUNKS)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+            stat_mbar_state = stat_mbar_state ^ cutlass.Int32(1)
+
+        tmem_base_epi = tmem_ptr_i32.load()
+
+        # Pre-declare for CTM if-staging — names used after the conditional
+        # must be bound on every path.
+        total_max_scaled = cutlass.Float32(0.0)
+        total_sum = cutlass.Float32(0.0)
+        if bounds.right > bounds.left:
+            bars.mb_stat_full.wait(stat_mbar_state)
+            stats_addr_epi = tmem_base_epi + cutlass.Int32(LAYOUT.STATS_OFF)
+            stats_vec_epi = nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(stats_addr_epi, cutlass.Float32),
+                num=2,
+            )
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+            total_max_scaled = stats_vec_epi[0]
+            total_sum = stats_vec_epi[1]
+            bars.mb_stat_empty.arrive()
+            stat_mbar_state = stat_mbar_state ^ cutlass.Int32(1)
+
+        LN2 = cutlass.Float32(0.6931471805599453)
+        total_max_nat = total_max_scaled * LN2
+        lse_val = cutlass.Float32(0.0)
+        inv_sum = cutlass.Float32(0.0)
+        if cutlass.const_expr(CFG.HAS_SINK):
+            sinks_arr = cutlass.make_array_view(sinks_tensor)
+            sink_logit = sinks_arr[head_idx]
+            new_max = cute.math.max(total_max_nat, sink_logit)
+            scale = cute.math.exp(total_max_nat - new_max, fastmath=True)
+            new_sum = total_sum * scale + cute.math.exp(sink_logit - new_max, fastmath=True)
+            lse_val = new_max + cute.math.log(new_sum, fastmath=True)
+            inv_sum = scale / new_sum
+        else:
+            lse_val = total_max_nat + cute.math.log(cute.math.max(total_sum, cutlass.Float32(1e-30)), fastmath=True)
+            inv_sum = cutlass.Float32(1.0) / cute.math.max(total_sum, cutlass.Float32(1e-30))
+
+        # --- empty KV range (zero-length sequence under the padding mask) ---
+        # Same guard as the d256 FP8 sibling: with an empty mainloop
+        # total_max/total_sum stay 0, so the 1e-30 floor makes LSE log(1e-30) =
+        # -69.08 and inv_sum +inf, and O becomes (TMEM residue) * inf -- NaN,
+        # since the residue can be a NaN bit pattern.  Zero O with a SELECT.
+        _kv_empty = bounds.right <= bounds.left
+        if cutlass.const_expr(not CFG.HAS_SINK):
+            # A sink leaves real mass and the branch above already yields
+            # LSE = sink_logit there; without one an empty row is -inf.
+            lse_val = cutlass.Float32(arith.select(_kv_empty.ir_value(), cutlass.Float32(float("-inf")).ir_value(), lse_val.ir_value()))
+
+        q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + tid_in_wg
+        if cutlass.const_expr(CFG.THD_VARLEN):
+            # THD: sequence-local row; LSE packed [1,QH,T] → [0, head, cu_q[b]+local].
+            _cu = cutlass.make_array_view(seq_kv_lens_tensor)
+            _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
+            _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
+            if cutlass.const_expr(lse_tensor is not None):
+                if q_row_global < _s_q_b:
+                    lse_arr = cutlass.make_array_view(lse_tensor)
+                    lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
+                    lse_row[_cu_q_b + q_row_global] = lse_val
+        else:
+            if cutlass.const_expr(lse_tensor is not None):
+                if q_row_global < seqlen_q:
+                    lse_arr = cutlass.make_array_view(lse_tensor)
+                    lse_row = lse_arr[batch_idx, head_idx, :]
+                    lse_row[q_row_global] = lse_val
+
+        parity_last_rt = cutlass.Int32(0)
+        if bounds.right > bounds.left:
+            parity_last_rt = (bounds.right - cutlass.Int32(1)) & cutlass.Int32(1)
+        bmm2_done_phase_last = (bmm2_done_phase_pair >> parity_last_rt) & cutlass.Int32(1)
+        bars.mb_bmm2_done[parity_last_rt].wait(bmm2_done_phase_last)
+        # P14 catch-up flip — bmm2_done_phase ^= 1 AFTER epilogue wait, BEFORE
+        # next-tile sched advance.
+        bmm2_done_phase_pair = bmm2_done_phase_pair ^ (cutlass.Int32(1) << parity_last_rt)
+
+        # Block grouping = 64 elems (= 4 O_CHUNK loads) to preserve the
+        # mb_o_full[chunk/2] firing schedule (one barrier per 2 epi blocks).
+        O_EPI_BLK = 64
+        N_BLOCKS_EPI = CFG.TILE_O // O_EPI_BLK
+        CHUNKS_PER_BLK = O_EPI_BLK // O_CHUNK
+
+        # amax_o over VALID rows of |o| (fp32, pre-cast).  atomicMax only grows,
+        # so a padded row would permanently inflate the graph's Amax_O -- gate
+        # the atomic exactly like the LSE write above.
+        _amax_o_ptr = Pointer(amax_o_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
+        _amax_o_local = cutlass.Float32(0.0)
+
+        sO_base = sO[0].base
+        epi_o_full_block_idx = 0
+
+        for block_idx in cutlass.range_constexpr(N_BLOCKS_EPI):
+            for sub in cutlass.range_constexpr(CHUNKS_PER_BLK):
+                chunk_idx_total = block_idx * CHUNKS_PER_BLK + sub
+                o_addr = tmem_base_epi + cutlass.Int32(LAYOUT.O_OFF + chunk_idx_total * O_CHUNK)
+                o_chunk = nvvm.tcgen05_ld(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                    num=O_CHUNK,
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                o_scaled = o_chunk * inv_sum
+                # SELECT the zero for an empty KV range, then fold amax over the
+                # substituted values -- an ungated NaN here would propagate into
+                # the graph's Amax_O for every other row via atomicMax.
+                # Statement-level loop: range_constexpr is not preprocessed
+                # inside a comprehension.
+                _o_elems = []
+                for _i in cutlass.range_constexpr(O_CHUNK):
+                    _e = cutlass.Float32(arith.select(_kv_empty.ir_value(), cutlass.Float32(0.0).ir_value(), o_scaled[_i].ir_value()))
+                    _amax_o_local = cute.math.max(_amax_o_local, cute.math.max(_e, -_e))
+                    _o_elems.append(_e)
+                o_out = cutlass.Vector.from_elements(tuple(_o_elems), cutlass.Float32).to(OUT_STORAGE_DTYPE)
+
+                col_offset_const = (chunk_idx_total * O_CHUNK) % D_BLOCK_SIZE
+                block_offset_const = ((chunk_idx_total * O_CHUNK) // D_BLOCK_SIZE) * TMA_O_GRANU_ELEMS_LOCAL
+                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
+                smem_ptr = sO_base.subview(smem_offset).data_ptr()
+
+                if block_idx == 0 and sub == 0:
+                    bars.mb_o_empty.wait(epilogue_state)
+                smem_ptr.store_swizzled(o_out, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+
+            # One mb_o_full per TMA-O store chunk.  BF16/FP16 O (BPE_O=2) doubles
+            # N_O_CHUNKS so _BLOCKS_PER_OCHUNK drops 2→1 (fire every block);
+            # keeps the TMA-STG consumer's N_O_CHUNKS waits balanced (FP8 unchanged).
+            _BLOCKS_PER_OCHUNK = N_BLOCKS_EPI // N_O_CHUNKS
+            fire_now = (block_idx + 1) % _BLOCKS_PER_OCHUNK == 0
+            if cutlass.const_expr(fire_now):
+                # fence_proxy needed before TMA reads SMEM written by swizzled store.
+                nvvm.fence_proxy("async.shared", space="cta")
+                bars.mb_o_full[block_idx // _BLOCKS_PER_OCHUNK].arrive()
+
+        if q_row_global < seqlen_q:
+            nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
+
+        epilogue_state = epilogue_state ^ cutlass.Int32(1)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        peer_cta = cta_id_x ^ cutlass.Int32(1)
+        bars.mb_tmem_dealloc.arrive_on_peer(peer_cta)
+    bars.mb_tmem_dealloc.arrive()
+
+
+# === Host launcher ===
+
+
+@cute.jit
+def _host(
+    q_tensor: cute.Tensor,
+    k_tensor: cute.Tensor,
+    v_tensor: cute.Tensor,
+    o_tensor: cute.Tensor,
+    sf_q_tensor: cute.Tensor,
+    sf_k_tensor: cute.Tensor,
+    sf_v_tensor: cute.Tensor,
+    lse_tensor: Optional[cute.Tensor],
+    # FROST's MXFP8 ABI puts amax_o RIGHT AFTER lse (position 9).
+    amax_o_tensor: cute.Tensor,
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    problem_size: Tuple[int, int, int, int, int, int],
+    scale_softmax_log2: cutlass.Float32,
+    n_thd_units: cutlass.Int32,
+    # FROST passes the dense padded-Q trim tensor POSITIONALLY on every call.
+    # These kernels have no Q-trim epilogue (Capabilities.dense_seq_q_trim=False)
+    # so it is accepted and unused -- but the SLOT is mandatory: without it the
+    # adapter's 12th positional lands on `stream` and execute dies with
+    # "got multiple values for argument 'stream'".
+    seq_q_lens_tensor: Optional[cute.Tensor] = None,
+    # Keyword-only in effect: FROST never passes these positionally (its SF
+    # extents are compile-time), and they are read only on the THD path, which
+    # this kernel declines.  They MUST sit after seq_q_lens_tensor: the adapter
+    # passes seq_q_lens positionally for the d256 quantized ABI, so an SF total
+    # in that slot would swallow it.
+    total_q_sf_tiles: cutlass.Int32 = 0,
+    total_kv_sf_tiles: cutlass.Int32 = 0,
+    # FROST plans must run on the caller's stream (engine contract; there is a
+    # dedicated stream-respect test).  Threaded exactly as the shipped
+    # prefill_d128_fp8_sm107.py sibling does.
+    stream: _cuda_driver.CUstream = None,
+) -> None:
+    """MXFP8 host launcher — builds TMA descriptors for Q/K/V/O + SF tensors.
+
+    THD/varlen: q/k/v/o/lse/SF are PACKED with batch dim 1; the SF descriptors use
+    B=1 + total_*_sf_tiles (per-sequence-TILE-padded SF layout); O uses a per-batch
+    descriptor array (build_thd_meta_o_descs_kernel)."""
+    B, QH, KH, SQ, SKV, _ = problem_size
+
+    _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE_O
+    qk_box_q = (1, CFG.TILE_M, 1, TMA_QK_GRANU_ELEMS)
+    qk_box_k = (1, CFG.TILE_N // CFG.CTA_MMA, 1, TMA_QK_GRANU_ELEMS)
+    vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M, 1, _O_GRANU_ELEMS)
+    stride_order = (3, 2, 1, 0)
+
+    SF_TMA_ROW_BYTES = 128
+    SF_NUM_ROWS_Q = SF_SMEM_SIZE_Q // SF_TMA_ROW_BYTES
+    SF_NUM_ROWS_K = SF_SMEM_SIZE_K // SF_TMA_ROW_BYTES
+    SF_NUM_ROWS_V = SF_SMEM_SIZE_V // SF_TMA_ROW_BYTES
+
+    def _tma_swz(byte_w: int):
+        return tmap.TensorMapSwizzle.s128b if byte_w == 128 else tmap.TensorMapSwizzle.s64b if byte_w == 64 else tmap.TensorMapSwizzle.s32b
+
+    tma_q_desc = tmap.create_tensor_map_tiled_from_view(
+        q_tensor,
+        box_dims=qk_box_q,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.Q_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_k_desc = tmap.create_tensor_map_tiled_from_view(
+        k_tensor,
+        box_dims=qk_box_k,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.K_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_v_desc = tmap.create_tensor_map_tiled_from_view(
+        v_tensor,
+        box_dims=vo_box_v,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.V_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_o_desc = tmap.create_tensor_map_tiled_from_view(
+        o_tensor,
+        box_dims=vo_box_o,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.O_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+
+    # SF TMA — 5-D explicit layout.  V_SF SMEM concatenates SF_NUM_BLOCKS_V
+    # non-K blocks contiguously per tile (no padding between blocks at
+    # TILE_N=128); the kernel's mma_ts_step nblk loop walks blocks via
+    # tmem_SF_V_n = tmem_SF_V + nblk * SF_V_COLS_PER_NBLOCK.
+    # Dense: per-batch tile counts (SQ/TILE_M, SKV/TILE_N), B-extent = B.  THD:
+    # the SF tensor is PACKED (batch dim 1) and per-sequence-TILE-padded, so the
+    # descriptor uses num_tiles = total_*_sf_tiles (Σ_b ceil(S/TILE)) and B = 1.
+    # _B_SF folds to the const 1 under THD so the descriptor's batch extent is correct.
+    sq_sf_tiles = (SQ + CFG.TILE_M - 1) // CFG.TILE_M
+    skv_sf_tiles = (SKV + CFG.TILE_N - 1) // CFG.TILE_N
+    _B_SF = 1 if cutlass.const_expr(CFG.THD_VARLEN) else B
+    _q_sf_num_tiles = total_q_sf_tiles if cutlass.const_expr(CFG.THD_VARLEN) else sq_sf_tiles
+    _kv_sf_num_tiles = total_kv_sf_tiles if cutlass.const_expr(CFG.THD_VARLEN) else skv_sf_tiles
+
+    def _build_sf_desc(sf_tensor, num_tiles, sf_smem_size, num_rows_box, num_heads):
+        sf_base = cutlass.Int64(sf_tensor.iterator.toint())
+        tile_stride_16 = sf_smem_size // 16
+        return tmap.create_tensor_map_tiled(
+            global_address=sf_base,
+            dtype=cutlass.Uint8,
+            global_dims=[
+                SF_TMA_ROW_BYTES,
+                sf_smem_size // SF_TMA_ROW_BYTES,
+                num_tiles,
+                num_heads,
+                _B_SF,
+            ],
+            global_strides=[
+                SF_TMA_ROW_BYTES // 16,
+                tile_stride_16,
+                num_tiles * tile_stride_16,
+                num_heads * num_tiles * tile_stride_16,
+            ],
+            box_dims=[SF_TMA_ROW_BYTES, num_rows_box, 1, 1, 1],
+            swizzle=tmap.TensorMapSwizzle.none,
+            l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+        )
+
+    tma_q_sf_desc = _build_sf_desc(sf_q_tensor, _q_sf_num_tiles, SF_SMEM_SIZE_Q, SF_NUM_ROWS_Q, QH)
+    tma_k_sf_desc = _build_sf_desc(sf_k_tensor, _kv_sf_num_tiles, SF_SMEM_SIZE_K, SF_NUM_ROWS_K // CFG.CTA_MMA, KH)
+    # V's SF is the COLUMNWISE (transposed-operand) quantization, and its GMEM
+    # layout is NOT the per-tile-contiguous one Q/K use.  The F8_128x4 atom rule
+    # is applied to the transposed scale matrix [D, S/32], so the atom grid is
+    # (D/128) x (b*KH*S/128) laid out ROW-MAJOR -- the D-block index is the
+    # OUTER one, and the SF_NUM_BLOCKS_V D-planes are separated by a whole plane
+    # of `v_sf_groups` atoms, a stride that GROWS WITH S.  Q/K are rowwise:
+    # their atom grid is (b*QH*S/128) x (D/128), so THEIR D-blocks are per-tile
+    # contiguous and _build_sf_desc is right for them.
+    #
+    # At d=128 there is exactly ONE D-plane, so the two layouts coincide -- which
+    # is why the d128 MXFP8 sibling passes with the per-tile form, and why d256
+    # was correct at S=128 (one KV tile => one group) and wrong from S=256 on.
+    # Mirrors prefill_d256_mxfp8_sm100.py's dense/THD stride split.
+    _v_sf_groups = _B_SF * KH * _kv_sf_num_tiles
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD packs both D-planes of a (head, sequence tile) contiguously.
+        _v_plane_stride_16 = SF_BYTES_PER_BLOCK // 16
+        _v_tile_stride_16 = SF_SMEM_SIZE_V // 16
+    else:
+        _v_plane_stride_16 = (_v_sf_groups * SF_BYTES_PER_BLOCK) // 16
+        _v_tile_stride_16 = SF_BYTES_PER_BLOCK // 16
+    tma_v_sf_desc = tmap.create_tensor_map_tiled(
+        global_address=cutlass.Int64(sf_v_tensor.iterator.toint()),
+        dtype=cutlass.Uint8,
+        global_dims=[
+            SF_TMA_ROW_BYTES,
+            SF_BYTES_PER_BLOCK // SF_TMA_ROW_BYTES,
+            SF_NUM_BLOCKS_V,
+            _kv_sf_num_tiles,
+            KH * _B_SF,
+        ],
+        global_strides=[
+            SF_TMA_ROW_BYTES // 16,
+            _v_plane_stride_16,
+            _v_tile_stride_16,
+            _kv_sf_num_tiles * _v_tile_stride_16,
+        ],
+        box_dims=[SF_TMA_ROW_BYTES, SF_BYTES_PER_BLOCK // SF_TMA_ROW_BYTES, V_SF_PLANES_PER_PEER, 1, 1],
+        swizzle=tmap.TensorMapSwizzle.none,
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+
+    rows_per_cluster = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+    q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
+    grid_q_supers = q_clusters * CFG.CTA_MMA
+    q_supers = grid_q_supers
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD: build the per-batch O descriptor array (reuse tma_o_desc over the
+        # packed [1,T,QH,D_v] O as base), then launch the exact flat
+        # batch-outermost grid (n_thd_units host-computed); grid_x = units*CGA_M.
+        _build_thd_meta_o_descs_kernel(
+            o_tensor,
+            tma_o_desc,
+            o_desc_words,
+            seq_kv_lens_tensor,
+            cutlass.Int32(QH),
+            cutlass.Int32(B),
+            cutlass.Int32(CFG.TILE_O),
+        ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
+        grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
+    else:
+        grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
+    _kernel(
+        tma_q_desc,
+        tma_k_desc,
+        tma_v_desc,
+        tma_o_desc,
+        tma_q_sf_desc,
+        tma_k_sf_desc,
+        tma_v_sf_desc,
+        lse_tensor,
+        amax_o_tensor,
+        sinks_tensor,
+        seq_kv_lens_tensor,
+        o_desc_words,
+        cutlass.Int32(SQ),
+        cutlass.Int32(SKV),
+        cutlass.Int32(q_supers),
+        cutlass.Int32(QH),
+        cutlass.Int32(B),
+        cutlass.Int32(QH // KH),
+        scale_softmax_log2,
+    ).launch(
+        grid=grid_shape,
+        block=[CFG.THREADS_PER_CTA, 1, 1],
+        cluster=(CFG.CTA_MMA, 1, 1),
+        stream=stream,
+    )
+
+
+@lru_cache(maxsize=None)
+def compile(  # noqa: A001
+    b: int = 1,
+    qh: int = 1,
+    kh: int = 1,
+    sq: int = 256,
+    skv: int = 128,
+    total_q_sf_tiles: int = 0,
+    total_kv_sf_tiles: int = 0,
+    d_qk: int = CFG.TILE_K,
+    d_v: int = CFG.TILE_O,
+    has_lse: bool = True,
+    lse_stride: Optional[tuple] = None,
+) -> Callable:
+    """Compile a kernel with concrete dims.
+
+    THD/varlen: q/k/v/o/lse + SF tensors are PACKED with batch dim 1; ``b`` is the
+    LOGICAL batch (sequence count).  The SF tensors are per-sequence-TILE-padded so
+    their packed tile extent is ``total_q_sf_tiles`` / ``total_kv_sf_tiles`` (=
+    Σ_b ceil(S/TILE)); pass those (they vary with the cu_seqlens partition, hence
+    part of the lru_cache key).  Default 0 → fall back to the dense per-batch tile
+    counts so the dense path is unaffected."""
+    # THD/varlen is NOT ported for this kernel yet.  The setup-kernel call site
+    # below still speaks the pre-upstream 7-arg contract, while FROST's
+    # thd_helpers.build_thd_meta_o_descs_kernel takes 14 args and a different
+    # metadata layout (4B+4 with batch_remap + a claim counter, vs the 3B+2
+    # here), and the scheduler decode differs to match.  Raise here rather than
+    # let it fail as an arity error deep in the trace -- and so no engine row
+    # can advertise thd=True for this kernel and appear to work.  The dense
+    # path is unaffected: CFG.THD_VARLEN is 0 and every THD branch folds out.
+    if CFG.THD_VARLEN:
+        raise NotImplementedError(f"{__name__}: THD/varlen not ported to the FROST setup-kernel contract")
+    # ---- FROST adapter ABI ------------------------------------------------
+    # lower_dsl_prefill calls EVERY kernel with the full forward signature.
+    # This body carries only what the port brought over, so anything
+    # it cannot honor RAISES rather than being silently ignored: a raise here
+    # means the engine's Capabilities row is lying, which is the failure we
+    # want loud.  (Capabilities: lse_optional=False, no strided Stats.)
+    if lse_stride is not None:
+        raise NotImplementedError(f"{__name__}: strided Stats not ported (contiguous [B, H, S] only)")
+    if d_qk > CFG.TILE_K or d_v > CFG.TILE_O or d_qk <= 0 or d_v <= 0:
+        raise ValueError(f"{__name__}: envelope is 0 < d_qk <= {CFG.TILE_K}, 0 < d_v <= {CFG.TILE_O}; " f"got ({d_qk}, {d_v})")
+    _fake_batch = 1 if CFG.THD_VARLEN else b
+
+    # Q SF tiles TILE_M-row wide → num_tiles = SQ/TILE_M; K/V SF TILE_N-row wide → num_tiles = SKV/TILE_N.
+    # THD: packed (batch dim 1) + per-sequence-TILE-padded → total_*_sf_tiles tiles.
+    sq_tiles = (sq + CFG.TILE_M - 1) // CFG.TILE_M
+    skv_tiles = (skv + CFG.TILE_N - 1) // CFG.TILE_N
+    if CFG.THD_VARLEN:
+        _q_sf_tiles = total_q_sf_tiles if total_q_sf_tiles > 0 else b * sq_tiles
+        _kv_sf_tiles = total_kv_sf_tiles if total_kv_sf_tiles > 0 else b * skv_tiles
+    else:
+        _q_sf_tiles = sq_tiles
+        _kv_sf_tiles = skv_tiles
+
+    fake_q = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, sq, qh, d_qk),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_k = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, d_qk),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_v = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, d_v),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_o = cute.runtime.make_fake_compact_tensor(
+        OUT_STORAGE_DTYPE,
+        (_fake_batch, sq, qh, d_v),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+
+    fake_sf_q = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int8,
+        (_fake_batch, qh, _q_sf_tiles, SF_SMEM_SIZE_Q),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_sf_k = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int8,
+        (_fake_batch, kh, _kv_sf_tiles, SF_SMEM_SIZE_K),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_sf_v = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int8,
+        (_fake_batch, kh, _kv_sf_tiles, SF_SMEM_SIZE_V),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+
+    # has_lse=False (no Stats output): the LSE argument is None-specialized and
+    # the store is compiled out entirely -- no dummy buffer exists at any level,
+    # which is what lets the dense graph report get_workspace_size() == 0.
+    # Mirrors the shipped prefill_d128_fp8_sm107.py.
+    fake_lse = (
+        cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (_fake_batch, qh, sq),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
+        if has_lse
+        else None
+    )
+    fake_sinks = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (qh,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    fake_amax_o = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (1,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # seq_kv_lens always part of the ABI; THD overloads it as the
+    # [seq_kv_lens(B)|cu_q(B+1)|cu_k(B+1)] metadata buffer (length 3B+2).
+    _skv_len = (3 * b + 2) if CFG.THD_VARLEN else b
+    fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (_skv_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # Per-batch O TMA-descriptor array (TENSOR_MAP_QWORDS int64 = 128 B each) + 1
+    # pad slot; dummy 1-elem when THD off (kernel never reads it).
+    _odesc_len = (b * _TENSOR_MAP_QWORDS + _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
+    fake_o_desc = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int64,
+        (_odesc_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    return cute.compile(
+        _host,
+        fake_q,
+        fake_k,
+        fake_v,
+        fake_o,
+        fake_sf_q,
+        fake_sf_k,
+        fake_sf_v,
+        fake_lse,
+        fake_amax_o,
+        fake_sinks,
+        fake_seq_kv_lens,
+        fake_o_desc,
+        (b, qh, kh, sq, skv, 0),
+        cutlass.Float32(0.0),
+        cutlass.Int32(0),
+        # BY KEYWORD, not position: the SF totals now sit AFTER
+        # seq_q_lens_tensor in _host's signature (the adapter passes that slot
+        # positionally for the d256 quantized ABI).  Passing them positionally
+        # here lands an Int32 in the tensor slot --
+        # "expects argument #16 (seq_q_lens_tensor) ... but got Int32".
+        total_q_sf_tiles=cutlass.Int32(_q_sf_tiles),
+        total_kv_sf_tiles=cutlass.Int32(_kv_sf_tiles),
+        stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
+        options="--enable-tvm-ffi",
+    )
+
+
+def _main():
+    """Minimal CLI for compile-check / perf bring-up."""
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--b", type=int, default=1)
+    parser.add_argument("--hq", type=int, default=1)
+    parser.add_argument("--hk", type=int, default=1)
+    parser.add_argument("--sq", type=int, default=256)
+    parser.add_argument("--skv", type=int, default=128)
+    parser.add_argument("--validate", action="store_true")
+    parser.add_argument("--iters", type=int, default=0)
+    args = parser.parse_args()
+
+    print(f"[d256_mxfp8] compile b={args.b} qh={args.hq} kh={args.hk} " f"sq={args.sq} skv={args.skv}", flush=True)
+    fn = compile(args.b, args.hq, args.hk, args.sq, args.skv)
+    print(f"[d256_mxfp8] compile OK: {fn}", flush=True)
+    if args.validate:
+        print("[d256_mxfp8] --validate: see tests/run_python_sweep.py")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_mxfp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_mxfp8_sm107.py
@@ -59,6 +59,20 @@ from cudnn.sdpa.fwd.config_sm107 import TemplateParams, make_cfg_d256_mxfp8
 
 PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
 CFG, _TMA = make_cfg_d256_mxfp8(PARAMS)
+
+# tcgen05 SMEM-descriptor version for EVERY SmemTile in this module -- ONE
+# decision point, wired into every construction below rather than repeated as a
+# per-tile literal.  A version-0 descriptor's ``start_address`` is 14 bits = a
+# 256 KiB window; Rubin raises the per-CTA SMEM cap to 327 KiB, so an operand
+# buffer at or above 256 KiB wraps to offset 0 and the MMA multiplies whatever
+# sits at the bottom of SMEM.  This flavor's buffers all stay below the line.
+#
+# Do NOT re-literal this at a call site: the d512 MXFP8 sibling shipped NaN on
+# 100% of cells because its scale-factor tiles were declared UNDER a comment
+# claiming "every operand tile here carries desc_version=1" -- without the
+# kwarg.  A single constant makes that class of drift impossible, and
+# test_sm107_descriptor_version_matches_the_smem_budget asserts it.
+DESC_VERSION: int = 0
 Cfg = type(CFG)
 TMA_QK_ITERS = _TMA.QK_ITERS
 TMA_VO_ITERS = _TMA.VO_ITERS
@@ -390,6 +404,7 @@ def _kernel(
         tma_loads_per_tile=TMA_QK_ITERS,
         tma_granu_elems=TMA_QK_GRANU_ELEMS,
         tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+        desc_version=DESC_VERSION,
     )
     sK = SmemTile(
         base=sK_raw,
@@ -401,6 +416,7 @@ def _kernel(
         tma_loads_per_tile=TMA_QK_ITERS,
         tma_granu_elems=TMA_QK_GRANU_ELEMS,
         tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+        desc_version=DESC_VERSION,
     )
     sV = SmemTile(
         base=sV_raw,
@@ -412,6 +428,7 @@ def _kernel(
         tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
         tma_granu_elems=TMA_VO_GRANU_ELEMS,
         tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+        desc_version=DESC_VERSION,
     )
     # sO shares backing with sQ (Q∪O alias) — OUT_STORAGE_DTYPE view for BPE_O offsets.
     sO = SmemTile(
@@ -424,6 +441,7 @@ def _kernel(
         tma_loads_per_tile=TMA_O_ITERS_HOST,
         tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
         tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+        desc_version=DESC_VERSION,
     )
 
     sQ_SF = SmemTile(
@@ -433,6 +451,7 @@ def _kernel(
         leading_byte_offset=SF_LEADING_BYTE_OFFSET,
         stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
         layout=SMEM_LAYOUT_SF,
+        desc_version=DESC_VERSION,
     )
     sK_SF = SmemTile(
         base=sK_SF_raw,
@@ -441,6 +460,7 @@ def _kernel(
         leading_byte_offset=SF_LEADING_BYTE_OFFSET,
         stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
         layout=SMEM_LAYOUT_SF,
+        desc_version=DESC_VERSION,
     )
     sP_SF = SmemTile(
         base=sP_SF_raw,
@@ -449,6 +469,7 @@ def _kernel(
         leading_byte_offset=SF_LEADING_BYTE_OFFSET,
         stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
         layout=SMEM_LAYOUT_SF,
+        desc_version=DESC_VERSION,
     )
     sV_SF = SmemTile(
         base=sV_SF_raw,
@@ -457,6 +478,7 @@ def _kernel(
         leading_byte_offset=SF_LEADING_BYTE_OFFSET,
         stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
         layout=SMEM_LAYOUT_SF,
+        desc_version=DESC_VERSION,
     )
 
     bars = make_d256_bars(CFG, N_O_CHUNKS=N_O_CHUNKS)
@@ -1898,19 +1920,25 @@ def _correction_warp_group(
             lse_val = cutlass.Float32(arith.select(_kv_empty.ir_value(), cutlass.Float32(float("-inf")).ir_value(), lse_val.ir_value()))
 
         q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + tid_in_wg
+        # ONE row bound for BOTH the LSE write and the amax atomic below.
+        # They must stay tied: amax is an atomicMax, which only GROWS, so a
+        # single padded row folded in permanently inflates the graph's Amax_O
+        # for the whole tensor and no per-row check ever shows it.
+        q_row_limit = seqlen_q
         if cutlass.const_expr(CFG.THD_VARLEN):
             # THD: sequence-local row; LSE packed [1,QH,T] → [0, head, cu_q[b]+local].
             _cu = cutlass.make_array_view(seq_kv_lens_tensor)
             _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
             _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
+            q_row_limit = _s_q_b
             if cutlass.const_expr(lse_tensor is not None):
-                if q_row_global < _s_q_b:
+                if q_row_global < q_row_limit:
                     lse_arr = cutlass.make_array_view(lse_tensor)
                     lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
                     lse_row[_cu_q_b + q_row_global] = lse_val
         else:
             if cutlass.const_expr(lse_tensor is not None):
-                if q_row_global < seqlen_q:
+                if q_row_global < q_row_limit:
                     lse_arr = cutlass.make_array_view(lse_tensor)
                     lse_row = lse_arr[batch_idx, head_idx, :]
                     lse_row[q_row_global] = lse_val
@@ -1981,7 +2009,7 @@ def _correction_warp_group(
                 nvvm.fence_proxy("async.shared", space="cta")
                 bars.mb_o_full[block_idx // _BLOCKS_PER_OCHUNK].arrive()
 
-        if q_row_global < seqlen_q:
+        if q_row_global < q_row_limit:
             nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
 
         epilogue_state = epilogue_state ^ cutlass.Int32(1)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_mxfp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_mxfp8_sm107.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-"""CTM-DSL qwen prefill SDPA MXFP8 kernel (d_qk = d_v = 256).
+"""pre-upstream DSL qwen prefill SDPA MXFP8 kernel (d_qk = d_v = 256).
 
 Qwen pipeline: TILES_Q=1, single softmax wg, Q∪O SMEM alias, Q*K(i+1)→S*V(i)
 lookahead, parity-keyed S_acc/P, bootstrap-only-lo-parity bmm2_ready in
@@ -164,7 +164,7 @@ elif CFG.DTYPE_O == 2:
 elif CFG.DTYPE_O == 3:
     OUT_STORAGE_DTYPE = cutlass.Float16
 else:
-    raise ValueError(f"prefill_sdpa_d256_mxfp8 CTM: DTYPE_O={CFG.DTYPE_O} not supported " f"(expected 0=E4M3 / 1=E5M2 / 2=BF16 / 3=FP16)")
+    raise ValueError(f"prefill_sdpa_d256_mxfp8: DTYPE_O={CFG.DTYPE_O} not supported " f"(expected 0=E4M3 / 1=E5M2 / 2=BF16 / 3=FP16)")
 
 
 # === MXFP8 SF constants (trace-time folded) ===
@@ -266,7 +266,7 @@ _resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
 
 # THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
 # factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
-# kernels/ctm/common/sdpa/thd.py.  Gated by CFG.THD_VARLEN (folds out otherwise).
+# the shared pre-upstream THD helper.  Gated by CFG.THD_VARLEN (folds out otherwise).
 # Supported at cga1 and cga2 (the per-batch O descriptor's seq extent OOB-clips
 # the 256-row cga2 store box).  seq_kv_lens overloaded as the THD metadata buffer
 # (int32 len 3B+2): [0..B-1]=seq_kv_lens [B..2B]=cu_q(B+1) [2B+1..3B+1]=cu_k(B+1).
@@ -1438,7 +1438,7 @@ def _softmax_warp_group(
         stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
         epilogue_state = epilogue_state ^ cutlass.Int32(1)
 
-        # Body inlined (no nested @cute.jit helper) so the CTM tracer can
+        # Body inlined (no nested @cute.jit helper) so the DSL tracer can
         # dispatch through cutlass.range without hitting the closure check.
         CHUNK = 64
         P_COLS_PER_CHUNK = CHUNK // 4  # fp8 packed 4:1 into FP32 cells
@@ -1874,7 +1874,7 @@ def _correction_warp_group(
 
         tmem_base_epi = tmem_ptr_i32.load()
 
-        # Pre-declare for CTM if-staging — names used after the conditional
+        # Pre-declare for DSL if-staging — names used after the conditional
         # must be bound on every path.
         total_max_scaled = cutlass.Float32(0.0)
         total_sum = cutlass.Float32(0.0)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d512_f16_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d512_f16_sm107.py
@@ -76,6 +76,23 @@ from cudnn.sdpa.fwd.config_sm107 import TemplateParams, make_cfg_d512
 
 PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
 CFG, _TMA = make_cfg_d512(PARAMS)
+
+# tcgen05 SMEM-descriptor version for EVERY SmemTile in this module -- ONE
+# decision point, wired into every construction below rather than repeated as a
+# per-tile literal.  A version-0 descriptor's ``start_address`` is 14 bits = a
+# 256 KiB window; Rubin raises the per-CTA SMEM cap to 327 KiB, and THIS flavor
+# crosses the line (the d512 slabs put the P transfer ring at exactly 262144),
+# so a version-0 descriptor would wrap to offset 0 and the MMA would multiply
+# whatever sits at the bottom of SMEM -- the accumulator comes out EXACTLY
+# zero, or the SF columns come back as data bytes (LSE = +inf, O = NaN).  No
+# crash either way.  Matches what C++ SmemTile::make_desc always emitted.
+#
+# Do NOT re-literal this at a call site: this kernel's MXFP8 sibling shipped
+# NaN on 100% of cells because its scale-factor tiles were declared UNDER a
+# comment claiming "every operand tile here carries desc_version=1" -- without
+# the kwarg.  A single constant makes that class of drift impossible, and
+# test_sm107_descriptor_version_matches_the_smem_budget asserts it.
+DESC_VERSION: int = 1
 Cfg = type(CFG)
 TMA_QK_ITERS = _TMA.QK_ITERS
 TMA_VO_ITERS = _TMA.VO_ITERS
@@ -536,12 +553,12 @@ def _kernel(
     # LSE staging on sg1 (sub-tile write-back from corr; cf. C++ line 198).
     sLSE_raw = cutlass.Array(cutlass.Float32, CFG.TILE_M, alignment=128, space=cutlass.AddressSpace.smem)
 
-    # Typed SmemTile handles.
-    # Rubin SM107 raises the per-CTA SMEM cap to 327 KiB, so an MMA-operand
-    # buffer can land at or above 256 KiB — past what a version-0 tcgen05 SMEM
-    # descriptor can address (14-bit start_address).  Every operand tile here
-    # therefore carries desc_version=1, matching what C++ SmemTile::make_desc
-    # always emitted.  See tile_dsl/handles.py SmemTile.desc_version.
+    # Typed SmemTile handles.  EVERY tile takes the module-level DESC_VERSION
+    # (= 1 here) -- see its declaration for why that is one constant and not a
+    # per-tile literal.  The short version: Rubin raises the per-CTA SMEM cap
+    # to 327 KiB, so a buffer can land past the 256 KiB a version-0 tcgen05
+    # descriptor can address (14-bit start_address), and the tiles that cross
+    # the line are not the ones you would guess.
     sQ = SmemTile(
         base=sQ_raw,
         elems_per_stage=qBufferElems,
@@ -552,7 +569,7 @@ def _kernel(
         tma_loads_per_tile=TMA_QK_ITERS,
         tma_granu_elems=TMA_QK_GRANU_ELEMS,
         tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
-        desc_version=1,
+        desc_version=DESC_VERSION,
     )
     sK = SmemTile(
         base=sK_raw,
@@ -564,7 +581,7 @@ def _kernel(
         tma_loads_per_tile=TMA_QK_ITERS,
         tma_granu_elems=TMA_QK_GRANU_ELEMS,
         tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
-        desc_version=1,
+        desc_version=DESC_VERSION,
     )
     sV = SmemTile(
         base=sV_raw,
@@ -576,7 +593,7 @@ def _kernel(
         tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
         tma_granu_elems=TMA_VO_GRANU_ELEMS,
         tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
-        desc_version=1,
+        desc_version=DESC_VERSION,
     )
     sO = SmemTile(
         base=sO_raw,
@@ -588,6 +605,7 @@ def _kernel(
         tma_loads_per_tile=TMA_O_ITERS_HOST,
         tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
         tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+        desc_version=DESC_VERSION,
     )
 
     # ------------------------------------------------------------------
@@ -1750,7 +1768,7 @@ def _mma_warp_group(
         leading_byte_offset=LEADING_BYTE_OFFSET_QK,
         stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
         layout=SMEM_LAYOUT_P,
-        desc_version=1,
+        desc_version=DESC_VERSION,
     )
 
     # BMM1 leader: desc_Q is tile-static (Q stays resident under d=512 / no Q∪K alias).

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d512_f16_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d512_f16_sm107.py
@@ -1,0 +1,2529 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Rubin SM107 DSv4 SDPA prefill — d_qk = d_v = 512, FP16/BF16.
+
+THD / varlen (``CFG.THD_VARLEN=1``, the pre-upstream packed-varlen entry point) is supported (f16/bf16): packed ``[1,T,H,D]``
+Q/K/V + per-sequence ``cu_seqlens`` coord offset, per-batch O TMA-descriptor
+array (shared ``kernels/ctm/common/sdpa/thd.py``), flat batch-outermost grid,
+packed ``[1,QH,T]`` LSE.  The dense ``[B,S,H,D]`` path is byte-identical.
+
+CTM-DSL Python port of the C++ Rubin baseline
+``kernels/c++/sm107/sdpa/prefill/prefill_sdpa_d512_f16.cu`` — same kernel,
+different language.  Pipeline shape, TMEM/SMEM layout, barrier inventory,
+scheduler, warp dispatch, and register split mirror the C++ source 1:1.
+
+Pipeline shape (cluster (4, 1, 1) = two cga2 sub-groups):
+  sg0 (CTAs 0, 1):  TMA-LDG Q + K_ring; BMM1 = Q*K^T → S_acc; streaming
+                    softmax; ship alpha + P + stats to sg1 via DSMEM.
+  sg1 (CTAs 2, 3):  TMA-LDG V_ring; recv alpha + P + stats via DSMEM;
+                    correction (apply alpha to O TMEM); BMM2 = P*V^T → O;
+                    epilogue normalize + fp32→half cast + TMA-STG O + LSE.
+
+SM107 deltas vs SM100:
+  - No Q∪K_ring alias — SMEM cap is 327 KiB, Q stays resident.
+  - No UTCCP(Q→TMEM) — Q feeds BMM1 directly from SMEM.
+  - No B1 / B2 / B3 alias-seam mbars (those are SM100-only).
+  - TMEM cap is 576 cols (is_exclusive=True on tcgen05_alloc).
+
+P12 / P13 patterns (cf. mbarrier-patterns.md, also project memory):
+  - mb_p_xfer_full (P12): sg1 leader's collective BMM2 reads BOTH peers' P
+    SMEM via crossbar.  Each sg1 CTA's mbar gets bytes from its own cross-sg
+    sg0 partner; non-leader sg1 forwards its `arrive` to the leader via
+    DSMEM so leader's wait flips only after the full pair has landed.
+    Leader init = CTA_MMA (own + DSMEM-forwarded); non-leader init = 1.
+  - mb_p_xfer_empty (P13): sg1 leader MMA fires a single
+    tcgen05.commit.cta_group::2.multicast with sg0_mcast_mask (= 0x3) so
+    BOTH sg0 CTAs see one arrive — pre-armed via PipelineState(0, 1).
+
+CTM-only adjustments applied (per cpp-to-ctm.md):
+  - is_exclusive=True on tmem_alloc (SM107 >512-col TMEM).
+  - tile_id_smem stride 8 Int32/stage.
+  - cga_arrive/wait wrapped with relaxed=True (per project memory:
+    dsv3 cga2 47%→92% SOL with this fix).
+  - DSMEM SMEM→peer-SMEM via cp_async_bulk_shared_cluster_shared_cta
+    (per project memory: bare nvvm op silently fires sender's local mbar).
+"""
+
+import os
+import sys
+from functools import lru_cache
+from typing import Callable, Optional, Tuple
+from dataclasses import dataclass
+from typing import NamedTuple
+
+
+from cutlass.experimental import primitives as nvvm
+from cutlass.experimental.primitives import vote_sync, VoteSync
+from cutlass._mlir.dialects import arith
+
+import cutlass
+from cutlass.experimental import primitives as prims
+import cutlass.cute as cute
+from cutlass.base_dsl.typing import Pointer
+from cutlass.experimental.cuda import tensor_map as tmap
+from cudnn.frost.tile_dsl.tma import cp_async_bulk_shared_cluster_shared_cta
+import cuda.bindings.driver as _cuda_driver  # noqa: F401  (cute.compile pulls cuda)
+
+# DSv4 has only one config flavor (dsv4); no env-var flavor switch needed.
+# Config comes from the FROST template loader, NOT an env var: the pre-upstream
+# kernels picked a flavor with an env var + a sdpa_config_<flavor> module, which the
+# FROST engine contract forbids ("no environment variables for configuration" --
+# parameters travel as typed dataclasses). The loader injects
+# FROST_TEMPLATE_PARAMS before this body runs; the default keeps a plain
+# `import` usable as a standalone driver.
+from cudnn.sdpa.fwd.config_sm107 import TemplateParams, make_cfg_d512
+
+PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
+CFG, _TMA = make_cfg_d512(PARAMS)
+Cfg = type(CFG)
+TMA_QK_ITERS = _TMA.QK_ITERS
+TMA_VO_ITERS = _TMA.VO_ITERS
+TMA_QK_GRANU_ELEMS = _TMA.QK_GRANU_ELEMS
+TMA_VO_GRANU_ELEMS = _TMA.VO_GRANU_ELEMS
+
+# O TMA box / store params follow O's swizzle (independent of V under cga2).
+TMA_O_GRANU_ELEMS_HOST = CFG.O_SWZ_BYTES // CFG.BPE_O
+TMA_O_ITERS_HOST = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
+
+
+# Generic tile primitives — never hand-roll equivalents.
+from cudnn.frost.tile_dsl.barrier import (
+    PipelineState,
+    advance,
+    cga_arrive,
+    cga_wait,
+    MBarrier,
+    Producer,
+    Scope,
+    # `wait` (free fn) — still used for sched.mb_* (Sched not in Bars).
+    wait,
+)
+from cudnn.frost.tile_dsl.scheduler import (
+    Sched,
+    scheduler_warp_loop,
+    read_tile_id_arrive,
+    SCHED_NATURAL,
+    SCHED_LPT,
+    SCHED_LPT_L2,
+)
+from cudnn.frost.tile_dsl.pointwise import (
+    tmem_load_max_reduction_tile,
+    row_reduction_pair,
+    row_max_reduction,
+    vec_scale_pair,
+)
+from cudnn.frost.tile_dsl.regtile import RegTile, vec_concat
+from cudnn.frost.tile_dsl.mma import mma_ss, mma_ts_step
+from cudnn.frost.tile_dsl.tma import (
+    tma_load_tile,
+    tma_store_tile,
+    tma_store_commit,
+    tma_store_wait,
+)
+from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, tma_slice_runtime_desc
+from cudnn.frost.tile_dsl.tmem import tmem_alloc, tmem_dealloc
+from cudnn.frost.tile_dsl.mask import (
+    apply_mask_chunk,
+    MASK_NONE,
+    MASK_PADDED,
+    MASK_CAUSAL,
+    MASK_SWA,
+)
+
+# Reuse sm107 SDPA pipeline-shared helpers (KvLoopBounds + closures factory).
+# Note: dsv4 forks Bars in this file (NOT imported from _sdpa_common) per the
+# per-pipeline fork pattern in cpp-to-ctm.md.
+from cudnn.sdpa.fwd.kernels._common_sm100 import (
+    KvLoopBounds,
+    compute_kv_loop_bounds,
+    lpt_tile_coords,
+    make_sdpa_helpers,
+)
+
+# ----------------------------------------------------------------------------
+# Storage dtype dispatch — folded at trace time on CFG.DTYPE_QKV.
+# ----------------------------------------------------------------------------
+if CFG.DTYPE_QKV == 2:
+    STORAGE_DTYPE = cutlass.BFloat16
+    P_STORAGE_DTYPE = cutlass.BFloat16
+    MMA_KIND = nvvm.Tcgen05MMAKind.F16
+    IS_TF32 = False
+elif CFG.DTYPE_QKV == 3:
+    STORAGE_DTYPE = cutlass.Float16
+    P_STORAGE_DTYPE = cutlass.Float16
+    MMA_KIND = nvvm.Tcgen05MMAKind.F16
+    IS_TF32 = False
+elif CFG.DTYPE_QKV == 4:
+    # TF32 — see prefill_sdpa_f16.py for the deltas (V SWIZZLE_128B_ATOM_32B
+    # SmemDesc+TMA, 1:1 P packing, BPE=4).  dsv4-specific: TILE_N=32 +
+    # STAGES_KV=1 to fit the d=512 Q∪O union under the cap (config).
+    STORAGE_DTYPE = cutlass.Float32
+    P_STORAGE_DTYPE = cutlass.Float32
+    MMA_KIND = nvvm.Tcgen05MMAKind.TF32
+    IS_TF32 = True
+else:
+    raise ValueError(
+        f"prefill_sdpa_d512_f16 (SM107): DTYPE_QKV={CFG.DTYPE_QKV} not supported " f"(expected 2=BF16, 3=FP16, or 4=TF32; FP8/MXFP8 ship in a separate kernel)"
+    )
+OUT_STORAGE_DTYPE = STORAGE_DTYPE
+
+
+# ----------------------------------------------------------------------------
+# Derived constants — mirror prefill_sdpa_d512_f16.cu:130-152.
+# ----------------------------------------------------------------------------
+CGA_SIZE = CFG.CGA_M * CFG.CGA_N
+CTA_GROUP_KIND = nvvm.CTAGroup.CTA_2 if CFG.CTA_MMA == 2 else nvvm.CTAGroup.CTA_1
+
+# Per-CTA buffer element counts + collective TMA transaction byte counts.
+qBufferElems = CFG.TILE_M * CFG.TILE_K  # 65536  → 128 KiB @ BPE=2
+kBufferElems = CFG.TILE_N * CFG.TILE_K // CFG.CTA_MMA  # 32768  →  64 KiB
+vBufferElems = CFG.TILE_O * CFG.TILE_N // CFG.CTA_MMA  # 32768  →  64 KiB
+oBufferElems = CFG.TILE_M * CFG.TILE_O  # 65536  → 128 KiB @ BPE_O=2
+pXferElems = CFG.TILE_M * CFG.TILE_N  # 16384  →  32 KiB / xfer stage
+
+# Per-stage xfer SMEM sizes (DSMEM peer-to-peer payloads).
+pXferBytes = pXferElems * CFG.BPE  # 32 KiB / stage
+alphaXferBytes = CFG.TILE_M * 4  # 512 B  / stage (FP32)
+statsXferBytes = 2 * CFG.TILE_M * 4  # 1 KiB total (ell + max)
+
+# Collective TMA transaction bytes (leader expect_tx under cga2).
+qTmaTransactionBytes = qBufferElems * CFG.BPE * CFG.CTA_MMA
+kTmaTransactionBytes = kBufferElems * CFG.BPE * CFG.CTA_MMA
+vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
+
+# Per-call BMM2 V SMEM advance (between the BMM2_LOOP_N_BLOCKS=2 BMM2 calls).
+# C++ prefill_sdpa_d512_f16.cu:97-98 — BPE factor is REQUIRED at f16 (per-CTA
+# inner = 2 swizzle lines wide at d_v=512, not 1).
+BMM2_V_NBLOCK_ADVANCE = CFG.TILE_N * (CFG.BMM2_N_PER_CALL // CFG.CTA_MMA) * CFG.BPE
+
+# O store chunks (TMA-STG arrive granularity — 128 B per chunk).
+N_O_CHUNKS = (CFG.TILE_O * CFG.BPE_O + 127) // 128  # 8 chunks @ d=512 f16
+
+CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+
+# ----------------------------------------------------------------------------
+# Softmax-body constants — module-level so the top-level @cute.jit helper
+# `_sg0_softmax_kv_iter` can read them without a closure capture (CTM-DSL
+# forbids closures inside @cute.jit traced under dynamic control flow).
+# ----------------------------------------------------------------------------
+# P SMEM layout helpers (TILE_M=128 rows × TILE_N=128 cols, Swz128B).
+# 1 row of TILE_N elements = (TILE_N*BPE/SWZ_BYTES) swizzle chunks of P_D_BLOCK each.
+P_TMA_ITERS = (CFG.TILE_N * CFG.BPE) // CFG.Q_SWZ_BYTES  # 2
+P_D_BLOCK = CFG.TILE_N // P_TMA_ITERS  # 64 elements / chunk
+P_BLOCK_BYTES = CFG.TILE_M * P_D_BLOCK  # 8192 elements / TMA chunk
+# Mask-path load chunk width (mirrors canonical _softmax_kv_body CHUNK=64).
+# Mask-path S load chunk = min(64, TILE_N) so TILE_N<64 (TF32 → 32) does a
+# single full-width load instead of zero 64-wide chunks.
+SOFTMAX_CHUNK = 64 if CFG.TILE_N >= 64 else CFG.TILE_N
+SOFTMAX_N_CHUNKS_LOAD = CFG.TILE_N // SOFTMAX_CHUNK  # 2 @ TILE_N=128, 1 @ 32
+# Swizzle for P SMEM stores (Swz128B at d=512 f16 — same as Q/O).
+P_SMEM_SWIZZLE = cutlass.Swizzle(3, 4, 3)
+# Streaming-softmax constants.
+NEG_INF_F32 = cutlass.Float32(-3.4028235e38)
+RESCALE_THRESHOLD_F32 = cutlass.Float32(CFG.RESCALE_THRESHOLD)
+
+
+# ----------------------------------------------------------------------------
+# Named arrival-count constants — mirror C++ prefill_sdpa_d512_f16.cu:1540-1564.
+# Per mbarrier-patterns.md P3, ALL init(...) counts must reference named
+# constants — never inline literals.
+# ----------------------------------------------------------------------------
+COMPUTE_LANES = CFG.SOFTMAX_WG_WARPS * 32  # 4 warps * 32 lanes = 128
+SM_LANES_TOTAL = 2 * COMPUTE_LANES  # 256 — both sg0 CTAs * 128 sm threads
+TWO_LANES_TOTAL = 2  # both sg1 CTAs * 1 elect-one to leader
+KV_EMPTY_ARRIVERS = CFG.CGA_N  # = 1 — cga2 commit multicast counts as 1
+
+# READ_TILE_ARRIVERS already derived in CFG (= 25 for dsv4 cga4x1).  Re-export
+# for inline visibility next to the init block.
+READ_TILE_ARRIVERS = CFG.READ_TILE_ARRIVERS
+
+
+# ----------------------------------------------------------------------------
+# Compile-time budget checks — Rubin SM107 caps (NOT 227/512 SM100 caps).
+# ----------------------------------------------------------------------------
+# Per-CTA SMEM budget under Rubin SM107 327 KiB oversized cap.  Each physical
+# CTA runs ONE role (sg0 or sg1), so the SharedStorage union covers
+# max(sg0_bytes, sg1_bytes), NOT the sum.  sg0 holds Q + K_ring + xfer
+# staging; sg1 holds V_ring + O + xfer staging + LSE.  Mirrors the C++
+# `union { sg0; sg1; }` in SharedStorage.
+_SG0_SMEM_DATA_KIB = (
+    qBufferElems * CFG.BPE  # Q (sg0)
+    + CFG.STAGES_KV * kBufferElems * CFG.BPE  # K_ring (sg0)
+    + CFG.XFER_STAGES * pXferBytes  # P xfer (source side staging)
+    + CFG.XFER_STAGES * alphaXferBytes  # alpha xfer (source side staging)
+    + statsXferBytes  # stats xfer
+) / 1024
+_SG1_SMEM_DATA_KIB = (
+    CFG.STAGES_KV * vBufferElems * CFG.BPE  # V_ring (sg1)
+    + oBufferElems * CFG.BPE_O  # O (sg1)
+    + CFG.XFER_STAGES * pXferBytes  # P xfer (sink side staging)
+    + CFG.XFER_STAGES * alphaXferBytes  # alpha xfer (sink side staging)
+    + statsXferBytes  # stats xfer
+    + CFG.TILE_M * 4  # LSE staging (sg1)
+) / 1024
+# RESOURCE-NOTE: SM107 oversized cap is 327 KiB; allow ~4 KiB scaffolding +
+# mbar headroom.  Per-sg data budgets must each fit under 323 KiB.
+assert _SG0_SMEM_DATA_KIB <= 323, f"sg0 SMEM data {_SG0_SMEM_DATA_KIB:.1f} KiB exceeds 323 KiB headroom under 327 KiB cap"
+assert _SG1_SMEM_DATA_KIB <= 323, f"sg1 SMEM data {_SG1_SMEM_DATA_KIB:.1f} KiB exceeds 323 KiB headroom under 327 KiB cap"
+
+# TMEM 576-col cap — Rubin SM107 (NOT SM100's 512).  is_exclusive=True required.
+_TMEM_SG0_COLS = CFG.XFER_STAGES * CFG.TILE_N  # 2 * 128 = 256 cols for S_acc parities
+_TMEM_SG1_COLS = CFG.TILE_O  # 512 cols for O
+assert _TMEM_SG0_COLS <= 576, f"sg0 S_acc TMEM overflow: {_TMEM_SG0_COLS} > 576"
+assert _TMEM_SG1_COLS <= 576, f"sg1 O TMEM overflow: {_TMEM_SG1_COLS} > 576"
+
+
+# ----------------------------------------------------------------------------
+# Bars — DSv4 role-split inventory, forked in this kernel file per the
+# per-pipeline fork pattern.  Mirrors C++ prefill_sdpa_d512_f16.cu:333-386.
+# ----------------------------------------------------------------------------
+# Barrier table (cga4x1 / CTA_MMA=2 — DSv4 role-split, SM107 baseline)
+# ============================================================================
+# | Name                     | Stages           | Init                       | Producer / arrive site                          | Consumer / wait site                  | Scope / bootstrap                                   |
+# |--------------------------|------------------|----------------------------|-------------------------------------------------|---------------------------------------|-----------------------------------------------------|
+# | mb_tma_q_full            | 1                | ONE_LANE                   | sg0 TMA-LDG : arrive_expect_tx (Q bytes)        | sg0 MMA (BMM1)                        | cga2 leader-only                                    |
+# | mb_tma_q_empty           | 1                | ONE_LANE                   | sg0 MMA : arrive_mma after last-iter BMM1 commit| sg0 TMA-LDG (next-tile Q load)        | leader-multicast; pre-arm via q_empty_state=1       |
+# | mb_tma_k_full[s]         | STAGES_KV (=2)   | ONE_LANE                   | sg0 TMA-LDG : arrive_expect_tx (K bytes)        | sg0 MMA (BMM1)                        | cga2 leader-only                                    |
+# | mb_tma_k_empty[s]        | STAGES_KV        | KV_EMPTY_ARRIVERS (=1)     | sg0 MMA : arrive_mma after BMM1 commit          | sg0 TMA-LDG (K_ring back-pressure)    | leader-multicast; pre-arm via PipelineState(0,1)    |
+# | mb_tma_v_full[s]         | STAGES_KV        | ONE_LANE                   | sg1 TMA-LDG : arrive_expect_tx (V bytes)        | sg1 MMA (BMM2)                        | cga2 leader-only                                    |
+# | mb_tma_v_empty[s]        | STAGES_KV        | KV_EMPTY_ARRIVERS (=1)     | sg1 MMA : arrive_mma after BMM2 commit          | sg1 TMA-LDG (V_ring back-pressure)    | leader-multicast; pre-arm via PipelineState(0,1)    |
+# | mb_bmm1_done[p]          | XFER_STAGES (=2) | ONE_LANE                   | sg0 MMA : arrive_mma after BMM1 commit          | sg0 softmax                           | local; not bootstrapped                             |
+# | mb_bmm2_done[p]          | XFER_STAGES      | ONE_LANE                   | sg1 MMA : arrive_mma after BMM2 commit          | sg1 corr (epilogue gate)              | local; not bootstrapped                             |
+# | mb_bmm2_ready[p*2+c]     | XFER_STAGES*2(=4)| SM_LANES_TOTAL (=256)      | sg1 corr (all-thread) : arrive_on_peer→leader   | sg1 MMA leader (per-half-N-block)     | cga2 leader-waited                                  |
+# | mb_s_acc_empty[p]        | XFER_STAGES      | SM_LANES_TOTAL (=256)      | sg0 softmax (all-thread) : arrive_on_peer→leader| sg0 MMA leader (S_acc TMEM free)      | cga2 leader-waited; pre-arm via PipelineState(0,1)  |
+# | mb_p_xfer_full[p]        | XFER_STAGES      | leader: CTA_MMA(=2)        | sg0 softmax bulk_copy→peer; sg1 peer→leader DSMEM| sg1 MMA leader (BMM2 P operand)       | P12; leader=2 / non-leader=1                        |
+# |                          |                  | non-leader: ONE_LANE(=1)   |                                                  |                                       |                                                     |
+# | mb_p_xfer_empty[p]       | XFER_STAGES      | ONE_LANE                   | sg1 MMA leader : arrive_mma multicast→sg0       | sg0 softmax (next P slot reuse)       | P13 MMA-commit multicast; pre-arm via PipelineState(0,1) |
+# | mb_alpha_xfer_full[p]    | XFER_STAGES      | ONE_LANE                   | sg1 corr (local) : arrive_expect_tx (alpha)     | sg1 corr (apply alpha)                | local; not bootstrapped                             |
+# | mb_alpha_xfer_empty[p]   | XFER_STAGES      | COMPUTE_LANES (=128)       | sg1 corr (all-thread) : arrive_on_peer→sg0      | sg0 softmax (next alpha slot reuse)   | local; pre-arm via PipelineState(0,1)               |
+# | mb_stats_xfer_full       | 1                | ONE_LANE                   | sg1 corr (local) : arrive_expect_tx (ell+max)   | sg1 corr (final stats consume)        | local; not bootstrapped                             |
+# | mb_stats_xfer_empty      | 1                | ONE_LANE                   | sg1 corr (elect) : arrive_on_peer→sg0           | sg0 softmax (next tile stats slot)    | local; pre-arm via stats_xfer_empty_phase=1         |
+# | mb_tma_o_full[c]         | N_O_CHUNKS (=8)  | COMPUTE_LANES (=128)       | sg1 corr (all-thread) : arrive per chunk        | sg1 TMA-STG (per-chunk TMA)           | local; not bootstrapped                             |
+# | mb_tma_o_empty           | 1                | ONE_WARP (=32)             | sg1 TMA-STG warp : arrive after STG drain       | sg1 corr (next-tile O staging reuse)  | local; pre-arm via PipelineState(0,1)               |
+# | mb_empty_mainloop        | 1                | TWO_LANES_TOTAL (=2)       | sg1 corr (both CTAs, elect) : arrive_on_peer→leader| sg1 MMA leader (empty-kv branch)   | cga2 leader-waited                                  |
+# | mb_tmem_dealloc          | 1                | ONE_LANE                   | both sgs compute (elect) : arrive_on_peer→partner| both sgs MMA (alloc/dealloc fence)   | local; not bootstrapped                             |
+# ============================================================================
+class Bars(NamedTuple):
+    """DSv4 role-split mbarrier inventory (Rubin SM107 baseline)."""
+
+    # ---- TMA Q/K/V handshakes (sg0: Q + K; sg1: V) ----------------------
+    mb_tma_q_full: object  # [1]            sg0  TMA-LDG → MMA
+    mb_tma_q_empty: object  # [1]            sg0  MMA → TMA-LDG (next-tile Q)
+    mb_tma_k_full: object  # [STAGES_KV]    sg0  TMA-LDG → MMA
+    mb_tma_k_empty: object  # [STAGES_KV]    sg0  MMA → TMA-LDG (back-pressure)
+    mb_tma_v_full: object  # [STAGES_KV]    sg1  TMA-LDG → MMA
+    mb_tma_v_empty: object  # [STAGES_KV]    sg1  MMA → TMA-LDG
+
+    # ---- MMA → softmax / corr handshakes -------------------------------
+    mb_bmm1_done: object  # [XFER_STAGES]      sg0 MMA → softmax
+    mb_bmm2_done: object  # [XFER_STAGES]      sg1 MMA → corr (epilogue gate)
+    mb_bmm2_ready: object  # [XFER_STAGES * 2]  sg1 corr → MMA (per half-N-block)
+    mb_s_acc_empty: object  # [XFER_STAGES]      sg0 softmax → MMA (S_acc TMEM free)
+
+    # ---- DSMEM xfer rings (sg0 → sg1) ----------------------------------
+    mb_p_xfer_full: object  # [XFER_STAGES]   sg0 → sg1 (P12 leader=2 / non-leader=1)
+    mb_p_xfer_empty: object  # [XFER_STAGES]   sg1 leader MMA → sg0 (P13 multicast)
+    mb_alpha_xfer_full: object  # [XFER_STAGES]   sg0 softmax (local expect_tx) → sg1 corr
+    mb_alpha_xfer_empty: object  # [XFER_STAGES]   sg1 corr (all-thread DSMEM) → sg0
+    mb_stats_xfer_full: object  # [1]             sg1 corr (local expect_tx) one-shot per tile
+    mb_stats_xfer_empty: object  # [1]             sg0 softmax (elect DSMEM) → sg1
+
+    # ---- sg1 TMA-STG handshakes -----------------------------------------
+    mb_tma_o_full: object  # [N_O_CHUNKS]   sg1 corr → TMA-STG (per-128B chunk)
+    mb_tma_o_empty: object  # [1]            sg1 TMA-STG warp → corr
+
+    # ---- End-of-kernel teardown -----------------------------------------
+    mb_empty_mainloop: object  # [1]            sg1 corr → sg1 MMA leader (empty-kv branch)
+    mb_tmem_dealloc: object  # [1]            both sgs compute → cga2 partner MMA
+
+
+# ----------------------------------------------------------------------------
+# KernelTmemLayout — sg-conditional carves total ≤ 576 cols on SM107.
+# Mirrors C++ prefill_sdpa_d512_f16.cu:252-267.
+# ----------------------------------------------------------------------------
+@dataclass(frozen=True)
+class KernelTmemLayout:
+    """SM107 TMEM carves: sg0 = S_acc(XFER_STAGES parities); sg1 = O.
+
+    sg0 uses TMEM cols [0, 256) for the two S_acc parity slots (128 cols each).
+    sg1 uses TMEM cols [0, 512) for the O accumulator (full d_v = 512 FP32 cols).
+    Both fit comfortably under the Rubin 576-col cap (sg0 = 256; sg1 = 512).
+
+    Use S_acc_at(parity) to pick the runtime parity slot (do NOT introduce
+    per-slot constexpr names; the formula scales beyond XFER_STAGES = 2 if
+    the SMEM budget ever allows it).
+    """
+
+    # Rubin SM107 cap; requires is_exclusive=True on tcgen05_alloc.
+    TOTAL_COLS: int = 576
+
+    # sg0 layout — per-parity S_acc slot at offset parity * S_ACC_COLS.
+    S_ACC_COLS: int = 128  # = CFG.TILE_N — one parity slot
+    # Per-parity offsets (only XFER_STAGES = 2 used today; formula = parity * S_ACC_COLS).
+    S_ACC_PARITY0_OFF: int = 0
+    S_ACC_PARITY1_OFF: int = 128
+
+    # sg1 layout — single fixed-offset O accumulator @ cols [0, TILE_O).
+    O_OFF: int = 0
+    O_COLS: int = 512  # = CFG.TILE_O
+
+
+LAYOUT = KernelTmemLayout()
+assert CFG.XFER_STAGES * LAYOUT.S_ACC_COLS <= LAYOUT.TOTAL_COLS, f"sg0 TMEM overflow: {CFG.XFER_STAGES * LAYOUT.S_ACC_COLS} > {LAYOUT.TOTAL_COLS}"
+assert LAYOUT.O_OFF + LAYOUT.O_COLS <= LAYOUT.TOTAL_COLS, f"sg1 TMEM overflow: {LAYOUT.O_OFF + LAYOUT.O_COLS} > {LAYOUT.TOTAL_COLS}"
+
+
+# ----------------------------------------------------------------------------
+# Bars factory — dsv4 role-split mbarrier inventory typed with MBarrier
+# wrapper.  Producer / scope tags + init counts derived from the barrier
+# table comment above + the explicit init logic below.  Note: mb_p_xfer_full
+# uses a RUNTIME-conditional init count (leader = CTA_MMA, non-leader = 1),
+# so the static init_count here is a placeholder — the kernel passes an
+# explicit override_count to .init() per CTA.
+# ----------------------------------------------------------------------------
+def _make_dsv4_bars(CFG, N_O_CHUNKS: int):
+    def _alloc(n):
+        return cutlass.Array(cutlass.Int64, n, alignment=16, space=cutlass.AddressSpace.smem)
+
+    return Bars(
+        # TMA Q/K/V
+        mb_tma_q_full=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_tma_q_empty=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.MMA_COMMIT),
+        mb_tma_k_full=MBarrier(_alloc(CFG.STAGES_KV), stages=CFG.STAGES_KV, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_tma_k_empty=MBarrier(_alloc(CFG.STAGES_KV), stages=CFG.STAGES_KV, init_count=KV_EMPTY_ARRIVERS, producer=Producer.MMA_COMMIT),
+        mb_tma_v_full=MBarrier(_alloc(CFG.STAGES_KV), stages=CFG.STAGES_KV, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_tma_v_empty=MBarrier(_alloc(CFG.STAGES_KV), stages=CFG.STAGES_KV, init_count=KV_EMPTY_ARRIVERS, producer=Producer.MMA_COMMIT),
+        # MMA → softmax / corr
+        mb_bmm1_done=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=CFG.ONE_LANE, producer=Producer.MMA_COMMIT),
+        mb_bmm2_done=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=CFG.ONE_LANE, producer=Producer.MMA_COMMIT),
+        mb_bmm2_ready=MBarrier(
+            _alloc(CFG.XFER_STAGES * CFG.N_BMM2_CHUNKS),
+            stages=CFG.XFER_STAGES * CFG.N_BMM2_CHUNKS,
+            init_count=SM_LANES_TOTAL,
+            producer=Producer.LEADER,
+            scope=Scope.LEADER,
+        ),
+        mb_s_acc_empty=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=SM_LANES_TOTAL, producer=Producer.LEADER, scope=Scope.LEADER),
+        # DSMEM xfer rings — mb_p_xfer_full has RUNTIME init count (P12):
+        # leader = CTA_MMA arrives (own + DSMEM forwarder); non-leader = 1.
+        # Static init_count here is CFG.CTA_MMA (the leader value); the
+        # kernel's init loop passes override_count=p_full_init for each stage.
+        mb_p_xfer_full=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=CFG.CTA_MMA, producer=Producer.TMA_LOAD),
+        mb_p_xfer_empty=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=CFG.ONE_LANE, producer=Producer.MMA_COMMIT),
+        mb_alpha_xfer_full=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_alpha_xfer_empty=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=COMPUTE_LANES, producer=Producer.THREAD),
+        mb_stats_xfer_full=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_stats_xfer_empty=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.THREAD),
+        # sg1 TMA-STG
+        mb_tma_o_full=MBarrier(_alloc(N_O_CHUNKS), stages=N_O_CHUNKS, init_count=COMPUTE_LANES, producer=Producer.THREAD),
+        mb_tma_o_empty=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_WARP, producer=Producer.THREAD),
+        # Teardown
+        mb_empty_mainloop=MBarrier(_alloc(1), stages=1, init_count=TWO_LANES_TOTAL, producer=Producer.LEADER, scope=Scope.LEADER),
+        mb_tmem_dealloc=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.THREAD),
+    )
+
+
+# ----------------------------------------------------------------------------
+# SMEM swizzle / layout enums.
+# ----------------------------------------------------------------------------
+_SWZ_ENUM = {128: 2, 64: 4, 32: 6}
+_SWZ_ATOM_32B = 1  # SWIZZLE_128B_ATOM_32B — TF32 transposed BMM2 operand (V)
+SMEM_LAYOUT_Q = _SWZ_ENUM[CFG.Q_SWZ_BYTES]
+SMEM_LAYOUT_K = _SWZ_ENUM[CFG.K_SWZ_BYTES]
+# V is the B-transposed BMM2 operand → TF32 needs SWIZZLE_128B_ATOM_32B.
+SMEM_LAYOUT_V = _SWZ_ATOM_32B if IS_TF32 else _SWZ_ENUM[CFG.V_SWZ_BYTES]
+SMEM_LAYOUT_O = _SWZ_ENUM[CFG.O_SWZ_BYTES]
+SMEM_LAYOUT_QKO = SMEM_LAYOUT_Q
+# P xfer SMEM layout matches Q swizzle (cf. C++ prefill_sdpa_d512_f16.cu:68).
+SMEM_LAYOUT_P = SMEM_LAYOUT_Q
+
+_O_SWZ_B = {128: 3, 64: 2, 32: 1}[CFG.O_SWZ_BYTES]
+_O_SMEM_SWIZZLE = cutlass.Swizzle(_O_SWZ_B, 4, 3)
+
+LEADING_BYTE_OFFSET_QK = 0
+STRIDE_BYTE_OFFSET_QK = 8 * CFG.Q_SWZ_BYTES
+
+_CORE_MATRIX_ROWS = 8
+_V_PC_COLS = CFG.TILE_O // CFG.CTA_MMA
+# TF32 ATOM32 override (see prefill_sdpa_f16.py): leading = TILE_N*128, stride = 512.
+_LEADING_PV_STD = 0 if (_V_PC_COLS // _CORE_MATRIX_ROWS) <= 8 else CFG.TILE_N * CFG.V_SWZ_BYTES
+LEADING_BYTE_OFFSET_PV = (CFG.TILE_N * 128) if IS_TF32 else _LEADING_PV_STD
+STRIDE_BYTE_OFFSET_PV = 512 if IS_TF32 else (8 * CFG.V_SWZ_BYTES)
+
+# BMM2 manual k-step iters.
+NUM_KPHASES_PV = CFG.TILE_N // CFG.TILE_K_HW_BMM2
+
+
+# ----------------------------------------------------------------------------
+# Helpers bound to CFG (scheduler topology + mask plumbing — unchanged from
+# the sm107 classic kernels; role-split doesn't change tile decoding).
+# ----------------------------------------------------------------------------
+_sdpa_h = make_sdpa_helpers(CFG)
+_decode_initial = _sdpa_h.decode_initial
+_decode_payload = _sdpa_h.decode_payload
+_bounds_for_tile = _sdpa_h.bounds_for_tile
+_resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+
+# THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
+# factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
+# kernels/ctm/common/sdpa/thd.py.  Gated by CFG.THD_VARLEN (folds out otherwise).
+# seq_kv_lens overloaded as the THD metadata buffer (int32 len 3B+2):
+#   [0..B-1]=seq_kv_lens  [B..2B]=cu_q(B+1)  [2B+1..3B+1]=cu_k(B+1)
+from cudnn.sdpa.fwd.kernels.thd_helpers import build_thd_meta_o_descs_kernel as _build_thd_meta_o_descs_kernel, TENSOR_MAP_QWORDS
+
+_TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
+_dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
+_dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
+_thd_tma_offsets = _sdpa_h.thd_tma_offsets
+
+
+# ============================================================================
+# Kernel entry.
+# ============================================================================
+@cute.kernel
+def _kernel(
+    tma_q_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_k_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_v_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_o_desc: cutlass.GridConstant[tmap.TensorMap],
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    seqlen_q: cutlass.Int32,
+    seqlen_kv: cutlass.Int32,
+    n_q_supers: cutlass.Int32,
+    n_qh: cutlass.Int32,
+    n_batch: cutlass.Int32,
+    qh_per_kh: cutlass.Int32,
+    scale_softmax_log2: cutlass.Float32,
+) -> None:
+
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    tidx, _, _ = cute.arch.thread_idx()
+
+    bidx = cute.arch.block_idx()[0]
+    bidy = cute.arch.block_idx()[1]
+    bidz = cute.arch.block_idx()[2]
+
+    # ------------------------------------------------------------------
+    # SMEM allocations — natural Q / K / V / O order, NO Q∪K_ring or
+    # O∪V_ring alias (Rubin SM107 cap fits everything; aliases are
+    # SM100-only).  Mirror C++ SharedStorage at prefill_sdpa_d512_f16.cu:161.
+    # ------------------------------------------------------------------
+    # RESOURCE-NOTE: each physical CTA runs ONE role (sg0 OR sg1), so the
+    # Q (sg0) ∪ O (sg1) and K_ring (sg0) ∪ V_ring (sg1) regions alias at
+    # the same SMEM offset.  Mirrors C++ `union QOAlias`/`union KVAlias` at
+    # prefill_sdpa_d512_f16.cu:162-174 — without these unions the per-CTA
+    # SMEM budget doubles (~580 KiB) and busts the 327 KiB Rubin cap.
+    _QO_ELEMS = qBufferElems if qBufferElems >= oBufferElems else oBufferElems
+    _KV_ELEMS = CFG.STAGES_KV * kBufferElems if kBufferElems >= vBufferElems else CFG.STAGES_KV * vBufferElems
+    sQO_raw = cutlass.Array(STORAGE_DTYPE, _QO_ELEMS, alignment=1024, space=cutlass.AddressSpace.smem)
+    sKV_raw = cutlass.Array(STORAGE_DTYPE, _KV_ELEMS, alignment=1024, space=cutlass.AddressSpace.smem)
+    # sQ / sO / sK / sV alias into sQO_raw / sKV_raw respectively.
+    sQ_raw = sQO_raw  # sg0 view
+    sO_raw = sQO_raw  # sg1 view
+    sK_raw = sKV_raw  # sg0 view
+    sV_raw = sKV_raw  # sg1 view
+
+    # P xfer (sg0 → sg1) SMEM — XFER_STAGES rings, kept resident.
+    sP_xfer_raw = cutlass.Array(P_STORAGE_DTYPE, CFG.XFER_STAGES * pXferElems, alignment=128, space=cutlass.AddressSpace.smem)
+    # alpha xfer (sg0 → sg1) SMEM.
+    sAlpha_xfer_raw = cutlass.Array(cutlass.Float32, CFG.XFER_STAGES * CFG.TILE_M, alignment=128, space=cutlass.AddressSpace.smem)
+    # stats xfer (sg0 → sg1) SMEM — 1-shot per tile, holds ell + max (2 * TILE_M floats).
+    sStats_xfer_raw = cutlass.Array(cutlass.Float32, 2 * CFG.TILE_M, alignment=128, space=cutlass.AddressSpace.smem)
+    # LSE staging on sg1 (sub-tile write-back from corr; cf. C++ line 198).
+    sLSE_raw = cutlass.Array(cutlass.Float32, CFG.TILE_M, alignment=128, space=cutlass.AddressSpace.smem)
+
+    # Typed SmemTile handles.
+    # Rubin SM107 raises the per-CTA SMEM cap to 327 KiB, so an MMA-operand
+    # buffer can land at or above 256 KiB — past what a version-0 tcgen05 SMEM
+    # descriptor can address (14-bit start_address).  Every operand tile here
+    # therefore carries desc_version=1, matching what C++ SmemTile::make_desc
+    # always emitted.  See tile_dsl/handles.py SmemTile.desc_version.
+    sQ = SmemTile(
+        base=sQ_raw,
+        elems_per_stage=qBufferElems,
+        stages=1,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+        desc_version=1,
+    )
+    sK = SmemTile(
+        base=sK_raw,
+        elems_per_stage=kBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+        desc_version=1,
+    )
+    sV = SmemTile(
+        base=sV_raw,
+        elems_per_stage=vBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_PV,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_PV,
+        layout=SMEM_LAYOUT_V,
+        tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
+        tma_granu_elems=TMA_VO_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+        desc_version=1,
+    )
+    sO = SmemTile(
+        base=sO_raw,
+        elems_per_stage=oBufferElems,
+        stages=1,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=SMEM_LAYOUT_O,
+        tma_loads_per_tile=TMA_O_ITERS_HOST,
+        tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+    )
+
+    # ------------------------------------------------------------------
+    # Bars allocation — per the barrier table above.
+    # ------------------------------------------------------------------
+    bars = _make_dsv4_bars(CFG, N_O_CHUNKS)
+
+    tmem_ptr_i32 = cutlass.Array(cutlass.Int32, 1, alignment=16, space=cutlass.AddressSpace.smem)
+
+    # tile_id_smem stride 8 Int32/stage (32 B per stage; 16 B payload + 16 B padding).
+    sched = Sched(
+        **{
+            "mb_scheduler": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "mb_read_tile_id": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "tile_id_smem": cutlass.Array(cutlass.Int32, CFG.SCHEDULER_STAGES * 8, alignment=16, space=cutlass.AddressSpace.smem),
+            "bidx_init": bidx,
+            "bidy_init": bidy,
+            "bidz_init": bidz,
+        }
+    )
+
+    # ------------------------------------------------------------------
+    # cga2 / role-split identity — hoisted ABOVE init because mb_p_xfer_full
+    # init count is leader-vs-non-leader runtime-conditional (P12 — leader
+    # sees CTA_MMA arrives, non-leader sees 1).
+    # ------------------------------------------------------------------
+    cta_id_x = cute.arch.block_idx_in_cluster() if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    cta_in_pair = (cta_id_x & cutlass.Int32(1)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    leader_cta_id = (cta_id_x & cutlass.Int32(~1 & 0xFFFFFFFF)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    mcast_mask = (cutlass.Int32(3) << leader_cta_id) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    # sg0_mcast_mask = 0x3 — both sg0 CTAs (used by sg1 leader's P13 multicast on mb_p_xfer_empty).
+    sg0_mcast_mask = cutlass.Int32(0x3)
+    # TMA-load self-bit mask: per cga2-mma.md / DKG `fp16_gemm_3.py`, each
+    # peer's `cta_group::2` TMA targets ITS OWN cluster bit (= cta_id_x);
+    # cga2 routing strips bit-24 so bytes land on the cga2 pair leader's
+    # mbar.  Use cluster-rank (cta_id_x), NOT pair-rank (cta_in_pair) — for
+    # cga2 (CGA_M=CTA_MMA=2) these coincide, but for cga4×1 (dsv4) the sg1
+    # pair has cta_in_pair ∈ {0,1} while cta_id_x ∈ {2,3}, and using
+    # cta_in_pair would target CTAs 0,1 (sg0) instead of CTAs 2,3 (sg1).
+    tma_mcast_mask = (cutlass.Int16(1) << cta_id_x.to(cutlass.Int16)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
+    is_leader = cta_in_pair == cutlass.Int32(0)
+
+    # Sub-group identity (sg0 = CTAs 0, 1; sg1 = CTAs 2, 3).
+    sg_id = cta_id_x // cutlass.Int32(CFG.CTA_MMA)
+    is_sg0 = sg_id == cutlass.Int32(0)
+    is_sg1 = sg_id == cutlass.Int32(1)
+    # Cross-sg peer = this CTA XOR CTA_MMA (CTAs 0↔2, 1↔3).
+    cross_sg_peer = cta_id_x ^ cutlass.Int32(CFG.CTA_MMA)
+
+    is_cga_first_cta = cta_id_x == cutlass.Int32(0)
+
+    # ------------------------------------------------------------------
+    # Mbar init — Phase 1 of cluster init (P4).  No Phase-2 bootstrap arrives:
+    # every consumer that would need one is pre-armed via PipelineState(0, 1)
+    # or per-warp `phase = 1` initial values.  MmaProducer<> typing forbids
+    # plain arrive() anyway.
+    #
+    # Per-CTA leader / non-leader split for mb_p_xfer_full follows P12:
+    # leader = CTA_MMA arrives (own + (CTA_MMA-1) DSMEM forwarder); non-leader = 1.
+    # ------------------------------------------------------------------
+    if warp_idx == 0:
+        if nvvm.elect_sync():
+            # ---- TMA Q/K/V handshakes ----
+            bars.mb_tma_q_full.init()
+            bars.mb_tma_q_empty.init()
+            for ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_tma_k_full[ks].init()
+                bars.mb_tma_k_empty[ks].init()
+                bars.mb_tma_v_full[ks].init()
+                bars.mb_tma_v_empty[ks].init()
+
+            # ---- MMA → softmax / corr handshakes ----
+            for p in cutlass.range_constexpr(CFG.XFER_STAGES):
+                bars.mb_bmm1_done[p].init()
+                bars.mb_bmm2_done[p].init()
+                bars.mb_s_acc_empty[p].init()
+                for c in cutlass.range_constexpr(CFG.N_BMM2_CHUNKS):
+                    bars.mb_bmm2_ready[p * CFG.N_BMM2_CHUNKS + c].init()
+
+                # ---- DSMEM xfer rings (sg0 → sg1) ----
+                # P12: leader = CTA_MMA arrives; non-leader = 1.  Runtime-
+                # conditional init count passed via override_count=.
+                p_full_init = cutlass.Int32(
+                    arith.select(
+                        is_leader.ir_value(),
+                        cutlass.Int32(CFG.CTA_MMA).ir_value(),
+                        cutlass.Int32(CFG.ONE_LANE).ir_value(),
+                    )
+                )
+                bars.mb_p_xfer_full[p].init(override_count=p_full_init)
+                bars.mb_p_xfer_empty[p].init()
+                bars.mb_alpha_xfer_full[p].init()
+                bars.mb_alpha_xfer_empty[p].init()
+
+            # ---- one-shot stats ring ----
+            bars.mb_stats_xfer_full.init()
+            bars.mb_stats_xfer_empty.init()
+
+            # ---- sg1 TMA-STG handshakes ----
+            for c in cutlass.range_constexpr(N_O_CHUNKS):
+                bars.mb_tma_o_full[c].init()
+            bars.mb_tma_o_empty.init()
+
+            # ---- end-of-kernel teardown ----
+            bars.mb_empty_mainloop.init()
+            bars.mb_tmem_dealloc.init()
+
+            # ---- scheduler ring (NOT in Bars; still raw nvvm.mbarrier_init) ----
+            for s in range(CFG.SCHEDULER_STAGES):
+                nvvm.mbarrier_init(sched.mb_scheduler.subview(s), CFG.ONE_LANE)
+                nvvm.mbarrier_init(sched.mb_read_tile_id.subview(s), READ_TILE_ARRIVERS)
+
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync()
+
+    # P4 cluster fence (cga2-aware) — required because Phase 2 of the kernel
+    # body issues cross-CTA arrive_on_peer BEFORE the receiving CTA has
+    # necessarily flushed its mbar init through the cluster.  relaxed=True
+    # (per project memory: dsv3 cga2 47%→92% SOL).
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        cga_arrive()
+        cga_wait()
+
+    # ------------------------------------------------------------------
+    # Per-warp role dispatch.  Role-split topology:
+    #   compute wg (warps 0..3): sg-conditional softmax (sg0) OR corr (sg1).
+    #   MMA       (warp 4): sg-conditional BMM1 (sg0) OR BMM2 (sg1);
+    #                       non-leader CTAs run quiet (sg0) or forwarder (sg1).
+    #   TMA-LDG   (warp 5): sg-conditional Q+K (sg0) OR V (sg1).
+    #   TMA-STG   (warp 6): sg1 only — O + LSE.  sg0 spins scheduler only.
+    #   Scheduler (warp 7): try_cancel; both sgs.
+    # ------------------------------------------------------------------
+    if warp_idx >= cutlass.Int32(CFG.SOFTMAX_WG0_BASE) and warp_idx < cutlass.Int32(CFG.SOFTMAX_WG0_BASE + CFG.SOFTMAX_WG_WARPS):
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        _compute_warp_group(
+            is_sg0=is_sg0,
+            is_sg1=is_sg1,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_softmax_log2,
+            tmem_ptr_i32=tmem_ptr_i32,
+            sQ=sQ,
+            sO=sO,
+            sP_xfer_raw=sP_xfer_raw,
+            sAlpha_xfer_raw=sAlpha_xfer_raw,
+            sStats_xfer_raw=sStats_xfer_raw,
+            sLSE_raw=sLSE_raw,
+            bars=bars,
+            sched=sched,
+            lse_tensor=lse_tensor,
+            sinks_tensor=sinks_tensor,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+            cta_id_x=cta_id_x,
+            cross_sg_peer=cross_sg_peer,
+        )
+
+    elif warp_idx == cutlass.Int32(CFG.MMA_WARP_ID):
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        # cga2 non-leader paths fork — sg0 non-leader is quiet, sg1 non-leader
+        # forwards mb_p_xfer_full to leader (P12) in a persistent loop.
+        if is_leader:
+            _mma_warp_group(
+                is_sg0=is_sg0,
+                is_sg1=is_sg1,
+                seqlen_q=seqlen_q,
+                seqlen_kv=seqlen_kv,
+                sQ=sQ,
+                sK=sK,
+                sV=sV,
+                sP_xfer_raw=sP_xfer_raw,
+                tmem_ptr_i32=tmem_ptr_i32,
+                bars=bars,
+                sched=sched,
+                seq_kv_lens_tensor=seq_kv_lens_tensor,
+                n_q_supers=n_q_supers,
+                n_qh=n_qh,
+                n_batch=n_batch,
+                mcast_mask=mcast_mask,
+                sg0_mcast_mask=sg0_mcast_mask,
+                cta_in_pair=cta_in_pair,
+            )
+        else:
+            _mma_warp_non_leader(
+                is_sg0=is_sg0,
+                is_sg1=is_sg1,
+                seqlen_q=seqlen_q,
+                seqlen_kv=seqlen_kv,
+                tmem_ptr_i32=tmem_ptr_i32,
+                bars=bars,
+                sched=sched,
+                seq_kv_lens_tensor=seq_kv_lens_tensor,
+                n_q_supers=n_q_supers,
+                n_qh=n_qh,
+                n_batch=n_batch,
+                cta_in_pair=cta_in_pair,
+                leader_cta_id=leader_cta_id,
+            )
+
+    elif warp_idx == cutlass.Int32(CFG.TMALDG_WARP_ID):
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        nvvm.prefetch_tensormap(tma_q_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_k_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_v_desc.get_ptr())
+        _tmaldg_warp_group(
+            is_sg0=is_sg0,
+            is_sg1=is_sg1,
+            tma_q_desc=tma_q_desc,
+            tma_k_desc=tma_k_desc,
+            tma_v_desc=tma_v_desc,
+            sQ=sQ,
+            sK=sK,
+            sV=sV,
+            bars=bars,
+            sched=sched,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            qh_per_kh=qh_per_kh,
+            is_leader=is_leader,
+            cta_in_pair=cta_in_pair,
+            tma_mcast_mask=tma_mcast_mask,
+        )
+
+    elif warp_idx == cutlass.Int32(CFG.TMASTG_WARP_ID):
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _tmastg_warp_group(
+            is_sg1=is_sg1,
+            tma_o_desc=tma_o_desc,
+            sO=sO,
+            bars=bars,
+            sched=sched,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            cta_in_pair=cta_in_pair,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
+        )
+
+    else:  # warp_idx == CFG.SCHED_WARP_ID
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
+
+
+# ============================================================================
+# sg0 softmax-iter helper — per-iter body for the 3-segment kv loop
+# (LEFT-masked / unmasked center / RIGHT-masked).  Mirrors canonical
+# `_softmax_kv_body` (prefill_sdpa_f16.py:923) and C++
+# `softmax_kv_body<ApplyMask>` (prefill_sdpa_d512_f16.cu:445).
+#
+# apply_mask=False uses fused HW row-max (tcgen05.ld.red.f32.max);
+# apply_mask=True uses tcgen05.ld + apply_mask_chunk + software row-max
+# (HW max can't observe -inf written by the mask after the load).
+#
+# Top-level @cute.jit so the dynamic call-graph contains no closure-capture
+# violations (CTM-DSL forbids closures under dynamic control flow).  All
+# kernel-local vars are passed as explicit args; constants come from
+# module-level (NEG_INF_F32, RESCALE_THRESHOLD_F32, P_*, SOFTMAX_*, etc.).
+# ============================================================================
+@cute.jit
+def _sg0_softmax_kv_iter(
+    apply_mask: cutlass.Constexpr[bool],
+    kv_loop,
+    # State (threaded, returned updated):
+    sg0_xfer_state,
+    bmm1_done_state,
+    total_max,
+    total_sum_vec,
+    # TMEM / SMEM bases:
+    tmem_base_addr,
+    bars,
+    sP_xfer_raw,
+    sAlpha_xfer_raw,
+    # Per-tile / per-lane:
+    q_abs,
+    eff_seqlen_kv,
+    seqlen_q,
+    scale_log2,
+    tid_in_wg,
+    is_lead_warp,
+    leader_cta_id,
+    cross_sg_peer,
+):
+    cur_parity_S = sg0_xfer_state.idx
+    cur_phase_S = sg0_xfer_state.phase
+    bars.mb_alpha_xfer_empty[cur_parity_S].wait(cur_phase_S)
+    bars.mb_p_xfer_empty[cur_parity_S].wait(cur_phase_S)
+    bars.mb_bmm1_done[bmm1_done_state.idx].wait(bmm1_done_state.phase)
+    sg0_xfer_state = advance(sg0_xfer_state, CFG.XFER_STAGES)
+    bmm1_done_state = advance(bmm1_done_state, CFG.XFER_STAGES)
+
+    s_addr_base = tmem_base_addr + cur_parity_S * cutlass.Int32(LAYOUT.S_ACC_COLS)
+
+    # The chunk path (tcgen05_ld + apply_mask_chunk + software row-max) also
+    # serves TILE_N < 64 (TF32 → 32): the HW-fused-max fast path below needs
+    # num_elems % 64 == 0, so 32-wide tiles route here.  apply_mask_chunk is
+    # an identity no-op when MASK_FLAGS == MASK_NONE, so this is correct for
+    # the unmasked case too (just without the HW max fusion).
+    if cutlass.const_expr(apply_mask or CFG.TILE_N < 64):
+        kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+        raw_chunks = [
+            nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * SOFTMAX_CHUNK), cutlass.Float32),
+                num=SOFTMAX_CHUNK,
+            )
+            for c in range(SOFTMAX_N_CHUNKS_LOAD)
+        ]
+        # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
+        # CFG.BOTTOM_RIGHT is 0 — top-left masking is unchanged).
+        causal_diag = eff_seqlen_kv - seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+        chunks_S = [
+            apply_mask_chunk(
+                raw_chunks[c],
+                q_abs,
+                kv_col_base + cutlass.Int32(c * SOFTMAX_CHUNK),
+                eff_seqlen_kv,
+                CFG.WINDOW_LEFT,
+                CFG.MASK_FLAGS,
+                N=SOFTMAX_CHUNK,
+                bottom_right=CFG.BOTTOM_RIGHT,
+                causal_diag=causal_diag,
+                window_right=CFG.WINDOW_RIGHT,
+            )
+            for c in range(SOFTMAX_N_CHUNKS_LOAD)
+        ]
+        chunks_max = [row_max_reduction(chunks_S[c]) for c in range(SOFTMAX_N_CHUNKS_LOAD)]
+        reg_S_vec = vec_concat(chunks_S)
+        current_max_raw = chunks_max[0]
+        for m in chunks_max[1:]:
+            current_max_raw = cute.math.max(current_max_raw, m)
+        reg_S_tile = RegTile(reg_S_vec, size=CFG.TILE_N)
+    else:
+        reg_S_tile, current_max_raw = tmem_load_max_reduction_tile(
+            s_addr_base,
+            num_elems=CFG.TILE_N,
+        )
+    current_max = current_max_raw * scale_log2
+
+    # All-thread DSMEM arrive on sg0 leader's mb_s_acc_empty (P11) —
+    # doubles as the tmem_load_fence cross-warp sync.
+    bars.mb_s_acc_empty[cur_parity_S].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+    # Online softmax (RESCALE_THRESHOLD skip).
+    old_total_max = total_max
+    is_first = total_max == NEG_INF_F32
+    update_cond = is_first | ((current_max - total_max) > RESCALE_THRESHOLD_F32)
+    total_max = cutlass.Float32(
+        arith.select(
+            update_cond.ir_value(),
+            current_max.ir_value(),
+            total_max.ir_value(),
+        )
+    )
+    exp_input = cutlass.Float32(
+        arith.select(
+            is_first.ir_value(),
+            NEG_INF_F32.ir_value(),
+            (old_total_max - total_max).ir_value(),
+        )
+    )
+    alpha = cute.math.exp2(exp_input, fastmath=True)
+
+    # reg_S = reg_S * scale_log2 - total_max; then exp2.
+    reg_S_scaled = reg_S_tile.vec * scale_log2 - total_max
+    reg_P_fp32 = cute.math.exp2(reg_S_scaled, fastmath=True)
+    reg_P_half_vec = reg_P_fp32.to(P_STORAGE_DTYPE)
+    reg_P_half = RegTile(reg_P_half_vec, size=CFG.TILE_N)
+
+    # ---- Write P[tid, :] to SMEM xfer ring slot[parity] ----
+    p_xfer_slot = sP_xfer_raw.subview(cur_parity_S * cutlass.Int32(pXferElems))
+    for chunk in cutlass.range_constexpr(P_TMA_ITERS):
+        smem_off = cutlass.Int32(chunk * P_BLOCK_BYTES) + tid_in_wg * cutlass.Int32(P_D_BLOCK)
+        smem_ptr = p_xfer_slot.subview(smem_off).data_ptr()
+        chunk_P = reg_P_half[chunk * P_D_BLOCK : (chunk + 1) * P_D_BLOCK].vec
+        smem_ptr.store_swizzled(
+            chunk_P,
+            alignment=64,
+            swizzle=P_SMEM_SWIZZLE,
+        )
+
+    # ---- Write alpha[tid] (FP32) to alpha xfer slot[parity] ----
+    alpha_slot = sAlpha_xfer_raw.subview(cur_parity_S * cutlass.Int32(CFG.TILE_M) + tid_in_wg)
+    alpha_slot.store(alpha)
+
+    # Update total_sum = total_sum * alpha + row_reduction(reg_P).
+    alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+    iter_sum_pair = row_reduction_pair(reg_P_fp32)
+    total_sum_vec = total_sum_vec * alpha_pair + iter_sum_pair
+
+    # Fence SMEM→async; sync the 4 compute warps so all 128 rows of
+    # alpha + P are written before bulk_copy issues.
+    nvvm.fence_proxy("async.shared", space="cta")
+    nvvm.barrier_cta_sync(barrier_id=8, thread_count=128)
+
+    # DSMEM bulk_copy alpha + P → cross-sg sg1 peer's SMEM, firing peer's
+    # mb_alpha_xfer_full + mb_p_xfer_full.  PREDICATED form: emit `@p
+    # cp.async.bulk` (matches C++'s uniform `@UP0 UBLKCP`) instead of an
+    # `if is_lead_warp: if elect_sync():` branch — that branch lowers to a
+    # warp-divergent BSSY/BSYNC + reconverge that also poisons ptxas's uniform
+    # analysis of nearby mbar waits (measured: removing the ship branches flips
+    # ~5 SYNCS.PHASECHK → USYNCS and is worth ~+12% on dsv4 d512).  All 128
+    # lanes compute the cheap mapa addresses up-front; only the lead warp's
+    # elected lane issues the UBLKCPs under ship_pred.
+    ship_pred = is_lead_warp & nvvm.elect_sync()
+    local_alpha_src = sAlpha_xfer_raw.subview(cur_parity_S * cutlass.Int32(CFG.TILE_M))
+    peer_alpha_dst = nvvm.mapa(local_alpha_src, cross_sg_peer, addrspace=7)
+    peer_alpha_full_mbar = nvvm.mapa(bars.mb_alpha_xfer_full[cur_parity_S].smem_ptr, cross_sg_peer, addrspace=7)
+    local_p_src = sP_xfer_raw.subview(cur_parity_S * cutlass.Int32(pXferElems))
+    peer_p_dst = nvvm.mapa(local_p_src, cross_sg_peer, addrspace=7)
+    peer_p_full_mbar = nvvm.mapa(bars.mb_p_xfer_full[cur_parity_S].smem_ptr, cross_sg_peer, addrspace=7)
+    cp_async_bulk_shared_cluster_shared_cta(
+        peer_alpha_dst,
+        local_alpha_src,
+        peer_alpha_full_mbar,
+        alphaXferBytes,
+        pred=ship_pred,
+    )
+    cp_async_bulk_shared_cluster_shared_cta(
+        peer_p_dst,
+        local_p_src,
+        peer_p_full_mbar,
+        pXferBytes,
+        pred=ship_pred,
+    )
+
+    return (sg0_xfer_state, bmm1_done_state, total_max, total_sum_vec)
+
+
+# ============================================================================
+# Compute warp group — sg-conditional softmax (sg0) or correction (sg1).
+# 4 warps × 32 lanes = 128 threads.  Port of C++ compute_warp_group
+# (prefill_sdpa_d512_f16.cu:543-1025).
+# ============================================================================
+@cute.jit
+def _compute_warp_group(
+    is_sg0,
+    is_sg1,
+    seqlen_q,
+    seqlen_kv,
+    scale_log2,
+    tmem_ptr_i32,
+    sQ,
+    sO,
+    sP_xfer_raw,
+    sAlpha_xfer_raw,
+    sStats_xfer_raw,
+    sLSE_raw,
+    bars,
+    sched,
+    lse_tensor,
+    sinks_tensor,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+    cta_id_x,
+    cross_sg_peer,
+):
+    """sg-conditional compute body (4 warps × 32 lanes = 128 threads).
+
+    sg0 path (port of C++ lines 599-749):
+        Streaming softmax — per kv iter wait BMM1 done, tmem_load S_acc + HW
+        row-max, online softmax (exp2 + alpha + new total_max / total_sum),
+        publish alpha (DSMEM bulk_copy to sg1), publish P (DSMEM bulk_copy
+        to sg1), all-thread arrive on mb_s_acc_empty.  End-of-tile ship
+        (max, ell) stats over DSMEM (1-shot).  Per-tile pre-armed empty
+        phases via PipelineState(0, 1).
+
+    sg1 path (port of C++ lines 750-1024):
+        Correction + epilogue — per kv iter wait alpha (local mbar), apply
+        alpha to O TMEM in two halves (gates BMM2 sub-tile 0 / 1 via
+        mb_bmm2_ready), DSMEM-arrive empty alpha on sg0.  Epilogue: wait
+        final BMM2, wait stats, normalize O by 1/ell + cast to half, store
+        to sO with per-chunk mb_tma_o_full arrive, write LSE to GMEM,
+        DSMEM-arrive empty stats on sg0.
+
+    Wait pattern: MMA warp publishes TMEM base via named barrier 1 (count =
+    32 * (SOFTMAX_WG_WARPS + 1) = 160) BEFORE any tmem_ptr_i32.load().
+    """
+    # Wait MMA's TMEM-alloc publish (C++ line 592 ``named_barrier_wait(TMEM_ALLOC_SOFTMAX_BARRIER, 160)``).
+    nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WG_WARPS + 1))
+    tmem_base_addr = tmem_ptr_i32.load()
+    tmem_raw = nvvm.make_tmem_ptr(tmem_base_addr, cutlass.Int8)
+
+    # Per-thread / per-warp identifiers — compute warps occupy CTA tid_x in
+    # [0, 128); tid_in_wg == tid_x, wid_in_wg = tid_x // 32 ∈ {0..3}.
+    tid_in_wg = cute.arch.thread_idx()[0]
+    wid_in_wg = tid_in_wg // cutlass.Int32(32)
+    is_lead_warp = wid_in_wg == cutlass.Int32(0)
+
+    # Common state — persistent-tile scheduler decode.
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    # kv_loop bounds — at MASK_NONE collapse to [0, seqlen_kv / TILE_N).
+    # When MASK_FLAGS != 0 the kv loop splits into 3 segments
+    # (LEFT-masked / fully-unmasked / RIGHT-masked) on unmasked_lo / unmasked_hi.
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_unmasked_lo = cutlass.Int32(0)
+        kv_unmasked_hi = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+        eff_seqlen_kv = seqlen_kv
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_unmasked_lo = bounds_init.unmasked_lo
+        kv_unmasked_hi = bounds_init.unmasked_hi
+        kv_right = bounds_init.right
+
+    # ---- Per-tensor swizzle for SMEM stores (same Swz128B as Q/O at d=512 f16) ----
+    # P SMEM swizzle hoisted to module-level (P_SMEM_SWIZZLE) — see top of file.
+    _O_EPI_SWIZZLE = cutlass.Swizzle(3, 4, 3)
+
+    # Epilogue tile params (O SMEM stride).  TILE_O=512, BPE_O=2 → 8 chunks.
+    O_EPI_BLOCK_SIZE = 64 // CFG.BPE_O  # 32 fp16, 64 fp8
+    O_TMA_ITERS = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES  # 8 chunks
+    O_D_BLOCK = CFG.TILE_O // O_TMA_ITERS  # 64 elements / chunk
+    O_TMA_GRANU_ELEMS = CFG.TILE_M * O_D_BLOCK  # 8192 elements / TMA chunk
+    O_BLOCKS_PER_SUB = 128 // O_EPI_BLOCK_SIZE  # 4 (f16) / 2 (fp8)
+    O_CHUNK_ELEMS = 128 // CFG.BPE_O  # 64 (f16) / 128 (fp8)
+
+    # ---- sg0 state — streaming softmax + DSMEM ship ----
+    bmm1_done_state = PipelineState.start(phase=0)
+    # PipelineState(0, 1) → both mb_p_xfer_empty and mb_alpha_xfer_empty are
+    # pre-armed; iter-0/1 wait passes immediately on fresh barriers.
+    sg0_xfer_state = PipelineState.start(phase=1)
+    stats_xfer_empty_phase = cutlass.Int32(1)
+
+    # ---- sg1 state — recv alpha + correction + epilogue ----
+    alpha_full_state = PipelineState.start(phase=0)
+    sg1_bmm2_done_state = PipelineState.start(phase=0)
+    stats_xfer_full_phase = cutlass.Int32(0)
+    epilogue_state = cutlass.Int32(0)
+
+    # ---- streaming-softmax accumulators (sg0) — Vector[Float32,2] for
+    #      packed FMUL2/FADD2 lowering, per the canonical f16 port pattern.
+    total_max = NEG_INF_F32
+    total_sum_vec = cutlass.Vector.from_elements(
+        (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+        cutlass.Float32,
+    )
+
+    # ==================================================================
+    # TODO(main agent): port sg0 streaming-softmax + DSMEM-ship body from
+    # C++ prefill_sdpa_d512_f16.cu lines 445-536 (softmax_kv_body) and
+    # 599-749 (per-tile loop), and sg1 correction + epilogue body from
+    # C++ lines 750-1024.
+    #
+    # Must preserve:
+    #   - sg0 mb_p_xfer_empty / mb_alpha_xfer_empty pre-armed at phase=1
+    #     (PipelineState(0, 1)) — matches C++ ``Sg0KvState s.sg0_state(0, 1)``.
+    #   - sg0 mb_bmm1_done_state NOT pre-armed (phase=0) — BMM1 commit must
+    #     land before sg0 sm reads S_acc[0].
+    #   - sg0 mb_s_acc_empty.arrive_on_peer(0u, 1u) — all-thread DSMEM-arrive
+    #     to sg0 leader (256 lanes total).  Cross-warp sync between
+    #     tmem_load_fence and the arrive is BUILT INTO the all-thread arrive
+    #     (P8 + P11) — no extra named_barrier_wait needed.
+    #   - sg0 DSMEM bulk_copy to peer SMEM uses
+    #     ``cp_async_bulk_shared_cluster_shared_cta`` (per project memory:
+    #     bare nvvm op silently fires sender's local mbar instead of receiver).
+    #   - sg1 mb_alpha_xfer_full[parity_cur].arrive(ALPHA_XFER_TILE_BYTES, lead_warp_elect)
+    #     — wrapper @p-gates on elect, the wait below spins on phase parity.
+    #   - sg1 iter-0 BOTH mb_bmm2_ready half slots fired immediately (BMM2(0)
+    #     doesn't depend on alpha — C++ lines 798-805).
+    #   - sg1 correction split into 2 halves of CORR_BLOCKS_PER_HALF blocks
+    #     each (TILE_O / correction_block_size / 2 blocks per half), with
+    #     mb_bmm2_ready[parity*2+0] fired after half-1, [parity*2+1] after
+    #     half-2.  Lets BMM2 sub-tile 0 start while corr works on half-2.
+    #   - sg1 epilogue: TMEM layout SCRAMBLED by cga2 N-split + 2-call N-block
+    #     split (cf. C++ lines 964-983).  Iterate in OUTPUT order with bit-
+    #     swap [0,2,1,3] permutation.
+    #   - sg1 mb_tma_o_full arrives per-128B chunk in output order.
+    #   - sg1 mb_tmem_dealloc.arrive_on_peer(cta_id_x ^ 1u) — DSMEM fan-out
+    #     between cga2 partners (cf. C++ lines 1023, 748).
+    # ==================================================================
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if is_sg0:
+            # ============================================================
+            # sg0 — streaming softmax + ship alpha + P + stats.
+            # Port of C++ prefill_sdpa_d512_f16.cu lines 445-536 + 599-749.
+            # ============================================================
+            total_max = NEG_INF_F32
+            total_sum_vec = cutlass.Vector.from_elements(
+                (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+                cutlass.Float32,
+            )
+
+            # Per-lane absolute Q row (used by apply_mask_chunk in
+            # LEFT/RIGHT segments).  Same anchor C++ uses at
+            # prefill_sdpa_d512_f16.cu:486 (`tc.q_row_coord + tid`).
+            q_abs = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + tid_in_wg
+
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+                pass
+            else:
+                # 3-segment kv loop: LEFT-masked / unmasked center / RIGHT-masked.
+                # MASK_NONE collapses the two masked sub-loops to empty range
+                # (kv_left == kv_unmasked_lo and kv_unmasked_hi == kv_right),
+                # so the LEFT/RIGHT branches fold out at trace time.
+                if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+                    for _kv in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                        sg0_xfer_state, bmm1_done_state, total_max, total_sum_vec = _sg0_softmax_kv_iter(
+                            False,
+                            _kv,
+                            sg0_xfer_state,
+                            bmm1_done_state,
+                            total_max,
+                            total_sum_vec,
+                            tmem_base_addr,
+                            bars,
+                            sP_xfer_raw,
+                            sAlpha_xfer_raw,
+                            q_abs,
+                            eff_seqlen_kv,
+                            seqlen_q,
+                            scale_log2,
+                            tid_in_wg,
+                            is_lead_warp,
+                            leader_cta_id,
+                            cross_sg_peer,
+                        )
+                else:
+                    for _kv in cutlass.range(kv_left, kv_unmasked_lo, 1, unroll=1):
+                        sg0_xfer_state, bmm1_done_state, total_max, total_sum_vec = _sg0_softmax_kv_iter(
+                            True,
+                            _kv,
+                            sg0_xfer_state,
+                            bmm1_done_state,
+                            total_max,
+                            total_sum_vec,
+                            tmem_base_addr,
+                            bars,
+                            sP_xfer_raw,
+                            sAlpha_xfer_raw,
+                            q_abs,
+                            eff_seqlen_kv,
+                            seqlen_q,
+                            scale_log2,
+                            tid_in_wg,
+                            is_lead_warp,
+                            leader_cta_id,
+                            cross_sg_peer,
+                        )
+                    for _kv in cutlass.range(kv_unmasked_lo, kv_unmasked_hi, 1, unroll=1):
+                        sg0_xfer_state, bmm1_done_state, total_max, total_sum_vec = _sg0_softmax_kv_iter(
+                            False,
+                            _kv,
+                            sg0_xfer_state,
+                            bmm1_done_state,
+                            total_max,
+                            total_sum_vec,
+                            tmem_base_addr,
+                            bars,
+                            sP_xfer_raw,
+                            sAlpha_xfer_raw,
+                            q_abs,
+                            eff_seqlen_kv,
+                            seqlen_q,
+                            scale_log2,
+                            tid_in_wg,
+                            is_lead_warp,
+                            leader_cta_id,
+                            cross_sg_peer,
+                        )
+                    for _kv in cutlass.range(kv_unmasked_hi, kv_right, 1, unroll=1):
+                        sg0_xfer_state, bmm1_done_state, total_max, total_sum_vec = _sg0_softmax_kv_iter(
+                            True,
+                            _kv,
+                            sg0_xfer_state,
+                            bmm1_done_state,
+                            total_max,
+                            total_sum_vec,
+                            tmem_base_addr,
+                            bars,
+                            sP_xfer_raw,
+                            sAlpha_xfer_raw,
+                            q_abs,
+                            eff_seqlen_kv,
+                            seqlen_q,
+                            scale_log2,
+                            tid_in_wg,
+                            is_lead_warp,
+                            leader_cta_id,
+                            cross_sg_peer,
+                        )
+
+            # ---- End-of-tile: ship final stats (max, ell) ----
+            bars.mb_stats_xfer_empty.wait(stats_xfer_empty_phase)
+            stats_xfer_empty_phase = stats_xfer_empty_phase ^ cutlass.Int32(1)
+
+            final_sum = total_sum_vec[0] + total_sum_vec[1]
+            # Stats layout in SMEM: ell[TILE_M] then max[TILE_M].
+            stats_sum_slot = sStats_xfer_raw.subview(tid_in_wg)
+            stats_max_slot = sStats_xfer_raw.subview(cutlass.Int32(CFG.TILE_M) + tid_in_wg)
+            stats_sum_slot.store(final_sum)
+            stats_max_slot.store(total_max)
+
+            nvvm.fence_proxy("async.shared", space="cta")
+            nvvm.barrier_cta_sync(barrier_id=8, thread_count=128)
+
+            # Predicated stats ship — same rationale as the per-iter alpha/P
+            # ship above (`@p UBLKCP`, no warp-divergent branch).
+            ship_pred = is_lead_warp & nvvm.elect_sync()
+            peer_stats_dst = nvvm.mapa(sStats_xfer_raw, cross_sg_peer, addrspace=7)
+            peer_stats_full_mbar = nvvm.mapa(bars.mb_stats_xfer_full.smem_ptr, cross_sg_peer, addrspace=7)
+            cp_async_bulk_shared_cluster_shared_cta(
+                peer_stats_dst,
+                sStats_xfer_raw,
+                peer_stats_full_mbar,
+                statsXferBytes,
+                pred=ship_pred,
+            )
+        else:
+            # ============================================================
+            # sg1 — correction (apply alpha) + epilogue (normalize, cast,
+            # store O, LSE).  Port of C++ lines 750-1024.
+            # ============================================================
+            tmem_O_base = tmem_base_addr + cutlass.Int32(LAYOUT.O_OFF)
+
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+                # Empty-kv branch: signal MMA's empty-mainloop wait
+                # (each sg1 CTA's elect lane DSMEM-arrives sg1 leader).
+                bars.mb_empty_mainloop.arrive_on_peer(leader_cta_id, pred=is_lead_warp & nvvm.elect_sync())
+            else:
+                # --- iter 0: BMM2(0) doesn't depend on alpha; fire both
+                #     bmm2_ready half slots immediately (C++ 798-805).
+                cur_parity_0 = alpha_full_state.idx
+                bars.mb_bmm2_ready[cur_parity_0 * cutlass.Int32(CFG.N_BMM2_CHUNKS)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+                bars.mb_bmm2_ready[cur_parity_0 * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(1)].arrive(
+                    leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA
+                )
+
+                # Arm + wait alpha_xfer_full[parity_0].  Wrapper @p-gates
+                # on elect; wait spins on phase parity (atomically observable).
+                bars.mb_alpha_xfer_full[cur_parity_0].arrive(n_bytes=alphaXferBytes, pred=is_lead_warp & nvvm.elect_sync())
+                bars.mb_alpha_xfer_full[cur_parity_0].wait(alpha_full_state.phase)
+                alpha_full_state = advance(alpha_full_state, CFG.XFER_STAGES)
+
+                # Notify sg0 (cross-sg peer) alpha slot is empty.
+                bars.mb_alpha_xfer_empty[cur_parity_0].arrive_on_peer(cross_sg_peer)
+
+                # --- iter 1..n_kv-1: apply alpha to O before BMM2(kv) ---
+                CORR_BLOCK_SIZE = 16
+                CORR_BLOCKS_TOTAL = CFG.TILE_O // CORR_BLOCK_SIZE  # 32
+                CORR_BLOCKS_PER_HALF = CORR_BLOCKS_TOTAL // 2  # 16
+
+                for _kv in cutlass.range(kv_left + cutlass.Int32(1), kv_right, 1, unroll=1):
+                    cur_parity = alpha_full_state.idx
+
+                    bars.mb_alpha_xfer_full[cur_parity].arrive(n_bytes=alphaXferBytes, pred=is_lead_warp & nvvm.elect_sync())
+                    bars.mb_alpha_xfer_full[cur_parity].wait(alpha_full_state.phase)
+                    alpha_full_state = advance(alpha_full_state, CFG.XFER_STAGES)
+
+                    # Wait prior BMM2 done so O is committed.
+                    bars.mb_bmm2_done[sg1_bmm2_done_state.idx].wait(sg1_bmm2_done_state.phase)
+                    sg1_bmm2_done_state = advance(sg1_bmm2_done_state, CFG.XFER_STAGES)
+
+                    # Read alpha[tid] from xfer_in[cur_parity].
+                    alpha_addr = sAlpha_xfer_raw.subview(cur_parity * cutlass.Int32(CFG.TILE_M) + tid_in_wg)
+                    alpha_corr = alpha_addr.load()
+
+                    # all_alpha_one ballot: skip rescale entirely if every
+                    # lane's alpha == 1.0.
+                    alpha_is_one = alpha_corr == cutlass.Float32(1.0)
+                    all_alpha_one = vote_sync(0xFFFFFFFF, alpha_is_one, VoteSync.ALL)
+
+                    # ---- Half-1: cols [0..TILE_O/2) ----
+                    if ~all_alpha_one:
+                        for block in cutlass.range_constexpr(CORR_BLOCKS_PER_HALF):
+                            o_off = tmem_O_base + cutlass.Int32(block * CORR_BLOCK_SIZE)
+                            o_chunk = nvvm.tcgen05_ld(
+                                "32x32b",
+                                nvvm.make_tmem_ptr(o_off, cutlass.Float32),
+                                num=CORR_BLOCK_SIZE,
+                            )
+                            o_scaled = vec_scale_pair(o_chunk, alpha_corr, CORR_BLOCK_SIZE)
+                            nvvm.tcgen05_st(
+                                "32x32b",
+                                nvvm.make_tmem_ptr(o_off, cutlass.Float32),
+                                o_scaled,
+                            )
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+
+                    # Notify sg0 alpha slot empty.
+                    bars.mb_alpha_xfer_empty[cur_parity].arrive_on_peer(cross_sg_peer)
+                    # Half-1 ready — sg1 leader BMM2 sub-tile 0 unblocked.
+                    bars.mb_bmm2_ready[cur_parity * cutlass.Int32(CFG.N_BMM2_CHUNKS)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                    # ---- Half-2: cols [TILE_O/2..TILE_O) ----
+                    if ~all_alpha_one:
+                        for block in cutlass.range_constexpr(CORR_BLOCKS_PER_HALF):
+                            block_idx = CORR_BLOCKS_PER_HALF + block
+                            o_off = tmem_O_base + cutlass.Int32(block_idx * CORR_BLOCK_SIZE)
+                            o_chunk = nvvm.tcgen05_ld(
+                                "32x32b",
+                                nvvm.make_tmem_ptr(o_off, cutlass.Float32),
+                                num=CORR_BLOCK_SIZE,
+                            )
+                            o_scaled = vec_scale_pair(o_chunk, alpha_corr, CORR_BLOCK_SIZE)
+                            nvvm.tcgen05_st(
+                                "32x32b",
+                                nvvm.make_tmem_ptr(o_off, cutlass.Float32),
+                                o_scaled,
+                            )
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+
+                    # Half-2 ready — sg1 leader BMM2 sub-tile 1 unblocked.
+                    bars.mb_bmm2_ready[cur_parity * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(1)].arrive(
+                        leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA
+                    )
+
+            # ---- Final BMM2-done wait (always runs — empty path covered) ----
+            bars.mb_bmm2_done[sg1_bmm2_done_state.idx].wait(sg1_bmm2_done_state.phase)
+            sg1_bmm2_done_state = advance(sg1_bmm2_done_state, CFG.XFER_STAGES)
+
+            # ---- Epilogue ----
+            epilogue_state = epilogue_state ^ cutlass.Int32(1)
+            bars.mb_tma_o_empty.wait(epilogue_state)
+
+            # Arm stats_xfer_full (sg0 delivers via DSMEM bulk_copy).
+            bars.mb_stats_xfer_full.arrive(n_bytes=statsXferBytes, pred=is_lead_warp & nvvm.elect_sync())
+            bars.mb_stats_xfer_full.wait(stats_xfer_full_phase)
+            stats_xfer_full_phase = stats_xfer_full_phase ^ cutlass.Int32(1)
+
+            # Per-thread lds_32 of final_ell / final_max.
+            ell_addr = sStats_xfer_raw.subview(tid_in_wg)
+            max_addr = sStats_xfer_raw.subview(cutlass.Int32(CFG.TILE_M) + tid_in_wg)
+            final_ell = ell_addr.load()
+            final_max = max_addr.load()
+
+            # Stats consumed → notify sg0 stats_xfer.out free to overwrite.
+            bars.mb_stats_xfer_empty.arrive_on_peer(cross_sg_peer, pred=is_lead_warp & nvvm.elect_sync())
+
+            # Compute beta, lse — HAS_SINK fold (dsv4 today: HAS_SINK=0,
+            # collapses to plain 1/total_sum normalization).
+            LN2 = cutlass.Float32(0.6931471805599453)
+            if cutlass.const_expr(CFG.HAS_SINK):
+                sinks_arr = cutlass.make_array_view(sinks_tensor)
+                sink_logit = sinks_arr[head_idx]
+                final_max_nat = final_max * LN2
+                new_max_nat = cute.math.max(final_max_nat, sink_logit)
+                scale_sink = cute.math.exp(final_max_nat - new_max_nat, fastmath=True)
+                new_sum = final_ell * scale_sink + cute.math.exp(sink_logit - new_max_nat, fastmath=True)
+                beta = scale_sink / new_sum
+                lse = new_max_nat + cute.math.log(new_sum, fastmath=True)
+            else:
+                final_ell_safe = cute.math.max(final_ell, cutlass.Float32(1e-30))
+                beta = cutlass.Float32(1.0) / final_ell_safe
+                lse = final_max * LN2 + cute.math.log(final_ell_safe, fastmath=True)
+
+            # --- row with no contributing column (empty KV range, or every
+            # column masked).  final_ell is then exactly 0 -- any row with one
+            # valid column sums to >= 1, because the max element contributes
+            # exp(0) after the max subtraction -- so this is a LOCAL emptiness
+            # test that needs no loop bounds in scope (the role split does not
+            # carry them into the epilogue).
+            #
+            # Without it the 1e-30 floor leaks: lse becomes
+            # final_max*LN2 + log(1e-30), i.e. the -FLT_MAX sentinel scaled
+            # (measured -2.359e+38 instead of -inf), and beta becomes 1e30 so
+            # O is (TMEM residue) * 1e30.
+            _row_empty = final_ell == cutlass.Float32(0.0)
+            if cutlass.const_expr(not CFG.HAS_SINK):
+                # A sink leaves real mass, and the sink branch already yields
+                # lse = sink_logit when final_ell == 0.
+                lse = cutlass.Float32(arith.select(_row_empty.ir_value(), cutlass.Float32(float("-inf")).ir_value(), lse.ir_value()))
+
+            # Cast O fp32 → bf16/fp16 with bit-permuted TMEM block index.
+            # TMEM layout is scrambled by cga2 N-split + 2-call N-block:
+            #   TMEM[ 0:128] = d_v[  0:128]   (call 0, leader half)
+            #   TMEM[128:256] = d_v[256:384]   (call 0, peer half)
+            #   TMEM[256:384] = d_v[128:256]   (call 1, leader half)
+            #   TMEM[384:512] = d_v[384:512]   (call 1, peer half)
+            # Iterate in OUTPUT order; bit-swap b_sub ∈ {0..3} → {0,2,1,3}.
+            sO_base = sO[0].base
+
+            for b in cutlass.range_constexpr(CFG.TILE_O // O_EPI_BLOCK_SIZE):
+                b_intra = b & (O_BLOCKS_PER_SUB - 1)
+                b_sub = b // O_BLOCKS_PER_SUB
+                tmem_sub = ((b_sub & 1) << 1) | ((b_sub & 2) >> 1)
+                tmem_block = tmem_sub * O_BLOCKS_PER_SUB + b_intra
+
+                o_addr = tmem_O_base + cutlass.Int32(tmem_block * O_EPI_BLOCK_SIZE)
+                o_fp32 = nvvm.tcgen05_ld(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                    num=O_EPI_BLOCK_SIZE,
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                o_scaled = o_fp32 * beta
+                # SELECT the zero (never `* 0`): the residue can be a NaN bit
+                # pattern, and NaN * 0 is NaN.  Statement-level loop, not a
+                # comprehension -- range_constexpr is only preprocessed there.
+                _o_elems = []
+                for _i in cutlass.range_constexpr(O_EPI_BLOCK_SIZE):
+                    _o_elems.append(cutlass.Float32(arith.select(_row_empty.ir_value(), cutlass.Float32(0.0).ir_value(), o_scaled[_i].ir_value())))
+                o_half = cutlass.Vector.from_elements(tuple(_o_elems), cutlass.Float32).to(OUT_STORAGE_DTYPE)
+
+                # SMEM store — TMA-O grain layout (O_D_BLOCK elements / chunk).
+                col_offset_const = (b * O_EPI_BLOCK_SIZE) % O_D_BLOCK
+                block_idx_const = (b * O_EPI_BLOCK_SIZE) // O_D_BLOCK
+                block_offset_const = block_idx_const * O_TMA_GRANU_ELEMS
+                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(O_D_BLOCK)
+                smem_ptr = sO_base.subview(smem_offset).data_ptr()
+                smem_ptr.store_swizzled(
+                    o_half,
+                    alignment=64,
+                    swizzle=_O_EPI_SWIZZLE,
+                )
+
+                # Per-128B-chunk arrive on TMA-STG.
+                if ((b + 1) * O_EPI_BLOCK_SIZE) % O_CHUNK_ELEMS == 0:
+                    chunk = (b * O_EPI_BLOCK_SIZE) // O_CHUNK_ELEMS
+                    nvvm.fence_proxy("async.shared", space="cta")
+                    bars.mb_tma_o_full[chunk].arrive()
+
+            # Write LSE — under cga2 each sg1 peer writes its half of O+LSE
+            # rows (leader = [0:128], peer = [128:256]).  Per-thread row.
+            q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + tid_in_wg
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: q_row_global is sequence-local; LSE is packed [1,QH,T] so
+                # index [0, head, cu_q[b] + local], bound by the per-sequence Q
+                # length S_q_b (NOT the total T) to skip straddle/padding rows.
+                _cu = cutlass.make_array_view(seq_kv_lens_tensor)
+                _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
+                _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
+                if cutlass.const_expr(lse_tensor is not None):
+                    if q_row_global < _s_q_b:
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
+                        lse_row[_cu_q_b + q_row_global] = lse
+            else:
+                if cutlass.const_expr(lse_tensor is not None):
+                    if q_row_global < seqlen_q:
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        lse_row = lse_arr[batch_idx, head_idx, :]
+                        lse_row[q_row_global] = lse
+
+        # End-of-tile: advance scheduler.
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+        nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+        nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_unmasked_lo = bounds_next.unmasked_lo
+            kv_unmasked_hi = bounds_next.unmasked_hi
+            kv_right = bounds_next.right
+
+    # End-of-kernel: trailing-arrive drain (sg0 only — sg1's late
+    # arrive_on_peer lands on a still-live mbar via this drain).  Per
+    # C++ lines 722-744: drain XFER_STAGES empty arrives + stats_xfer_empty
+    # before sg0 sm exits.
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        if is_sg0:
+            if is_lead_warp:
+                if nvvm.elect_sync():
+                    for _p in cutlass.range_constexpr(CFG.XFER_STAGES):
+                        bars.mb_p_xfer_empty[sg0_xfer_state.idx].wait(sg0_xfer_state.phase)
+                        bars.mb_alpha_xfer_empty[sg0_xfer_state.idx].wait(sg0_xfer_state.phase)
+                        sg0_xfer_state = advance(sg0_xfer_state, CFG.XFER_STAGES)
+                    bars.mb_stats_xfer_empty.wait(stats_xfer_empty_phase)
+            nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        # Each CTA's compute warp fires 1 elect-arrive_on_peer to its cga2
+        # partner → 1 arrive per CTA (init = ONE_LANE matches).
+        peer_cta = cta_id_x ^ cutlass.Int32(1)
+        bars.mb_tmem_dealloc.arrive_on_peer(peer_cta, pred=is_lead_warp & nvvm.elect_sync())
+
+
+# ============================================================================
+# MMA warp group — sg-conditional BMM1 (sg0 leader) / BMM2 (sg1 leader).
+# Port of C++ mma_warp_group (prefill_sdpa_d512_f16.cu:1033-1247).
+# ============================================================================
+@cute.jit
+def _mma_warp_group(
+    is_sg0,
+    is_sg1,
+    seqlen_q,
+    seqlen_kv,
+    sQ,
+    sK,
+    sV,
+    sP_xfer_raw,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    mcast_mask,
+    sg0_mcast_mask,
+    cta_in_pair,
+):
+    """MMA warp leader — sg-conditional BMM1 (sg0 leader) or BMM2 (sg1 leader).
+
+    sg0 leader (port of C++ lines 1101-1163):
+        For each tile: wait Q full, then for each kv iter: wait S_acc[parity]
+        empty (pre-armed at iter 0/1 via PipelineState(0, 1)), wait K[stage]
+        full, mma_ss(Q, K) → S_acc[parity] (collective N = TILE_M*CTA_MMA),
+        commit_mma on bmm1_done[parity] AND k_empty[stage] (P13 multicast,
+        sg0_mcast_mask).  After last BMM1: commit_mma on q_empty (multicast).
+
+    sg1 leader (port of C++ lines 1165-1246):
+        For each tile: if n_kv > 0: for each kv iter: arrive own
+        mb_p_xfer_full (own + DSMEM-forwarded from non-leader), wait
+        mb_p_xfer_full, wait V[stage] full, for each of BMM2_LOOP_N_BLOCKS=2
+        N-block calls: wait mb_bmm2_ready[parity*2+nblock], mma_ss(P, V) →
+        O_block (per-call N=256, advance V desc by BMM2_V_NBLOCK_ADVANCE),
+        commit bmm2_done[parity], v_empty[stage], p_xfer_empty[parity]
+        (P13 multicast with sg0_mcast_mask).
+        Empty-kv branch: wait mb_empty_mainloop, commit bmm2_done[parity].
+
+    Both leaders share the TMEM alloc + named-barrier publish:
+        tmem_alloc(576 cols, is_exclusive=True) → barrier_arrive(barrier_id=1,
+        count = 32 * (SOFTMAX_WG_WARPS + 1) = 160).  No barrier_id=2 here
+        (DSv4 has no separate correction-warp publish; correction is fused
+        into the compute warp group's sg1 branch).
+    """
+    # SM107 cap = 576 cols; is_exclusive=True enforced inside tmem_alloc wrapper.
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND, is_exclusive=True)
+    # Publish to compute warpgroup (waits on barrier_id=1 with count 160).
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WG_WARPS + 1))
+
+    # Do column arithmetic on raw Int8 ptr; retype at use site.  (Per
+    # cpp-to-ctm.md: make_tmem_ptr(addr, Float16) + N strides FP16 elems
+    # not columns — silent-wrong-result bug.)
+    tmem_raw = nvvm.make_tmem_ptr(tmem_ptr_i32.load(), cutlass.Int8)
+
+    # idesc M is COLLECTIVE (per-CTA M * CTA_MMA) under cga2.
+    idesc_qk = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_N,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+    )
+    # BMM2 idesc — N per call = 256 (NOT TILE_O); 2 calls per BMM2.
+    idesc_pv = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.BMM2_N_PER_CALL,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        b_major=1,
+    )
+    bmm1_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_N,
+        K=CFG.TILE_K,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=CFG.TILE_K_HW_BMM1,
+        btranspose=False,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_qk,
+        kind=MMA_KIND,
+    )
+    # BMM2 with N per call = 256, B-transpose, manual k-step driven by kernel.
+    bmm2_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.BMM2_N_PER_CALL,
+        K=CFG.TILE_N,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=CFG.TILE_K_HW_BMM2,
+        btranspose=True,
+        k_subtile=CFG.V_SWZ_BYTES // CFG.BPE,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_pv,
+        kind=MMA_KIND,
+    )
+
+    # Persistent-tile scheduler state.
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    # sg0 leader state (BMM1).
+    q_full_phase = cutlass.Int32(0)
+    kv_state_K = PipelineState.start(phase=0)
+    # pre-armed: PipelineState(0, 1) so iter-0/1 wait passes on fresh barriers.
+    s_acc_empty_state = PipelineState.start(phase=1)
+
+    # sg1 leader state (BMM2).
+    kv_state_V = PipelineState.start(phase=0)
+    sg1_mma_state = PipelineState.start(phase=0)
+    # bmm2_ready_state walks XFER_STAGES * N_BMM2_CHUNKS slots linearly
+    # (parity*2 + nblock); phase flips every XFER_STAGES*N_BMM2_CHUNKS arrives.
+    bmm2_ready_state = PipelineState.start(phase=0)
+    bmm2_done_prod_state = PipelineState.start(phase=0)
+    empty_mainloop_phase = cutlass.Int32(0)
+
+    # Pre-build a SmemTile wrapper for the P xfer ring (sg1 leader only — sg0
+    # builds its descriptor on its own SMEM, but for parity_cur lookup we use
+    # the same swizzle/layout that sg0 used when writing).  P xfer SMEM is
+    # TILE_M × TILE_N (cf. C++ P_Layout); matches Q swizzle (Swz128B for f16
+    # d=512).
+    sP_xfer = SmemTile(
+        base=sP_xfer_raw,
+        elems_per_stage=pXferElems,
+        stages=CFG.XFER_STAGES,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_P,
+        desc_version=1,
+    )
+
+    # BMM1 leader: desc_Q is tile-static (Q stays resident under d=512 / no Q∪K alias).
+    desc_Q = sQ[0].desc()
+    # BMM2 leader: V N-block advance in ELEMENTS (BMM2_V_NBLOCK_ADVANCE is bytes).
+    V_NBLOCK_ADVANCE_ELEMS = BMM2_V_NBLOCK_ADVANCE // CFG.BPE
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if is_sg0:
+            # ============================================================
+            # sg0 leader — BMM1: Q × K^T → S_acc[parity]
+            # ============================================================
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+                pass
+            else:
+                bars.mb_tma_q_full.wait(q_full_phase)
+                q_full_phase = q_full_phase ^ cutlass.Int32(1)
+
+                for _kv in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                    cur_parity_K = s_acc_empty_state.idx
+                    bars.mb_s_acc_empty[cur_parity_K].wait(s_acc_empty_state.phase)
+                    s_acc_empty_state = advance(s_acc_empty_state, CFG.XFER_STAGES)
+
+                    bars.mb_tma_k_full[kv_state_K.idx].wait(kv_state_K.phase)
+                    desc_K = sK[kv_state_K.idx].desc()
+                    # S_acc TMEM offset = parity * S_ACC_COLS (TmemTile layout).
+                    s_acc_off = cur_parity_K * cutlass.Int32(LAYOUT.S_ACC_COLS)
+                    mma_ss(bmm1_desc, desc_Q, desc_K, tmem_raw.subview(s_acc_off), accumulate=False)
+                    elect_p = nvvm.elect_sync()
+                    bars.mb_bmm1_done[cur_parity_K].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                    bars.mb_tma_k_empty[kv_state_K.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                    kv_state_K = advance(kv_state_K, CFG.STAGES_KV)
+
+                # After last BMM1: multicast Q-empty so both peers' TMA warps
+                # advance.  tcgen05.commit fires AFTER MMA drain (P13) so TMA
+                # can't overwrite Q SMEM mid-read.
+                bars.mb_tma_q_empty.arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=nvvm.elect_sync())
+        else:
+            # ============================================================
+            # sg1 leader — BMM2: P × V → O via mma_ss, 2 N-block calls
+            # ============================================================
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+                # Empty-kv branch — keep bmm2_done producer/consumer states
+                # in lockstep across mixed empty/normal sequences.
+                bars.mb_empty_mainloop.wait(empty_mainloop_phase)
+                empty_mainloop_phase = empty_mainloop_phase ^ cutlass.Int32(1)
+                bars.mb_bmm2_done[bmm2_done_prod_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=nvvm.elect_sync())
+                bmm2_done_prod_state = advance(bmm2_done_prod_state, CFG.XFER_STAGES)
+            else:
+                for kv_loop in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                    cur_parity = sg1_mma_state.idx
+
+                    # Leader's own arrive on mb_p_xfer_full[parity] (own
+                    # P-bytes were just delivered by cross-sg sg0 partner
+                    # via DSMEM bulk_copy).  Init = CTA_MMA arrives — this
+                    # contributes 1, the non-leader forwarder contributes
+                    # the other 1 (P12).
+                    bars.mb_p_xfer_full[cur_parity].arrive(n_bytes=pXferBytes, pred=nvvm.elect_sync())
+                    bars.mb_p_xfer_full[cur_parity].wait(sg1_mma_state.phase)
+                    sg1_mma_state = advance(sg1_mma_state, CFG.XFER_STAGES)
+
+                    bars.mb_tma_v_full[kv_state_V.idx].wait(kv_state_V.phase)
+
+                    accum_b2 = kv_loop > kv_left
+
+                    # Rebuild SmemDescs for this iter's P parity and V stage.
+                    desc_P = sP_xfer[cur_parity].desc()
+                    desc_V_n0 = sV[kv_state_V.idx].desc()
+                    desc_V_n1 = sV[kv_state_V.idx].shifted(V_NBLOCK_ADVANCE_ELEMS).desc()
+
+                    # N-block 0: writes O TMEM cols [0..BMM2_N_PER_CALL).
+                    bars.mb_bmm2_ready[bmm2_ready_state.idx].wait(bmm2_ready_state.phase)
+                    bmm2_ready_state = advance(bmm2_ready_state, CFG.XFER_STAGES * CFG.N_BMM2_CHUNKS)
+                    mma_ss(bmm2_desc, desc_P, desc_V_n0, tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF)), accumulate=accum_b2)
+
+                    # N-block 1: writes O TMEM cols [BMM2_N_PER_CALL..TILE_O).
+                    bars.mb_bmm2_ready[bmm2_ready_state.idx].wait(bmm2_ready_state.phase)
+                    bmm2_ready_state = advance(bmm2_ready_state, CFG.XFER_STAGES * CFG.N_BMM2_CHUNKS)
+                    mma_ss(bmm2_desc, desc_P, desc_V_n1, tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF + CFG.BMM2_N_PER_CALL)), accumulate=accum_b2)
+
+                    elect_p = nvvm.elect_sync()
+                    bars.mb_bmm2_done[bmm2_done_prod_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                    bars.mb_tma_v_empty[kv_state_V.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                    # P13 multicast on mb_p_xfer_empty — sg0_mcast_mask
+                    # (= 0x3) targets BOTH sg0 CTAs so sg0 sm's next P
+                    # slot reuse is unblocked.
+                    bars.mb_p_xfer_empty[cur_parity].arrive(mcast_mask=sg0_mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                    kv_state_V = advance(kv_state_V, CFG.STAGES_KV)
+                    bmm2_done_prod_state = advance(bmm2_done_prod_state, CFG.XFER_STAGES)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+
+    # End-of-warp tmem_dealloc — wait fan-in from both compute warps then free.
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+# ============================================================================
+# MMA warp non-leader paths — sg0 minimal quiet vs sg1 P12 forwarder.
+# Port of C++ mma_warp_group non-leader paths (prefill_sdpa_d512_f16.cu:1048-1093).
+# ============================================================================
+@cute.jit
+def _mma_warp_non_leader(
+    is_sg0,
+    is_sg1,
+    seqlen_q,
+    seqlen_kv,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    cta_in_pair,
+    leader_cta_id,
+):
+    """sg0 non-leader: minimal quiet (alloc + wait dealloc + free).
+    sg1 non-leader: persistent loop forwarding mb_p_xfer_full to leader (P12).
+
+    sg0 quiet (port of C++ lines 1049-1054):
+        Just participates in TMEM alloc + named-barrier publish (sm warps
+        read the published base ptr from peer's TMEM under cga2 collective
+        MMA), then waits on mb_tmem_dealloc and frees.
+
+    sg1 forwarder (port of C++ lines 1055-1093):
+        Persistent tile loop — at iter scope, per kv_local:
+          - arrive(mb_p_xfer_full[parity], P_XFER_TILE_BYTES, elect) — local mbar
+          - wait(mb_p_xfer_full[parity], nlmma_state.phase) — local mbar
+          - arrive_on_peer(mb_p_xfer_full[parity], leader_cta_id) — DSMEM forward
+        Required because BMM2's collective mma_ss reads BOTH peers' P SMEM via
+        crossbar; leader's local mbar only sees its own cross-sg sg0 partner's
+        bytes, so non-leader must DSMEM-arrive on leader after observing own bytes.
+    """
+    # All-lanes warp-collective tmem_alloc (no elect_sync gating).
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND, is_exclusive=True)
+    # Match leader's named-barrier arrive count (lead is +1 on barrier_id=1).
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WG_WARPS + 1))
+
+    # sg0 non-leader is quiet (just wait dealloc); sg1 non-leader runs the
+    # persistent P12 forwarder loop.  `return` is forbidden inside @cute.jit
+    # (CTM gotcha), so we gate the forwarder on `is_sg1` and let both arms
+    # fall through to the shared dealloc wait + free at the bottom.
+    if is_sg1:
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+            sched.bidx_init,
+            sched.bidy_init,
+            sched.bidz_init,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = cutlass.Int32(1)
+        sched_state = PipelineState.start()
+
+        if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+            kv_left = cutlass.Int32(0)
+            kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+        else:
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_init.left
+            kv_right = bounds_init.right
+
+        nlmma_state = PipelineState.start(phase=0)
+
+        while is_valid_tile > cutlass.Int32(0):
+            read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+                pass
+            else:
+                for _kv in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                    # Arm own expect_tx for P-bytes delivered by cross-sg sg0
+                    # partner (via DSMEM bulk_copy).  Wait local mbar
+                    # (init = ONE_LANE — own arrive only).
+                    bars.mb_p_xfer_full[nlmma_state.idx].arrive(n_bytes=pXferBytes, pred=nvvm.elect_sync())
+                    bars.mb_p_xfer_full[nlmma_state.idx].wait(nlmma_state.phase)
+                    cur_parity = nlmma_state.idx
+                    nlmma_state = advance(nlmma_state, CFG.XFER_STAGES)
+                    # DSMEM-arrive on leader's mb_p_xfer_full[parity] — leader's
+                    # init = CTA_MMA (own + this forwarded arrive), so wait
+                    # flips only when both peers' bytes have landed (P12).
+                    bars.mb_p_xfer_full[cur_parity].arrive_on_peer(leader_cta_id, pred=nvvm.elect_sync())
+
+            nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+            wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+            nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+            nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+            nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+            q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+                nxt_q,
+                nxt_hb,
+                cta_in_pair,
+                n_q_supers,
+                n_qh,
+                n_batch,
+                seq_kv_lens_tensor,
+            )
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+            sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+                eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+                bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+                kv_left = bounds_next.left
+                kv_right = bounds_next.right
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+# ============================================================================
+# TMA-LDG warp group — sg-conditional Q+K (sg0) or V (sg1).
+# Port of C++ tmaldg_warp_group (prefill_sdpa_d512_f16.cu:1254-1399).
+# ============================================================================
+@cute.jit
+def _tmaldg_warp_group(
+    is_sg0,
+    is_sg1,
+    tma_q_desc,
+    tma_k_desc,
+    tma_v_desc,
+    sQ,
+    sK,
+    sV,
+    bars,
+    sched,
+    seqlen_q,
+    seqlen_kv,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    qh_per_kh,
+    is_leader,
+    cta_in_pair,
+    tma_mcast_mask,
+):
+    """sg0: Q + K TMA-LDG.  sg1: V TMA-LDG.
+
+    Both sgs decode the persistent-tile scheduler payload.  Leader of each
+    pair issues expect_tx for the collective TMA byte count; both peers
+    issue the cta_group::2 multicast TMA (mcast_mask bits = bit_per_peer).
+
+    sg0 (port of C++ lines 1265-1338):
+        Per tile, if n_kv > 0:
+            wait(q_empty, q_empty_phase); leader arrive_expect_tx(q_full, qBytes);
+            tma_load_tile(sQ[0], q_gmem, q_full, multicast).
+            For each kv:
+              wait(k_empty[stage]); leader arrive_expect_tx(k_full[stage], kBytes);
+              tma_load_tile(sK[stage], k_gmem(kv * TILE_N + k_row_off), k_full, multicast).
+        q_empty pre-armed via q_empty_state=1 (iter-0 wait passes on phase 0 != 1).
+
+    sg1 (port of C++ lines 1339-1397):
+        Per tile, if n_kv > 0, per kv:
+          wait(v_empty[stage]); leader arrive_expect_tx(v_full[stage], vBytes);
+          tma_load_tile(sV[stage], v_gmem(v_col_off + cta_in_pair * (TILE_O/CTA_MMA) * BPE,
+                                        kv * TILE_N), v_full, multicast).
+        Note: C++ uses BYTE coord for V because UINT8 TMA descriptors; CTM's
+        typed descriptor uses ELEMENT coord — so multiply only when descriptor
+        is UINT8.  Current CTM descriptors are element-typed, so plain cta_in_pair *
+        (TILE_O/CTA_MMA) suffices.
+
+    Both sgs drain trailing K/V/Q empty arrives at end-of-kernel under cga2.
+    """
+    q_empty_phase = cutlass.Int32(1)  # pre-armed (iter-0 wait passes)
+    kv_state = PipelineState.start(phase=1)
+
+    tma_q = GmemTileTma(tma_q_desc)
+    tma_k = GmemTileTma(tma_k_desc)
+    tma_v = GmemTileTma(tma_v_desc)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+    q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    # Per-peer K row offset (sg0 only — sg1's V offset is along d_v).
+    K_ROW_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_N // CFG.CTA_MMA)
+    # Per-peer V d_v offset (sg1 only — sg0's K offset is along seq).
+    V_COL_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_O // CFG.CTA_MMA)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        # n_kv > 0 gate at MASK_NONE collapses to "always" since kv_right > 0.
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+            pass
+        else:
+            if is_sg0:
+                # ---- sg0: Q (one-shot per tile) + K_ring ----------------
+                bars.mb_tma_q_empty.wait(q_empty_phase)
+                q_empty_phase = q_empty_phase ^ cutlass.Int32(1)
+                bars.mb_tma_q_full.arrive(n_bytes=qTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                tma_load_tile(
+                    sQ[0],
+                    tma_q(cutlass.Int32(0), head_idx, q_row_base + q_seq_off, tma_batch),
+                    bars.mb_tma_q_full.smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=None,
+                )
+
+                for kv_loop in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                    kv_row_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+                    bars.mb_tma_k_empty[kv_state.idx].wait(kv_state.phase)
+                    bars.mb_tma_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                    tma_load_tile(
+                        sK[kv_state.idx],
+                        tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
+                        bars.mb_tma_k_full[kv_state.idx].smem_ptr,
+                        cta_group=CFG.CTA_MMA,
+                        mcast_mask=None,
+                    )
+                    kv_state = advance(kv_state, CFG.STAGES_KV)
+            else:
+                # ---- sg1: V_ring only -----------------------------------
+                # V split along d_v: per-CTA inner = TILE_O / CTA_MMA.  CTM
+                # TMA descriptors are element-typed so the per-peer offset
+                # is in elements (NOT bytes — C++ uses bytes because its
+                # TMA descriptors are UINT8-typed).
+                for kv_loop in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                    kv_row_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+                    bars.mb_tma_v_empty[kv_state.idx].wait(kv_state.phase)
+                    bars.mb_tma_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                    tma_load_tile(
+                        sV[kv_state.idx],
+                        tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
+                        bars.mb_tma_v_full[kv_state.idx].smem_ptr,
+                        cta_group=CFG.CTA_MMA,
+                        mcast_mask=None,
+                    )
+                    kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+        nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+        nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+        q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+
+    # cga2: drain trailing K/V/Q empty arrives so SMEM isn't torn down while
+    # leader's multicast commits are still in-flight.
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        if is_sg0:
+            for _ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_tma_k_empty[kv_state.idx].wait(kv_state.phase)
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+            bars.mb_tma_q_empty.wait(q_empty_phase)
+        else:
+            for _ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_tma_v_empty[kv_state.idx].wait(kv_state.phase)
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+
+# ============================================================================
+# TMA-STG warp — sg1 only: O TMA store + LSE write back.
+# Port of C++ tmastg_warp_group (prefill_sdpa_d512_f16.cu:1406-1467).
+# ============================================================================
+@cute.jit
+def _tmastg_warp_group(
+    is_sg1,
+    tma_o_desc,
+    sO,
+    bars,
+    sched,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    cta_in_pair,
+    seq_kv_lens_tensor,
+    o_desc_words,
+):
+    """sg1: persistent O-store + per-chunk mb_tma_o_empty drain.
+
+    sg0 TMASTG (port of C++ lines 1417-1428): idle — just spin scheduler so
+    persistent tile claims advance in lockstep with sg1.  Does NOT call
+    read_tile_id_arrive (per the READ_TILE_ARRIVERS = 25 derivation — sg0's
+    TMASTG slot is NOT in the arriver list).
+
+    sg1 TMASTG (port of C++ lines 1430-1467):
+        Per tile:
+          - read_tile_id_arrive on the scheduler's read_tile_id mbar.
+          - For each chunk c in [0, N_O_CHUNKS):
+              wait(mb_tma_o_full[c], epilogue_state).
+          - tma_store_tile(sO[0], o_gmem(0, q_row_coord, head_idx, batch_idx)).
+          - tma_store_commit; tma_store_wait(0).
+          - arrive(mb_tma_o_empty).
+          - Flip epilogue_state.
+    """
+    o_full_phase = cutlass.Int32(0)
+
+    tma_o = GmemTileTma(tma_o_desc)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        # sg0's TMA-STG slot is idle but spins the scheduler so persistent
+        # tile claims advance in lockstep with sg1.  sg0 does NOT call
+        # read_tile_id_arrive (per the READ_TILE_ARRIVERS=25 derivation —
+        # sg0's TMA-STG slot is intentionally NOT in the arriver list).
+        if is_sg1:
+            read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+            # Wait every chunk of O ready.
+            for chunk in cutlass.range_constexpr(N_O_CHUNKS):
+                bars.mb_tma_o_full[chunk].wait(o_full_phase)
+
+            # Both sg1 peers issue the O TMA store with their own q_row_coord —
+            # cga2 splits C along M, so leader writes rows [0:128] and peer
+            # writes [128:256].
+            q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: store through this batch's pre-built descriptor (base
+                # already at the sequence's packed row, seq extent = S_q_b so a
+                # box past S_q_b is OOB-clipped → free last-tile predication).
+                # q_row_coord is sequence-local; batch coord collapses to 0.
+                o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_coord, cutlass.Int32(0))
+                tma_store_tile(sO[0], o_slice)
+            else:
+                tma_store_tile(
+                    sO[0],
+                    tma_o(cutlass.Int32(0), head_idx, q_row_coord, batch_idx),
+                )
+            tma_store_commit()
+            tma_store_wait(0)
+
+            bars.mb_tma_o_empty.arrive()
+            nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+            o_full_phase = o_full_phase ^ cutlass.Int32(1)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+
+# ============================================================================
+# Host launcher.
+# ============================================================================
+@cute.jit
+def _host(
+    q_tensor: cute.Tensor,
+    k_tensor: cute.Tensor,
+    v_tensor: cute.Tensor,
+    o_tensor: cute.Tensor,
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    problem_size: Tuple[int, int, int, int, int, int],
+    scale_softmax_log2: cutlass.Float32,
+    n_thd_units: cutlass.Int32,
+    # FROST passes the dense padded-Q trim tensor POSITIONALLY on every call.
+    # These kernels have no Q-trim epilogue (Capabilities.dense_seq_q_trim=False)
+    # so it is accepted and unused -- but the SLOT is mandatory: without it the
+    # adapter's 12th positional lands on `stream` and execute dies with
+    # "got multiple values for argument 'stream'".
+    seq_q_lens_tensor: Optional[cute.Tensor] = None,
+    # FROST plans must run on the caller's stream (engine contract; there is a
+    # dedicated stream-respect test).  Threaded exactly as the shipped
+    # prefill_d128_fp8_sm107.py sibling does.
+    stream: _cuda_driver.CUstream = None,
+) -> None:
+    B, QH, KH, SQ, SKV, _ = problem_size
+
+    # Tensors are [B, S, H, D] with stride_order=(3, 2, 1, 0); D is fastest.
+    # Under cga2 K is split along seq (per-CTA box rows are TILE_N / CTA_MMA),
+    # V is split along d_v (per-CTA inner is TILE_O / CTA_MMA).  O's TMA box
+    # inner follows O's swizzle, NOT V's (V may drop to narrower under cga2).
+    _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE_O
+    qk_box_q = (1, CFG.TILE_M, 1, TMA_QK_GRANU_ELEMS)
+    qk_box_k = (1, CFG.TILE_N // CFG.CTA_MMA, 1, TMA_QK_GRANU_ELEMS)
+    vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M, 1, _O_GRANU_ELEMS)
+    stride_order = (3, 2, 1, 0)
+
+    def _tma_swz(byte_w: int):
+        return tmap.TensorMapSwizzle.s128b if byte_w == 128 else tmap.TensorMapSwizzle.s64b if byte_w == 64 else tmap.TensorMapSwizzle.s32b
+
+    tma_q_desc = tmap.create_tensor_map_tiled_from_view(
+        q_tensor,
+        box_dims=qk_box_q,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.Q_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_k_desc = tmap.create_tensor_map_tiled_from_view(
+        k_tensor,
+        box_dims=qk_box_k,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.K_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    # V TMA: TF32 transposed BMM2 operand needs SWIZZLE_128B_ATOM_32B (same box).
+    _v_tma_swz = tmap.TensorMapSwizzle.s128b_atom_32b if IS_TF32 else _tma_swz(CFG.V_SWZ_BYTES)
+    tma_v_desc = tmap.create_tensor_map_tiled_from_view(
+        v_tensor,
+        box_dims=vo_box_v,
+        stride_order=stride_order,
+        swizzle=_v_tma_swz,
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_o_desc = tmap.create_tensor_map_tiled_from_view(
+        o_tensor,
+        box_dims=vo_box_o,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.O_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+
+    # Each cluster (CGA_M = 4 CTAs; CTA_MMA = 2 sg pairs collectively share Q)
+    # covers CGA_TILE_M = TILES_Q * TILE_M * CTA_MMA = 256 Q rows.  grid_x
+    # must scale by CGA_M (cluster x-dim) so the cluster shape divides the
+    # grid — for non-dsv4 flavors CGA_M == CTA_MMA and this collapses to the
+    # historical formula.  Mirrors C++ runner
+    # (the pre-upstream host runner).
+    rows_per_cluster = CGA_TILE_M
+    q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
+    grid_q_supers = q_clusters * CFG.CGA_M
+    # n_q_supers passed to kernel is the LOGICAL q-tile count (not the grid x
+    # span).  For SCHED_LPT it's `q_clusters * CTA_MMA` (each cluster owns
+    # CTA_MMA rows of distinct q_super_idx values); for NATURAL the kernel
+    # reads bidx directly so this value is unused.
+    q_supers = q_clusters * CFG.CTA_MMA
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD: (1) build the per-batch O descriptor array in a separate device
+        # call (reuses tma_o_desc — built over the packed [1,T,QH,D_v] O — as the
+        # base), then (2) launch with the EXACT flat batch-outermost grid.  The
+        # cluster-head unit count (Σ_b ceil(S_q_b/CGA_TILE_M) * QH) depends on
+        # cu_seqlens, so it is host-computed and passed as n_thd_units;
+        # grid_x = n_thd_units * CGA_M (CGA_M CTAs per cluster).
+        _build_thd_meta_o_descs_kernel(
+            o_tensor,
+            tma_o_desc,
+            o_desc_words,
+            seq_kv_lens_tensor,
+            cutlass.Int32(QH),
+            cutlass.Int32(B),
+            cutlass.Int32(CFG.TILE_O),
+        ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
+        grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
+    else:
+        grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
+    _kernel(
+        tma_q_desc,
+        tma_k_desc,
+        tma_v_desc,
+        tma_o_desc,
+        lse_tensor,
+        sinks_tensor,
+        seq_kv_lens_tensor,
+        o_desc_words,
+        cutlass.Int32(SQ),
+        cutlass.Int32(SKV),
+        cutlass.Int32(q_supers),
+        cutlass.Int32(QH),
+        cutlass.Int32(B),
+        cutlass.Int32(QH // KH),
+        scale_softmax_log2,
+    ).launch(
+        # cluster = (CGA_M, CGA_N, 1) = (4, 1, 1) under dsv4.
+        grid=grid_shape,
+        block=[CFG.THREADS_PER_CTA, 1, 1],
+        cluster=(CFG.CGA_M, CFG.CGA_N, 1),
+        stream=stream,
+    )
+
+
+@lru_cache(maxsize=None)
+def compile(  # noqa: A001
+    b: int = 1,
+    qh: int = 1,
+    kh: int = 1,
+    sq: int = 256,
+    skv: int = 128,
+    d_qk: int = CFG.TILE_K,
+    d_v: int = CFG.TILE_O,
+    has_lse: bool = True,
+    lse_stride: Optional[tuple] = None,
+) -> Callable:
+    """Compile a kernel with ALL dims concrete to pin TMA descriptor strides at compile time.
+
+    THD/varlen: q/k/v/o/lse are PACKED with a batch dim of 1 ([1,T,H,D]), while
+    ``b`` carries the LOGICAL batch (number of sequences) that drives n_batch /
+    the decode loop / the metadata + O-descriptor-array sizes.  Non-THD: the
+    tensor batch dim == b as before."""
+    # THD/varlen is NOT ported for this kernel yet.  The setup-kernel call site
+    # below still speaks the pre-upstream 7-arg contract, while FROST's
+    # thd_helpers.build_thd_meta_o_descs_kernel takes 14 args and a different
+    # metadata layout (4B+4 with batch_remap + a claim counter, vs the 3B+2
+    # here), and the scheduler decode differs to match.  Raise here rather than
+    # let it fail as an arity error deep in the trace -- and so no engine row
+    # can advertise thd=True for this kernel and appear to work.  The dense
+    # path is unaffected: CFG.THD_VARLEN is 0 and every THD branch folds out.
+    if CFG.THD_VARLEN:
+        raise NotImplementedError(f"{__name__}: THD/varlen not ported to the FROST setup-kernel contract")
+    # ---- FROST adapter ABI ------------------------------------------------
+    # lower_dsl_prefill calls EVERY kernel with the full forward signature.
+    # This body carries only what the port brought over, so anything
+    # it cannot honor RAISES rather than being silently ignored: a raise here
+    # means the engine's Capabilities row is lying, which is the failure we
+    # want loud.  (Capabilities: lse_optional=False, no strided Stats.)
+    if lse_stride is not None:
+        raise NotImplementedError(f"{__name__}: strided Stats not ported (contiguous [B, H, S] only)")
+    if d_qk > CFG.TILE_K or d_v > CFG.TILE_O or d_qk <= 0 or d_v <= 0:
+        raise ValueError(f"{__name__}: envelope is 0 < d_qk <= {CFG.TILE_K}, 0 < d_v <= {CFG.TILE_O}; " f"got ({d_qk}, {d_v})")
+    _fake_batch = 1 if CFG.THD_VARLEN else b
+    fake_q = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, sq, qh, d_qk),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_k = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, d_qk),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_v = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, d_v),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_o = cute.runtime.make_fake_compact_tensor(
+        OUT_STORAGE_DTYPE,
+        (_fake_batch, sq, qh, d_v),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    # has_lse=False (no Stats output): the LSE argument is None-specialized and
+    # the store is compiled out entirely -- no dummy buffer exists at any level,
+    # which is what lets the dense graph report get_workspace_size() == 0.
+    # Mirrors the shipped prefill_d128_fp8_sm107.py.
+    fake_lse = (
+        cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (_fake_batch, qh, sq),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
+        if has_lse
+        else None
+    )
+    fake_sinks = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (qh,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # THD overloads seq_kv_lens as the [seq_kv_lens(B) | cu_q(B+1) | cu_k(B+1)]
+    # metadata buffer (length 3B+2); non-THD keeps the [B] per-batch-lens slot.
+    _skv_len = (3 * b + 2) if CFG.THD_VARLEN else b
+    fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (_skv_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # Per-batch O TMA-descriptor array (16 int64 = 128 B each) + one slot of
+    # alignment pad.  Dummy 1-elem when THD is off (kernel never reads it).
+    _odesc_len = (b * _TENSOR_MAP_QWORDS + _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
+    fake_o_desc = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int64,
+        (_odesc_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    return cute.compile(
+        _host,
+        fake_q,
+        fake_k,
+        fake_v,
+        fake_o,
+        fake_lse,
+        fake_sinks,
+        fake_seq_kv_lens,
+        fake_o_desc,
+        (b, qh, kh, sq, skv, 0),
+        cutlass.Float32(0.0),
+        cutlass.Int32(0),
+        stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
+        options="--enable-tvm-ffi",
+    )

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d512_f16_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d512_f16_sm107.py
@@ -5,10 +5,10 @@
 
 THD / varlen (``CFG.THD_VARLEN=1``, the pre-upstream packed-varlen entry point) is supported (f16/bf16): packed ``[1,T,H,D]``
 Q/K/V + per-sequence ``cu_seqlens`` coord offset, per-batch O TMA-descriptor
-array (shared ``kernels/ctm/common/sdpa/thd.py``), flat batch-outermost grid,
+array (the shared pre-upstream THD helper), flat batch-outermost grid,
 packed ``[1,QH,T]`` LSE.  The dense ``[B,S,H,D]`` path is byte-identical.
 
-CTM-DSL Python port of the C++ Rubin baseline
+Python port (from the pre-upstream DSL) of the C++ Rubin baseline
 ``kernels/c++/sm107/sdpa/prefill/prefill_sdpa_d512_f16.cu`` — same kernel,
 different language.  Pipeline shape, TMEM/SMEM layout, barrier inventory,
 scheduler, warp dispatch, and register split mirror the C++ source 1:1.
@@ -36,7 +36,7 @@ P12 / P13 patterns (cf. mbarrier-patterns.md, also project memory):
     tcgen05.commit.cta_group::2.multicast with sg0_mcast_mask (= 0x3) so
     BOTH sg0 CTAs see one arrive — pre-armed via PipelineState(0, 1).
 
-CTM-only adjustments applied (per cpp-to-ctm.md):
+DSL-only adjustments applied (per the C++-to-DSL porting notes):
   - is_exclusive=True on tmem_alloc (SM107 >512-col TMEM).
   - tile_id_smem stride 8 Int32/stage.
   - cga_arrive/wait wrapped with relaxed=True (per project memory:
@@ -150,7 +150,7 @@ from cudnn.frost.tile_dsl.mask import (
 
 # Reuse sm107 SDPA pipeline-shared helpers (KvLoopBounds + closures factory).
 # Note: dsv4 forks Bars in this file (NOT imported from _sdpa_common) per the
-# per-pipeline fork pattern in cpp-to-ctm.md.
+# per-pipeline fork pattern in the C++-to-DSL porting notes.
 from cudnn.sdpa.fwd.kernels._common_sm100 import (
     KvLoopBounds,
     compute_kv_loop_bounds,
@@ -221,7 +221,7 @@ CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
 
 # ----------------------------------------------------------------------------
 # Softmax-body constants — module-level so the top-level @cute.jit helper
-# `_sg0_softmax_kv_iter` can read them without a closure capture (CTM-DSL
+# `_sg0_softmax_kv_iter` can read them without a closure capture (pre-upstream DSL
 # forbids closures inside @cute.jit traced under dynamic control flow).
 # ----------------------------------------------------------------------------
 # P SMEM layout helpers (TILE_M=128 rows × TILE_N=128 cols, Swz128B).
@@ -484,7 +484,7 @@ _resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
 
 # THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
 # factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
-# kernels/ctm/common/sdpa/thd.py.  Gated by CFG.THD_VARLEN (folds out otherwise).
+# the shared pre-upstream THD helper.  Gated by CFG.THD_VARLEN (folds out otherwise).
 # seq_kv_lens overloaded as the THD metadata buffer (int32 len 3B+2):
 #   [0..B-1]=seq_kv_lens  [B..2B]=cu_q(B+1)  [2B+1..3B+1]=cu_k(B+1)
 from cudnn.sdpa.fwd.kernels.thd_helpers import build_thd_meta_o_descs_kernel as _build_thd_meta_o_descs_kernel, TENSOR_MAP_QWORDS
@@ -638,7 +638,7 @@ def _kernel(
     mcast_mask = (cutlass.Int32(3) << leader_cta_id) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
     # sg0_mcast_mask = 0x3 — both sg0 CTAs (used by sg1 leader's P13 multicast on mb_p_xfer_empty).
     sg0_mcast_mask = cutlass.Int32(0x3)
-    # TMA-load self-bit mask: per cga2-mma.md / DKG `fp16_gemm_3.py`, each
+    # TMA-load self-bit mask: per cga2-mma.md and a reference fp16 GEMM sample, each
     # peer's `cta_group::2` TMA targets ITS OWN cluster bit (= cta_id_x);
     # cga2 routing strips bit-24 so bytes land on the cga2 pair leader's
     # mbar.  Use cluster-rank (cta_id_x), NOT pair-rank (cta_in_pair) — for
@@ -869,7 +869,7 @@ def _kernel(
 # (HW max can't observe -inf written by the mask after the load).
 #
 # Top-level @cute.jit so the dynamic call-graph contains no closure-capture
-# violations (CTM-DSL forbids closures under dynamic control flow).  All
+# violations (the pre-upstream DSL forbids closures under dynamic control flow).  All
 # kernel-local vars are passed as explicit args; constants come from
 # module-level (NEG_INF_F32, RESCALE_THRESHOLD_F32, P_*, SOFTMAX_*, etc.).
 # ============================================================================
@@ -1011,13 +1011,13 @@ def _sg0_softmax_kv_iter(
 
     # DSMEM bulk_copy alpha + P → cross-sg sg1 peer's SMEM, firing peer's
     # mb_alpha_xfer_full + mb_p_xfer_full.  PREDICATED form: emit `@p
-    # cp.async.bulk` (matches C++'s uniform `@UP0 UBLKCP`) instead of an
+    # cp.async.bulk` (matches the C++ reference's uniform predicated form) instead of an
     # `if is_lead_warp: if elect_sync():` branch — that branch lowers to a
     # warp-divergent BSSY/BSYNC + reconverge that also poisons ptxas's uniform
     # analysis of nearby mbar waits (measured: removing the ship branches flips
     # ~5 SYNCS.PHASECHK → USYNCS and is worth ~+12% on dsv4 d512).  All 128
     # lanes compute the cheap mapa addresses up-front; only the lead warp's
-    # elected lane issues the UBLKCPs under ship_pred.
+    # elected lane issues the bulk copies under ship_pred.
     ship_pred = is_lead_warp & nvvm.elect_sync()
     local_alpha_src = sAlpha_xfer_raw.subview(cur_parity_S * cutlass.Int32(CFG.TILE_M))
     peer_alpha_dst = nvvm.mapa(local_alpha_src, cross_sg_peer, addrspace=7)
@@ -1332,7 +1332,7 @@ def _compute_warp_group(
             nvvm.barrier_cta_sync(barrier_id=8, thread_count=128)
 
             # Predicated stats ship — same rationale as the per-iter alpha/P
-            # ship above (`@p UBLKCP`, no warp-divergent branch).
+            # ship above (predicated, no warp-divergent branch).
             ship_pred = is_lead_warp & nvvm.elect_sync()
             peer_stats_dst = nvvm.mapa(sStats_xfer_raw, cross_sg_peer, addrspace=7)
             peer_stats_full_mbar = nvvm.mapa(bars.mb_stats_xfer_full.smem_ptr, cross_sg_peer, addrspace=7)
@@ -1670,7 +1670,7 @@ def _mma_warp_group(
     nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WG_WARPS + 1))
 
     # Do column arithmetic on raw Int8 ptr; retype at use site.  (Per
-    # cpp-to-ctm.md: make_tmem_ptr(addr, Float16) + N strides FP16 elems
+    # C++-to-DSL porting notes: make_tmem_ptr(addr, Float16) + N strides FP16 elems
     # not columns — silent-wrong-result bug.)
     tmem_raw = nvvm.make_tmem_ptr(tmem_ptr_i32.load(), cutlass.Int8)
 
@@ -1933,7 +1933,7 @@ def _mma_warp_non_leader(
 
     # sg0 non-leader is quiet (just wait dealloc); sg1 non-leader runs the
     # persistent P12 forwarder loop.  `return` is forbidden inside @cute.jit
-    # (CTM gotcha), so we gate the forwarder on `is_sg1` and let both arms
+    # (DSL gotcha), so we gate the forwarder on `is_sg1` and let both arms
     # fall through to the shared dealloc wait + free at the bottom.
     if is_sg1:
         q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
@@ -2053,9 +2053,9 @@ def _tmaldg_warp_group(
           wait(v_empty[stage]); leader arrive_expect_tx(v_full[stage], vBytes);
           tma_load_tile(sV[stage], v_gmem(v_col_off + cta_in_pair * (TILE_O/CTA_MMA) * BPE,
                                         kv * TILE_N), v_full, multicast).
-        Note: C++ uses BYTE coord for V because UINT8 TMA descriptors; CTM's
+        Note: C++ uses BYTE coord for V because UINT8 TMA descriptors; the DSL's
         typed descriptor uses ELEMENT coord — so multiply only when descriptor
-        is UINT8.  Current CTM descriptors are element-typed, so plain cta_in_pair *
+        is UINT8.  Current DSL descriptors are element-typed, so plain cta_in_pair *
         (TILE_O/CTA_MMA) suffices.
 
     Both sgs drain trailing K/V/Q empty arrives at end-of-kernel under cga2.
@@ -2132,7 +2132,7 @@ def _tmaldg_warp_group(
                     kv_state = advance(kv_state, CFG.STAGES_KV)
             else:
                 # ---- sg1: V_ring only -----------------------------------
-                # V split along d_v: per-CTA inner = TILE_O / CTA_MMA.  CTM
+                # V split along d_v: per-CTA inner = TILE_O / CTA_MMA.  the pre-upstream DSL
                 # TMA descriptors are element-typed so the per-peer offset
                 # is in elements (NOT bytes — C++ uses bytes because its
                 # TMA descriptors are UINT8-typed).

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d512_fp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d512_fp8_sm107.py
@@ -93,6 +93,23 @@ from cudnn.sdpa.fwd.config_sm107 import TemplateParams, make_cfg_d512
 
 PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
 CFG, _TMA = make_cfg_d512(PARAMS)
+
+# tcgen05 SMEM-descriptor version for EVERY SmemTile in this module -- ONE
+# decision point, wired into every construction below rather than repeated as a
+# per-tile literal.  A version-0 descriptor's ``start_address`` is 14 bits = a
+# 256 KiB window; Rubin raises the per-CTA SMEM cap to 327 KiB, and THIS flavor
+# crosses the line (the d512 slabs put the P transfer ring at exactly 262144),
+# so a version-0 descriptor would wrap to offset 0 and the MMA would multiply
+# whatever sits at the bottom of SMEM -- the accumulator comes out EXACTLY
+# zero, or the SF columns come back as data bytes (LSE = +inf, O = NaN).  No
+# crash either way.  Matches what C++ SmemTile::make_desc always emitted.
+#
+# Do NOT re-literal this at a call site: this kernel's MXFP8 sibling shipped
+# NaN on 100% of cells because its scale-factor tiles were declared UNDER a
+# comment claiming "every operand tile here carries desc_version=1" -- without
+# the kwarg.  A single constant makes that class of drift impossible, and
+# test_sm107_descriptor_version_matches_the_smem_budget asserts it.
+DESC_VERSION: int = 1
 Cfg = type(CFG)
 TMA_QK_ITERS = _TMA.QK_ITERS
 TMA_VO_ITERS = _TMA.VO_ITERS
@@ -586,12 +603,12 @@ def _kernel(
     # LSE staging on sg1 (sub-tile write-back from corr; cf. C++ line 198).
     sLSE_raw = cutlass.Array(cutlass.Float32, CFG.TILE_M, alignment=128, space=cutlass.AddressSpace.smem)
 
-    # Typed SmemTile handles.
-    # Rubin SM107 raises the per-CTA SMEM cap to 327 KiB, so an MMA-operand
-    # buffer can land at or above 256 KiB — past what a version-0 tcgen05 SMEM
-    # descriptor can address (14-bit start_address).  Every operand tile here
-    # therefore carries desc_version=1, matching what C++ SmemTile::make_desc
-    # always emitted.  See tile_dsl/handles.py SmemTile.desc_version.
+    # Typed SmemTile handles.  EVERY tile takes the module-level DESC_VERSION
+    # (= 1 here) -- see its declaration for why that is one constant and not a
+    # per-tile literal.  The short version: Rubin raises the per-CTA SMEM cap
+    # to 327 KiB, so a buffer can land past the 256 KiB a version-0 tcgen05
+    # descriptor can address (14-bit start_address), and the tiles that cross
+    # the line are not the ones you would guess.
     sQ = SmemTile(
         base=sQ_raw,
         elems_per_stage=qBufferElems,
@@ -602,7 +619,7 @@ def _kernel(
         tma_loads_per_tile=TMA_QK_ITERS,
         tma_granu_elems=TMA_QK_GRANU_ELEMS,
         tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
-        desc_version=1,
+        desc_version=DESC_VERSION,
     )
     sK = SmemTile(
         base=sK_raw,
@@ -614,7 +631,7 @@ def _kernel(
         tma_loads_per_tile=TMA_QK_ITERS,
         tma_granu_elems=TMA_QK_GRANU_ELEMS,
         tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
-        desc_version=1,
+        desc_version=DESC_VERSION,
     )
     sV = SmemTile(
         base=sV_raw,
@@ -626,7 +643,7 @@ def _kernel(
         tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
         tma_granu_elems=TMA_VO_GRANU_ELEMS,
         tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
-        desc_version=1,
+        desc_version=DESC_VERSION,
     )
     sO = SmemTile(
         base=sO_raw,
@@ -638,6 +655,7 @@ def _kernel(
         tma_loads_per_tile=TMA_O_ITERS_HOST,
         tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
         tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+        desc_version=DESC_VERSION,
     )
 
     # ------------------------------------------------------------------
@@ -1820,7 +1838,7 @@ def _mma_warp_group(
         leading_byte_offset=LEADING_BYTE_OFFSET_QK,
         stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
         layout=SMEM_LAYOUT_P,
-        desc_version=1,
+        desc_version=DESC_VERSION,
     )
 
     # BMM1 leader: desc_Q is tile-static (Q stays resident under d=512 / no Q∪K alias).

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d512_fp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d512_fp8_sm107.py
@@ -1,0 +1,2628 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Rubin SM107 DSv4 SDPA prefill — d_qk = d_v = 512, FP8 (E4M3 / E5M2).
+
+THD / varlen (``CFG.THD_VARLEN=1``) is supported — FP8 is element-addressed (no
+block-scale SF), so it rides the same THD path as f16: packed ``[1,T,H,D]`` +
+``cu_seqlens`` coord offset, per-batch O TMA-descriptor array (shared
+``kernels/ctm/common/sdpa/thd.py``), packed ``[1,QH,T]`` LSE.  Dense path
+byte-identical.  Public-API fp8 THD glue is a follow-up (THD-aware quantizer);
+drive via the kernel module / --backend ctm.
+
+CTM-DSL Python port of the C++ Rubin baseline
+``kernels/c++/sm107/sdpa/prefill/prefill_sdpa_d512_fp8.cu`` — same kernel,
+different language.  Pipeline shape, TMEM/SMEM layout, barrier inventory,
+scheduler, warp dispatch, and register split mirror the C++ source 1:1.
+
+Pipeline shape (cluster (4, 1, 1) = two cga2 sub-groups):
+  sg0 (CTAs 0, 1):  TMA-LDG Q + K_ring; BMM1 = Q*K^T → S_acc; streaming
+                    softmax; ship alpha + P + stats to sg1 via DSMEM.
+  sg1 (CTAs 2, 3):  TMA-LDG V_ring; recv alpha + P + stats via DSMEM;
+                    correction (apply alpha to O TMEM); BMM2 = P*V^T → O;
+                    epilogue normalize + fp32→fp8/half cast + TMA-STG O + LSE.
+
+FP8 deltas vs d512_f16 (CFG fields DTYPE_QKV-driven via sdpa_config_dsv4.py):
+  - STAGES_KV = 3, XFER_STAGES = 4 (BPE=1 fits more stages in 327 KiB).
+  - TILE_K_HW_BMM1/2 ∈ {32, 64}; MMA_KIND = F8F6F4.
+  - P stays FP8-typed (P_STORAGE_DTYPE).
+  - BMM2_V_NBLOCK_ADVANCE = TILE_N * V_SWZ_BYTES (NO BPE factor at FP8 —
+    per-CTA V inner = (TILE_O/CTA_MMA)*BPE = 256*1 = 256 B = 2 swz lines).
+  - DTYPE_O independent of DTYPE_QKV: E4M3 / E5M2 / BF16 / FP16 (BPE_O ∈ {1, 2}).
+  - Epilogue cast loop must handle BPE_O ∈ {1, 2}:
+      epilogue_block_size = 64 / sizeof(ElementO)  (fp8: 64, half: 32)
+      CHUNK_ELEMS         = 128 / sizeof(ElementO) (fp8: 128, half: 64)
+      BLOCKS_PER_SUBTILE  = 128 / epilogue_block_size (fp8: 2, half: 4)
+  - 2-bit sub-tile permutation [0,2,1,3] unchanged — formula stays generic.
+
+SM107 deltas vs SM100:
+  - No Q∪K_ring alias — SMEM cap is 327 KiB, Q stays resident.
+  - No UTCCP(Q→TMEM) — Q feeds BMM1 directly from SMEM.
+  - No B1 / B2 / B3 alias-seam mbars (those are SM100-only).
+  - TMEM cap is 576 cols (is_exclusive=True on tcgen05_alloc).
+
+P12 / P13 patterns (cf. mbarrier-patterns.md, also project memory):
+  - mb_p_xfer_full (P12): sg1 leader's collective BMM2 reads BOTH peers' P
+    SMEM via crossbar.  Each sg1 CTA's mbar gets bytes from its own cross-sg
+    sg0 partner; non-leader sg1 forwards its `arrive` to the leader via
+    DSMEM so leader's wait flips only after the full pair has landed.
+    Leader init = CTA_MMA (own + DSMEM-forwarded); non-leader init = 1.
+  - mb_p_xfer_empty (P13): sg1 leader MMA fires a single
+    tcgen05.commit.cta_group::2.multicast with sg0_mcast_mask (= 0x3) so
+    BOTH sg0 CTAs see one arrive — pre-armed via PipelineState(0, 1).
+
+CTM-only adjustments applied (per cpp-to-ctm.md):
+  - is_exclusive=True on tmem_alloc (SM107 >512-col TMEM).
+  - tile_id_smem stride 8 Int32/stage.
+  - cga_arrive/wait wrapped with relaxed=True (per project memory:
+    dsv3 cga2 47%→92% SOL with this fix).
+  - DSMEM SMEM→peer-SMEM via cp_async_bulk_shared_cluster_shared_cta
+    (per project memory: bare nvvm op silently fires sender's local mbar).
+  - RegTile(Float8E4M3FN) is illegal at JIT — FP8 P_cast skips the RegTile
+    wrap; pass raw vec to store_swizzled / slice via vec_slice on Float32.
+"""
+
+import os
+import sys
+from functools import lru_cache
+from typing import Callable, Optional, Tuple
+from dataclasses import dataclass
+from typing import NamedTuple
+
+
+from cutlass.experimental import primitives as nvvm
+from cutlass.experimental.primitives import vote_sync, VoteSync
+from cutlass._mlir.dialects import arith
+
+import cutlass
+from cutlass.experimental import primitives as prims
+import cutlass.cute as cute
+from cutlass.base_dsl.typing import Pointer
+from cutlass.experimental.cuda import tensor_map as tmap
+from cudnn.frost.tile_dsl.tma import cp_async_bulk_shared_cluster_shared_cta
+import cuda.bindings.driver as _cuda_driver  # noqa: F401  (cute.compile pulls cuda)
+
+# DSv4 has only one config flavor (dsv4); no env-var flavor switch needed.
+# Config comes from the FROST template loader, NOT an env var: the pre-upstream
+# kernels picked a flavor with an env var + a sdpa_config_<flavor> module, which the
+# FROST engine contract forbids ("no environment variables for configuration" --
+# parameters travel as typed dataclasses). The loader injects
+# FROST_TEMPLATE_PARAMS before this body runs; the default keeps a plain
+# `import` usable as a standalone driver.
+from cudnn.sdpa.fwd.config_sm107 import TemplateParams, make_cfg_d512
+
+PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
+CFG, _TMA = make_cfg_d512(PARAMS)
+Cfg = type(CFG)
+TMA_QK_ITERS = _TMA.QK_ITERS
+TMA_VO_ITERS = _TMA.VO_ITERS
+TMA_QK_GRANU_ELEMS = _TMA.QK_GRANU_ELEMS
+TMA_VO_GRANU_ELEMS = _TMA.VO_GRANU_ELEMS
+
+# Rubin's dense-FP8 MMA runs K=64 per instruction, and every
+# ``Tcgen05InstrDesc.build`` site in this body hardcodes the matching idesc
+# ``k_dim=1``.  ``config_sm107.tile_k_hw()`` derives the 64; this guard is the
+# tripwire for the pairing, which is arch-OPPOSITE (Blackwell wants k_dim=0 with
+# TILE_K_HW=32) and fails SILENTLY -- a mismatch scrambles rows of the
+# accumulator rather than raising (rules/mma-tma-matrix.md S1).
+if CFG.TILE_K_HW_BMM1 != 64 or CFG.TILE_K_HW_BMM2 != 64:
+    raise ValueError(f"{__name__}: this body's idesc k_dim=1 requires TILE_K_HW=64 on Rubin; " f"got BMM1={CFG.TILE_K_HW_BMM1} BMM2={CFG.TILE_K_HW_BMM2}")
+
+# O TMA box / store params follow O's swizzle (independent of V under cga2).
+TMA_O_GRANU_ELEMS_HOST = CFG.O_SWZ_BYTES // CFG.BPE_O
+TMA_O_ITERS_HOST = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
+
+
+# Generic tile primitives — never hand-roll equivalents.
+from cudnn.frost.tile_dsl.barrier import (
+    PipelineState,
+    advance,
+    cga_arrive,
+    cga_wait,
+    MBarrier,
+    Producer,
+    Scope,
+    # `wait` (free fn) — still used for sched.mb_* (Sched not in Bars).
+    wait,
+)
+from cudnn.frost.tile_dsl.scheduler import (
+    Sched,
+    scheduler_warp_loop,
+    read_tile_id_arrive,
+    SCHED_NATURAL,
+    SCHED_LPT,
+    SCHED_LPT_L2,
+)
+from cudnn.frost.tile_dsl.pointwise import (
+    tmem_load_max_reduction_tile,
+    row_reduction_pair,
+    row_max_reduction,
+    vec_scale_pair,
+)
+from cudnn.frost.tile_dsl.regtile import RegTile, vec_concat
+from cudnn.frost.tile_dsl.mma import mma_ss, mma_ts_step
+from cudnn.frost.tile_dsl.tma import (
+    tma_load_tile,
+    tma_store_tile,
+    tma_store_commit,
+    tma_store_wait,
+)
+from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, tma_slice_runtime_desc
+from cudnn.frost.tile_dsl.tmem import tmem_alloc, tmem_dealloc
+from cudnn.frost.tile_dsl.mask import (
+    apply_mask_chunk,
+    MASK_NONE,
+    MASK_PADDED,
+    MASK_CAUSAL,
+    MASK_SWA,
+)
+
+# Reuse sm107 SDPA pipeline-shared helpers (KvLoopBounds + closures factory).
+# Note: dsv4 forks Bars in this file (NOT imported from _sdpa_common) per the
+# per-pipeline fork pattern in cpp-to-ctm.md.
+from cudnn.sdpa.fwd.kernels._common_sm100 import (
+    KvLoopBounds,
+    compute_kv_loop_bounds,
+    lpt_tile_coords,
+    make_sdpa_helpers,
+)
+
+# ----------------------------------------------------------------------------
+# Storage dtype dispatch — folded at trace time on CFG.DTYPE_QKV.
+# FP8 (E4M3 / E5M2) only — BF16/FP16 ships in prefill_sdpa_d512_f16.py.
+# ----------------------------------------------------------------------------
+if CFG.DTYPE_QKV == 0:
+    STORAGE_DTYPE = cutlass.Float8E4M3FN
+    P_STORAGE_DTYPE = cutlass.Float8E4M3FN
+    MMA_KIND = nvvm.Tcgen05MMAKind.F8F6F4
+elif CFG.DTYPE_QKV == 1:
+    STORAGE_DTYPE = cutlass.Float8E5M2
+    P_STORAGE_DTYPE = cutlass.Float8E5M2
+    MMA_KIND = nvvm.Tcgen05MMAKind.F8F6F4
+else:
+    raise ValueError(
+        f"prefill_sdpa_d512_fp8 (SM107): DTYPE_QKV={CFG.DTYPE_QKV} not supported " f"(expected 0=E4M3 or 1=E5M2; BF16/FP16 ship in prefill_sdpa_d512_f16.py)"
+    )
+
+# DTYPE_O is independent of DTYPE_QKV (C++ Cfg::DTYPE_O — defaults to DTYPE_QKV
+# but can be promoted to BF16/FP16 to skip downstream dequant).  Dispatch on
+# Cfg::DTYPE_O.  BPE_O ∈ {1, 2}; epilogue cast loop generic over the result.
+if CFG.DTYPE_O == 0:
+    OUT_STORAGE_DTYPE = cutlass.Float8E4M3FN
+elif CFG.DTYPE_O == 1:
+    OUT_STORAGE_DTYPE = cutlass.Float8E5M2
+elif CFG.DTYPE_O == 2:
+    OUT_STORAGE_DTYPE = cutlass.BFloat16
+elif CFG.DTYPE_O == 3:
+    OUT_STORAGE_DTYPE = cutlass.Float16
+else:
+    raise ValueError(f"prefill_sdpa_d512_fp8 (SM107): DTYPE_O={CFG.DTYPE_O} not supported " f"(expected 0=E4M3/1=E5M2/2=BF16/3=FP16)")
+
+
+# ----------------------------------------------------------------------------
+# Derived constants — mirror prefill_sdpa_d512_fp8.cu:120-140.
+# ----------------------------------------------------------------------------
+CGA_SIZE = CFG.CGA_M * CFG.CGA_N
+CTA_GROUP_KIND = nvvm.CTAGroup.CTA_2 if CFG.CTA_MMA == 2 else nvvm.CTAGroup.CTA_1
+
+# Per-CTA buffer element counts + collective TMA transaction byte counts.
+qBufferElems = CFG.TILE_M * CFG.TILE_K  # 65536  → 128 KiB @ BPE=2
+kBufferElems = CFG.TILE_N * CFG.TILE_K // CFG.CTA_MMA  # 32768  →  64 KiB
+vBufferElems = CFG.TILE_O * CFG.TILE_N // CFG.CTA_MMA  # 32768  →  64 KiB
+oBufferElems = CFG.TILE_M * CFG.TILE_O  # 65536  → 128 KiB @ BPE_O=2
+pXferElems = CFG.TILE_M * CFG.TILE_N  # 16384  →  32 KiB / xfer stage
+
+# Per-stage xfer SMEM sizes (DSMEM peer-to-peer payloads).
+pXferBytes = pXferElems * CFG.BPE  # 32 KiB / stage
+alphaXferBytes = CFG.TILE_M * 4  # 512 B  / stage (FP32)
+statsXferBytes = 2 * CFG.TILE_M * 4  # 1 KiB total (ell + max)
+
+# Collective TMA transaction bytes (leader expect_tx under cga2).
+qTmaTransactionBytes = qBufferElems * CFG.BPE * CFG.CTA_MMA
+kTmaTransactionBytes = kBufferElems * CFG.BPE * CFG.CTA_MMA
+vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
+
+# Per-call BMM2 V SMEM advance (between the BMM2_LOOP_N_BLOCKS=2 BMM2 calls).
+# C++ prefill_sdpa_d512_fp8.cu:87 — at FP8 (BPE=1) the per-CTA V inner =
+# (TILE_O/CTA_MMA)*BPE = 256 B = 2 swizzle lines, so the slab stride works
+# out to TILE_N * V_SWZ_BYTES bytes per N-block (NO extra BPE factor).
+BMM2_V_NBLOCK_ADVANCE = CFG.TILE_N * CFG.V_SWZ_BYTES
+
+# O store chunks (TMA-STG arrive granularity — 128 B per chunk).
+N_O_CHUNKS = (CFG.TILE_O * CFG.BPE_O + 127) // 128  # FP8 out: 4; half out: 8
+
+CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+
+# ----------------------------------------------------------------------------
+# Softmax-body constants — module-level so the top-level @cute.jit helper
+# `_sg0_softmax_kv_iter` can read them without a closure capture (CTM-DSL
+# forbids closures inside @cute.jit traced under dynamic control flow).
+# ----------------------------------------------------------------------------
+# P SMEM layout helpers (TILE_M=128 rows × TILE_N=128 cols, Swz128B).
+# 1 row of TILE_N elements = (TILE_N*BPE/SWZ_BYTES) swizzle chunks of P_D_BLOCK each.
+P_TMA_ITERS = (CFG.TILE_N * CFG.BPE) // CFG.Q_SWZ_BYTES  # 2
+P_D_BLOCK = CFG.TILE_N // P_TMA_ITERS  # 64 elements / chunk
+P_BLOCK_BYTES = CFG.TILE_M * P_D_BLOCK  # 8192 elements / TMA chunk
+# Mask-path load chunk width (mirrors canonical _softmax_kv_body CHUNK=64).
+SOFTMAX_CHUNK = 64
+SOFTMAX_N_CHUNKS_LOAD = CFG.TILE_N // SOFTMAX_CHUNK  # 2 for TILE_N=128
+# Swizzle for P SMEM stores (Swz128B at d=512 — same as Q/O).
+P_SMEM_SWIZZLE = cutlass.Swizzle(3, 4, 3)
+# Streaming-softmax constants.
+NEG_INF_F32 = cutlass.Float32(-3.4028235e38)
+RESCALE_THRESHOLD_F32 = cutlass.Float32(CFG.RESCALE_THRESHOLD)
+
+
+# ----------------------------------------------------------------------------
+# Named arrival-count constants — mirror C++ prefill_sdpa_d512_fp8.cu:1500-1520.
+# Per mbarrier-patterns.md P3, ALL init(...) counts must reference named
+# constants — never inline literals.
+# ----------------------------------------------------------------------------
+COMPUTE_LANES = CFG.SOFTMAX_WG_WARPS * 32  # 4 warps * 32 lanes = 128
+SM_LANES_TOTAL = 2 * COMPUTE_LANES  # 256 — both sg0 CTAs * 128 sm threads
+TWO_LANES_TOTAL = 2  # both sg1 CTAs * 1 elect-one to leader
+KV_EMPTY_ARRIVERS = CFG.CGA_N  # = 1 — cga2 commit multicast counts as 1
+
+# READ_TILE_ARRIVERS already derived in CFG (= 25 for dsv4 cga4x1).  Re-export
+# for inline visibility next to the init block.
+READ_TILE_ARRIVERS = CFG.READ_TILE_ARRIVERS
+
+
+# ----------------------------------------------------------------------------
+# Compile-time budget checks — Rubin SM107 caps (NOT 227/512 SM100 caps).
+# ----------------------------------------------------------------------------
+# Per-CTA SMEM budget under Rubin SM107 327 KiB oversized cap.  Each physical
+# CTA runs ONE role (sg0 or sg1), so the SharedStorage union covers
+# max(sg0_bytes, sg1_bytes), NOT the sum.  sg0 holds Q + K_ring + xfer
+# staging; sg1 holds V_ring + O + xfer staging + LSE.  Mirrors the C++
+# `union { sg0; sg1; }` in SharedStorage.
+_SG0_SMEM_DATA_KIB = (
+    qBufferElems * CFG.BPE  # Q (sg0)
+    + CFG.STAGES_KV * kBufferElems * CFG.BPE  # K_ring (sg0)
+    + CFG.XFER_STAGES * pXferBytes  # P xfer (source side staging)
+    + CFG.XFER_STAGES * alphaXferBytes  # alpha xfer (source side staging)
+    + statsXferBytes  # stats xfer
+) / 1024
+_SG1_SMEM_DATA_KIB = (
+    CFG.STAGES_KV * vBufferElems * CFG.BPE  # V_ring (sg1)
+    + oBufferElems * CFG.BPE_O  # O (sg1)
+    + CFG.XFER_STAGES * pXferBytes  # P xfer (sink side staging)
+    + CFG.XFER_STAGES * alphaXferBytes  # alpha xfer (sink side staging)
+    + statsXferBytes  # stats xfer
+    + CFG.TILE_M * 4  # LSE staging (sg1)
+) / 1024
+# RESOURCE-NOTE: SM107 oversized cap is 327 KiB; allow ~4 KiB scaffolding +
+# mbar headroom.  Per-sg data budgets must each fit under 323 KiB.
+assert _SG0_SMEM_DATA_KIB <= 323, f"sg0 SMEM data {_SG0_SMEM_DATA_KIB:.1f} KiB exceeds 323 KiB headroom under 327 KiB cap"
+assert _SG1_SMEM_DATA_KIB <= 323, f"sg1 SMEM data {_SG1_SMEM_DATA_KIB:.1f} KiB exceeds 323 KiB headroom under 327 KiB cap"
+
+# TMEM 576-col cap — Rubin SM107 (NOT SM100's 512).  is_exclusive=True required.
+_TMEM_SG0_COLS = CFG.XFER_STAGES * CFG.TILE_N  # FP8: 4 * 128 = 512 cols for S_acc parities
+_TMEM_SG1_COLS = CFG.TILE_O  # 512 cols for O
+assert _TMEM_SG0_COLS <= 576, f"sg0 S_acc TMEM overflow: {_TMEM_SG0_COLS} > 576"
+assert _TMEM_SG1_COLS <= 576, f"sg1 O TMEM overflow: {_TMEM_SG1_COLS} > 576"
+
+
+# ----------------------------------------------------------------------------
+# Bars — DSv4 role-split inventory, forked in this kernel file per the
+# per-pipeline fork pattern.  Mirrors C++ prefill_sdpa_d512_fp8.cu:320-373.
+# ----------------------------------------------------------------------------
+# Barrier table (cga4x1 / CTA_MMA=2 — DSv4 role-split, SM107 baseline)
+# ============================================================================
+# | Name                     | Stages           | Init                       | Producer / arrive site                          | Consumer / wait site                  | Scope / bootstrap                                   |
+# |--------------------------|------------------|----------------------------|-------------------------------------------------|---------------------------------------|-----------------------------------------------------|
+# | mb_tma_q_full            | 1                | ONE_LANE                   | sg0 TMA-LDG : arrive_expect_tx (Q bytes)        | sg0 MMA (BMM1)                        | cga2 leader-only                                    |
+# | mb_tma_q_empty           | 1                | ONE_LANE                   | sg0 MMA : arrive_mma after last-iter BMM1 commit| sg0 TMA-LDG (next-tile Q load)        | leader-multicast; pre-arm via q_empty_state=1       |
+# | mb_tma_k_full[s]         | STAGES_KV (=2)   | ONE_LANE                   | sg0 TMA-LDG : arrive_expect_tx (K bytes)        | sg0 MMA (BMM1)                        | cga2 leader-only                                    |
+# | mb_tma_k_empty[s]        | STAGES_KV        | KV_EMPTY_ARRIVERS (=1)     | sg0 MMA : arrive_mma after BMM1 commit          | sg0 TMA-LDG (K_ring back-pressure)    | leader-multicast; pre-arm via PipelineState(0,1)    |
+# | mb_tma_v_full[s]         | STAGES_KV        | ONE_LANE                   | sg1 TMA-LDG : arrive_expect_tx (V bytes)        | sg1 MMA (BMM2)                        | cga2 leader-only                                    |
+# | mb_tma_v_empty[s]        | STAGES_KV        | KV_EMPTY_ARRIVERS (=1)     | sg1 MMA : arrive_mma after BMM2 commit          | sg1 TMA-LDG (V_ring back-pressure)    | leader-multicast; pre-arm via PipelineState(0,1)    |
+# | mb_bmm1_done[p]          | XFER_STAGES (=2) | ONE_LANE                   | sg0 MMA : arrive_mma after BMM1 commit          | sg0 softmax                           | local; not bootstrapped                             |
+# | mb_bmm2_done[p]          | XFER_STAGES      | ONE_LANE                   | sg1 MMA : arrive_mma after BMM2 commit          | sg1 corr (epilogue gate)              | local; not bootstrapped                             |
+# | mb_bmm2_ready[p*2+c]     | XFER_STAGES*2(=4)| SM_LANES_TOTAL (=256)      | sg1 corr (all-thread) : arrive_on_peer→leader   | sg1 MMA leader (per-half-N-block)     | cga2 leader-waited                                  |
+# | mb_s_acc_empty[p]        | XFER_STAGES      | SM_LANES_TOTAL (=256)      | sg0 softmax (all-thread) : arrive_on_peer→leader| sg0 MMA leader (S_acc TMEM free)      | cga2 leader-waited; pre-arm via PipelineState(0,1)  |
+# | mb_p_xfer_full[p]        | XFER_STAGES      | leader: CTA_MMA(=2)        | sg0 softmax bulk_copy→peer; sg1 peer→leader DSMEM| sg1 MMA leader (BMM2 P operand)       | P12; leader=2 / non-leader=1                        |
+# |                          |                  | non-leader: ONE_LANE(=1)   |                                                  |                                       |                                                     |
+# | mb_p_xfer_empty[p]       | XFER_STAGES      | ONE_LANE                   | sg1 MMA leader : arrive_mma multicast→sg0       | sg0 softmax (next P slot reuse)       | P13 MMA-commit multicast; pre-arm via PipelineState(0,1) |
+# | mb_alpha_xfer_full[p]    | XFER_STAGES      | ONE_LANE                   | sg1 corr (local) : arrive_expect_tx (alpha)     | sg1 corr (apply alpha)                | local; not bootstrapped                             |
+# | mb_alpha_xfer_empty[p]   | XFER_STAGES      | COMPUTE_LANES (=128)       | sg1 corr (all-thread) : arrive_on_peer→sg0      | sg0 softmax (next alpha slot reuse)   | local; pre-arm via PipelineState(0,1)               |
+# | mb_stats_xfer_full       | 1                | ONE_LANE                   | sg1 corr (local) : arrive_expect_tx (ell+max)   | sg1 corr (final stats consume)        | local; not bootstrapped                             |
+# | mb_stats_xfer_empty      | 1                | ONE_LANE                   | sg1 corr (elect) : arrive_on_peer→sg0           | sg0 softmax (next tile stats slot)    | local; pre-arm via stats_xfer_empty_phase=1         |
+# | mb_tma_o_full[c]         | N_O_CHUNKS (=8)  | COMPUTE_LANES (=128)       | sg1 corr (all-thread) : arrive per chunk        | sg1 TMA-STG (per-chunk TMA)           | local; not bootstrapped                             |
+# | mb_tma_o_empty           | 1                | ONE_WARP (=32)             | sg1 TMA-STG warp : arrive after STG drain       | sg1 corr (next-tile O staging reuse)  | local; pre-arm via PipelineState(0,1)               |
+# | mb_empty_mainloop        | 1                | TWO_LANES_TOTAL (=2)       | sg1 corr (both CTAs, elect) : arrive_on_peer→leader| sg1 MMA leader (empty-kv branch)   | cga2 leader-waited                                  |
+# | mb_tmem_dealloc          | 1                | ONE_LANE                   | both sgs compute (elect) : arrive_on_peer→partner| both sgs MMA (alloc/dealloc fence)   | local; not bootstrapped                             |
+# ============================================================================
+class Bars(NamedTuple):
+    """DSv4 role-split mbarrier inventory (Rubin SM107 baseline)."""
+
+    # ---- TMA Q/K/V handshakes (sg0: Q + K; sg1: V) ----------------------
+    mb_tma_q_full: object  # [1]            sg0  TMA-LDG → MMA
+    mb_tma_q_empty: object  # [1]            sg0  MMA → TMA-LDG (next-tile Q)
+    mb_tma_k_full: object  # [STAGES_KV]    sg0  TMA-LDG → MMA
+    mb_tma_k_empty: object  # [STAGES_KV]    sg0  MMA → TMA-LDG (back-pressure)
+    mb_tma_v_full: object  # [STAGES_KV]    sg1  TMA-LDG → MMA
+    mb_tma_v_empty: object  # [STAGES_KV]    sg1  MMA → TMA-LDG
+
+    # ---- MMA → softmax / corr handshakes -------------------------------
+    mb_bmm1_done: object  # [XFER_STAGES]      sg0 MMA → softmax
+    mb_bmm2_done: object  # [XFER_STAGES]      sg1 MMA → corr (epilogue gate)
+    mb_bmm2_ready: object  # [XFER_STAGES * 2]  sg1 corr → MMA (per half-N-block)
+    mb_s_acc_empty: object  # [XFER_STAGES]      sg0 softmax → MMA (S_acc TMEM free)
+
+    # ---- DSMEM xfer rings (sg0 → sg1) ----------------------------------
+    mb_p_xfer_full: object  # [XFER_STAGES]   sg0 → sg1 (P12 leader=2 / non-leader=1)
+    mb_p_xfer_empty: object  # [XFER_STAGES]   sg1 leader MMA → sg0 (P13 multicast)
+    mb_alpha_xfer_full: object  # [XFER_STAGES]   sg0 softmax (local expect_tx) → sg1 corr
+    mb_alpha_xfer_empty: object  # [XFER_STAGES]   sg1 corr (all-thread DSMEM) → sg0
+    mb_stats_xfer_full: object  # [1]             sg1 corr (local expect_tx) one-shot per tile
+    mb_stats_xfer_empty: object  # [1]             sg0 softmax (elect DSMEM) → sg1
+
+    # ---- sg1 TMA-STG handshakes -----------------------------------------
+    mb_tma_o_full: object  # [N_O_CHUNKS]   sg1 corr → TMA-STG (per-128B chunk)
+    mb_tma_o_empty: object  # [1]            sg1 TMA-STG warp → corr
+
+    # ---- End-of-kernel teardown -----------------------------------------
+    mb_empty_mainloop: object  # [1]            sg1 corr → sg1 MMA leader (empty-kv branch)
+    mb_tmem_dealloc: object  # [1]            both sgs compute → cga2 partner MMA
+
+
+# ----------------------------------------------------------------------------
+# KernelTmemLayout — sg-conditional carves total ≤ 576 cols on SM107.
+# Mirrors C++ prefill_sdpa_d512_fp8.cu KernelTmemLayout (XFER_STAGES=4).
+# ----------------------------------------------------------------------------
+@dataclass(frozen=True)
+class KernelTmemLayout:
+    """SM107 TMEM carves: sg0 = S_acc(XFER_STAGES parities); sg1 = O.
+
+    sg0 uses TMEM cols [0, XFER_STAGES * 128) for the parity S_acc slots.
+        FP8 (XFER_STAGES=4) → [0, 512) = full S_acc area.
+    sg1 uses TMEM cols [0, 512) for the O accumulator (full d_v = 512 FP32 cols).
+    Both fit under the Rubin 576-col cap.
+
+    Use S_acc_at(parity) to pick the runtime parity slot (do NOT introduce
+    per-slot constexpr names; the formula scales over XFER_STAGES generically).
+    """
+
+    # Rubin SM107 cap; requires is_exclusive=True on tcgen05_alloc.
+    TOTAL_COLS: int = 576
+
+    # sg0 layout — per-parity S_acc slot at offset parity * S_ACC_COLS.
+    S_ACC_COLS: int = 128  # = CFG.TILE_N — one parity slot
+    # Per-parity offsets (formula = parity * S_ACC_COLS).
+    S_ACC_PARITY0_OFF: int = 0
+    S_ACC_PARITY1_OFF: int = 128
+
+    # sg1 layout — single fixed-offset O accumulator @ cols [0, TILE_O).
+    O_OFF: int = 0
+    O_COLS: int = 512  # = CFG.TILE_O
+
+
+LAYOUT = KernelTmemLayout()
+assert CFG.XFER_STAGES * LAYOUT.S_ACC_COLS <= LAYOUT.TOTAL_COLS, f"sg0 TMEM overflow: {CFG.XFER_STAGES * LAYOUT.S_ACC_COLS} > {LAYOUT.TOTAL_COLS}"
+assert LAYOUT.O_OFF + LAYOUT.O_COLS <= LAYOUT.TOTAL_COLS, f"sg1 TMEM overflow: {LAYOUT.O_OFF + LAYOUT.O_COLS} > {LAYOUT.TOTAL_COLS}"
+
+
+# ----------------------------------------------------------------------------
+# Bars factory — dsv4 role-split mbarrier inventory typed with MBarrier
+# wrapper.  Producer / scope tags + init counts derived from the barrier
+# table comment above + the explicit init logic below.  Note: mb_p_xfer_full
+# uses a RUNTIME-conditional init count (leader = CTA_MMA, non-leader = 1),
+# so the static init_count here is a placeholder — the kernel passes an
+# explicit override_count to .init() per CTA.
+# ----------------------------------------------------------------------------
+def _make_dsv4_bars(CFG, N_O_CHUNKS: int):
+    def _alloc(n):
+        return cutlass.Array(cutlass.Int64, n, alignment=16, space=cutlass.AddressSpace.smem)
+
+    return Bars(
+        # TMA Q/K/V
+        mb_tma_q_full=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_tma_q_empty=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.MMA_COMMIT),
+        mb_tma_k_full=MBarrier(_alloc(CFG.STAGES_KV), stages=CFG.STAGES_KV, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_tma_k_empty=MBarrier(_alloc(CFG.STAGES_KV), stages=CFG.STAGES_KV, init_count=KV_EMPTY_ARRIVERS, producer=Producer.MMA_COMMIT),
+        mb_tma_v_full=MBarrier(_alloc(CFG.STAGES_KV), stages=CFG.STAGES_KV, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_tma_v_empty=MBarrier(_alloc(CFG.STAGES_KV), stages=CFG.STAGES_KV, init_count=KV_EMPTY_ARRIVERS, producer=Producer.MMA_COMMIT),
+        # MMA → softmax / corr
+        mb_bmm1_done=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=CFG.ONE_LANE, producer=Producer.MMA_COMMIT),
+        mb_bmm2_done=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=CFG.ONE_LANE, producer=Producer.MMA_COMMIT),
+        mb_bmm2_ready=MBarrier(
+            _alloc(CFG.XFER_STAGES * CFG.N_BMM2_CHUNKS),
+            stages=CFG.XFER_STAGES * CFG.N_BMM2_CHUNKS,
+            init_count=SM_LANES_TOTAL,
+            producer=Producer.LEADER,
+            scope=Scope.LEADER,
+        ),
+        mb_s_acc_empty=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=SM_LANES_TOTAL, producer=Producer.LEADER, scope=Scope.LEADER),
+        # DSMEM xfer rings — mb_p_xfer_full has RUNTIME init count (P12):
+        # leader = CTA_MMA arrives (own + DSMEM forwarder); non-leader = 1.
+        # Static init_count here is CFG.CTA_MMA (the leader value); the
+        # kernel's init loop passes override_count=p_full_init for each stage.
+        mb_p_xfer_full=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=CFG.CTA_MMA, producer=Producer.TMA_LOAD),
+        mb_p_xfer_empty=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=CFG.ONE_LANE, producer=Producer.MMA_COMMIT),
+        mb_alpha_xfer_full=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_alpha_xfer_empty=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=COMPUTE_LANES, producer=Producer.THREAD),
+        mb_stats_xfer_full=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_stats_xfer_empty=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.THREAD),
+        # sg1 TMA-STG
+        mb_tma_o_full=MBarrier(_alloc(N_O_CHUNKS), stages=N_O_CHUNKS, init_count=COMPUTE_LANES, producer=Producer.THREAD),
+        mb_tma_o_empty=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_WARP, producer=Producer.THREAD),
+        # Teardown
+        mb_empty_mainloop=MBarrier(_alloc(1), stages=1, init_count=TWO_LANES_TOTAL, producer=Producer.LEADER, scope=Scope.LEADER),
+        mb_tmem_dealloc=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.THREAD),
+    )
+
+
+# ----------------------------------------------------------------------------
+# SMEM swizzle / layout enums.
+# ----------------------------------------------------------------------------
+_SWZ_ENUM = {128: 2, 64: 4, 32: 6}
+SMEM_LAYOUT_Q = _SWZ_ENUM[CFG.Q_SWZ_BYTES]
+SMEM_LAYOUT_K = _SWZ_ENUM[CFG.K_SWZ_BYTES]
+SMEM_LAYOUT_V = _SWZ_ENUM[CFG.V_SWZ_BYTES]
+SMEM_LAYOUT_O = _SWZ_ENUM[CFG.O_SWZ_BYTES]
+SMEM_LAYOUT_QKO = SMEM_LAYOUT_Q
+# P xfer SMEM layout matches Q swizzle (cf. C++ prefill_sdpa_d512_fp8.cu:60).
+SMEM_LAYOUT_P = SMEM_LAYOUT_Q
+
+_O_SWZ_B = {128: 3, 64: 2, 32: 1}[CFG.O_SWZ_BYTES]
+_O_SMEM_SWIZZLE = cutlass.Swizzle(_O_SWZ_B, 4, 3)
+
+LEADING_BYTE_OFFSET_QK = 0
+STRIDE_BYTE_OFFSET_QK = 8 * CFG.Q_SWZ_BYTES
+
+_CORE_MATRIX_ROWS = 8
+_V_PC_COLS = CFG.TILE_O // CFG.CTA_MMA
+LEADING_BYTE_OFFSET_PV = 0 if (_V_PC_COLS // _CORE_MATRIX_ROWS) <= 8 else CFG.TILE_N * CFG.V_SWZ_BYTES
+STRIDE_BYTE_OFFSET_PV = 8 * CFG.V_SWZ_BYTES
+
+# BMM2 manual k-step iters.
+NUM_KPHASES_PV = CFG.TILE_N // CFG.TILE_K_HW_BMM2
+
+
+# ----------------------------------------------------------------------------
+# Helpers bound to CFG (scheduler topology + mask plumbing — unchanged from
+# the sm107 classic kernels; role-split doesn't change tile decoding).
+# ----------------------------------------------------------------------------
+_sdpa_h = make_sdpa_helpers(CFG)
+_decode_initial = _sdpa_h.decode_initial
+_decode_payload = _sdpa_h.decode_payload
+_bounds_for_tile = _sdpa_h.bounds_for_tile
+_resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+
+# THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
+# factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
+# kernels/ctm/common/sdpa/thd.py.  Gated by CFG.THD_VARLEN (folds out otherwise).
+# FP8 is element-addressed (per-tensor dequant scalars, no block-scale SF), so
+# THD rides the same path as f16.  seq_kv_lens overloaded as the THD metadata
+# buffer (int32 len 3B+2): [0..B-1]=seq_kv_lens [B..2B]=cu_q [2B+1..3B+1]=cu_k.
+from cudnn.sdpa.fwd.kernels.thd_helpers import build_thd_meta_o_descs_kernel as _build_thd_meta_o_descs_kernel, TENSOR_MAP_QWORDS
+
+_TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
+_dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
+_dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
+_thd_tma_offsets = _sdpa_h.thd_tma_offsets
+
+
+# ============================================================================
+# Kernel entry.
+# ============================================================================
+@cute.kernel
+def _kernel(
+    tma_q_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_k_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_v_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_o_desc: cutlass.GridConstant[tmap.TensorMap],
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    seqlen_q: cutlass.Int32,
+    seqlen_kv: cutlass.Int32,
+    n_q_supers: cutlass.Int32,
+    n_qh: cutlass.Int32,
+    n_batch: cutlass.Int32,
+    qh_per_kh: cutlass.Int32,
+    scale_softmax_log2: cutlass.Float32,
+    o_scale_fused: cutlass.Float32,
+    # FROST's quantized ABI: the four 1-element fp32 scales arrive as DEVICE
+    # TENSORS and the amax of O is an OUTPUT.  The pre-upstream contract pre-folded on the host
+    # and produced no amax.  Template: prefill_d128_fp8_sm107.py (same lineage).
+    descale_q_t: cute.Tensor,
+    descale_k_t: cute.Tensor,
+    descale_v_t: cute.Tensor,
+    scale_o_t: cute.Tensor,
+    amax_o_tensor: cute.Tensor,
+) -> None:
+
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    tidx, _, _ = cute.arch.thread_idx()
+
+    bidx = cute.arch.block_idx()[0]
+    bidy = cute.arch.block_idx()[1]
+    bidz = cute.arch.block_idx()[2]
+
+    # Device-scale fold (same as the shipped d128 sibling): every thread reads
+    # the four 1-element fp32 scales -- identical addresses, so L2 broadcast --
+    # and folds them into the softmax and output scales.
+    _dsc_q = cutlass.Float32(cutlass.make_array_view(descale_q_t)[0])
+    _dsc_k = cutlass.Float32(cutlass.make_array_view(descale_k_t)[0])
+    _dsc_v = cutlass.Float32(cutlass.make_array_view(descale_v_t)[0])
+    _scl_o = cutlass.Float32(cutlass.make_array_view(scale_o_t)[0])
+    scale_softmax_log2 = scale_softmax_log2 * _dsc_q * _dsc_k
+    o_scale_fused = o_scale_fused * _dsc_v * _scl_o
+
+    # ------------------------------------------------------------------
+    # SMEM allocations — natural Q / K / V / O order, NO Q∪K_ring or
+    # O∪V_ring alias (Rubin SM107 cap fits everything; aliases are
+    # SM100-only).  Mirror C++ SharedStorage at prefill_sdpa_d512_fp8.cu:148.
+    # ------------------------------------------------------------------
+    # RESOURCE-NOTE: each physical CTA runs ONE role (sg0 OR sg1), so the
+    # Q (sg0) ∪ O (sg1) and K_ring (sg0) ∪ V_ring (sg1) regions alias at
+    # the same SMEM offset.  Mirrors C++ `union QOAlias`/`union KVAlias` at
+    # prefill_sdpa_d512_fp8.cu:149-161 — without these unions the per-CTA
+    # SMEM budget doubles (~580 KiB) and busts the 327 KiB Rubin cap.
+    # Q∪O alias byte-sized to max(Q@BPE, O@BPE_O) — STORAGE_DTYPE is FP8 (1 B)
+    # so element count == byte count.  BF16/FP16 O (BPE_O=2) would overflow a
+    # qBufferElems-only allocation; size for the larger of the two views.
+    _QO_ELEMS = max(qBufferElems * CFG.BPE, oBufferElems * CFG.BPE_O)
+    _KV_ELEMS = CFG.STAGES_KV * kBufferElems if kBufferElems >= vBufferElems else CFG.STAGES_KV * vBufferElems
+    sQO_raw = cutlass.Array(STORAGE_DTYPE, _QO_ELEMS, alignment=1024, space=cutlass.AddressSpace.smem)
+    sKV_raw = cutlass.Array(STORAGE_DTYPE, _KV_ELEMS, alignment=1024, space=cutlass.AddressSpace.smem)
+    # sQ / sO / sK / sV alias into sQO_raw / sKV_raw respectively.  sO's view
+    # reinterprets the backing as OUT_STORAGE_DTYPE so epilogue store offsets
+    # advance in BPE_O units (no-op recast for FP8 output).
+    sQ_raw = sQO_raw  # sg0 view
+    sO_raw = cutlass.Array(sQO_raw.data_ptr(), shape=oBufferElems, dtype=OUT_STORAGE_DTYPE)  # sg1 view
+    sK_raw = sKV_raw  # sg0 view
+    sV_raw = sKV_raw  # sg1 view
+
+    # P xfer (sg0 → sg1) SMEM — XFER_STAGES rings, kept resident.
+    sP_xfer_raw = cutlass.Array(P_STORAGE_DTYPE, CFG.XFER_STAGES * pXferElems, alignment=128, space=cutlass.AddressSpace.smem)
+    # alpha xfer (sg0 → sg1) SMEM.
+    sAlpha_xfer_raw = cutlass.Array(cutlass.Float32, CFG.XFER_STAGES * CFG.TILE_M, alignment=128, space=cutlass.AddressSpace.smem)
+    # stats xfer (sg0 → sg1) SMEM — 1-shot per tile, holds ell + max (2 * TILE_M floats).
+    sStats_xfer_raw = cutlass.Array(cutlass.Float32, 2 * CFG.TILE_M, alignment=128, space=cutlass.AddressSpace.smem)
+    # LSE staging on sg1 (sub-tile write-back from corr; cf. C++ line 198).
+    sLSE_raw = cutlass.Array(cutlass.Float32, CFG.TILE_M, alignment=128, space=cutlass.AddressSpace.smem)
+
+    # Typed SmemTile handles.
+    # Rubin SM107 raises the per-CTA SMEM cap to 327 KiB, so an MMA-operand
+    # buffer can land at or above 256 KiB — past what a version-0 tcgen05 SMEM
+    # descriptor can address (14-bit start_address).  Every operand tile here
+    # therefore carries desc_version=1, matching what C++ SmemTile::make_desc
+    # always emitted.  See tile_dsl/handles.py SmemTile.desc_version.
+    sQ = SmemTile(
+        base=sQ_raw,
+        elems_per_stage=qBufferElems,
+        stages=1,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+        desc_version=1,
+    )
+    sK = SmemTile(
+        base=sK_raw,
+        elems_per_stage=kBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+        desc_version=1,
+    )
+    sV = SmemTile(
+        base=sV_raw,
+        elems_per_stage=vBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_PV,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_PV,
+        layout=SMEM_LAYOUT_V,
+        tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
+        tma_granu_elems=TMA_VO_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+        desc_version=1,
+    )
+    sO = SmemTile(
+        base=sO_raw,
+        elems_per_stage=oBufferElems,
+        stages=1,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=SMEM_LAYOUT_O,
+        tma_loads_per_tile=TMA_O_ITERS_HOST,
+        tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+    )
+
+    # ------------------------------------------------------------------
+    # Bars allocation — per the barrier table above.
+    # ------------------------------------------------------------------
+    bars = _make_dsv4_bars(CFG, N_O_CHUNKS)
+
+    tmem_ptr_i32 = cutlass.Array(cutlass.Int32, 1, alignment=16, space=cutlass.AddressSpace.smem)
+
+    # tile_id_smem stride 8 Int32/stage (32 B per stage; 16 B payload + 16 B padding).
+    sched = Sched(
+        **{
+            "mb_scheduler": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "mb_read_tile_id": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "tile_id_smem": cutlass.Array(cutlass.Int32, CFG.SCHEDULER_STAGES * 8, alignment=16, space=cutlass.AddressSpace.smem),
+            "bidx_init": bidx,
+            "bidy_init": bidy,
+            "bidz_init": bidz,
+        }
+    )
+
+    # ------------------------------------------------------------------
+    # cga2 / role-split identity — hoisted ABOVE init because mb_p_xfer_full
+    # init count is leader-vs-non-leader runtime-conditional (P12 — leader
+    # sees CTA_MMA arrives, non-leader sees 1).
+    # ------------------------------------------------------------------
+    cta_id_x = cute.arch.block_idx_in_cluster() if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    cta_in_pair = (cta_id_x & cutlass.Int32(1)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    leader_cta_id = (cta_id_x & cutlass.Int32(~1 & 0xFFFFFFFF)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    mcast_mask = (cutlass.Int32(3) << leader_cta_id) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    # sg0_mcast_mask = 0x3 — both sg0 CTAs (used by sg1 leader's P13 multicast on mb_p_xfer_empty).
+    sg0_mcast_mask = cutlass.Int32(0x3)
+    # TMA-load self-bit mask: per cga2-mma.md / DKG `fp16_gemm_3.py`, each
+    # peer's `cta_group::2` TMA targets ITS OWN cluster bit (= cta_id_x);
+    # cga2 routing strips bit-24 so bytes land on the cga2 pair leader's
+    # mbar.  Use cluster-rank (cta_id_x), NOT pair-rank (cta_in_pair) — for
+    # cga2 (CGA_M=CTA_MMA=2) these coincide, but for cga4×1 (dsv4) the sg1
+    # pair has cta_in_pair ∈ {0,1} while cta_id_x ∈ {2,3}, and using
+    # cta_in_pair would target CTAs 0,1 (sg0) instead of CTAs 2,3 (sg1).
+    tma_mcast_mask = (cutlass.Int16(1) << cta_id_x.to(cutlass.Int16)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
+    is_leader = cta_in_pair == cutlass.Int32(0)
+
+    # Sub-group identity (sg0 = CTAs 0, 1; sg1 = CTAs 2, 3).
+    sg_id = cta_id_x // cutlass.Int32(CFG.CTA_MMA)
+    is_sg0 = sg_id == cutlass.Int32(0)
+    is_sg1 = sg_id == cutlass.Int32(1)
+    # Cross-sg peer = this CTA XOR CTA_MMA (CTAs 0↔2, 1↔3).
+    cross_sg_peer = cta_id_x ^ cutlass.Int32(CFG.CTA_MMA)
+
+    is_cga_first_cta = cta_id_x == cutlass.Int32(0)
+
+    # ------------------------------------------------------------------
+    # Mbar init — Phase 1 of cluster init (P4).  No Phase-2 bootstrap arrives:
+    # every consumer that would need one is pre-armed via PipelineState(0, 1)
+    # or per-warp `phase = 1` initial values.  MmaProducer<> typing forbids
+    # plain arrive() anyway.
+    #
+    # Per-CTA leader / non-leader split for mb_p_xfer_full follows P12:
+    # leader = CTA_MMA arrives (own + (CTA_MMA-1) DSMEM forwarder); non-leader = 1.
+    # ------------------------------------------------------------------
+    if warp_idx == 0:
+        if nvvm.elect_sync():
+            # ---- TMA Q/K/V handshakes ----
+            bars.mb_tma_q_full.init()
+            bars.mb_tma_q_empty.init()
+            for ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_tma_k_full[ks].init()
+                bars.mb_tma_k_empty[ks].init()
+                bars.mb_tma_v_full[ks].init()
+                bars.mb_tma_v_empty[ks].init()
+
+            # ---- MMA → softmax / corr handshakes ----
+            for p in cutlass.range_constexpr(CFG.XFER_STAGES):
+                bars.mb_bmm1_done[p].init()
+                bars.mb_bmm2_done[p].init()
+                bars.mb_s_acc_empty[p].init()
+                for c in cutlass.range_constexpr(CFG.N_BMM2_CHUNKS):
+                    bars.mb_bmm2_ready[p * CFG.N_BMM2_CHUNKS + c].init()
+
+                # ---- DSMEM xfer rings (sg0 → sg1) ----
+                # P12: leader = CTA_MMA arrives; non-leader = 1.  Runtime-
+                # conditional init count passed via override_count=.
+                p_full_init = cutlass.Int32(
+                    arith.select(
+                        is_leader.ir_value(),
+                        cutlass.Int32(CFG.CTA_MMA).ir_value(),
+                        cutlass.Int32(CFG.ONE_LANE).ir_value(),
+                    )
+                )
+                bars.mb_p_xfer_full[p].init(override_count=p_full_init)
+                bars.mb_p_xfer_empty[p].init()
+                bars.mb_alpha_xfer_full[p].init()
+                bars.mb_alpha_xfer_empty[p].init()
+
+            # ---- one-shot stats ring ----
+            bars.mb_stats_xfer_full.init()
+            bars.mb_stats_xfer_empty.init()
+
+            # ---- sg1 TMA-STG handshakes ----
+            for c in cutlass.range_constexpr(N_O_CHUNKS):
+                bars.mb_tma_o_full[c].init()
+            bars.mb_tma_o_empty.init()
+
+            # ---- end-of-kernel teardown ----
+            bars.mb_empty_mainloop.init()
+            bars.mb_tmem_dealloc.init()
+
+            # ---- scheduler ring (NOT in Bars; still raw nvvm.mbarrier_init) ----
+            for s in range(CFG.SCHEDULER_STAGES):
+                nvvm.mbarrier_init(sched.mb_scheduler.subview(s), CFG.ONE_LANE)
+                nvvm.mbarrier_init(sched.mb_read_tile_id.subview(s), READ_TILE_ARRIVERS)
+
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync()
+
+    # P4 cluster fence (cga2-aware) — required because Phase 2 of the kernel
+    # body issues cross-CTA arrive_on_peer BEFORE the receiving CTA has
+    # necessarily flushed its mbar init through the cluster.  relaxed=True
+    # (per project memory: dsv3 cga2 47%→92% SOL).
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        cga_arrive()
+        cga_wait()
+
+    # ------------------------------------------------------------------
+    # Per-warp role dispatch.  Role-split topology:
+    #   compute wg (warps 0..3): sg-conditional softmax (sg0) OR corr (sg1).
+    #   MMA       (warp 4): sg-conditional BMM1 (sg0) OR BMM2 (sg1);
+    #                       non-leader CTAs run quiet (sg0) or forwarder (sg1).
+    #   TMA-LDG   (warp 5): sg-conditional Q+K (sg0) OR V (sg1).
+    #   TMA-STG   (warp 6): sg1 only — O + LSE.  sg0 spins scheduler only.
+    #   Scheduler (warp 7): try_cancel; both sgs.
+    # ------------------------------------------------------------------
+    if warp_idx >= cutlass.Int32(CFG.SOFTMAX_WG0_BASE) and warp_idx < cutlass.Int32(CFG.SOFTMAX_WG0_BASE + CFG.SOFTMAX_WG_WARPS):
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        _compute_warp_group(
+            is_sg0=is_sg0,
+            is_sg1=is_sg1,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_softmax_log2,
+            tmem_ptr_i32=tmem_ptr_i32,
+            sQ=sQ,
+            sO=sO,
+            sP_xfer_raw=sP_xfer_raw,
+            sAlpha_xfer_raw=sAlpha_xfer_raw,
+            sStats_xfer_raw=sStats_xfer_raw,
+            sLSE_raw=sLSE_raw,
+            bars=bars,
+            sched=sched,
+            lse_tensor=lse_tensor,
+            sinks_tensor=sinks_tensor,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+            cta_id_x=cta_id_x,
+            cross_sg_peer=cross_sg_peer,
+            o_scale_fused=o_scale_fused,
+            amax_o_tensor=amax_o_tensor,
+        )
+
+    elif warp_idx == cutlass.Int32(CFG.MMA_WARP_ID):
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        # cga2 non-leader paths fork — sg0 non-leader is quiet, sg1 non-leader
+        # forwards mb_p_xfer_full to leader (P12) in a persistent loop.
+        if is_leader:
+            _mma_warp_group(
+                is_sg0=is_sg0,
+                is_sg1=is_sg1,
+                seqlen_q=seqlen_q,
+                seqlen_kv=seqlen_kv,
+                sQ=sQ,
+                sK=sK,
+                sV=sV,
+                sP_xfer_raw=sP_xfer_raw,
+                tmem_ptr_i32=tmem_ptr_i32,
+                bars=bars,
+                sched=sched,
+                seq_kv_lens_tensor=seq_kv_lens_tensor,
+                n_q_supers=n_q_supers,
+                n_qh=n_qh,
+                n_batch=n_batch,
+                mcast_mask=mcast_mask,
+                sg0_mcast_mask=sg0_mcast_mask,
+                cta_in_pair=cta_in_pair,
+            )
+        else:
+            _mma_warp_non_leader(
+                is_sg0=is_sg0,
+                is_sg1=is_sg1,
+                seqlen_q=seqlen_q,
+                seqlen_kv=seqlen_kv,
+                tmem_ptr_i32=tmem_ptr_i32,
+                bars=bars,
+                sched=sched,
+                seq_kv_lens_tensor=seq_kv_lens_tensor,
+                n_q_supers=n_q_supers,
+                n_qh=n_qh,
+                n_batch=n_batch,
+                cta_in_pair=cta_in_pair,
+                leader_cta_id=leader_cta_id,
+            )
+
+    elif warp_idx == cutlass.Int32(CFG.TMALDG_WARP_ID):
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        nvvm.prefetch_tensormap(tma_q_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_k_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_v_desc.get_ptr())
+        _tmaldg_warp_group(
+            is_sg0=is_sg0,
+            is_sg1=is_sg1,
+            tma_q_desc=tma_q_desc,
+            tma_k_desc=tma_k_desc,
+            tma_v_desc=tma_v_desc,
+            sQ=sQ,
+            sK=sK,
+            sV=sV,
+            bars=bars,
+            sched=sched,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            qh_per_kh=qh_per_kh,
+            is_leader=is_leader,
+            cta_in_pair=cta_in_pair,
+            tma_mcast_mask=tma_mcast_mask,
+        )
+
+    elif warp_idx == cutlass.Int32(CFG.TMASTG_WARP_ID):
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _tmastg_warp_group(
+            is_sg1=is_sg1,
+            tma_o_desc=tma_o_desc,
+            sO=sO,
+            bars=bars,
+            sched=sched,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            cta_in_pair=cta_in_pair,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
+        )
+
+    else:  # warp_idx == CFG.SCHED_WARP_ID
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
+
+
+# ============================================================================
+# sg0 softmax-iter helper — per-iter body for the 3-segment kv loop
+# (LEFT-masked / unmasked center / RIGHT-masked).  Mirrors canonical
+# `_softmax_kv_body` (prefill_sdpa_f16.py:923) and C++
+# `softmax_kv_body<ApplyMask>` (prefill_sdpa_d512_fp8.cu:432).
+#
+# apply_mask=False uses fused HW row-max (tcgen05.ld.red.f32.max);
+# apply_mask=True uses tcgen05.ld + apply_mask_chunk + software row-max
+# (HW max can't observe -inf written by the mask after the load).
+#
+# Top-level @cute.jit so the dynamic call-graph contains no closure-capture
+# violations (CTM-DSL forbids closures under dynamic control flow).  All
+# kernel-local vars are passed as explicit args; constants come from
+# module-level (NEG_INF_F32, RESCALE_THRESHOLD_F32, P_*, SOFTMAX_*, etc.).
+# ============================================================================
+@cute.jit
+def _sg0_softmax_kv_iter(
+    apply_mask: cutlass.Constexpr[bool],
+    kv_loop,
+    # State (threaded, returned updated):
+    sg0_xfer_state,
+    bmm1_done_state,
+    total_max,
+    total_sum_vec,
+    # TMEM / SMEM bases:
+    tmem_base_addr,
+    bars,
+    sP_xfer_raw,
+    sAlpha_xfer_raw,
+    # Per-tile / per-lane:
+    q_abs,
+    eff_seqlen_kv,
+    seqlen_q,
+    scale_log2,
+    tid_in_wg,
+    is_lead_warp,
+    leader_cta_id,
+    cross_sg_peer,
+):
+    cur_parity_S = sg0_xfer_state.idx
+    cur_phase_S = sg0_xfer_state.phase
+    bars.mb_alpha_xfer_empty[cur_parity_S].wait(cur_phase_S)
+    bars.mb_p_xfer_empty[cur_parity_S].wait(cur_phase_S)
+    bars.mb_bmm1_done[bmm1_done_state.idx].wait(bmm1_done_state.phase)
+    sg0_xfer_state = advance(sg0_xfer_state, CFG.XFER_STAGES)
+    bmm1_done_state = advance(bmm1_done_state, CFG.XFER_STAGES)
+
+    s_addr_base = tmem_base_addr + cur_parity_S * cutlass.Int32(LAYOUT.S_ACC_COLS)
+
+    if cutlass.const_expr(apply_mask):
+        kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+        raw_chunks = [
+            nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * SOFTMAX_CHUNK), cutlass.Float32),
+                num=SOFTMAX_CHUNK,
+            )
+            for c in range(SOFTMAX_N_CHUNKS_LOAD)
+        ]
+        # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
+        # CFG.BOTTOM_RIGHT is 0 — top-left masking is unchanged).
+        causal_diag = eff_seqlen_kv - seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+        chunks_S = [
+            apply_mask_chunk(
+                raw_chunks[c],
+                q_abs,
+                kv_col_base + cutlass.Int32(c * SOFTMAX_CHUNK),
+                eff_seqlen_kv,
+                CFG.WINDOW_LEFT,
+                CFG.MASK_FLAGS,
+                N=SOFTMAX_CHUNK,
+                bottom_right=CFG.BOTTOM_RIGHT,
+                causal_diag=causal_diag,
+                window_right=CFG.WINDOW_RIGHT,
+            )
+            for c in range(SOFTMAX_N_CHUNKS_LOAD)
+        ]
+        chunks_max = [row_max_reduction(chunks_S[c]) for c in range(SOFTMAX_N_CHUNKS_LOAD)]
+        reg_S_vec = vec_concat(chunks_S)
+        current_max_raw = chunks_max[0]
+        for m in chunks_max[1:]:
+            current_max_raw = cute.math.max(current_max_raw, m)
+        reg_S_tile = RegTile(reg_S_vec, size=CFG.TILE_N)
+    else:
+        reg_S_tile, current_max_raw = tmem_load_max_reduction_tile(
+            s_addr_base,
+            num_elems=CFG.TILE_N,
+        )
+    current_max = current_max_raw * scale_log2
+
+    # Online softmax (RESCALE_THRESHOLD skip).
+    old_total_max = total_max
+    is_first = total_max == NEG_INF_F32
+    update_cond = is_first | ((current_max - total_max) > RESCALE_THRESHOLD_F32)
+    total_max = cutlass.Float32(
+        arith.select(
+            update_cond.ir_value(),
+            current_max.ir_value(),
+            total_max.ir_value(),
+        )
+    )
+    exp_input = cutlass.Float32(
+        arith.select(
+            is_first.ir_value(),
+            NEG_INF_F32.ir_value(),
+            (old_total_max - total_max).ir_value(),
+        )
+    )
+    alpha = cute.math.exp2(exp_input, fastmath=True)
+
+    # reg_S = reg_S * scale_log2 - total_max; then exp2.  Keep the FP32
+    # RegTile (slice via .vec slicing) and cast each chunk to FP8 inside the
+    # P_TMA_ITERS loop — RegTile(Float8E4M3FN) is illegal at JIT, but slicing
+    # the FP32 RegTile then casting the slice is fine (per d256_fp8 pattern).
+    reg_S_scaled = reg_S_tile.vec * scale_log2 - total_max
+    reg_P_fp32 = cute.math.exp2(reg_S_scaled, fastmath=True)
+    reg_P_tile = RegTile(reg_P_fp32, size=CFG.TILE_N)
+
+    # ---- Write P[tid, :] to SMEM xfer ring slot[parity] ----
+    p_xfer_slot = sP_xfer_raw.subview(cur_parity_S * cutlass.Int32(pXferElems))
+    for chunk in cutlass.range_constexpr(P_TMA_ITERS):
+        smem_off = cutlass.Int32(chunk * P_BLOCK_BYTES) + tid_in_wg * cutlass.Int32(P_D_BLOCK)
+        smem_ptr = p_xfer_slot.subview(smem_off).data_ptr()
+        # Slice FP32 RegTile chunk, then cast → FP8.  Avoids RegTile(FP8).
+        chunk_P_fp32 = reg_P_tile[chunk * P_D_BLOCK : (chunk + 1) * P_D_BLOCK].vec
+        chunk_P = chunk_P_fp32.to(P_STORAGE_DTYPE)
+        smem_ptr.store_swizzled(
+            chunk_P,
+            alignment=64,
+            swizzle=P_SMEM_SWIZZLE,
+        )
+
+    # ---- Write alpha[tid] (FP32) to alpha xfer slot[parity] ----
+    alpha_slot = sAlpha_xfer_raw.subview(cur_parity_S * cutlass.Int32(CFG.TILE_M) + tid_in_wg)
+    alpha_slot.store(alpha)
+
+    # Update total_sum = total_sum * alpha + row_reduction(reg_P).
+    alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+    iter_sum_pair = row_reduction_pair(reg_P_fp32)
+    total_sum_vec = total_sum_vec * alpha_pair + iter_sum_pair
+
+    # Fence SMEM→async; sync the 4 compute warps so all 128 rows of
+    # alpha + P are written before bulk_copy issues.
+    nvvm.fence_proxy("async.shared", space="cta")
+    nvvm.barrier_cta_sync(barrier_id=8, thread_count=128)
+
+    # DSMEM bulk_copy alpha + P → cross-sg sg1 peer's SMEM, firing peer's
+    # mb_alpha_xfer_full + mb_p_xfer_full.  PREDICATED form: emit `@p
+    # cp.async.bulk` (matches C++'s uniform `@UP0 UBLKCP`) instead of an
+    # `if is_lead_warp: if elect_sync():` branch — that branch lowers to a
+    # warp-divergent BSSY/BSYNC + reconverge that also poisons ptxas's uniform
+    # analysis of nearby mbar waits (measured: removing the ship branches flips
+    # ~5 SYNCS.PHASECHK → USYNCS and is worth ~+12% on dsv4 d512).  All 128
+    # lanes compute the cheap mapa addresses up-front; only the lead warp's
+    # elected lane issues the UBLKCPs under ship_pred.
+    ship_pred = is_lead_warp & nvvm.elect_sync()
+    local_alpha_src = sAlpha_xfer_raw.subview(cur_parity_S * cutlass.Int32(CFG.TILE_M))
+    peer_alpha_dst = nvvm.mapa(local_alpha_src, cross_sg_peer, addrspace=7)
+    peer_alpha_full_mbar = nvvm.mapa(bars.mb_alpha_xfer_full[cur_parity_S].smem_ptr, cross_sg_peer, addrspace=7)
+    local_p_src = sP_xfer_raw.subview(cur_parity_S * cutlass.Int32(pXferElems))
+    peer_p_dst = nvvm.mapa(local_p_src, cross_sg_peer, addrspace=7)
+    peer_p_full_mbar = nvvm.mapa(bars.mb_p_xfer_full[cur_parity_S].smem_ptr, cross_sg_peer, addrspace=7)
+    cp_async_bulk_shared_cluster_shared_cta(
+        peer_alpha_dst,
+        local_alpha_src,
+        peer_alpha_full_mbar,
+        alphaXferBytes,
+        pred=ship_pred,
+    )
+    cp_async_bulk_shared_cluster_shared_cta(
+        peer_p_dst,
+        local_p_src,
+        peer_p_full_mbar,
+        pXferBytes,
+        pred=ship_pred,
+    )
+
+    # All-thread DSMEM arrive on sg0 leader's mb_s_acc_empty — fired at the
+    # END of the iter (after the P/alpha DSMEM ship), matching the C++
+    # baseline's perf-tuned placement (softmax_kv_body tail:
+    # `mb_s_acc_empty[parity].arrive_on_peer(0u,1u)`).  The barrier_id=8 sync
+    # above already guarantees all 128 lanes finished reading S_acc from TMEM,
+    # so freeing the slot here is safe; firing it early (right after the TMEM
+    # read) measurably regressed perf — the MMA reclaims the S_acc slot too
+    # eagerly and contends with the in-flight softmax.
+    bars.mb_s_acc_empty[cur_parity_S].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+    return (sg0_xfer_state, bmm1_done_state, total_max, total_sum_vec)
+
+
+# ============================================================================
+# Compute warp group — sg-conditional softmax (sg0) or correction (sg1).
+# 4 warps × 32 lanes = 128 threads.  Port of C++ compute_warp_group
+# (prefill_sdpa_d512_fp8.cu:529-1013).
+# ============================================================================
+@cute.jit
+def _compute_warp_group(
+    is_sg0,
+    is_sg1,
+    seqlen_q,
+    seqlen_kv,
+    scale_log2,
+    tmem_ptr_i32,
+    sQ,
+    sO,
+    sP_xfer_raw,
+    sAlpha_xfer_raw,
+    sStats_xfer_raw,
+    sLSE_raw,
+    bars,
+    sched,
+    lse_tensor,
+    sinks_tensor,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+    cta_id_x,
+    cross_sg_peer,
+    o_scale_fused,
+    amax_o_tensor,
+):
+    """sg-conditional compute body (4 warps × 32 lanes = 128 threads).
+
+    sg0 path (port of C++ lines 599-749):
+        Streaming softmax — per kv iter wait BMM1 done, tmem_load S_acc + HW
+        row-max, online softmax (exp2 + alpha + new total_max / total_sum),
+        publish alpha (DSMEM bulk_copy to sg1), publish P (DSMEM bulk_copy
+        to sg1), all-thread arrive on mb_s_acc_empty.  End-of-tile ship
+        (max, ell) stats over DSMEM (1-shot).  Per-tile pre-armed empty
+        phases via PipelineState(0, 1).
+
+    sg1 path (port of C++ lines 750-1024):
+        Correction + epilogue — per kv iter wait alpha (local mbar), apply
+        alpha to O TMEM in two halves (gates BMM2 sub-tile 0 / 1 via
+        mb_bmm2_ready), DSMEM-arrive empty alpha on sg0.  Epilogue: wait
+        final BMM2, wait stats, normalize O by 1/ell + cast to half, store
+        to sO with per-chunk mb_tma_o_full arrive, write LSE to GMEM,
+        DSMEM-arrive empty stats on sg0.
+
+    Wait pattern: MMA warp publishes TMEM base via named barrier 1 (count =
+    32 * (SOFTMAX_WG_WARPS + 1) = 160) BEFORE any tmem_ptr_i32.load().
+    """
+    # Wait MMA's TMEM-alloc publish (C++ line 592 ``named_barrier_wait(TMEM_ALLOC_SOFTMAX_BARRIER, 160)``).
+    nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WG_WARPS + 1))
+    tmem_base_addr = tmem_ptr_i32.load()
+    tmem_raw = nvvm.make_tmem_ptr(tmem_base_addr, cutlass.Int8)
+
+    # Per-thread / per-warp identifiers — compute warps occupy CTA tid_x in
+    # [0, 128); tid_in_wg == tid_x, wid_in_wg = tid_x // 32 ∈ {0..3}.
+    tid_in_wg = cute.arch.thread_idx()[0]
+    wid_in_wg = tid_in_wg // cutlass.Int32(32)
+    is_lead_warp = wid_in_wg == cutlass.Int32(0)
+
+    # Common state — persistent-tile scheduler decode.
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    # kv_loop bounds — at MASK_NONE collapse to [0, seqlen_kv / TILE_N).
+    # When MASK_FLAGS != 0 the kv loop splits into 3 segments
+    # (LEFT-masked / fully-unmasked / RIGHT-masked) on unmasked_lo / unmasked_hi.
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_unmasked_lo = cutlass.Int32(0)
+        kv_unmasked_hi = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+        eff_seqlen_kv = seqlen_kv
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_unmasked_lo = bounds_init.unmasked_lo
+        kv_unmasked_hi = bounds_init.unmasked_hi
+        kv_right = bounds_init.right
+
+    # ---- Per-tensor swizzle for SMEM stores (same Swz128B as Q/O at d=512) ----
+    # P SMEM swizzle hoisted to module-level (P_SMEM_SWIZZLE) — see top of file.
+    _O_EPI_SWIZZLE = cutlass.Swizzle(3, 4, 3)
+
+    # Epilogue tile params (O SMEM stride).  TILE_O=512, BPE_O=2 → 8 chunks.
+    O_EPI_BLOCK_SIZE = 64 // CFG.BPE_O  # 32 fp16, 64 fp8
+    O_TMA_ITERS = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES  # 8 chunks
+    O_D_BLOCK = CFG.TILE_O // O_TMA_ITERS  # 64 elements / chunk
+    O_TMA_GRANU_ELEMS = CFG.TILE_M * O_D_BLOCK  # 8192 elements / TMA chunk
+    O_BLOCKS_PER_SUB = 128 // O_EPI_BLOCK_SIZE  # 4 (f16) / 2 (fp8)
+    O_CHUNK_ELEMS = 128 // CFG.BPE_O  # 64 (f16) / 128 (fp8)
+
+    # ---- sg0 state — streaming softmax + DSMEM ship ----
+    bmm1_done_state = PipelineState.start(phase=0)
+    # PipelineState(0, 1) → both mb_p_xfer_empty and mb_alpha_xfer_empty are
+    # pre-armed; iter-0/1 wait passes immediately on fresh barriers.
+    sg0_xfer_state = PipelineState.start(phase=1)
+    stats_xfer_empty_phase = cutlass.Int32(1)
+
+    # ---- sg1 state — recv alpha + correction + epilogue ----
+    alpha_full_state = PipelineState.start(phase=0)
+    sg1_bmm2_done_state = PipelineState.start(phase=0)
+    stats_xfer_full_phase = cutlass.Int32(0)
+    epilogue_state = cutlass.Int32(0)
+
+    # ---- streaming-softmax accumulators (sg0) — Vector[Float32,2] for
+    #      packed FMUL2/FADD2 lowering, per the canonical f16 port pattern.
+    total_max = NEG_INF_F32
+    total_sum_vec = cutlass.Vector.from_elements(
+        (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+        cutlass.Float32,
+    )
+
+    # ==================================================================
+    # TODO(main agent): port sg0 streaming-softmax + DSMEM-ship body from
+    # C++ prefill_sdpa_d512_fp8.cu lines 432-522 (softmax_kv_body) and
+    # 599-749 (per-tile loop), and sg1 correction + epilogue body from
+    # C++ lines 750-1024.
+    #
+    # Must preserve:
+    #   - sg0 mb_p_xfer_empty / mb_alpha_xfer_empty pre-armed at phase=1
+    #     (PipelineState(0, 1)) — matches C++ ``Sg0KvState s.sg0_state(0, 1)``.
+    #   - sg0 mb_bmm1_done_state NOT pre-armed (phase=0) — BMM1 commit must
+    #     land before sg0 sm reads S_acc[0].
+    #   - sg0 mb_s_acc_empty.arrive_on_peer(0u, 1u) — all-thread DSMEM-arrive
+    #     to sg0 leader (256 lanes total).  Cross-warp sync between
+    #     tmem_load_fence and the arrive is BUILT INTO the all-thread arrive
+    #     (P8 + P11) — no extra named_barrier_wait needed.
+    #   - sg0 DSMEM bulk_copy to peer SMEM uses
+    #     ``cp_async_bulk_shared_cluster_shared_cta`` (per project memory:
+    #     bare nvvm op silently fires sender's local mbar instead of receiver).
+    #   - sg1 mb_alpha_xfer_full[parity_cur].arrive(ALPHA_XFER_TILE_BYTES, lead_warp_elect)
+    #     — wrapper @p-gates on elect, the wait below spins on phase parity.
+    #   - sg1 iter-0 BOTH mb_bmm2_ready half slots fired immediately (BMM2(0)
+    #     doesn't depend on alpha — C++ lines 798-805).
+    #   - sg1 correction split into 2 halves of CORR_BLOCKS_PER_HALF blocks
+    #     each (TILE_O / correction_block_size / 2 blocks per half), with
+    #     mb_bmm2_ready[parity*2+0] fired after half-1, [parity*2+1] after
+    #     half-2.  Lets BMM2 sub-tile 0 start while corr works on half-2.
+    #   - sg1 epilogue: TMEM layout SCRAMBLED by cga2 N-split + 2-call N-block
+    #     split (cf. C++ lines 964-983).  Iterate in OUTPUT order with bit-
+    #     swap [0,2,1,3] permutation.
+    #   - sg1 mb_tma_o_full arrives per-128B chunk in output order.
+    #   - sg1 mb_tmem_dealloc.arrive_on_peer(cta_id_x ^ 1u) — DSMEM fan-out
+    #     between cga2 partners (cf. C++ lines 1023, 748).
+    # ==================================================================
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if is_sg0:
+            # ============================================================
+            # sg0 — streaming softmax + ship alpha + P + stats.
+            # Port of C++ prefill_sdpa_d512_fp8.cu lines 432-522 + 585-735.
+            # ============================================================
+            total_max = NEG_INF_F32
+            total_sum_vec = cutlass.Vector.from_elements(
+                (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+                cutlass.Float32,
+            )
+
+            # Per-lane absolute Q row (used by apply_mask_chunk in
+            # LEFT/RIGHT segments).  Same anchor C++ uses at
+            # prefill_sdpa_d512_fp8.cu:473 (`tc.q_row_coord + tid`).
+            q_abs = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + tid_in_wg
+
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+                pass
+            else:
+                # 3-segment kv loop: LEFT-masked / unmasked center / RIGHT-masked.
+                # MASK_NONE collapses the two masked sub-loops to empty range
+                # (kv_left == kv_unmasked_lo and kv_unmasked_hi == kv_right),
+                # so the LEFT/RIGHT branches fold out at trace time.
+                if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+                    for _kv in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                        sg0_xfer_state, bmm1_done_state, total_max, total_sum_vec = _sg0_softmax_kv_iter(
+                            False,
+                            _kv,
+                            sg0_xfer_state,
+                            bmm1_done_state,
+                            total_max,
+                            total_sum_vec,
+                            tmem_base_addr,
+                            bars,
+                            sP_xfer_raw,
+                            sAlpha_xfer_raw,
+                            q_abs,
+                            eff_seqlen_kv,
+                            seqlen_q,
+                            scale_log2,
+                            tid_in_wg,
+                            is_lead_warp,
+                            leader_cta_id,
+                            cross_sg_peer,
+                        )
+                else:
+                    for _kv in cutlass.range(kv_left, kv_unmasked_lo, 1, unroll=1):
+                        sg0_xfer_state, bmm1_done_state, total_max, total_sum_vec = _sg0_softmax_kv_iter(
+                            True,
+                            _kv,
+                            sg0_xfer_state,
+                            bmm1_done_state,
+                            total_max,
+                            total_sum_vec,
+                            tmem_base_addr,
+                            bars,
+                            sP_xfer_raw,
+                            sAlpha_xfer_raw,
+                            q_abs,
+                            eff_seqlen_kv,
+                            seqlen_q,
+                            scale_log2,
+                            tid_in_wg,
+                            is_lead_warp,
+                            leader_cta_id,
+                            cross_sg_peer,
+                        )
+                    for _kv in cutlass.range(kv_unmasked_lo, kv_unmasked_hi, 1, unroll=1):
+                        sg0_xfer_state, bmm1_done_state, total_max, total_sum_vec = _sg0_softmax_kv_iter(
+                            False,
+                            _kv,
+                            sg0_xfer_state,
+                            bmm1_done_state,
+                            total_max,
+                            total_sum_vec,
+                            tmem_base_addr,
+                            bars,
+                            sP_xfer_raw,
+                            sAlpha_xfer_raw,
+                            q_abs,
+                            eff_seqlen_kv,
+                            seqlen_q,
+                            scale_log2,
+                            tid_in_wg,
+                            is_lead_warp,
+                            leader_cta_id,
+                            cross_sg_peer,
+                        )
+                    for _kv in cutlass.range(kv_unmasked_hi, kv_right, 1, unroll=1):
+                        sg0_xfer_state, bmm1_done_state, total_max, total_sum_vec = _sg0_softmax_kv_iter(
+                            True,
+                            _kv,
+                            sg0_xfer_state,
+                            bmm1_done_state,
+                            total_max,
+                            total_sum_vec,
+                            tmem_base_addr,
+                            bars,
+                            sP_xfer_raw,
+                            sAlpha_xfer_raw,
+                            q_abs,
+                            eff_seqlen_kv,
+                            seqlen_q,
+                            scale_log2,
+                            tid_in_wg,
+                            is_lead_warp,
+                            leader_cta_id,
+                            cross_sg_peer,
+                        )
+
+            # ---- End-of-tile: ship final stats (max, ell) ----
+            bars.mb_stats_xfer_empty.wait(stats_xfer_empty_phase)
+            stats_xfer_empty_phase = stats_xfer_empty_phase ^ cutlass.Int32(1)
+
+            final_sum = total_sum_vec[0] + total_sum_vec[1]
+            # Stats layout in SMEM: ell[TILE_M] then max[TILE_M].
+            stats_sum_slot = sStats_xfer_raw.subview(tid_in_wg)
+            stats_max_slot = sStats_xfer_raw.subview(cutlass.Int32(CFG.TILE_M) + tid_in_wg)
+            stats_sum_slot.store(final_sum)
+            stats_max_slot.store(total_max)
+
+            nvvm.fence_proxy("async.shared", space="cta")
+            nvvm.barrier_cta_sync(barrier_id=8, thread_count=128)
+
+            # Predicated stats ship — same rationale as the per-iter alpha/P
+            # ship above (`@p UBLKCP`, no warp-divergent branch).
+            ship_pred = is_lead_warp & nvvm.elect_sync()
+            peer_stats_dst = nvvm.mapa(sStats_xfer_raw, cross_sg_peer, addrspace=7)
+            peer_stats_full_mbar = nvvm.mapa(bars.mb_stats_xfer_full.smem_ptr, cross_sg_peer, addrspace=7)
+            cp_async_bulk_shared_cluster_shared_cta(
+                peer_stats_dst,
+                sStats_xfer_raw,
+                peer_stats_full_mbar,
+                statsXferBytes,
+                pred=ship_pred,
+            )
+        else:
+            # ============================================================
+            # sg1 — correction (apply alpha) + epilogue (normalize, cast,
+            # store O, LSE).  Port of C++ lines 750-1024.
+            # ============================================================
+            tmem_O_base = tmem_base_addr + cutlass.Int32(LAYOUT.O_OFF)
+
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+                # Empty-kv branch: signal MMA's empty-mainloop wait
+                # (each sg1 CTA's elect lane DSMEM-arrives sg1 leader).
+                bars.mb_empty_mainloop.arrive_on_peer(leader_cta_id, pred=is_lead_warp & nvvm.elect_sync())
+            else:
+                # --- iter 0: BMM2(0) doesn't depend on alpha; fire both
+                #     bmm2_ready half slots immediately (C++ 798-805).
+                cur_parity_0 = alpha_full_state.idx
+                bars.mb_bmm2_ready[cur_parity_0 * cutlass.Int32(CFG.N_BMM2_CHUNKS)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+                bars.mb_bmm2_ready[cur_parity_0 * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(1)].arrive(
+                    leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA
+                )
+
+                # Arm + wait alpha_xfer_full[parity_0].  Wrapper @p-gates
+                # on elect; wait spins on phase parity (atomically observable).
+                bars.mb_alpha_xfer_full[cur_parity_0].arrive(n_bytes=alphaXferBytes, pred=is_lead_warp & nvvm.elect_sync())
+                bars.mb_alpha_xfer_full[cur_parity_0].wait(alpha_full_state.phase)
+                alpha_full_state = advance(alpha_full_state, CFG.XFER_STAGES)
+
+                # Notify sg0 (cross-sg peer) alpha slot is empty.
+                bars.mb_alpha_xfer_empty[cur_parity_0].arrive_on_peer(cross_sg_peer)
+
+                # --- iter 1..n_kv-1: apply alpha to O before BMM2(kv) ---
+                CORR_BLOCK_SIZE = 16
+                CORR_BLOCKS_TOTAL = CFG.TILE_O // CORR_BLOCK_SIZE  # 32
+                CORR_BLOCKS_PER_HALF = CORR_BLOCKS_TOTAL // 2  # 16
+
+                for _kv in cutlass.range(kv_left + cutlass.Int32(1), kv_right, 1, unroll=1):
+                    cur_parity = alpha_full_state.idx
+
+                    bars.mb_alpha_xfer_full[cur_parity].arrive(n_bytes=alphaXferBytes, pred=is_lead_warp & nvvm.elect_sync())
+                    bars.mb_alpha_xfer_full[cur_parity].wait(alpha_full_state.phase)
+                    alpha_full_state = advance(alpha_full_state, CFG.XFER_STAGES)
+
+                    # Wait prior BMM2 done so O is committed.
+                    bars.mb_bmm2_done[sg1_bmm2_done_state.idx].wait(sg1_bmm2_done_state.phase)
+                    sg1_bmm2_done_state = advance(sg1_bmm2_done_state, CFG.XFER_STAGES)
+
+                    # Read alpha[tid] from xfer_in[cur_parity].
+                    alpha_addr = sAlpha_xfer_raw.subview(cur_parity * cutlass.Int32(CFG.TILE_M) + tid_in_wg)
+                    alpha_corr = alpha_addr.load()
+
+                    # all_alpha_one ballot: skip rescale entirely if every
+                    # lane's alpha == 1.0.
+                    alpha_is_one = alpha_corr == cutlass.Float32(1.0)
+                    all_alpha_one = vote_sync(0xFFFFFFFF, alpha_is_one, VoteSync.ALL)
+
+                    # ---- Half-1: cols [0..TILE_O/2) ----
+                    if ~all_alpha_one:
+                        for block in cutlass.range_constexpr(CORR_BLOCKS_PER_HALF):
+                            o_off = tmem_O_base + cutlass.Int32(block * CORR_BLOCK_SIZE)
+                            o_chunk = nvvm.tcgen05_ld(
+                                "32x32b",
+                                nvvm.make_tmem_ptr(o_off, cutlass.Float32),
+                                num=CORR_BLOCK_SIZE,
+                            )
+                            o_scaled = vec_scale_pair(o_chunk, alpha_corr, CORR_BLOCK_SIZE)
+                            nvvm.tcgen05_st(
+                                "32x32b",
+                                nvvm.make_tmem_ptr(o_off, cutlass.Float32),
+                                o_scaled,
+                            )
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+
+                    # Notify sg0 alpha slot empty.
+                    bars.mb_alpha_xfer_empty[cur_parity].arrive_on_peer(cross_sg_peer)
+                    # Half-1 ready — sg1 leader BMM2 sub-tile 0 unblocked.
+                    bars.mb_bmm2_ready[cur_parity * cutlass.Int32(CFG.N_BMM2_CHUNKS)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                    # ---- Half-2: cols [TILE_O/2..TILE_O) ----
+                    if ~all_alpha_one:
+                        for block in cutlass.range_constexpr(CORR_BLOCKS_PER_HALF):
+                            block_idx = CORR_BLOCKS_PER_HALF + block
+                            o_off = tmem_O_base + cutlass.Int32(block_idx * CORR_BLOCK_SIZE)
+                            o_chunk = nvvm.tcgen05_ld(
+                                "32x32b",
+                                nvvm.make_tmem_ptr(o_off, cutlass.Float32),
+                                num=CORR_BLOCK_SIZE,
+                            )
+                            o_scaled = vec_scale_pair(o_chunk, alpha_corr, CORR_BLOCK_SIZE)
+                            nvvm.tcgen05_st(
+                                "32x32b",
+                                nvvm.make_tmem_ptr(o_off, cutlass.Float32),
+                                o_scaled,
+                            )
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+
+                    # Half-2 ready — sg1 leader BMM2 sub-tile 1 unblocked.
+                    bars.mb_bmm2_ready[cur_parity * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(1)].arrive(
+                        leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA
+                    )
+
+            # ---- Final BMM2-done wait (always runs — empty path covered) ----
+            bars.mb_bmm2_done[sg1_bmm2_done_state.idx].wait(sg1_bmm2_done_state.phase)
+            sg1_bmm2_done_state = advance(sg1_bmm2_done_state, CFG.XFER_STAGES)
+
+            # ---- Epilogue ----
+            epilogue_state = epilogue_state ^ cutlass.Int32(1)
+            bars.mb_tma_o_empty.wait(epilogue_state)
+
+            # Arm stats_xfer_full (sg0 delivers via DSMEM bulk_copy).
+            bars.mb_stats_xfer_full.arrive(n_bytes=statsXferBytes, pred=is_lead_warp & nvvm.elect_sync())
+            bars.mb_stats_xfer_full.wait(stats_xfer_full_phase)
+            stats_xfer_full_phase = stats_xfer_full_phase ^ cutlass.Int32(1)
+
+            # Per-thread lds_32 of final_ell / final_max.
+            ell_addr = sStats_xfer_raw.subview(tid_in_wg)
+            max_addr = sStats_xfer_raw.subview(cutlass.Int32(CFG.TILE_M) + tid_in_wg)
+            final_ell = ell_addr.load()
+            final_max = max_addr.load()
+
+            # Stats consumed → notify sg0 stats_xfer.out free to overwrite.
+            bars.mb_stats_xfer_empty.arrive_on_peer(cross_sg_peer, pred=is_lead_warp & nvvm.elect_sync())
+
+            # Compute beta, lse — HAS_SINK fold (dsv4 today: HAS_SINK=0,
+            # collapses to plain 1/total_sum normalization).
+            LN2 = cutlass.Float32(0.6931471805599453)
+            if cutlass.const_expr(CFG.HAS_SINK):
+                sinks_arr = cutlass.make_array_view(sinks_tensor)
+                sink_logit = sinks_arr[head_idx]
+                final_max_nat = final_max * LN2
+                new_max_nat = cute.math.max(final_max_nat, sink_logit)
+                scale_sink = cute.math.exp(final_max_nat - new_max_nat, fastmath=True)
+                new_sum = final_ell * scale_sink + cute.math.exp(sink_logit - new_max_nat, fastmath=True)
+                beta = (scale_sink * o_scale_fused) / new_sum
+                lse = new_max_nat + cute.math.log(new_sum, fastmath=True)
+            else:
+                final_ell_safe = cute.math.max(final_ell, cutlass.Float32(1e-30))
+                beta = o_scale_fused / final_ell_safe
+                lse = final_max * LN2 + cute.math.log(final_ell_safe, fastmath=True)
+
+            # Empty KV range (fully-masked / zero-length sequence): the mainloop
+            # ran ZERO iterations, so final_ell is exactly 0 and the O
+            # accumulator is RESIDUE (the suite poisons TMEM on purpose, so it
+            # can be a NaN bit pattern).  The 1e-30 floor above keeps the
+            # division finite but LEAKS: beta becomes ~1e30 -> +inf after the
+            # o_scale fold, and residue * inf = NaN; lse becomes log(1e-30) =
+            # -69.08 instead of -inf.  SELECT the answer -- never `* 0`, which
+            # a NaN residue survives.  Mirrors the d512 f16 / MXFP8 siblings.
+            # (sdpa-invariants.md S2/S3; the sink arm already yields
+            # sink_logit at total_sum == 0, so it needs no LSE substitution.)
+            _row_empty = final_ell == cutlass.Float32(0.0)
+            if cutlass.const_expr(not CFG.HAS_SINK):
+                lse = cutlass.Float32(arith.select(_row_empty.ir_value(), cutlass.Float32(float("-inf")).ir_value(), lse.ir_value()))
+
+            # Cast O fp32 → fp8/bf16/fp16 (CFG.DTYPE_O) with bit-permuted TMEM block index.
+            # TMEM layout is scrambled by cga2 N-split + 2-call N-block:
+            #   TMEM[ 0:128] = d_v[  0:128]   (call 0, leader half)
+            #   TMEM[128:256] = d_v[256:384]   (call 0, peer half)
+            #   TMEM[256:384] = d_v[128:256]   (call 1, leader half)
+            #   TMEM[384:512] = d_v[384:512]   (call 1, peer half)
+            # Iterate in OUTPUT order; bit-swap b_sub ∈ {0..3} → {0,2,1,3}.
+            sO_base = sO[0].base
+
+            # amax_o = max over VALID rows of |o| (fp32, pre-cast).  The atomic
+            # itself is gated on row validity further down, where q_row_global
+            # exists -- atomicMax only grows, so a padded row would permanently
+            # inflate the graph's Amax_O with no error anywhere.
+            _amax_o_ptr = Pointer(amax_o_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
+            _amax_o_local = cutlass.Float32(0.0)
+
+            for b in cutlass.range_constexpr(CFG.TILE_O // O_EPI_BLOCK_SIZE):
+                b_intra = b & (O_BLOCKS_PER_SUB - 1)
+                b_sub = b // O_BLOCKS_PER_SUB
+                tmem_sub = ((b_sub & 1) << 1) | ((b_sub & 2) >> 1)
+                tmem_block = tmem_sub * O_BLOCKS_PER_SUB + b_intra
+
+                o_addr = tmem_O_base + cutlass.Int32(tmem_block * O_EPI_BLOCK_SIZE)
+                o_fp32 = nvvm.tcgen05_ld(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                    num=O_EPI_BLOCK_SIZE,
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                o_scaled = o_fp32 * beta
+                # Zero an empty row with a SELECT (see above), and fold amax
+                # over the SUBSTITUTED values so a dead row cannot poison Amax_O.
+                _o_elems = []
+                for _i in cutlass.range_constexpr(O_EPI_BLOCK_SIZE):
+                    _e = cutlass.Float32(arith.select(_row_empty.ir_value(), cutlass.Float32(0.0).ir_value(), o_scaled[_i].ir_value()))
+                    _amax_o_local = cute.math.max(_amax_o_local, cute.math.max(_e, -_e))
+                    _o_elems.append(_e)
+                o_half = cutlass.Vector.from_elements(tuple(_o_elems), cutlass.Float32).to(OUT_STORAGE_DTYPE)
+
+                # SMEM store — TMA-O grain layout (O_D_BLOCK elements / chunk).
+                col_offset_const = (b * O_EPI_BLOCK_SIZE) % O_D_BLOCK
+                block_idx_const = (b * O_EPI_BLOCK_SIZE) // O_D_BLOCK
+                block_offset_const = block_idx_const * O_TMA_GRANU_ELEMS
+                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(O_D_BLOCK)
+                smem_ptr = sO_base.subview(smem_offset).data_ptr()
+                smem_ptr.store_swizzled(
+                    o_half,
+                    alignment=64,
+                    swizzle=_O_EPI_SWIZZLE,
+                )
+
+                # Per-128B-chunk arrive on TMA-STG.
+                if ((b + 1) * O_EPI_BLOCK_SIZE) % O_CHUNK_ELEMS == 0:
+                    chunk = (b * O_EPI_BLOCK_SIZE) // O_CHUNK_ELEMS
+                    nvvm.fence_proxy("async.shared", space="cta")
+                    bars.mb_tma_o_full[chunk].arrive()
+
+            # Write LSE — under cga2 each sg1 peer writes its half of O+LSE
+            # rows (leader = [0:128], peer = [128:256]).  Per-thread row.
+            q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + tid_in_wg
+            # Gated exactly like the LSE write below.
+            if q_row_global < seqlen_q:
+                nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: q_row_global is sequence-local; LSE is packed [1,QH,T] →
+                # index [0, head, cu_q[b] + local], bound by per-sequence Q len S_q_b.
+                _cu = cutlass.make_array_view(seq_kv_lens_tensor)
+                _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
+                _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
+                if cutlass.const_expr(lse_tensor is not None):
+                    if q_row_global < _s_q_b:
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
+                        lse_row[_cu_q_b + q_row_global] = lse
+            else:
+                if cutlass.const_expr(lse_tensor is not None):
+                    if q_row_global < seqlen_q:
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        lse_row = lse_arr[batch_idx, head_idx, :]
+                        lse_row[q_row_global] = lse
+
+        # End-of-tile: advance scheduler.
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+        nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+        nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_unmasked_lo = bounds_next.unmasked_lo
+            kv_unmasked_hi = bounds_next.unmasked_hi
+            kv_right = bounds_next.right
+
+    # End-of-kernel: trailing-arrive drain (sg0 only — sg1's late
+    # arrive_on_peer lands on a still-live mbar via this drain).  Per
+    # C++ lines 722-744: drain XFER_STAGES empty arrives + stats_xfer_empty
+    # before sg0 sm exits.
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        if is_sg0:
+            if is_lead_warp:
+                if nvvm.elect_sync():
+                    for _p in cutlass.range_constexpr(CFG.XFER_STAGES):
+                        bars.mb_p_xfer_empty[sg0_xfer_state.idx].wait(sg0_xfer_state.phase)
+                        bars.mb_alpha_xfer_empty[sg0_xfer_state.idx].wait(sg0_xfer_state.phase)
+                        sg0_xfer_state = advance(sg0_xfer_state, CFG.XFER_STAGES)
+                    bars.mb_stats_xfer_empty.wait(stats_xfer_empty_phase)
+            nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        # Each CTA's compute warp fires 1 elect-arrive_on_peer to its cga2
+        # partner → 1 arrive per CTA (init = ONE_LANE matches).
+        peer_cta = cta_id_x ^ cutlass.Int32(1)
+        bars.mb_tmem_dealloc.arrive_on_peer(peer_cta, pred=is_lead_warp & nvvm.elect_sync())
+
+
+# ============================================================================
+# MMA warp group — sg-conditional BMM1 (sg0 leader) / BMM2 (sg1 leader).
+# Port of C++ mma_warp_group (prefill_sdpa_d512_fp8.cu:1021-1233).
+# ============================================================================
+@cute.jit
+def _mma_warp_group(
+    is_sg0,
+    is_sg1,
+    seqlen_q,
+    seqlen_kv,
+    sQ,
+    sK,
+    sV,
+    sP_xfer_raw,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    mcast_mask,
+    sg0_mcast_mask,
+    cta_in_pair,
+):
+    """MMA warp leader — sg-conditional BMM1 (sg0 leader) or BMM2 (sg1 leader).
+
+    sg0 leader (port of C++ lines 1101-1163):
+        For each tile: wait Q full, then for each kv iter: wait S_acc[parity]
+        empty (pre-armed at iter 0/1 via PipelineState(0, 1)), wait K[stage]
+        full, mma_ss(Q, K) → S_acc[parity] (collective N = TILE_M*CTA_MMA),
+        commit_mma on bmm1_done[parity] AND k_empty[stage] (P13 multicast,
+        sg0_mcast_mask).  After last BMM1: commit_mma on q_empty (multicast).
+
+    sg1 leader (port of C++ lines 1165-1246):
+        For each tile: if n_kv > 0: for each kv iter: arrive own
+        mb_p_xfer_full (own + DSMEM-forwarded from non-leader), wait
+        mb_p_xfer_full, wait V[stage] full, for each of BMM2_LOOP_N_BLOCKS=2
+        N-block calls: wait mb_bmm2_ready[parity*2+nblock], mma_ss(P, V) →
+        O_block (per-call N=256, advance V desc by BMM2_V_NBLOCK_ADVANCE),
+        commit bmm2_done[parity], v_empty[stage], p_xfer_empty[parity]
+        (P13 multicast with sg0_mcast_mask).
+        Empty-kv branch: wait mb_empty_mainloop, commit bmm2_done[parity].
+
+    Both leaders share the TMEM alloc + named-barrier publish:
+        tmem_alloc(576 cols, is_exclusive=True) → barrier_arrive(barrier_id=1,
+        count = 32 * (SOFTMAX_WG_WARPS + 1) = 160).  No barrier_id=2 here
+        (DSv4 has no separate correction-warp publish; correction is fused
+        into the compute warp group's sg1 branch).
+    """
+    # SM107 cap = 576 cols; is_exclusive=True enforced inside tmem_alloc wrapper.
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND, is_exclusive=True)
+    # Publish to compute warpgroup (waits on barrier_id=1 with count 160).
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WG_WARPS + 1))
+
+    # Do column arithmetic on raw Int8 ptr; retype at use site.  (Per
+    # cpp-to-ctm.md: make_tmem_ptr(addr, Float16) + N strides FP16 elems
+    # not columns — silent-wrong-result bug.)
+    tmem_raw = nvvm.make_tmem_ptr(tmem_ptr_i32.load(), cutlass.Int8)
+
+    # idesc M is COLLECTIVE (per-CTA M * CTA_MMA) under cga2.
+    # k_dim=1 = Rubin K=64 2-chunk fast path (TILE_K_HW_BMM1=64).  Without it the
+    # QMMA descriptor encodes K=32 → each tcgen05.mma processes half the K bytes
+    # per step → silently-scrambled per-row S_acc.
+    idesc_qk = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_N,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        k_dim=1,
+    )
+    # BMM2 idesc — N per call = 256 (NOT TILE_O); 2 calls per BMM2.
+    idesc_pv = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.BMM2_N_PER_CALL,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        b_major=1,
+        k_dim=1,
+    )
+    bmm1_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_N,
+        K=CFG.TILE_K,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=CFG.TILE_K_HW_BMM1,
+        btranspose=False,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_qk,
+        kind=MMA_KIND,
+    )
+    # BMM2 with N per call = 256, B-transpose, manual k-step driven by kernel.
+    bmm2_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.BMM2_N_PER_CALL,
+        K=CFG.TILE_N,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=CFG.TILE_K_HW_BMM2,
+        btranspose=True,
+        k_subtile=CFG.V_SWZ_BYTES // CFG.BPE,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_pv,
+        kind=MMA_KIND,
+    )
+
+    # Persistent-tile scheduler state.
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    # sg0 leader state (BMM1).
+    q_full_phase = cutlass.Int32(0)
+    kv_state_K = PipelineState.start(phase=0)
+    # pre-armed: PipelineState(0, 1) so iter-0/1 wait passes on fresh barriers.
+    s_acc_empty_state = PipelineState.start(phase=1)
+
+    # sg1 leader state (BMM2).
+    kv_state_V = PipelineState.start(phase=0)
+    sg1_mma_state = PipelineState.start(phase=0)
+    # bmm2_ready_state walks XFER_STAGES * N_BMM2_CHUNKS slots linearly
+    # (parity*2 + nblock); phase flips every XFER_STAGES*N_BMM2_CHUNKS arrives.
+    bmm2_ready_state = PipelineState.start(phase=0)
+    bmm2_done_prod_state = PipelineState.start(phase=0)
+    empty_mainloop_phase = cutlass.Int32(0)
+
+    # Pre-build a SmemTile wrapper for the P xfer ring (sg1 leader only — sg0
+    # builds its descriptor on its own SMEM, but for parity_cur lookup we use
+    # the same swizzle/layout that sg0 used when writing).  P xfer SMEM is
+    # TILE_M × TILE_N (cf. C++ P_Layout); matches Q swizzle (Swz128B at d=512).
+    sP_xfer = SmemTile(
+        base=sP_xfer_raw,
+        elems_per_stage=pXferElems,
+        stages=CFG.XFER_STAGES,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_P,
+        desc_version=1,
+    )
+
+    # BMM1 leader: desc_Q is tile-static (Q stays resident under d=512 / no Q∪K alias).
+    desc_Q = sQ[0].desc()
+    # BMM2 leader: V N-block advance in ELEMENTS (BMM2_V_NBLOCK_ADVANCE is bytes).
+    V_NBLOCK_ADVANCE_ELEMS = BMM2_V_NBLOCK_ADVANCE // CFG.BPE
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if is_sg0:
+            # ============================================================
+            # sg0 leader — BMM1: Q × K^T → S_acc[parity]
+            # ============================================================
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+                pass
+            else:
+                bars.mb_tma_q_full.wait(q_full_phase)
+                q_full_phase = q_full_phase ^ cutlass.Int32(1)
+
+                for _kv in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                    cur_parity_K = s_acc_empty_state.idx
+                    bars.mb_s_acc_empty[cur_parity_K].wait(s_acc_empty_state.phase)
+                    s_acc_empty_state = advance(s_acc_empty_state, CFG.XFER_STAGES)
+
+                    bars.mb_tma_k_full[kv_state_K.idx].wait(kv_state_K.phase)
+                    desc_K = sK[kv_state_K.idx].desc()
+                    # S_acc TMEM offset = parity * S_ACC_COLS (TmemTile layout).
+                    s_acc_off = cur_parity_K * cutlass.Int32(LAYOUT.S_ACC_COLS)
+                    mma_ss(bmm1_desc, desc_Q, desc_K, tmem_raw.subview(s_acc_off), accumulate=False)
+                    elect_p = nvvm.elect_sync()
+                    bars.mb_bmm1_done[cur_parity_K].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                    bars.mb_tma_k_empty[kv_state_K.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                    kv_state_K = advance(kv_state_K, CFG.STAGES_KV)
+
+                # After last BMM1: multicast Q-empty so both peers' TMA warps
+                # advance.  tcgen05.commit fires AFTER MMA drain (P13) so TMA
+                # can't overwrite Q SMEM mid-read.
+                bars.mb_tma_q_empty.arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=nvvm.elect_sync())
+        else:
+            # ============================================================
+            # sg1 leader — BMM2: P × V → O via mma_ss, 2 N-block calls
+            # ============================================================
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+                # Empty-kv branch — keep bmm2_done producer/consumer states
+                # in lockstep across mixed empty/normal sequences.
+                bars.mb_empty_mainloop.wait(empty_mainloop_phase)
+                empty_mainloop_phase = empty_mainloop_phase ^ cutlass.Int32(1)
+                bars.mb_bmm2_done[bmm2_done_prod_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=nvvm.elect_sync())
+                bmm2_done_prod_state = advance(bmm2_done_prod_state, CFG.XFER_STAGES)
+            else:
+                for kv_loop in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                    cur_parity = sg1_mma_state.idx
+
+                    # Leader's own arrive on mb_p_xfer_full[parity] (own
+                    # P-bytes were just delivered by cross-sg sg0 partner
+                    # via DSMEM bulk_copy).  Init = CTA_MMA arrives — this
+                    # contributes 1, the non-leader forwarder contributes
+                    # the other 1 (P12).
+                    bars.mb_p_xfer_full[cur_parity].arrive(n_bytes=pXferBytes, pred=nvvm.elect_sync())
+                    bars.mb_p_xfer_full[cur_parity].wait(sg1_mma_state.phase)
+                    sg1_mma_state = advance(sg1_mma_state, CFG.XFER_STAGES)
+
+                    bars.mb_tma_v_full[kv_state_V.idx].wait(kv_state_V.phase)
+
+                    accum_b2 = kv_loop > kv_left
+
+                    # Rebuild SmemDescs for this iter's P parity and V stage.
+                    desc_P = sP_xfer[cur_parity].desc()
+                    desc_V_n0 = sV[kv_state_V.idx].desc()
+                    desc_V_n1 = sV[kv_state_V.idx].shifted(V_NBLOCK_ADVANCE_ELEMS).desc()
+
+                    # N-block 0: writes O TMEM cols [0..BMM2_N_PER_CALL).
+                    bars.mb_bmm2_ready[bmm2_ready_state.idx].wait(bmm2_ready_state.phase)
+                    bmm2_ready_state = advance(bmm2_ready_state, CFG.XFER_STAGES * CFG.N_BMM2_CHUNKS)
+                    mma_ss(bmm2_desc, desc_P, desc_V_n0, tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF)), accumulate=accum_b2)
+
+                    # N-block 1: writes O TMEM cols [BMM2_N_PER_CALL..TILE_O).
+                    bars.mb_bmm2_ready[bmm2_ready_state.idx].wait(bmm2_ready_state.phase)
+                    bmm2_ready_state = advance(bmm2_ready_state, CFG.XFER_STAGES * CFG.N_BMM2_CHUNKS)
+                    mma_ss(bmm2_desc, desc_P, desc_V_n1, tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF + CFG.BMM2_N_PER_CALL)), accumulate=accum_b2)
+
+                    elect_p = nvvm.elect_sync()
+                    bars.mb_bmm2_done[bmm2_done_prod_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                    bars.mb_tma_v_empty[kv_state_V.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                    # P13 multicast on mb_p_xfer_empty — sg0_mcast_mask
+                    # (= 0x3) targets BOTH sg0 CTAs so sg0 sm's next P
+                    # slot reuse is unblocked.
+                    bars.mb_p_xfer_empty[cur_parity].arrive(mcast_mask=sg0_mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                    kv_state_V = advance(kv_state_V, CFG.STAGES_KV)
+                    bmm2_done_prod_state = advance(bmm2_done_prod_state, CFG.XFER_STAGES)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+
+    # End-of-warp tmem_dealloc — wait fan-in from both compute warps then free.
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+# ============================================================================
+# MMA warp non-leader paths — sg0 minimal quiet vs sg1 P12 forwarder.
+# Port of C++ mma_warp_group non-leader paths (prefill_sdpa_d512_fp8.cu:1036-1082).
+# ============================================================================
+@cute.jit
+def _mma_warp_non_leader(
+    is_sg0,
+    is_sg1,
+    seqlen_q,
+    seqlen_kv,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    cta_in_pair,
+    leader_cta_id,
+):
+    """sg0 non-leader: minimal quiet (alloc + wait dealloc + free).
+    sg1 non-leader: persistent loop forwarding mb_p_xfer_full to leader (P12).
+
+    sg0 quiet (port of C++ lines 1049-1054):
+        Just participates in TMEM alloc + named-barrier publish (sm warps
+        read the published base ptr from peer's TMEM under cga2 collective
+        MMA), then waits on mb_tmem_dealloc and frees.
+
+    sg1 forwarder (port of C++ lines 1055-1093):
+        Persistent tile loop — at iter scope, per kv_local:
+          - arrive(mb_p_xfer_full[parity], P_XFER_TILE_BYTES, elect) — local mbar
+          - wait(mb_p_xfer_full[parity], nlmma_state.phase) — local mbar
+          - arrive_on_peer(mb_p_xfer_full[parity], leader_cta_id) — DSMEM forward
+        Required because BMM2's collective mma_ss reads BOTH peers' P SMEM via
+        crossbar; leader's local mbar only sees its own cross-sg sg0 partner's
+        bytes, so non-leader must DSMEM-arrive on leader after observing own bytes.
+    """
+    # All-lanes warp-collective tmem_alloc (no elect_sync gating).
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND, is_exclusive=True)
+    # Match leader's named-barrier arrive count (lead is +1 on barrier_id=1).
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WG_WARPS + 1))
+
+    # sg0 non-leader is quiet (just wait dealloc); sg1 non-leader runs the
+    # persistent P12 forwarder loop.  `return` is forbidden inside @cute.jit
+    # (CTM gotcha), so we gate the forwarder on `is_sg1` and let both arms
+    # fall through to the shared dealloc wait + free at the bottom.
+    if is_sg1:
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+            sched.bidx_init,
+            sched.bidy_init,
+            sched.bidz_init,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = cutlass.Int32(1)
+        sched_state = PipelineState.start()
+
+        if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+            kv_left = cutlass.Int32(0)
+            kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+        else:
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_init.left
+            kv_right = bounds_init.right
+
+        nlmma_state = PipelineState.start(phase=0)
+
+        while is_valid_tile > cutlass.Int32(0):
+            read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+                pass
+            else:
+                for _kv in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                    # Arm own expect_tx for P-bytes delivered by cross-sg sg0
+                    # partner (via DSMEM bulk_copy).  Wait local mbar
+                    # (init = ONE_LANE — own arrive only).
+                    bars.mb_p_xfer_full[nlmma_state.idx].arrive(n_bytes=pXferBytes, pred=nvvm.elect_sync())
+                    bars.mb_p_xfer_full[nlmma_state.idx].wait(nlmma_state.phase)
+                    cur_parity = nlmma_state.idx
+                    nlmma_state = advance(nlmma_state, CFG.XFER_STAGES)
+                    # DSMEM-arrive on leader's mb_p_xfer_full[parity] — leader's
+                    # init = CTA_MMA (own + this forwarded arrive), so wait
+                    # flips only when both peers' bytes have landed (P12).
+                    bars.mb_p_xfer_full[cur_parity].arrive_on_peer(leader_cta_id, pred=nvvm.elect_sync())
+
+            nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+            wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+            nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+            nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+            nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+            q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+                nxt_q,
+                nxt_hb,
+                cta_in_pair,
+                n_q_supers,
+                n_qh,
+                n_batch,
+                seq_kv_lens_tensor,
+            )
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+            sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+                eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+                bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+                kv_left = bounds_next.left
+                kv_right = bounds_next.right
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+# ============================================================================
+# TMA-LDG warp group — sg-conditional Q+K (sg0) or V (sg1).
+# Port of C++ tmaldg_warp_group (prefill_sdpa_d512_fp8.cu:1241-1385).
+# ============================================================================
+@cute.jit
+def _tmaldg_warp_group(
+    is_sg0,
+    is_sg1,
+    tma_q_desc,
+    tma_k_desc,
+    tma_v_desc,
+    sQ,
+    sK,
+    sV,
+    bars,
+    sched,
+    seqlen_q,
+    seqlen_kv,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    qh_per_kh,
+    is_leader,
+    cta_in_pair,
+    tma_mcast_mask,
+):
+    """sg0: Q + K TMA-LDG.  sg1: V TMA-LDG.
+
+    Both sgs decode the persistent-tile scheduler payload.  Leader of each
+    pair issues expect_tx for the collective TMA byte count; both peers
+    issue the cta_group::2 multicast TMA (mcast_mask bits = bit_per_peer).
+
+    sg0 (port of C++ lines 1265-1338):
+        Per tile, if n_kv > 0:
+            wait(q_empty, q_empty_phase); leader arrive_expect_tx(q_full, qBytes);
+            tma_load_tile(sQ[0], q_gmem, q_full, multicast).
+            For each kv:
+              wait(k_empty[stage]); leader arrive_expect_tx(k_full[stage], kBytes);
+              tma_load_tile(sK[stage], k_gmem(kv * TILE_N + k_row_off), k_full, multicast).
+        q_empty pre-armed via q_empty_state=1 (iter-0 wait passes on phase 0 != 1).
+
+    sg1 (port of C++ lines 1339-1397):
+        Per tile, if n_kv > 0, per kv:
+          wait(v_empty[stage]); leader arrive_expect_tx(v_full[stage], vBytes);
+          tma_load_tile(sV[stage], v_gmem(v_col_off + cta_in_pair * (TILE_O/CTA_MMA) * BPE,
+                                        kv * TILE_N), v_full, multicast).
+        Note: C++ uses BYTE coord for V because UINT8 TMA descriptors; CTM's
+        typed descriptor uses ELEMENT coord — so multiply only when descriptor
+        is UINT8.  Current CTM descriptors are element-typed, so plain cta_in_pair *
+        (TILE_O/CTA_MMA) suffices.
+
+    Both sgs drain trailing K/V/Q empty arrives at end-of-kernel under cga2.
+    """
+    q_empty_phase = cutlass.Int32(1)  # pre-armed (iter-0 wait passes)
+    kv_state = PipelineState.start(phase=1)
+
+    tma_q = GmemTileTma(tma_q_desc)
+    tma_k = GmemTileTma(tma_k_desc)
+    tma_v = GmemTileTma(tma_v_desc)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+    q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    # Per-peer K row offset (sg0 only — sg1's V offset is along d_v).
+    K_ROW_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_N // CFG.CTA_MMA)
+    # Per-peer V d_v offset (sg1 only — sg0's K offset is along seq).
+    V_COL_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_O // CFG.CTA_MMA)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        # n_kv > 0 gate at MASK_NONE collapses to "always" since kv_right > 0.
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+            pass
+        else:
+            if is_sg0:
+                # ---- sg0: Q (one-shot per tile) + K_ring ----------------
+                bars.mb_tma_q_empty.wait(q_empty_phase)
+                q_empty_phase = q_empty_phase ^ cutlass.Int32(1)
+                bars.mb_tma_q_full.arrive(n_bytes=qTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                tma_load_tile(
+                    sQ[0],
+                    tma_q(cutlass.Int32(0), head_idx, q_row_base + q_seq_off, tma_batch),
+                    bars.mb_tma_q_full.smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=None,
+                )
+
+                for kv_loop in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                    kv_row_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+                    bars.mb_tma_k_empty[kv_state.idx].wait(kv_state.phase)
+                    bars.mb_tma_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                    tma_load_tile(
+                        sK[kv_state.idx],
+                        tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
+                        bars.mb_tma_k_full[kv_state.idx].smem_ptr,
+                        cta_group=CFG.CTA_MMA,
+                        mcast_mask=None,
+                    )
+                    kv_state = advance(kv_state, CFG.STAGES_KV)
+            else:
+                # ---- sg1: V_ring only -----------------------------------
+                # V split along d_v: per-CTA inner = TILE_O / CTA_MMA.  CTM
+                # TMA descriptors are element-typed so the per-peer offset
+                # is in elements (NOT bytes — C++ uses bytes because its
+                # TMA descriptors are UINT8-typed).
+                for kv_loop in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                    kv_row_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+                    bars.mb_tma_v_empty[kv_state.idx].wait(kv_state.phase)
+                    bars.mb_tma_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                    tma_load_tile(
+                        sV[kv_state.idx],
+                        tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
+                        bars.mb_tma_v_full[kv_state.idx].smem_ptr,
+                        cta_group=CFG.CTA_MMA,
+                        mcast_mask=None,
+                    )
+                    kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+        nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+        nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+        q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+
+    # cga2: drain trailing K/V/Q empty arrives so SMEM isn't torn down while
+    # leader's multicast commits are still in-flight.
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        if is_sg0:
+            for _ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_tma_k_empty[kv_state.idx].wait(kv_state.phase)
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+            bars.mb_tma_q_empty.wait(q_empty_phase)
+        else:
+            for _ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_tma_v_empty[kv_state.idx].wait(kv_state.phase)
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+
+# ============================================================================
+# TMA-STG warp — sg1 only: O TMA store + LSE write back.
+# Port of C++ tmastg_warp_group (prefill_sdpa_d512_fp8.cu:1392-1453).
+# ============================================================================
+@cute.jit
+def _tmastg_warp_group(
+    is_sg1,
+    tma_o_desc,
+    sO,
+    bars,
+    sched,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    cta_in_pair,
+    seq_kv_lens_tensor,
+    o_desc_words,
+):
+    """sg1: persistent O-store + per-chunk mb_tma_o_empty drain.
+
+    sg0 TMASTG (port of C++ lines 1417-1428): idle — just spin scheduler so
+    persistent tile claims advance in lockstep with sg1.  Does NOT call
+    read_tile_id_arrive (per the READ_TILE_ARRIVERS = 25 derivation — sg0's
+    TMASTG slot is NOT in the arriver list).
+
+    sg1 TMASTG (port of C++ lines 1430-1467):
+        Per tile:
+          - read_tile_id_arrive on the scheduler's read_tile_id mbar.
+          - For each chunk c in [0, N_O_CHUNKS):
+              wait(mb_tma_o_full[c], epilogue_state).
+          - tma_store_tile(sO[0], o_gmem(0, q_row_coord, head_idx, batch_idx)).
+          - tma_store_commit; tma_store_wait(0).
+          - arrive(mb_tma_o_empty).
+          - Flip epilogue_state.
+    """
+    o_full_phase = cutlass.Int32(0)
+
+    tma_o = GmemTileTma(tma_o_desc)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        # sg0's TMA-STG slot is idle but spins the scheduler so persistent
+        # tile claims advance in lockstep with sg1.  sg0 does NOT call
+        # read_tile_id_arrive (per the READ_TILE_ARRIVERS=25 derivation —
+        # sg0's TMA-STG slot is intentionally NOT in the arriver list).
+        if is_sg1:
+            read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+            # Wait every chunk of O ready.
+            for chunk in cutlass.range_constexpr(N_O_CHUNKS):
+                bars.mb_tma_o_full[chunk].wait(o_full_phase)
+
+            # Both sg1 peers issue the O TMA store with their own q_row_coord —
+            # cga2 splits C along M, so leader writes rows [0:128] and peer
+            # writes [128:256].
+            q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: store through this batch's pre-built descriptor (base at
+                # the sequence's packed row, seq extent = S_q_b → box past S_q_b
+                # OOB-clipped).  q_row_coord sequence-local; batch coord → 0.
+                o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_coord, cutlass.Int32(0))
+                tma_store_tile(sO[0], o_slice)
+            else:
+                tma_store_tile(
+                    sO[0],
+                    tma_o(cutlass.Int32(0), head_idx, q_row_coord, batch_idx),
+                )
+            tma_store_commit()
+            tma_store_wait(0)
+
+            bars.mb_tma_o_empty.arrive()
+            nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+            o_full_phase = o_full_phase ^ cutlass.Int32(1)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+
+# ============================================================================
+# Host launcher.
+# ============================================================================
+@cute.jit
+def _host(
+    q_tensor: cute.Tensor,
+    k_tensor: cute.Tensor,
+    v_tensor: cute.Tensor,
+    o_tensor: cute.Tensor,
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    problem_size: Tuple[int, int, int, int, int, int],
+    scale_softmax_log2: cutlass.Float32,
+    o_scale_fused: cutlass.Float32,
+    n_thd_units: cutlass.Int32,
+    # FROST's quantized ABI: the four 1-element fp32 scales arrive as DEVICE
+    # TENSORS and the amax of O is an OUTPUT.  The pre-upstream contract pre-folded on the host
+    # and produced no amax.  Template: prefill_d128_fp8_sm107.py (same lineage).
+    descale_q_t: cute.Tensor,
+    descale_k_t: cute.Tensor,
+    descale_v_t: cute.Tensor,
+    scale_o_t: cute.Tensor,
+    amax_o_tensor: cute.Tensor,
+    # FROST passes the dense padded-Q trim tensor POSITIONALLY on every call.
+    # These kernels have no Q-trim epilogue (Capabilities.dense_seq_q_trim=False)
+    # so it is accepted and unused -- but the SLOT is mandatory: without it the
+    # adapter's 12th positional lands on `stream` and execute dies with
+    # "got multiple values for argument 'stream'".
+    seq_q_lens_tensor: Optional[cute.Tensor] = None,
+    # FROST plans must run on the caller's stream (engine contract; there is a
+    # dedicated stream-respect test).  Threaded exactly as the shipped
+    # prefill_d128_fp8_sm107.py sibling does.
+    stream: _cuda_driver.CUstream = None,
+) -> None:
+    B, QH, KH, SQ, SKV, _ = problem_size
+
+    # Tensors are [B, S, H, D] with stride_order=(3, 2, 1, 0); D is fastest.
+    # Under cga2 K is split along seq (per-CTA box rows are TILE_N / CTA_MMA),
+    # V is split along d_v (per-CTA inner is TILE_O / CTA_MMA).  O's TMA box
+    # inner follows O's swizzle, NOT V's (V may drop to narrower under cga2).
+    _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE_O
+    qk_box_q = (1, CFG.TILE_M, 1, TMA_QK_GRANU_ELEMS)
+    qk_box_k = (1, CFG.TILE_N // CFG.CTA_MMA, 1, TMA_QK_GRANU_ELEMS)
+    vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M, 1, _O_GRANU_ELEMS)
+    stride_order = (3, 2, 1, 0)
+
+    def _tma_swz(byte_w: int):
+        return tmap.TensorMapSwizzle.s128b if byte_w == 128 else tmap.TensorMapSwizzle.s64b if byte_w == 64 else tmap.TensorMapSwizzle.s32b
+
+    tma_q_desc = tmap.create_tensor_map_tiled_from_view(
+        q_tensor,
+        box_dims=qk_box_q,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.Q_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_k_desc = tmap.create_tensor_map_tiled_from_view(
+        k_tensor,
+        box_dims=qk_box_k,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.K_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_v_desc = tmap.create_tensor_map_tiled_from_view(
+        v_tensor,
+        box_dims=vo_box_v,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.V_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_o_desc = tmap.create_tensor_map_tiled_from_view(
+        o_tensor,
+        box_dims=vo_box_o,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.O_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+
+    # Each cluster (CGA_M = 4 CTAs; CTA_MMA = 2 sg pairs collectively share Q)
+    # covers CGA_TILE_M = TILES_Q * TILE_M * CTA_MMA = 256 Q rows.  grid_x
+    # must scale by CGA_M (cluster x-dim) so the cluster shape divides the
+    # grid — for non-dsv4 flavors CGA_M == CTA_MMA and this collapses to the
+    # historical formula.  Mirrors C++ runner
+    # (the pre-upstream host runner).
+    rows_per_cluster = CGA_TILE_M
+    q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
+    grid_q_supers = q_clusters * CFG.CGA_M
+    # n_q_supers passed to kernel is the LOGICAL q-tile count (not the grid x
+    # span).  For SCHED_LPT it's `q_clusters * CTA_MMA` (each cluster owns
+    # CTA_MMA rows of distinct q_super_idx values); for NATURAL the kernel
+    # reads bidx directly so this value is unused.
+    q_supers = q_clusters * CFG.CTA_MMA
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD: build the per-batch O descriptor array (reuse tma_o_desc over the
+        # packed [1,T,QH,D_v] O as base), then launch the exact flat
+        # batch-outermost grid (n_thd_units host-computed); grid_x = units*CGA_M.
+        _build_thd_meta_o_descs_kernel(
+            o_tensor,
+            tma_o_desc,
+            o_desc_words,
+            seq_kv_lens_tensor,
+            cutlass.Int32(QH),
+            cutlass.Int32(B),
+            cutlass.Int32(CFG.TILE_O),
+        ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
+        grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
+    else:
+        grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
+    _kernel(
+        tma_q_desc,
+        tma_k_desc,
+        tma_v_desc,
+        tma_o_desc,
+        lse_tensor,
+        sinks_tensor,
+        seq_kv_lens_tensor,
+        o_desc_words,
+        cutlass.Int32(SQ),
+        cutlass.Int32(SKV),
+        cutlass.Int32(q_supers),
+        cutlass.Int32(QH),
+        cutlass.Int32(B),
+        cutlass.Int32(QH // KH),
+        scale_softmax_log2,
+        o_scale_fused,
+        descale_q_t,
+        descale_k_t,
+        descale_v_t,
+        scale_o_t,
+        amax_o_tensor,
+    ).launch(
+        # cluster = (CGA_M, CGA_N, 1) = (4, 1, 1) under dsv4.
+        grid=grid_shape,
+        block=[CFG.THREADS_PER_CTA, 1, 1],
+        cluster=(CFG.CGA_M, CFG.CGA_N, 1),
+        stream=stream,
+    )
+
+
+@lru_cache(maxsize=None)
+def compile(  # noqa: A001
+    b: int = 1,
+    qh: int = 1,
+    kh: int = 1,
+    sq: int = 256,
+    skv: int = 128,
+    d_qk: int = CFG.TILE_K,
+    d_v: int = CFG.TILE_O,
+    has_lse: bool = True,
+    lse_stride: Optional[tuple] = None,
+) -> Callable:
+    """Compile a kernel with ALL dims concrete to pin TMA descriptor strides at compile time.
+
+    THD/varlen: q/k/v/o/lse PACKED with batch dim 1 ([1,T,H,D]); ``b`` is the
+    LOGICAL batch (sequence count) driving n_batch / metadata + O-desc sizes."""
+    # THD/varlen is NOT ported for this kernel yet.  The setup-kernel call site
+    # below still speaks the pre-upstream 7-arg contract, while FROST's
+    # thd_helpers.build_thd_meta_o_descs_kernel takes 14 args and a different
+    # metadata layout (4B+4 with batch_remap + a claim counter, vs the 3B+2
+    # here), and the scheduler decode differs to match.  Raise here rather than
+    # let it fail as an arity error deep in the trace -- and so no engine row
+    # can advertise thd=True for this kernel and appear to work.  The dense
+    # path is unaffected: CFG.THD_VARLEN is 0 and every THD branch folds out.
+    if CFG.THD_VARLEN:
+        raise NotImplementedError(f"{__name__}: THD/varlen not ported to the FROST setup-kernel contract")
+    # ---- FROST adapter ABI ------------------------------------------------
+    # lower_dsl_prefill calls EVERY kernel with the full forward signature.
+    # This body carries only what the port brought over, so anything
+    # it cannot honor RAISES rather than being silently ignored: a raise here
+    # means the engine's Capabilities row is lying, which is the failure we
+    # want loud.  (Capabilities: lse_optional=False, no strided Stats.)
+    if lse_stride is not None:
+        raise NotImplementedError(f"{__name__}: strided Stats not ported (contiguous [B, H, S] only)")
+    if d_qk > CFG.TILE_K or d_v > CFG.TILE_O or d_qk <= 0 or d_v <= 0:
+        raise ValueError(f"{__name__}: envelope is 0 < d_qk <= {CFG.TILE_K}, 0 < d_v <= {CFG.TILE_O}; " f"got ({d_qk}, {d_v})")
+    _fake_batch = 1 if CFG.THD_VARLEN else b
+    fake_q = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, sq, qh, d_qk),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_k = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, d_qk),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_v = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, d_v),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_o = cute.runtime.make_fake_compact_tensor(
+        OUT_STORAGE_DTYPE,
+        (_fake_batch, sq, qh, d_v),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    # has_lse=False (no Stats output): the LSE argument is None-specialized and
+    # the store is compiled out entirely -- no dummy buffer exists at any level,
+    # which is what lets the dense graph report get_workspace_size() == 0.
+    # Mirrors the shipped prefill_d128_fp8_sm107.py.
+    fake_lse = (
+        cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (_fake_batch, qh, sq),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
+        if has_lse
+        else None
+    )
+    fake_sinks = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (qh,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # THD overloads seq_kv_lens as [seq_kv_lens(B)|cu_q(B+1)|cu_k(B+1)] (len 3B+2).
+    _skv_len = (3 * b + 2) if CFG.THD_VARLEN else b
+    fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (_skv_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # Per-batch O TMA-descriptor array (16 int64 = 128 B each) + 1 pad slot.
+    _odesc_len = (b * _TENSOR_MAP_QWORDS + _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
+    fake_o_desc = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int64,
+        (_odesc_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+
+    # The four 1-element fp32 device scales + the amax_o output slot; the
+    # compiled artifact must declare them or the adapter's positional call
+    # cannot bind (FROST quantized ABI).
+    def _fake_scale():
+        return cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (1,),
+            stride_order=(0,),
+            assumed_align=4,
+        )
+
+    fake_amax_o = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (1,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    return cute.compile(
+        _host,
+        fake_q,
+        fake_k,
+        fake_v,
+        fake_o,
+        fake_lse,
+        fake_sinks,
+        fake_seq_kv_lens,
+        fake_o_desc,
+        (b, qh, kh, sq, skv, 0),
+        cutlass.Float32(0.0),
+        cutlass.Float32(0.0),
+        cutlass.Int32(0),
+        _fake_scale(),
+        _fake_scale(),
+        _fake_scale(),
+        _fake_scale(),
+        fake_amax_o,
+        stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
+        options="--enable-tvm-ffi",
+    )

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d512_fp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d512_fp8_sm107.py
@@ -6,11 +6,11 @@
 THD / varlen (``CFG.THD_VARLEN=1``) is supported — FP8 is element-addressed (no
 block-scale SF), so it rides the same THD path as f16: packed ``[1,T,H,D]`` +
 ``cu_seqlens`` coord offset, per-batch O TMA-descriptor array (shared
-``kernels/ctm/common/sdpa/thd.py``), packed ``[1,QH,T]`` LSE.  Dense path
+the shared pre-upstream THD helper), packed ``[1,QH,T]`` LSE.  Dense path
 byte-identical.  Public-API fp8 THD glue is a follow-up (THD-aware quantizer);
-drive via the kernel module / --backend ctm.
+drive via the kernel module directly.
 
-CTM-DSL Python port of the C++ Rubin baseline
+Python port (from the pre-upstream DSL) of the C++ Rubin baseline
 ``kernels/c++/sm107/sdpa/prefill/prefill_sdpa_d512_fp8.cu`` — same kernel,
 different language.  Pipeline shape, TMEM/SMEM layout, barrier inventory,
 scheduler, warp dispatch, and register split mirror the C++ source 1:1.
@@ -51,7 +51,7 @@ P12 / P13 patterns (cf. mbarrier-patterns.md, also project memory):
     tcgen05.commit.cta_group::2.multicast with sg0_mcast_mask (= 0x3) so
     BOTH sg0 CTAs see one arrive — pre-armed via PipelineState(0, 1).
 
-CTM-only adjustments applied (per cpp-to-ctm.md):
+DSL-only adjustments applied (per the C++-to-DSL porting notes):
   - is_exclusive=True on tmem_alloc (SM107 >512-col TMEM).
   - tile_id_smem stride 8 Int32/stage.
   - cga_arrive/wait wrapped with relaxed=True (per project memory:
@@ -176,7 +176,7 @@ from cudnn.frost.tile_dsl.mask import (
 
 # Reuse sm107 SDPA pipeline-shared helpers (KvLoopBounds + closures factory).
 # Note: dsv4 forks Bars in this file (NOT imported from _sdpa_common) per the
-# per-pipeline fork pattern in cpp-to-ctm.md.
+# per-pipeline fork pattern in the C++-to-DSL porting notes.
 from cudnn.sdpa.fwd.kernels._common_sm100 import (
     KvLoopBounds,
     compute_kv_loop_bounds,
@@ -252,7 +252,7 @@ CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
 
 # ----------------------------------------------------------------------------
 # Softmax-body constants — module-level so the top-level @cute.jit helper
-# `_sg0_softmax_kv_iter` can read them without a closure capture (CTM-DSL
+# `_sg0_softmax_kv_iter` can read them without a closure capture (pre-upstream DSL
 # forbids closures inside @cute.jit traced under dynamic control flow).
 # ----------------------------------------------------------------------------
 # P SMEM layout helpers (TILE_M=128 rows × TILE_N=128 cols, Swz128B).
@@ -509,7 +509,7 @@ _resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
 
 # THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
 # factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
-# kernels/ctm/common/sdpa/thd.py.  Gated by CFG.THD_VARLEN (folds out otherwise).
+# the shared pre-upstream THD helper.  Gated by CFG.THD_VARLEN (folds out otherwise).
 # FP8 is element-addressed (per-tensor dequant scalars, no block-scale SF), so
 # THD rides the same path as f16.  seq_kv_lens overloaded as the THD metadata
 # buffer (int32 len 3B+2): [0..B-1]=seq_kv_lens [B..2B]=cu_q [2B+1..3B+1]=cu_k.
@@ -688,7 +688,7 @@ def _kernel(
     mcast_mask = (cutlass.Int32(3) << leader_cta_id) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
     # sg0_mcast_mask = 0x3 — both sg0 CTAs (used by sg1 leader's P13 multicast on mb_p_xfer_empty).
     sg0_mcast_mask = cutlass.Int32(0x3)
-    # TMA-load self-bit mask: per cga2-mma.md / DKG `fp16_gemm_3.py`, each
+    # TMA-load self-bit mask: per cga2-mma.md and a reference fp16 GEMM sample, each
     # peer's `cta_group::2` TMA targets ITS OWN cluster bit (= cta_id_x);
     # cga2 routing strips bit-24 so bytes land on the cga2 pair leader's
     # mbar.  Use cluster-rank (cta_id_x), NOT pair-rank (cta_in_pair) — for
@@ -921,7 +921,7 @@ def _kernel(
 # (HW max can't observe -inf written by the mask after the load).
 #
 # Top-level @cute.jit so the dynamic call-graph contains no closure-capture
-# violations (CTM-DSL forbids closures under dynamic control flow).  All
+# violations (the pre-upstream DSL forbids closures under dynamic control flow).  All
 # kernel-local vars are passed as explicit args; constants come from
 # module-level (NEG_INF_F32, RESCALE_THRESHOLD_F32, P_*, SOFTMAX_*, etc.).
 # ============================================================================
@@ -1058,13 +1058,13 @@ def _sg0_softmax_kv_iter(
 
     # DSMEM bulk_copy alpha + P → cross-sg sg1 peer's SMEM, firing peer's
     # mb_alpha_xfer_full + mb_p_xfer_full.  PREDICATED form: emit `@p
-    # cp.async.bulk` (matches C++'s uniform `@UP0 UBLKCP`) instead of an
+    # cp.async.bulk` (matches the C++ reference's uniform predicated form) instead of an
     # `if is_lead_warp: if elect_sync():` branch — that branch lowers to a
     # warp-divergent BSSY/BSYNC + reconverge that also poisons ptxas's uniform
     # analysis of nearby mbar waits (measured: removing the ship branches flips
     # ~5 SYNCS.PHASECHK → USYNCS and is worth ~+12% on dsv4 d512).  All 128
     # lanes compute the cheap mapa addresses up-front; only the lead warp's
-    # elected lane issues the UBLKCPs under ship_pred.
+    # elected lane issues the bulk copies under ship_pred.
     ship_pred = is_lead_warp & nvvm.elect_sync()
     local_alpha_src = sAlpha_xfer_raw.subview(cur_parity_S * cutlass.Int32(CFG.TILE_M))
     peer_alpha_dst = nvvm.mapa(local_alpha_src, cross_sg_peer, addrspace=7)
@@ -1391,7 +1391,7 @@ def _compute_warp_group(
             nvvm.barrier_cta_sync(barrier_id=8, thread_count=128)
 
             # Predicated stats ship — same rationale as the per-iter alpha/P
-            # ship above (`@p UBLKCP`, no warp-divergent branch).
+            # ship above (predicated, no warp-divergent branch).
             ship_pred = is_lead_warp & nvvm.elect_sync()
             peer_stats_dst = nvvm.mapa(sStats_xfer_raw, cross_sg_peer, addrspace=7)
             peer_stats_full_mbar = nvvm.mapa(bars.mb_stats_xfer_full.smem_ptr, cross_sg_peer, addrspace=7)
@@ -1736,7 +1736,7 @@ def _mma_warp_group(
     nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WG_WARPS + 1))
 
     # Do column arithmetic on raw Int8 ptr; retype at use site.  (Per
-    # cpp-to-ctm.md: make_tmem_ptr(addr, Float16) + N strides FP16 elems
+    # C++-to-DSL porting notes: make_tmem_ptr(addr, Float16) + N strides FP16 elems
     # not columns — silent-wrong-result bug.)
     tmem_raw = nvvm.make_tmem_ptr(tmem_ptr_i32.load(), cutlass.Int8)
 
@@ -2003,7 +2003,7 @@ def _mma_warp_non_leader(
 
     # sg0 non-leader is quiet (just wait dealloc); sg1 non-leader runs the
     # persistent P12 forwarder loop.  `return` is forbidden inside @cute.jit
-    # (CTM gotcha), so we gate the forwarder on `is_sg1` and let both arms
+    # (DSL gotcha), so we gate the forwarder on `is_sg1` and let both arms
     # fall through to the shared dealloc wait + free at the bottom.
     if is_sg1:
         q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
@@ -2123,9 +2123,9 @@ def _tmaldg_warp_group(
           wait(v_empty[stage]); leader arrive_expect_tx(v_full[stage], vBytes);
           tma_load_tile(sV[stage], v_gmem(v_col_off + cta_in_pair * (TILE_O/CTA_MMA) * BPE,
                                         kv * TILE_N), v_full, multicast).
-        Note: C++ uses BYTE coord for V because UINT8 TMA descriptors; CTM's
+        Note: C++ uses BYTE coord for V because UINT8 TMA descriptors; the DSL's
         typed descriptor uses ELEMENT coord — so multiply only when descriptor
-        is UINT8.  Current CTM descriptors are element-typed, so plain cta_in_pair *
+        is UINT8.  Current DSL descriptors are element-typed, so plain cta_in_pair *
         (TILE_O/CTA_MMA) suffices.
 
     Both sgs drain trailing K/V/Q empty arrives at end-of-kernel under cga2.
@@ -2202,7 +2202,7 @@ def _tmaldg_warp_group(
                     kv_state = advance(kv_state, CFG.STAGES_KV)
             else:
                 # ---- sg1: V_ring only -----------------------------------
-                # V split along d_v: per-CTA inner = TILE_O / CTA_MMA.  CTM
+                # V split along d_v: per-CTA inner = TILE_O / CTA_MMA.  the pre-upstream DSL
                 # TMA descriptors are element-typed so the per-peer offset
                 # is in elements (NOT bytes — C++ uses bytes because its
                 # TMA descriptors are UINT8-typed).

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d512_mxfp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d512_mxfp8_sm107.py
@@ -3,7 +3,7 @@
 
 """Rubin SM107 DSv4 SDPA prefill — d_qk = d_v = 512, MXFP8 (block-scale FP8).
 
-CTM-DSL Python port of the C++ Rubin baseline
+Python port (from the pre-upstream DSL) of the C++ Rubin baseline
 ``kernels/c++/sm107/sdpa/prefill/prefill_sdpa_d512_mxfp8.cu`` — same kernel,
 different language.  Pipeline shape, TMEM/SMEM layout, barrier inventory,
 scheduler, warp dispatch, and register split mirror the C++ source 1:1.
@@ -59,7 +59,7 @@ P12 / P13 patterns (cf. mbarrier-patterns.md, also project memory):
     tcgen05.commit.cta_group::2.multicast with sg0_mcast_mask (= 0x3) so
     BOTH sg0 CTAs see one arrive — pre-armed via PipelineState(0, 1).
 
-CTM-only adjustments applied (per cpp-to-ctm.md):
+DSL-only adjustments applied (per the C++-to-DSL porting notes):
   - is_exclusive=True on tmem_alloc (SM107 >512-col TMEM).
   - tile_id_smem stride 8 Int32/stage.
   - cga_arrive/wait wrapped with relaxed=True (per project memory:
@@ -76,9 +76,9 @@ SF-tile prefix base (cu_sf_q/k from _thd_sf_tile_bases) added to the SF tile
 coord (batch coord -> 0).  The cga4x1 within-tile peer SF byte offsets + the
 SF_NUM_BLOCKS_V=4 / BMM2_LOOP_N_BLOCKS=2 V-SF N-block split are orthogonal to the
 sequence-tile axis and unchanged.  Per-batch O TMA descriptor array + packed
-[1,QH,T] LSE (shared kernels/ctm/common/sdpa/thd.py).  Dense path (THD_VARLEN=0)
+[1,QH,T] LSE (the shared pre-upstream THD helper).  Dense path (THD_VARLEN=0)
 folds to identity (cu_sf=0, tma_batch=batch_idx) — byte-identical.  Public-API
-MXFP8 THD glue is a follow-up (THD-aware quantizer); drive via --backend ctm.
+MXFP8 THD glue is a follow-up (THD-aware quantizer); drive via the kernel module directly.
 """
 
 import os
@@ -198,7 +198,7 @@ from cudnn.frost.tile_dsl.mask import (
 
 # Reuse sm107 SDPA pipeline-shared helpers (KvLoopBounds + closures factory).
 # Note: dsv4 forks Bars in this file (NOT imported from _sdpa_common) per the
-# per-pipeline fork pattern in cpp-to-ctm.md.
+# per-pipeline fork pattern in the C++-to-DSL porting notes.
 from cudnn.sdpa.fwd.kernels._common_sm100 import (
     KvLoopBounds,
     compute_kv_loop_bounds,
@@ -334,7 +334,7 @@ CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
 
 # ----------------------------------------------------------------------------
 # Softmax-body constants — module-level so the top-level @cute.jit helper
-# `_sg0_softmax_kv_iter` can read them without a closure capture (CTM-DSL
+# `_sg0_softmax_kv_iter` can read them without a closure capture (pre-upstream DSL
 # forbids closures inside @cute.jit traced under dynamic control flow).
 # ----------------------------------------------------------------------------
 # P SMEM layout helpers (TILE_M=128 rows × TILE_N=128 cols, Swz128B).
@@ -607,7 +607,7 @@ _resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
 
 # THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
 # factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
-# kernels/ctm/common/sdpa/thd.py.  Gated by CFG.THD_VARLEN (folds out otherwise).
+# the shared pre-upstream THD helper.  Gated by CFG.THD_VARLEN (folds out otherwise).
 # Supported at cga4x1 (the per-batch O descriptor's seq extent OOB-clips the
 # 256-row store box).  seq_kv_lens overloaded as the THD metadata buffer (int32
 # len 3B+2): [0..B-1]=seq_kv_lens [B..2B]=cu_q(B+1) [2B+1..3B+1]=cu_k(B+1).
@@ -837,7 +837,7 @@ def _kernel(
     mcast_mask = (cutlass.Int32(3) << leader_cta_id) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
     # sg0_mcast_mask = 0x3 — both sg0 CTAs (used by sg1 leader's P13 multicast on mb_p_xfer_empty).
     sg0_mcast_mask = cutlass.Int32(0x3)
-    # TMA-load self-bit mask: per cga2-mma.md / DKG `fp16_gemm_3.py`, each
+    # TMA-load self-bit mask: per cga2-mma.md and a reference fp16 GEMM sample, each
     # peer's `cta_group::2` TMA targets ITS OWN cluster bit (= cta_id_x);
     # cga2 routing strips bit-24 so bytes land on the cga2 pair leader's
     # mbar.  Use cluster-rank (cta_id_x), NOT pair-rank (cta_in_pair) — for
@@ -1097,7 +1097,7 @@ def _kernel(
 # (HW max can't observe -inf written by the mask after the load).
 #
 # Top-level @cute.jit so the dynamic call-graph contains no closure-capture
-# violations (CTM-DSL forbids closures under dynamic control flow).  All
+# violations (the pre-upstream DSL forbids closures under dynamic control flow).  All
 # kernel-local vars are passed as explicit args; constants come from
 # module-level (NEG_INF_F32, RESCALE_THRESHOLD_F32, P_*, SOFTMAX_*, etc.).
 # ============================================================================
@@ -1234,11 +1234,11 @@ def _sg0_softmax_kv_iter(
 
     # DSMEM bulk_copy alpha + P → cross-sg sg1 peer's SMEM, firing peer's
     # mb_alpha_xfer_full + mb_p_xfer_full.  PREDICATED form: emit `@p
-    # cp.async.bulk` (matches C++'s uniform `@UP0 UBLKCP`) instead of an
+    # cp.async.bulk` (matches the C++ reference's uniform predicated form) instead of an
     # `if is_lead_warp: if elect_sync():` branch — that branch lowers to a
     # warp-divergent BSSY/BSYNC + reconverge in the hot softmax iter.  All 128
     # lanes compute the (cheap) mapa addresses up-front; only the lead warp's
-    # elected lane issues the two UBLKCPs under ship_pred.  nvvm.elect_sync()
+    # elected lane issues the two bulk copies under ship_pred.  nvvm.elect_sync()
     # is warp-convergent — every compute warp's lanes call it (each warp elects
     # its own lowest lane); `is_lead_warp &` masks the predicate to (lead warp,
     # elected lane) == the single C++ issuing thread.
@@ -1883,7 +1883,7 @@ def _mma_warp_group(
     nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WG_WARPS + 1))
 
     # Do column arithmetic on raw Int8 ptr; retype at use site.  (Per
-    # cpp-to-ctm.md: make_tmem_ptr(addr, Float16) + N strides FP16 elems
+    # C++-to-DSL porting notes: make_tmem_ptr(addr, Float16) + N strides FP16 elems
     # not columns — silent-wrong-result bug.)
     tmem_raw = nvvm.make_tmem_ptr(tmem_ptr_i32.load(), cutlass.Int8)
 
@@ -2240,7 +2240,7 @@ def _mma_warp_non_leader(
 
     # sg0 non-leader is quiet (just wait dealloc); sg1 non-leader runs the
     # persistent P12 forwarder loop.  `return` is forbidden inside @cute.jit
-    # (CTM gotcha), so we gate the forwarder on `is_sg1` and let both arms
+    # (DSL gotcha), so we gate the forwarder on `is_sg1` and let both arms
     # fall through to the shared dealloc wait + free at the bottom.
     if is_sg1:
         q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
@@ -2497,7 +2497,7 @@ def _tmaldg_warp_group(
                     kv_state = advance(kv_state, CFG.STAGES_KV)
             else:
                 # ---- sg1: V_ring only -----------------------------------
-                # V split along d_v: per-CTA inner = TILE_O / CTA_MMA.  CTM
+                # V split along d_v: per-CTA inner = TILE_O / CTA_MMA.  the pre-upstream DSL
                 # TMA descriptors are element-typed so the per-peer offset
                 # is in elements (NOT bytes — C++ uses bytes because its
                 # TMA descriptors are UINT8-typed).

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d512_mxfp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d512_mxfp8_sm107.py
@@ -112,6 +112,23 @@ from cudnn.sdpa.fwd.config_sm107 import TemplateParams, make_cfg_d512_mxfp8
 
 PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
 CFG, _TMA = make_cfg_d512_mxfp8(PARAMS)
+
+# tcgen05 SMEM-descriptor version for EVERY SmemTile in this module -- ONE
+# decision point, wired into every construction below rather than repeated as a
+# per-tile literal.  A version-0 descriptor's ``start_address`` is 14 bits = a
+# 256 KiB window; Rubin raises the per-CTA SMEM cap to 327 KiB, and THIS flavor
+# crosses the line (the d512 slabs put the P transfer ring at exactly 262144),
+# so a version-0 descriptor would wrap to offset 0 and the MMA would multiply
+# whatever sits at the bottom of SMEM -- the accumulator comes out EXACTLY
+# zero, or the SF columns come back as data bytes (LSE = +inf, O = NaN).  No
+# crash either way.  Matches what C++ SmemTile::make_desc always emitted.
+#
+# Do NOT re-literal this at a call site: this kernel's MXFP8 sibling shipped
+# NaN on 100% of cells because its scale-factor tiles were declared UNDER a
+# comment claiming "every operand tile here carries desc_version=1" -- without
+# the kwarg.  A single constant makes that class of drift impossible, and
+# test_sm107_descriptor_version_matches_the_smem_budget asserts it.
+DESC_VERSION: int = 1
 Cfg = type(CFG)
 TMA_QK_ITERS = _TMA.QK_ITERS
 TMA_VO_ITERS = _TMA.VO_ITERS
@@ -686,12 +703,12 @@ def _kernel(
     sP_SF_raw = cutlass.Array(cutlass.Int8, SF_SMEM_SIZE_P, alignment=1024, space=cutlass.AddressSpace.smem)
     sV_SF_raw = cutlass.Array(cutlass.Int8, CFG.STAGES_KV * SF_SMEM_SIZE_V, alignment=1024, space=cutlass.AddressSpace.smem)
 
-    # Typed SmemTile handles.
-    # Rubin SM107 raises the per-CTA SMEM cap to 327 KiB, so an MMA-operand
-    # buffer can land at or above 256 KiB — past what a version-0 tcgen05 SMEM
-    # descriptor can address (14-bit start_address).  Every operand tile here
-    # therefore carries desc_version=1, matching what C++ SmemTile::make_desc
-    # always emitted.  See tile_dsl/handles.py SmemTile.desc_version.
+    # Typed SmemTile handles.  EVERY tile takes the module-level DESC_VERSION
+    # (= 1 here) -- see its declaration for why that is one constant and not a
+    # per-tile literal.  The short version: Rubin raises the per-CTA SMEM cap
+    # to 327 KiB, so a buffer can land past the 256 KiB a version-0 tcgen05
+    # descriptor can address (14-bit start_address), and the tiles that cross
+    # the line are not the ones you would guess.
     sQ = SmemTile(
         base=sQ_raw,
         elems_per_stage=qBufferElems,
@@ -702,7 +719,7 @@ def _kernel(
         tma_loads_per_tile=TMA_QK_ITERS,
         tma_granu_elems=TMA_QK_GRANU_ELEMS,
         tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
-        desc_version=1,
+        desc_version=DESC_VERSION,
     )
     sK = SmemTile(
         base=sK_raw,
@@ -714,7 +731,7 @@ def _kernel(
         tma_loads_per_tile=TMA_QK_ITERS,
         tma_granu_elems=TMA_QK_GRANU_ELEMS,
         tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
-        desc_version=1,
+        desc_version=DESC_VERSION,
     )
     sV = SmemTile(
         base=sV_raw,
@@ -726,7 +743,7 @@ def _kernel(
         tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
         tma_granu_elems=TMA_VO_GRANU_ELEMS,
         tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
-        desc_version=1,
+        desc_version=DESC_VERSION,
     )
     sO = SmemTile(
         base=sO_raw,
@@ -738,6 +755,7 @@ def _kernel(
         tma_loads_per_tile=TMA_O_ITERS_HOST,
         tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
         tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+        desc_version=DESC_VERSION,
     )
 
     # ---- SF SmemTile handles (no swizzle; utccp_32x128b_warpx4 stride) ----
@@ -759,7 +777,7 @@ def _kernel(
         leading_byte_offset=SF_LEADING_BYTE_OFFSET,
         stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
         layout=SMEM_LAYOUT_SF,
-        desc_version=1,
+        desc_version=DESC_VERSION,
     )
     sK_SF = SmemTile(
         base=sK_SF_raw,
@@ -768,7 +786,7 @@ def _kernel(
         leading_byte_offset=SF_LEADING_BYTE_OFFSET,
         stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
         layout=SMEM_LAYOUT_SF,
-        desc_version=1,
+        desc_version=DESC_VERSION,
     )
     sP_SF = SmemTile(
         base=sP_SF_raw,
@@ -777,7 +795,7 @@ def _kernel(
         leading_byte_offset=SF_LEADING_BYTE_OFFSET,
         stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
         layout=SMEM_LAYOUT_SF,
-        desc_version=1,
+        desc_version=DESC_VERSION,
     )
     sV_SF = SmemTile(
         base=sV_SF_raw,
@@ -786,7 +804,7 @@ def _kernel(
         leading_byte_offset=SF_LEADING_BYTE_OFFSET,
         stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
         layout=SMEM_LAYOUT_SF,
-        desc_version=1,
+        desc_version=DESC_VERSION,
     )
 
     # ------------------------------------------------------------------
@@ -1731,22 +1749,31 @@ def _compute_warp_group(
             # Write LSE — under cga2 each sg1 peer writes its half of O+LSE
             # rows (leader = [0:128], peer = [128:256]).  Per-thread row.
             q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + tid_in_wg
+            # ONE row bound for BOTH the LSE write and the amax atomic below.
+            # They must stay tied: amax is an atomicMax, which only GROWS, so a
+            # single padded row folded in permanently inflates the graph's
+            # Amax_O for the whole tensor and no per-row check ever shows it.
+            # The atomic also sits OUTSIDE the dense/THD branch: it used to live
+            # in the dense arm only, so a THD graph never folded amax at all.
+            q_row_limit = seqlen_q
             if cutlass.const_expr(CFG.THD_VARLEN):
                 # THD: q_row_global is sequence-local; LSE is packed [1,QH,T] →
                 # index [0, head, cu_q[b] + local], bound by per-sequence Q len S_q_b.
                 _cu = cutlass.make_array_view(seq_kv_lens_tensor)
                 _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
                 _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
+                q_row_limit = _s_q_b
+            if q_row_global < q_row_limit:
+                nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
+            if cutlass.const_expr(CFG.THD_VARLEN):
                 if cutlass.const_expr(lse_tensor is not None):
-                    if q_row_global < _s_q_b:
+                    if q_row_global < q_row_limit:
                         lse_arr = cutlass.make_array_view(lse_tensor)
                         lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
                         lse_row[_cu_q_b + q_row_global] = lse
             else:
-                if q_row_global < seqlen_q:
-                    nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
                 if cutlass.const_expr(lse_tensor is not None):
-                    if q_row_global < seqlen_q:
+                    if q_row_global < q_row_limit:
                         lse_arr = cutlass.make_array_view(lse_tensor)
                         lse_row = lse_arr[batch_idx, head_idx, :]
                         lse_row[q_row_global] = lse
@@ -1985,7 +2012,7 @@ def _mma_warp_group(
         leading_byte_offset=LEADING_BYTE_OFFSET_QK,
         stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
         layout=SMEM_LAYOUT_P,
-        desc_version=1,
+        desc_version=DESC_VERSION,
     )
 
     # BMM1 leader: desc_Q is tile-static (Q stays resident under d=512 / no Q∪K alias).

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d512_mxfp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d512_mxfp8_sm107.py
@@ -1,0 +1,3067 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Rubin SM107 DSv4 SDPA prefill — d_qk = d_v = 512, MXFP8 (block-scale FP8).
+
+CTM-DSL Python port of the C++ Rubin baseline
+``kernels/c++/sm107/sdpa/prefill/prefill_sdpa_d512_mxfp8.cu`` — same kernel,
+different language.  Pipeline shape, TMEM/SMEM layout, barrier inventory,
+scheduler, warp dispatch, and register split mirror the C++ source 1:1.
+
+Pipeline shape (cluster (4, 1, 1) = two cga2 sub-groups):
+  sg0 (CTAs 0, 1):  TMA-LDG Q/K + SF_Q/SF_K; BMM1 = Q*K^T → S_acc with E8M0
+                    block scaling; streaming softmax; ship alpha + P + stats
+                    to sg1 via DSMEM.
+  sg1 (CTAs 2, 3):  TMA-LDG V_ring + SF_V; recv alpha + P + stats via DSMEM;
+                    correction (apply alpha to O TMEM); BMM2 = P*V^T → O with
+                    E8M0 block scaling (SF_P constant 1.0); epilogue normalize
+                    + fp32→fp8/half cast + TMA-STG O + LSE.
+
+MXFP8 deltas vs d512_fp8 (additive — same FP8 deltas + SF plumbing):
+  - MMA_KIND = MXF8F6F4; idesc built via Tcgen05MxInstrDesc (block-scale).
+    is_block_scale=True + sf_blocks_per_step on both BMM1 / BMM2 MmaDesc.
+  - SF Q (sg0): per-CTA along M (each peer holds 2 KiB), DSMEM-arrives on
+    sg0 leader's mb_tma_q_full.
+  - SF K (sg0): multicast-full to both sg0 peers (sg0 leader bulk_copy with
+    sf_mcast_mask=0x3 within sg0 pair).
+  - SF V (sg1): multicast-full to both sg1 peers (sg1 leader bulk_copy with
+    sf_mcast_mask=0xC within sg1 pair).
+  - SF P (sg1): constant 0x7F (= E8M0 1.0) — initialised once at kernel entry
+    by sg1 CTAs' compute warps.
+  - BMM2 N-block split: TILE_O=512 → 2 BMM2 calls of N=256 collective.  Per
+    call: shifted tmem_O view + shifted tmem_SF_V_nblk view (SF_V_TMEM_COLS_PER_CALL
+    = SF_TMEM_COLS_V / BMM2_LOOP_N_BLOCKS = 8 cols).  SF V SMEM→TMEM copy
+    uses per-N-block tcgen05_cp loop (multicast=WARPX4).
+  - TMEM SF layout (sg0 / sg1 carves) at cols [512, ...) past the S_acc / O
+    region — see KernelTmemLayout.
+
+FP8 deltas (inherited from d512_fp8):
+  - STAGES_KV = 3, XFER_STAGES = 4 (BPE=1 fits more stages in 327 KiB).
+  - TILE_K_HW_BMM1/2 ∈ {32, 64}.
+  - P stays FP8-typed (P_STORAGE_DTYPE).
+  - BMM2_V_NBLOCK_ADVANCE = TILE_N * V_SWZ_BYTES.
+  - DTYPE_O independent of DTYPE_QKV.
+  - 2-bit sub-tile permutation [0,2,1,3] for the epilogue cast loop.
+
+SM107 deltas vs SM100:
+  - No Q∪K_ring alias — SMEM cap is 327 KiB, Q stays resident.
+  - No UTCCP(Q→TMEM) — Q feeds BMM1 directly from SMEM.
+  - No B1 / B2 / B3 alias-seam mbars (those are SM100-only).
+  - TMEM cap is 576 cols (is_exclusive=True on tcgen05_alloc).
+
+P12 / P13 patterns (cf. mbarrier-patterns.md, also project memory):
+  - mb_p_xfer_full (P12): sg1 leader's collective BMM2 reads BOTH peers' P
+    SMEM via crossbar.  Each sg1 CTA's mbar gets bytes from its own cross-sg
+    sg0 partner; non-leader sg1 forwards its `arrive` to the leader via
+    DSMEM so leader's wait flips only after the full pair has landed.
+    Leader init = CTA_MMA (own + DSMEM-forwarded); non-leader init = 1.
+  - mb_p_xfer_empty (P13): sg1 leader MMA fires a single
+    tcgen05.commit.cta_group::2.multicast with sg0_mcast_mask (= 0x3) so
+    BOTH sg0 CTAs see one arrive — pre-armed via PipelineState(0, 1).
+
+CTM-only adjustments applied (per cpp-to-ctm.md):
+  - is_exclusive=True on tmem_alloc (SM107 >512-col TMEM).
+  - tile_id_smem stride 8 Int32/stage.
+  - cga_arrive/wait wrapped with relaxed=True (per project memory:
+    dsv3 cga2 47%→92% SOL with this fix).
+  - DSMEM SMEM→peer-SMEM via cp_async_bulk_shared_cluster_shared_cta
+    (per project memory: bare nvvm op silently fires sender's local mbar).
+  - RegTile(Float8E4M3FN) is illegal at JIT — FP8 P_cast skips the RegTile
+    wrap; pass raw vec to store_swizzled / slice via vec_slice on Float32.
+
+THD / varlen (CFG.THD_VARLEN=1) supported (E4M3/E5M2) at cga4x1 via the shared
+thd helpers: Q/K/V data ride the packed [1,T,H,D] + cu_seqlens coord path; the
+MXFP8 SF tensors use B=1 + total_*_sf_tiles descriptors with a per-sequence
+SF-tile prefix base (cu_sf_q/k from _thd_sf_tile_bases) added to the SF tile
+coord (batch coord -> 0).  The cga4x1 within-tile peer SF byte offsets + the
+SF_NUM_BLOCKS_V=4 / BMM2_LOOP_N_BLOCKS=2 V-SF N-block split are orthogonal to the
+sequence-tile axis and unchanged.  Per-batch O TMA descriptor array + packed
+[1,QH,T] LSE (shared kernels/ctm/common/sdpa/thd.py).  Dense path (THD_VARLEN=0)
+folds to identity (cu_sf=0, tma_batch=batch_idx) — byte-identical.  Public-API
+MXFP8 THD glue is a follow-up (THD-aware quantizer); drive via --backend ctm.
+"""
+
+import os
+import sys
+from functools import lru_cache
+from typing import Callable, Optional, Tuple
+from dataclasses import dataclass
+from typing import NamedTuple
+
+
+from cutlass.experimental import primitives as nvvm
+from cutlass.experimental.primitives import vote_sync, VoteSync
+from cutlass._mlir.dialects import arith
+
+import cutlass
+from cutlass.experimental import primitives as prims
+import cutlass.cute as cute
+from cutlass.base_dsl.typing import Pointer
+from cutlass.experimental.cuda import tensor_map as tmap
+from cudnn.frost.tile_dsl.tma import cp_async_bulk_shared_cluster_shared_cta
+import cuda.bindings.driver as _cuda_driver  # noqa: F401  (cute.compile pulls cuda)
+
+# DSv4 has only one config flavor (dsv4); no env-var flavor switch needed.
+# Config comes from the FROST template loader, NOT an env var: the pre-upstream
+# kernels picked a flavor with an env var + a sdpa_config_<flavor> module, which the
+# FROST engine contract forbids ("no environment variables for configuration" --
+# parameters travel as typed dataclasses). The loader injects
+# FROST_TEMPLATE_PARAMS before this body runs; the default keeps a plain
+# `import` usable as a standalone driver.
+from cudnn.sdpa.fwd.config_sm107 import TemplateParams, make_cfg_d512_mxfp8
+
+PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
+CFG, _TMA = make_cfg_d512_mxfp8(PARAMS)
+Cfg = type(CFG)
+TMA_QK_ITERS = _TMA.QK_ITERS
+TMA_VO_ITERS = _TMA.VO_ITERS
+TMA_QK_GRANU_ELEMS = _TMA.QK_GRANU_ELEMS
+TMA_VO_GRANU_ELEMS = _TMA.VO_GRANU_ELEMS
+
+# MXFP8 K-step pin -- k_dim=1 selects 64-element K chunks, halving the
+# tcgen05.mma.block_scale issue count versus k_dim=0.  ``config_sm107`` derives
+# TILE_K_HW from the dtype; this guard pins the two together, because the
+# pairing is arch-OPPOSITE (Blackwell wants k_dim=0 with 32) and a mismatch
+# scrambles accumulator rows SILENTLY (rules/mma-tma-matrix.md S1).
+_MXFP8_K_DIM = 1
+_MXFP8_TILE_K_HW = 32 if _MXFP8_K_DIM == 0 else 64
+if CFG.TILE_K_HW_BMM1 != _MXFP8_TILE_K_HW or CFG.TILE_K_HW_BMM2 != _MXFP8_TILE_K_HW:
+    raise ValueError(
+        f"{__name__}: idesc k_dim={_MXFP8_K_DIM} requires TILE_K_HW={_MXFP8_TILE_K_HW}; " f"got BMM1={CFG.TILE_K_HW_BMM1} BMM2={CFG.TILE_K_HW_BMM2}"
+    )
+
+# O TMA box / store params follow O's swizzle (independent of V under cga2).
+TMA_O_GRANU_ELEMS_HOST = CFG.O_SWZ_BYTES // CFG.BPE_O
+TMA_O_ITERS_HOST = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
+
+
+# Generic tile primitives — never hand-roll equivalents.
+from cudnn.frost.tile_dsl.barrier import (
+    PipelineState,
+    advance,
+    cga_arrive,
+    cga_wait,
+    MBarrier,
+    Producer,
+    Scope,
+    # `wait` (free fn) — still used for sched.mb_* (Sched not in Bars).
+    wait,
+)
+from cudnn.frost.tile_dsl.scheduler import (
+    Sched,
+    scheduler_warp_loop,
+    read_tile_id_arrive,
+    SCHED_NATURAL,
+    SCHED_LPT,
+    SCHED_LPT_L2,
+)
+from cudnn.frost.tile_dsl.pointwise import (
+    tmem_load_max_reduction_tile,
+    row_reduction_pair,
+    row_max_reduction,
+    vec_scale_pair,
+)
+from cudnn.frost.tile_dsl.regtile import RegTile, vec_concat
+from cudnn.frost.tile_dsl.mma import mma_ss, mma_ts_step
+from cudnn.frost.tile_dsl.tma import (
+    tma_load_tile,
+    tma_store_tile,
+    tma_store_commit,
+    tma_store_wait,
+)
+from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, tma_slice_runtime_desc
+from cudnn.frost.tile_dsl.tmem import tmem_alloc, tmem_dealloc
+from cudnn.frost.tile_dsl.mask import (
+    apply_mask_chunk,
+    MASK_NONE,
+    MASK_PADDED,
+    MASK_CAUSAL,
+    MASK_SWA,
+)
+
+# Reuse sm107 SDPA pipeline-shared helpers (KvLoopBounds + closures factory).
+# Note: dsv4 forks Bars in this file (NOT imported from _sdpa_common) per the
+# per-pipeline fork pattern in cpp-to-ctm.md.
+from cudnn.sdpa.fwd.kernels._common_sm100 import (
+    KvLoopBounds,
+    compute_kv_loop_bounds,
+    lpt_tile_coords,
+    make_sdpa_helpers,
+)
+
+# ----------------------------------------------------------------------------
+# Storage dtype dispatch — folded at trace time on CFG.DTYPE_QKV.
+# MXFP8 (E4M3 / E5M2 block-scale) only — BF16/FP16 ships in d512_f16.py,
+# per-tensor FP8 in d512_fp8.py.
+# ----------------------------------------------------------------------------
+if CFG.DTYPE_QKV == 0:
+    STORAGE_DTYPE = cutlass.Float8E4M3FN
+    P_STORAGE_DTYPE = cutlass.Float8E4M3FN
+elif CFG.DTYPE_QKV == 1:
+    STORAGE_DTYPE = cutlass.Float8E5M2
+    P_STORAGE_DTYPE = cutlass.Float8E5M2
+else:
+    raise ValueError(
+        f"prefill_sdpa_d512_mxfp8 (SM107): DTYPE_QKV={CFG.DTYPE_QKV} not supported " f"(expected 0=E4M3 or 1=E5M2; BF16/FP16 ship in prefill_sdpa_d512_f16.py)"
+    )
+
+# Block-scale MXFP8 MMA kind + scale-vec size (32-element blocks share one
+# E8M0 SF byte; mirrors d256_mxfp8.py).
+MMA_KIND = nvvm.MMABlockScaleKind.MXF8F6F4
+SCALE_VEC_SIZE = nvvm.Tcgen05MMAScaleVecSize.BLOCK32
+
+
+# DTYPE_O is independent of DTYPE_QKV (C++ Cfg::DTYPE_O — defaults to DTYPE_QKV
+# but can be promoted to BF16/FP16 to skip downstream dequant).  Dispatch on
+# Cfg::DTYPE_O.  BPE_O ∈ {1, 2}; epilogue cast loop generic over the result.
+if CFG.DTYPE_O == 0:
+    OUT_STORAGE_DTYPE = cutlass.Float8E4M3FN
+elif CFG.DTYPE_O == 1:
+    OUT_STORAGE_DTYPE = cutlass.Float8E5M2
+elif CFG.DTYPE_O == 2:
+    OUT_STORAGE_DTYPE = cutlass.BFloat16
+elif CFG.DTYPE_O == 3:
+    OUT_STORAGE_DTYPE = cutlass.Float16
+else:
+    raise ValueError(f"prefill_sdpa_d512_mxfp8 (SM107): DTYPE_O={CFG.DTYPE_O} not supported " f"(expected 0=E4M3/1=E5M2/2=BF16/3=FP16)")
+
+
+# ----------------------------------------------------------------------------
+# MXFP8 SF constants (trace-time folded).  Mirrors d256_mxfp8.py + C++
+# prefill_sdpa_d512_mxfp8.cu:104-144.
+# ----------------------------------------------------------------------------
+BITS_PER_SF_ELEMENT = 8  # E8M0
+BLOCK_SCALE_BLOCK_SIZE = 32  # 32 elems share one SF byte
+SF_BLOCK_DIM_NON_K = 128
+SF_BLOCK_DIM_K = 4
+SF_SWIZZLED_BLOCK_DIM_K = 16
+SF_BYTES_PER_BLOCK = SF_BLOCK_DIM_NON_K * SF_BLOCK_DIM_K * BITS_PER_SF_ELEMENT // 8  # 512
+
+
+def _round_up(a: int, b: int) -> int:
+    return (a + b - 1) // b * b
+
+
+# BMM1 SF block counts (TILE_M=128, TILE_N=128, TILE_K=512).
+SF_NUM_BLOCKS_M = CFG.TILE_M // SF_BLOCK_DIM_NON_K  # 1
+SF_NUM_BLOCKS_N = CFG.TILE_N // SF_BLOCK_DIM_NON_K  # 1
+SF_NUM_BLOCKS_K = _round_up(CFG.TILE_K, 128) // BLOCK_SCALE_BLOCK_SIZE // SF_BLOCK_DIM_K  # 4
+
+SF_REGISTERS_PER_BLOCK = SF_SWIZZLED_BLOCK_DIM_K * BITS_PER_SF_ELEMENT // 32  # 4
+SF_TMEM_COLS_Q = SF_NUM_BLOCKS_M * SF_NUM_BLOCKS_K * SF_REGISTERS_PER_BLOCK  # 16
+SF_TMEM_COLS_K = SF_NUM_BLOCKS_N * SF_NUM_BLOCKS_K * SF_REGISTERS_PER_BLOCK  # 16
+
+# Per-CTA SF Q SMEM (per-CTA along M; each sg0 peer holds 2 KiB).
+SF_SMEM_SIZE_Q = CFG.TILE_M * _round_up(CFG.TILE_K, 128) // BLOCK_SCALE_BLOCK_SIZE  # 2048 B
+SF_SMEM_SIZE_K = CFG.TILE_N * _round_up(CFG.TILE_K, 128) // BLOCK_SCALE_BLOCK_SIZE  # 2048 B
+
+# BMM2 SF block counts (K dim of BMM2 = TILE_N=128 → 1 SF K block per call;
+# N dim of BMM2 = TILE_O=512 → 4 SF V N-blocks total).
+SF_NUM_BLOCKS_P = CFG.TILE_M // SF_BLOCK_DIM_NON_K  # 1
+SF_NUM_BLOCKS_V = _round_up(CFG.TILE_O, 128) // SF_BLOCK_DIM_NON_K  # 4
+SF_NUM_BLOCKS_K_BMM2 = CFG.TILE_N // BLOCK_SCALE_BLOCK_SIZE // SF_BLOCK_DIM_K  # 1
+SF_TMEM_COLS_P = SF_NUM_BLOCKS_P * SF_NUM_BLOCKS_K_BMM2 * SF_REGISTERS_PER_BLOCK  # 4
+SF_TMEM_COLS_V = SF_NUM_BLOCKS_V * SF_NUM_BLOCKS_K_BMM2 * SF_REGISTERS_PER_BLOCK  # 16
+SF_SMEM_SIZE_P = _round_up(CFG.TILE_M, 128) * CFG.TILE_N // BLOCK_SCALE_BLOCK_SIZE  # 512 B
+SF_SMEM_SIZE_V = _round_up(CFG.TILE_O, 128) * CFG.TILE_N // BLOCK_SCALE_BLOCK_SIZE  # 2048 B
+
+# SF V N-block split for BMM2 (mirrors C++ d512_mxfp8.cu:144).  Per-call covers
+# SF_NUM_BLOCKS_V / BMM2_LOOP_N_BLOCKS = 2 SF N-blocks.
+SF_V_TMEM_COLS_PER_CALL = SF_TMEM_COLS_V // CFG.BMM2_LOOP_N_BLOCKS  # 8
+
+# Per-N-block stride within tmem_SF_V (cols / N-block).
+SF_V_COLS_PER_NBLOCK = SF_NUM_BLOCKS_K_BMM2 * SF_REGISTERS_PER_BLOCK  # 4
+
+# E8M0 = 1.0 (= 2^0) — fills SF P SMEM at kernel entry.
+SF_CONST_VALUE = 0x7F
+
+# SF expect_tx bytes per TMA call.
+Q_SF_EXPECT_BYTES = SF_SMEM_SIZE_Q * CFG.CTA_MMA
+K_SF_EXPECT_BYTES = SF_SMEM_SIZE_K * CFG.CTA_MMA
+V_SF_EXPECT_BYTES = SF_SMEM_SIZE_V * CFG.CTA_MMA
+
+
+# ----------------------------------------------------------------------------
+# Derived constants — mirror prefill_sdpa_d512_mxfp8.cu:120-140.
+# ----------------------------------------------------------------------------
+CGA_SIZE = CFG.CGA_M * CFG.CGA_N
+CTA_GROUP_KIND = nvvm.CTAGroup.CTA_2 if CFG.CTA_MMA == 2 else nvvm.CTAGroup.CTA_1
+
+# Per-CTA buffer element counts + collective TMA transaction byte counts.
+qBufferElems = CFG.TILE_M * CFG.TILE_K  # 65536  → 128 KiB @ BPE=2
+kBufferElems = CFG.TILE_N * CFG.TILE_K // CFG.CTA_MMA  # 32768  →  64 KiB
+vBufferElems = CFG.TILE_O * CFG.TILE_N // CFG.CTA_MMA  # 32768  →  64 KiB
+oBufferElems = CFG.TILE_M * CFG.TILE_O  # 65536  → 128 KiB @ BPE_O=2
+pXferElems = CFG.TILE_M * CFG.TILE_N  # 16384  →  32 KiB / xfer stage
+
+# Per-stage xfer SMEM sizes (DSMEM peer-to-peer payloads).
+pXferBytes = pXferElems * CFG.BPE  # 32 KiB / stage
+alphaXferBytes = CFG.TILE_M * 4  # 512 B  / stage (FP32)
+statsXferBytes = 2 * CFG.TILE_M * 4  # 1 KiB total (ell + max)
+
+# Collective TMA transaction bytes (leader expect_tx under cga2).
+qTmaTransactionBytes = qBufferElems * CFG.BPE * CFG.CTA_MMA
+kTmaTransactionBytes = kBufferElems * CFG.BPE * CFG.CTA_MMA
+vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
+
+# Per-call BMM2 V SMEM advance (between the BMM2_LOOP_N_BLOCKS=2 BMM2 calls).
+# C++ prefill_sdpa_d512_mxfp8.cu:87 — at FP8 (BPE=1) the per-CTA V inner =
+# (TILE_O/CTA_MMA)*BPE = 256 B = 2 swizzle lines, so the slab stride works
+# out to TILE_N * V_SWZ_BYTES bytes per N-block (NO extra BPE factor).
+BMM2_V_NBLOCK_ADVANCE = CFG.TILE_N * CFG.V_SWZ_BYTES
+
+# O store chunks (TMA-STG arrive granularity — 128 B per chunk).
+N_O_CHUNKS = (CFG.TILE_O * CFG.BPE_O + 127) // 128  # FP8 out: 4; half out: 8
+
+CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+
+# ----------------------------------------------------------------------------
+# Softmax-body constants — module-level so the top-level @cute.jit helper
+# `_sg0_softmax_kv_iter` can read them without a closure capture (CTM-DSL
+# forbids closures inside @cute.jit traced under dynamic control flow).
+# ----------------------------------------------------------------------------
+# P SMEM layout helpers (TILE_M=128 rows × TILE_N=128 cols, Swz128B).
+# 1 row of TILE_N elements = (TILE_N*BPE/SWZ_BYTES) swizzle chunks of P_D_BLOCK each.
+P_TMA_ITERS = (CFG.TILE_N * CFG.BPE) // CFG.Q_SWZ_BYTES  # 2
+P_D_BLOCK = CFG.TILE_N // P_TMA_ITERS  # 64 elements / chunk
+P_BLOCK_BYTES = CFG.TILE_M * P_D_BLOCK  # 8192 elements / TMA chunk
+# Mask-path load chunk width (mirrors canonical _softmax_kv_body CHUNK=64).
+SOFTMAX_CHUNK = 64
+SOFTMAX_N_CHUNKS_LOAD = CFG.TILE_N // SOFTMAX_CHUNK  # 2 for TILE_N=128
+# Swizzle for P SMEM stores (Swz128B at d=512 — same as Q/O).
+P_SMEM_SWIZZLE = cutlass.Swizzle(3, 4, 3)
+# Streaming-softmax constants.
+NEG_INF_F32 = cutlass.Float32(-3.4028235e38)
+RESCALE_THRESHOLD_F32 = cutlass.Float32(CFG.RESCALE_THRESHOLD)
+
+
+# ----------------------------------------------------------------------------
+# Named arrival-count constants — mirror C++ prefill_sdpa_d512_mxfp8.cu:1500-1520.
+# Per mbarrier-patterns.md P3, ALL init(...) counts must reference named
+# constants — never inline literals.
+# ----------------------------------------------------------------------------
+COMPUTE_LANES = CFG.SOFTMAX_WG_WARPS * 32  # 4 warps * 32 lanes = 128
+SM_LANES_TOTAL = 2 * COMPUTE_LANES  # 256 — both sg0 CTAs * 128 sm threads
+TWO_LANES_TOTAL = 2  # both sg1 CTAs * 1 elect-one to leader
+KV_EMPTY_ARRIVERS = CFG.CGA_N  # = 1 — cga2 commit multicast counts as 1
+
+# READ_TILE_ARRIVERS already derived in CFG (= 25 for dsv4 cga4x1).  Re-export
+# for inline visibility next to the init block.
+READ_TILE_ARRIVERS = CFG.READ_TILE_ARRIVERS
+
+
+# ----------------------------------------------------------------------------
+# Compile-time budget checks — Rubin SM107 caps (NOT 227/512 SM100 caps).
+# ----------------------------------------------------------------------------
+# Per-CTA SMEM budget under Rubin SM107 327 KiB oversized cap.  Each physical
+# CTA runs ONE role (sg0 or sg1), so the SharedStorage union covers
+# max(sg0_bytes, sg1_bytes), NOT the sum.  sg0 holds Q + K_ring + xfer
+# staging; sg1 holds V_ring + O + xfer staging + LSE.  Mirrors the C++
+# `union { sg0; sg1; }` in SharedStorage.
+_SG0_SMEM_DATA_KIB = (
+    qBufferElems * CFG.BPE  # Q (sg0)
+    + CFG.STAGES_KV * kBufferElems * CFG.BPE  # K_ring (sg0)
+    + CFG.XFER_STAGES * pXferBytes  # P xfer (source side staging)
+    + CFG.XFER_STAGES * alphaXferBytes  # alpha xfer (source side staging)
+    + statsXferBytes  # stats xfer
+) / 1024
+_SG1_SMEM_DATA_KIB = (
+    CFG.STAGES_KV * vBufferElems * CFG.BPE  # V_ring (sg1)
+    + oBufferElems * CFG.BPE_O  # O (sg1)
+    + CFG.XFER_STAGES * pXferBytes  # P xfer (sink side staging)
+    + CFG.XFER_STAGES * alphaXferBytes  # alpha xfer (sink side staging)
+    + statsXferBytes  # stats xfer
+    + CFG.TILE_M * 4  # LSE staging (sg1)
+) / 1024
+# RESOURCE-NOTE: SM107 oversized cap is 327 KiB; allow ~4 KiB scaffolding +
+# mbar headroom.  Per-sg data budgets must each fit under 323 KiB.
+assert _SG0_SMEM_DATA_KIB <= 323, f"sg0 SMEM data {_SG0_SMEM_DATA_KIB:.1f} KiB exceeds 323 KiB headroom under 327 KiB cap"
+assert _SG1_SMEM_DATA_KIB <= 323, f"sg1 SMEM data {_SG1_SMEM_DATA_KIB:.1f} KiB exceeds 323 KiB headroom under 327 KiB cap"
+
+# TMEM 576-col cap — Rubin SM107 (NOT SM100's 512).  is_exclusive=True required.
+_TMEM_SG0_COLS = CFG.XFER_STAGES * CFG.TILE_N  # FP8: 4 * 128 = 512 cols for S_acc parities
+_TMEM_SG1_COLS = CFG.TILE_O  # 512 cols for O
+assert _TMEM_SG0_COLS <= 576, f"sg0 S_acc TMEM overflow: {_TMEM_SG0_COLS} > 576"
+assert _TMEM_SG1_COLS <= 576, f"sg1 O TMEM overflow: {_TMEM_SG1_COLS} > 576"
+
+
+# ----------------------------------------------------------------------------
+# Bars — DSv4 role-split inventory, forked in this kernel file per the
+# per-pipeline fork pattern.  Mirrors C++ prefill_sdpa_d512_mxfp8.cu:320-373.
+# ----------------------------------------------------------------------------
+# Barrier table (cga4x1 / CTA_MMA=2 — DSv4 role-split, SM107 baseline)
+# ============================================================================
+# | Name                     | Stages           | Init                       | Producer / arrive site                          | Consumer / wait site                  | Scope / bootstrap                                   |
+# |--------------------------|------------------|----------------------------|-------------------------------------------------|---------------------------------------|-----------------------------------------------------|
+# | mb_tma_q_full            | 1                | ONE_LANE                   | sg0 TMA-LDG : arrive_expect_tx (Q bytes)        | sg0 MMA (BMM1)                        | cga2 leader-only                                    |
+# | mb_tma_q_empty           | 1                | ONE_LANE                   | sg0 MMA : arrive_mma after last-iter BMM1 commit| sg0 TMA-LDG (next-tile Q load)        | leader-multicast; pre-arm via q_empty_state=1       |
+# | mb_tma_k_full[s]         | STAGES_KV (=2)   | ONE_LANE                   | sg0 TMA-LDG : arrive_expect_tx (K bytes)        | sg0 MMA (BMM1)                        | cga2 leader-only                                    |
+# | mb_tma_k_empty[s]        | STAGES_KV        | KV_EMPTY_ARRIVERS (=1)     | sg0 MMA : arrive_mma after BMM1 commit          | sg0 TMA-LDG (K_ring back-pressure)    | leader-multicast; pre-arm via PipelineState(0,1)    |
+# | mb_tma_v_full[s]         | STAGES_KV        | ONE_LANE                   | sg1 TMA-LDG : arrive_expect_tx (V bytes)        | sg1 MMA (BMM2)                        | cga2 leader-only                                    |
+# | mb_tma_v_empty[s]        | STAGES_KV        | KV_EMPTY_ARRIVERS (=1)     | sg1 MMA : arrive_mma after BMM2 commit          | sg1 TMA-LDG (V_ring back-pressure)    | leader-multicast; pre-arm via PipelineState(0,1)    |
+# | mb_bmm1_done[p]          | XFER_STAGES (=2) | ONE_LANE                   | sg0 MMA : arrive_mma after BMM1 commit          | sg0 softmax                           | local; not bootstrapped                             |
+# | mb_bmm2_done[p]          | XFER_STAGES      | ONE_LANE                   | sg1 MMA : arrive_mma after BMM2 commit          | sg1 corr (epilogue gate)              | local; not bootstrapped                             |
+# | mb_bmm2_ready[p*2+c]     | XFER_STAGES*2(=4)| SM_LANES_TOTAL (=256)      | sg1 corr (all-thread) : arrive_on_peer→leader   | sg1 MMA leader (per-half-N-block)     | cga2 leader-waited                                  |
+# | mb_s_acc_empty[p]        | XFER_STAGES      | SM_LANES_TOTAL (=256)      | sg0 softmax (all-thread) : arrive_on_peer→leader| sg0 MMA leader (S_acc TMEM free)      | cga2 leader-waited; pre-arm via PipelineState(0,1)  |
+# | mb_p_xfer_full[p]        | XFER_STAGES      | leader: CTA_MMA(=2)        | sg0 softmax bulk_copy→peer; sg1 peer→leader DSMEM| sg1 MMA leader (BMM2 P operand)       | P12; leader=2 / non-leader=1                        |
+# |                          |                  | non-leader: ONE_LANE(=1)   |                                                  |                                       |                                                     |
+# | mb_p_xfer_empty[p]       | XFER_STAGES      | ONE_LANE                   | sg1 MMA leader : arrive_mma multicast→sg0       | sg0 softmax (next P slot reuse)       | P13 MMA-commit multicast; pre-arm via PipelineState(0,1) |
+# | mb_alpha_xfer_full[p]    | XFER_STAGES      | ONE_LANE                   | sg1 corr (local) : arrive_expect_tx (alpha)     | sg1 corr (apply alpha)                | local; not bootstrapped                             |
+# | mb_alpha_xfer_empty[p]   | XFER_STAGES      | COMPUTE_LANES (=128)       | sg1 corr (all-thread) : arrive_on_peer→sg0      | sg0 softmax (next alpha slot reuse)   | local; pre-arm via PipelineState(0,1)               |
+# | mb_stats_xfer_full       | 1                | ONE_LANE                   | sg1 corr (local) : arrive_expect_tx (ell+max)   | sg1 corr (final stats consume)        | local; not bootstrapped                             |
+# | mb_stats_xfer_empty      | 1                | ONE_LANE                   | sg1 corr (elect) : arrive_on_peer→sg0           | sg0 softmax (next tile stats slot)    | local; pre-arm via stats_xfer_empty_phase=1         |
+# | mb_tma_o_full[c]         | N_O_CHUNKS (=8)  | COMPUTE_LANES (=128)       | sg1 corr (all-thread) : arrive per chunk        | sg1 TMA-STG (per-chunk TMA)           | local; not bootstrapped                             |
+# | mb_tma_o_empty           | 1                | ONE_WARP (=32)             | sg1 TMA-STG warp : arrive after STG drain       | sg1 corr (next-tile O staging reuse)  | local; pre-arm via PipelineState(0,1)               |
+# | mb_empty_mainloop        | 1                | TWO_LANES_TOTAL (=2)       | sg1 corr (both CTAs, elect) : arrive_on_peer→leader| sg1 MMA leader (empty-kv branch)   | cga2 leader-waited                                  |
+# | mb_tmem_dealloc          | 1                | ONE_LANE                   | both sgs compute (elect) : arrive_on_peer→partner| both sgs MMA (alloc/dealloc fence)   | local; not bootstrapped                             |
+# ============================================================================
+class Bars(NamedTuple):
+    """DSv4 role-split mbarrier inventory (Rubin SM107 baseline)."""
+
+    # ---- TMA Q/K/V handshakes (sg0: Q + K; sg1: V) ----------------------
+    mb_tma_q_full: object  # [1]            sg0  TMA-LDG → MMA
+    mb_tma_q_empty: object  # [1]            sg0  MMA → TMA-LDG (next-tile Q)
+    mb_tma_k_full: object  # [STAGES_KV]    sg0  TMA-LDG → MMA
+    mb_tma_k_empty: object  # [STAGES_KV]    sg0  MMA → TMA-LDG (back-pressure)
+    mb_tma_v_full: object  # [STAGES_KV]    sg1  TMA-LDG → MMA
+    mb_tma_v_empty: object  # [STAGES_KV]    sg1  MMA → TMA-LDG
+
+    # ---- MMA → softmax / corr handshakes -------------------------------
+    mb_bmm1_done: object  # [XFER_STAGES]      sg0 MMA → softmax
+    mb_bmm2_done: object  # [XFER_STAGES]      sg1 MMA → corr (epilogue gate)
+    mb_bmm2_ready: object  # [XFER_STAGES * 2]  sg1 corr → MMA (per half-N-block)
+    mb_s_acc_empty: object  # [XFER_STAGES]      sg0 softmax → MMA (S_acc TMEM free)
+
+    # ---- DSMEM xfer rings (sg0 → sg1) ----------------------------------
+    mb_p_xfer_full: object  # [XFER_STAGES]   sg0 → sg1 (P12 leader=2 / non-leader=1)
+    mb_p_xfer_empty: object  # [XFER_STAGES]   sg1 leader MMA → sg0 (P13 multicast)
+    mb_alpha_xfer_full: object  # [XFER_STAGES]   sg0 softmax (local expect_tx) → sg1 corr
+    mb_alpha_xfer_empty: object  # [XFER_STAGES]   sg1 corr (all-thread DSMEM) → sg0
+    mb_stats_xfer_full: object  # [1]             sg1 corr (local expect_tx) one-shot per tile
+    mb_stats_xfer_empty: object  # [1]             sg0 softmax (elect DSMEM) → sg1
+
+    # ---- sg1 TMA-STG handshakes -----------------------------------------
+    mb_tma_o_full: object  # [N_O_CHUNKS]   sg1 corr → TMA-STG (per-128B chunk)
+    mb_tma_o_empty: object  # [1]            sg1 TMA-STG warp → corr
+
+    # ---- End-of-kernel teardown -----------------------------------------
+    mb_empty_mainloop: object  # [1]            sg1 corr → sg1 MMA leader (empty-kv branch)
+    mb_tmem_dealloc: object  # [1]            both sgs compute → cga2 partner MMA
+
+
+# ----------------------------------------------------------------------------
+# KernelTmemLayout — sg-conditional carves total ≤ 576 cols on SM107.
+# Mirrors C++ prefill_sdpa_d512_mxfp8.cu KernelTmemLayout (XFER_STAGES=4).
+#
+#   sg0: 4 × S_acc parities (4 * 128 = 512) + SF_Q (16) + SF_K (16) = 544 cols.
+#   sg1: O (512) + SF_P (4) + SF_V (16)                              = 532 cols.
+# Both fit under 576-col Rubin cap.
+# ----------------------------------------------------------------------------
+@dataclass(frozen=True)
+class KernelTmemLayout:
+    """SM107 TMEM carves: sg0 = S_acc parities + SF_Q + SF_K; sg1 = O + SF_P + SF_V.
+
+    sg0 uses TMEM cols [0, XFER_STAGES * 128) for S_acc parity slots, then
+        SF_Q at [512, 528), SF_K at [528, 544).
+    sg1 uses TMEM cols [0, 512) for O accumulator, then SF_P at [512, 516),
+        SF_V at [516, 532).
+    """
+
+    # Rubin SM107 cap; requires is_exclusive=True on tcgen05_alloc.
+    TOTAL_COLS: int = 576
+
+    # sg0 layout — per-parity S_acc slot at offset parity * S_ACC_COLS.
+    S_ACC_COLS: int = 128  # = CFG.TILE_N — one parity slot
+    # Per-parity offsets (formula = parity * S_ACC_COLS).
+    S_ACC_PARITY0_OFF: int = 0
+    S_ACC_PARITY1_OFF: int = 128
+
+    # sg1 layout — single fixed-offset O accumulator @ cols [0, TILE_O).
+    O_OFF: int = 0
+    O_COLS: int = 512  # = CFG.TILE_O
+
+    # sg0 SF tiles — placed AFTER all XFER_STAGES S_acc slots.
+    SF_Q_OFF: int = 512  # XFER_STAGES * 128 = 512 at XFER_STAGES=4
+    SF_K_OFF: int = 512 + 16  # SF_Q_OFF + SF_TMEM_COLS_Q (=16)
+    # sg1 SF tiles — placed AFTER O accumulator.
+    SF_P_OFF: int = 512  # = O_COLS
+    SF_V_OFF: int = 512 + 4  # SF_P_OFF + SF_TMEM_COLS_P (=4)
+
+
+LAYOUT = KernelTmemLayout()
+assert CFG.XFER_STAGES * LAYOUT.S_ACC_COLS <= LAYOUT.TOTAL_COLS, f"sg0 TMEM overflow: {CFG.XFER_STAGES * LAYOUT.S_ACC_COLS} > {LAYOUT.TOTAL_COLS}"
+assert LAYOUT.O_OFF + LAYOUT.O_COLS <= LAYOUT.TOTAL_COLS, f"sg1 TMEM overflow: {LAYOUT.O_OFF + LAYOUT.O_COLS} > {LAYOUT.TOTAL_COLS}"
+# SF region bounds (mirror C++ d512_mxfp8.cu:327-330 static_asserts).
+assert LAYOUT.SF_K_OFF + SF_TMEM_COLS_K <= LAYOUT.TOTAL_COLS, f"sg0 SF TMEM overflow: {LAYOUT.SF_K_OFF + SF_TMEM_COLS_K} > {LAYOUT.TOTAL_COLS}"
+assert LAYOUT.SF_V_OFF + SF_TMEM_COLS_V <= LAYOUT.TOTAL_COLS, f"sg1 SF TMEM overflow: {LAYOUT.SF_V_OFF + SF_TMEM_COLS_V} > {LAYOUT.TOTAL_COLS}"
+
+
+# ----------------------------------------------------------------------------
+# Bars factory — dsv4 role-split mbarrier inventory typed with MBarrier
+# wrapper.  Producer / scope tags + init counts derived from the barrier
+# table comment above + the explicit init logic below.  Note: mb_p_xfer_full
+# uses a RUNTIME-conditional init count (leader = CTA_MMA, non-leader = 1),
+# so the static init_count here is a placeholder — the kernel passes an
+# explicit override_count to .init() per CTA.
+# ----------------------------------------------------------------------------
+def _make_dsv4_bars(CFG, N_O_CHUNKS: int):
+    def _alloc(n):
+        return cutlass.Array(cutlass.Int64, n, alignment=16, space=cutlass.AddressSpace.smem)
+
+    return Bars(
+        # TMA Q/K/V
+        mb_tma_q_full=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_tma_q_empty=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.MMA_COMMIT),
+        mb_tma_k_full=MBarrier(_alloc(CFG.STAGES_KV), stages=CFG.STAGES_KV, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_tma_k_empty=MBarrier(_alloc(CFG.STAGES_KV), stages=CFG.STAGES_KV, init_count=KV_EMPTY_ARRIVERS, producer=Producer.MMA_COMMIT),
+        mb_tma_v_full=MBarrier(_alloc(CFG.STAGES_KV), stages=CFG.STAGES_KV, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_tma_v_empty=MBarrier(_alloc(CFG.STAGES_KV), stages=CFG.STAGES_KV, init_count=KV_EMPTY_ARRIVERS, producer=Producer.MMA_COMMIT),
+        # MMA → softmax / corr
+        mb_bmm1_done=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=CFG.ONE_LANE, producer=Producer.MMA_COMMIT),
+        mb_bmm2_done=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=CFG.ONE_LANE, producer=Producer.MMA_COMMIT),
+        mb_bmm2_ready=MBarrier(
+            _alloc(CFG.XFER_STAGES * CFG.N_BMM2_CHUNKS),
+            stages=CFG.XFER_STAGES * CFG.N_BMM2_CHUNKS,
+            init_count=SM_LANES_TOTAL,
+            producer=Producer.LEADER,
+            scope=Scope.LEADER,
+        ),
+        mb_s_acc_empty=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=SM_LANES_TOTAL, producer=Producer.LEADER, scope=Scope.LEADER),
+        # DSMEM xfer rings — mb_p_xfer_full has RUNTIME init count (P12):
+        # leader = CTA_MMA arrives (own + DSMEM forwarder); non-leader = 1.
+        # Static init_count here is CFG.CTA_MMA (the leader value); the
+        # kernel's init loop passes override_count=p_full_init for each stage.
+        mb_p_xfer_full=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=CFG.CTA_MMA, producer=Producer.TMA_LOAD),
+        mb_p_xfer_empty=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=CFG.ONE_LANE, producer=Producer.MMA_COMMIT),
+        mb_alpha_xfer_full=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_alpha_xfer_empty=MBarrier(_alloc(CFG.XFER_STAGES), stages=CFG.XFER_STAGES, init_count=COMPUTE_LANES, producer=Producer.THREAD),
+        mb_stats_xfer_full=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.TMA_LOAD),
+        mb_stats_xfer_empty=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.THREAD),
+        # sg1 TMA-STG
+        mb_tma_o_full=MBarrier(_alloc(N_O_CHUNKS), stages=N_O_CHUNKS, init_count=COMPUTE_LANES, producer=Producer.THREAD),
+        mb_tma_o_empty=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_WARP, producer=Producer.THREAD),
+        # Teardown
+        mb_empty_mainloop=MBarrier(_alloc(1), stages=1, init_count=TWO_LANES_TOTAL, producer=Producer.LEADER, scope=Scope.LEADER),
+        mb_tmem_dealloc=MBarrier(_alloc(1), stages=1, init_count=CFG.ONE_LANE, producer=Producer.THREAD),
+    )
+
+
+# ----------------------------------------------------------------------------
+# SMEM swizzle / layout enums.
+# ----------------------------------------------------------------------------
+_SWZ_ENUM = {128: 2, 64: 4, 32: 6}
+SMEM_LAYOUT_Q = _SWZ_ENUM[CFG.Q_SWZ_BYTES]
+SMEM_LAYOUT_K = _SWZ_ENUM[CFG.K_SWZ_BYTES]
+SMEM_LAYOUT_V = _SWZ_ENUM[CFG.V_SWZ_BYTES]
+SMEM_LAYOUT_O = _SWZ_ENUM[CFG.O_SWZ_BYTES]
+SMEM_LAYOUT_QKO = SMEM_LAYOUT_Q
+# P xfer SMEM layout matches Q swizzle (cf. C++ prefill_sdpa_d512_mxfp8.cu:75).
+SMEM_LAYOUT_P = SMEM_LAYOUT_Q
+
+# SF SmemDesc — no swizzle, leading=16, stride=128 (utccp_32x128b_warpx4).
+SMEM_LAYOUT_SF = 0
+SF_LEADING_BYTE_OFFSET = 16
+SF_STRIDE_BYTE_OFFSET = 128
+
+_O_SWZ_B = {128: 3, 64: 2, 32: 1}[CFG.O_SWZ_BYTES]
+_O_SMEM_SWIZZLE = cutlass.Swizzle(_O_SWZ_B, 4, 3)
+
+LEADING_BYTE_OFFSET_QK = 0
+STRIDE_BYTE_OFFSET_QK = 8 * CFG.Q_SWZ_BYTES
+
+_CORE_MATRIX_ROWS = 8
+_V_PC_COLS = CFG.TILE_O // CFG.CTA_MMA
+LEADING_BYTE_OFFSET_PV = 0 if (_V_PC_COLS // _CORE_MATRIX_ROWS) <= 8 else CFG.TILE_N * CFG.V_SWZ_BYTES
+STRIDE_BYTE_OFFSET_PV = 8 * CFG.V_SWZ_BYTES
+
+# BMM2 manual k-step iters.
+NUM_KPHASES_PV = CFG.TILE_N // CFG.TILE_K_HW_BMM2
+
+
+# ----------------------------------------------------------------------------
+# Helpers bound to CFG (scheduler topology + mask plumbing — unchanged from
+# the sm107 classic kernels; role-split doesn't change tile decoding).
+# ----------------------------------------------------------------------------
+_sdpa_h = make_sdpa_helpers(CFG)
+_decode_initial = _sdpa_h.decode_initial
+_decode_payload = _sdpa_h.decode_payload
+_bounds_for_tile = _sdpa_h.bounds_for_tile
+_resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+
+# THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
+# factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
+# kernels/ctm/common/sdpa/thd.py.  Gated by CFG.THD_VARLEN (folds out otherwise).
+# Supported at cga4x1 (the per-batch O descriptor's seq extent OOB-clips the
+# 256-row store box).  seq_kv_lens overloaded as the THD metadata buffer (int32
+# len 3B+2): [0..B-1]=seq_kv_lens [B..2B]=cu_q(B+1) [2B+1..3B+1]=cu_k(B+1).
+# MXFP8-only: _thd_sf_tile_bases returns the per-sequence SF-tile prefix bases
+# (cu_sf_q_base / cu_sf_k_base) for the packed scale-factor layout.
+from cudnn.sdpa.fwd.kernels.thd_helpers import build_thd_meta_o_descs_kernel as _build_thd_meta_o_descs_kernel, TENSOR_MAP_QWORDS
+
+_TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
+_dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
+_dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
+_thd_tma_offsets = _sdpa_h.thd_tma_offsets
+_thd_sf_tile_bases = _sdpa_h.thd_sf_tile_bases
+
+
+# ============================================================================
+# Kernel entry.
+# ============================================================================
+@cute.kernel
+def _kernel(
+    tma_q_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_k_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_v_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_o_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_q_sf_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_k_sf_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_v_sf_desc: cutlass.GridConstant[tmap.TensorMap],
+    lse_tensor: Optional[cute.Tensor],
+    # FROST's MXFP8 ABI puts amax_o RIGHT AFTER lse (position 9); _host and the
+    # compute warp group already spoke it, only this signature was missed.
+    amax_o_tensor: cute.Tensor,
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    seqlen_q: cutlass.Int32,
+    seqlen_kv: cutlass.Int32,
+    n_q_supers: cutlass.Int32,
+    n_qh: cutlass.Int32,
+    n_batch: cutlass.Int32,
+    qh_per_kh: cutlass.Int32,
+    scale_softmax_log2: cutlass.Float32,
+) -> None:
+
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    tidx, _, _ = cute.arch.thread_idx()
+
+    bidx = cute.arch.block_idx()[0]
+    bidy = cute.arch.block_idx()[1]
+    bidz = cute.arch.block_idx()[2]
+
+    # ------------------------------------------------------------------
+    # SMEM allocations — natural Q / K / V / O order, NO Q∪K_ring or
+    # O∪V_ring alias (Rubin SM107 cap fits everything; aliases are
+    # SM100-only).  Mirror C++ SharedStorage at prefill_sdpa_d512_mxfp8.cu:148.
+    # ------------------------------------------------------------------
+    # RESOURCE-NOTE: each physical CTA runs ONE role (sg0 OR sg1), so the
+    # Q (sg0) ∪ O (sg1) and K_ring (sg0) ∪ V_ring (sg1) regions alias at
+    # the same SMEM offset.  Mirrors C++ `union QOAlias`/`union KVAlias` at
+    # prefill_sdpa_d512_mxfp8.cu:149-161 — without these unions the per-CTA
+    # SMEM budget doubles (~580 KiB) and busts the 327 KiB Rubin cap.
+    # Q∪O alias byte-sized to max(Q@BPE, O@BPE_O) — STORAGE_DTYPE is FP8 (1 B)
+    # so element count == byte count; BF16/FP16 O (BPE_O=2, DTYPE_O override)
+    # needs 2× the bytes and would otherwise overflow a qBufferElems-only
+    # allocation (the dense-fp8-out path happened to fit, hiding the bug).
+    # Mirrors d256_mxfp8.py:355-362.
+    _QO_ELEMS = max(qBufferElems * CFG.BPE, oBufferElems * CFG.BPE_O)
+    _KV_ELEMS = CFG.STAGES_KV * kBufferElems if kBufferElems >= vBufferElems else CFG.STAGES_KV * vBufferElems
+    sQO_raw = cutlass.Array(STORAGE_DTYPE, _QO_ELEMS, alignment=1024, space=cutlass.AddressSpace.smem)
+    sKV_raw = cutlass.Array(STORAGE_DTYPE, _KV_ELEMS, alignment=1024, space=cutlass.AddressSpace.smem)
+    # sQ / sK / sV alias into sQO_raw / sKV_raw respectively.
+    sQ_raw = sQO_raw  # sg0 view (FP8, STORAGE_DTYPE)
+    sK_raw = sKV_raw  # sg0 view
+    sV_raw = sKV_raw  # sg1 view
+    # sO: OUT_STORAGE_DTYPE (FP8/BF16/FP16) view of the Q∪O backing so the
+    # epilogue store offsets advance in BPE_O units (no-op recast for FP8 out).
+    sO_raw = cutlass.Array(sQO_raw.data_ptr(), shape=oBufferElems, dtype=OUT_STORAGE_DTYPE)
+
+    # P xfer (sg0 → sg1) SMEM — XFER_STAGES rings, kept resident.
+    sP_xfer_raw = cutlass.Array(P_STORAGE_DTYPE, CFG.XFER_STAGES * pXferElems, alignment=128, space=cutlass.AddressSpace.smem)
+    # alpha xfer (sg0 → sg1) SMEM.
+    sAlpha_xfer_raw = cutlass.Array(cutlass.Float32, CFG.XFER_STAGES * CFG.TILE_M, alignment=128, space=cutlass.AddressSpace.smem)
+    # stats xfer (sg0 → sg1) SMEM — 1-shot per tile, holds ell + max (2 * TILE_M floats).
+    sStats_xfer_raw = cutlass.Array(cutlass.Float32, 2 * CFG.TILE_M, alignment=128, space=cutlass.AddressSpace.smem)
+    # LSE staging on sg1 (sub-tile write-back from corr; cf. C++ line 198).
+    sLSE_raw = cutlass.Array(cutlass.Float32, CFG.TILE_M, alignment=128, space=cutlass.AddressSpace.smem)
+
+    # ---- MXFP8 SF SMEM buffers (Int8, alignment=1024) ----
+    # Both sub-groups declare both sets to keep SharedStorage uniform across
+    # CTAs (per-CTA unused slots are dead SMEM, ~6 KiB extra) — mirrors C++
+    # d512_mxfp8.cu:222-229 comment.  Aliasing SF Q/K with SF V/P would save
+    # the bytes but add a sg-conditional union and break TMA byte routing.
+    sQ_SF_raw = cutlass.Array(cutlass.Int8, SF_SMEM_SIZE_Q, alignment=1024, space=cutlass.AddressSpace.smem)
+    sK_SF_raw = cutlass.Array(cutlass.Int8, CFG.STAGES_KV * SF_SMEM_SIZE_K, alignment=1024, space=cutlass.AddressSpace.smem)
+    sP_SF_raw = cutlass.Array(cutlass.Int8, SF_SMEM_SIZE_P, alignment=1024, space=cutlass.AddressSpace.smem)
+    sV_SF_raw = cutlass.Array(cutlass.Int8, CFG.STAGES_KV * SF_SMEM_SIZE_V, alignment=1024, space=cutlass.AddressSpace.smem)
+
+    # Typed SmemTile handles.
+    # Rubin SM107 raises the per-CTA SMEM cap to 327 KiB, so an MMA-operand
+    # buffer can land at or above 256 KiB — past what a version-0 tcgen05 SMEM
+    # descriptor can address (14-bit start_address).  Every operand tile here
+    # therefore carries desc_version=1, matching what C++ SmemTile::make_desc
+    # always emitted.  See tile_dsl/handles.py SmemTile.desc_version.
+    sQ = SmemTile(
+        base=sQ_raw,
+        elems_per_stage=qBufferElems,
+        stages=1,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+        desc_version=1,
+    )
+    sK = SmemTile(
+        base=sK_raw,
+        elems_per_stage=kBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+        desc_version=1,
+    )
+    sV = SmemTile(
+        base=sV_raw,
+        elems_per_stage=vBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_PV,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_PV,
+        layout=SMEM_LAYOUT_V,
+        tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
+        tma_granu_elems=TMA_VO_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+        desc_version=1,
+    )
+    sO = SmemTile(
+        base=sO_raw,
+        elems_per_stage=oBufferElems,
+        stages=1,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=SMEM_LAYOUT_O,
+        tma_loads_per_tile=TMA_O_ITERS_HOST,
+        tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+    )
+
+    # ---- SF SmemTile handles (no swizzle; utccp_32x128b_warpx4 stride) ----
+    # Matches d256_mxfp8.py:348-367.  leading=16, stride=128, layout=0.
+    #
+    # desc_version=1 is MANDATORY here, not decoration.  These four are the LAST
+    # buffers allocated, so at d512 they start ABOVE 256 KiB (measured: sQ_SF at
+    # ~292 KiB behind Q u O 128 + K/V ring 96 + P xfer 64 + stats), past what a
+    # version-0 tcgen05 SMEM descriptor's 14-bit start_address can address.  A
+    # version-0 SF descriptor wraps to the bottom of SMEM, so the UTCCP copies Q
+    # DATA bytes into the SF TMEM columns and the block-scale BMM1 multiplies by
+    # garbage E8M0 exponents -- S_acc comes back +/-inf, LSE=+inf, O=NaN, at
+    # every shape.  The comment above only covered the MMA-operand tiles; these
+    # were added below it and missed.  See rules/mma-tma-matrix.md S6.
+    sQ_SF = SmemTile(
+        base=sQ_SF_raw,
+        elems_per_stage=SF_SMEM_SIZE_Q,
+        stages=1,
+        leading_byte_offset=SF_LEADING_BYTE_OFFSET,
+        stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
+        layout=SMEM_LAYOUT_SF,
+        desc_version=1,
+    )
+    sK_SF = SmemTile(
+        base=sK_SF_raw,
+        elems_per_stage=SF_SMEM_SIZE_K,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=SF_LEADING_BYTE_OFFSET,
+        stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
+        layout=SMEM_LAYOUT_SF,
+        desc_version=1,
+    )
+    sP_SF = SmemTile(
+        base=sP_SF_raw,
+        elems_per_stage=SF_SMEM_SIZE_P,
+        stages=1,
+        leading_byte_offset=SF_LEADING_BYTE_OFFSET,
+        stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
+        layout=SMEM_LAYOUT_SF,
+        desc_version=1,
+    )
+    sV_SF = SmemTile(
+        base=sV_SF_raw,
+        elems_per_stage=SF_SMEM_SIZE_V,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=SF_LEADING_BYTE_OFFSET,
+        stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
+        layout=SMEM_LAYOUT_SF,
+        desc_version=1,
+    )
+
+    # ------------------------------------------------------------------
+    # Bars allocation — per the barrier table above.
+    # ------------------------------------------------------------------
+    bars = _make_dsv4_bars(CFG, N_O_CHUNKS)
+
+    tmem_ptr_i32 = cutlass.Array(cutlass.Int32, 1, alignment=16, space=cutlass.AddressSpace.smem)
+
+    # tile_id_smem stride 8 Int32/stage (32 B per stage; 16 B payload + 16 B padding).
+    sched = Sched(
+        **{
+            "mb_scheduler": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "mb_read_tile_id": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "tile_id_smem": cutlass.Array(cutlass.Int32, CFG.SCHEDULER_STAGES * 8, alignment=16, space=cutlass.AddressSpace.smem),
+            "bidx_init": bidx,
+            "bidy_init": bidy,
+            "bidz_init": bidz,
+        }
+    )
+
+    # ------------------------------------------------------------------
+    # cga2 / role-split identity — hoisted ABOVE init because mb_p_xfer_full
+    # init count is leader-vs-non-leader runtime-conditional (P12 — leader
+    # sees CTA_MMA arrives, non-leader sees 1).
+    # ------------------------------------------------------------------
+    cta_id_x = cute.arch.block_idx_in_cluster() if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    cta_in_pair = (cta_id_x & cutlass.Int32(1)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    leader_cta_id = (cta_id_x & cutlass.Int32(~1 & 0xFFFFFFFF)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    mcast_mask = (cutlass.Int32(3) << leader_cta_id) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    # sg0_mcast_mask = 0x3 — both sg0 CTAs (used by sg1 leader's P13 multicast on mb_p_xfer_empty).
+    sg0_mcast_mask = cutlass.Int32(0x3)
+    # TMA-load self-bit mask: per cga2-mma.md / DKG `fp16_gemm_3.py`, each
+    # peer's `cta_group::2` TMA targets ITS OWN cluster bit (= cta_id_x);
+    # cga2 routing strips bit-24 so bytes land on the cga2 pair leader's
+    # mbar.  Use cluster-rank (cta_id_x), NOT pair-rank (cta_in_pair) — for
+    # cga2 (CGA_M=CTA_MMA=2) these coincide, but for cga4×1 (dsv4) the sg1
+    # pair has cta_in_pair ∈ {0,1} while cta_id_x ∈ {2,3}, and using
+    # cta_in_pair would target CTAs 0,1 (sg0) instead of CTAs 2,3 (sg1).
+    tma_mcast_mask = (cutlass.Int16(1) << cta_id_x.to(cutlass.Int16)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
+    # SF K/V multicast mask — full within the issuing CTA's sg pair so both
+    # peers accumulate the complete (split-loaded) SF tile.  `3 << leader_cta_id`
+    # = 0x3 for sg0 (CTAs 0,1) and 0xC for sg1 (CTAs 2,3) — the data-loading sg.
+    sf_mcast_mask = (cutlass.Int16(3) << leader_cta_id.to(cutlass.Int16)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
+    is_leader = cta_in_pair == cutlass.Int32(0)
+
+    # Sub-group identity (sg0 = CTAs 0, 1; sg1 = CTAs 2, 3).
+    sg_id = cta_id_x // cutlass.Int32(CFG.CTA_MMA)
+    is_sg0 = sg_id == cutlass.Int32(0)
+    is_sg1 = sg_id == cutlass.Int32(1)
+    # Cross-sg peer = this CTA XOR CTA_MMA (CTAs 0↔2, 1↔3).
+    cross_sg_peer = cta_id_x ^ cutlass.Int32(CFG.CTA_MMA)
+
+    is_cga_first_cta = cta_id_x == cutlass.Int32(0)
+
+    # ------------------------------------------------------------------
+    # Mbar init — Phase 1 of cluster init (P4).  No Phase-2 bootstrap arrives:
+    # every consumer that would need one is pre-armed via PipelineState(0, 1)
+    # or per-warp `phase = 1` initial values.  MmaProducer<> typing forbids
+    # plain arrive() anyway.
+    #
+    # Per-CTA leader / non-leader split for mb_p_xfer_full follows P12:
+    # leader = CTA_MMA arrives (own + (CTA_MMA-1) DSMEM forwarder); non-leader = 1.
+    # ------------------------------------------------------------------
+    if warp_idx == 0:
+        if nvvm.elect_sync():
+            # ---- TMA Q/K/V handshakes ----
+            bars.mb_tma_q_full.init()
+            bars.mb_tma_q_empty.init()
+            for ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_tma_k_full[ks].init()
+                bars.mb_tma_k_empty[ks].init()
+                bars.mb_tma_v_full[ks].init()
+                bars.mb_tma_v_empty[ks].init()
+
+            # ---- MMA → softmax / corr handshakes ----
+            for p in cutlass.range_constexpr(CFG.XFER_STAGES):
+                bars.mb_bmm1_done[p].init()
+                bars.mb_bmm2_done[p].init()
+                bars.mb_s_acc_empty[p].init()
+                for c in cutlass.range_constexpr(CFG.N_BMM2_CHUNKS):
+                    bars.mb_bmm2_ready[p * CFG.N_BMM2_CHUNKS + c].init()
+
+                # ---- DSMEM xfer rings (sg0 → sg1) ----
+                # P12: leader = CTA_MMA arrives; non-leader = 1.  Runtime-
+                # conditional init count passed via override_count=.
+                p_full_init = cutlass.Int32(
+                    arith.select(
+                        is_leader.ir_value(),
+                        cutlass.Int32(CFG.CTA_MMA).ir_value(),
+                        cutlass.Int32(CFG.ONE_LANE).ir_value(),
+                    )
+                )
+                bars.mb_p_xfer_full[p].init(override_count=p_full_init)
+                bars.mb_p_xfer_empty[p].init()
+                bars.mb_alpha_xfer_full[p].init()
+                bars.mb_alpha_xfer_empty[p].init()
+
+            # ---- one-shot stats ring ----
+            bars.mb_stats_xfer_full.init()
+            bars.mb_stats_xfer_empty.init()
+
+            # ---- sg1 TMA-STG handshakes ----
+            for c in cutlass.range_constexpr(N_O_CHUNKS):
+                bars.mb_tma_o_full[c].init()
+            bars.mb_tma_o_empty.init()
+
+            # ---- end-of-kernel teardown ----
+            bars.mb_empty_mainloop.init()
+            bars.mb_tmem_dealloc.init()
+
+            # ---- scheduler ring (NOT in Bars; still raw nvvm.mbarrier_init) ----
+            for s in range(CFG.SCHEDULER_STAGES):
+                nvvm.mbarrier_init(sched.mb_scheduler.subview(s), CFG.ONE_LANE)
+                nvvm.mbarrier_init(sched.mb_read_tile_id.subview(s), READ_TILE_ARRIVERS)
+
+    # ---- SF_P SMEM fill with 0x7F (E8M0 1.0) — MUST precede cga_arrive/cga_wait
+    # so both cga2 peers see filled SMEM before any cta_group::2 MMA.  All
+    # threads (both sg0 + sg1 CTAs) participate — sg0's SF_P SMEM is unused but
+    # filling it is harmless and keeps the SharedStorage layout uniform.
+    _SF_P_ITERS = (SF_SMEM_SIZE_P + CFG.THREADS_PER_CTA - 1) // CFG.THREADS_PER_CTA
+    for _i in cutlass.range_constexpr(_SF_P_ITERS):
+        _off = tidx + cutlass.Int32(_i * CFG.THREADS_PER_CTA)
+        if _off < cutlass.Int32(SF_SMEM_SIZE_P):
+            sP_SF_raw.subview(_off).store(cutlass.Int8(SF_CONST_VALUE))
+
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync()
+
+    # P4 cluster fence (cga2-aware) — required because Phase 2 of the kernel
+    # body issues cross-CTA arrive_on_peer BEFORE the receiving CTA has
+    # necessarily flushed its mbar init through the cluster.  relaxed=True
+    # (per project memory: dsv3 cga2 47%→92% SOL).
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        cga_arrive()
+        cga_wait()
+
+    # ------------------------------------------------------------------
+    # Per-warp role dispatch.  Role-split topology:
+    #   compute wg (warps 0..3): sg-conditional softmax (sg0) OR corr (sg1).
+    #   MMA       (warp 4): sg-conditional BMM1 (sg0) OR BMM2 (sg1);
+    #                       non-leader CTAs run quiet (sg0) or forwarder (sg1).
+    #   TMA-LDG   (warp 5): sg-conditional Q+K (sg0) OR V (sg1).
+    #   TMA-STG   (warp 6): sg1 only — O + LSE.  sg0 spins scheduler only.
+    #   Scheduler (warp 7): try_cancel; both sgs.
+    # ------------------------------------------------------------------
+    if warp_idx >= cutlass.Int32(CFG.SOFTMAX_WG0_BASE) and warp_idx < cutlass.Int32(CFG.SOFTMAX_WG0_BASE + CFG.SOFTMAX_WG_WARPS):
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        _compute_warp_group(
+            is_sg0=is_sg0,
+            is_sg1=is_sg1,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_softmax_log2,
+            tmem_ptr_i32=tmem_ptr_i32,
+            sQ=sQ,
+            sO=sO,
+            sP_xfer_raw=sP_xfer_raw,
+            sAlpha_xfer_raw=sAlpha_xfer_raw,
+            sStats_xfer_raw=sStats_xfer_raw,
+            sLSE_raw=sLSE_raw,
+            bars=bars,
+            sched=sched,
+            lse_tensor=lse_tensor,
+            amax_o_tensor=amax_o_tensor,
+            sinks_tensor=sinks_tensor,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+            cta_id_x=cta_id_x,
+            cross_sg_peer=cross_sg_peer,
+        )
+
+    elif warp_idx == cutlass.Int32(CFG.MMA_WARP_ID):
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        # cga2 non-leader paths fork — sg0 non-leader is quiet, sg1 non-leader
+        # forwards mb_p_xfer_full to leader (P12) in a persistent loop.
+        if is_leader:
+            _mma_warp_group(
+                is_sg0=is_sg0,
+                is_sg1=is_sg1,
+                seqlen_q=seqlen_q,
+                seqlen_kv=seqlen_kv,
+                sQ=sQ,
+                sK=sK,
+                sV=sV,
+                sQ_SF=sQ_SF,
+                sK_SF=sK_SF,
+                sP_SF=sP_SF,
+                sV_SF=sV_SF,
+                sP_xfer_raw=sP_xfer_raw,
+                tmem_ptr_i32=tmem_ptr_i32,
+                bars=bars,
+                sched=sched,
+                seq_kv_lens_tensor=seq_kv_lens_tensor,
+                n_q_supers=n_q_supers,
+                n_qh=n_qh,
+                n_batch=n_batch,
+                mcast_mask=mcast_mask,
+                sg0_mcast_mask=sg0_mcast_mask,
+                cta_in_pair=cta_in_pair,
+            )
+        else:
+            _mma_warp_non_leader(
+                is_sg0=is_sg0,
+                is_sg1=is_sg1,
+                seqlen_q=seqlen_q,
+                seqlen_kv=seqlen_kv,
+                tmem_ptr_i32=tmem_ptr_i32,
+                bars=bars,
+                sched=sched,
+                seq_kv_lens_tensor=seq_kv_lens_tensor,
+                n_q_supers=n_q_supers,
+                n_qh=n_qh,
+                n_batch=n_batch,
+                cta_in_pair=cta_in_pair,
+                leader_cta_id=leader_cta_id,
+            )
+
+    elif warp_idx == cutlass.Int32(CFG.TMALDG_WARP_ID):
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        nvvm.prefetch_tensormap(tma_q_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_k_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_v_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_q_sf_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_k_sf_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_v_sf_desc.get_ptr())
+        _tmaldg_warp_group(
+            is_sg0=is_sg0,
+            is_sg1=is_sg1,
+            tma_q_desc=tma_q_desc,
+            tma_k_desc=tma_k_desc,
+            tma_v_desc=tma_v_desc,
+            tma_q_sf_desc=tma_q_sf_desc,
+            tma_k_sf_desc=tma_k_sf_desc,
+            tma_v_sf_desc=tma_v_sf_desc,
+            sQ=sQ,
+            sK=sK,
+            sV=sV,
+            sQ_SF=sQ_SF,
+            sK_SF=sK_SF,
+            sV_SF=sV_SF,
+            bars=bars,
+            sched=sched,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            qh_per_kh=qh_per_kh,
+            is_leader=is_leader,
+            cta_in_pair=cta_in_pair,
+            tma_mcast_mask=tma_mcast_mask,
+            sf_mcast_mask=sf_mcast_mask,
+        )
+
+    elif warp_idx == cutlass.Int32(CFG.TMASTG_WARP_ID):
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _tmastg_warp_group(
+            is_sg1=is_sg1,
+            tma_o_desc=tma_o_desc,
+            sO=sO,
+            bars=bars,
+            sched=sched,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            cta_in_pair=cta_in_pair,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
+        )
+
+    else:  # warp_idx == CFG.SCHED_WARP_ID
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
+
+
+# ============================================================================
+# sg0 softmax-iter helper — per-iter body for the 3-segment kv loop
+# (LEFT-masked / unmasked center / RIGHT-masked).  Mirrors canonical
+# `_softmax_kv_body` (prefill_sdpa_f16.py:923) and C++
+# `softmax_kv_body<ApplyMask>` (prefill_sdpa_d512_mxfp8.cu:432).
+#
+# apply_mask=False uses fused HW row-max (tcgen05.ld.red.f32.max);
+# apply_mask=True uses tcgen05.ld + apply_mask_chunk + software row-max
+# (HW max can't observe -inf written by the mask after the load).
+#
+# Top-level @cute.jit so the dynamic call-graph contains no closure-capture
+# violations (CTM-DSL forbids closures under dynamic control flow).  All
+# kernel-local vars are passed as explicit args; constants come from
+# module-level (NEG_INF_F32, RESCALE_THRESHOLD_F32, P_*, SOFTMAX_*, etc.).
+# ============================================================================
+@cute.jit
+def _sg0_softmax_kv_iter(
+    apply_mask: cutlass.Constexpr[bool],
+    kv_loop,
+    # State (threaded, returned updated):
+    sg0_xfer_state,
+    bmm1_done_state,
+    total_max,
+    total_sum_vec,
+    # TMEM / SMEM bases:
+    tmem_base_addr,
+    bars,
+    sP_xfer_raw,
+    sAlpha_xfer_raw,
+    # Per-tile / per-lane:
+    q_abs,
+    eff_seqlen_kv,
+    seqlen_q,
+    scale_log2,
+    tid_in_wg,
+    is_lead_warp,
+    leader_cta_id,
+    cross_sg_peer,
+):
+    cur_parity_S = sg0_xfer_state.idx
+    cur_phase_S = sg0_xfer_state.phase
+    bars.mb_alpha_xfer_empty[cur_parity_S].wait(cur_phase_S)
+    bars.mb_p_xfer_empty[cur_parity_S].wait(cur_phase_S)
+    bars.mb_bmm1_done[bmm1_done_state.idx].wait(bmm1_done_state.phase)
+    sg0_xfer_state = advance(sg0_xfer_state, CFG.XFER_STAGES)
+    bmm1_done_state = advance(bmm1_done_state, CFG.XFER_STAGES)
+
+    s_addr_base = tmem_base_addr + cur_parity_S * cutlass.Int32(LAYOUT.S_ACC_COLS)
+
+    if cutlass.const_expr(apply_mask):
+        kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+        raw_chunks = [
+            nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * SOFTMAX_CHUNK), cutlass.Float32),
+                num=SOFTMAX_CHUNK,
+            )
+            for c in range(SOFTMAX_N_CHUNKS_LOAD)
+        ]
+        # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
+        # CFG.BOTTOM_RIGHT is 0 — top-left masking is unchanged).
+        causal_diag = eff_seqlen_kv - seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+        chunks_S = [
+            apply_mask_chunk(
+                raw_chunks[c],
+                q_abs,
+                kv_col_base + cutlass.Int32(c * SOFTMAX_CHUNK),
+                eff_seqlen_kv,
+                CFG.WINDOW_LEFT,
+                CFG.MASK_FLAGS,
+                N=SOFTMAX_CHUNK,
+                bottom_right=CFG.BOTTOM_RIGHT,
+                causal_diag=causal_diag,
+                window_right=CFG.WINDOW_RIGHT,
+            )
+            for c in range(SOFTMAX_N_CHUNKS_LOAD)
+        ]
+        chunks_max = [row_max_reduction(chunks_S[c]) for c in range(SOFTMAX_N_CHUNKS_LOAD)]
+        reg_S_vec = vec_concat(chunks_S)
+        current_max_raw = chunks_max[0]
+        for m in chunks_max[1:]:
+            current_max_raw = cute.math.max(current_max_raw, m)
+        reg_S_tile = RegTile(reg_S_vec, size=CFG.TILE_N)
+    else:
+        reg_S_tile, current_max_raw = tmem_load_max_reduction_tile(
+            s_addr_base,
+            num_elems=CFG.TILE_N,
+        )
+    current_max = current_max_raw * scale_log2
+
+    # Online softmax (RESCALE_THRESHOLD skip).
+    old_total_max = total_max
+    is_first = total_max == NEG_INF_F32
+    update_cond = is_first | ((current_max - total_max) > RESCALE_THRESHOLD_F32)
+    total_max = cutlass.Float32(
+        arith.select(
+            update_cond.ir_value(),
+            current_max.ir_value(),
+            total_max.ir_value(),
+        )
+    )
+    exp_input = cutlass.Float32(
+        arith.select(
+            is_first.ir_value(),
+            NEG_INF_F32.ir_value(),
+            (old_total_max - total_max).ir_value(),
+        )
+    )
+    alpha = cute.math.exp2(exp_input, fastmath=True)
+
+    # reg_S = reg_S * scale_log2 - total_max; then exp2.  Keep the FP32
+    # RegTile (slice via .vec slicing) and cast each chunk to FP8 inside the
+    # P_TMA_ITERS loop — RegTile(Float8E4M3FN) is illegal at JIT, but slicing
+    # the FP32 RegTile then casting the slice is fine (per d256_fp8 pattern).
+    reg_S_scaled = reg_S_tile.vec * scale_log2 - total_max
+    reg_P_fp32 = cute.math.exp2(reg_S_scaled, fastmath=True)
+    reg_P_tile = RegTile(reg_P_fp32, size=CFG.TILE_N)
+
+    # ---- Write P[tid, :] to SMEM xfer ring slot[parity] ----
+    p_xfer_slot = sP_xfer_raw.subview(cur_parity_S * cutlass.Int32(pXferElems))
+    for chunk in cutlass.range_constexpr(P_TMA_ITERS):
+        smem_off = cutlass.Int32(chunk * P_BLOCK_BYTES) + tid_in_wg * cutlass.Int32(P_D_BLOCK)
+        smem_ptr = p_xfer_slot.subview(smem_off).data_ptr()
+        # Slice FP32 RegTile chunk, then cast → FP8.  Avoids RegTile(FP8).
+        chunk_P_fp32 = reg_P_tile[chunk * P_D_BLOCK : (chunk + 1) * P_D_BLOCK].vec
+        chunk_P = chunk_P_fp32.to(P_STORAGE_DTYPE)
+        smem_ptr.store_swizzled(
+            chunk_P,
+            alignment=64,
+            swizzle=P_SMEM_SWIZZLE,
+        )
+
+    # ---- Write alpha[tid] (FP32) to alpha xfer slot[parity] ----
+    alpha_slot = sAlpha_xfer_raw.subview(cur_parity_S * cutlass.Int32(CFG.TILE_M) + tid_in_wg)
+    alpha_slot.store(alpha)
+
+    # Update total_sum = total_sum * alpha + row_reduction(reg_P).
+    alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+    iter_sum_pair = row_reduction_pair(reg_P_fp32)
+    total_sum_vec = total_sum_vec * alpha_pair + iter_sum_pair
+
+    # Fence SMEM→async; sync the 4 compute warps so all 128 rows of
+    # alpha + P are written before bulk_copy issues.
+    nvvm.fence_proxy("async.shared", space="cta")
+    nvvm.barrier_cta_sync(barrier_id=8, thread_count=128)
+
+    # DSMEM bulk_copy alpha + P → cross-sg sg1 peer's SMEM, firing peer's
+    # mb_alpha_xfer_full + mb_p_xfer_full.  PREDICATED form: emit `@p
+    # cp.async.bulk` (matches C++'s uniform `@UP0 UBLKCP`) instead of an
+    # `if is_lead_warp: if elect_sync():` branch — that branch lowers to a
+    # warp-divergent BSSY/BSYNC + reconverge in the hot softmax iter.  All 128
+    # lanes compute the (cheap) mapa addresses up-front; only the lead warp's
+    # elected lane issues the two UBLKCPs under ship_pred.  nvvm.elect_sync()
+    # is warp-convergent — every compute warp's lanes call it (each warp elects
+    # its own lowest lane); `is_lead_warp &` masks the predicate to (lead warp,
+    # elected lane) == the single C++ issuing thread.
+    ship_pred = is_lead_warp & nvvm.elect_sync()
+    local_alpha_src = sAlpha_xfer_raw.subview(cur_parity_S * cutlass.Int32(CFG.TILE_M))
+    peer_alpha_dst = nvvm.mapa(local_alpha_src, cross_sg_peer, addrspace=7)
+    peer_alpha_full_mbar = nvvm.mapa(bars.mb_alpha_xfer_full[cur_parity_S].smem_ptr, cross_sg_peer, addrspace=7)
+    local_p_src = sP_xfer_raw.subview(cur_parity_S * cutlass.Int32(pXferElems))
+    peer_p_dst = nvvm.mapa(local_p_src, cross_sg_peer, addrspace=7)
+    peer_p_full_mbar = nvvm.mapa(bars.mb_p_xfer_full[cur_parity_S].smem_ptr, cross_sg_peer, addrspace=7)
+    cp_async_bulk_shared_cluster_shared_cta(
+        peer_alpha_dst,
+        local_alpha_src,
+        peer_alpha_full_mbar,
+        alphaXferBytes,
+        pred=ship_pred,
+    )
+    cp_async_bulk_shared_cluster_shared_cta(
+        peer_p_dst,
+        local_p_src,
+        peer_p_full_mbar,
+        pXferBytes,
+        pred=ship_pred,
+    )
+
+    # All-thread DSMEM arrive on sg0 leader's mb_s_acc_empty — fired at the
+    # END of the iter (after the P/alpha DSMEM ship), matching the C++
+    # baseline's perf-tuned placement (softmax_kv_body tail:
+    # `mb_s_acc_empty[parity].arrive_on_peer(0u,1u)`).  The barrier_id=8 sync
+    # above already guarantees all 128 lanes finished reading S_acc from TMEM,
+    # so freeing the slot here is safe; firing it early (right after the TMEM
+    # read) measurably regressed perf — the MMA reclaims the S_acc slot too
+    # eagerly and contends with the in-flight softmax.
+    bars.mb_s_acc_empty[cur_parity_S].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+    return (sg0_xfer_state, bmm1_done_state, total_max, total_sum_vec)
+
+
+# ============================================================================
+# Compute warp group — sg-conditional softmax (sg0) or correction (sg1).
+# 4 warps × 32 lanes = 128 threads.  Port of C++ compute_warp_group
+# (prefill_sdpa_d512_mxfp8.cu:529-1013).
+# ============================================================================
+@cute.jit
+def _compute_warp_group(
+    is_sg0,
+    is_sg1,
+    seqlen_q,
+    seqlen_kv,
+    scale_log2,
+    tmem_ptr_i32,
+    sQ,
+    sO,
+    sP_xfer_raw,
+    sAlpha_xfer_raw,
+    sStats_xfer_raw,
+    sLSE_raw,
+    bars,
+    sched,
+    lse_tensor,
+    amax_o_tensor,
+    sinks_tensor,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+    cta_id_x,
+    cross_sg_peer,
+):
+    """sg-conditional compute body (4 warps × 32 lanes = 128 threads).
+
+    sg0 path (port of C++ lines 599-749):
+        Streaming softmax — per kv iter wait BMM1 done, tmem_load S_acc + HW
+        row-max, online softmax (exp2 + alpha + new total_max / total_sum),
+        publish alpha (DSMEM bulk_copy to sg1), publish P (DSMEM bulk_copy
+        to sg1), all-thread arrive on mb_s_acc_empty.  End-of-tile ship
+        (max, ell) stats over DSMEM (1-shot).  Per-tile pre-armed empty
+        phases via PipelineState(0, 1).
+
+    sg1 path (port of C++ lines 750-1024):
+        Correction + epilogue — per kv iter wait alpha (local mbar), apply
+        alpha to O TMEM in two halves (gates BMM2 sub-tile 0 / 1 via
+        mb_bmm2_ready), DSMEM-arrive empty alpha on sg0.  Epilogue: wait
+        final BMM2, wait stats, normalize O by 1/ell + cast to half, store
+        to sO with per-chunk mb_tma_o_full arrive, write LSE to GMEM,
+        DSMEM-arrive empty stats on sg0.
+
+    Wait pattern: MMA warp publishes TMEM base via named barrier 1 (count =
+    32 * (SOFTMAX_WG_WARPS + 1) = 160) BEFORE any tmem_ptr_i32.load().
+    """
+    # Wait MMA's TMEM-alloc publish (C++ line 592 ``named_barrier_wait(TMEM_ALLOC_SOFTMAX_BARRIER, 160)``).
+    nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WG_WARPS + 1))
+    tmem_base_addr = tmem_ptr_i32.load()
+    tmem_raw = nvvm.make_tmem_ptr(tmem_base_addr, cutlass.Int8)
+
+    # Per-thread / per-warp identifiers — compute warps occupy CTA tid_x in
+    # [0, 128); tid_in_wg == tid_x, wid_in_wg = tid_x // 32 ∈ {0..3}.
+    tid_in_wg = cute.arch.thread_idx()[0]
+    wid_in_wg = tid_in_wg // cutlass.Int32(32)
+    is_lead_warp = wid_in_wg == cutlass.Int32(0)
+
+    # Common state — persistent-tile scheduler decode.
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    # kv_loop bounds — at MASK_NONE collapse to [0, seqlen_kv / TILE_N).
+    # When MASK_FLAGS != 0 the kv loop splits into 3 segments
+    # (LEFT-masked / fully-unmasked / RIGHT-masked) on unmasked_lo / unmasked_hi.
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_unmasked_lo = cutlass.Int32(0)
+        kv_unmasked_hi = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+        eff_seqlen_kv = seqlen_kv
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_unmasked_lo = bounds_init.unmasked_lo
+        kv_unmasked_hi = bounds_init.unmasked_hi
+        kv_right = bounds_init.right
+
+    # ---- Per-tensor swizzle for SMEM stores (same Swz128B as Q/O at d=512) ----
+    # P SMEM swizzle hoisted to module-level (P_SMEM_SWIZZLE) — see top of file.
+    _O_EPI_SWIZZLE = cutlass.Swizzle(3, 4, 3)
+
+    # Epilogue tile params (O SMEM stride).  TILE_O=512, BPE_O=2 → 8 chunks.
+    O_EPI_BLOCK_SIZE = 64 // CFG.BPE_O  # 32 fp16, 64 fp8
+    O_TMA_ITERS = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES  # 8 chunks
+    O_D_BLOCK = CFG.TILE_O // O_TMA_ITERS  # 64 elements / chunk
+    O_TMA_GRANU_ELEMS = CFG.TILE_M * O_D_BLOCK  # 8192 elements / TMA chunk
+    O_BLOCKS_PER_SUB = 128 // O_EPI_BLOCK_SIZE  # 4 (f16) / 2 (fp8)
+    O_CHUNK_ELEMS = 128 // CFG.BPE_O  # 64 (f16) / 128 (fp8)
+
+    # ---- sg0 state — streaming softmax + DSMEM ship ----
+    bmm1_done_state = PipelineState.start(phase=0)
+    # PipelineState(0, 1) → both mb_p_xfer_empty and mb_alpha_xfer_empty are
+    # pre-armed; iter-0/1 wait passes immediately on fresh barriers.
+    sg0_xfer_state = PipelineState.start(phase=1)
+    stats_xfer_empty_phase = cutlass.Int32(1)
+
+    # ---- sg1 state — recv alpha + correction + epilogue ----
+    alpha_full_state = PipelineState.start(phase=0)
+    sg1_bmm2_done_state = PipelineState.start(phase=0)
+    stats_xfer_full_phase = cutlass.Int32(0)
+    epilogue_state = cutlass.Int32(0)
+
+    # ---- streaming-softmax accumulators (sg0) — Vector[Float32,2] for
+    #      packed FMUL2/FADD2 lowering, per the canonical f16 port pattern.
+    total_max = NEG_INF_F32
+    total_sum_vec = cutlass.Vector.from_elements(
+        (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+        cutlass.Float32,
+    )
+
+    # sg0 = streaming softmax + DSMEM-ship (alpha / P / stats); sg1 =
+    # correction (apply alpha) + BMM2 N-block gating + epilogue.  Port of C++
+    # prefill_sdpa_d512_mxfp8.cu lines 432-1024.
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if is_sg0:
+            # ============================================================
+            # sg0 — streaming softmax + ship alpha + P + stats.
+            # Port of C++ prefill_sdpa_d512_mxfp8.cu lines 432-522 + 585-735.
+            # ============================================================
+            total_max = NEG_INF_F32
+            total_sum_vec = cutlass.Vector.from_elements(
+                (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+                cutlass.Float32,
+            )
+
+            # Per-lane absolute Q row (used by apply_mask_chunk in
+            # LEFT/RIGHT segments).  Same anchor C++ uses at
+            # prefill_sdpa_d512_mxfp8.cu:473 (`tc.q_row_coord + tid`).
+            q_abs = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + tid_in_wg
+
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+                pass
+            else:
+                # 3-segment kv loop: LEFT-masked / unmasked center / RIGHT-masked.
+                # MASK_NONE collapses the two masked sub-loops to empty range
+                # (kv_left == kv_unmasked_lo and kv_unmasked_hi == kv_right),
+                # so the LEFT/RIGHT branches fold out at trace time.
+                if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+                    for _kv in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                        sg0_xfer_state, bmm1_done_state, total_max, total_sum_vec = _sg0_softmax_kv_iter(
+                            False,
+                            _kv,
+                            sg0_xfer_state,
+                            bmm1_done_state,
+                            total_max,
+                            total_sum_vec,
+                            tmem_base_addr,
+                            bars,
+                            sP_xfer_raw,
+                            sAlpha_xfer_raw,
+                            q_abs,
+                            eff_seqlen_kv,
+                            seqlen_q,
+                            scale_log2,
+                            tid_in_wg,
+                            is_lead_warp,
+                            leader_cta_id,
+                            cross_sg_peer,
+                        )
+                else:
+                    for _kv in cutlass.range(kv_left, kv_unmasked_lo, 1, unroll=1):
+                        sg0_xfer_state, bmm1_done_state, total_max, total_sum_vec = _sg0_softmax_kv_iter(
+                            True,
+                            _kv,
+                            sg0_xfer_state,
+                            bmm1_done_state,
+                            total_max,
+                            total_sum_vec,
+                            tmem_base_addr,
+                            bars,
+                            sP_xfer_raw,
+                            sAlpha_xfer_raw,
+                            q_abs,
+                            eff_seqlen_kv,
+                            seqlen_q,
+                            scale_log2,
+                            tid_in_wg,
+                            is_lead_warp,
+                            leader_cta_id,
+                            cross_sg_peer,
+                        )
+                    for _kv in cutlass.range(kv_unmasked_lo, kv_unmasked_hi, 1, unroll=1):
+                        sg0_xfer_state, bmm1_done_state, total_max, total_sum_vec = _sg0_softmax_kv_iter(
+                            False,
+                            _kv,
+                            sg0_xfer_state,
+                            bmm1_done_state,
+                            total_max,
+                            total_sum_vec,
+                            tmem_base_addr,
+                            bars,
+                            sP_xfer_raw,
+                            sAlpha_xfer_raw,
+                            q_abs,
+                            eff_seqlen_kv,
+                            seqlen_q,
+                            scale_log2,
+                            tid_in_wg,
+                            is_lead_warp,
+                            leader_cta_id,
+                            cross_sg_peer,
+                        )
+                    for _kv in cutlass.range(kv_unmasked_hi, kv_right, 1, unroll=1):
+                        sg0_xfer_state, bmm1_done_state, total_max, total_sum_vec = _sg0_softmax_kv_iter(
+                            True,
+                            _kv,
+                            sg0_xfer_state,
+                            bmm1_done_state,
+                            total_max,
+                            total_sum_vec,
+                            tmem_base_addr,
+                            bars,
+                            sP_xfer_raw,
+                            sAlpha_xfer_raw,
+                            q_abs,
+                            eff_seqlen_kv,
+                            seqlen_q,
+                            scale_log2,
+                            tid_in_wg,
+                            is_lead_warp,
+                            leader_cta_id,
+                            cross_sg_peer,
+                        )
+
+            # ---- End-of-tile: ship final stats (max, ell) ----
+            bars.mb_stats_xfer_empty.wait(stats_xfer_empty_phase)
+            stats_xfer_empty_phase = stats_xfer_empty_phase ^ cutlass.Int32(1)
+
+            final_sum = total_sum_vec[0] + total_sum_vec[1]
+            # Stats layout in SMEM: ell[TILE_M] then max[TILE_M].
+            stats_sum_slot = sStats_xfer_raw.subview(tid_in_wg)
+            stats_max_slot = sStats_xfer_raw.subview(cutlass.Int32(CFG.TILE_M) + tid_in_wg)
+            stats_sum_slot.store(final_sum)
+            stats_max_slot.store(total_max)
+
+            nvvm.fence_proxy("async.shared", space="cta")
+            nvvm.barrier_cta_sync(barrier_id=8, thread_count=128)
+
+            ship_pred = is_lead_warp & nvvm.elect_sync()
+
+            peer_stats_dst = nvvm.mapa(sStats_xfer_raw, cross_sg_peer, addrspace=7)
+            peer_stats_full_mbar = nvvm.mapa(bars.mb_stats_xfer_full.smem_ptr, cross_sg_peer, addrspace=7)
+            cp_async_bulk_shared_cluster_shared_cta(
+                peer_stats_dst,
+                sStats_xfer_raw,
+                peer_stats_full_mbar,
+                statsXferBytes,
+                pred=ship_pred,
+            )
+        else:
+            # ============================================================
+            # sg1 — correction (apply alpha) + epilogue (normalize, cast,
+            # store O, LSE).  Port of C++ lines 750-1024.
+            # ============================================================
+            tmem_O_base = tmem_base_addr + cutlass.Int32(LAYOUT.O_OFF)
+
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+                # Empty-kv branch: signal MMA's empty-mainloop wait
+                # (each sg1 CTA's elect lane DSMEM-arrives sg1 leader).
+                bars.mb_empty_mainloop.arrive_on_peer(leader_cta_id, pred=is_lead_warp & nvvm.elect_sync())
+            else:
+                # --- iter 0: BMM2(0) doesn't depend on alpha; fire both
+                #     bmm2_ready half slots immediately (C++ 798-805).
+                cur_parity_0 = alpha_full_state.idx
+                bars.mb_bmm2_ready[cur_parity_0 * cutlass.Int32(CFG.N_BMM2_CHUNKS)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+                bars.mb_bmm2_ready[cur_parity_0 * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(1)].arrive(
+                    leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA
+                )
+
+                # Arm + wait alpha_xfer_full[parity_0].  Wrapper @p-gates
+                # on elect; wait spins on phase parity (atomically observable).
+                bars.mb_alpha_xfer_full[cur_parity_0].arrive(n_bytes=alphaXferBytes, pred=is_lead_warp & nvvm.elect_sync())
+                bars.mb_alpha_xfer_full[cur_parity_0].wait(alpha_full_state.phase)
+                alpha_full_state = advance(alpha_full_state, CFG.XFER_STAGES)
+
+                # Notify sg0 (cross-sg peer) alpha slot is empty.
+                bars.mb_alpha_xfer_empty[cur_parity_0].arrive_on_peer(cross_sg_peer)
+
+                # --- iter 1..n_kv-1: apply alpha to O before BMM2(kv) ---
+                CORR_BLOCK_SIZE = 16
+                CORR_BLOCKS_TOTAL = CFG.TILE_O // CORR_BLOCK_SIZE  # 32
+                CORR_BLOCKS_PER_HALF = CORR_BLOCKS_TOTAL // 2  # 16
+
+                for _kv in cutlass.range(kv_left + cutlass.Int32(1), kv_right, 1, unroll=1):
+                    cur_parity = alpha_full_state.idx
+
+                    bars.mb_alpha_xfer_full[cur_parity].arrive(n_bytes=alphaXferBytes, pred=is_lead_warp & nvvm.elect_sync())
+                    bars.mb_alpha_xfer_full[cur_parity].wait(alpha_full_state.phase)
+                    alpha_full_state = advance(alpha_full_state, CFG.XFER_STAGES)
+
+                    # Wait prior BMM2 done so O is committed.
+                    bars.mb_bmm2_done[sg1_bmm2_done_state.idx].wait(sg1_bmm2_done_state.phase)
+                    sg1_bmm2_done_state = advance(sg1_bmm2_done_state, CFG.XFER_STAGES)
+
+                    # Read alpha[tid] from xfer_in[cur_parity].
+                    alpha_addr = sAlpha_xfer_raw.subview(cur_parity * cutlass.Int32(CFG.TILE_M) + tid_in_wg)
+                    alpha_corr = alpha_addr.load()
+
+                    # all_alpha_one ballot: skip rescale entirely if every
+                    # lane's alpha == 1.0.
+                    alpha_is_one = alpha_corr == cutlass.Float32(1.0)
+                    all_alpha_one = vote_sync(0xFFFFFFFF, alpha_is_one, VoteSync.ALL)
+
+                    # ---- Half-1: cols [0..TILE_O/2) ----
+                    if ~all_alpha_one:
+                        for block in cutlass.range_constexpr(CORR_BLOCKS_PER_HALF):
+                            o_off = tmem_O_base + cutlass.Int32(block * CORR_BLOCK_SIZE)
+                            o_chunk = nvvm.tcgen05_ld(
+                                "32x32b",
+                                nvvm.make_tmem_ptr(o_off, cutlass.Float32),
+                                num=CORR_BLOCK_SIZE,
+                            )
+                            o_scaled = vec_scale_pair(o_chunk, alpha_corr, CORR_BLOCK_SIZE)
+                            nvvm.tcgen05_st(
+                                "32x32b",
+                                nvvm.make_tmem_ptr(o_off, cutlass.Float32),
+                                o_scaled,
+                            )
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+
+                    # Notify sg0 alpha slot empty.
+                    bars.mb_alpha_xfer_empty[cur_parity].arrive_on_peer(cross_sg_peer)
+                    # Half-1 ready — sg1 leader BMM2 sub-tile 0 unblocked.
+                    bars.mb_bmm2_ready[cur_parity * cutlass.Int32(CFG.N_BMM2_CHUNKS)].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+                    # ---- Half-2: cols [TILE_O/2..TILE_O) ----
+                    if ~all_alpha_one:
+                        for block in cutlass.range_constexpr(CORR_BLOCKS_PER_HALF):
+                            block_idx = CORR_BLOCKS_PER_HALF + block
+                            o_off = tmem_O_base + cutlass.Int32(block_idx * CORR_BLOCK_SIZE)
+                            o_chunk = nvvm.tcgen05_ld(
+                                "32x32b",
+                                nvvm.make_tmem_ptr(o_off, cutlass.Float32),
+                                num=CORR_BLOCK_SIZE,
+                            )
+                            o_scaled = vec_scale_pair(o_chunk, alpha_corr, CORR_BLOCK_SIZE)
+                            nvvm.tcgen05_st(
+                                "32x32b",
+                                nvvm.make_tmem_ptr(o_off, cutlass.Float32),
+                                o_scaled,
+                            )
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+
+                    # Half-2 ready — sg1 leader BMM2 sub-tile 1 unblocked.
+                    bars.mb_bmm2_ready[cur_parity * cutlass.Int32(CFG.N_BMM2_CHUNKS) + cutlass.Int32(1)].arrive(
+                        leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA
+                    )
+
+            # ---- Final BMM2-done wait (always runs — empty path covered) ----
+            bars.mb_bmm2_done[sg1_bmm2_done_state.idx].wait(sg1_bmm2_done_state.phase)
+            sg1_bmm2_done_state = advance(sg1_bmm2_done_state, CFG.XFER_STAGES)
+
+            # ---- Epilogue ----
+            epilogue_state = epilogue_state ^ cutlass.Int32(1)
+            bars.mb_tma_o_empty.wait(epilogue_state)
+
+            # Arm stats_xfer_full (sg0 delivers via DSMEM bulk_copy).
+            bars.mb_stats_xfer_full.arrive(n_bytes=statsXferBytes, pred=is_lead_warp & nvvm.elect_sync())
+            bars.mb_stats_xfer_full.wait(stats_xfer_full_phase)
+            stats_xfer_full_phase = stats_xfer_full_phase ^ cutlass.Int32(1)
+
+            # Per-thread lds_32 of final_ell / final_max.
+            ell_addr = sStats_xfer_raw.subview(tid_in_wg)
+            max_addr = sStats_xfer_raw.subview(cutlass.Int32(CFG.TILE_M) + tid_in_wg)
+            final_ell = ell_addr.load()
+            final_max = max_addr.load()
+
+            # Stats consumed → notify sg0 stats_xfer.out free to overwrite.
+            bars.mb_stats_xfer_empty.arrive_on_peer(cross_sg_peer, pred=is_lead_warp & nvvm.elect_sync())
+
+            # Compute beta, lse — HAS_SINK fold (dsv4 today: HAS_SINK=0,
+            # collapses to plain 1/total_sum normalization).
+            LN2 = cutlass.Float32(0.6931471805599453)
+            if cutlass.const_expr(CFG.HAS_SINK):
+                sinks_arr = cutlass.make_array_view(sinks_tensor)
+                sink_logit = sinks_arr[head_idx]
+                final_max_nat = final_max * LN2
+                new_max_nat = cute.math.max(final_max_nat, sink_logit)
+                scale_sink = cute.math.exp(final_max_nat - new_max_nat, fastmath=True)
+                new_sum = final_ell * scale_sink + cute.math.exp(sink_logit - new_max_nat, fastmath=True)
+                beta = scale_sink / new_sum
+                lse = new_max_nat + cute.math.log(new_sum, fastmath=True)
+            else:
+                final_ell_safe = cute.math.max(final_ell, cutlass.Float32(1e-30))
+                beta = cutlass.Float32(1.0) / final_ell_safe
+                lse = final_max * LN2 + cute.math.log(final_ell_safe, fastmath=True)
+
+            # Row with no contributing column (empty KV range, or fully masked):
+            # final_ell is exactly 0, so the 1e-30 floor would leak -- lse
+            # becomes the -FLT_MAX sentinel scaled (~-2.36e38 rather than -inf)
+            # and beta 1e30, making O = residue * 1e30.  Substitute with a
+            # SELECT; `* 0` is wrong because the residue can be NaN.
+            _row_empty = final_ell == cutlass.Float32(0.0)
+            if cutlass.const_expr(not CFG.HAS_SINK):
+                lse = cutlass.Float32(arith.select(_row_empty.ir_value(), cutlass.Float32(float("-inf")).ir_value(), lse.ir_value()))
+            _amax_o_ptr = Pointer(amax_o_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
+            _amax_o_local = cutlass.Float32(0.0)
+
+            # Cast O fp32 → fp8/bf16/fp16 (CFG.DTYPE_O) with bit-permuted TMEM block index.
+            # TMEM layout is scrambled by cga2 N-split + 2-call N-block:
+            #   TMEM[ 0:128] = d_v[  0:128]   (call 0, leader half)
+            #   TMEM[128:256] = d_v[256:384]   (call 0, peer half)
+            #   TMEM[256:384] = d_v[128:256]   (call 1, leader half)
+            #   TMEM[384:512] = d_v[384:512]   (call 1, peer half)
+            # Iterate in OUTPUT order; bit-swap b_sub ∈ {0..3} → {0,2,1,3}.
+            sO_base = sO[0].base
+
+            for b in cutlass.range_constexpr(CFG.TILE_O // O_EPI_BLOCK_SIZE):
+                b_intra = b & (O_BLOCKS_PER_SUB - 1)
+                b_sub = b // O_BLOCKS_PER_SUB
+                tmem_sub = ((b_sub & 1) << 1) | ((b_sub & 2) >> 1)
+                tmem_block = tmem_sub * O_BLOCKS_PER_SUB + b_intra
+
+                o_addr = tmem_O_base + cutlass.Int32(tmem_block * O_EPI_BLOCK_SIZE)
+                o_fp32 = nvvm.tcgen05_ld(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                    num=O_EPI_BLOCK_SIZE,
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                o_scaled = o_fp32 * beta
+                # SELECT the zero (never `* 0`) and fold amax over the
+                # SUBSTITUTED values, so a dead row cannot poison Amax_O.
+                _o_elems = []
+                for _i in cutlass.range_constexpr(O_EPI_BLOCK_SIZE):
+                    _e = cutlass.Float32(arith.select(_row_empty.ir_value(), cutlass.Float32(0.0).ir_value(), o_scaled[_i].ir_value()))
+                    _amax_o_local = cute.math.max(_amax_o_local, cute.math.max(_e, -_e))
+                    _o_elems.append(_e)
+                o_half = cutlass.Vector.from_elements(tuple(_o_elems), cutlass.Float32).to(OUT_STORAGE_DTYPE)
+
+                # SMEM store — TMA-O grain layout (O_D_BLOCK elements / chunk).
+                col_offset_const = (b * O_EPI_BLOCK_SIZE) % O_D_BLOCK
+                block_idx_const = (b * O_EPI_BLOCK_SIZE) // O_D_BLOCK
+                block_offset_const = block_idx_const * O_TMA_GRANU_ELEMS
+                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(O_D_BLOCK)
+                smem_ptr = sO_base.subview(smem_offset).data_ptr()
+                smem_ptr.store_swizzled(
+                    o_half,
+                    alignment=64,
+                    swizzle=_O_EPI_SWIZZLE,
+                )
+
+                # Per-128B-chunk arrive on TMA-STG.
+                if ((b + 1) * O_EPI_BLOCK_SIZE) % O_CHUNK_ELEMS == 0:
+                    chunk = (b * O_EPI_BLOCK_SIZE) // O_CHUNK_ELEMS
+                    nvvm.fence_proxy("async.shared", space="cta")
+                    bars.mb_tma_o_full[chunk].arrive()
+
+            # Write LSE — under cga2 each sg1 peer writes its half of O+LSE
+            # rows (leader = [0:128], peer = [128:256]).  Per-thread row.
+            q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + tid_in_wg
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: q_row_global is sequence-local; LSE is packed [1,QH,T] →
+                # index [0, head, cu_q[b] + local], bound by per-sequence Q len S_q_b.
+                _cu = cutlass.make_array_view(seq_kv_lens_tensor)
+                _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
+                _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
+                if cutlass.const_expr(lse_tensor is not None):
+                    if q_row_global < _s_q_b:
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
+                        lse_row[_cu_q_b + q_row_global] = lse
+            else:
+                if q_row_global < seqlen_q:
+                    nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
+                if cutlass.const_expr(lse_tensor is not None):
+                    if q_row_global < seqlen_q:
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        lse_row = lse_arr[batch_idx, head_idx, :]
+                        lse_row[q_row_global] = lse
+
+        # End-of-tile: advance scheduler.
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+        nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+        nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_unmasked_lo = bounds_next.unmasked_lo
+            kv_unmasked_hi = bounds_next.unmasked_hi
+            kv_right = bounds_next.right
+
+    # End-of-kernel: trailing-arrive drain (sg0 only — sg1's late
+    # arrive_on_peer lands on a still-live mbar via this drain).  Per
+    # C++ lines 722-744: drain XFER_STAGES empty arrives + stats_xfer_empty
+    # before sg0 sm exits.
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        if is_sg0:
+            if is_lead_warp:
+                if nvvm.elect_sync():
+                    for _p in cutlass.range_constexpr(CFG.XFER_STAGES):
+                        bars.mb_p_xfer_empty[sg0_xfer_state.idx].wait(sg0_xfer_state.phase)
+                        bars.mb_alpha_xfer_empty[sg0_xfer_state.idx].wait(sg0_xfer_state.phase)
+                        sg0_xfer_state = advance(sg0_xfer_state, CFG.XFER_STAGES)
+                    bars.mb_stats_xfer_empty.wait(stats_xfer_empty_phase)
+            nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        # Each CTA's compute warp fires 1 elect-arrive_on_peer to its cga2
+        # partner → 1 arrive per CTA (init = ONE_LANE matches).
+        peer_cta = cta_id_x ^ cutlass.Int32(1)
+        bars.mb_tmem_dealloc.arrive_on_peer(peer_cta, pred=is_lead_warp & nvvm.elect_sync())
+
+
+# ============================================================================
+# MMA warp group — sg-conditional BMM1 (sg0 leader) / BMM2 (sg1 leader).
+# Port of C++ mma_warp_group (prefill_sdpa_d512_mxfp8.cu:1021-1233).
+# ============================================================================
+@cute.jit
+def _mma_warp_group(
+    is_sg0,
+    is_sg1,
+    seqlen_q,
+    seqlen_kv,
+    sQ,
+    sK,
+    sV,
+    sQ_SF,
+    sK_SF,
+    sP_SF,
+    sV_SF,
+    sP_xfer_raw,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    mcast_mask,
+    sg0_mcast_mask,
+    cta_in_pair,
+):
+    """MMA warp leader — sg-conditional BMM1 (sg0 leader) or BMM2 (sg1 leader).
+
+    sg0 leader (port of C++ lines 1101-1163):
+        For each tile: wait Q full, then for each kv iter: wait S_acc[parity]
+        empty (pre-armed at iter 0/1 via PipelineState(0, 1)), wait K[stage]
+        full, mma_ss(Q, K) → S_acc[parity] (collective N = TILE_M*CTA_MMA),
+        commit_mma on bmm1_done[parity] AND k_empty[stage] (P13 multicast,
+        sg0_mcast_mask).  After last BMM1: commit_mma on q_empty (multicast).
+
+    sg1 leader (port of C++ lines 1165-1246):
+        For each tile: if n_kv > 0: for each kv iter: arrive own
+        mb_p_xfer_full (own + DSMEM-forwarded from non-leader), wait
+        mb_p_xfer_full, wait V[stage] full, for each of BMM2_LOOP_N_BLOCKS=2
+        N-block calls: wait mb_bmm2_ready[parity*2+nblock], mma_ss(P, V) →
+        O_block (per-call N=256, advance V desc by BMM2_V_NBLOCK_ADVANCE),
+        commit bmm2_done[parity], v_empty[stage], p_xfer_empty[parity]
+        (P13 multicast with sg0_mcast_mask).
+        Empty-kv branch: wait mb_empty_mainloop, commit bmm2_done[parity].
+
+    Both leaders share the TMEM alloc + named-barrier publish:
+        tmem_alloc(576 cols, is_exclusive=True) → barrier_arrive(barrier_id=1,
+        count = 32 * (SOFTMAX_WG_WARPS + 1) = 160).  No barrier_id=2 here
+        (DSv4 has no separate correction-warp publish; correction is fused
+        into the compute warp group's sg1 branch).
+    """
+    # SM107 cap = 576 cols; is_exclusive=True enforced inside tmem_alloc wrapper.
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND, is_exclusive=True)
+    # Publish to compute warpgroup (waits on barrier_id=1 with count 160).
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WG_WARPS + 1))
+
+    # Do column arithmetic on raw Int8 ptr; retype at use site.  (Per
+    # cpp-to-ctm.md: make_tmem_ptr(addr, Float16) + N strides FP16 elems
+    # not columns — silent-wrong-result bug.)
+    tmem_raw = nvvm.make_tmem_ptr(tmem_ptr_i32.load(), cutlass.Int8)
+
+    # Block-scale idesc — mirror d256_mxfp8.py:817-827.  MXF8F6F4 needs
+    # Tcgen05MxInstrDesc (NOT Tcgen05InstrDesc) + k_dim=1.
+    idesc_qk_bs = prims.Tcgen05MxInstrDesc.build(
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_N,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        k_dim=_MXFP8_K_DIM,
+    )
+    idesc_pv_bs = prims.Tcgen05MxInstrDesc.build(
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.BMM2_N_PER_CALL,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        b_major=1,
+        k_dim=_MXFP8_K_DIM,
+    )
+    _MXFP8_SF_BLOCKS_PER_STEP = _MXFP8_TILE_K_HW // 32
+
+    bmm1_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_N,
+        K=CFG.TILE_K,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=_MXFP8_TILE_K_HW,
+        btranspose=False,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_qk_bs,
+        kind=MMA_KIND,
+        is_block_scale=True,
+        sf_blocks_per_step=_MXFP8_SF_BLOCKS_PER_STEP,
+        scale_vec_size=SCALE_VEC_SIZE,
+    )
+    bmm2_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.BMM2_N_PER_CALL,
+        K=CFG.TILE_N,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=_MXFP8_TILE_K_HW,
+        btranspose=True,
+        k_subtile=CFG.V_SWZ_BYTES // CFG.BPE,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_pv_bs,
+        kind=MMA_KIND,
+        is_block_scale=True,
+        sf_blocks_per_step=_MXFP8_SF_BLOCKS_PER_STEP,
+        scale_vec_size=SCALE_VEC_SIZE,
+    )
+
+    # ---- SF TMEM bases.  Each per-iter SF tile is copied SMEM→TMEM via a
+    # per-block `tcgen05_cp` (SHAPE_32X128B, WARPX4) loop just before its MMA:
+    # SF_NUM_BLOCKS_K blocks for BMM1 (SF Q once per tile + SF K per kv), and
+    # SF_NUM_BLOCKS_V blocks for BMM2 SF V per kv.  Both BMM1 and BMM2 use the
+    # block-scale `mma_ss` form (`tmem_sf_a` / `tmem_sf_b`) — `mma_ss` walks K
+    # internally and advances the SF column per k-step, so no manual k-walk is
+    # needed; BMM2's two N-block calls select their SF V slab via
+    # `tmem_SF_V + nblk * SF_V_TMEM_COLS_PER_CALL`.
+    tmem_SF_Q = tmem_raw.subview(LAYOUT.SF_Q_OFF)
+    tmem_SF_K = tmem_raw.subview(LAYOUT.SF_K_OFF)
+    tmem_SF_P = tmem_raw.subview(LAYOUT.SF_P_OFF)
+    tmem_SF_V = tmem_raw.subview(LAYOUT.SF_V_OFF)
+
+    # SF P SmemDesc + one-shot tcgen05_cp SMEM(P_SF) → TMEM(SF_P) — P_SF is
+    # constant 1.0 (filled at kernel entry).  Mirrors d256_mxfp8.py:861-867.
+    desc_P_SF = sP_SF[0].desc()
+    if nvvm.elect_sync():
+        nvvm.tcgen05_cp(
+            nvvm.Tcgen05CpShape.SHAPE_32X128B,
+            tmem_SF_P,
+            desc_P_SF,
+            group=CTA_GROUP_KIND,
+            multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+        )
+
+    # Persistent-tile scheduler state.
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    # sg0 leader state (BMM1).
+    q_full_phase = cutlass.Int32(0)
+    kv_state_K = PipelineState.start(phase=0)
+    # pre-armed: PipelineState(0, 1) so iter-0/1 wait passes on fresh barriers.
+    s_acc_empty_state = PipelineState.start(phase=1)
+
+    # sg1 leader state (BMM2).
+    kv_state_V = PipelineState.start(phase=0)
+    sg1_mma_state = PipelineState.start(phase=0)
+    # bmm2_ready_state walks XFER_STAGES * N_BMM2_CHUNKS slots linearly
+    # (parity*2 + nblock); phase flips every XFER_STAGES*N_BMM2_CHUNKS arrives.
+    bmm2_ready_state = PipelineState.start(phase=0)
+    bmm2_done_prod_state = PipelineState.start(phase=0)
+    empty_mainloop_phase = cutlass.Int32(0)
+
+    # Pre-build a SmemTile wrapper for the P xfer ring (sg1 leader only — sg0
+    # builds its descriptor on its own SMEM, but for parity_cur lookup we use
+    # the same swizzle/layout that sg0 used when writing).  P xfer SMEM is
+    # TILE_M × TILE_N (cf. C++ P_Layout); matches Q swizzle (Swz128B at d=512).
+    sP_xfer = SmemTile(
+        base=sP_xfer_raw,
+        elems_per_stage=pXferElems,
+        stages=CFG.XFER_STAGES,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_P,
+        desc_version=1,
+    )
+
+    # BMM1 leader: desc_Q is tile-static (Q stays resident under d=512 / no Q∪K alias).
+    desc_Q = sQ[0].desc()
+    desc_Q_SF = sQ_SF[0].desc()  # SF Q SmemDesc — tile-static (TILES_Q=1).
+    # BMM2 leader: V N-block advance in ELEMENTS (BMM2_V_NBLOCK_ADVANCE is bytes).
+    V_NBLOCK_ADVANCE_ELEMS = BMM2_V_NBLOCK_ADVANCE // CFG.BPE
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if is_sg0:
+            # ============================================================
+            # sg0 leader — BMM1: Q × K^T → S_acc[parity]
+            # ============================================================
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+                pass
+            else:
+                bars.mb_tma_q_full.wait(q_full_phase)
+                q_full_phase = q_full_phase ^ cutlass.Int32(1)
+
+                # SF Q → TMEM once per tile (Q single-buffered; TILES_Q=1).  SF
+                # Q TMEM tile stays valid for every kv iter below.  copy_sf_cg<
+                # SF_NUM_BLOCKS_K, SF_NUM_BLOCKS_M=1>; mirror C++
+                # prefill_sdpa_d512_mxfp8.cu:1259-1260 / d256_mxfp8.py:932-939.
+                if nvvm.elect_sync():
+                    for _sf_k in cutlass.range_constexpr(SF_NUM_BLOCKS_K):
+                        nvvm.tcgen05_cp(
+                            nvvm.Tcgen05CpShape.SHAPE_32X128B,
+                            tmem_SF_Q.subview(_sf_k * SF_REGISTERS_PER_BLOCK),
+                            desc_Q_SF + _sf_k * (SF_BYTES_PER_BLOCK // 16),
+                            group=CTA_GROUP_KIND,
+                            multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+                        )
+
+                for _kv in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                    cur_parity_K = s_acc_empty_state.idx
+                    bars.mb_s_acc_empty[cur_parity_K].wait(s_acc_empty_state.phase)
+                    s_acc_empty_state = advance(s_acc_empty_state, CFG.XFER_STAGES)
+
+                    bars.mb_tma_k_full[kv_state_K.idx].wait(kv_state_K.phase)
+                    desc_K = sK[kv_state_K.idx].desc()
+                    desc_K_SF = sK_SF[kv_state_K.idx].desc()
+                    # SF K → TMEM for this stage.  copy_sf_cg<SF_NUM_BLOCKS_K,
+                    # SF_NUM_BLOCKS_N=1>; mirror C++ :1271-1272.
+                    if nvvm.elect_sync():
+                        for _sf_k in cutlass.range_constexpr(SF_NUM_BLOCKS_K):
+                            nvvm.tcgen05_cp(
+                                nvvm.Tcgen05CpShape.SHAPE_32X128B,
+                                tmem_SF_K.subview(_sf_k * SF_REGISTERS_PER_BLOCK),
+                                desc_K_SF + _sf_k * (SF_BYTES_PER_BLOCK // 16),
+                                group=CTA_GROUP_KIND,
+                                multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+                            )
+                    # S_acc TMEM offset = parity * S_ACC_COLS (TmemTile layout).
+                    s_acc_off = cur_parity_K * cutlass.Int32(LAYOUT.S_ACC_COLS)
+                    mma_ss(bmm1_desc, desc_Q, desc_K, tmem_raw.subview(s_acc_off), tmem_sf_a=tmem_SF_Q, tmem_sf_b=tmem_SF_K, accumulate=False)
+                    elect_p = nvvm.elect_sync()
+                    bars.mb_bmm1_done[cur_parity_K].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                    bars.mb_tma_k_empty[kv_state_K.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                    kv_state_K = advance(kv_state_K, CFG.STAGES_KV)
+
+                # After last BMM1: multicast Q-empty so both peers' TMA warps
+                # advance.  tcgen05.commit fires AFTER MMA drain (P13) so TMA
+                # can't overwrite Q SMEM mid-read.
+                bars.mb_tma_q_empty.arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=nvvm.elect_sync())
+        else:
+            # ============================================================
+            # sg1 leader — BMM2: P × V → O via mma_ss, 2 N-block calls
+            # ============================================================
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+                # Empty-kv branch — keep bmm2_done producer/consumer states
+                # in lockstep across mixed empty/normal sequences.
+                bars.mb_empty_mainloop.wait(empty_mainloop_phase)
+                empty_mainloop_phase = empty_mainloop_phase ^ cutlass.Int32(1)
+                bars.mb_bmm2_done[bmm2_done_prod_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=nvvm.elect_sync())
+                bmm2_done_prod_state = advance(bmm2_done_prod_state, CFG.XFER_STAGES)
+            else:
+                for kv_loop in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                    cur_parity = sg1_mma_state.idx
+
+                    # Leader's own arrive on mb_p_xfer_full[parity] (own
+                    # P-bytes were just delivered by cross-sg sg0 partner
+                    # via DSMEM bulk_copy).  Init = CTA_MMA arrives — this
+                    # contributes 1, the non-leader forwarder contributes
+                    # the other 1 (P12).
+                    bars.mb_p_xfer_full[cur_parity].arrive(n_bytes=pXferBytes, pred=nvvm.elect_sync())
+                    bars.mb_p_xfer_full[cur_parity].wait(sg1_mma_state.phase)
+                    sg1_mma_state = advance(sg1_mma_state, CFG.XFER_STAGES)
+
+                    bars.mb_tma_v_full[kv_state_V.idx].wait(kv_state_V.phase)
+
+                    accum_b2 = kv_loop > kv_left
+
+                    # Rebuild SmemDescs for this iter's P parity and V stage.
+                    desc_P = sP_xfer[cur_parity].desc()
+                    desc_V_n0 = sV[kv_state_V.idx].desc()
+                    desc_V_n1 = sV[kv_state_V.idx].shifted(V_NBLOCK_ADVANCE_ELEMS).desc()
+                    desc_V_SF = sV_SF[kv_state_V.idx].desc()
+
+                    # SF V → TMEM (covers FULL d_v=512; SF_NUM_BLOCKS_V=4 blocks).
+                    # Copied in NATURAL block order — the [N0,N2,N1,N3] interleave
+                    # needed by the cga2 per-peer V-data split is baked into the
+                    # SMEM SF V LOAD layout (tmaldg), so this copy + the per-N-
+                    # block tmem_SF_V_n shift below + the cga2 MMA SF auto-shift
+                    # line up.  copy_sf_cg<SF_NUM_BLOCKS_K_BMM2, SF_NUM_BLOCKS_V>;
+                    # mirror C++ prefill_sdpa_d512_mxfp8.cu:1362-1363.
+                    if nvvm.elect_sync():
+                        for _sf_n in cutlass.range_constexpr(SF_NUM_BLOCKS_V):
+                            nvvm.tcgen05_cp(
+                                nvvm.Tcgen05CpShape.SHAPE_32X128B,
+                                tmem_SF_V.subview(_sf_n * SF_REGISTERS_PER_BLOCK),
+                                desc_V_SF + _sf_n * (SF_BYTES_PER_BLOCK // 16),
+                                group=CTA_GROUP_KIND,
+                                multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+                            )
+
+                    # N-block 0: writes O TMEM cols [0..BMM2_N_PER_CALL).  SF V
+                    # base = tmem_SF_V (cols [0..SF_V_TMEM_COLS_PER_CALL)).
+                    bars.mb_bmm2_ready[bmm2_ready_state.idx].wait(bmm2_ready_state.phase)
+                    bmm2_ready_state = advance(bmm2_ready_state, CFG.XFER_STAGES * CFG.N_BMM2_CHUNKS)
+                    mma_ss(
+                        bmm2_desc,
+                        desc_P,
+                        desc_V_n0,
+                        tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF)),
+                        tmem_sf_a=tmem_SF_P,
+                        tmem_sf_b=tmem_SF_V,
+                        accumulate=accum_b2,
+                    )
+
+                    # N-block 1: writes O TMEM cols [BMM2_N_PER_CALL..TILE_O).
+                    # SF V base = tmem_SF_V + SF_V_TMEM_COLS_PER_CALL.
+                    bars.mb_bmm2_ready[bmm2_ready_state.idx].wait(bmm2_ready_state.phase)
+                    bmm2_ready_state = advance(bmm2_ready_state, CFG.XFER_STAGES * CFG.N_BMM2_CHUNKS)
+                    mma_ss(
+                        bmm2_desc,
+                        desc_P,
+                        desc_V_n1,
+                        tmem_raw.subview(cutlass.Int32(LAYOUT.O_OFF + CFG.BMM2_N_PER_CALL)),
+                        tmem_sf_a=tmem_SF_P,
+                        tmem_sf_b=tmem_SF_V.subview(cutlass.Int32(SF_V_TMEM_COLS_PER_CALL)),
+                        accumulate=accum_b2,
+                    )
+
+                    elect_p = nvvm.elect_sync()
+                    bars.mb_bmm2_done[bmm2_done_prod_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                    bars.mb_tma_v_empty[kv_state_V.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                    # P13 multicast on mb_p_xfer_empty — sg0_mcast_mask
+                    # (= 0x3) targets BOTH sg0 CTAs so sg0 sm's next P
+                    # slot reuse is unblocked.
+                    bars.mb_p_xfer_empty[cur_parity].arrive(mcast_mask=sg0_mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                    kv_state_V = advance(kv_state_V, CFG.STAGES_KV)
+                    bmm2_done_prod_state = advance(bmm2_done_prod_state, CFG.XFER_STAGES)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+
+    # End-of-warp tmem_dealloc — wait fan-in from both compute warps then free.
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+# ============================================================================
+# MMA warp non-leader paths — sg0 minimal quiet vs sg1 P12 forwarder.
+# Port of C++ mma_warp_group non-leader paths (prefill_sdpa_d512_mxfp8.cu:1036-1082).
+# ============================================================================
+@cute.jit
+def _mma_warp_non_leader(
+    is_sg0,
+    is_sg1,
+    seqlen_q,
+    seqlen_kv,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    cta_in_pair,
+    leader_cta_id,
+):
+    """sg0 non-leader: minimal quiet (alloc + wait dealloc + free).
+    sg1 non-leader: persistent loop forwarding mb_p_xfer_full to leader (P12).
+
+    sg0 quiet (port of C++ lines 1049-1054):
+        Just participates in TMEM alloc + named-barrier publish (sm warps
+        read the published base ptr from peer's TMEM under cga2 collective
+        MMA), then waits on mb_tmem_dealloc and frees.
+
+    sg1 forwarder (port of C++ lines 1055-1093):
+        Persistent tile loop — at iter scope, per kv_local:
+          - arrive(mb_p_xfer_full[parity], P_XFER_TILE_BYTES, elect) — local mbar
+          - wait(mb_p_xfer_full[parity], nlmma_state.phase) — local mbar
+          - arrive_on_peer(mb_p_xfer_full[parity], leader_cta_id) — DSMEM forward
+        Required because BMM2's collective mma_ss reads BOTH peers' P SMEM via
+        crossbar; leader's local mbar only sees its own cross-sg sg0 partner's
+        bytes, so non-leader must DSMEM-arrive on leader after observing own bytes.
+    """
+    # All-lanes warp-collective tmem_alloc (no elect_sync gating).
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND, is_exclusive=True)
+    # Match leader's named-barrier arrive count (lead is +1 on barrier_id=1).
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WG_WARPS + 1))
+
+    # sg0 non-leader is quiet (just wait dealloc); sg1 non-leader runs the
+    # persistent P12 forwarder loop.  `return` is forbidden inside @cute.jit
+    # (CTM gotcha), so we gate the forwarder on `is_sg1` and let both arms
+    # fall through to the shared dealloc wait + free at the bottom.
+    if is_sg1:
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+            sched.bidx_init,
+            sched.bidy_init,
+            sched.bidz_init,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = cutlass.Int32(1)
+        sched_state = PipelineState.start()
+
+        if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+            kv_left = cutlass.Int32(0)
+            kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+        else:
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_init.left
+            kv_right = bounds_init.right
+
+        nlmma_state = PipelineState.start(phase=0)
+
+        while is_valid_tile > cutlass.Int32(0):
+            read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+                pass
+            else:
+                for _kv in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                    # Arm own expect_tx for P-bytes delivered by cross-sg sg0
+                    # partner (via DSMEM bulk_copy).  Wait local mbar
+                    # (init = ONE_LANE — own arrive only).
+                    bars.mb_p_xfer_full[nlmma_state.idx].arrive(n_bytes=pXferBytes, pred=nvvm.elect_sync())
+                    bars.mb_p_xfer_full[nlmma_state.idx].wait(nlmma_state.phase)
+                    cur_parity = nlmma_state.idx
+                    nlmma_state = advance(nlmma_state, CFG.XFER_STAGES)
+                    # DSMEM-arrive on leader's mb_p_xfer_full[parity] — leader's
+                    # init = CTA_MMA (own + this forwarded arrive), so wait
+                    # flips only when both peers' bytes have landed (P12).
+                    bars.mb_p_xfer_full[cur_parity].arrive_on_peer(leader_cta_id, pred=nvvm.elect_sync())
+
+            nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+            wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+            nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+            nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+            nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+            q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+                nxt_q,
+                nxt_hb,
+                cta_in_pair,
+                n_q_supers,
+                n_qh,
+                n_batch,
+                seq_kv_lens_tensor,
+            )
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+            sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+            if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+                eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+                bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+                kv_left = bounds_next.left
+                kv_right = bounds_next.right
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+# ============================================================================
+# TMA-LDG warp group — sg-conditional Q+K (sg0) or V (sg1).
+# Port of C++ tmaldg_warp_group (prefill_sdpa_d512_mxfp8.cu:1241-1385).
+# ============================================================================
+@cute.jit
+def _tmaldg_warp_group(
+    is_sg0,
+    is_sg1,
+    tma_q_desc,
+    tma_k_desc,
+    tma_v_desc,
+    tma_q_sf_desc,
+    tma_k_sf_desc,
+    tma_v_sf_desc,
+    sQ,
+    sK,
+    sV,
+    sQ_SF,
+    sK_SF,
+    sV_SF,
+    bars,
+    sched,
+    seqlen_q,
+    seqlen_kv,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    qh_per_kh,
+    is_leader,
+    cta_in_pair,
+    tma_mcast_mask,
+    sf_mcast_mask,
+):
+    """sg0: Q + K TMA-LDG (+ SF Q + SF K).  sg1: V TMA-LDG (+ SF V).
+
+    Both sgs decode the persistent-tile scheduler payload.  Leader of each
+    pair issues expect_tx for the collective TMA byte count; both peers
+    issue the cta_group::2 multicast TMA (mcast_mask bits = bit_per_peer).
+
+    sg0 (port of C++ d512_mxfp8.cu sg0 tmaldg lines):
+        Per tile, if n_kv > 0:
+            wait(q_empty, q_empty_phase); leader arrive_expect_tx(q_full,
+                qBytes + Q_SF_EXPECT_BYTES);
+            tma_load_tile(sQ[0],    q_gmem,    q_full, multicast).
+            tma_load_tile(sQ_SF[0], q_sf_gmem, q_full, tma_mcast_mask).
+            For each kv:
+              wait(k_empty[stage]); leader arrive_expect_tx(k_full[stage],
+                  kBytes + K_SF_EXPECT_BYTES);
+              tma_load_tile(sK[stage], ...).
+              tma_load_tile(sK_SF[stage].shifted(k_sf_peer_off), ..., mcast=sf_mcast_mask).
+        q_empty pre-armed via q_empty_state=1.
+
+    sg1 (port of C++ d512_mxfp8.cu sg1 tmaldg lines):
+        Per tile, if n_kv > 0, per kv:
+          wait(v_empty[stage]); leader arrive_expect_tx(v_full[stage],
+              vBytes + V_SF_EXPECT_BYTES);
+          tma_load_tile(sV[stage], ...).
+          for j in SF_NUM_BLOCKS_V//CTA_MMA: per-N-block SF V load at the
+              INTERLEAVED SMEM offset (smem_blk = cta_in_pair + j*CTA_MMA),
+              reading GMEM N-block (cta_in_pair*blocks_per_peer + j),
+              mcast=sf_mcast_mask.  Produces SMEM SF V layout [N0,N2,N1,N3]
+              so the cga2 BMM2 per-peer +1-block SF auto-shift lines up.
+        Note: SF K / SF V are multicast-full within the sg pair (sf_mcast_mask
+        = 0x3 for sg0 pair, 0xC for sg1 pair).  SF Q is per-CTA along M (each
+        sg0 peer holds 2 KiB; collective cta_group::2 splits M).
+
+    Both sgs drain trailing K/V/Q empty arrives at end-of-kernel under cga2.
+    """
+    q_empty_phase = cutlass.Int32(1)  # pre-armed (iter-0 wait passes)
+    kv_state = PipelineState.start(phase=1)
+
+    tma_q = GmemTileTma(tma_q_desc)
+    tma_k = GmemTileTma(tma_k_desc)
+    tma_v = GmemTileTma(tma_v_desc)
+    tma_q_sf = GmemTileTma(tma_q_sf_desc)
+    tma_k_sf = GmemTileTma(tma_k_sf_desc)
+    tma_v_sf = GmemTileTma(tma_v_sf_desc)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+    # THD packed-tensor seq offsets (fold to (0,0,batch_idx) dense); SF-tile bases
+    # fold to (0,0) dense.
+    q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+    cu_sf_q_base, cu_sf_k_base = _thd_sf_tile_bases(seq_kv_lens_tensor, batch_idx, n_batch)
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    # Per-peer K row offset (sg0 only — sg1's V offset is along d_v).
+    K_ROW_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_N // CFG.CTA_MMA)
+    # Per-peer V d_v offset (sg1 only — sg0's K offset is along seq).
+    V_COL_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_O // CFG.CTA_MMA)
+
+    # ---- SF per-peer split (cga2: each pair-peer loads HALF, multicasts to
+    # both via sf_mcast_mask so each peer's SMEM accumulates the full SF tile).
+    # SF SMEM dst offset (bytes) + SF GMEM row coordinate, both keyed on
+    # cta_in_pair.  Mirrors d256_mxfp8.py:588-595.  SF Q is per-CTA along M
+    # (collective TMA splits M), so no peer offset.
+    SF_TMA_ROW_BYTES_K = 128
+    K_SF_BYTES_PER_PEER = SF_SMEM_SIZE_K // CFG.CTA_MMA
+    K_SF_ROWS_PER_PEER = K_SF_BYTES_PER_PEER // SF_TMA_ROW_BYTES_K
+    k_sf_peer_off = cta_in_pair * cutlass.Int32(K_SF_BYTES_PER_PEER)
+    k_sf_peer_row = cta_in_pair * cutlass.Int32(K_SF_ROWS_PER_PEER)
+    # SF V is loaded per-D-plane (interleaved into SMEM); the plane is TMA dim2
+    # of the D-plane-major V SF descriptor built in _host.
+    n_kh = n_qh // qh_per_kh
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        # n_kv > 0 gate at MASK_NONE collapses to "always" since kv_right > 0.
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+            pass
+        else:
+            if is_sg0:
+                # ---- sg0: Q (one-shot per tile) + K_ring ----------------
+                bars.mb_tma_q_empty.wait(q_empty_phase)
+                q_empty_phase = q_empty_phase ^ cutlass.Int32(1)
+                # Leader expect_tx = collective Q TMA bytes + collective SF Q
+                # bytes (both route to leader's mbar under cga2 tensor TMA, P9).
+                bars.mb_tma_q_full.arrive(n_bytes=qTmaTransactionBytes + Q_SF_EXPECT_BYTES, pred=is_leader & nvvm.elect_sync())
+                tma_load_tile(
+                    sQ[0],
+                    tma_q(cutlass.Int32(0), head_idx, q_row_base + q_seq_off, tma_batch),
+                    bars.mb_tma_q_full.smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=None,
+                )
+                # SF Q — collective along M (cta_group::2 splits M between sg0
+                # peers); rides mb_tma_q_full.  q_sf_tile_base = q_super_idx
+                # (TILES_Q=1 ⇒ q_row_base // TILE_M == q_super_idx).
+                q_sf_tile_base = q_row_base // cutlass.Int32(CFG.TILE_M)
+                tma_load_tile(
+                    sQ_SF[0],
+                    tma_q_sf(cutlass.Int32(0), cu_sf_q_base + q_sf_tile_base, head_idx, tma_batch, coord_0=cutlass.Int32(0)),
+                    bars.mb_tma_q_full.smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=None,
+                )
+
+                for kv_loop in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                    kv_row_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+                    bars.mb_tma_k_empty[kv_state.idx].wait(kv_state.phase)
+                    bars.mb_tma_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES, pred=is_leader & nvvm.elect_sync())
+                    tma_load_tile(
+                        sK[kv_state.idx],
+                        tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
+                        bars.mb_tma_k_full[kv_state.idx].smem_ptr,
+                        cta_group=CFG.CTA_MMA,
+                        mcast_mask=None,
+                    )
+                    # SF K — per-peer half (contract-dim, not interleaved);
+                    # sf_mcast_mask (=0x3, sg0 pair) gives each peer the full
+                    # SF K.  Rides mb_tma_k_full.  Mirror d256_mxfp8.py:669-674.
+                    tma_load_tile(
+                        sK_SF[kv_state.idx].shifted(k_sf_peer_off),
+                        tma_k_sf(k_sf_peer_row, cu_sf_k_base + kv_loop, kv_head_idx, tma_batch, coord_0=cutlass.Int32(0)),
+                        bars.mb_tma_k_full[kv_state.idx].smem_ptr,
+                        cta_group=CFG.CTA_MMA,
+                        mcast_mask=sf_mcast_mask,
+                    )
+                    kv_state = advance(kv_state, CFG.STAGES_KV)
+            else:
+                # ---- sg1: V_ring only -----------------------------------
+                # V split along d_v: per-CTA inner = TILE_O / CTA_MMA.  CTM
+                # TMA descriptors are element-typed so the per-peer offset
+                # is in elements (NOT bytes — C++ uses bytes because its
+                # TMA descriptors are UINT8-typed).
+                for kv_loop in cutlass.range(kv_left, kv_right, 1, unroll=1):
+                    kv_row_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+                    bars.mb_tma_v_empty[kv_state.idx].wait(kv_state.phase)
+                    bars.mb_tma_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes + V_SF_EXPECT_BYTES, pred=is_leader & nvvm.elect_sync())
+                    tma_load_tile(
+                        sV[kv_state.idx],
+                        tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
+                        bars.mb_tma_v_full[kv_state.idx].smem_ptr,
+                        cta_group=CFG.CTA_MMA,
+                        mcast_mask=None,
+                    )
+                    # SF V — INTERLEAVED per-N-block loads.  cga2 BMM2 reads the
+                    # 4 SF V N-blocks as [N0,N2,N1,N3] in SMEM: BMM2 call c reads
+                    # leader's N-block c and (via the cga2 +1-block SF auto-shift)
+                    # the peer's N-block c, which must be d_v block c+2.  So each
+                    # sg1 peer p loads its 2 GMEM N-blocks {2p, 2p+1} into SMEM
+                    # blocks {p, p+CTA_MMA}.  Multicast (sf_mcast_mask=0xC) so both
+                    # sg1 peers' SMEM accumulate all 4 blocks.  C++ :1574-1616.
+                    for _j in cutlass.range_constexpr(SF_NUM_BLOCKS_V // CFG.CTA_MMA):
+                        gmem_blk = cta_in_pair * cutlass.Int32(SF_NUM_BLOCKS_V // CFG.CTA_MMA) + cutlass.Int32(_j)
+                        smem_blk = cta_in_pair + cutlass.Int32(_j * CFG.CTA_MMA)
+                        tma_load_tile(
+                            sV_SF[kv_state.idx].shifted(smem_blk * cutlass.Int32(SF_BYTES_PER_BLOCK)),
+                            tma_v_sf(cutlass.Int32(0), gmem_blk, cu_sf_k_base + kv_loop, tma_batch * n_kh + kv_head_idx, coord_0=cutlass.Int32(0)),
+                            bars.mb_tma_v_full[kv_state.idx].smem_ptr,
+                            cta_group=CFG.CTA_MMA,
+                            mcast_mask=sf_mcast_mask,
+                        )
+                    kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+        nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+        nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+        q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+        cu_sf_q_base, cu_sf_k_base = _thd_sf_tile_bases(seq_kv_lens_tensor, batch_idx, n_batch)
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+
+    # cga2: drain trailing K/V/Q empty arrives so SMEM isn't torn down while
+    # leader's multicast commits are still in-flight.
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        if is_sg0:
+            for _ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_tma_k_empty[kv_state.idx].wait(kv_state.phase)
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+            bars.mb_tma_q_empty.wait(q_empty_phase)
+        else:
+            for _ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_tma_v_empty[kv_state.idx].wait(kv_state.phase)
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+
+# ============================================================================
+# TMA-STG warp — sg1 only: O TMA store + LSE write back.
+# Port of C++ tmastg_warp_group (prefill_sdpa_d512_mxfp8.cu:1392-1453).
+# ============================================================================
+@cute.jit
+def _tmastg_warp_group(
+    is_sg1,
+    tma_o_desc,
+    sO,
+    bars,
+    sched,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    cta_in_pair,
+    seq_kv_lens_tensor,
+    o_desc_words,
+):
+    """sg1: persistent O-store + per-chunk mb_tma_o_empty drain.
+
+    sg0 TMASTG (port of C++ lines 1417-1428): idle — just spin scheduler so
+    persistent tile claims advance in lockstep with sg1.  Does NOT call
+    read_tile_id_arrive (per the READ_TILE_ARRIVERS = 25 derivation — sg0's
+    TMASTG slot is NOT in the arriver list).
+
+    sg1 TMASTG (port of C++ lines 1430-1467):
+        Per tile:
+          - read_tile_id_arrive on the scheduler's read_tile_id mbar.
+          - For each chunk c in [0, N_O_CHUNKS):
+              wait(mb_tma_o_full[c], epilogue_state).
+          - tma_store_tile(sO[0], o_gmem(0, q_row_coord, head_idx, batch_idx)).
+          - tma_store_commit; tma_store_wait(0).
+          - arrive(mb_tma_o_empty).
+          - Flip epilogue_state.
+    """
+    o_full_phase = cutlass.Int32(0)
+
+    tma_o = GmemTileTma(tma_o_desc)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        # sg0's TMA-STG slot is idle but spins the scheduler so persistent
+        # tile claims advance in lockstep with sg1.  sg0 does NOT call
+        # read_tile_id_arrive (per the READ_TILE_ARRIVERS=25 derivation —
+        # sg0's TMA-STG slot is intentionally NOT in the arriver list).
+        if is_sg1:
+            read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+            # Wait every chunk of O ready.
+            for chunk in cutlass.range_constexpr(N_O_CHUNKS):
+                bars.mb_tma_o_full[chunk].wait(o_full_phase)
+
+            # Both sg1 peers issue the O TMA store with their own q_row_coord —
+            # cga2 splits C along M, so leader writes rows [0:128] and peer
+            # writes [128:256].
+            q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: store through this batch's pre-built descriptor (base at
+                # the sequence's packed row, seq extent = S_q_b → box past S_q_b
+                # OOB-clipped).  q_row_coord sequence-local; batch coord → 0.
+                o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_coord, cutlass.Int32(0))
+                tma_store_tile(sO[0], o_slice)
+            else:
+                tma_store_tile(
+                    sO[0],
+                    tma_o(cutlass.Int32(0), head_idx, q_row_coord, batch_idx),
+                )
+            tma_store_commit()
+            tma_store_wait(0)
+
+            bars.mb_tma_o_empty.arrive()
+            nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+            o_full_phase = o_full_phase ^ cutlass.Int32(1)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+
+# ============================================================================
+# Host launcher.
+# ============================================================================
+@cute.jit
+def _host(
+    q_tensor: cute.Tensor,
+    k_tensor: cute.Tensor,
+    v_tensor: cute.Tensor,
+    o_tensor: cute.Tensor,
+    sf_q_tensor: cute.Tensor,
+    sf_k_tensor: cute.Tensor,
+    sf_v_tensor: cute.Tensor,
+    lse_tensor: Optional[cute.Tensor],
+    # FROST's MXFP8 ABI puts amax_o RIGHT AFTER lse (position 9).
+    amax_o_tensor: cute.Tensor,
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    problem_size: Tuple[int, int, int, int, int, int],
+    scale_softmax_log2: cutlass.Float32,
+    n_thd_units: cutlass.Int32,
+    # FROST passes the dense padded-Q trim tensor POSITIONALLY on every call.
+    # These kernels have no Q-trim epilogue (Capabilities.dense_seq_q_trim=False)
+    # so it is accepted and unused -- but the SLOT is mandatory: without it the
+    # adapter's 12th positional lands on `stream` and execute dies with
+    # "got multiple values for argument 'stream'".
+    seq_q_lens_tensor: Optional[cute.Tensor] = None,
+    # Keyword-only in effect: FROST never passes these positionally (its SF
+    # extents are compile-time), and they are read only on the THD path, which
+    # this kernel declines.  They MUST sit after seq_q_lens_tensor: the adapter
+    # passes seq_q_lens positionally for the d256 quantized ABI, so an SF total
+    # in that slot would swallow it.
+    total_q_sf_tiles: cutlass.Int32 = 0,
+    total_kv_sf_tiles: cutlass.Int32 = 0,
+    # FROST plans must run on the caller's stream (engine contract; there is a
+    # dedicated stream-respect test).  Threaded exactly as the shipped
+    # prefill_d128_fp8_sm107.py sibling does.
+    stream: _cuda_driver.CUstream = None,
+) -> None:
+    """MXFP8 host launcher — builds TMA descriptors for Q/K/V/O + SF tensors.
+
+    THD/varlen: q/k/v/o/lse/SF are PACKED with batch dim 1; the SF descriptors use
+    B=1 + total_*_sf_tiles (per-sequence-TILE-padded SF layout); O uses a per-batch
+    descriptor array (build_thd_meta_o_descs_kernel)."""
+    B, QH, KH, SQ, SKV, _ = problem_size
+
+    # Tensors are [B, S, H, D] with stride_order=(3, 2, 1, 0); D is fastest.
+    # Under cga2 K is split along seq (per-CTA box rows are TILE_N / CTA_MMA),
+    # V is split along d_v (per-CTA inner is TILE_O / CTA_MMA).  O's TMA box
+    # inner follows O's swizzle, NOT V's (V may drop to narrower under cga2).
+    _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE_O
+    qk_box_q = (1, CFG.TILE_M, 1, TMA_QK_GRANU_ELEMS)
+    qk_box_k = (1, CFG.TILE_N // CFG.CTA_MMA, 1, TMA_QK_GRANU_ELEMS)
+    vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M, 1, _O_GRANU_ELEMS)
+    stride_order = (3, 2, 1, 0)
+
+    # SF TMA box layout — 5-D explicit (mirrors d256_mxfp8.py:1731-1759).
+    SF_TMA_ROW_BYTES = 128
+    SF_NUM_ROWS_Q = SF_SMEM_SIZE_Q // SF_TMA_ROW_BYTES
+    SF_NUM_ROWS_K = SF_SMEM_SIZE_K // SF_TMA_ROW_BYTES
+
+    def _tma_swz(byte_w: int):
+        return tmap.TensorMapSwizzle.s128b if byte_w == 128 else tmap.TensorMapSwizzle.s64b if byte_w == 64 else tmap.TensorMapSwizzle.s32b
+
+    tma_q_desc = tmap.create_tensor_map_tiled_from_view(
+        q_tensor,
+        box_dims=qk_box_q,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.Q_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_k_desc = tmap.create_tensor_map_tiled_from_view(
+        k_tensor,
+        box_dims=qk_box_k,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.K_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_v_desc = tmap.create_tensor_map_tiled_from_view(
+        v_tensor,
+        box_dims=vo_box_v,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.V_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_o_desc = tmap.create_tensor_map_tiled_from_view(
+        o_tensor,
+        box_dims=vo_box_o,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.O_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+
+    # SF TMA descriptors — 5-D explicit layout.  Per-tile bytes packed
+    # contiguously per (batch, head, tile).  Mirrors d256_mxfp8.py:1737-1765.
+    sq_sf_tiles = (SQ + CFG.TILE_M - 1) // CFG.TILE_M
+    skv_sf_tiles = (SKV + CFG.TILE_N - 1) // CFG.TILE_N
+    # Dense: per-batch tile counts (SQ/TILE_M, SKV/TILE_N), B-extent = B.  THD:
+    # the SF tensor is PACKED (batch dim 1) and per-sequence-TILE-padded, so the
+    # descriptor uses num_tiles = total_*_sf_tiles (Σ_b ceil(S/TILE)) and B = 1.
+    # _B_SF folds to the const 1 under THD so the descriptor's batch extent is correct.
+    _B_SF = 1 if cutlass.const_expr(CFG.THD_VARLEN) else B
+    _q_sf_num_tiles = total_q_sf_tiles if cutlass.const_expr(CFG.THD_VARLEN) else sq_sf_tiles
+    _kv_sf_num_tiles = total_kv_sf_tiles if cutlass.const_expr(CFG.THD_VARLEN) else skv_sf_tiles
+
+    def _build_sf_desc(sf_tensor, num_tiles, sf_smem_size, num_rows_box, num_heads):
+        sf_base = cutlass.Int64(sf_tensor.iterator.toint())
+        tile_stride_16 = sf_smem_size // 16
+        return tmap.create_tensor_map_tiled(
+            global_address=sf_base,
+            dtype=cutlass.Uint8,
+            global_dims=[
+                SF_TMA_ROW_BYTES,
+                sf_smem_size // SF_TMA_ROW_BYTES,
+                num_tiles,
+                num_heads,
+                _B_SF,
+            ],
+            global_strides=[
+                SF_TMA_ROW_BYTES // 16,
+                tile_stride_16,
+                num_tiles * tile_stride_16,
+                num_heads * num_tiles * tile_stride_16,
+            ],
+            box_dims=[SF_TMA_ROW_BYTES, num_rows_box, 1, 1, 1],
+            swizzle=tmap.TensorMapSwizzle.none,
+            l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+        )
+
+    tma_q_sf_desc = _build_sf_desc(sf_q_tensor, _q_sf_num_tiles, SF_SMEM_SIZE_Q, SF_NUM_ROWS_Q, QH)
+    # SF K is per-CTA along the contract dim — each sg0 peer gets half (cga2),
+    # box has SF_NUM_ROWS_K / CTA_MMA rows; kernel offsets by cta_in_pair.
+    tma_k_sf_desc = _build_sf_desc(sf_k_tensor, _kv_sf_num_tiles, SF_SMEM_SIZE_K, SF_NUM_ROWS_K // CFG.CTA_MMA, KH)
+    # SF V is the COLUMNWISE (transposed-operand) quantization, and its GMEM
+    # layout is NOT the per-tile-contiguous one Q/K use.  The F8_128x4 atom rule
+    # is applied to the transposed scale matrix [D, S/32], so the atom grid is
+    # (D/128) x (b*KH*S/128) laid out ROW-MAJOR -- the D-block index is the
+    # OUTER one, and the SF_NUM_BLOCKS_V D-planes are separated by a whole plane
+    # of `v_sf_groups` atoms, a stride that GROWS WITH S.  Q/K are rowwise:
+    # their atom grid is (b*QH*S/128) x (D/128), so THEIR D-blocks are per-tile
+    # contiguous and _build_sf_desc is right for them.
+    #
+    # At d=128 there is exactly ONE D-plane, so the two layouts coincide -- which
+    # is why the d128 MXFP8 sibling passes with the per-tile form.  d256 was
+    # correct at S=128 (one KV tile => one group) and wrong from S=256 on until
+    # this was fixed; the same defect lives here at 4 planes.  Mirrors
+    # prefill_d256_mxfp8_sm100.py's dense/THD stride split.
+    #
+    # Box = ONE D-plane: each sg1 peer issues SF_NUM_BLOCKS_V/CTA_MMA per-plane
+    # loads at INTERLEAVED SMEM offsets (see the loop in _tmaldg_warp_group), so
+    # the plane is a COORD here, not part of the box.
+    _v_sf_groups = _B_SF * KH * _kv_sf_num_tiles
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD packs all D-planes of a (head, sequence tile) contiguously.
+        _v_plane_stride_16 = SF_BYTES_PER_BLOCK // 16
+        _v_tile_stride_16 = SF_SMEM_SIZE_V // 16
+    else:
+        _v_plane_stride_16 = (_v_sf_groups * SF_BYTES_PER_BLOCK) // 16
+        _v_tile_stride_16 = SF_BYTES_PER_BLOCK // 16
+    tma_v_sf_desc = tmap.create_tensor_map_tiled(
+        global_address=cutlass.Int64(sf_v_tensor.iterator.toint()),
+        dtype=cutlass.Uint8,
+        global_dims=[
+            SF_TMA_ROW_BYTES,
+            SF_BYTES_PER_BLOCK // SF_TMA_ROW_BYTES,
+            SF_NUM_BLOCKS_V,
+            _kv_sf_num_tiles,
+            KH * _B_SF,
+        ],
+        global_strides=[
+            SF_TMA_ROW_BYTES // 16,
+            _v_plane_stride_16,
+            _v_tile_stride_16,
+            _kv_sf_num_tiles * _v_tile_stride_16,
+        ],
+        box_dims=[SF_TMA_ROW_BYTES, SF_BYTES_PER_BLOCK // SF_TMA_ROW_BYTES, 1, 1, 1],
+        swizzle=tmap.TensorMapSwizzle.none,
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+
+    # Each cluster (CGA_M = 4 CTAs; CTA_MMA = 2 sg pairs collectively share Q)
+    # covers CGA_TILE_M = TILES_Q * TILE_M * CTA_MMA = 256 Q rows.  grid_x
+    # must scale by CGA_M (cluster x-dim) so the cluster shape divides the
+    # grid — for non-dsv4 flavors CGA_M == CTA_MMA and this collapses to the
+    # historical formula.  Mirrors C++ runner
+    # (the pre-upstream host runner).
+    rows_per_cluster = CGA_TILE_M
+    q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
+    grid_q_supers = q_clusters * CFG.CGA_M
+    # n_q_supers passed to kernel is the LOGICAL q-tile count (not the grid x
+    # span).  For SCHED_LPT it's `q_clusters * CTA_MMA` (each cluster owns
+    # CTA_MMA rows of distinct q_super_idx values); for NATURAL the kernel
+    # reads bidx directly so this value is unused.
+    q_supers = q_clusters * CFG.CTA_MMA
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD: build the per-batch O descriptor array (reuse tma_o_desc over the
+        # packed [1,T,QH,D_v] O as base), then launch the exact flat
+        # batch-outermost grid (n_thd_units host-computed); grid_x = units*CGA_M.
+        _build_thd_meta_o_descs_kernel(
+            o_tensor,
+            tma_o_desc,
+            o_desc_words,
+            seq_kv_lens_tensor,
+            cutlass.Int32(QH),
+            cutlass.Int32(B),
+            cutlass.Int32(CFG.TILE_O),
+        ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
+        grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
+    else:
+        grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
+    _kernel(
+        tma_q_desc,
+        tma_k_desc,
+        tma_v_desc,
+        tma_o_desc,
+        tma_q_sf_desc,
+        tma_k_sf_desc,
+        tma_v_sf_desc,
+        lse_tensor,
+        amax_o_tensor,
+        sinks_tensor,
+        seq_kv_lens_tensor,
+        o_desc_words,
+        cutlass.Int32(SQ),
+        cutlass.Int32(SKV),
+        cutlass.Int32(q_supers),
+        cutlass.Int32(QH),
+        cutlass.Int32(B),
+        cutlass.Int32(QH // KH),
+        scale_softmax_log2,
+    ).launch(
+        # cluster = (CGA_M, CGA_N, 1) = (4, 1, 1) under dsv4.
+        grid=grid_shape,
+        block=[CFG.THREADS_PER_CTA, 1, 1],
+        cluster=(CFG.CGA_M, CFG.CGA_N, 1),
+        stream=stream,
+    )
+
+
+@lru_cache(maxsize=None)
+def compile(  # noqa: A001
+    b: int = 1,
+    qh: int = 1,
+    kh: int = 1,
+    sq: int = 256,
+    skv: int = 128,
+    total_q_sf_tiles: int = 0,
+    total_kv_sf_tiles: int = 0,
+    d_qk: int = CFG.TILE_K,
+    d_v: int = CFG.TILE_O,
+    has_lse: bool = True,
+    lse_stride: Optional[tuple] = None,
+) -> Callable:
+    """Compile a kernel with ALL dims concrete to pin TMA descriptor strides at compile time.
+
+    THD/varlen: q/k/v/o/lse + SF tensors are PACKED with batch dim 1; ``b`` is the
+    LOGICAL batch (sequence count).  The SF tensors are per-sequence-TILE-padded so
+    their packed tile extent is ``total_q_sf_tiles`` / ``total_kv_sf_tiles`` (=
+    Σ_b ceil(S/TILE)); pass those (they vary with the cu_seqlens partition, hence
+    part of the lru_cache key).  Default 0 → fall back to the dense per-batch tile
+    counts so the dense path is unaffected."""
+    # THD/varlen is NOT ported for this kernel yet.  The setup-kernel call site
+    # below still speaks the pre-upstream 7-arg contract, while FROST's
+    # thd_helpers.build_thd_meta_o_descs_kernel takes 14 args and a different
+    # metadata layout (4B+4 with batch_remap + a claim counter, vs the 3B+2
+    # here), and the scheduler decode differs to match.  Raise here rather than
+    # let it fail as an arity error deep in the trace -- and so no engine row
+    # can advertise thd=True for this kernel and appear to work.  The dense
+    # path is unaffected: CFG.THD_VARLEN is 0 and every THD branch folds out.
+    if CFG.THD_VARLEN:
+        raise NotImplementedError(f"{__name__}: THD/varlen not ported to the FROST setup-kernel contract")
+    # ---- FROST adapter ABI ------------------------------------------------
+    # lower_dsl_prefill calls EVERY kernel with the full forward signature.
+    # This body carries only what the port brought over, so anything
+    # it cannot honor RAISES rather than being silently ignored: a raise here
+    # means the engine's Capabilities row is lying, which is the failure we
+    # want loud.  (Capabilities: lse_optional=False, no strided Stats.)
+    if lse_stride is not None:
+        raise NotImplementedError(f"{__name__}: strided Stats not ported (contiguous [B, H, S] only)")
+    if d_qk > CFG.TILE_K or d_v > CFG.TILE_O or d_qk <= 0 or d_v <= 0:
+        raise ValueError(f"{__name__}: envelope is 0 < d_qk <= {CFG.TILE_K}, 0 < d_v <= {CFG.TILE_O}; " f"got ({d_qk}, {d_v})")
+    _fake_batch = 1 if CFG.THD_VARLEN else b
+
+    # Q SF tiles TILE_M-row wide → num_tiles = SQ/TILE_M; K/V SF TILE_N-row wide → num_tiles = SKV/TILE_N.
+    # THD: packed (batch dim 1) + per-sequence-TILE-padded → total_*_sf_tiles tiles.
+    sq_tiles = (sq + CFG.TILE_M - 1) // CFG.TILE_M
+    skv_tiles = (skv + CFG.TILE_N - 1) // CFG.TILE_N
+    if CFG.THD_VARLEN:
+        _q_sf_tiles = total_q_sf_tiles if total_q_sf_tiles > 0 else b * sq_tiles
+        _kv_sf_tiles = total_kv_sf_tiles if total_kv_sf_tiles > 0 else b * skv_tiles
+    else:
+        _q_sf_tiles = sq_tiles
+        _kv_sf_tiles = skv_tiles
+
+    fake_q = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, sq, qh, d_qk),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_k = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, d_qk),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_v = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, d_v),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_o = cute.runtime.make_fake_compact_tensor(
+        OUT_STORAGE_DTYPE,
+        (_fake_batch, sq, qh, d_v),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+
+    # MXFP8 SF tensors — shape [B, H, num_tiles, SF_SMEM_SIZE].  SF Q is
+    # per-Q-head (qh); SF K / V are per-KV-head (kh).  Stride order: SF block
+    # is innermost.  Mirrors d256_mxfp8.py:1811-1824.  THD: packed (batch dim 1)
+    # + per-sequence-TILE-padded → total_*_sf_tiles tiles.
+    fake_sf_q = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int8,
+        (_fake_batch, qh, _q_sf_tiles, SF_SMEM_SIZE_Q),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_sf_k = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int8,
+        (_fake_batch, kh, _kv_sf_tiles, SF_SMEM_SIZE_K),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_sf_v = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int8,
+        (_fake_batch, kh, _kv_sf_tiles, SF_SMEM_SIZE_V),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+
+    # has_lse=False (no Stats output): the LSE argument is None-specialized and
+    # the store is compiled out entirely -- no dummy buffer exists at any level,
+    # which is what lets the dense graph report get_workspace_size() == 0.
+    # Mirrors the shipped prefill_d128_fp8_sm107.py.
+    fake_lse = (
+        cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (_fake_batch, qh, sq),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
+        if has_lse
+        else None
+    )
+    fake_sinks = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (qh,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    fake_amax_o = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (1,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # seq_kv_lens always part of the ABI; THD overloads it as the
+    # [seq_kv_lens(B)|cu_q(B+1)|cu_k(B+1)] metadata buffer (length 3B+2).
+    _skv_len = (3 * b + 2) if CFG.THD_VARLEN else b
+    fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (_skv_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # Per-batch O TMA-descriptor array (TENSOR_MAP_QWORDS int64 = 128 B each) + 1
+    # pad slot; dummy 1-elem when THD off (kernel never reads it).
+    _odesc_len = (b * _TENSOR_MAP_QWORDS + _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
+    fake_o_desc = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int64,
+        (_odesc_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    return cute.compile(
+        _host,
+        fake_q,
+        fake_k,
+        fake_v,
+        fake_o,
+        fake_sf_q,
+        fake_sf_k,
+        fake_sf_v,
+        fake_lse,
+        fake_amax_o,
+        fake_sinks,
+        fake_seq_kv_lens,
+        fake_o_desc,
+        (b, qh, kh, sq, skv, 0),
+        cutlass.Float32(0.0),
+        cutlass.Int32(0),
+        # BY KEYWORD, not position: the SF totals now sit AFTER
+        # seq_q_lens_tensor in _host's signature (the adapter passes that slot
+        # positionally for the d256 quantized ABI).  Passing them positionally
+        # here lands an Int32 in the tensor slot --
+        # "expects argument #16 (seq_q_lens_tensor) ... but got Int32".
+        total_q_sf_tiles=cutlass.Int32(_q_sf_tiles),
+        total_kv_sf_tiles=cutlass.Int32(_kv_sf_tiles),
+        stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
+        options="--enable-tvm-ffi",
+    )

--- a/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
+++ b/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
@@ -85,10 +85,15 @@ def test_per_tensor_fp8_rows_split_per_arch_line():
     assert sm107.d_shapes == frozenset({(128, 128), (256, 256), (512, 512)})
     assert (192, 128) not in sm107.d_shapes
     # Envelope FLOORS keep an inexact graph off a flavor whose padded path is
-    # not validated.  They are SM100-row data: the Rubin row carries none, so
-    # its d512 kernel serves the whole (0, 512] band its d_shapes admit.
+    # not validated.  BOTH rows carry them, and the Rubin one differs only by
+    # the (192, 128) entry it has no flavor for -- the floors' rationale is the
+    # kernel geometry (a cga4x1 d512 role-split; an unvalidated d256 padded
+    # path), which the Rubin ports inherit unchanged.  They must also match
+    # api_dsl._SM100_FP8_ENVELOPE_FLOORS, which the adapter enforces on BOTH
+    # arch lines -- a row that admits what the adapter rejects is a plan that
+    # enters the ranked list only to die in check_support.
     assert sm100.d_envelope_floors == (((192, 128), 128), ((256, 256), 255), ((512, 512), 256))
-    assert sm107.d_envelope_floors == ()
+    assert sm107.d_envelope_floors == (((256, 256), 255), ((512, 512), 256))
 
     # The f16x2 exponent arm is Rubin-row data, not a notch.
     assert sm100.softmax_precisions == frozenset({_c.data_type.FLOAT})
@@ -112,11 +117,15 @@ def test_per_tensor_fp8_rows_split_per_arch_line():
     assert sm100.thd and sm107.thd and sm100.cu_seq_len and sm107.cu_seq_len
 
 
-def test_sm107_row_ranks_the_lpt_remap_for_causal():
-    """The LPT/LPT_L2 remap (issue #653) is live on the Rubin row: a causal
-    per-tensor FP8 graph at cc10.7 ranks LPT_L2 first, exactly as its SM100
-    twin does, and both remap specializations template-load. Pure — facts pin
-    the device, and nothing here compiles."""
+def test_sm107_row_ranks_natural_only_for_causal():
+    """The LPT/LPT_L2 remap (issue #653) is an SM100-row property.  A causal
+    per-tensor FP8 graph ranks [LPT_L2, LPT, NATURAL] there, but the Rubin row
+    declares a SINGLE-element domain -- its ported kernels raise on the L2
+    decode and do not honor LPT -- so ranking must offer exactly [NATURAL] and
+    never bolt a fallback on beside it.  The LPT specialization still
+    template-LOADS; it is the decode that is unvalidated, which is why the ROW
+    declines rather than the template raising.  Pure — facts pin the device,
+    and nothing here compiles."""
     import cudnn as _c
     from cudnn.frost.tile_dsl.constants import SCHED_LPT, SCHED_LPT_L2, SCHED_NATURAL
     from cudnn.sdpa import graph_analyzer as ga
@@ -426,17 +435,19 @@ def test_fp8_envelope_mismatch_rules():
     # but has no d192 flavor at all.
     sm107 = caps[engines.engine_name(arch="sm107", fp8=True)]
     assert engines.mismatch(sm107, _fp8_facts(device_cc=(10, 7))) is None
-    # d192xd128 has no Rubin FP8 FLAVOR, but the SHAPE is still served: it rides
-    # the (256, 256) envelope with zero padding, exactly as any other
-    # non-native d in the band does.  "No flavor" is not "declined".
-    assert engines.mismatch(sm107, _fp8_facts(device_cc=(10, 7), d_qk=192, d_v=128)) is None
+    # d192xd128 has no Rubin FP8 FLAVOR *and* is not served: the (256, 256)
+    # floor (255) keeps every inexact graph off that flavor's unvalidated
+    # padded path, exactly as on the SM100 row.  Asserting the DECLINE rather
+    # than skipping it -- INVERTS-WHEN a Rubin d192 FP8 sibling lands, or the
+    # d256 padded envelope is validated through test_mhas_v2.
+    assert "no kernel-flavor envelope" in engines.mismatch(sm107, _fp8_facts(device_cc=(10, 7), d_qk=192, d_v=128))
     assert "dense-only" in engines.mismatch(sm107, _fp8_facts(device_cc=(10, 7), thd=True, padded=True))
     # INVERTED: the Rubin line gained a d512 per-tensor FP8 kernel, so the
     # native d512 shape is now SERVED rather than declined.  d192xd128 is the
     # one flavor it still lacks (asserted above), and the (256, 512] floor
     # applies here exactly as on the SM100 row.
     assert engines.mismatch(sm107, _fp8_facts(device_cc=(10, 7), d_qk=512, d_v=512)) is None
-    # ...and, carrying NO envelope floors (unlike the SM100 row), its d512
-    # flavor also serves the padded band below the native shape.
-    assert engines.mismatch(sm107, _fp8_facts(device_cc=(10, 7), d_qk=512, d_v=256)) is None
+    assert engines.mismatch(sm107, _fp8_facts(device_cc=(10, 7), d_qk=384, d_v=448)) is None
+    # ...and straddling the floor declines on BOTH rows, identically.
+    assert "no kernel-flavor envelope" in engines.mismatch(sm107, _fp8_facts(device_cc=(10, 7), d_qk=512, d_v=256))
     assert "no kernel-flavor envelope" in engines.mismatch(sm100, _fp8_facts(d_qk=512, d_v=256))

--- a/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
+++ b/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
@@ -53,8 +53,11 @@ def test_sm100_module_unchanged():
     assert mod.NUM_KPHASES_PV == 4
 
 
-def test_sm107_per_tensor_fp8_advertises_only_d128():
-    assert _sm100_fp8_shapes(pertensor=True, device_cc=(10, 7)) == frozenset({(128, 128)})
+def test_sm107_per_tensor_fp8_native_shapes():
+    """INVERTED 2026-09-04: the SM107 port added d256 and d512 per-tensor FP8.
+    d192xd128 still has no Rubin sibling, so it must stay absent."""
+    assert _sm100_fp8_shapes(pertensor=True, device_cc=(10, 7)) == frozenset({(128, 128), (256, 256), (512, 512)})
+    assert (192, 128) not in _sm100_fp8_shapes(pertensor=True, device_cc=(10, 7))
     assert (192, 128) in _sm100_fp8_shapes(pertensor=True, device_cc=(10, 0))
     assert (256, 256) in _sm100_fp8_shapes(pertensor=True, device_cc=(10, 0))
 
@@ -74,12 +77,16 @@ def test_per_tensor_fp8_rows_split_per_arch_line():
     # Arch ranges tile the SM100 family at the Rubin boundary, no overlap.
     assert (sm100.sm_lo, sm100.sm_hi) == (100, 106)
     assert (sm107.sm_lo, sm107.sm_hi) == (107, 119)
-    # Kernel flavors are row DATA: Rubin has no d192, d256, or d512 sibling.
+    # Kernel flavors are row DATA.  PARTIALLY INVERTED: the Rubin line gained
+    # d256 and d512 per-tensor FP8 siblings; only d192xd128 still has none.
     assert sm100.d_shapes == frozenset({(128, 128), (192, 128), (256, 256), (512, 512)})
-    assert sm107.d_shapes == frozenset({(128, 128)})
-    # d512 carries an envelope FLOOR: it serves (256, 512] on both head dims,
-    # so a smaller graph is declined rather than routed onto the d512 kernel at
-    # a multiple-x zero-padding cost.  Rubin has no d512 flavor, hence no floor.
+    # PARTIALLY INVERTED: the Rubin line gained d256 and d512 per-tensor FP8
+    # siblings; only d192xd128 still has none.
+    assert sm107.d_shapes == frozenset({(128, 128), (256, 256), (512, 512)})
+    assert (192, 128) not in sm107.d_shapes
+    # Envelope FLOORS keep an inexact graph off a flavor whose padded path is
+    # not validated.  They are SM100-row data: the Rubin row carries none, so
+    # its d512 kernel serves the whole (0, 512] band its d_shapes admit.
     assert sm100.d_envelope_floors == (((192, 128), 128), ((256, 256), 255), ((512, 512), 256))
     assert sm107.d_envelope_floors == ()
 
@@ -93,7 +100,12 @@ def test_per_tensor_fp8_rows_split_per_arch_line():
     # so the sched domain is the same on both rows.
     assert sm107.split_kv_supported is True
     assert sm100.split_kv_supported is True
-    assert sm107.sched_policies == frozenset({SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2})
+    # INVERTED: BOTH remap policies came off the Rubin row.  LPT_L2 went first
+    # (the ported decode sites never thread qh_per_kh / seqlen_kv); plain LPT
+    # followed once heuristics could actually reach it -- a causal d512 FP8
+    # graph under LPT returns NaN, and all 12 masked d512 cases go green with
+    # the row narrowed.  A knob is honored or the engine is ineligible.
+    assert sm107.sched_policies == frozenset({SCHED_NATURAL})
     assert sm100.sched_policies == frozenset({SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2})
 
     # Both d128 cells carry the write_thd_meta THD leg.
@@ -134,12 +146,18 @@ def test_sm107_row_ranks_the_lpt_remap_for_causal():
     # the remap groups against, so the L2 variant leads on BOTH rows. Before
     # the port the Rubin row had a one-element domain and took _sched_points'
     # sole-element shortcut, which is what pinned it to NATURAL.
-    assert heuristics._sched_points(sm107, facts((10, 7))) == [SCHED_LPT_L2, SCHED_LPT, SCHED_NATURAL]
+    # INVERTED: the Rubin row dropped SCHED_LPT_L2 (its ported kernels raise on
+    # the L2 decode), so heuristics ranks LPT first there while the SM100 twin
+    # still leads with LPT_L2.  A proposal outside the row's domain would be a
+    # heuristics bug, so the ranking must not offer it at all.
+    # The Rubin row's domain is now a single element, so ranking has one point.
+    assert heuristics._sched_points(sm107, facts((10, 7))) == [SCHED_NATURAL]
     assert heuristics._sched_points(sm100, facts((10, 0))) == [SCHED_LPT_L2, SCHED_LPT, SCHED_NATURAL]
 
-    # Both remap specializations template-load on the Rubin sibling.
-    for policy in (SCHED_LPT, SCHED_LPT_L2):
-        assert _load(rubin=True, sched_policy=policy).CFG.SCHEDULER_POLICY == policy
+    # The LPT specialization still template-LOADS -- it is the decode that is
+    # unvalidated on the ported kernels, which is why the ROW declines it rather
+    # than the template raising.
+    assert _load(rubin=True, sched_policy=SCHED_LPT).CFG.SCHEDULER_POLICY == SCHED_LPT
 
 
 def test_softmax_half_declines_by_row_domain():
@@ -408,7 +426,17 @@ def test_fp8_envelope_mismatch_rules():
     # but has no d192 flavor at all.
     sm107 = caps[engines.engine_name(arch="sm107", fp8=True)]
     assert engines.mismatch(sm107, _fp8_facts(device_cc=(10, 7))) is None
-    assert "no kernel-flavor envelope" in engines.mismatch(sm107, _fp8_facts(device_cc=(10, 7), d_qk=192, d_v=128))
+    # d192xd128 has no Rubin FP8 FLAVOR, but the SHAPE is still served: it rides
+    # the (256, 256) envelope with zero padding, exactly as any other
+    # non-native d in the band does.  "No flavor" is not "declined".
+    assert engines.mismatch(sm107, _fp8_facts(device_cc=(10, 7), d_qk=192, d_v=128)) is None
     assert "dense-only" in engines.mismatch(sm107, _fp8_facts(device_cc=(10, 7), thd=True, padded=True))
-    # There is no Rubin d512 kernel at all.
-    assert "no kernel-flavor envelope" in engines.mismatch(sm107, _fp8_facts(device_cc=(10, 7), d_qk=512, d_v=512))
+    # INVERTED: the Rubin line gained a d512 per-tensor FP8 kernel, so the
+    # native d512 shape is now SERVED rather than declined.  d192xd128 is the
+    # one flavor it still lacks (asserted above), and the (256, 512] floor
+    # applies here exactly as on the SM100 row.
+    assert engines.mismatch(sm107, _fp8_facts(device_cc=(10, 7), d_qk=512, d_v=512)) is None
+    # ...and, carrying NO envelope floors (unlike the SM100 row), its d512
+    # flavor also serves the padded band below the native shape.
+    assert engines.mismatch(sm107, _fp8_facts(device_cc=(10, 7), d_qk=512, d_v=256)) is None
+    assert "no kernel-flavor envelope" in engines.mismatch(sm100, _fp8_facts(d_qk=512, d_v=256))

--- a/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
@@ -12,12 +12,31 @@ import torch
 from test_utils import torch_fork_set_rng
 
 from cudnn.sdpa.fwd.engines import engine_name
-from frost_test_utils import make_dense_stats, requires_pre_rubin_blackwell, requires_dsl, _dsl_installed
+from frost_test_utils import _SM, make_dense_stats, requires_blackwell, requires_dsl, _dsl_installed
 
 
 from frost_test_utils import select_engine as _select_engine  # noqa: F401
 
-pytestmark = requires_pre_rubin_blackwell
+pytestmark = requires_blackwell
+
+# ONE engine per arch line: pin the row that serves the device under test.
+# ``engine_name(arch=_ARCH)`` defaults to arch="sm100", whose row stops at cc 10.6, so an
+# unqualified pin fails on Rubin with "no plan for engine" for routing reasons
+# that have nothing to do with the kernel.  Same shape as
+# test_sdpa_fwd_fp8_sm100.py / test_sdpa_fwd_mxfp8_sm100.py.
+_ARCH = "sm107" if _SM == 107 else "sm100"
+
+# Features the Rubin f16 row DECLINES (it is a strict subset of its Blackwell
+# counterpart -- see engines._sm107_spec).  These are capability declines the
+# row states honestly, not kernel bugs: the graph is never served, so the test
+# cannot run.  Flip each condition when the gap closes.
+_skip_split_kv_on_rubin = pytest.mark.skipif(_SM == 107, reason="the ported Rubin f16 kernels wire no SplitHelpers (row: split_kv_supported=False)")
+_skip_pack_gqa_on_rubin = pytest.mark.skipif(_SM == 107, reason="no PackGQA path in the ported Rubin f16 kernels (row: pack_gqas={False})")
+_skip_thd_on_rubin = pytest.mark.skipif(_SM == 107, reason="THD/varlen not ported to the Rubin f16 kernels (row: thd=False)")
+_skip_stats_trim_on_rubin = pytest.mark.skipif(
+    _SM == 107,
+    reason="per-batch seq_len_q O/LSE trim not carried by the Rubin f16 kernels " "(row: padded_stats=False / dense_seq_q_trim=False)",
+)
 
 
 def _ref_sdpa(q, k, v, *, is_causal, scale):
@@ -81,7 +100,7 @@ def test_sdpa_fwd_dsl_sm100_graph_api(dtype, is_causal, d):
     graph.validate()
     graph.build_operation_graph()
     graph.create_execution_plans([cudnn.heur_mode.A])
-    _select_engine(graph, engine_name())
+    _select_engine(graph, engine_name(arch=_ARCH))
     graph.check_support()
     graph.build_plans()
     # Honest workspace: no Stats output, so the kernel compiles the LSE store
@@ -224,7 +243,7 @@ def _run_dsl_graph(
     g.validate()
     g.build_operation_graph()
     g.create_execution_plans([cudnn.heur_mode.A])
-    _select_engine(g, engine_name(), pack_gqa=pack_gqa)
+    _select_engine(g, engine_name(arch=_ARCH), pack_gqa=pack_gqa)
     g.check_support()
     g.build_plans()
     vp[o] = o_gpu
@@ -418,6 +437,7 @@ def test_dsl_sm100_padded(dtype, d):
     torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
 
 
+@_skip_stats_trim_on_rubin
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
 def test_dsl_sm100_graph_api_padded_bottom_right_gqa():
@@ -452,6 +472,7 @@ def test_dsl_sm100_graph_api_padded_bottom_right_gqa():
     torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
 
 
+@_skip_stats_trim_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("d_qk,d_v", [(128, 128), (192, 128), (256, 256), (512, 512)], ids=["llama_d128", "mla_d192_d128", "qwen_d256", "dsv4_d512"])
 @torch_fork_set_rng(seed=0)
@@ -522,6 +543,7 @@ def test_dsl_sm100_sink(dtype, d):
     torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
 
 
+@_skip_thd_on_rubin  # second half of this contract test is THD-only
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
 def test_dsl_sm100_execute_sink_lse_contract():
@@ -633,6 +655,7 @@ def _pack_gqa_case(d, h_q, h_kv, s_q, s_kv, dtype, *, sdpa_kwargs):
     return q, k, v, scale, o
 
 
+@_skip_pack_gqa_on_rubin
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
 def test_dsl_sm100_pack_gqa_false_pinned():
@@ -650,6 +673,7 @@ def test_dsl_sm100_pack_gqa_false_pinned():
     torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
 
 
+@_skip_pack_gqa_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize(
     "h_q,h_kv",
@@ -666,6 +690,7 @@ def test_dsl_sm100_pack_gqa_ratios(d, h_q, h_kv):
     torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
 
 
+@_skip_pack_gqa_on_rubin
 @pytest.mark.L1
 @pytest.mark.parametrize("h_q,h_kv", [(8, 2), (64, 1), (128, 1)], ids=["g4", "g64_mqa", "g128_mqa"])
 @pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)
@@ -681,6 +706,7 @@ def test_dsl_sm100_pack_gqa_d512(dtype, h_q, h_kv):
     torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
 
 
+@_skip_pack_gqa_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("h_q,s_q", [(64, 1), (64, 3), (128, 4)], ids=["g64_q1", "g64_q3_mtp", "g128_q4_mtp"])
 @torch_fork_set_rng(seed=0)
@@ -701,6 +727,7 @@ def test_dsl_sm100_pack_gqa_d512_mqa_decode(h_q, s_q):
     torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
 
 
+@_skip_pack_gqa_on_rubin
 @pytest.mark.L1
 @pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)
 @torch_fork_set_rng(seed=0)
@@ -717,6 +744,7 @@ def test_dsl_sm100_pack_gqa_d192_d128(dtype):
     torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
 
 
+@_skip_pack_gqa_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize(
     "d,h_q,h_kv,s_q",
@@ -741,6 +769,7 @@ def test_dsl_sm100_pack_gqa_tiles(d, h_q, h_kv, s_q):
     torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
 
 
+@_skip_pack_gqa_on_rubin
 @pytest.mark.L1
 @pytest.mark.parametrize("s_q", [1, 129, 1023, 2048])
 @torch_fork_set_rng(seed=0)
@@ -752,6 +781,7 @@ def test_dsl_sm100_pack_gqa_tiles_deep(s_q):
     torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
 
 
+@_skip_pack_gqa_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize(
     "mask",
@@ -795,6 +825,7 @@ def test_dsl_sm100_pack_gqa_features(mask):
     torch.testing.assert_close(lse.squeeze(-1), lse_ref, atol=5e-2, rtol=3e-2)
 
 
+@_skip_pack_gqa_on_rubin
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
 def test_dsl_sm100_pack_gqa_qtrim():
@@ -823,6 +854,7 @@ def test_dsl_sm100_pack_gqa_qtrim():
     torch.testing.assert_close(lse.squeeze(-1), lse_ref, atol=5e-2, rtol=3e-2)
 
 
+@_skip_pack_gqa_on_rubin
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
 def test_dsl_sm100_pack_gqa_knob_contract():
@@ -842,7 +874,7 @@ def test_dsl_sm100_pack_gqa_knob_contract():
         g.validate()
         g.build_operation_graph()
         g.create_execution_plans([cudnn.heur_mode.A])
-        name = engine_name()
+        name = engine_name(arch=_ARCH)
         out = []
         for i in range(len(g.plans)):
             pn = g.get_plan_name_at_index(i)
@@ -867,6 +899,7 @@ def test_dsl_sm100_pack_gqa_knob_contract():
     assert pg[0] is False and True in pg, f"full-prefill GQA should rank unpacked first with packed runner-up; got {pg}"
 
 
+@_skip_thd_on_rubin
 # THD/varlen: packed [T,H,D] + per-operand ragged_offset (exclusive-prefix-sum of
 # seq_len) + seq_len_q/kv + use_padding_mask. Each sequence attends only within
 # itself (no cross-sequence attention).
@@ -938,7 +971,7 @@ def test_dsl_sm100_thd(dtype, d):
     g.validate()
     g.build_operation_graph()
     g.create_execution_plans([cudnn.heur_mode.A])
-    _select_engine(g, engine_name())
+    _select_engine(g, engine_name(arch=_ARCH))
     g.check_support()
     g.build_plans()
     vp = {tq: q_gpu, tk: k_gpu, tv: v_gpu, o: o_gpu, sq: slq, skv: slk, qro: ro, kro: ro, vro: ro, oro: ro}
@@ -958,6 +991,7 @@ def test_dsl_sm100_thd(dtype, d):
     torch.testing.assert_close(o_out, o_ref, atol=5e-2, rtol=3e-2)
 
 
+@_skip_thd_on_rubin
 # Issue #624: a THD caller binds K/V at BUFFER CAPACITY, not at the packed
 # total, and the descriptor extent is the host-derived capacity. Rows in
 # [total, capacity) are therefore inside the extent and get loaded. They are
@@ -1039,7 +1073,7 @@ def test_dsl_sm100_thd_nan_capacity_tail(dtype, d_qk, d_v):
     g.validate()
     g.build_operation_graph()
     g.create_execution_plans([cudnn.heur_mode.A])
-    _select_engine(g, engine_name())
+    _select_engine(g, engine_name(arch=_ARCH))
     g.check_support()
     g.build_plans()
     vp = {tq: q_gpu, tk: k_gpu, tv: v_gpu, o: o_gpu, sq: slq, skv: slk, qro: ro_qk, kro: ro_qk, vro: ro_v, oro: ro_v}
@@ -1060,6 +1094,7 @@ def test_dsl_sm100_thd_nan_capacity_tail(dtype, d_qk, d_v):
     torch.testing.assert_close(o_out, o_ref, atol=5e-2, rtol=3e-2)
 
 
+@_skip_thd_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("d", _FLAVORS, ids=_FLAVOR_IDS)
 @pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)
@@ -1130,7 +1165,7 @@ def test_dsl_sm100_thd_cross(dtype, d):
     g.validate()
     g.build_operation_graph()
     g.create_execution_plans([cudnn.heur_mode.A])
-    _select_engine(g, engine_name())
+    _select_engine(g, engine_name(arch=_ARCH))
     g.check_support()
     g.build_plans()
     vp = {tq: q_gpu, tk: k_gpu, tv: v_gpu, o: o_gpu, sq: slq, skv: slk, qro: ro_q, kro: ro_k, vro: ro_k, oro: ro_q}
@@ -1300,7 +1335,7 @@ def _run_dsl_thd_graph(
     g.validate()
     g.build_operation_graph()
     g.create_execution_plans([cudnn.heur_mode.A])
-    _select_engine(g, engine_name())
+    _select_engine(g, engine_name(arch=_ARCH))
     g.check_support()
     g.build_plans()
     vp[o] = o_gpu
@@ -1445,6 +1480,7 @@ def _run_thd_stats_case(
         torch.testing.assert_close(got_lse, expected_lse, atol=2e-2, rtol=2e-2)
 
 
+@_skip_thd_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("stats_layout", ["token_major", "head_major"])
 @pytest.mark.parametrize("d", _FLAVORS, ids=_FLAVOR_IDS)
@@ -1457,6 +1493,7 @@ def test_dsl_sm100_thd_stats(d, stats_layout):
     _run_thd_stats_case(seq_lens_q=[200, 150], seq_lens_kv=[200, 150], d=d, mask="causal", stats_layout=stats_layout)
 
 
+@_skip_thd_on_rubin
 @pytest.mark.L1
 @torch_fork_set_rng(seed=32)
 def test_dsl_sm100_thd_swa_stats():
@@ -1466,6 +1503,7 @@ def test_dsl_sm100_thd_swa_stats():
     _run_thd_stats_case(seq_lens_q=[150, 90], seq_lens_kv=[150, 90], mask="swa", stats_layout="token_major")
 
 
+@_skip_thd_on_rubin
 @pytest.mark.L1
 @pytest.mark.parametrize("stats_layout", ["token_major", "head_major"])
 @torch_fork_set_rng(seed=25)
@@ -1476,6 +1514,7 @@ def test_dsl_sm100_thd_gqa_sink_stats(stats_layout):
     _run_thd_stats_case(seq_lens_q=[130, 70], seq_lens_kv=[130, 70], H_q=8, H_kv=2, mask="causal", with_sink=True, stats_layout=stats_layout)
 
 
+@_skip_thd_on_rubin
 @pytest.mark.L1
 @torch_fork_set_rng(seed=26)
 def test_dsl_sm100_thd_zero_length_sequence_stats():
@@ -1487,6 +1526,7 @@ def test_dsl_sm100_thd_zero_length_sequence_stats():
     _run_thd_stats_case(seq_lens_q=[128, 0, 64], seq_lens_kv=[100, 0, 0], mask="causal", stats_layout="token_major")
 
 
+@_skip_thd_on_rubin
 @pytest.mark.L1
 @pytest.mark.parametrize("stats_layout", ["token_major", "head_major"])
 @pytest.mark.parametrize("with_sink", [False, True], ids=["no_sink", "sink"])
@@ -1501,6 +1541,7 @@ def test_dsl_sm100_thd_all_kv_zero_stats(with_sink, stats_layout):
     _run_thd_stats_case(seq_lens_q=[64, 32], seq_lens_kv=[0, 0], mask="none", with_sink=with_sink, stats_layout=stats_layout)
 
 
+@_skip_thd_on_rubin
 @pytest.mark.L1
 @pytest.mark.parametrize("stats_layout", ["token_major", "head_major"])
 @torch_fork_set_rng(seed=34)
@@ -1514,6 +1555,7 @@ def test_dsl_sm100_thd_all_q_zero_stats(stats_layout):
     _run_thd_stats_case(seq_lens_q=[0, 0], seq_lens_kv=[0, 0], mask="none", stats_layout=stats_layout)
 
 
+@_skip_thd_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("stats_layout", ["token_major", "head_major"])
 @torch_fork_set_rng(seed=35)
@@ -1526,6 +1568,7 @@ def test_dsl_sm100_thd_cu_seq_len_stats(stats_layout):
     _run_thd_stats_case(seq_lens_q=[200, 150], seq_lens_kv=[200, 150], mask="causal", stats_layout=stats_layout, cu_lens=True)
 
 
+@_skip_thd_on_rubin
 @pytest.mark.L1
 @torch_fork_set_rng(seed=36)
 def test_dsl_sm100_thd_cu_seq_len_zero_lens():
@@ -1537,6 +1580,7 @@ def test_dsl_sm100_thd_cu_seq_len_zero_lens():
     _run_thd_stats_case(seq_lens_q=[64, 32], seq_lens_kv=[0, 0], mask="none", cu_lens=True)
 
 
+@_skip_thd_on_rubin
 @pytest.mark.L0
 @torch_fork_set_rng(seed=37)
 def test_dsl_sm100_thd_compile_key_plan_time_only():
@@ -1589,6 +1633,7 @@ def test_dsl_sm100_thd_compile_key_plan_time_only():
     assert info_exec.hits >= info_plan.hits + 2
 
 
+@_skip_thd_on_rubin
 @pytest.mark.L0
 @torch_fork_set_rng(seed=38)
 def test_dsl_sm100_thd_over_launched_units_are_dead(monkeypatch):
@@ -1611,6 +1656,7 @@ def test_dsl_sm100_thd_over_launched_units_are_dead(monkeypatch):
     _run_thd_stats_case(seq_lens_q=[64, 32], seq_lens_kv=[0, 0], mask="none", stats_layout="token_major")
 
 
+@_skip_thd_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("d", _FLAVORS, ids=_FLAVOR_IDS)
 @torch_fork_set_rng(seed=41)
@@ -1637,6 +1683,7 @@ def test_dsl_sm100_thd_multi_unit_per_cta(monkeypatch, d):
     _run_thd_stats_case(seq_lens_q=lens, seq_lens_kv=lens, d=d, mask="causal", stats_layout="head_major")
 
 
+@_skip_thd_on_rubin
 @pytest.mark.L0
 @torch_fork_set_rng(seed=39)
 def test_dsl_sm100_thd_lens_never_reach_host():
@@ -1654,6 +1701,7 @@ def test_dsl_sm100_thd_lens_never_reach_host():
     _run_thd_stats_case(seq_lens_q=[200, 150], seq_lens_kv=[180, 120], mask="causal", stats_layout="head_major", cu_lens=True)
 
 
+@_skip_thd_on_rubin
 @pytest.mark.L0
 @torch_fork_set_rng(seed=41)
 def test_dsl_sm100_thd_execute_never_syncs():
@@ -1691,6 +1739,7 @@ def test_dsl_sm100_thd_execute_never_syncs():
     assert torch.equal(o, o_ref)
 
 
+@_skip_thd_on_rubin
 @pytest.mark.L1
 @torch_fork_set_rng(seed=44)
 def test_dsl_sm100_thd_cu_nonzero_base_normalized():
@@ -1725,6 +1774,7 @@ def test_dsl_sm100_thd_cu_nonzero_base_normalized():
     assert torch.equal(_run(0, 0), _run(1000, 7000))
 
 
+@_skip_thd_on_rubin
 @pytest.mark.L1
 @torch_fork_set_rng(seed=43)
 def test_dsl_sm100_thd_d192_d128_device_meta():
@@ -1763,6 +1813,7 @@ def test_dsl_sm100_thd_d192_d128_device_meta():
         off += length
 
 
+@_skip_thd_on_rubin
 @pytest.mark.L0
 @torch_fork_set_rng(seed=44)
 def test_dsl_sm100_thd_d192_d128_multi_unit_per_cta(monkeypatch):
@@ -1804,6 +1855,7 @@ def test_dsl_sm100_thd_d192_d128_multi_unit_per_cta(monkeypatch):
         off += length
 
 
+@_skip_thd_on_rubin
 @pytest.mark.L0
 @torch_fork_set_rng(seed=42)
 def test_dsl_sm100_thd_execute_cuda_graph_capture():
@@ -1862,6 +1914,7 @@ def test_dsl_sm100_thd_execute_cuda_graph_capture():
     _check([64, 33])
 
 
+@_skip_thd_on_rubin
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
 def test_dsl_sm100_thd_declared_total_bounds_capacity_tail():
@@ -1936,7 +1989,7 @@ def test_dsl_sm100_thd_declared_total_bounds_capacity_tail():
         g.validate()
         g.build_operation_graph()
         g.create_execution_plans([cudnn.heur_mode.A])
-        _select_engine(g, engine_name())
+        _select_engine(g, engine_name(arch=_ARCH))
         g.check_support()
         g.build_plans()
         o_buf = torch.zeros(T, H, d, device=dev, dtype=dtype)
@@ -1971,6 +2024,7 @@ def test_dsl_sm100_thd_declared_total_bounds_capacity_tail():
     assert torch.equal(declared_nan, undeclared_nan), "declaring the packed total must not change the result"
 
 
+@_skip_thd_on_rubin
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
 def test_dsl_sm100_thd_interleaved_kv_views():
@@ -2025,7 +2079,7 @@ def test_dsl_sm100_thd_interleaved_kv_views():
         g.validate()
         g.build_operation_graph()
         g.create_execution_plans([cudnn.heur_mode.A])
-        _select_engine(g, engine_name())
+        _select_engine(g, engine_name(arch=_ARCH))
         g.check_support()
         g.build_plans()
         o_buf = torch.zeros(T, H, d, device=dev, dtype=dtype)
@@ -2039,6 +2093,7 @@ def test_dsl_sm100_thd_interleaved_kv_views():
     assert torch.equal(o_views, o_packed), f"interleaved K/V views diverge from packed binding: max|diff|={(o_views - o_packed).abs().max().item()}"
 
 
+@_skip_thd_on_rubin
 @pytest.mark.L1
 @torch_fork_set_rng(seed=40)
 def test_dsl_sm100_thd_kv_zero_capacity_clamp():
@@ -2090,7 +2145,14 @@ def _combo_cases():
     cases, ids = [], []
     for flavor, dtype, heads, sink, layout in itertools.product(_FLAVORS, _DTYPES, ["mha", "gqa"], [False, True], ["dense", "thd"]):
         for mask in _COMBO_MASKS[layout]:
-            cases.append((flavor, dtype, heads, sink, layout, mask))
+            # THD is not ported to the Rubin f16 kernels, so its half of the
+            # cartesian is a capability decline there -- mark the PARAM, not
+            # the test, so the dense half still runs on Rubin.
+            cases.append(
+                pytest.param(flavor, dtype, heads, sink, layout, mask, marks=_skip_thd_on_rubin)
+                if layout == "thd"
+                else (flavor, dtype, heads, sink, layout, mask)
+            )
             ids.append(
                 "-".join(
                     [

--- a/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm107.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm107.py
@@ -15,6 +15,8 @@ so they run on any host.  End-to-end numerics ride the shared SM10x suites,
 which exercise whichever part is present.
 """
 
+import dataclasses
+
 import pytest
 
 from frost_test_utils import requires_dsl
@@ -28,8 +30,14 @@ _E4M3, _BF16_OUT = 0, 2
 _FLAVORS = [(128, 128), (256, 256), (512, 512)]
 
 
-def _load(flavor, rubin, **params):
-    return _load_sm100_kernel_module(flavor, TemplateParams(**params), rubin=rubin)
+def _load(flavor, rubin, *, fp8=False, pertensor=False, **params):
+    return _load_sm100_kernel_module(flavor, TemplateParams(**params), fp8=fp8, pertensor=pertensor, rubin=rubin)
+
+
+def _code_lines(src):
+    """Source with whole-line comments dropped -- the prose in these modules
+    quotes ``desc_version=1`` when explaining the hazard."""
+    return "\n".join(ln for ln in src.splitlines() if not ln.lstrip().startswith("#"))
 
 
 @pytest.mark.parametrize("flavor", _FLAVORS)
@@ -42,26 +50,65 @@ def test_f16_routes_to_the_sm107_sibling(flavor):
 # Which flavors' MMA-operand SMEM crosses 256 KiB -- the boundary above which a
 # version-0 tcgen05 descriptor cannot address the buffer.  d512 alone does: its
 # Q(u)O and K(u)V slabs are 128 KiB each, putting the P transfer ring at exactly
-# 262144.  Keep d128/d256 on version 0 so they stay byte-identical to the
-# shipped prefill_d128_fp8_sm107.py sibling.
+# 262144 (and, on the MXFP8 sibling, the scale-factor tiles near 292 KiB).  Keep
+# d128/d256 on version 0 so they stay byte-identical to the shipped
+# prefill_d128_fp8_sm107.py sibling.
 _NEEDS_DESC_V1 = {(512, 512)}
 
+# (kind, loader kwargs) for every SM107 dtype family, so the check below covers
+# the QUANTIZED kernels too -- the d512 MXFP8 sibling is where a missing
+# version-1 descriptor actually shipped (LSE = +inf, O = NaN on 100% of cells).
+# dtype_qkv=_E4M3 is load-bearing on the quantized arms: the FP8/MXFP8 SM107
+# bodies pin idesc k_dim=1 and raise unless TILE_K_HW=64, which only the FP8
+# dtypes select (config_sm107.tile_k_hw).
+_DTYPE_FAMILIES = [
+    ("f16", {}),
+    ("fp8", {"fp8": True, "pertensor": True, "dtype_qkv": _E4M3, "dtype_o": _BF16_OUT}),
+    ("mxfp8", {"fp8": True, "pertensor": False, "dtype_qkv": _E4M3, "dtype_o": _BF16_OUT}),
+]
 
+
+@pytest.mark.parametrize("kind,load_kw", _DTYPE_FAMILIES, ids=[k for k, _ in _DTYPE_FAMILIES])
 @pytest.mark.parametrize("flavor", _FLAVORS)
-def test_sm107_descriptor_version_matches_the_smem_budget(flavor):
+def test_sm107_descriptor_version_matches_the_smem_budget(flavor, kind, load_kw):
     """A version-0 descriptor's ``start_address`` is 14 bits = a 256 KiB
     window; Rubin raises the per-CTA cap to 327 KiB.  An operand buffer at or
     above 256 KiB therefore wraps to offset 0 and the MMA multiplies whatever
-    is at the bottom of SMEM -- O comes out EXACTLY zero, no crash, both
-    operands provably correct in SMEM, every race probe clean.
+    is at the bottom of SMEM -- O comes out EXACTLY zero (or, when the wrapped
+    tile is a scale factor, LSE = +inf and O = NaN), no crash, both operands
+    provably correct in SMEM, every race probe clean.
+
+    Asserted against the module's own ``DESC_VERSION`` constant, which every
+    ``SmemTile`` in that module is constructed with -- so this pins the value
+    the kernel actually uses, not the presence of a substring that a comment
+    could also supply.
 
     This is the counter-assertion for the flavors below the boundary: if a tile
     config ever pushes one of them over 256 KiB, move it into _NEEDS_DESC_V1
-    and set desc_version=1 on its operand tiles -- do not delete the check."""
-    mod = _load(flavor, rubin=True)
-    src = open(mod.__file__).read() if getattr(mod, "__file__", None) else ""
-    has_v1 = "desc_version=1" in src
-    assert has_v1 is (flavor in _NEEDS_DESC_V1), f"{mod.__name__}: desc_version=1 present={has_v1}, expected={flavor in _NEEDS_DESC_V1}"
+    and flip its DESC_VERSION -- do not delete the check."""
+    mod = _load(flavor, rubin=True, **load_kw)
+    want = 1 if flavor in _NEEDS_DESC_V1 else 0
+    assert mod.DESC_VERSION == want, f"{mod.__name__}: DESC_VERSION={mod.DESC_VERSION}, expected {want}"
+
+
+@pytest.mark.parametrize("kind,load_kw", _DTYPE_FAMILIES, ids=[k for k, _ in _DTYPE_FAMILIES])
+@pytest.mark.parametrize("flavor", _FLAVORS)
+def test_sm107_every_smem_tile_takes_the_module_desc_version(flavor, kind, load_kw):
+    """DESC_VERSION is only meaningful if EVERY ``SmemTile`` is built with it.
+    The d512 MXFP8 kernel shipped NaN on 100% of cells because its four
+    scale-factor tiles were declared under a comment claiming "every operand
+    tile here carries desc_version=1" -- without the kwarg.  One re-literalled
+    call site is all it takes, so count them."""
+    import re
+
+    mod = _load(flavor, rubin=True, **load_kw)
+    with open(mod.__file__, encoding="utf-8") as fh:
+        code = _code_lines(fh.read())
+    n_tiles = len(re.findall(r"\bSmemTile\($", code, re.M))
+    assert n_tiles > 0, mod.__name__
+    n_wired = code.count("desc_version=DESC_VERSION")
+    assert n_wired == n_tiles, f"{mod.__name__}: {n_tiles} SmemTile(s) but {n_wired} wired to DESC_VERSION"
+    assert not re.search(r"desc_version=[01]\b", code), f"{mod.__name__}: a re-literalled desc_version bypasses DESC_VERSION"
 
 
 def test_sm107_f16_kernels_do_not_claim_thd():
@@ -102,9 +149,16 @@ def test_rubin_f16_never_picks_a_flavor_it_has_no_kernel_for():
     rubin_fp8_pool = tuple(f for f in _SM100_FLAVORS if f in _SM107_FP8_KERNEL_FILES)
     assert (192, 128) not in rubin_fp8_pool
     assert _pick_flavor(192, 128, rubin_fp8_pool) == (256, 256)
-    # Every flavor Rubin can pick has a module on disk.
+    # Every flavor Rubin can pick has a module ON DISK -- the map is the only
+    # thing standing between _pick_flavor and a KeyError/ImportError deep in
+    # module loading, so check the file, not the map key it came from.
+    import pathlib
+
+    import cudnn.sdpa.fwd.kernels as _k
+
+    kdir = pathlib.Path(_k.__file__).parent
     for flavor in rubin_pool:
-        assert flavor in _SM107_KERNEL_FILES
+        assert (kdir / _SM107_KERNEL_FILES[flavor]).is_file(), (flavor, _SM107_KERNEL_FILES[flavor])
 
 
 # --------------------------------------------------------------------------
@@ -190,12 +244,22 @@ def test_sm107_f16_accepts_the_measured_feature_set(feature):
     assert engines.mismatch(_caps("sdpa_fwd_prefill_sm107"), _f16_facts(**feature)) is None
 
 
-def test_sm107_f16_serves_d192_through_the_d256_envelope():
-    """No native d192xd128 Rubin kernel, but the graph is still served -- it
-    rides the next covering envelope at that flavor's MMA cost."""
+def test_sm107_f16_serves_d192_on_its_native_kernel():
+    """d192xd128 is a NATIVE f16 Rubin flavor (``prefill_d192_d128_f16_sm107.py``
+    -- the d128 body with ``make_cfg_d192``), not an envelope ride.
+
+    Both halves of that claim are pinned, because they can drift apart
+    silently: the row must LIST the shape (an envelope acceptance would pass
+    this assertion too, which is why the d_shapes membership is asserted
+    separately), and the adapter must PICK the native kernel for it
+    (test_rubin_f16_never_picks_a_flavor_it_has_no_kernel_for).  The FP8 and
+    MXFP8 Rubin lines genuinely lack the sibling -- see
+    test_sdpa_fp8_sm107.py, where d192 is DECLINED rather than padded."""
     from cudnn.sdpa.fwd import engines
 
-    assert engines.mismatch(_caps("sdpa_fwd_prefill_sm107"), _f16_facts(d_qk=192, d_v=128)) is None
+    caps = _caps("sdpa_fwd_prefill_sm107")
+    assert (192, 128) in caps.d_shapes
+    assert engines.mismatch(caps, _f16_facts(d_qk=192, d_v=128)) is None
 
 
 def test_sm107_f16_declines_thd():
@@ -268,6 +332,16 @@ def test_sched_points_falls_back_along_the_preference_order():
     # Single-element domain today (see the row): the ranking must still be that
     # one element, never a NATURAL fallback bolted on beside it.
     assert points == [SCHED_NATURAL], points
+
+    # ...and the multi-element case, which is the branch the single-element
+    # shortcut above skips: with a causal primary (LPT_L2) OUT of domain, the
+    # fallback must walk the preference order rather than dropping straight to
+    # NATURAL -- the bug this function was fixed for.
+    widened = dataclasses.replace(rubin_fp8, sched_policies=frozenset({SCHED_NATURAL, SCHED_LPT}))
+    widened_points = heuristics._sched_points(widened, facts)
+    assert widened_points[0] == SCHED_LPT, widened_points
+    assert set(widened_points) == {SCHED_NATURAL, SCHED_LPT}, widened_points
+    assert len(widened_points) == len(set(widened_points)), widened_points
 
 
 def test_sm107_rows_claim_optional_stats():

--- a/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm107.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm107.py
@@ -1,0 +1,301 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SM107 (Rubin) routing of the f16/bf16 forward SDPA kernels.
+
+The adapter routes cc10.7 graphs to the SM107 sibling modules, which bake the
+Rubin geometry the Blackwell modules cannot express — notably the **version-1
+tcgen05 SMEM descriptor** every operand tile needs once the per-CTA SMEM budget
+passes 256 KiB (a version-0 descriptor's ``start_address`` is 14 bits, so a
+buffer at 256 KiB wraps to offset 0 and the MMA silently multiplies whatever
+lives at the bottom of SMEM).
+
+These tests are device-independent: everything here happens before any compile,
+so they run on any host.  End-to-end numerics ride the shared SM10x suites,
+which exercise whichever part is present.
+"""
+
+import pytest
+
+from frost_test_utils import requires_dsl
+
+from cudnn.sdpa.fwd.api_dsl import _load_sm100_kernel_module
+from cudnn.sdpa.fwd.config_sm100 import TemplateParams
+
+pytestmark = [pytest.mark.L0, requires_dsl]
+
+_E4M3, _BF16_OUT = 0, 2
+_FLAVORS = [(128, 128), (256, 256), (512, 512)]
+
+
+def _load(flavor, rubin, **params):
+    return _load_sm100_kernel_module(flavor, TemplateParams(**params), rubin=rubin)
+
+
+@pytest.mark.parametrize("flavor", _FLAVORS)
+def test_f16_routes_to_the_sm107_sibling(flavor):
+    """Every f16 flavor has a Rubin sibling, and Blackwell keeps the SM100 one."""
+    assert "sm107" in _load(flavor, rubin=True).__name__
+    assert "sm100" in _load(flavor, rubin=False).__name__
+
+
+# Which flavors' MMA-operand SMEM crosses 256 KiB -- the boundary above which a
+# version-0 tcgen05 descriptor cannot address the buffer.  d512 alone does: its
+# Q(u)O and K(u)V slabs are 128 KiB each, putting the P transfer ring at exactly
+# 262144.  Keep d128/d256 on version 0 so they stay byte-identical to the
+# shipped prefill_d128_fp8_sm107.py sibling.
+_NEEDS_DESC_V1 = {(512, 512)}
+
+
+@pytest.mark.parametrize("flavor", _FLAVORS)
+def test_sm107_descriptor_version_matches_the_smem_budget(flavor):
+    """A version-0 descriptor's ``start_address`` is 14 bits = a 256 KiB
+    window; Rubin raises the per-CTA cap to 327 KiB.  An operand buffer at or
+    above 256 KiB therefore wraps to offset 0 and the MMA multiplies whatever
+    is at the bottom of SMEM -- O comes out EXACTLY zero, no crash, both
+    operands provably correct in SMEM, every race probe clean.
+
+    This is the counter-assertion for the flavors below the boundary: if a tile
+    config ever pushes one of them over 256 KiB, move it into _NEEDS_DESC_V1
+    and set desc_version=1 on its operand tiles -- do not delete the check."""
+    mod = _load(flavor, rubin=True)
+    src = open(mod.__file__).read() if getattr(mod, "__file__", None) else ""
+    has_v1 = "desc_version=1" in src
+    assert has_v1 is (flavor in _NEEDS_DESC_V1), f"{mod.__name__}: desc_version=1 present={has_v1}, expected={flavor in _NEEDS_DESC_V1}"
+
+
+def test_sm107_f16_kernels_do_not_claim_thd():
+    """THD is NOT ported: the setup-kernel call site still speaks the
+    pre-upstream 7-arg contract against a 14-arg helper, and the metadata
+    layout differs (3B+2 vs 4B+4).  compile() must refuse loudly rather than
+    fail as an arity error deep in a trace -- and no engine row may advertise
+    it."""
+    mod = _load((128, 128), rubin=True, seq_kv_lens_present=True)
+    assert mod.CFG.THD_VARLEN == 0
+
+
+def test_rubin_f16_never_picks_a_flavor_it_has_no_kernel_for():
+    """The adapter must narrow the f16 candidate pool BY ARCH LINE, or a graph
+    picks a flavor with no Rubin module and dies with a KeyError inside module
+    loading instead of riding the next covering envelope.
+
+    PARTIALLY INVERTED 2026-09-04: d192xd128 now HAS a Rubin sibling
+    (``prefill_d192_d128_f16_sm107.py`` -- the same body as d128 with
+    ``make_cfg_d192``), so a d=192 f16 graph lowers onto the NATIVE kernel
+    instead of riding the d256 envelope.  The pool-narrowing invariant is
+    unchanged and is what this test really pins; the FP8/MXFP8 lines still have
+    no d192 sibling, which is why the narrowing cannot be deleted.
+    """
+    from cudnn.sdpa.fwd.api_dsl import (
+        _SM100_FLAVORS,
+        _SM107_FP8_KERNEL_FILES,
+        _SM107_KERNEL_FILES,
+        _pick_flavor,
+    )
+
+    rubin_pool = tuple(f for f in _SM100_FLAVORS if f in _SM107_KERNEL_FILES)
+    assert _pick_flavor(192, 128, rubin_pool) == (192, 128)
+    # Blackwell keeps its native d192xd128 kernel.
+    assert _pick_flavor(192, 128, None) == (192, 128)
+    # The quantized Rubin lines have NO d192 sibling -- a d=192 FP8 graph must
+    # still ride the next covering envelope rather than KeyError.
+    rubin_fp8_pool = tuple(f for f in _SM100_FLAVORS if f in _SM107_FP8_KERNEL_FILES)
+    assert (192, 128) not in rubin_fp8_pool
+    assert _pick_flavor(192, 128, rubin_fp8_pool) == (256, 256)
+    # Every flavor Rubin can pick has a module on disk.
+    for flavor in rubin_pool:
+        assert flavor in _SM107_KERNEL_FILES
+
+
+# --------------------------------------------------------------------------
+# Capability row: what sdpa_fwd_prefill_sm107 accepts, and what it declines.
+# Every accept below corresponds to a case MEASURED on Rubin against an
+# explicit fp32 reference; every decline corresponds to machinery the kernels
+# genuinely lack.  Declines are asserted, never skipped -- and the ones marked
+# INVERTS-WHEN are counter-assertions to flip, not delete, when the feature
+# lands.
+# --------------------------------------------------------------------------
+
+
+def _f16_facts(**kw):
+    import cudnn
+    from cudnn.sdpa import graph_analyzer as ga
+
+    base = dict(
+        b=2,
+        h_q=8,
+        h_kv=8,
+        s_q=512,
+        s_kv=512,
+        d_qk=128,
+        d_v=128,
+        dtype=cudnn.data_type.HALF,
+        dtype_o=cudnn.data_type.HALF,
+        device_cc=(10, 7),
+    )
+    base.update(kw)
+    return ga.SdpaGraphFacts(**base)
+
+
+def _caps(name):
+    from cudnn.sdpa.fwd import engines
+
+    return {s.name: s.capabilities for s in engines.ENGINE_SPECS}[name]
+
+
+def test_sm107_f16_row_owns_the_rubin_lane():
+    """One row per ARCH LINE: sm100 stops at cc 10.6, sm107 starts at 10.7."""
+    from cudnn.sdpa.fwd import engines
+
+    sm107, sm100 = _caps("sdpa_fwd_prefill_sm107"), _caps("sdpa_fwd_prefill_sm100")
+    assert engines.mismatch(sm107, _f16_facts()) is None
+    assert "SM107-119" in engines.mismatch(sm107, _f16_facts(device_cc=(10, 0)))
+    assert "SM100-106" in engines.mismatch(sm100, _f16_facts(device_cc=(10, 7)))
+
+
+@pytest.mark.parametrize("d", [(128, 128), (256, 256), (512, 512)])
+def test_sm107_f16_accepts_every_native_shape(d):
+    from cudnn.sdpa.fwd import engines
+
+    assert engines.mismatch(_caps("sdpa_fwd_prefill_sm107"), _f16_facts(d_qk=d[0], d_v=d[1])) is None
+
+
+def test_sm107_f16_accepts_both_dtypes():
+    """A frozenset field is one claim PER MEMBER -- exercise bf16, not just the
+    fp16 the suite happens to default to."""
+    import cudnn
+    from cudnn.sdpa.fwd import engines
+
+    caps = _caps("sdpa_fwd_prefill_sm107")
+    for dt in (cudnn.data_type.HALF, cudnn.data_type.BFLOAT16):
+        assert engines.mismatch(caps, _f16_facts(dtype=dt, dtype_o=dt)) is None
+
+
+@pytest.mark.parametrize(
+    "feature",
+    [
+        dict(causal=True),
+        dict(causal=True, bottom_right=True),
+        dict(right_band_widening=True),
+        dict(window_left=128, causal=True),
+        dict(padded=True),
+        dict(has_sink=True),
+        dict(h_kv=2),  # GQA 4:1
+    ],
+)
+def test_sm107_f16_accepts_the_measured_feature_set(feature):
+    """Each of these was validated on Rubin (cos = 1.000000)."""
+    from cudnn.sdpa.fwd import engines
+
+    assert engines.mismatch(_caps("sdpa_fwd_prefill_sm107"), _f16_facts(**feature)) is None
+
+
+def test_sm107_f16_serves_d192_through_the_d256_envelope():
+    """No native d192xd128 Rubin kernel, but the graph is still served -- it
+    rides the next covering envelope at that flavor's MMA cost."""
+    from cudnn.sdpa.fwd import engines
+
+    assert engines.mismatch(_caps("sdpa_fwd_prefill_sm107"), _f16_facts(d_qk=192, d_v=128)) is None
+
+
+def test_sm107_f16_declines_thd():
+    """INVERTS-WHEN the THD setup-kernel contract is ported: the call site
+    still passes 7 args to a 14-arg helper and the metadata layout differs
+    (3B+2 vs 4B+4).  Asserted on a real facts object, not just the dataclass
+    field, so it exercises the path mismatch() actually walks."""
+    from cudnn.sdpa.fwd import engines
+
+    caps = _caps("sdpa_fwd_prefill_sm107")
+    assert caps.thd is False
+    assert engines.mismatch(caps, _f16_facts(thd=True, padded=True)) is not None
+
+
+def test_sm107_f16_declines_split_kv_and_pack_gqa():
+    """Neither is wired in these kernels (no SplitHelpers, no PackGQA path)."""
+    from cudnn.sdpa.fwd import engines
+
+    caps = _caps("sdpa_fwd_prefill_sm107")
+    assert caps.split_kv_supported is False
+    assert caps.pack_gqas == frozenset({False})
+    assert engines.mismatch(caps, _f16_facts(), engines.SdpaFwdKnobs(split_kv=2)) is not None
+    assert engines.mismatch(caps, _f16_facts(), engines.SdpaFwdKnobs(pack_gqa=True)) is not None
+
+
+def test_sm107_f16_declines_the_stats_trim_it_lacks():
+    """padded_stats / dense_seq_q_trim both need the per-batch seq_len_q LSE
+    trim (padded q rows write LSE=-inf, O=0), which these kernels do not
+    carry.  INVERTS-WHEN that epilogue lands."""
+    caps = _caps("sdpa_fwd_prefill_sm107")
+    assert caps.padded_stats is False
+    assert caps.dense_seq_q_trim is False
+
+
+def test_sm107_rows_serve_natural_scheduling_only():
+    """SCHED_LPT is NOT honored by the ported Rubin kernels: with the row
+    claiming it, a causal graph picks LPT and comes back with max|O-ref| ~ 1.9
+    (dense stays correct).  Session 6 had already dropped SCHED_LPT_L2 for the
+    same reason -- the ported decode sites never thread qh_per_kh / seqlen_kv --
+    and LPT only stayed hidden because heuristics could not REACH it (its causal
+    primary is LPT_L2, and the old out-of-domain fallback dropped to NATURAL).
+
+    A knob is honored or the engine is ineligible.  INVERTS-WHEN the LPT decode
+    is threaded and validated on the ported Rubin kernels."""
+    from cudnn.frost.tile_dsl.constants import SCHED_LPT, SCHED_LPT_L2, SCHED_NATURAL
+
+    for row in ("sdpa_fwd_prefill_sm107", "sdpa_fwd_prefill_sm107_fp8", "sdpa_fwd_prefill_sm107_mxfp8"):
+        caps = _caps(row)
+        assert caps.sched_policies == frozenset({SCHED_NATURAL}), row
+        assert SCHED_LPT not in caps.sched_policies, row
+        assert SCHED_LPT_L2 not in caps.sched_policies, row
+
+
+def test_sched_points_falls_back_along_the_preference_order():
+    """A row whose heuristic primary is outside its DOMAIN must fall back along
+    the same preference order, not drop to NATURAL -- and must not list a policy
+    twice.  The old form returned [NATURAL, LPT, NATURAL] for a causal Rubin FP8
+    graph: NATURAL first (losing the LPT balancing) and a duplicate autotune
+    slot.  Rows whose primary IS in domain are unaffected."""
+    from cudnn.frost.tile_dsl.constants import SCHED_LPT, SCHED_LPT_L2, SCHED_NATURAL
+    from cudnn.sdpa.fwd import engines, heuristics
+
+    caps = {s.name: s.capabilities for s in engines.ENGINE_SPECS}
+    rubin_fp8 = caps["sdpa_fwd_prefill_sm107_fp8"]
+    facts = _f16_facts()
+    facts = facts.__class__(**{**facts.__dict__, "causal": True, "is_fp8": True, "device_cc": (10, 7)})
+    points = heuristics._sched_points(rubin_fp8, facts)
+    assert len(points) == len(set(points)), points
+    assert SCHED_LPT_L2 not in rubin_fp8.sched_policies
+    # Single-element domain today (see the row): the ranking must still be that
+    # one element, never a NATURAL fallback bolted on beside it.
+    assert points == [SCHED_NATURAL], points
+
+
+def test_sm107_rows_claim_optional_stats():
+    """INVERTED 2026-09-08: every Rubin kernel now const_expr's its LSE store
+    out on a None ``lse_tensor`` and ``compile(has_lse=False)`` binds no dummy
+    buffer, so a stats-less graph reports ``get_workspace_size() == 0``.  The
+    FP8 row already claimed this from the shared spec -- which was a LIE for the
+    d256/d512 FP8 kernels it was widened to in the session-5 work, and is now
+    true."""
+    for row in ("sdpa_fwd_prefill_sm107", "sdpa_fwd_prefill_sm107_fp8", "sdpa_fwd_prefill_sm107_mxfp8"):
+        assert _caps(row).lse_optional is True, row
+
+
+def test_rubin_mxfp8_forward_row_exists():
+    """INVERTED 2026-09-04: the Rubin MXFP8 row landed (slot 16).  It is WIDER
+    than its Blackwell counterpart at the top end -- Rubin has a d512 MXFP8
+    kernel and SM100 does not -- and narrower at d192xd128, which has no Rubin
+    MXFP8 sibling.  SM100's row stays capped at cc 10.6."""
+    from cudnn.sdpa.fwd import engines
+
+    caps = _caps("sdpa_fwd_prefill_sm107_mxfp8")
+    assert caps.is_mxfp8 is True
+    assert caps.d_shapes == frozenset({(128, 128), (256, 256), (512, 512)})
+    assert (512, 512) not in _caps("sdpa_fwd_prefill_sm100_mxfp8").d_shapes
+    assert (192, 128) not in caps.d_shapes
+    # Exact-native only: the SF tensors are not zero-padded.
+    assert caps.d_pad_multiple == 0
+    # The machinery the ported kernels lack stays declined.
+    assert caps.thd is False and caps.split_kv_supported is False
+    assert caps.pack_gqas == frozenset({False})
+    assert _caps("sdpa_fwd_prefill_sm100_mxfp8").sm_hi == 106

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -39,8 +39,43 @@ pytestmark = [requires_blackwell, requires_dsl]
 # under test. The d192xd128 kernel flavor exists on the sm100 engine only.
 _D128_ARCH = "sm107" if _SM == 107 else "sm100"
 _skip_on_rubin = pytest.mark.skipif(_SM == 107, reason="the d192xd128 per-tensor FP8 flavor has no Rubin kernel (sm107 serves d128 only)")
-_skip_d256_on_rubin = pytest.mark.skipif(_SM == 107, reason="the d256xd256 per-tensor FP8 flavor has no Rubin kernel (sm107 serves d128 only)")
+# d256 is SERVED on Rubin as of the SM107 port -- kept as a no-op marker so
+# the many _D128_D256 call sites need no churn.
+_skip_d256_on_rubin = pytest.mark.skipif(False, reason="d256 per-tensor FP8 is served on Rubin")
 _D128_D256 = [pytest.param(128, id="d128"), pytest.param(256, id="d256", marks=_skip_d256_on_rubin)]
+# Same gate, accurate for ANY flavor wider than d128 (the d192xd128 THD case
+# below needs it too, and the d256-specific wording would read wrong there).
+# Only d192xd128 lacks a Rubin per-tensor FP8 kernel now.
+_skip_wide_fp8_on_rubin = pytest.mark.skipif(False, reason="d256/d512 per-tensor FP8 are served on Rubin")
+
+# Rubin serves per-tensor FP8 at d128/d256/d512, but its THD and PackGQA legs
+# are d128-ONLY -- the row says so per shape (`thd_d_shapes` /
+# `pack_gqa_d_shapes` are both frozenset({(128, 128)})), so a d256/d512 THD or
+# PackGQA graph is DECLINED and the test cannot run.  Honest capability gaps,
+# not kernel bugs; flip the condition when the ported kernels grow the legs.
+_skip_wide_thd_on_rubin = pytest.mark.skipif(
+    _SM == 107,
+    reason="THD/varlen is d128-only on the Rubin FP8 line (row: thd_d_shapes={(128,128)})",
+)
+_skip_wide_pack_gqa_on_rubin = pytest.mark.skipif(
+    _SM == 107,
+    reason="PackGQA is d128-only on the Rubin FP8 line (row: pack_gqa_d_shapes={(128,128)})",
+)
+_D128_D256_THD = [pytest.param(128, id="d128"), pytest.param(256, id="d256", marks=_skip_wide_thd_on_rubin)]
+_D128_D256_PACK_GQA = [pytest.param(128, id="d128"), pytest.param(256, id="d256", marks=_skip_wide_pack_gqa_on_rubin)]
+
+# The PORTED d256/d512 Rubin FP8 kernels carry neither a strided-Stats store
+# (compile() raises "strided Stats not ported (contiguous [B, H, S] only)") nor
+# the per-batch seq_len_q O/LSE trim (row: padded_stats / dense_seq_q_trim are
+# both off for the Rubin line).  Honest declines; flip when either lands.
+_skip_wide_strided_stats_on_rubin = pytest.mark.skipif(
+    _SM == 107,
+    reason="strided Stats not ported to the wide Rubin FP8 kernels (contiguous [B,H,S] only)",
+)
+_skip_dense_q_trim_on_rubin = pytest.mark.skipif(
+    _SM == 107,
+    reason="dense padded-Q O/LSE trim not carried by the Rubin kernels (row: dense_seq_q_trim=False)",
+)
 
 _FP8 = {"e4m3": torch.float8_e4m3fn, "e5m2": torch.float8_e5m2}
 _FP8_MAX = {"e4m3": 448.0, "e5m2": 57344.0}
@@ -323,8 +358,10 @@ _MASKS = {
 
 
 def _check_fp8_strided_stats(d_qk, d_v, in_key):
-    if torch.cuda.get_device_capability() == (10, 7) and d_qk != 128:
-        pytest.skip("SM107 per-tensor FP8 supports only d128")
+    # Rubin now ships d128/d256/d512 per-tensor FP8; d192xd128 still has no
+    # sibling there, so that one flavor stays skipped.
+    if torch.cuda.get_device_capability() == (10, 7) and (d_qk, d_v) == (192, 128):
+        pytest.skip("SM107 per-tensor FP8 has no d192xd128 kernel")
     kwargs = dict(
         B=2,
         H_q=4,
@@ -614,6 +651,7 @@ def test_fp8_d256_masks(in_key, mask):
     _check(out, o_ref, torch.float16, in_key, a_o, a_o_ref)
 
 
+@_skip_wide_strided_stats_on_rubin
 @pytest.mark.L1
 @_skip_d256_on_rubin
 @pytest.mark.parametrize("in_key", _INS)
@@ -702,6 +740,7 @@ def test_fp8_d256_padding(in_key, causal):
     _check(out, o_ref, torch.float16, in_key, a_o, a_o_ref)
 
 
+@_skip_dense_q_trim_on_rubin
 @pytest.mark.L1
 @_skip_d256_on_rubin
 @torch_fork_set_rng(seed=0)
@@ -822,7 +861,7 @@ def test_fp8_gqa(in_key):
     [(8, 4), (8, 2), (8, 1), (16, 1)],
     ids=["g2", "g4", "g8_mqa", "g16_mqa"],
 )
-@pytest.mark.parametrize("d", _D128_D256)
+@pytest.mark.parametrize("d", _D128_D256_PACK_GQA)
 @torch_fork_set_rng(seed=0)
 def test_fp8_pack_gqa_ratios(d, h_q, h_kv):
     """Packed plans across GQA ratios, causal, tile-unaligned s_q, LSE checked."""
@@ -865,7 +904,7 @@ def test_fp8_pack_gqa_tiles(s_q):
     "mask",
     ["none_padded", "causal", "causal_br", "swa", "sink_causal"],
 )
-@pytest.mark.parametrize("d", _D128_D256)
+@pytest.mark.parametrize("d", _D128_D256_PACK_GQA)
 @torch_fork_set_rng(seed=0)
 def test_fp8_pack_gqa_features(d, mask, out_dt):
     """Packed plans x the fp8 mask/sink envelope x both output dtypes."""
@@ -906,7 +945,7 @@ def test_fp8_pack_gqa_features(d, mask, out_dt):
 
 
 @pytest.mark.L1
-@pytest.mark.parametrize("d", _D128_D256)
+@pytest.mark.parametrize("d", _D128_D256_PACK_GQA)
 @torch_fork_set_rng(seed=0)
 def test_fp8_pack_gqa_e5m2(d):
     """Packed e5m2 input path."""
@@ -1380,7 +1419,18 @@ def test_fp8_d192_d128_thd_features():
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("d_qk,d_v", [(128, 128), (192, 128), (256, 256)], ids=["d128", "d192_d128", "d256"])
+# Rubin serves d128 only on this row, so the two wider flavors have no kernel
+# there -- same gate _D128_D256 applies, spelled out because this list is
+# inline.  Without it the test pins sdpa_fwd_prefill_sm107_fp8 for a shape
+# the row correctly declines and fails with "no plan for engine".
+@pytest.mark.parametrize(
+    "d_qk,d_v",
+    [
+        pytest.param(128, 128, id="d128"),
+        pytest.param(192, 128, id="d192_d128", marks=_skip_wide_thd_on_rubin),
+        pytest.param(256, 256, id="d256", marks=_skip_wide_thd_on_rubin),
+    ],
+)
 @torch_fork_set_rng(seed=0)
 def test_fp8_thd_multi_unit_per_cta(monkeypatch, d_qk, d_v):
     """THD where a cluster claims more than one unit (issue #618).
@@ -1396,6 +1446,7 @@ def test_fp8_thd_multi_unit_per_cta(monkeypatch, d_qk, d_v):
     _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
 
 
+@_skip_wide_thd_on_rubin
 @pytest.mark.L0
 @_skip_d256_on_rubin
 @pytest.mark.parametrize("in_key", _INS)
@@ -1418,7 +1469,7 @@ def test_fp8_d256_thd(in_key, causal):
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("d", _D128_D256)
+@pytest.mark.parametrize("d", _D128_D256_THD)
 @pytest.mark.parametrize("in_key", _INS)
 @pytest.mark.parametrize("bottom_right", [False, True])
 @torch_fork_set_rng(seed=0)
@@ -1445,7 +1496,7 @@ def test_fp8_thd_sliding_window(d, in_key, bottom_right):
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("d", _D128_D256)
+@pytest.mark.parametrize("d", _D128_D256_THD)
 @torch_fork_set_rng(seed=0)
 def test_fp8_thd_cross_gqa(d):
     """THD cross-attention (unequal packed Q and K/V totals) with GQA heads."""
@@ -1455,7 +1506,7 @@ def test_fp8_thd_cross_gqa(d):
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("d", _D128_D256)
+@pytest.mark.parametrize("d", _D128_D256_THD)
 @torch_fork_set_rng(seed=0)
 def test_fp8_thd_sink(d):
     """THD causal + attention sink."""
@@ -1466,7 +1517,7 @@ def test_fp8_thd_sink(d):
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("d", _D128_D256)
+@pytest.mark.parametrize("d", _D128_D256_THD)
 @torch_fork_set_rng(seed=0)
 def test_fp8_thd_stats(d):
     """THD + generate_stats: the ragged token-major TH1 LSE is written next to O."""
@@ -1477,7 +1528,7 @@ def test_fp8_thd_stats(d):
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("d", _D128_D256)
+@pytest.mark.parametrize("d", _D128_D256_THD)
 @torch_fork_set_rng(seed=0)
 def test_fp8_thd_zero_len_kv(d):
     """Zero-length Q and KV sequences (test_mhas_v2 ragged parity, e.g.
@@ -1493,7 +1544,7 @@ def test_fp8_thd_zero_len_kv(d):
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("d", _D128_D256)
+@pytest.mark.parametrize("d", _D128_D256_THD)
 @torch_fork_set_rng(seed=0)
 def test_fp8_thd_cu_seq_len(d):
     """THD via the (B+1,) cu_seq_len prefix-sum length form."""
@@ -1596,7 +1647,7 @@ def test_fp8_sm100_device_scales_execute_reads_no_device_memory():
 # kernel, so this whole section is sm100-only.
 # ===========================================================================
 
-_skip_d512_on_rubin = pytest.mark.skipif(_SM == 107, reason="the d512 per-tensor FP8 flavor has no Rubin kernel (sm107 serves d128 only)")
+_skip_d512_on_rubin = pytest.mark.skipif(False, reason="d512 per-tensor FP8 is served on Rubin")
 _D512 = 512
 _D512_SCALE = 1.0 / math.sqrt(_D512)
 
@@ -1685,6 +1736,7 @@ def test_fp8_d512_multi_tile():
 # --- d512 THD / varlen -----------------------------------------------------
 
 
+@_skip_wide_thd_on_rubin
 @pytest.mark.L0
 @_skip_d512_on_rubin
 @pytest.mark.parametrize("in_key", _INS)
@@ -1697,6 +1749,7 @@ def test_fp8_d512_thd(in_key, causal):
     _check(out, o_ref, torch.float16, in_key, a_o, a_o_ref)
 
 
+@_skip_wide_thd_on_rubin
 @pytest.mark.L0
 @_skip_d512_on_rubin
 @torch_fork_set_rng(seed=0)
@@ -1707,6 +1760,7 @@ def test_fp8_d512_thd_cross_gqa():
     _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
 
 
+@_skip_wide_thd_on_rubin
 @pytest.mark.L0
 @_skip_d512_on_rubin
 @torch_fork_set_rng(seed=0)
@@ -1719,6 +1773,7 @@ def test_fp8_d512_thd_sink_stats():
     assert diff <= 5e-2, f"max|LSE-ref| = {diff:.4f}"
 
 
+@_skip_wide_thd_on_rubin
 @pytest.mark.L0
 @_skip_d512_on_rubin
 @torch_fork_set_rng(seed=0)
@@ -1741,6 +1796,7 @@ def test_fp8_d512_thd_zero_len_kv():
     _check(out, o_ref, torch.float16, "e5m2", a_o, a_o_ref)
 
 
+@_skip_wide_thd_on_rubin
 @pytest.mark.L0
 @_skip_d512_on_rubin
 @torch_fork_set_rng(seed=0)
@@ -1812,4 +1868,5 @@ def test_fp8_d512_mxfp8_declines():
 
     assert (512, 512) in _sm100_fp8_shapes(pertensor=True, device_cc=(10, 0))
     assert (512, 512) not in _sm100_fp8_shapes(pertensor=False, device_cc=(10, 0))
-    assert (512, 512) not in _sm100_fp8_shapes(pertensor=True, device_cc=(10, 7))
+    # INVERTED 2026-09-04: Rubin gained the d512 per-tensor FP8 kernel.
+    assert (512, 512) in _sm100_fp8_shapes(pertensor=True, device_cc=(10, 7))

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -39,14 +39,13 @@ pytestmark = [requires_blackwell, requires_dsl]
 # under test. The d192xd128 kernel flavor exists on the sm100 engine only.
 _D128_ARCH = "sm107" if _SM == 107 else "sm100"
 _skip_on_rubin = pytest.mark.skipif(_SM == 107, reason="the d192xd128 per-tensor FP8 flavor has no Rubin kernel (sm107 serves d128 only)")
-# d256 is SERVED on Rubin as of the SM107 port -- kept as a no-op marker so
-# the many _D128_D256 call sites need no churn.
-_skip_d256_on_rubin = pytest.mark.skipif(False, reason="d256 per-tensor FP8 is served on Rubin")
-_D128_D256 = [pytest.param(128, id="d128"), pytest.param(256, id="d256", marks=_skip_d256_on_rubin)]
-# Same gate, accurate for ANY flavor wider than d128 (the d192xd128 THD case
-# below needs it too, and the d256-specific wording would read wrong there).
-# Only d192xd128 lacks a Rubin per-tensor FP8 kernel now.
-_skip_wide_fp8_on_rubin = pytest.mark.skipif(False, reason="d256/d512 per-tensor FP8 are served on Rubin")
+# Rubin serves per-tensor FP8 at d128/d256/d512 as of the SM107 port, so no
+# flavor gate is needed for the dense cases.  Only d192xd128 lacks a Rubin
+# sibling; that one is gated by _skip_on_rubin above.  (These used to be
+# skipif(False) no-op markers -- a marker that reads like a live gate and never
+# skips, whose `reason` states why the case IS served.  If a flavor ever loses
+# its Rubin kernel, add a real `_SM == 107` marker back.)
+_D128_D256 = [pytest.param(128, id="d128"), pytest.param(256, id="d256")]
 
 # Rubin serves per-tensor FP8 at d128/d256/d512, but its THD and PackGQA legs
 # are d128-ONLY -- the row says so per shape (`thd_d_shapes` /
@@ -606,7 +605,6 @@ def test_fp8_large_flavors_serve_exact_shapes_only():
 
 
 @pytest.mark.L0
-@_skip_d256_on_rubin
 @pytest.mark.parametrize("out_key", ["fp16", "bf16", "e4m3", "e5m2"])
 @pytest.mark.parametrize("in_key", _INS)
 @torch_fork_set_rng(seed=0)
@@ -629,7 +627,6 @@ def test_fp8_d256_output_dtypes(in_key, out_key):
 
 
 @pytest.mark.L0
-@_skip_d256_on_rubin
 @pytest.mark.parametrize("in_key", _INS)
 @pytest.mark.parametrize("mask", ["none", "causal_br", "swa"])
 @torch_fork_set_rng(seed=0)
@@ -653,7 +650,6 @@ def test_fp8_d256_masks(in_key, mask):
 
 @_skip_wide_strided_stats_on_rubin
 @pytest.mark.L1
-@_skip_d256_on_rubin
 @pytest.mark.parametrize("in_key", _INS)
 @torch_fork_set_rng(seed=59)
 def test_fp8_d256_strided_stats(in_key):
@@ -662,7 +658,6 @@ def test_fp8_d256_strided_stats(in_key):
 
 
 @pytest.mark.L1
-@_skip_d256_on_rubin
 @pytest.mark.parametrize("in_key", _INS)
 @torch_fork_set_rng(seed=0)
 def test_fp8_d256_bottom_right_rectangular(in_key):
@@ -685,7 +680,6 @@ def test_fp8_d256_bottom_right_rectangular(in_key):
 
 
 @pytest.mark.L1
-@_skip_d256_on_rubin
 @pytest.mark.parametrize("case", ["right", "bottom_right", "right_swa"])
 @torch_fork_set_rng(seed=0)
 def test_fp8_d256_right_band_combinations(case):
@@ -715,7 +709,6 @@ def test_fp8_d256_right_band_combinations(case):
 
 
 @pytest.mark.L1
-@_skip_d256_on_rubin
 @pytest.mark.parametrize("in_key", _INS)
 @pytest.mark.parametrize("causal", [False, True])
 @torch_fork_set_rng(seed=0)
@@ -742,7 +735,6 @@ def test_fp8_d256_padding(in_key, causal):
 
 @_skip_dense_q_trim_on_rubin
 @pytest.mark.L1
-@_skip_d256_on_rubin
 @torch_fork_set_rng(seed=0)
 def test_fp8_d256_dense_q_trim_stats_sink():
     """Short dense Q rows trim O/LSE even when a sink makes softmax finite."""
@@ -772,7 +764,6 @@ def test_fp8_d256_dense_q_trim_stats_sink():
 
 
 @pytest.mark.L1
-@_skip_d256_on_rubin
 @pytest.mark.parametrize("in_key", _INS)
 @torch_fork_set_rng(seed=0)
 def test_fp8_d256_gqa_sink(in_key):
@@ -798,7 +789,6 @@ def test_fp8_d256_gqa_sink(in_key):
 
 
 @pytest.mark.L0
-@_skip_d256_on_rubin
 @pytest.mark.parametrize(
     ("in_key", "out_key", "with_sink"),
     [
@@ -1419,10 +1409,11 @@ def test_fp8_d192_d128_thd_features():
 
 
 @pytest.mark.L0
-# Rubin serves d128 only on this row, so the two wider flavors have no kernel
-# there -- same gate _D128_D256 applies, spelled out because this list is
-# inline.  Without it the test pins sdpa_fwd_prefill_sm107_fp8 for a shape
-# the row correctly declines and fails with "no plan for engine".
+# Rubin serves per-tensor FP8 at d128/d256/d512, but its THD leg is d128-ONLY
+# (row: thd_d_shapes={(128, 128)}), so the two wider THD flavors are DECLINED
+# there -- a capability gap, not a missing kernel.  Without the gate the test
+# pins sdpa_fwd_prefill_sm107_fp8 for a shape the row correctly declines and
+# fails with "no plan for engine".
 @pytest.mark.parametrize(
     "d_qk,d_v",
     [
@@ -1448,7 +1439,6 @@ def test_fp8_thd_multi_unit_per_cta(monkeypatch, d_qk, d_v):
 
 @_skip_wide_thd_on_rubin
 @pytest.mark.L0
-@_skip_d256_on_rubin
 @pytest.mark.parametrize("in_key", _INS)
 @pytest.mark.parametrize("causal", [False, True])
 @torch_fork_set_rng(seed=0)
@@ -1643,17 +1633,15 @@ def test_fp8_sm100_device_scales_execute_reads_no_device_memory():
 #
 # Same cga4x1 role-split kernel family as the d512 f16 sibling; the FP8 fork
 # runs STAGES_KV = XFER_STAGES = 3 with a 128-column TMEM-resident Q and the
-# Blackwell K=32 QMMA step.  There is no d512 MXFP8 kernel and no Rubin d512
-# kernel, so this whole section is sm100-only.
+# Blackwell K=32 QMMA step.  There is no d512 MXFP8 kernel on EITHER line; the
+# Rubin per-tensor d512 kernel exists and runs this section too.
 # ===========================================================================
 
-_skip_d512_on_rubin = pytest.mark.skipif(False, reason="d512 per-tensor FP8 is served on Rubin")
 _D512 = 512
 _D512_SCALE = 1.0 / math.sqrt(_D512)
 
 
 @pytest.mark.L0
-@_skip_d512_on_rubin
 @pytest.mark.parametrize("in_key", _INS)
 @pytest.mark.parametrize("mask", list(_MASKS))
 @torch_fork_set_rng(seed=0)
@@ -1664,7 +1652,6 @@ def test_fp8_d512_masks(in_key, mask):
 
 
 @pytest.mark.L0
-@_skip_d512_on_rubin
 @pytest.mark.parametrize("out_key", ["fp16", "bf16", "e4m3", "e5m2"])
 @pytest.mark.parametrize("in_key", _INS)
 @torch_fork_set_rng(seed=0)
@@ -1679,7 +1666,6 @@ def test_fp8_d512_output_dtypes(in_key, out_key):
 
 
 @pytest.mark.L0
-@_skip_d512_on_rubin
 @torch_fork_set_rng(seed=0)
 def test_fp8_d512_sink():
     """Attention sink on d512: one extra softmax column with V = 0."""
@@ -1689,7 +1675,6 @@ def test_fp8_d512_sink():
 
 
 @pytest.mark.L0
-@_skip_d512_on_rubin
 @pytest.mark.parametrize("h_q,h_kv", [(8, 2), (8, 1)], ids=["g4", "mqa"])
 @torch_fork_set_rng(seed=0)
 def test_fp8_d512_gqa(h_q, h_kv):
@@ -1699,7 +1684,6 @@ def test_fp8_d512_gqa(h_q, h_kv):
 
 
 @pytest.mark.L0
-@_skip_d512_on_rubin
 @torch_fork_set_rng(seed=0)
 def test_fp8_d512_padded_kv():
     """Per-batch KV padding (seq_len_kv) on d512: KV columns past the batch's
@@ -1710,7 +1694,6 @@ def test_fp8_d512_padded_kv():
 
 
 @pytest.mark.L0
-@_skip_d512_on_rubin
 @torch_fork_set_rng(seed=0)
 def test_fp8_d512_stats():
     """generate_stats on d512: the dense LSE matches the natural-log reference."""
@@ -1721,7 +1704,6 @@ def test_fp8_d512_stats():
 
 
 @pytest.mark.L0
-@_skip_d512_on_rubin
 @torch_fork_set_rng(seed=0)
 def test_fp8_d512_multi_tile():
     """A shape that spans several Q tiles and several persistent waves, so the
@@ -1738,7 +1720,6 @@ def test_fp8_d512_multi_tile():
 
 @_skip_wide_thd_on_rubin
 @pytest.mark.L0
-@_skip_d512_on_rubin
 @pytest.mark.parametrize("in_key", _INS)
 @pytest.mark.parametrize("causal", [False, True])
 @torch_fork_set_rng(seed=0)
@@ -1751,7 +1732,6 @@ def test_fp8_d512_thd(in_key, causal):
 
 @_skip_wide_thd_on_rubin
 @pytest.mark.L0
-@_skip_d512_on_rubin
 @torch_fork_set_rng(seed=0)
 def test_fp8_d512_thd_cross_gqa():
     """THD cross-attention on d512: unequal per-sequence Q and KV lengths with
@@ -1762,7 +1742,6 @@ def test_fp8_d512_thd_cross_gqa():
 
 @_skip_wide_thd_on_rubin
 @pytest.mark.L0
-@_skip_d512_on_rubin
 @torch_fork_set_rng(seed=0)
 def test_fp8_d512_thd_sink_stats():
     """THD + sink + ragged Stats on d512 (packed token-major TH1 layout)."""
@@ -1775,7 +1754,6 @@ def test_fp8_d512_thd_sink_stats():
 
 @_skip_wide_thd_on_rubin
 @pytest.mark.L0
-@_skip_d512_on_rubin
 @torch_fork_set_rng(seed=0)
 def test_fp8_d512_thd_zero_len_kv():
     """Zero-length KV and Q sequences on d512 (the d128 sibling's shapes).
@@ -1798,7 +1776,6 @@ def test_fp8_d512_thd_zero_len_kv():
 
 @_skip_wide_thd_on_rubin
 @pytest.mark.L0
-@_skip_d512_on_rubin
 @torch_fork_set_rng(seed=0)
 def test_fp8_d512_thd_cu_seq_len():
     """THD on d512 via the cu_seq_len prefix-sum length form."""
@@ -1807,7 +1784,6 @@ def test_fp8_d512_thd_cu_seq_len():
 
 
 @pytest.mark.L0
-@_skip_d512_on_rubin
 @pytest.mark.parametrize(
     ("d_qk", "d_v"),
     [(384, 448), (464, 368), (272, 272), (512, 496)],
@@ -1830,7 +1806,6 @@ def test_fp8_d512_head_dim_envelope(d_qk, d_v, mask):
 
 
 @pytest.mark.L0
-@_skip_d512_on_rubin
 def test_fp8_d512_envelope_floor_declines_straddling_shapes():
     """The D512 flavor serves the (256, 512] band on both head dims; shapes
     straddling its floor decline.  Below it the D256 flavor is exact-shape only
@@ -1855,15 +1830,22 @@ def test_fp8_envelope_floor_matches_engine_row():
     from cudnn.sdpa.fwd import engines
     from cudnn.sdpa.fwd.api_dsl import _SM100_FP8_ENVELOPE_FLOORS
 
-    row = {s.name: s.capabilities for s in engines.ENGINE_SPECS}[engines.engine_name(fp8=True)]
+    caps = {s.name: s.capabilities for s in engines.ENGINE_SPECS}
+    row = caps[engines.engine_name(fp8=True)]
     assert dict(row.d_envelope_floors) == _SM100_FP8_ENVELOPE_FLOORS
+    # The RUBIN row too: the adapter consults one arch-independent table, so a
+    # Rubin row with different floors admits shapes check_support then rejects
+    # with a bare ValueError.  Rubin has no (192, 128) flavor, so its floors
+    # are the SM100 ones restricted to the shapes it serves.
+    rubin = caps[engines.engine_name(arch="sm107", fp8=True)]
+    assert dict(rubin.d_envelope_floors) == {f: v for f, v in _SM100_FP8_ENVELOPE_FLOORS.items() if f in rubin.d_shapes}
 
 
 @pytest.mark.L0
-@_skip_d512_on_rubin
 def test_fp8_d512_mxfp8_declines():
-    """There is no d512 block-scale kernel: an MXFP8 d512 graph must be
-    rejected up front, not fail late in the lowering."""
+    """There is no d512 BLOCK-SCALE kernel on either arch line: an MXFP8 d512
+    graph must be rejected up front, not fail late in the lowering.  The
+    per-tensor d512 flavor is a different claim and exists on both."""
     from cudnn.sdpa.fwd.api_dsl import _sm100_fp8_shapes
 
     assert (512, 512) in _sm100_fp8_shapes(pertensor=True, device_cc=(10, 0))

--- a/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
@@ -34,12 +34,39 @@ import torch
 from test_utils import torch_fork_set_rng
 
 from cudnn.sdpa.fwd.engines import engine_name
-from frost_test_utils import make_dense_stats, requires_pre_rubin_blackwell, requires_dsl
+from frost_test_utils import _SM, make_dense_stats, requires_blackwell, requires_dsl
 
 
 from frost_test_utils import select_engine as _select_engine  # noqa: F401
 
-pytestmark = [requires_pre_rubin_blackwell, requires_dsl]
+# Rubin (cc10.7) now has MXFP8 lowerings of its own, so this suite is no longer
+# pre-Rubin only.  ONE engine per arch line: pin the row that serves the device
+# under test, exactly as test_sdpa_fwd_fp8_sm100.py does -- engine_name()
+# defaults to arch="sm100", whose row stops at cc10.6, so an unqualified pin
+# fails on Rubin with "no plan for engine" for routing reasons that have
+# nothing to do with the kernel.
+_ARCH = "sm107" if _SM == 107 else "sm100"
+
+# Rubin gaps the SM100 line does not have.  These are CAPABILITY declines the
+# engine row states honestly, not kernel bugs -- the graph is never served, so
+# the test cannot run.  Flip the condition to False when the gap closes.
+_skip_d192_mxfp8_on_rubin = pytest.mark.skipif(
+    _SM == 107,
+    reason="no d192xd128 MXFP8 kernel on the Rubin line; the row's exact-native d_shapes (d_pad_multiple=0) declines the shape",
+)
+# THD/varlen is not ported to the Rubin MXFP8 kernels: the setup-kernel call
+# site still speaks the pre-upstream 7-arg contract against a 14-arg helper and
+# the metadata layout differs (3B+2 vs 4B+4), so compile() raises and the row
+# declares thd=False.  Flip to False when the THD port lands.
+_skip_thd_mxfp8_on_rubin = pytest.mark.skipif(
+    _SM == 107,
+    reason="THD/varlen not ported to the Rubin MXFP8 kernels (row sets thd=False)",
+)
+_skip_dense_q_trim_on_rubin = pytest.mark.skipif(
+    _SM == 107,
+    reason="dense padded-Q O/LSE trim not carried by the Rubin kernels (row sets dense_seq_q_trim=False / padded_stats=False)",
+)
+pytestmark = [requires_blackwell, requires_dsl]
 
 
 _FP8 = {"e4m3": torch.float8_e4m3fn, "e5m2": torch.float8_e5m2}
@@ -239,7 +266,7 @@ def _run(
     g.validate()
     g.build_operation_graph()
     g.create_execution_plans([cudnn.heur_mode.A])
-    _select_engine(g, engine_name(mxfp8=True))
+    _select_engine(g, engine_name(arch=_ARCH, mxfp8=True))
     g.check_support()
     g.build_plans()
     if not stats:
@@ -498,6 +525,7 @@ def test_mxfp8_d256_dense_padding(in_key, causal):
     assert abs(amax.item() - O_ref.abs().max().item()) <= 0.03
 
 
+@_skip_dense_q_trim_on_rubin
 @pytest.mark.L1
 @torch_fork_set_rng(seed=0)
 def test_mxfp8_d256_dense_q_trim_stats_sink():
@@ -610,6 +638,7 @@ def test_mxfp8_masks(in_key, mask):
     _check(O, O_ref, torch.float16, in_key)
 
 
+@_skip_d192_mxfp8_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("in_key", _INS)
 @pytest.mark.parametrize("mask", list(_MASKS))
@@ -632,6 +661,7 @@ def test_mxfp8_d192_d128(in_key, mask):
     _check(O, O_ref, torch.bfloat16, in_key, d_qk=d_qk)
 
 
+@_skip_d192_mxfp8_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("out_key", ["fp16", "bf16", "e4m3", "e5m2"])
 @torch_fork_set_rng(seed=0)
@@ -656,6 +686,7 @@ def test_mxfp8_d192_d128_output_dtypes(out_key):
     assert abs(amax_value - amax_ref) <= 0.03, f"amax {amax_value:.4f} vs ref {amax_ref:.4f}"
 
 
+@_skip_d192_mxfp8_on_rubin
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
 def test_mxfp8_d192_d128_gqa_sink():
@@ -678,6 +709,7 @@ def test_mxfp8_d192_d128_gqa_sink():
     _check(O, O_ref, torch.float16, "e5m2", d_qk=d_qk)
 
 
+@_skip_d192_mxfp8_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize(
     ("out_key", "with_sink"),
@@ -712,6 +744,7 @@ def test_mxfp8_d192_d128_leading_zero_length_kv(out_key: str, with_sink: bool):
     assert abs(result.amax.item() - result.reference.abs().max().item()) <= 0.03
 
 
+@_skip_d192_mxfp8_on_rubin
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
 def test_mxfp8_d192_d128_stats_less():
@@ -769,7 +802,10 @@ def test_mxfp8_gqa(in_key):
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("d_qk,d_v", [(128, 128), (192, 128)])
+@pytest.mark.parametrize(
+    "d_qk,d_v",
+    [(128, 128), pytest.param(192, 128, marks=_skip_d192_mxfp8_on_rubin)],
+)
 @torch_fork_set_rng(seed=0)
 def test_mxfp8_bottom_right_rectangular(d_qk, d_v):
     """Bottom-right causal with S_q != S_kv (the case where it differs from top-left)."""
@@ -837,7 +873,7 @@ def _run_rect(B, H, S_q, S_kv, in_key, out_dt, *, scale, sdpa_kwargs, d_qk=128, 
     g.validate()
     g.build_operation_graph()
     g.create_execution_plans([cudnn.heur_mode.A])
-    _select_engine(g, engine_name(mxfp8=True))
+    _select_engine(g, engine_name(arch=_ARCH, mxfp8=True))
     g.check_support()
     g.build_plans()
     g.execute(
@@ -1094,7 +1130,7 @@ def _run_thd(
     g.validate()
     g.build_operation_graph()
     g.create_execution_plans([cudnn.heur_mode.A])
-    _select_engine(g, engine_name(mxfp8=True))
+    _select_engine(g, engine_name(arch=_ARCH, mxfp8=True))
     g.check_support()
     g.build_plans()
     vp.update({o: o_gpu, amax_o: amax})
@@ -1125,6 +1161,7 @@ def _run_thd(
     return o_out, o_ref, amax, lse_out
 
 
+@_skip_thd_mxfp8_on_rubin
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
 def test_mxfp8_thd_declared_totals():
@@ -1149,6 +1186,7 @@ def test_mxfp8_thd_declared_totals():
     assert torch.equal(o_dec, o_inf), "declaring the packed totals must not change O"
 
 
+@_skip_thd_mxfp8_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("in_key", _INS)
 @pytest.mark.parametrize("causal", [False, True])
@@ -1161,6 +1199,7 @@ def test_mxfp8_thd(in_key, causal):
     assert abs(amax.item() - o_ref.abs().max().item()) <= 0.03
 
 
+@_skip_thd_mxfp8_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("d_qk,d_v", [(128, 128), (192, 128), (256, 256)], ids=["d128", "d192_d128", "d256"])
 @pytest.mark.parametrize("in_key", _INS)
@@ -1181,6 +1220,7 @@ def test_mxfp8_thd_multi_unit_per_cta(monkeypatch, in_key, d_qk, d_v):
     assert abs(amax.item() - o_ref.abs().max().item()) <= 0.03
 
 
+@_skip_thd_mxfp8_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("in_key", _INS)
 @pytest.mark.parametrize("causal", [False, True])
@@ -1204,6 +1244,7 @@ def test_mxfp8_d256_thd(in_key, causal):
     assert abs(amax.item() - o_ref.abs().max().item()) <= 0.03
 
 
+@_skip_thd_mxfp8_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("d", [128, 256])
 @pytest.mark.parametrize("in_key", _INS)
@@ -1234,6 +1275,7 @@ def test_mxfp8_thd_sliding_window(d, in_key, bottom_right):
     assert lse is not None and torch.isfinite(lse).all()
 
 
+@_skip_thd_mxfp8_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("d", [128, 256])
 @torch_fork_set_rng(seed=0)
@@ -1244,6 +1286,7 @@ def test_mxfp8_thd_cross_gqa(d):
     _check(o_out, o_ref, torch.float16, "e4m3", d_qk=d)
 
 
+@_skip_thd_mxfp8_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("d", [128, 256])
 @torch_fork_set_rng(seed=0)
@@ -1255,6 +1298,7 @@ def test_mxfp8_thd_sink(d):
     _check(o_out, o_ref, torch.float16, "e4m3", d_qk=d)
 
 
+@_skip_thd_mxfp8_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("d", [128, 256])
 @torch_fork_set_rng(seed=0)
@@ -1266,6 +1310,7 @@ def test_mxfp8_thd_stats(d):
     assert lse is not None and torch.isfinite(lse).all()
 
 
+@_skip_thd_mxfp8_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("d", [128, 256])
 @torch_fork_set_rng(seed=0)
@@ -1278,6 +1323,7 @@ def test_mxfp8_thd_zero_len_kv(d):
     _check(o_out, o_ref, torch.float16, "e4m3", d_qk=d)
 
 
+@_skip_thd_mxfp8_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("d", [128, 256])
 @torch_fork_set_rng(seed=0)
@@ -1299,6 +1345,7 @@ def test_mxfp8_thd_cu_seq_len(d):
     _check(o_out, o_ref, torch.float16, "e4m3", d_qk=d)
 
 
+@_skip_d192_mxfp8_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("in_key", _INS)
 @torch_fork_set_rng(seed=0)
@@ -1324,6 +1371,7 @@ def test_mxfp8_d192_d128_thd_cross_gqa_stats(in_key):
     assert lse is not None and torch.isfinite(lse).all()
 
 
+@_skip_d192_mxfp8_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("in_key", _INS)
 @pytest.mark.parametrize("mask", ["causal_br", "swa"])
@@ -1351,6 +1399,7 @@ def test_mxfp8_d192_d128_thd_mask_variants(in_key, mask):
     assert abs(amax.item() - o_ref.abs().max().item()) <= 0.03
 
 
+@_skip_thd_mxfp8_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("d_qk", [128, 192])
 @pytest.mark.parametrize("in_key", _INS)


### PR DESCRIPTION
## What

Ports the **SM107 (Rubin) prefill forward** family onto the FROST engine surface
and registers it end to end. Nine new kernels join the already-shipped d128 FP8
sibling behind three opt-in engine rows:

| | f16 / bf16 | per-tensor FP8 | MXFP8 |
|---|---|---|---|
| **d128** | new | shipped | new |
| **d192 × d128** | new | — (rides d256) | — (declined) |
| **d256** | new | new | new |
| **d512** | new | new | new |

Engine rows: `sdpa_fwd_prefill_sm107` (slot **15**, new), `sdpa_fwd_prefill_sm107_fp8`
(slot 14, widened to d256/d512), `sdpa_fwd_prefill_sm107_mxfp8` (slot **16**, new).
All `opt_in=True`.

## Why a separate `config_sm107.py`

Rubin is a different kernel *lineage*, not the Blackwell kernels recompiled — the
two share flavor NAMES and almost nothing else. Routing the SM107 d256 FP8 kernel
through the Blackwell `make_cfg_d256` gave a scheduler mbarrier init count of **15
against 11 actual arrivers**: an unreachable barrier that hung at *every* shape,
down to `B=1 H=1 S=128`, with no fault and nothing for a sanitizer to find. The
new module carries that and two more geometry constraints as raising validators.

## Kernel fixes this port required

Each is a silent-wrong-answer class — no crash, no error, wrong numbers:

- **V scale factors are D-plane-major in GMEM** (d256/d512 MXFP8). The columnwise
  quantization applies the F8_128x4 atom rule to the *transposed* `[D, S/32]`
  matrix, so the D-block is the OUTER index and the planes sit a whole plane of
  atoms apart — a stride that **grows with S**. Reusing the Q/K per-tile
  descriptor builder was correct at one KV tile and degraded from there
  (cos 0.9997 → 0.980 → 0.969). d=128 has a single plane, so the passing sibling
  could not catch it.
- **Version-1 tcgen05 SMEM descriptors past 256 KiB.** A version-0 descriptor
  truncates `start_address` to 14 bits and wraps to the bottom of SMEM. The d512
  MXFP8 scale-factor tiles start near 292 KiB, so the UTCCP copied **Q data** into
  the SF TMEM columns and BMM1 multiplied by garbage E8M0 exponents: `LSE=+inf`,
  `O=NaN` at every shape. Applied per buffer, only where the line is crossed —
  setting it everywhere regressed d128/d256 MXFP8.
- **`SCHED_LPT` is not honored by the ported kernels.** A heuristics fallback bug
  hid it: when a row's domain excluded the primary policy, ranking fell back to
  NATURAL (and listed it twice) instead of walking the preference order. Fixing
  that let causal graphs reach LPT for the first time — where it returns NaN
  (d512 FP8) or `max|O-ref| ≈ 1.9` (d128 MXFP8). All three rows now declare
  `sched_policies={SCHED_NATURAL}`, and the standalone wrapper's own derivation
  is arch-gated to match.
- **`has_lse=False` specialization** on all nine kernels: a stats-less graph binds
  no dummy buffer at any level and reports `get_workspace_size() == 0`. The FP8
  row already claimed `lse_optional`, which was untrue for the wide kernels it
  was widened to.
- **Empty-KV guard** (d256/d512): an empty mainloop leaves `total_sum == 0`, where
  the `1e-30` division floor leaks into the output — `LSE = log(1e-30) = -69.08`
  and `residue * inf = NaN`. Substituted with a SELECT, never `* 0`.

## Coverage

The SM100 forward suites now run on cc 10.7 with an arch-aware engine pin
(`test_sdpa_fwd_dsl_sm100.py`, `..._fp8_sm100.py`, `..._mxfp8_sm100.py`), which is
how the f16/bf16 row gets its first automated numerics — **273 executing tests
that previously had none**. Plus `test_sdpa_fwd_dsl_sm107.py` (device-independent
row/config assertions).

Every feature a Rubin row declines — THD, PackGQA, split-KV, dense padded-Q trim,
d192 MXFP8, wide-shape strided Stats — is a `skipif(_SM == 107, ...)` whose reason
names the row field that declines it, so the skip **inverts** when the gap closes
rather than being deleted. `SUPPORT_MATRIX_TRACKER.md` updated per SDPA **Rule S2**.

## Validation

`pytest sdpa/frost/ -m "L0 or L1"` on each arch:

| arch | result |
|---|---|
| **SM107** Rubin (`w2u1g-lc-0030`) | **746 passed**, 10 failed — all 10 pre-existing |
| **SM100** Blackwell (`4u4g-gen-0150`) | **1371 passed**, 9 failed — the same pre-existing module |
| **SM80** A100 | **363 passed, 0 failed** |

**No failure is attributable to this PR:**

- **9 ×** `test_tile_dsl_q_loop_bounds.py` — arrived with #948 and fails on
  **both** SM100 and SM107. *Measured, not argued:* checked out pure
  `origin/develop` (c541e716) on the Rubin node and it fails 9/9 there, with none
  of this branch applied. It imports only `tile_dsl.mask`, which this PR does not
  touch. Worth its own issue.
- **1 ×** `test_fp8_thd_sliding_window[False-e5m2-d128]` (Rubin only) — the known
  pre-existing E5M2 case: 1 element in 3600 at LSE diff 0.0337 against a 0.02
  tolerance, on the *shipped* d128 FP8 kernel. Not fixed and **not widened**;
  it needs its own look.

## Not in this PR

- **Scheduler (`SCHED_LPT` / `LPT_L2`) on the Rubin line.** Recovering it for the
  shipped d128 FP8 kernel — which does honor both and loses them here because
  `sched_policies` is row-wide — needs a per-shape domain
  (`sched_policies_by_d_shape`, mirroring `cgas_by_d_shape`).
- **THD/varlen** on the ported kernels (7-arg vs 14-arg setup contract, 3B+2 vs
  4B+4 metadata). Declined honestly by every row.
- **d512 MXFP8 test module.** The kernel is correct (cos 0.9997, LSE exact, SQ ∈
  {128…512}) but SM100 has no d512 MXFP8 sibling, so the shared suite carries no
  d512 case to widen — it needs new cases, not a widened gate. Marked ⚠️ in the
  tracker rather than ✅.
- Perf. Functional only.

## Labels

`cat-feature` · `area:frost` · `op:sdpa` · `orig-nvidia`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added SDPA forward support for SM107/Rubin GPUs across FP16, BF16, per-tensor FP8, and MXFP8 formats.
  - Expanded supported head dimensions, including d128, d192, d256, and d512 where applicable.
  - Added support for masking, GQA, LSE outputs, stream-aware execution, and architecture-specific scheduling.

- **Bug Fixes**
  - Improved scheduler fallback behavior and configuration validation.
  - Corrected empty-KV results to return zero outputs and appropriate LSE values.

- **Documentation**
  - Updated the SM107/Rubin support matrix with supported features and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->