### PR TITLE
test(sdpa): fuzz head-axis stride gaps in the ragged sweeps

### DIFF
--- a/test/python/sdpa/random_config.py
+++ b/test/python/sdpa/random_config.py
@@ -68,7 +68,7 @@ def compute_default_BHSD_strides(shape):
     return tuple(strides)
 
 
-def compute_packed_strides(shape, token_gap=0):
+def compute_packed_strides(shape, token_gap=0, head_gap=0):
     """Compute packed (ragged) BSHD strides for BHSD shape: (s*h*d, d, h*d, 1).
 
     ``token_gap`` widens the token stride to ``h*d + token_gap`` elements —
@@ -76,12 +76,14 @@ def compute_packed_strides(shape, token_gap=0):
     ``token_gap == h*d`` this is exactly a K or V view of a kv-interleaved
     ``[T, 2, H, D]`` buffer (token stride ``2*h*d``), the layout
     ``torch.nn.attention.varlen`` users produce by slicing a fused KV
-    projection."""
+    projection. ``head_gap`` widens the head stride to ``d + head_gap``; the
+    token record then spans ``h * (d + head_gap) + token_gap``."""
     if shape is None:
         return None
     _, h, s, d = shape
-    token_stride = h * d + token_gap
-    return (s * token_stride, d, token_stride, 1)
+    head_stride = d + head_gap
+    token_stride = h * head_stride + token_gap
+    return (s * token_stride, head_stride, token_stride, 1)
 
 
 @dataclass
@@ -142,6 +144,12 @@ class ExecConfig:
     # fp8/mxfp8 harnesses (#537). Configs with explicit strides are
     # unaffected (the gap only fills strides left None).
     with_ragged_token_gap: bool = True
+    # Sibling of the above for the HEAD axis (stride[1] != d, e.g. head-interleaved
+    # buffers): each ragged tensor independently widens its head stride by 0-3
+    # units of 16 bytes, only where d itself is 16-byte granular so every head base
+    # keeps the packed layout's alignment class. Drawn after the token gaps from the
+    # same RNG, so existing seeds keep their token layouts.
+    with_ragged_head_gap: bool = True
     # Packed (THD) token capacities, first-class: buffer allocation sizes the
     # packed Q/O and K/V buffers from these (not a locally recomputed
     # sum-of-seq-lens), knobs may fuzz slack capacity beyond the packed
@@ -244,29 +252,33 @@ class ExecConfig:
         #    packed strides (#537).
         _gap_applicable = (
             self.is_ragged
-            and self.with_ragged_token_gap
+            and (self.with_ragged_token_gap or self.with_ragged_head_gap)
             and not self.is_cu_seq_len
             and not self.with_ragged_offset_multiplier
             and not (self.data_type is not None and self.data_type.itemsize == 1)
         )
         if _gap_applicable:
             _gap_rng = random.Random((self.rng_geom_seed or 0) ^ 0xA80517)
-            # Draw ALL FOUR gaps up front, in fixed Q/K/V/O order: an
+            # Draw ALL gaps up front, in fixed Q/K/V/O order: an
             # explicitly provided stride must not shift the gaps the
             # remaining tensors get (same rng_geom_seed -> same per-tensor
             # layouts regardless of which strides were overridden).
-            _gaps = {name: _gap_rng.randint(0, 3) for name in ("q", "k", "v", "o")}
+            _token_gaps = {name: _gap_rng.randint(0, 3) for name in ("q", "k", "v", "o")}
+            _head_gaps = {name: _gap_rng.randint(0, 3) for name in ("q", "k", "v", "o")}
+            _head_gap_quantum = 16 // (self.data_type.itemsize if self.data_type is not None else 2)
 
-            def _make_gap_fn(gap_tokens):
+            def _make_gap_fn(token_gap_units, head_gap_units):
                 def _gapped(shape):
                     if shape is None:
                         return None
                     h, d = shape[1], shape[3]
-                    return compute_packed_strides(shape, gap_tokens * h * d)
+                    token_gap = token_gap_units * h * d if self.with_ragged_token_gap else 0
+                    head_gap = head_gap_units * _head_gap_quantum if self.with_ragged_head_gap and d % _head_gap_quantum == 0 else 0
+                    return compute_packed_strides(shape, token_gap, head_gap)
 
                 return _gapped
 
-            gap_q, gap_k, gap_v, gap_o = (_make_gap_fn(_gaps[n]) for n in ("q", "k", "v", "o"))
+            gap_q, gap_k, gap_v, gap_o = (_make_gap_fn(_token_gaps[n], _head_gaps[n]) for n in ("q", "k", "v", "o"))
         elif self.is_ragged:
             gap_q = gap_k = gap_v = gap_o = compute_packed_strides
         else:

--- a/test/python/sdpa/random_config.py
+++ b/test/python/sdpa/random_config.py
@@ -234,12 +234,14 @@ class ExecConfig:
         # the drawn seq_lens (sum rounded up to 64). Explicit totals (e.g. a
         # slack-capacity fuzz) must cover the packed payload.
         if self.is_ragged:
+            seq_len_q = self.seq_len_q or [self.s_q] * (self.batches or 1)
+            seq_len_kv = self.seq_len_kv or [self.s_kv] * (self.batches or 1)
             if self.total_q is None:
-                self.total_q = packed_token_capacity(self.seq_len_q or [self.s_q] * (self.batches or 1))
+                self.total_q = packed_token_capacity(seq_len_q)
             if self.total_kv is None:
-                self.total_kv = packed_token_capacity(self.seq_len_kv or [self.s_kv] * (self.batches or 1))
-            assert self.total_q >= sum(self.seq_len_q or []), f"total_q={self.total_q} < sum(seq_len_q)"
-            assert self.total_kv >= sum(self.seq_len_kv or []), f"total_kv={self.total_kv} < sum(seq_len_kv)"
+                self.total_kv = packed_token_capacity(seq_len_kv)
+            assert self.total_q >= sum(seq_len_q), f"total_q={self.total_q} < sum(seq_len_q)"
+            assert self.total_kv >= sum(seq_len_kv), f"total_kv={self.total_kv} < sum(seq_len_kv)"
 
         # Compute strides if not provided (packed for ragged, default BHSD otherwise).
         # with_ragged_token_gap (default True): per-tensor token-stride gaps,

--- a/test/python/test_mhas_v2.py
+++ b/test/python/test_mhas_v2.py
@@ -1156,6 +1156,7 @@ def test_sdpa_thd_batch_stride_int32_overflow_L0(env_info, request, cudnn_handle
         is_cu_seq_len=False,
         is_ragged=True,
         with_ragged_token_gap=False,  # packed contract: token stride = h*d exactly
+        with_ragged_head_gap=False,
         is_dropout=False,
         is_determin=False,
         batches=len(seq_len_kv),

--- a/test/python/test_mhas_v2.py
+++ b/test/python/test_mhas_v2.py
@@ -369,6 +369,33 @@ def test_sdpa_random_fwd_ragged_L0(env_info, test_no, request, cudnn_handle):
 
 
 @pytest.mark.L0
+@pytest.mark.parametrize("side,seq_lens,minimum,default_capacity", [
+    ("q", [], 256, 320),
+    ("kv", [], 128, 192),
+    ("q", [0, 7], 7, 64),
+    ("kv", [0, 7], 7, 64),
+    ("q", [0, 0], 0, 64),
+    ("kv", [0, 0], 0, 64),
+])
+def test_ragged_capacity_uses_effective_seq_lens(side, seq_lens, minimum, default_capacity):
+    cfg = ExecConfig(
+        batches=2, h_q=8, h_k=8, h_v=8, s_q=128, s_kv=64, d_qk=128, d_v=128,
+        data_type=torch.float16, is_ragged=True, **{f"seq_len_{side}": seq_lens},
+    )
+    total = f"total_{side}"
+    cfg.fill_derived_fields()
+    assert getattr(cfg, total) == default_capacity
+
+    setattr(cfg, total, minimum)
+    cfg.fill_derived_fields()
+    assert getattr(cfg, total) == minimum
+
+    setattr(cfg, total, minimum - 1)
+    with pytest.raises(AssertionError, match=total):
+        cfg.fill_derived_fields()
+
+
+@pytest.mark.L0
 def test_ragged_stride_gaps_stable_under_stride_overrides():
     """The seeded per-tensor token and head gaps must not depend on which strides
     were explicitly provided, head gaps must respect the 16-byte rule, and turning

--- a/test/python/test_mhas_v2.py
+++ b/test/python/test_mhas_v2.py
@@ -369,40 +369,50 @@ def test_sdpa_random_fwd_ragged_L0(env_info, test_no, request, cudnn_handle):
 
 
 @pytest.mark.L0
-def test_ragged_token_gap_stable_under_stride_overrides():
-    """Regression: the seeded per-tensor token gaps must not depend on which
-    strides were explicitly provided — pinning stride_q must leave the gaps
-    K/V/O derive from the same rng_geom_seed unchanged (the gap RNG draws all
-    four values up front, not lazily per missing stride). Also locks in the
-    default-on semantics: gaps apply to plain ragged configs by default, and
-    auto-fall-back to packed for the forms that cannot express or handle
-    them yet (cu / offset-multiplier: #538; fp8 harness: #537)."""
+def test_ragged_stride_gaps_stable_under_stride_overrides():
+    """The seeded per-tensor token and head gaps must not depend on which strides
+    were explicitly provided, head gaps must respect the 16-byte rule, and turning
+    head gaps off must leave the token gaps of the same seed unchanged."""
     from sdpa.random_config import ExecConfig, compute_packed_strides
 
+    names = ("q", "k", "v", "o")
     base = dict(
         batches=2, h_q=8, h_k=8, h_v=8, s_q=64, s_kv=64, d_qk=128, d_v=128,
-        is_ragged=True, rng_geom_seed=7,
+        data_type=torch.float16, is_ragged=True, rng_geom_seed=7,
     )
     plain = ExecConfig(**base)
     plain.fill_derived_fields()
+    token_only = ExecConfig(**base, with_ragged_head_gap=False)
+    token_only.fill_derived_fields()
 
     pinned_q = (64 * 8 * 128, 128, 8 * 128, 1)  # explicit packed Q, no gap
     pinned = ExecConfig(**base, stride_q=pinned_q)
     pinned.fill_derived_fields()
-
     assert pinned.stride_q == pinned_q
     assert (pinned.stride_k, pinned.stride_v, pinned.stride_o) == (plain.stride_k, plain.stride_v, plain.stride_o)
 
-    # Default-on: seed 7 draws at least one non-packed layout for plain ragged.
-    packed = {n: compute_packed_strides(getattr(plain, f"shape_{n}")) for n in ("q", "k", "v", "o")}
-    assert any(getattr(plain, f"stride_{n}") != packed[n] for n in ("q", "k", "v", "o"))
+    quantum = 16 // plain.data_type.itemsize
+    head_gaps, token_gaps = [], []
+    for name in names:
+        _, h, _, d = getattr(plain, f"shape_{name}")
+        _, head_stride, token_stride, _ = getattr(plain, f"stride_{name}")
+        head_gap, token_gap = head_stride - d, token_stride - h * head_stride
+        assert head_gap >= 0 and head_gap % quantum == 0
+        assert token_gap >= 0 and token_gap % (h * d) == 0
+        # the head-gap knob must not disturb the token gap drawn for the same seed
+        _, off_head_stride, off_token_stride, _ = getattr(token_only, f"stride_{name}")
+        assert off_head_stride == d and off_token_stride - h * d == token_gap
+        head_gaps.append(head_gap)
+        token_gaps.append(token_gap)
+    assert any(head_gaps) and any(token_gaps)
 
     # Auto-packed fallbacks: cu / multiplier offset forms (#538) and 1-byte
     # (fp8) data types (#537) derive packed strides regardless of the default.
+    packed = {n: compute_packed_strides(getattr(plain, f"shape_{n}")) for n in names}
     for override in (dict(is_cu_seq_len=True), dict(with_ragged_offset_multiplier=True), dict(data_type=torch.float8_e4m3fn)):
-        cfg = ExecConfig(**base, **override)
+        cfg = ExecConfig(**{**base, **override})
         cfg.fill_derived_fields()
-        assert all(getattr(cfg, f"stride_{n}") == packed[n] for n in ("q", "k", "v", "o")), override
+        assert all(getattr(cfg, f"stride_{n}") == packed[n] for n in names), override
 
 
 @pytest.mark.parametrize("test_no", generate_test_seeds(num_tests=128, rng_seed=888), ids=lambda p: f"test{p[0]}")


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of LICENSE.txt.
- [x] I ran the changed-file pre-commit checks; no formatting changes were needed.
- [x] I reviewed the applicable root and test AGENTS.md guidance.
- [x] Required labels need maintainer permissions: `cat-enhancements`, `area:global_attention`, `area:frost`, `orig-external`.

## Affected area

CI or test infrastructure: ragged SDPA random sweeps.

## Summary

- Add `with_ragged_head_gap`, enabled by default alongside the token-gap knob. Each ragged Q/K/V/O independently draws a head gap of 0–3 units of 16 bytes, only when the head dimension preserves the required alignment.
- Compute token strides from the head-padded record, preserve seeded token-gap draws and explicit stride overrides, and keep the existing packed-layout fallbacks.
- Extend the existing stride-override stability test to check head-gap alignment and token-gap invariance when head gaps are disabled.

## Why

The native THD path supports head-axis stride gaps, but the existing random sweeps only fuzz token-axis gaps. This extends that coverage without adding a separate sweep or changing kernel code.

## Related issues

Closes #540. Opening the PR following the [maintainer's review of the commit](https://github.com/NVIDIA/cudnn-frontend/issues/540#issuecomment-5592233690).

## API and compatibility impact

None for public APIs or kernels. Test configuration only.

## Testing

### September 10 retest

Tested PR commit `d5ca43cf` against upstream `develop` at `70d7eb2c` after rebasing. Both include the old-version waiver from #944.

Environment: **NVIDIA H200 (SM90), PyTorch 2.13.0+cu132, CUDA 13.2, cuDNN 9.22.0, cuDNN frontend 1.29.0**. Both frontend versions were built separately, and their imported source paths and exact Git revisions were verified.

| Existing suite | PR `d5ca43cf` | Baseline `70d7eb2c` |
|---|---|---|
| Stride-override stability | 1 passed | 1 passed |
| Forward ragged L0 | 205 passed, 51 skipped | 205 passed, 51 skipped |
| Backward ragged L0 | 133 passed, 250 skipped, 1 failed | 133 passed, 250 skipped, 1 failed |

Both arms fail `test_mhas_v2.py::test_sdpa_random_bwd_ragged_L0[test61]` with gradient NaNs/numerical mismatches. JUnit comparisons show no per-case status differences between the two ragged suites, so this tested matrix has no additional failing cases relative to the baseline. **The backward commands and complete validation run exited with code 1; this is not a fully passing validation.**

Isolated runs reproduce the failure on the upstream baseline with finite live inputs. Changing output/workspace initialization changes the symptoms but does not restore numerical correctness. The frontend/backend root cause remains unresolved, and this PR does not fix that shared failure.

The 51 forward skips and 210 backward skips are the cuDNN < 9.25 zero-length waiver; the remaining 40 backward skips are unsupported graphs.

These results apply to `d5ca43cf`, not the latest head `f988d6f`. The later commit only sets `with_ragged_head_gap=False` in the separate packed-THD overflow regression; the full GPU validation has not been rerun on that commit.

Ragged sweep commands, run separately from `test/python` in each environment:

```bash
python -m pytest -q -p no:cacheprovider --tb=short -ra -m L0 test_mhas_v2.py::test_sdpa_random_fwd_ragged_L0
python -m pytest -q -p no:cacheprovider --tb=short -ra -m L0 test_mhas_v2.py::test_sdpa_random_bwd_ragged_L0
```

### Earlier validation (historical commits only)

- September 9: PR `ec59dfe5` versus baseline `e45ac96b`, on cuDNN 9.22.0. Both arms had 131 forward passes / 125 skips, 22 backward passes / 362 skips, and 6 skipped explicit zero-length edge cases. Stride stability and changed-file Black, notebook Black, and SPDX checks passed. These earlier passing results do not replace the September 10 result above.
- September 8: archived `3a1e34ae`, on cuDNN 9.25.1.1. Both arms had 256 forward passes and 280 backward passes / 104 skips. Separate zero-length edge probes produced 3 passes / 3 graph-construction failures in both arms, as [reported in #943](https://github.com/NVIDIA/cudnn-frontend/issues/943#issuecomment-5583397247). This PR does not address those failures, and the updated head has not been rerun with cuDNN 9.25.

Coverage is limited to the **SM90 backend route**. The FROST SM100/SM120 native THD path was not exercised.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for ragged tensor layouts with independent token and head spacing.
  * Added validation for deterministic stride generation, alignment requirements, explicit stride overrides, and disabled head-gap behavior.
  * Added regression checks for cumulative sequence lengths, offset multipliers, 1-byte data types, and large packed layouts.
  * Added coverage for zero-length sequences, optional capacity slack, head-major statistics, and declared sequence capacities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
