### PR TITLE
Support independent output strides in HSTU LMSD backward

### DIFF
--- a/docs/fe-oss-apis/hstu/hstu_lmsd.md
+++ b/docs/fe-oss-apis/hstu/hstu_lmsd.md
@@ -88,14 +88,14 @@ another.
 | `y`, `dy` | `(N, SD)` | BF16 | `S = 1 + concat_u + concat_x`; `y` is contiguous; `dy` may have a padded row stride |
 | `mean`, `rstd` | `(N,)` | FP32 | contiguous |
 | `mask` | `(N, D)` or `None` | `int8` | contiguous when dropout is enabled; `None` otherwise |
-| `dx`, `du` | `(N, D)` | BF16 | contiguous |
+| `dx`, `du` | `(N, D)` | BF16 | inner stride 1; each output independently supports a padded row stride |
 | `dweight`, `dbias` | `(D,)` | BF16 | contiguous; dWeight may be `None` when disabled |
 
 For BF16 matrices with a padded row stride, each row must remain 16-byte
 aligned. A cached compiled implementation accepts any runtime `N` in the
-supported range. The `x`, `u`, and `dy` row strides are runtime values and do
-not participate in the compile-cache key; `D`, dtypes, devices, and feature
-flags remain plan-time configuration.
+supported range. The `x`, `u`, `dy`, `dx`, and `du` row strides are runtime
+values and do not participate in the compile-cache key; `D`, dtypes, devices,
+and feature flags remain plan-time configuration.
 
 The launch grid adapts to the runtime row count without changing the compiled
 plan. Forward caps its persistent row blocks by the device SM count. Backward

--- a/python/cudnn/hstu/hstu_lmsd/_kernels/hstu_lmsd_bwd.py
+++ b/python/cudnn/hstu/hstu_lmsd/_kernels/hstu_lmsd_bwd.py
@@ -152,6 +152,8 @@ class HSTULMSDBackward:
             gDYLmsd_row = domain_offset_i64(row_coord, gDYLmsd)
             gX_row = domain_offset_i64(row_coord, gX)
             gU_row = domain_offset_i64(row_coord, gU)
+            gDX_row = domain_offset_i64(row_coord, gDX)
+            gDU_row = domain_offset_i64(row_coord, gDU)
             mean = gMean[row]
             rstd = gRstd[row]
             norm_bias = -mean * rstd
@@ -164,7 +166,6 @@ class HSTULMSDBackward:
                 rDirectDX = cute.make_rmem_tensor(self.vector_size, cutlass.Float32)
                 vector_index = j * self.threads_per_row + thread_in_row
                 if const_expr(self.hidden_size % (self.threads_per_row * self.vector_size) == 0) or vector_index < self.hidden_size // self.vector_size:
-                    tile_coord = ((None, None), (row_block, j))
                     row_tile_coord = ((None, None), (0, j))
                     tXgX = thread_copy.partition_S(gX_row[row_tile_coord])
                     tXgU = thread_copy.partition_S(gU_row[row_tile_coord])
@@ -189,7 +190,7 @@ class HSTULMSDBackward:
                     if const_expr(self.has_dropout):
                         cute.copy(mask_copy_atom, tXgMask, rMask)
 
-                    tXgDU = thread_copy.partition_D(gDU[tile_coord])
+                    tXgDU = thread_copy.partition_D(gDU_row[row_tile_coord])
                     rDU = cute.make_fragment_like(tXgDU)
                     for e in cutlass.range_constexpr(self.vector_size):
                         xf = rX[e].to(cutlass.Float32)
@@ -263,8 +264,8 @@ class HSTULMSDBackward:
             for j in cutlass.range_constexpr(num_column_tiles):
                 vector_index = j * self.threads_per_row + thread_in_row
                 if const_expr(self.hidden_size % (self.threads_per_row * self.vector_size) == 0) or vector_index < self.hidden_size // self.vector_size:
-                    tile_coord = ((None, None), (row_block, j))
-                    tXgDX = thread_copy.partition_D(gDX[tile_coord])
+                    row_tile_coord = ((None, None), (0, j))
+                    tXgDX = thread_copy.partition_D(gDX_row[row_tile_coord])
                     rDX = cute.make_fragment_like(tXgDX)
                     for e in cutlass.range_constexpr(self.vector_size):
                         rDX[e] = (rDirectDX_tiles[j][e] + (rWdy_tiles[j][e] - (rXhat_tiles[j][e] * sum_xhat_wdy + sum_wdy)) * rstd).to(gX.element_type)

--- a/python/cudnn/hstu/hstu_lmsd/api.py
+++ b/python/cudnn/hstu/hstu_lmsd/api.py
@@ -518,7 +518,7 @@ class HSTULMSDBwd(_HSTULMSDBase):
         for desc, name in ((self.dx_desc, "dx"), (self.du_desc, "du")):
             if desc.shape != (n, d) or desc.dtype != x.dtype:
                 raise ValueError(f"{name} must have shape ({n}, {d}) and dtype {x.dtype}")
-            _require_matrix_layout(desc, name, row_stride=d)
+            _require_matrix_layout(desc, name)
         if self.compute_dweight:
             if self.dweight_desc is None or self.dweight_workspace_desc is None:
                 raise ValueError("dweight and dweight_workspace are required when compute_dweight is True")
@@ -568,8 +568,8 @@ class HSTULMSDBwd(_HSTULMSDBase):
         fake_x = self._fake_matrix(self.x_desc, rows, dynamic_row_stride=True)
         fake_u = self._fake_matrix(self.u_desc, rows, dynamic_row_stride=True)
         fake_mask = self._fake_matrix(self.mask_desc, rows) if self.has_dropout else fake_x
-        fake_dx = self._fake_matrix(self.dx_desc, rows)
-        fake_du = self._fake_matrix(self.du_desc, rows)
+        fake_dx = self._fake_matrix(self.dx_desc, rows, dynamic_row_stride=True)
+        fake_du = self._fake_matrix(self.du_desc, rows, dynamic_row_stride=True)
         fake_mean = self._fake_vector(self.mean_desc, rows)
         fake_rstd = self._fake_vector(self.rstd_desc, rows)
         main = cute.compile(
@@ -642,8 +642,8 @@ class HSTULMSDBwd(_HSTULMSDBase):
             (dy_tensor, self.dy_desc, "dy", True, True),
             (mean_tensor, self.mean_desc, "mean", True, False),
             (rstd_tensor, self.rstd_desc, "rstd", True, False),
-            (dx_tensor, self.dx_desc, "dx", True, False),
-            (du_tensor, self.du_desc, "du", True, False),
+            (dx_tensor, self.dx_desc, "dx", True, True),
+            (du_tensor, self.du_desc, "du", True, True),
             (dbias_tensor, self.dbias_desc, "dbias", False, False),
             (dbias_workspace, self.dbias_workspace_desc, "dbias_workspace", False, False),
         ]

--- a/test/python/fe_api/hstu/hstu_lmsd/test_integration.py
+++ b/test/python/fe_api/hstu/hstu_lmsd/test_integration.py
@@ -61,6 +61,10 @@ def test_forward_outputs_feed_explicit_backward(d):
     weight = torch.randn((d,), device="cuda", dtype=torch.bfloat16)
     bias = torch.randn((d,), device="cuda", dtype=torch.bfloat16)
     dy = torch.randn((n, 3 * d), device="cuda", dtype=torch.bfloat16)
+    dx_storage = torch.empty((n, 2 * d), device="cuda", dtype=torch.bfloat16)
+    dx = dx_storage[:, :d]
+    du_storage = torch.empty((n, 5 * d), device="cuda", dtype=torch.bfloat16)
+    du = du_storage[:, :d]
 
     forward = hstu_lmsd_forward(x, u, weight, bias, eps=eps, dropout_ratio=p, seed=29)
     y, mean, rstd, mask = forward
@@ -80,6 +84,8 @@ def test_forward_outputs_feed_explicit_backward(d):
         apply_u_silu=True,
         concat_u=True,
         concat_x=True,
+        dx_tensor=dx,
+        du_tensor=du,
     )
     expected = hstu_lmsd_backward_reference(dy, x, u, weight, bias, mask, p, eps)
     tolerances = (
@@ -206,10 +212,10 @@ def test_wrappers_reuse_compiled_binaries_across_dynamic_n_and_row_strides(monke
     first_fwd_binary = first_bwd_binary = None
     try:
         cases = (
-            (37, 512, 2048, 1536),
-            (513, 1536, 2560, 2048),
+            (37, 512, 2048, 1536, 1024, 2560),
+            (513, 1536, 2560, 2048, 3072, 3584),
         )
-        for case, (n, x_row_stride, u_row_stride, dy_row_stride) in enumerate(cases):
+        for case, (n, x_row_stride, u_row_stride, dy_row_stride, dx_row_stride, du_row_stride) in enumerate(cases):
             torch.manual_seed(3100 + n)
             d, p, eps = 512, 0.1, 1e-6
             x_storage = torch.randn((n, x_row_stride), device="cuda", dtype=torch.bfloat16)
@@ -261,6 +267,10 @@ def test_wrappers_reuse_compiled_binaries_across_dynamic_n_and_row_strides(monke
 
             dy_storage = torch.randn((n, dy_row_stride), device="cuda", dtype=torch.bfloat16)
             dy = dy_storage[:, : 3 * d]
+            dx_storage = torch.empty((n, dx_row_stride), device="cuda", dtype=torch.bfloat16)
+            dx = dx_storage[:, :d]
+            du_storage = torch.empty((n, du_row_stride), device="cuda", dtype=torch.bfloat16)
+            du = du_storage[:, :d]
             actual = hstu_lmsd_backward(
                 dy,
                 x,
@@ -274,12 +284,16 @@ def test_wrappers_reuse_compiled_binaries_across_dynamic_n_and_row_strides(monke
                 apply_u_silu=True,
                 concat_u=True,
                 concat_x=True,
+                dx_tensor=dx,
+                du_tensor=du,
             )
             expected = hstu_lmsd_backward_reference(dy, x, u, weight, bias, mask, p, eps)
             assert actual["dx_tensor"].shape == (n, d)
             assert actual["du_tensor"].shape == (n, d)
             assert actual["dweight_tensor"].shape == (d,)
             assert actual["dbias_tensor"].shape == (d,)
+            assert actual["dx_tensor"].stride() == (dx_row_stride, 1)
+            assert actual["du_tensor"].stride() == (du_row_stride, 1)
             tolerances = (
                 (2.5e-2, 2.5e-2),
                 (2.5e-2, 2.5e-2),
@@ -306,6 +320,8 @@ def test_wrappers_reuse_compiled_binaries_across_dynamic_n_and_row_strides(monke
                 assert tuple(fwd_api.x_desc.stride) != tuple(x.stride())
                 assert tuple(fwd_api.u_desc.stride) != tuple(u.stride())
                 assert tuple(bwd_api.dy_desc.stride) != tuple(dy.stride())
+                assert tuple(bwd_api.dx_desc.stride) != tuple(dx.stride())
+                assert tuple(bwd_api.du_desc.stride) != tuple(du.stride())
 
         assert compile_calls == {"forward": 1, "backward": 1}
     finally:


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [ ] I ran `pre-commit run` and committed any formatting changes. (`pre-commit` is not installed in the local environment.)
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches and the changes comply.
- [x] I added the required GitHub labels. (A repository maintainer must add them.)

## Affected area

FE OSS kernels or CuTeDSL

## Summary

Allow LMSD backward `dx` and `du` outputs to use independent padded row strides.

## Why

The backward API previously required compact `(N, D)` outputs. This change lets the kernel address supported padded output views directly without allocation or copy-back.

## Related issues

None.

## API and compatibility impact

This is a backward-compatible expansion of the accepted output layouts. The innermost stride must remain 1, rows must not overlap, and BF16 row starts must remain 16-byte aligned.

## Testing

- Python syntax and whitespace checks
- Correctness coverage for independent `dx` and `du` row strides
- Compile-cache reuse coverage across different runtime row strides
