### PR TITLE
sdpa: serve paged KV caches through the FROST SM100 engine (#920)

### DIFF
--- a/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
+++ b/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
@@ -7,7 +7,7 @@ class it was tuned for in brackets) crossed with the pass; rows are features.
 Source of truth is the `Capabilities` row of each engine
 (`python/cudnn/sdpa/fwd/engines.py`, `python/cudnn/sdpa/bwd/engines.py`) — a
 cell here is ✅ only when that row admits it. Anything not listed as a row
-(dropout, ALiBi, paged KV, `block_mask`, `score_mod`, `rng_dump`,
+(dropout, ALiBi, `block_mask`, `score_mod`, `rng_dump`,
 `score_max`/`score_sum_exp`, tensor `attn_scale`, `unfuse_fma`, `Amax_S`) is
 **declined by every FROST SDPA engine on every arch**.
 
@@ -87,6 +87,25 @@ MMA as d=512.
 | `use_deterministic_algorithm` | — | — | — | — | — | ❌ᵇ · ✅ᵍ |
 | Ragged `S_kv` (non-multiple of 128) | ✅⁶ | ✅⁶ | ✅⁶ | ✅⁶ | ✅⁶ | ✅ᵇ ᵉ ᵍ |
 | Decode-shaped (`S_q == 1`) | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ᵇ · ✅ᵍ |
+| Paged KV cache (`paged_attention_k/v_table` + padding mask)ᵖ | ✅ᵖ (d128 envelope) | ✅ᵖ | ❌ | ✅ᵖ | ❌ | ❌ |
+
+ᵖ **Paged KV (issue #920), f16/bf16 only, d128 and d256 flavors** (`d_qk, d_v <= 256`;
+d=64 rides the d128 envelope, d=192/192 the d256 one; mixed dims that would select
+d192x128 are declined). The graph is cuDNN's own paged-cache contract: K/V are page
+pools `[num_pages, H_kv, page_size, D]` — HND compact, or NHD (`[num_pages, page_size,
+H_kv, D]` storage) declared through the strides — plus `(B, 1, max_pages, 1)` int32
+block tables and `use_padding_mask` with `seq_len_q` / `seq_len_kv` (the per-batch KV
+length is read on device; `paged_attention_max_seq_len_kv` defaults to `max_pages *
+page_size`). `page_size` is a multiple of 8 that divides the 128-row KV tile or is a
+multiple of it. Any `S_q` (decode or paged prefill), GQA (PackGQA when the group
+divides the tile), Stats out, and **THD queries**: ragged Q/O (ragged offsets +
+`seq_len_q`) over the same pools — chunked prefill — with the THD scheduler walking
+the Q units (no KV split there). KV split is proposed on dense-Q paged graphs (they
+are padded by construction, and `B * H_kv` is far below the SM count at serving batch
+sizes) and recombined by `split_combine_sm100`. Not yet: sink, fp8/mxfp8 pools,
+packed (ragged-offset) block tables. Served by `prefill_d128_f16_sm100.py`'s `PAGED_KV`
+specialization (block-table indirection on the K/V TMA loads; boxes past a
+sequence's live pages are TMA-OOB zero-filled).
 
 ¹ **Reads as: on a quantized (fp8/mxfp8) graph in this column, O may be FP16,
 BF16, E4M3 or E5M2.** It does NOT mean an f16/bf16 graph may convert O — the f16
@@ -487,4 +506,5 @@ feature-free d=64 graph.
 | **Native d=64 (GPT-OSS) forward kernel** | **SM100, SM107** — served via the d128 envelope at ~2× MMA cost |
 | d=64 MXFP8 / d=64 quantized THD | SM100, SM107 (exact-shape gates) |
 | Bias forward | SM100, SM107, SM120 |
-| Dropout, ALiBi, paged KV, `block_mask`, `score_mod` | every arch, both passes |
+| Dropout, ALiBi, `block_mask`, `score_mod` | every arch, both passes |
+| Paged KV cache | every arch except SM100/SM103 f16/bf16 d128 forward (see ᵖ); fp8/mxfp8 pools, sink, THD, packed block tables everywhere |

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -457,12 +457,27 @@ class SdpaFwdDsl(APIBase):
         split_kv: Optional[int] = None,
         softmax_precision: Optional[int] = None,
         pack_gqa: Optional[bool] = None,
+        paged_page_size: int = 0,
+        paged_max_seq_len_kv: Optional[int] = None,
+        paged_table_stride: Optional[tuple] = None,
+        paged_table_v_stride: Optional[tuple] = None,
     ) -> None:
         """Capture the common SDPA operation and tuning contract.
 
         Optional operands are accepted by every adapter. A concrete
         implementation that cannot lower one raises :class:`NotImplementedError`
         from ``check_support``.
+
+        Paged KV (``paged_page_size > 0``): ``sample_k`` / ``sample_v`` are the
+        page POOLS ``[num_pages, H_kv, page_size, D]`` — HND compact, or NHD
+        storage declared through the strides; the layout is nothing but those
+        strides and they are compiled in — execute() takes the ``(B, max_pages)``
+        int32 block tables, and ``paged_max_seq_len_kv`` (required) is the logical
+        S_kv the masks clamp against (per-batch lengths are mandatory:
+        ``seq_kv_lens_present``). ``paged_table_stride`` / ``paged_table_v_stride``
+        are the tables' declared ``(batch, page)`` strides, compiled in so any
+        layout (row-major, batch-innermost, padded) binds as a view; None =
+        row-major compact.
         """
 
         super().__init__()
@@ -542,6 +557,10 @@ class SdpaFwdDsl(APIBase):
         # yet, so anything non-None is rejected in check_support.
         self.softmax_precision = softmax_precision
         self.pack_gqa = bool(pack_gqa) if pack_gqa is not None else False
+        self.paged_page_size = int(paged_page_size or 0)
+        self.paged_max_seq_len_kv = None if paged_max_seq_len_kv is None else int(paged_max_seq_len_kv)
+        self.paged_table_stride = None if paged_table_stride is None else tuple(int(s) for s in paged_table_stride)
+        self.paged_table_v_stride = None if paged_table_v_stride is None else tuple(int(s) for s in paged_table_v_stride)
 
         self.batch_size: Optional[int] = None
         self.s_q_max: Optional[int] = None
@@ -554,6 +573,10 @@ class SdpaFwdDsl(APIBase):
         self._dummy_cache: dict[tuple[str, torch.device], torch.Tensor] = {}
         self._initialize_implementation()
         self._logger.debug("__init__ completed")
+
+    @property
+    def paged(self) -> bool:
+        return self.paged_page_size > 0
 
     @abstractmethod
     def _initialize_implementation(self) -> None:
@@ -594,6 +617,10 @@ class SdpaFwdDsl(APIBase):
         st = (int(desc.stride[2]), int(desc.stride[1]), int(desc.stride[3]))
         return st, st == (h * d, d, 1)
 
+    def _thd_descs(self) -> tuple:
+        """The THD-packed operands: Q/K/V/O, or just Q/O when K/V are paged pools."""
+        return (self.q_desc, self.o_desc) if self.paged else (self.q_desc, self.k_desc, self.v_desc, self.o_desc)
+
     def _thd_check_strides_native(self) -> None:
         """Reject THD stride declarations the kernels cannot address
         natively: TMA's 16-byte global-stride rule — the head dim must be
@@ -605,7 +632,7 @@ class SdpaFwdDsl(APIBase):
         token >= h*head): an overlapping declaration would alias distinct O
         rows onto the same storage (a write race) and is outside the
         kernels' addressing contract."""
-        for desc in (self.q_desc, self.k_desc, self.v_desc, self.o_desc):
+        for desc in self._thd_descs():
             (ts, hs, es), _ = self._thd_declared(desc)
             h, d = desc.shape[1], desc.shape[3]
             # The 16-byte TMA rule in this tensor's OWN element units: 8 at
@@ -623,7 +650,7 @@ class SdpaFwdDsl(APIBase):
         """FP8 THD serves only the packed contract for now (its kernel and
         harness are not audited for declared strides) — decline anything else
         rather than adapt (AGENTS.md Hard Rule 2)."""
-        for desc in (self.q_desc, self.k_desc, self.v_desc, self.o_desc):
+        for desc in self._thd_descs():
             _, packed = self._thd_declared(desc)
             self._not_implemented_error_if(
                 not packed,
@@ -1085,7 +1112,8 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 f"{d.name} must be rank-4 (B, H, S, D); got {d.ndim}",
             )
             _shape, _stride = d.shape, d.stride
-            if self.thd:
+            # Paged pools are dense tensors even under THD (only Q/O are packed).
+            if self.thd and not (self.paged and desc_name in ("k_desc", "v_desc")):
                 _act = tuple(ax for ax in d.stride_order if _shape[ax] != 1)
                 _exp = tuple(ax for ax in _REQ if _shape[ax] != 1)
                 self._value_error_if(
@@ -1110,12 +1138,24 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 self._thd_check_strides_native()
 
         b, h_qo, s_qo, d_qk = self.q_desc.shape
-        _, h_kv, s_kv, _ = self.k_desc.shape
         _, _, _, d_v = self.v_desc.shape
-
+        if self.paged:
+            # K/V are page pools [num_pages, H_kv, page_size, D]; the logical
+            # S_kv is the declared maximum, else what the block table addresses.
+            num_pages, h_kv, page_size, _ = self.k_desc.shape
+            self._value_error_if(page_size != self.paged_page_size, f"K container page_size {page_size} != declared {self.paged_page_size}")
+            self._check_tensor_shape(self.k_desc, (num_pages, h_kv, page_size, d_qk), name="K")
+            self._check_tensor_shape(self.v_desc, (num_pages, h_kv, page_size, d_v), name="V")
+            self._value_error_if(
+                self.paged_max_seq_len_kv is None or self.paged_max_seq_len_kv <= 0,
+                "paged KV needs paged_max_seq_len_kv (the logical S_kv the block tables address)",
+            )
+            s_kv = self.paged_max_seq_len_kv
+        else:
+            _, h_kv, s_kv, _ = self.k_desc.shape
+            self._check_tensor_shape(self.k_desc, (b, h_kv, s_kv, d_qk), name="K")
+            self._check_tensor_shape(self.v_desc, (b, h_kv, s_kv, d_v), name="V")
         self._check_tensor_shape(self.q_desc, (b, h_qo, s_qo, d_qk), name="Q")
-        self._check_tensor_shape(self.k_desc, (b, h_kv, s_kv, d_qk), name="K")
-        self._check_tensor_shape(self.v_desc, (b, h_kv, s_kv, d_v), name="V")
         self._check_tensor_shape(self.o_desc, (b, h_qo, s_qo, d_v), name="O")
 
         for label, val in (
@@ -1312,6 +1352,21 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             self.softmax_precision == _cudnn_dtype.HALF and (self._device_cc != (10, 7) or self.flavor != (128, 128)),
             "softmax_precision=HALF is served for per-tensor FP8 d128 on cc10.7 only (FLOAT is the default everywhere)",
         )
+        if self.paged:
+            # Paged KV rides the d128 f16/bf16 kernel's PAGED_KV specialization
+            # (config_sm100._validate_params is the backstop for the same set).
+            self._not_implemented_error_if(self._fp8, "paged KV is served by the f16/bf16 kernel only")
+            self._not_implemented_error_if(
+                self.flavor not in ((128, 128), (256, 256)),
+                f"paged KV is wired on the d128 and d256 flavors only; head dims ({d_qk}, {d_v}) select {self.flavor}",
+            )
+            self._value_error_if(not self.seq_kv_lens_present, "paged KV requires per-batch KV lengths (seq_kv_lens_present)")
+            self._not_implemented_error_if(self.has_sink, "paged KV with an attention sink is not validated")
+            p = self.paged_page_size
+            self._value_error_if(
+                p % 8 != 0 or (p < _SM100_TILE_N and _SM100_TILE_N % p != 0) or (p > _SM100_TILE_N and p % _SM100_TILE_N != 0),
+                f"page_size {p} must be a multiple of 8 that divides {_SM100_TILE_N} or is a multiple of it",
+            )
         if self.split_kv > 1:
             # Split-KV: partials weighted by the per-split LSE, recombined by
             # sm100/split_combine (which also owns the FP8 amax of the
@@ -1319,8 +1374,10 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             # facts x knobs gate so the standalone API declines identically.
             self._not_implemented_error_if(self.thd, "split_kv > 1 is dense-only (THD packs its own flat grid)")
             self._value_error_if(self.has_sink, "split_kv > 1 with an attention sink is not supported")
+            # Paged KV is padded by construction; its split composes with the
+            # per-batch lengths (validated in test_sdpa_fwd_paged_sm100).
             self._value_error_if(
-                self.seq_kv_lens_present or self.seq_q_lens_present,
+                not self.paged and (self.seq_kv_lens_present or self.seq_q_lens_present),
                 "split_kv > 1 serves unpadded dense graphs only",
             )
             # cc10.7 routes every family to an SM107 sibling, and only the
@@ -1505,6 +1562,8 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             cta_mma=(1 if self._fp8 and self.flavor == (256, 256) else 2) if self.cga is None else self.cga,
             fused_ldtm_stat=fused_ldtm_stat,
             softmax_f16=self.softmax_precision == _cudnn_dtype.HALF,
+            paged_kv=self.paged,
+            page_size=self.paged_page_size,
         )
         if self.flavor == (192, 128):
             from cudnn.sdpa.fwd.heuristics import select_d192_auto_knobs
@@ -1618,6 +1677,11 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 d_v=self.head_dim_v,
                 has_lse=(self.lse_desc is not None) or self.split_kv > 1,
                 lse_stride=None if self.split_kv > 1 else self._lse_stride,
+                # Paged KV: the pools are bound as declared — their strides in
+                # the kernel's [num_pages, page_size, H_kv, D] order (the
+                # container's head/row axes swapped); num_pages / max_pages are
+                # dynamic extents of the artifact.
+                **(self._paged_compile_kwargs() if self.paged else {}),
             )
         self._combine_kernel = None
         if self.split_kv > 1:
@@ -1642,6 +1706,28 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 lse_stride=self._lse_stride,
             )
         self._logger.debug("compile completed")
+
+    @staticmethod
+    def _paged_pool_stride(desc) -> tuple:
+        """Container strides ``[num_pages, H_kv, page_size, D]`` re-expressed in
+        the kernel's ``[num_pages, page_size, H_kv, D]`` order (a permutation,
+        so HND and NHD storage both bind as views)."""
+        s = tuple(int(x) for x in desc.stride)
+        return (s[0], s[2], s[1], s[3])
+
+    def _paged_compile_kwargs(self) -> dict:
+        """The paged entries of the kernel compile key: pool strides in the
+        kernel's order and the tables' declared (batch, page) strides."""
+        return dict(
+            k_stride=self._paged_pool_stride(self.k_desc),
+            v_stride=self._paged_pool_stride(self.v_desc),
+            block_table_stride=self.paged_table_stride,
+            block_table_v_stride=self.paged_table_v_stride,
+        )
+
+    def _paged_table_expected_stride(self, which_v: bool, n_pages: int) -> tuple:
+        declared = self.paged_table_v_stride if which_v else self.paged_table_stride
+        return declared if declared is not None else (n_pages, 1)
 
     def scratch_workspace_bytes(self) -> int:
         """Per-execute scratch ``execute()`` carves from its ``workspace``.
@@ -1706,6 +1792,8 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         descale_v: Optional[torch.Tensor] = None,
         scale_o: Optional[torch.Tensor] = None,
         workspace: Optional[torch.Tensor] = None,
+        block_table: Optional[torch.Tensor] = None,
+        block_table_v: Optional[torch.Tensor] = None,
     ) -> None:
         """Launch the compiled kernel.
 
@@ -1714,10 +1802,38 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         per-execute scratch buffer (the THD metadata / O-descriptor buffers)
         is carved from it — zero per-execute allocations. When None
         (standalone use), those buffers are torch-allocated as before.
+
+        ``block_table`` / ``block_table_v``: paged KV only — ``(B, max_pages)``
+        int32 device tensors (``block_table_v`` defaults to ``block_table``);
+        ``k_tensor`` / ``v_tensor`` are then the page pools in their declared
+        layout, bound as views.
         """
         self._logger.debug("Entering execute")
         if self._compiled_kernel is None:
             raise RuntimeError("SdpaFwdDslSm100 is not compiled")
+        if self.paged:
+            if block_table is None:
+                raise ValueError("paged KV: block_table is required")
+            block_table_v = block_table if block_table_v is None else block_table_v
+            min_pages = -(-self.s_k_max // self.paged_page_size)
+            for name, bt, is_v in (("block_table", block_table, False), ("block_table_v", block_table_v, True)):
+                if bt.ndim != 2 or bt.shape[0] != self.batch_size or bt.shape[1] < min_pages or bt.dtype != torch.int32:
+                    raise ValueError(
+                        f"paged KV: {name} must be an int32 ({self.batch_size}, >= {min_pages}) tensor covering S_kv={self.s_k_max}; got {tuple(bt.shape)} {bt.dtype}"
+                    )
+                # Strides are compiled in (a view of the declared layout, never a
+                # copy); size-1 axes are stride-agnostic.
+                want = self._paged_table_expected_stride(is_v, bt.shape[1])
+                got = tuple(bt.stride())
+                if any(g != w for g, w, n in zip(got, want, bt.shape) if n != 1):
+                    raise ValueError(f"paged KV: {name} strides {got} do not match the declared table strides {want}")
+            for name, t, d in (("k_tensor", k_tensor, self.k_desc), ("v_tensor", v_tensor, self.v_desc)):
+                if tuple(t.shape) != tuple(d.shape) or tuple(t.stride()) != tuple(d.stride):
+                    raise ValueError(
+                        f"paged KV: {name} must match the declared pool {tuple(d.shape)} / {tuple(d.stride)}; got {tuple(t.shape)} / {tuple(t.stride())}"
+                    )
+        elif block_table is not None or block_table_v is not None:
+            raise ValueError("block_table given but the adapter was not built for paged KV")
         # Run on the caller's stream (ExecutionContext.stream, resolved from the
         # execute-time handle); None -> the default stream. Threaded to every
         # kernel launch below (dense / fp8 / mxfp8 / THD).
@@ -1818,13 +1934,25 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 lse_tensor=lse_tensor,
                 workspace=workspace,
                 current_stream=current_stream,
+                block_table=block_table,
+                block_table_v=block_table_v,
             )
             return
 
         Q = self._to_bshd(q_tensor)
-        K = self._to_bshd(k_tensor)
-        V = self._to_bshd(v_tensor)
+        if self.paged:
+            # Page pools [num_pages, H_kv, page_size, D] -> the kernel's
+            # [num_pages, page_size, H_kv, D] view; the strides carry HND/NHD
+            # and were compiled in, so this is a view, never a copy.
+            K = k_tensor.permute(0, 2, 1, 3)
+            V = v_tensor.permute(0, 2, 1, 3)
+        else:
+            K = self._to_bshd(k_tensor)
+            V = self._to_bshd(v_tensor)
         O_view, o_needs_copy_back, O_scratch = self._to_bshd_writable(o_tensor)
+        # Trailing THD-only ABI slots (None) + the paged block tables; omitted
+        # entirely on dense builds, whose compiled signature ends at seq_q_lens.
+        paged_kwargs = {"block_table_tensor": block_table, "block_table_v_tensor": block_table_v} if self.paged else {}
 
         device = q_tensor.device
         sinks_t = (
@@ -1873,6 +2001,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 cutlass.Int32(0),
                 seq_q_t,
                 **({"o_partial_f32": o_partial} if self._fp32_partial_split() else {}),
+                **paged_kwargs,
                 stream=current_stream,
             )
             self._combine_kernel(
@@ -1901,6 +2030,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 cutlass.Int32(0),
                 seq_q_t,
                 **({"o_partial_f32": o_partial} if self._fp32_partial_split() else {}),
+                **paged_kwargs,
                 stream=current_stream,
             )
         if o_needs_copy_back:
@@ -1945,10 +2075,14 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             d_qk=self.head_dim_qk,
             d_v=self.head_dim_v,
             q_stride=_key(self.q_desc),
-            k_stride=_key(self.k_desc),
-            v_stride=_key(self.v_desc),
+            # Paged pools bind as declared (strides in the kernel's
+            # [num_pages, page_size, H_kv, D] order); no token-stride key.
+            k_stride=self._paged_pool_stride(self.k_desc) if self.paged else _key(self.k_desc),
+            v_stride=self._paged_pool_stride(self.v_desc) if self.paged else _key(self.v_desc),
             o_stride=_key(self.o_desc),
         )
+        if self.paged:
+            kwargs.update(block_table_stride=self.paged_table_stride, block_table_v_stride=self.paged_table_v_stride)
         return kwargs
 
     def _thd_unit_envelope(self) -> int:
@@ -2046,9 +2180,18 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
 
         Q = self._thd_view(q_buf, self.q_desc, t_q)
         O = self._thd_view(o_buf, self.o_desc, t_q)
-        t_kv = min(self._thd_capacity(k_buf, self.k_desc), self._thd_capacity(v_buf, self.v_desc))
-        t_kv = self._thd_declared_total(t_kv, self.max_total_seq_len_kv)
-        if t_kv == 0:
+        if self.paged:
+            # K/V are page pools, addressed through the block tables: bind the
+            # kernel's [num_pages, page_size, H_kv, D] views (no packed extent).
+            t_kv = 0
+            K = k_buf.permute(0, 2, 1, 3)
+            V = v_buf.permute(0, 2, 1, 3)
+        else:
+            t_kv = min(self._thd_capacity(k_buf, self.k_desc), self._thd_capacity(v_buf, self.v_desc))
+            t_kv = self._thd_declared_total(t_kv, self.max_total_seq_len_kv)
+        if self.paged:
+            pass
+        elif t_kv == 0:
             # No KV storage at all:
             # every query row is dead — served by the KERNEL's own dead-row
             # path (total_sum <= 0 -> O := 0 and LSE := -inf, or the sink
@@ -2126,7 +2269,22 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             return lse_tensor.as_strided((1, qh, head_stride), (qh * head_stride, head_stride, 1), lse_tensor.storage_offset())
         return lse_tensor.as_strided((t_q, qh), (qh, 1), lse_tensor.storage_offset())
 
-    def _execute_thd(self, q_buf, k_buf, v_buf, o_buf, scale_softmax_log2, sinks, seq_len_kv, seq_q_lens, lse_tensor=None, workspace=None, current_stream=None):
+    def _execute_thd(
+        self,
+        q_buf,
+        k_buf,
+        v_buf,
+        o_buf,
+        scale_softmax_log2,
+        sinks,
+        seq_len_kv,
+        seq_q_lens,
+        lse_tensor=None,
+        workspace=None,
+        current_stream=None,
+        block_table=None,
+        block_table_v=None,
+    ):
         """THD / varlen execute (f16 kernels): shared packing + launch.
 
         ``lse_tensor``, when given, is the caller's ragged Stats buffer,
@@ -2159,8 +2317,11 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         # mints its own cache entry); the batch stride is zeroed out of the
         # key (a runtime value the kernel rebuilds symbolically).
         kwargs = self._thd_compile_kwargs()
-        kwargs.update(k_stride=(0, *pack.K.stride()[1:]), v_stride=(0, *pack.V.stride()[1:]))
+        if not self.paged:
+            kwargs.update(k_stride=(0, *pack.K.stride()[1:]), v_stride=(0, *pack.V.stride()[1:]))
         fn = self._k_mod.compile(**kwargs)
+        # Paged pools: the block tables follow the THD length slots in the ABI.
+        paged_kwargs = {"block_table_tensor": block_table, "block_table_v_tensor": block_table_v} if self.paged else {}
         # The caller's length tensors ride to the setup kernel, which builds
         # the metadata buffer device-side; the form bitmask is a runtime
         # value (no compile key grows). problem_size sq/skv slots are 0 by
@@ -2181,6 +2342,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             pack.q_lens_dev,
             pack.kv_lens_dev,
             cutlass.Int32(pack.lens_form),
+            **paged_kwargs,
             stream=current_stream,
         )
         self._logger.debug("execute (THD) completed")
@@ -2861,6 +3023,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
     def check_support(self) -> bool:
         self._logger.debug("Entering check_support")
 
+        self._not_implemented_error_if(self.paged, "paged KV is served by the SM100 f16/bf16 engine only")
         if self.thd:
             self._value_error_if(self.seq_q_lens_present, "seq_q_lens_present is dense-only (THD carries per-sequence Q lengths via cu_seqlens)")
             self.seq_kv_lens_present = True
@@ -4183,6 +4346,7 @@ class SdpaFwdDslSm80(SdpaFwdDsl):
 
         from cudnn.sdpa.graph_analyzer import dense_layout_ok
 
+        self._not_implemented_error_if(self.paged, "paged KV is served by the SM100 f16/bf16 engine only")
         for desc in (self.q_desc, self.k_desc, self.v_desc, self.o_desc):
             self._value_error_if(
                 desc.ndim != 4,

--- a/python/cudnn/sdpa/fwd/config_sm100.py
+++ b/python/cudnn/sdpa/fwd/config_sm100.py
@@ -132,7 +132,20 @@ class TemplateParams:
     # exp arguments are bounded (<= RESCALE_THRESHOLD + P_CAST_LOG2_SCALE),
     # so f16 range is exact where it matters and P quantizes to FP8 either way.
     softmax_f16: bool = False
+    # Paged KV cache (FlashInfer / vLLM decode contract): K/V are page pools
+    # indexed through a per-batch ``block_table`` [B, max_pages] int32, and
+    # the per-batch KV length is the (B,) ``seq_kv_lens`` device tensor
+    # (``seq_kv_lens_present`` is therefore mandatory). ``page_size`` tokens
+    # per page. The in-page layout (HND ``[num_pages, H_kv, page_size, D]`` vs
+    # NHD ``[num_pages, page_size, H_kv, D]``) is NOT a parameter: it is the
+    # pool's strides, which the per-shape compile() already pins. Dense-only.
+    paged_kv: bool = False
+    page_size: int = 0
 
+
+# Paged KV is wired through the K/V TMA-LDG sites of these flavors only; any
+# other flavor must reject it rather than silently reading K/V as dense.
+_PAGED_KV_FLAVORS = frozenset({"d128", "d256"})
 
 # split_kv / cta_mma live on the TemplateParams shared by every SM100 flavor, but
 # a flavor only honours them once its make_cfg_* threads them into a Cfg AND its
@@ -211,6 +224,23 @@ def _validate_params(flavor: str, k: TemplateParams) -> None:
     if k.pack_gqa:
         if k.thd_varlen:
             raise ValueError(f"{flavor}: pack_gqa is not supported for THD-varlen")
+    if k.paged_kv:
+        if flavor not in _PAGED_KV_FLAVORS:
+            raise ValueError(f"{flavor}: paged_kv is not implemented on this flavor; supported: {sorted(_PAGED_KV_FLAVORS)}")
+        if not k.seq_kv_lens_present:
+            raise ValueError(f"{flavor}: paged_kv requires seq_kv_lens_present (the per-batch KV length bounds the block-table walk)")
+        if fp8:
+            raise ValueError(f"{flavor}: paged_kv is wired for the f16/bf16 kernel only")
+        # A K/V tile is loaded as a stack of page-sized row boxes (or one box
+        # inside a page when the page is taller than the tile). Either way a
+        # box must never straddle a page, and the 128 B swizzle atom is 8 rows.
+        p = k.page_size
+        if p < 8 or p % 8 != 0:
+            raise ValueError(f"{flavor}: page_size must be a positive multiple of 8; got {p}")
+        if (p < 128 and 128 % p != 0) or (p > 128 and p % 128 != 0):
+            raise ValueError(f"{flavor}: page_size must divide the 128-row KV tile or be a multiple of it; got {p}")
+    elif k.page_size:
+        raise ValueError(f"{flavor}: page_size requires paged_kv=True")
 
 
 def _mask_flags_from(params: TemplateParams) -> int:
@@ -407,6 +437,10 @@ class CfgD256:
     PACK_GQA: int = 0
 
     QH_PER_KH: int = 1
+
+    # Paged KV cache; see TemplateParams.paged_kv.  PAGE_SIZE tokens per page.
+    PAGED_KV: int = 0
+    PAGE_SIZE: int = 0
 
 
 def _validate_cfg_d256(cfg: CfgD256) -> None:
@@ -611,6 +645,8 @@ def _make_cfg_d256(params: TemplateParams, *, mxfp8: bool) -> Tuple[CfgD256, Tma
         SPLIT_KV=int(params.split_kv),
         PACK_GQA=int(params.pack_gqa),
         QH_PER_KH=int(params.qh_per_kh),
+        PAGED_KV=int(params.paged_kv),
+        PAGE_SIZE=int(params.page_size),
     )
     _validate_cfg_d256(cfg)
     if cfg.PACK_GQA and cfg.TILE_M % cfg.QH_PER_KH != 0:
@@ -930,6 +966,10 @@ class CfgD128:
 
     QH_PER_KH: int = 1
 
+    # Paged KV cache; see TemplateParams.paged_kv.  PAGE_SIZE tokens per page.
+    PAGED_KV: int = 0
+    PAGE_SIZE: int = 0
+
 
 # Blackwell SM100 per-CTA dynamic SMEM cap (228 KiB physical, 227 KiB usable).
 _SM100_MAX_DYN_SMEM = 227 * 1024
@@ -1047,6 +1087,8 @@ def make_cfg_d128(params: TemplateParams) -> Tuple[CfgD128, TmaIters]:
         SPLIT_KV=int(params.split_kv),
         PACK_GQA=int(params.pack_gqa),
         QH_PER_KH=int(params.qh_per_kh),
+        PAGED_KV=int(params.paged_kv),
+        PAGE_SIZE=int(params.page_size),
     )
     _validate_cfg_d128(cfg)
     if cfg.PACK_GQA and cfg.TILE_M % cfg.QH_PER_KH != 0:

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -400,7 +400,10 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
             # per-split LSE is the combine weight; the THD/sink/padded paths
             # do not produce per-split partials). Declined HERE so a split
             # request never reaches a kernel that cannot honor it.
-            if facts.thd or facts.has_sink or facts.padded or facts.seq_q_trim:
+            # Paged KV is padded by construction and its split composes with
+            # the per-batch lengths (the decode path — B*H_kv is far below
+            # the SM count), so it is exempt from the padded exclusion.
+            if facts.thd or facts.has_sink or (facts.padded and not facts.has_paged_kv) or facts.seq_q_trim:
                 return "split_kv > 1 serves dense, unpadded, sink-free graphs only"
             if capabilities.skv_tail_via_padding and facts.s_kv % (capabilities.skv_tile or 128) != 0 and not _band_covers_kv_tail(facts):
                 # The lowering would serve this ragged S_kv through the padded
@@ -511,6 +514,23 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
         if fact and not cap:
             return f"graph uses {label}, which this engine does not support"
 
+    if facts.has_paged_kv:
+        # Served by the d128 f16/bf16 kernel's PAGED_KV specialization
+        # (config_sm100._validate_params mirrors these as its backstop).
+        if facts.is_fp8 or facts.is_mxfp8:
+            return "paged KV is served by the f16/bf16 kernel only"
+        if not facts.padded:
+            return "paged KV requires use_padding_mask with seq_len_kv (the per-batch KV length bounds the block-table walk)"
+        if facts.d_qk > 256 or facts.d_v > 256:
+            return f"paged KV is wired on the d128 / d256 flavors only (d_qk, d_v <= 256); got ({facts.d_qk}, {facts.d_v})"
+        if (facts.d_qk > 128 or facts.d_v > 128) and not (facts.d_qk > 128 and facts.d_v > 128):
+            return f"paged KV with mixed head dims ({facts.d_qk}, {facts.d_v}) would select the d192x128 flavor, which is not wired"
+        if facts.has_sink:
+            return "paged KV with an attention sink is not validated"
+        p = facts.page_size
+        if p % 8 != 0 or (p < 128 and 128 % p != 0) or (p > 128 and p % 128 != 0):
+            return f"page_size {p} must be a multiple of 8 that divides the 128-row KV tile or is a multiple of it"
+
     if facts.has_sink and capabilities.sink_dtypes is not None and facts.dtype not in capabilities.sink_dtypes:
         return f"sink token with dtype {facts.dtype} not in {sorted(str(d) for d in capabilities.sink_dtypes)}"
 
@@ -612,6 +632,11 @@ def _sm100_spec() -> EngineSpec:
             right_band_widening=True,
             swa=True,
             padded=True,
+            # Paged KV caches (paged_attention_k/v_table + seq_len_kv) on the
+            # d128 flavor: block-table indirection on the K/V TMA loads, HND
+            # and NHD page layouts, KV split + combine (mismatch() holds the
+            # d128 / dense / padded / page-geometry conditions).
+            paged_kv=True,
             sink=True,
             stats=True,
             lse_optional=True,
@@ -1185,6 +1210,18 @@ def build(spec: EngineSpec, graph, knobs: Optional[SdpaFwdKnobs] = None):
     return spec.lower(spec, facts, knobs)
 
 
+def _table_stride(t) -> tuple:
+    """A paged block table's ``(batch, page)`` strides from its ``(B, 1, max_pages, 1)`` IR ref."""
+    s = tuple(int(x) for x in t.get_stride())
+    return (s[0], s[2])
+
+
+def _table_view(buf, ir_t, b: int):
+    """The kernel's ``(B, max_pages)`` view of a bound ``(B, 1, max_pages, 1)`` table — a
+    view of the declared layout (size-1 axes dropped), never a copy."""
+    return buf.as_strided((b, int(ir_t.get_dim()[2])), _table_stride(ir_t), buf.storage_offset())
+
+
 def lower_dsl_prefill(
     spec: EngineSpec,
     facts: "ga.SdpaGraphFacts",
@@ -1250,6 +1287,15 @@ def lower_dsl_prefill(
         # of TMA reach. Only ever tightens (see _thd_declared_total).
         max_total_seq_len_q=facts.max_total_seq_len_q,
         max_total_seq_len_kv=facts.max_total_seq_len_kv,
+        # Paged KV: K/V samples are the page pools; the adapter needs the page
+        # geometry and the declared KV maximum the masks clamp against.
+        paged_page_size=facts.page_size if facts.has_paged_kv else 0,
+        paged_max_seq_len_kv=facts.s_kv if facts.has_paged_kv else None,
+        # The tables' declared (batch, page) strides — the (B, 1, max_pages, 1)
+        # IR tensor's axes 0 and 2 — so batch-innermost / padded tables bind
+        # as views.
+        paged_table_stride=_table_stride(facts.paged_k_table_t) if facts.has_paged_kv else None,
+        paged_table_v_stride=_table_stride(facts.paged_v_table_t) if facts.has_paged_kv else None,
         dtype_o=facts.dtype_o if (facts.is_mxfp8 or facts.is_fp8) else None,
         pertensor_fp8=facts.is_fp8,
         sched_policy=knobs.sched_policy if knobs is not None else None,
@@ -1307,6 +1353,8 @@ def lower_dsl_prefill(
         seq_len_q=seq_q_t,
         cu_seq_len_q=facts.cu_seq_q_t,
         cu_seq_len_kv=facts.cu_seq_kv_t,
+        paged_k_table=facts.paged_k_table_t,
+        paged_v_table=facts.paged_v_table_t,
         bias=facts.bias_t,
         sf_q=facts.sf_q_t,
         sf_k=facts.sf_k_t,
@@ -1347,6 +1395,10 @@ def lower_dsl_prefill(
             k_buf = _ir_view(k_buf, binding.k)
             v_buf = _ir_view(v_buf, binding.v)
             o_buf = _ir_view(o_buf, binding.o)
+        elif facts.has_paged_kv:
+            # THD Q/O stay packed; the pools are ordinary dense tensors.
+            k_buf = _ir_view(k_buf, binding.k)
+            v_buf = _ir_view(v_buf, binding.v)
         # Scratch comes from the CALLER's workspace (never allocated here): the
         # CompiledPlan sized/validated it against workspace_bytes; the carver
         # re-validates so a direct call cannot silently corrupt memory.
@@ -1405,6 +1457,18 @@ def lower_dsl_prefill(
             # ExecutionContext's stream); None keeps the default stream.
             current_stream=_cuda_driver().CUstream(stream) if stream is not None else None,
         )
+        if facts.has_paged_kv:
+            # (B, 1, max_pages, 1) int32 tables bound as the kernel's flat
+            # (B, max_pages) views — a view, never a copy (Rule 1); the same
+            # buffer may back both.
+            bt_k = resolved.get(id(binding.paged_k_table))
+            bt_v = resolved.get(id(binding.paged_v_table))
+            if bt_k is None or bt_v is None:
+                raise ValueError("cudnn.sdpa: paged_attention_k_table / paged_attention_v_table requested but no buffer was provided")
+            execute_kwargs.update(
+                block_table=_table_view(bt_k, binding.paged_k_table, facts.b),
+                block_table_v=_table_view(bt_v, binding.paged_v_table, facts.b),
+            )
         if facts.is_mxfp8 or facts.is_fp8:
             execute_kwargs.update(
                 sf_q=sf_q_buf,

--- a/python/cudnn/sdpa/fwd/heuristics.py
+++ b/python/cudnn/sdpa/fwd/heuristics.py
@@ -664,7 +664,9 @@ def _split_points(
     no_split = 1
     if not caps.split_kv_supported:
         return [no_split]
-    if facts.thd or facts.has_sink or facts.padded or facts.seq_q_trim:
+    # Paged KV is padded by construction and the split composes with the
+    # per-batch lengths (it IS the decode lever there) — see mismatch().
+    if facts.thd or facts.has_sink or (facts.padded and not facts.has_paged_kv) or facts.seq_q_trim:
         return [no_split]
     if caps.skv_tail_via_padding and facts.s_kv % (caps.skv_tile or 128) != 0 and not _band_covers_kv_tail(facts):
         # This S_kv would be served through the synthesized KV-tail padding,

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d128_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d128_f16.py
@@ -70,6 +70,22 @@ Gated (config_sm100._validate_params) to SCHED_NATURAL, dense (non-THD), no
 sink; requires ``has_lse=True`` since the per-split LSE drives the combine.
 At SPLIT_KV == 1 every split helper const-folds away and the traced code is the
 classic single-pass kernel.
+
+Paged KV (``CFG.PAGED_KV=1``, issue #920): K/V are page POOLS —
+``[num_pages, page_size, H_kv, D]`` (NHD) or ``[num_pages, H_kv, page_size, D]``
+(HND, a stride permutation of the same descriptor) — and a per-batch
+``block_table`` [B, max_pages] int32 names the pages of each sequence.  Only
+the TMA-LDG warp changes: a K/V tile is issued as ``TILE_N / page_size`` row
+boxes (one box inside the page when the page is taller than the tile), each
+box's page coordinate read from the block table on device.  Boxes past the
+batch's ``ceil(seq_kv_len / page_size)`` pages get page coordinate ``-1`` —
+TMA-OOB, so they land as exact zeros and still complete their mbarrier bytes
+(the same trick issue #624 uses for the THD tail).  Rows inside the last live
+page but past ``seq_kv_len`` are loaded and masked (MASK_PADDED is mandatory),
+so the cache bytes of an allocated page must be finite — the contract every
+paged-attention kernel has.  The per-batch length rides the existing
+``seq_kv_lens_tensor`` and ``seqlen_kv`` is the static maximum
+``max_pages * page_size``, so nothing is read back to the host (Rule 3).
 """
 
 from functools import lru_cache
@@ -263,6 +279,21 @@ _bounds_for_tile_split = _split_h.bounds_for_tile_split
 _nomask_range_split = _split_h.nomask_range_split
 _partial_batch = _split_h.partial_batch
 
+# === Paged KV ===
+#
+# A K tile is TILE_N/CTA_MMA rows per CTA (the cga2 pair splits it), a V tile is
+# the full TILE_N rows (the pair splits V along d_v instead).  Each is loaded as
+# a stack of ``*_BOXES`` row boxes of ``*_BOX_ROWS`` rows, so that no box ever
+# straddles a page: box rows = min(page_size, tile rows).  The config validator
+# guarantees page_size | 128 or 128 | page_size, so this is exact.
+PAGED_KV = bool(CFG.PAGED_KV)
+PAGE_SIZE = CFG.PAGE_SIZE if PAGED_KV else 0
+_K_TILE_ROWS = CFG.TILE_N // CFG.CTA_MMA
+K_BOX_ROWS = min(PAGE_SIZE, _K_TILE_ROWS) if PAGED_KV else _K_TILE_ROWS
+V_BOX_ROWS = min(PAGE_SIZE, CFG.TILE_N) if PAGED_KV else CFG.TILE_N
+K_BOXES = _K_TILE_ROWS // K_BOX_ROWS
+V_BOXES = CFG.TILE_N // V_BOX_ROWS
+
 
 # P (BMM2 operand) aliases the TAIL of each 128-col S_acc slot since BMM1
 # finishes (and softmax loads S into registers) before P is written.
@@ -335,6 +366,15 @@ def _kernel(
     # ABI is unchanged.
     seq_q_lens_tensor: Optional[cute.Tensor] = None,
     o_partial_f32: Optional[cute.Tensor] = None,
+    # Paged KV: [B, max_pages] int32 page ids per batch, one table for K and
+    # one for V (the graph contract declares them separately; callers with a
+    # shared table bind the same buffer twice). None (folded out of the ABI)
+    # unless CFG.PAGED_KV.
+    block_table_tensor: Optional[cute.Tensor] = None,
+    block_table_v_tensor: Optional[cute.Tensor] = None,
+    # Paged KV: HND pool (row stride below head stride) -> descriptor dims
+    # (D, row, H_kv, page); derived by _host from the bound strides.
+    paged_hnd: cutlass.Constexpr[bool] = False,
 ) -> None:
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
     tidx, _, _ = cute.arch.thread_idx()
@@ -442,6 +482,7 @@ def _kernel(
                 bars.mb_o_empty[qs].init()
                 if cutlass.const_expr(IS_QO_ALIAS):
                     bars.mb_q_o_alias[qs].init()
+                    bars.mb_qo_slab_free[qs].init()
                 for c in cutlass.range_constexpr(CFG.N_BMM2_CHUNKS):
                     bars.mb_bmm2_ready[qs * CFG.N_BMM2_CHUNKS + c].init()
             for ks in cutlass.range_constexpr(CFG.STAGES_KV):
@@ -612,6 +653,9 @@ def _kernel(
             is_leader=is_leader,
             cta_in_pair=cta_in_pair,
             tma_mcast_mask=tma_mcast_mask,
+            block_table_tensor=block_table_tensor,
+            block_table_v_tensor=block_table_v_tensor,
+            paged_hnd=paged_hnd,
         )
 
     elif warp_idx == CFG.TMASTG_WARP_ID:
@@ -666,6 +710,52 @@ _kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
 
 @cute.jit
+def _paged_load_tile(
+    smem_tile,
+    tma,
+    block_table_tensor,
+    batch_idx,
+    kv_head_idx,
+    n_pages_b,
+    kv_tile,
+    row_off,
+    d_coord,
+    mbar,
+    tma_mcast_mask,
+    box_rows: cutlass.Constexpr[int],
+    n_boxes: cutlass.Constexpr[int],
+    granu_elems: cutlass.Constexpr[int],
+):
+    """Issue one paged K or V tile as ``n_boxes`` row boxes through the block table.
+
+    Box ``j`` covers sequence rows ``[kv_tile*TILE_N + row_off + j*box_rows, +box_rows)``
+    and lands at that row offset in SMEM (``shifted`` keeps the D-subtile
+    iteration of ``tma_load_tile`` intact; 128 B swizzle repeats every 8 rows
+    and box_rows is a multiple of 8, so stacked boxes equal one tall box).  A
+    box whose page slot is at or past this batch's live page count gets page
+    ``-1``: TMA-OOB, zero-filled, bytes still credited to ``mbar``.  The block
+    table read itself is clamped into the live range so it never leaves the
+    row, whatever the caller left in the padding slots.
+    """
+    bt = cutlass.make_array_view(block_table_tensor)
+    last_live = cute.math.max(n_pages_b - cutlass.Int32(1), cutlass.Int32(0))
+    for j in cutlass.range_constexpr(n_boxes):
+        g = kv_tile * cutlass.Int32(CFG.TILE_N) + row_off + cutlass.Int32(j * box_rows)
+        slot = g // cutlass.Int32(PAGE_SIZE)
+        row_in_page = g % cutlass.Int32(PAGE_SIZE)
+        page_live = cutlass.Int32(bt[batch_idx, cute.math.min(slot, last_live)])
+        in_range = slot < n_pages_b
+        page = cutlass.Int32(arith.select(in_range.ir_value(), page_live.ir_value(), cutlass.Int32(-1).ir_value()))
+        tma_load_tile(
+            smem_tile.shifted(j * box_rows * granu_elems),
+            tma(d_coord, kv_head_idx, row_in_page, page),
+            mbar,
+            cta_group=CFG.CTA_MMA,
+            mcast_mask=tma_mcast_mask,
+        )
+
+
+@cute.jit
 def _tmaldg_warp_group(
     tma_q_desc,
     tma_k_desc,
@@ -687,6 +777,9 @@ def _tmaldg_warp_group(
     is_leader,
     cta_in_pair,
     tma_mcast_mask,
+    block_table_tensor=None,
+    block_table_v_tensor=None,
+    paged_hnd: cutlass.Constexpr[bool] = False,
 ):
     """Unified TMA-LDG warp — cga1 / cga2 x MASK_NONE / PADDED / CAUSAL / SWA.
 
@@ -704,7 +797,7 @@ def _tmaldg_warp_group(
     mb_q_reload = bars.mb_q_o_alias if cutlass.const_expr(IS_QO_ALIAS) else bars.mb_q_empty
 
     tma_q = GmemTileTma(tma_q_desc)
-    if cutlass.const_expr(CFG.THD_VARLEN):
+    if cutlass.const_expr(CFG.THD_VARLEN and not PAGED_KV):
         # THD: K/V ride the setup kernel's packed-total-clamped runtime
         # descriptors (o_desc_words slots n_batch+1 / n_batch+2), so the last
         # sequence's tile-tail lands as exact zeros instead of reading the
@@ -714,6 +807,13 @@ def _tmaldg_warp_group(
         _v_rt_ptr = (o_desc_words.iterator.raw_ptr() + (n_batch + cutlass.Int32(2)) * cutlass.Int32(TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
         tma_k = lambda *coords: tma_slice_runtime_desc(_k_rt_ptr, *coords)  # noqa: E731
         tma_v = lambda *coords: tma_slice_runtime_desc(_v_rt_ptr, *coords)  # noqa: E731
+    elif cutlass.const_expr(PAGED_KV and paged_hnd):
+        # HND page pools: the row stride is below the head stride, so _host
+        # built the descriptors with dims (D, row, H_kv, page). Every load site
+        # keeps the (d, head, row, page) vocabulary; the swap lives here.
+        _tk, _tv = GmemTileTma(tma_k_desc), GmemTileTma(tma_v_desc)
+        tma_k = lambda d, h, r, p: _tk(d, r, h, p)  # noqa: E731
+        tma_v = lambda d, h, r, p: _tv(d, r, h, p)  # noqa: E731
     else:
         tma_k = GmemTileTma(tma_k_desc)
         tma_v = GmemTileTma(tma_v_desc)
@@ -750,6 +850,12 @@ def _tmaldg_warp_group(
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
+    # Paged KV: this batch's live page count bounds the block-table walk (MASK_PADDED
+    # is mandatory under PAGED_KV, so eff_seqlen_kv is always defined here).
+    n_pages_b = cutlass.Int32(0)
+    if cutlass.const_expr(PAGED_KV):
+        n_pages_b = (eff_seqlen_kv + cutlass.Int32(PAGE_SIZE - 1)) // cutlass.Int32(PAGE_SIZE)
+
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
 
@@ -761,13 +867,28 @@ def _tmaldg_warp_group(
         read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
 
         if cutlass.const_expr(MAY_BE_EMPTY) and (kv_right <= kv_left):
-            pass
+            if cutlass.const_expr(IS_QO_ALIAS):
+                # TMA-STG advances the Q∪O alias gate for EVERY tile, empty
+                # ones included (correction still writes O := 0 and STG still
+                # drains it).  Consume that phase even though no Q reload is
+                # needed, or the next live tile's wait passes on stale parity
+                # and its Q load races the previous tile's O drain — observed
+                # as a corrupted long batch whenever a persistent CTA picked up
+                # an empty split before it (cga1, multi-wave, mixed lengths).
+                # mb_qo_slab_free is the return edge; see make_classic_bars.
+                mb_q_reload[0].wait(q_empty_phase)
+                bars.mb_qo_slab_free[0].arrive()
+                mb_q_reload[1].wait(q_empty_phase)
+                bars.mb_qo_slab_free[1].arrive()
+                q_empty_phase = q_empty_phase ^ 1
         else:
             # Prologue interleave Q[0] -> K[first] -> Q[1] -> V[first] -> mainloop —
             # K load starts before Q[1] is issued and V before kv mainloop.
             kv_row_base = kv_left * CFG.TILE_N
 
             mb_q_reload[0].wait(q_empty_phase)
+            if cutlass.const_expr(IS_QO_ALIAS):
+                bars.mb_qo_slab_free[0].arrive()
             if cutlass.const_expr(CFG.CTA_MMA == 2):
                 bars.mb_q_full[0].arrive(n_bytes=qTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
             else:
@@ -790,23 +911,43 @@ def _tmaldg_warp_group(
                 bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
             else:
                 bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=nvvm.elect_sync())
-            tma_load_tile(
-                sK[kv_state.idx],
-                # THD: the prologue K load MUST apply the per-sequence kv offset
-                # (kv_seq_off = cu_k[batch]) and use the packed batch coord
-                # (tma_batch), exactly like the mainloop K load below and the V
-                # loads.  The old form (`+ K_ROW_OFFSET_PEER, batch_idx`) is
-                # byte-identical for the dense path (kv_seq_off=0,
-                # tma_batch==batch_idx) but reads the WRONG packed location for
-                # THD batch>=1 — corrupting the first (diagonal) KV tile and, via
-                # the online-softmax running max/sum, the whole batch>=1 output.
-                tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
-                bars.mb_k_full[kv_state.idx].smem_ptr,
-                cta_group=CFG.CTA_MMA,
-                mcast_mask=tma_mcast_mask,
-            )
+            if cutlass.const_expr(PAGED_KV):
+                _paged_load_tile(
+                    sK[kv_state.idx],
+                    tma_k,
+                    block_table_tensor,
+                    batch_idx,
+                    kv_head_idx,
+                    n_pages_b,
+                    kv_left,
+                    K_ROW_OFFSET_PEER,
+                    cutlass.Int32(0),
+                    bars.mb_k_full[kv_state.idx].smem_ptr,
+                    tma_mcast_mask,
+                    K_BOX_ROWS,
+                    K_BOXES,
+                    TMA_QK_GRANU_ELEMS,
+                )
+            else:
+                tma_load_tile(
+                    sK[kv_state.idx],
+                    # THD: the prologue K load MUST apply the per-sequence kv offset
+                    # (kv_seq_off = cu_k[batch]) and use the packed batch coord
+                    # (tma_batch), exactly like the mainloop K load below and the V
+                    # loads.  The old form (`+ K_ROW_OFFSET_PEER, batch_idx`) is
+                    # byte-identical for the dense path (kv_seq_off=0,
+                    # tma_batch==batch_idx) but reads the WRONG packed location for
+                    # THD batch>=1 — corrupting the first (diagonal) KV tile and, via
+                    # the online-softmax running max/sum, the whole batch>=1 output.
+                    tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
+                    bars.mb_k_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
 
             mb_q_reload[1].wait(q_empty_phase)
+            if cutlass.const_expr(IS_QO_ALIAS):
+                bars.mb_qo_slab_free[1].arrive()
             if cutlass.const_expr(CFG.CTA_MMA == 2):
                 bars.mb_q_full[1].arrive(n_bytes=qTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
             else:
@@ -830,13 +971,31 @@ def _tmaldg_warp_group(
                 bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
             else:
                 bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=nvvm.elect_sync())
-            tma_load_tile(
-                sV[kv_state.idx],
-                tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
-                bars.mb_v_full[kv_state.idx].smem_ptr,
-                cta_group=CFG.CTA_MMA,
-                mcast_mask=tma_mcast_mask,
-            )
+            if cutlass.const_expr(PAGED_KV):
+                _paged_load_tile(
+                    sV[kv_state.idx],
+                    tma_v,
+                    block_table_v_tensor,
+                    batch_idx,
+                    kv_head_idx,
+                    n_pages_b,
+                    kv_left,
+                    cutlass.Int32(0),
+                    V_COL_OFFSET_PEER,
+                    bars.mb_v_full[kv_state.idx].smem_ptr,
+                    tma_mcast_mask,
+                    V_BOX_ROWS,
+                    V_BOXES,
+                    TMA_VO_GRANU_ELEMS,
+                )
+            else:
+                tma_load_tile(
+                    sV[kv_state.idx],
+                    tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
+                    bars.mb_v_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
             kv_state = advance(kv_state, CFG.STAGES_KV)
 
             for kv_loop in cutlass.range(kv_left + cutlass.Int32(1), kv_right, 1, unroll=1):
@@ -847,26 +1006,62 @@ def _tmaldg_warp_group(
                     bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
                 else:
                     bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=nvvm.elect_sync())
-                tma_load_tile(
-                    sK[kv_state.idx],
-                    tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
-                    bars.mb_k_full[kv_state.idx].smem_ptr,
-                    cta_group=CFG.CTA_MMA,
-                    mcast_mask=tma_mcast_mask,
-                )
+                if cutlass.const_expr(PAGED_KV):
+                    _paged_load_tile(
+                        sK[kv_state.idx],
+                        tma_k,
+                        block_table_tensor,
+                        batch_idx,
+                        kv_head_idx,
+                        n_pages_b,
+                        kv_loop,
+                        K_ROW_OFFSET_PEER,
+                        cutlass.Int32(0),
+                        bars.mb_k_full[kv_state.idx].smem_ptr,
+                        tma_mcast_mask,
+                        K_BOX_ROWS,
+                        K_BOXES,
+                        TMA_QK_GRANU_ELEMS,
+                    )
+                else:
+                    tma_load_tile(
+                        sK[kv_state.idx],
+                        tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
+                        bars.mb_k_full[kv_state.idx].smem_ptr,
+                        cta_group=CFG.CTA_MMA,
+                        mcast_mask=tma_mcast_mask,
+                    )
 
                 bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
                 if cutlass.const_expr(CFG.CTA_MMA == 2):
                     bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
                 else:
                     bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=nvvm.elect_sync())
-                tma_load_tile(
-                    sV[kv_state.idx],
-                    tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
-                    bars.mb_v_full[kv_state.idx].smem_ptr,
-                    cta_group=CFG.CTA_MMA,
-                    mcast_mask=tma_mcast_mask,
-                )
+                if cutlass.const_expr(PAGED_KV):
+                    _paged_load_tile(
+                        sV[kv_state.idx],
+                        tma_v,
+                        block_table_v_tensor,
+                        batch_idx,
+                        kv_head_idx,
+                        n_pages_b,
+                        kv_loop,
+                        cutlass.Int32(0),
+                        V_COL_OFFSET_PEER,
+                        bars.mb_v_full[kv_state.idx].smem_ptr,
+                        tma_mcast_mask,
+                        V_BOX_ROWS,
+                        V_BOXES,
+                        TMA_VO_GRANU_ELEMS,
+                    )
+                else:
+                    tma_load_tile(
+                        sV[kv_state.idx],
+                        tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
+                        bars.mb_v_full[kv_state.idx].smem_ptr,
+                        cta_group=CFG.CTA_MMA,
+                        mcast_mask=tma_mcast_mask,
+                    )
 
                 kv_state = advance(kv_state, CFG.STAGES_KV)
 
@@ -902,6 +1097,8 @@ def _tmaldg_warp_group(
             bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
+            if cutlass.const_expr(PAGED_KV):
+                n_pages_b = (eff_seqlen_kv + cutlass.Int32(PAGE_SIZE - 1)) // cutlass.Int32(PAGE_SIZE)
 
     # cga2: drain trailing empty mbar arrives so SMEM isn't torn down while
     # leader's multicast commits are still in-flight.
@@ -938,6 +1135,10 @@ def _tmastg_warp_group(
     via scheduler warp's clusterlaunchcontrol.try_cancel.async.
     """
     o_full_phase = cutlass.Int32(0)  # consumer waits — first-arrive flips 0 → 1
+    # Q∪O alias return edge (consumer side): LDG arrives mb_qo_slab_free after
+    # consuming each alias phase; this warp waits it before its next alias
+    # arrive, so it can never lap LDG by two phases (mbarrier parity deadlock).
+    slab_free_phase = cutlass.Int32(0)
 
     tma_o = GmemTileTma(tma_o_desc)
 
@@ -1003,11 +1204,15 @@ def _tmastg_warp_group(
 
             bars.mb_o_empty[qs].arrive()
             # QO_ALIAS: O[qs] has drained to GMEM → the shared Q∪O slab is free
-            # for TMA-LDG to clobber with the next tile's Q[qs].
+            # for TMA-LDG to clobber with the next tile's Q[qs].  Throttled by
+            # the return edge: at most ONE alias phase ahead of LDG.
             if cutlass.const_expr(IS_QO_ALIAS):
+                bars.mb_qo_slab_free[qs].wait(slab_free_phase)
                 bars.mb_q_o_alias[qs].arrive()
 
         o_full_phase = o_full_phase ^ 1
+        if cutlass.const_expr(IS_QO_ALIAS):
+            slab_free_phase = slab_free_phase ^ 1
 
         wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
         nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
@@ -2163,6 +2368,11 @@ def _host(
     thd_kv_lens_tensor: Optional[cute.Tensor] = None,
     thd_lens_form: Optional[cutlass.Int32] = None,
     o_partial_f32: Optional[cute.Tensor] = None,
+    # Paged KV: [B, max_pages] int32 block table; None (folded out) unless
+    # CFG.PAGED_KV.  Its page axis is a DYNAMIC extent and defines the static
+    # KV maximum the masks clamp against: seqlen_kv = max_pages * PAGE_SIZE.
+    block_table_tensor: Optional[cute.Tensor] = None,
+    block_table_v_tensor: Optional[cute.Tensor] = None,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
     B, QH, KH, SQ, SKV, _ = problem_size
@@ -2171,6 +2381,8 @@ def _host(
         # problem_size slots are 0 by contract.
         SQ = q_tensor.shape[1]
         SKV = k_tensor.shape[1]
+    if cutlass.const_expr(PAGED_KV):
+        SKV = block_table_tensor.shape[1] * cutlass.Int32(PAGE_SIZE)
 
     # Tensors are [B, S, H, D] with stride_order=(3, 2, 1, 0); D is fastest.
     # K is split along seq under cga2 — box rows are per-CTA.  V is split along d_v
@@ -2179,10 +2391,24 @@ def _host(
     if cutlass.const_expr(CFG.PACK_GQA and q_tensor.shape[2] != k_tensor.shape[2] * CFG.QH_PER_KH):
         raise ValueError(f"CFG.QH_PER_KH ({CFG.QH_PER_KH}) does not match tensor head extents H_q={q_tensor.shape[2]}, H_kv={k_tensor.shape[2]}")
     qk_box_q = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, TMA_QK_GRANU_ELEMS)
-    qk_box_k = (1, CFG.TILE_N // CFG.CTA_MMA, 1, TMA_QK_GRANU_ELEMS)
-    vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
+    # Paged KV: K/V are [num_pages, page_size, H_kv, D] views of the page pool
+    # (batch -> page, seq -> row-in-page) and a tile is a stack of K_BOXES /
+    # V_BOXES row boxes, so the descriptor box is one box tall.  Dense: the
+    # full per-CTA tile.
+    qk_box_k = (1, K_BOX_ROWS, 1, TMA_QK_GRANU_ELEMS)
+    vo_box_v = (1, V_BOX_ROWS, 1, TMA_VO_GRANU_ELEMS)
     vo_box_o = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, _O_GRANU_ELEMS)
     stride_order = (3, 2, 1, 0)
+    # Paged KV: the in-page layout is nothing but the pool's strides (static —
+    # compiled in).  HND storage ([num_pages, H_kv, page_size, D]) viewed as
+    # [page, row, H_kv, D] has the row stride BELOW the head stride, so its
+    # descriptor must list dims innermost-first as (D, row, H_kv, page) and the
+    # TMA-LDG warp swaps its (head, row) coords to match; NHD is the dense BSHD
+    # order with batch -> page.
+    paged_hnd = bool(PAGED_KV) and k_tensor.stride[1] < k_tensor.stride[2]
+    if cutlass.const_expr(PAGED_KV and (v_tensor.stride[1] < v_tensor.stride[2]) != paged_hnd):
+        raise ValueError("paged K and V pools must share an in-page layout (both HND or both NHD)")
+    kv_stride_order = (3, 1, 2, 0) if paged_hnd else stride_order
 
     # Per-tensor TMA swizzle tracks per-CTA inner bytes (derived from CFG.*_SWZ_BYTES).
     def _tma_swz(byte_w: int):
@@ -2198,7 +2424,7 @@ def _host(
     tma_k_desc = tmap.create_tensor_map_tiled_from_view(
         k_tensor,
         box_dims=qk_box_k,
-        stride_order=stride_order,
+        stride_order=kv_stride_order,
         swizzle=_tma_swz(CFG.K_SWZ_BYTES),
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
     )
@@ -2209,7 +2435,7 @@ def _host(
     tma_v_desc = tmap.create_tensor_map_tiled_from_view(
         v_tensor,
         box_dims=vo_box_v,
-        stride_order=stride_order,
+        stride_order=kv_stride_order,
         swizzle=_v_tma_swz,
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
     )
@@ -2264,6 +2490,7 @@ def _host(
             cutlass.Int32(o_tensor.stride[1]),
             cutlass.Int32(CGA_TILE_M),
             n_thd_units,
+            not PAGED_KV,  # clamp_kv: paged pools have no packed KV total to clamp to
         ).launch(grid=(1, 1, 1), block=(THD_SETUP_THREADS, 1, 1), stream=stream)
         grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
     else:
@@ -2295,6 +2522,9 @@ def _host(
         scale_softmax_log2,
         seq_q_lens_tensor,
         o_partial_f32,
+        block_table_tensor,
+        block_table_v_tensor,
+        paged_hnd,
     ).launch(
         grid=grid_shape,
         block=[CFG.THREADS_PER_CTA, 1, 1],
@@ -2320,8 +2550,18 @@ def compile(  # noqa: A001
     v_stride: Optional[tuple] = None,
     o_stride: Optional[tuple] = None,
     lse_stride: Optional[tuple[int, int, int]] = None,
+    block_table_stride: Optional[tuple[int, int]] = None,
+    block_table_v_stride: Optional[tuple[int, int]] = None,
 ) -> Callable:
     """Compile a kernel with ALL dims concrete to pin TMA descriptor strides at compile time.
+
+    PAGED KV (``CFG.PAGED_KV``): ``k_stride`` / ``v_stride`` (REQUIRED) describe the
+    page pool viewed as ``[num_pages, page_size, H_kv, D]`` (batch -> page, seq ->
+    row-in-page; the strides alone say whether the pool is HND or NHD) and
+    ``skv`` is IGNORED — the page count and the block table's page axis are
+    runtime extents (``cute.sym_int``), so one artifact serves every cache size
+    and every ``max_pages`` (Rule 4); the kernel derives its static KV maximum
+    as ``block_table.shape[1] * page_size``.
 
     THD/varlen: q/k/v/o/lse are PACKED with batch dim 1 ([1,T,H,D]); ``b`` is the
     LOGICAL batch (sequence count) driving n_batch / metadata + O-desc sizes.
@@ -2373,7 +2613,7 @@ def compile(  # noqa: A001
     _o_batch = _fake_batch * SPLIT_KV
     _lse_batch = b * SPLIT_KV
 
-    def _fake_bshd(shape, stride, dtype=STORAGE_DTYPE, bpe=CFG.BPE):
+    def _fake_bshd(shape, stride, dtype=STORAGE_DTYPE, bpe=CFG.BPE, thd_packed=True):
         if stride is None:
             return cute.runtime.make_fake_compact_tensor(dtype, shape, stride_order=(3, 2, 1, 0), assumed_align=16)
         if stride[3] != 1:
@@ -2381,16 +2621,43 @@ def compile(  # noqa: A001
         for axis in (1, 2):  # seq/head global strides feed TMA: 16-byte rule
             if (stride[axis] * bpe) % 16 != 0:
                 raise ValueError(f"declared stride {stride} axis {axis} must be a 16-byte multiple at BPE={bpe} (TMA global-stride rule)")
-        if CFG.THD_VARLEN:
+        if CFG.THD_VARLEN and thd_packed:
             # Extent-1 batch dim: bind the token stride, as _thd_view does at
             # runtime -- T * token_stride is never stepped and overflows the int32
             # stride slot on long packed KV with wide tokens (GitHub #980).
+            # Paged pools are dense tensors and skip this (thd_packed=False).
             return cute.runtime.make_fake_tensor(dtype, shape, (stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
         return cute.runtime.make_fake_tensor(dtype, shape, tuple(stride), assumed_align=16)
 
     fake_q = _fake_bshd((_fake_batch, sq, qh, d_qk), q_stride)
-    fake_k = _fake_bshd((_fake_batch, skv, kh, d_qk), k_stride)
-    fake_v = _fake_bshd((_fake_batch, skv, kh, d_v), v_stride)
+    if PAGED_KV:
+        # [num_pages, page_size, H_kv, D] view of the page pool; the declared
+        # strides ARE the in-page layout (HND: row stride D below head stride
+        # P*D; NHD: BSHD-contiguous) and _host reads the layout off them.
+        # Neither depends on num_pages, which therefore compiles dynamic.
+        if k_stride is None or v_stride is None:
+            raise ValueError("PAGED_KV: k_stride / v_stride (the pools' strides in [num_pages, page_size, H_kv, D] order) are required")
+        n_pages = cute.sym_int(divisibility=1)
+        fake_k = _fake_bshd((n_pages, PAGE_SIZE, kh, d_qk), k_stride, thd_packed=False)
+        fake_v = _fake_bshd((n_pages, PAGE_SIZE, kh, d_v), v_stride, thd_packed=False)
+        # K and V tables share one dynamic page-axis symbol: the kernel reads
+        # its KV maximum from the K table, so both must have the same extent.
+        # Their strides are declared (plan-time) and bound as views: a
+        # batch-innermost table ((1, B) strides) is as legal as a row-major one.
+        _max_pages = cute.sym_int(divisibility=1)
+
+        def _fake_table(stride):
+            if stride is None:
+                return cute.runtime.make_fake_compact_tensor(cutlass.Int32, (b, _max_pages), stride_order=(1, 0), assumed_align=4)
+            return cute.runtime.make_fake_tensor(cutlass.Int32, (b, _max_pages), tuple(stride), assumed_align=4)
+
+        fake_block_table = _fake_table(block_table_stride)
+        fake_block_table_v = _fake_table(block_table_v_stride)
+    else:
+        fake_k = _fake_bshd((_fake_batch, skv, kh, d_qk), k_stride)
+        fake_v = _fake_bshd((_fake_batch, skv, kh, d_v), v_stride)
+        fake_block_table = None
+        fake_block_table_v = None
     fake_o = _fake_bshd((_o_batch, sq, qh, d_v), o_stride, dtype=cutlass.Float32 if _FP32_PARTIALS else STORAGE_DTYPE)
     if not has_lse:
         # No Stats output: the LSE argument is None-specialized and the store
@@ -2512,7 +2779,10 @@ def compile(  # noqa: A001
         fake_thd_q_lens,
         fake_thd_kv_lens,
         fake_thd_lens_form,
-        *((fake_o,) if _FP32_PARTIALS else ()),
+        # o_partial_f32 slot: the fp32 partial O under a split, else — only
+        # when the paged tables follow it positionally — an explicit None.
+        *((fake_o,) if _FP32_PARTIALS else ((None,) if PAGED_KV else ())),
+        *((fake_block_table, fake_block_table_v) if PAGED_KV else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d256_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d256_f16.py
@@ -170,6 +170,19 @@ _bounds_for_tile_split = _split_h.bounds_for_tile_split
 _nomask_range_split = _split_h.nomask_range_split
 _partial_batch = _split_h.partial_batch
 
+# === Paged KV (see prefill_d128_f16_sm100.py for the design notes) ===
+#
+# A K tile is TILE_N/CTA_MMA rows per CTA, a V tile the full TILE_N rows; each
+# is loaded as a stack of page-sized row boxes (or one box inside a taller
+# page), so no box ever straddles a page.
+PAGED_KV = bool(CFG.PAGED_KV)
+PAGE_SIZE = CFG.PAGE_SIZE if PAGED_KV else 0
+_K_TILE_ROWS = CFG.TILE_N // CFG.CTA_MMA
+K_BOX_ROWS = min(PAGE_SIZE, _K_TILE_ROWS) if PAGED_KV else _K_TILE_ROWS
+V_BOX_ROWS = min(PAGE_SIZE, CFG.TILE_N) if PAGED_KV else CFG.TILE_N
+K_BOXES = _K_TILE_ROWS // K_BOX_ROWS
+V_BOXES = CFG.TILE_N // V_BOX_ROWS
+
 
 @dataclass(frozen=True)
 class KernelTmemLayout:
@@ -236,6 +249,12 @@ def _kernel(
     # ABI is unchanged.
     seq_q_lens_tensor: Optional[cute.Tensor] = None,
     o_partial_f32: Optional[cute.Tensor] = None,
+    # Paged KV: [B, max_pages] int32 page ids per batch for K and for V; None
+    # (folded out of the ABI) unless CFG.PAGED_KV. paged_hnd: HND pool (row
+    # stride below head stride) -> descriptor dims (D, row, H_kv, page).
+    block_table_tensor: Optional[cute.Tensor] = None,
+    block_table_v_tensor: Optional[cute.Tensor] = None,
+    paged_hnd: cutlass.Constexpr[bool] = False,
 ) -> None:
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
     tidx, _, _ = cute.arch.thread_idx()
@@ -467,6 +486,9 @@ def _kernel(
             is_leader=is_leader,
             cta_in_pair=cta_in_pair,
             tma_mcast_mask=tma_mcast_mask,
+            block_table_tensor=block_table_tensor,
+            block_table_v_tensor=block_table_v_tensor,
+            paged_hnd=paged_hnd,
         )
 
     elif warp_idx == CFG.TMASTG_WARP_ID:
@@ -513,6 +535,44 @@ _kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
 
 @cute.jit
+def _paged_load_tile(
+    smem_tile,
+    tma,
+    block_table_tensor,
+    batch_idx,
+    kv_head_idx,
+    n_pages_b,
+    kv_tile,
+    row_off,
+    d_coord,
+    mbar,
+    tma_mcast_mask,
+    box_rows: cutlass.Constexpr[int],
+    n_boxes: cutlass.Constexpr[int],
+    granu_elems: cutlass.Constexpr[int],
+):
+    """One paged K or V tile as ``n_boxes`` row boxes through the block table
+    (same contract as prefill_d128_f16_sm100._paged_load_tile: boxes past the
+    batch's live pages take page -1 = TMA-OOB zeros, bytes still credited)."""
+    bt = cutlass.make_array_view(block_table_tensor)
+    last_live = cute.math.max(n_pages_b - cutlass.Int32(1), cutlass.Int32(0))
+    for j in cutlass.range_constexpr(n_boxes):
+        g = kv_tile * cutlass.Int32(CFG.TILE_N) + row_off + cutlass.Int32(j * box_rows)
+        slot = g // cutlass.Int32(PAGE_SIZE)
+        row_in_page = g % cutlass.Int32(PAGE_SIZE)
+        page_live = cutlass.Int32(bt[batch_idx, cute.math.min(slot, last_live)])
+        in_range = slot < n_pages_b
+        page = cutlass.Int32(arith.select(in_range.ir_value(), page_live.ir_value(), cutlass.Int32(-1).ir_value()))
+        tma_load_tile(
+            smem_tile.shifted(j * box_rows * granu_elems),
+            tma(d_coord, kv_head_idx, row_in_page, page),
+            mbar,
+            cta_group=CFG.CTA_MMA,
+            mcast_mask=tma_mcast_mask,
+        )
+
+
+@cute.jit
 def _tmaldg_warp_group(
     tma_q_desc,
     tma_k_desc,
@@ -534,12 +594,15 @@ def _tmaldg_warp_group(
     is_leader,
     cta_in_pair,
     tma_mcast_mask,
+    block_table_tensor=None,
+    block_table_v_tensor=None,
+    paged_hnd: cutlass.Constexpr[bool] = False,
 ):
     q_o_alias_phase = cutlass.Int32(0)
     kv_state = PipelineState.start(phase=1)
 
     tma_q = GmemTileTma(tma_q_desc)
-    if cutlass.const_expr(CFG.THD_VARLEN):
+    if cutlass.const_expr(CFG.THD_VARLEN and not PAGED_KV):
         # THD: K/V ride the setup kernel's packed-total-clamped runtime
         # descriptors (o_desc_words slots n_batch+1 / n_batch+2), so the last
         # sequence's tile-tail lands as exact zeros instead of reading the
@@ -549,6 +612,12 @@ def _tmaldg_warp_group(
         _v_rt_ptr = (o_desc_words.iterator.raw_ptr() + (n_batch + cutlass.Int32(2)) * cutlass.Int32(TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
         tma_k = lambda *coords: tma_slice_runtime_desc(_k_rt_ptr, *coords)  # noqa: E731
         tma_v = lambda *coords: tma_slice_runtime_desc(_v_rt_ptr, *coords)  # noqa: E731
+    elif cutlass.const_expr(PAGED_KV and paged_hnd):
+        # HND page pools: descriptor dims are (D, row, H_kv, page); every load
+        # site keeps the (d, head, row, page) vocabulary, the swap lives here.
+        _tk, _tv = GmemTileTma(tma_k_desc), GmemTileTma(tma_v_desc)
+        tma_k = lambda d, h, r, p: _tk(d, r, h, p)  # noqa: E731
+        tma_v = lambda d, h, r, p: _tv(d, r, h, p)  # noqa: E731
     else:
         tma_k = GmemTileTma(tma_k_desc)
         tma_v = GmemTileTma(tma_v_desc)
@@ -585,6 +654,12 @@ def _tmaldg_warp_group(
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
+    # Paged KV: this batch's live page count bounds the block-table walk
+    # (MASK_PADDED is mandatory under PAGED_KV, so eff_seqlen_kv is defined).
+    n_pages_b = cutlass.Int32(0)
+    if cutlass.const_expr(PAGED_KV):
+        n_pages_b = (eff_seqlen_kv + cutlass.Int32(PAGE_SIZE - 1)) // cutlass.Int32(PAGE_SIZE)
+
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
 
@@ -620,26 +695,62 @@ def _tmaldg_warp_group(
                     bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
                 else:
                     bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=nvvm.elect_sync())
-                tma_load_tile(
-                    sK[kv_state.idx],
-                    tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
-                    bars.mb_k_full[kv_state.idx].smem_ptr,
-                    cta_group=CFG.CTA_MMA,
-                    mcast_mask=tma_mcast_mask,
-                )
+                if cutlass.const_expr(PAGED_KV):
+                    _paged_load_tile(
+                        sK[kv_state.idx],
+                        tma_k,
+                        block_table_tensor,
+                        batch_idx,
+                        kv_head_idx,
+                        n_pages_b,
+                        kv_loop,
+                        K_ROW_OFFSET_PEER,
+                        cutlass.Int32(0),
+                        bars.mb_k_full[kv_state.idx].smem_ptr,
+                        tma_mcast_mask,
+                        K_BOX_ROWS,
+                        K_BOXES,
+                        TMA_QK_GRANU_ELEMS,
+                    )
+                else:
+                    tma_load_tile(
+                        sK[kv_state.idx],
+                        tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
+                        bars.mb_k_full[kv_state.idx].smem_ptr,
+                        cta_group=CFG.CTA_MMA,
+                        mcast_mask=tma_mcast_mask,
+                    )
 
                 bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
                 if cutlass.const_expr(CFG.CTA_MMA == 2):
                     bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
                 else:
                     bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=nvvm.elect_sync())
-                tma_load_tile(
-                    sV[kv_state.idx],
-                    tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
-                    bars.mb_v_full[kv_state.idx].smem_ptr,
-                    cta_group=CFG.CTA_MMA,
-                    mcast_mask=tma_mcast_mask,
-                )
+                if cutlass.const_expr(PAGED_KV):
+                    _paged_load_tile(
+                        sV[kv_state.idx],
+                        tma_v,
+                        block_table_v_tensor,
+                        batch_idx,
+                        kv_head_idx,
+                        n_pages_b,
+                        kv_loop,
+                        cutlass.Int32(0),
+                        V_COL_OFFSET_PEER,
+                        bars.mb_v_full[kv_state.idx].smem_ptr,
+                        tma_mcast_mask,
+                        V_BOX_ROWS,
+                        V_BOXES,
+                        TMA_VO_GRANU_ELEMS,
+                    )
+                else:
+                    tma_load_tile(
+                        sV[kv_state.idx],
+                        tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
+                        bars.mb_v_full[kv_state.idx].smem_ptr,
+                        cta_group=CFG.CTA_MMA,
+                        mcast_mask=tma_mcast_mask,
+                    )
 
                 kv_state = advance(kv_state, CFG.STAGES_KV)
 
@@ -676,6 +787,8 @@ def _tmaldg_warp_group(
             bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
+            if cutlass.const_expr(PAGED_KV):
+                n_pages_b = (eff_seqlen_kv + cutlass.Int32(PAGE_SIZE - 1)) // cutlass.Int32(PAGE_SIZE)
 
     if cutlass.const_expr(CFG.CTA_MMA == 2):
         for _ks in cutlass.range_constexpr(CFG.STAGES_KV):
@@ -1785,6 +1898,11 @@ def _host(
     thd_kv_lens_tensor: Optional[cute.Tensor] = None,
     thd_lens_form: Optional[cutlass.Int32] = None,
     o_partial_f32: Optional[cute.Tensor] = None,
+    # Paged KV: [B, max_pages] int32 block tables (K and V); None unless
+    # CFG.PAGED_KV. The page axis is a DYNAMIC extent and defines the static
+    # KV maximum the masks clamp against: seqlen_kv = max_pages * PAGE_SIZE.
+    block_table_tensor: Optional[cute.Tensor] = None,
+    block_table_v_tensor: Optional[cute.Tensor] = None,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
     B, QH, KH, SQ, SKV, _ = problem_size
@@ -1793,35 +1911,48 @@ def _host(
         # problem_size slots are 0 by contract.
         SQ = q_tensor.shape[1]
         SKV = k_tensor.shape[1]
+    if cutlass.const_expr(PAGED_KV):
+        SKV = block_table_tensor.shape[1] * cutlass.Int32(PAGE_SIZE)
 
     _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE_O
     if cutlass.const_expr(CFG.PACK_GQA and q_tensor.shape[2] != k_tensor.shape[2] * CFG.QH_PER_KH):
         raise ValueError(f"CFG.QH_PER_KH ({CFG.QH_PER_KH}) does not match tensor head extents H_q={q_tensor.shape[2]}, H_kv={k_tensor.shape[2]}")
     qk_box_q = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, TMA_QK_GRANU_ELEMS)
-    qk_box_k = (1, CFG.TILE_N // CFG.CTA_MMA, 1, TMA_QK_GRANU_ELEMS)
-    vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
+    # Paged KV: K/V are [num_pages, page_size, H_kv, D] views of the page pool
+    # and a tile is a stack of K_BOXES / V_BOXES row boxes, so the descriptor
+    # box is one box tall. Dense: the full per-CTA tile.
+    qk_box_k = (1, K_BOX_ROWS, 1, TMA_QK_GRANU_ELEMS)
+    vo_box_v = (1, V_BOX_ROWS, 1, TMA_VO_GRANU_ELEMS)
     vo_box_o = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, _O_GRANU_ELEMS)
     stride_order = (3, 2, 1, 0)
+    # Paged KV: the in-page layout is only the pool's (static) strides. HND
+    # storage viewed as [page, row, H_kv, D] has the row stride BELOW the head
+    # stride, so its descriptor lists dims innermost-first as (D, row, H_kv,
+    # page) and the TMA-LDG warp swaps its (head, row) coords to match.
+    paged_hnd = bool(PAGED_KV) and k_tensor.stride[1] < k_tensor.stride[2]
+    if cutlass.const_expr(PAGED_KV and (v_tensor.stride[1] < v_tensor.stride[2]) != paged_hnd):
+        raise ValueError("paged K and V pools must share an in-page layout (both HND or both NHD)")
+    kv_stride_order = (3, 1, 2, 0) if paged_hnd else stride_order
 
     def _tma_swz(byte_w: int):
         return tmap.TensorMapSwizzle.s128b if byte_w == 128 else tmap.TensorMapSwizzle.s64b if byte_w == 64 else tmap.TensorMapSwizzle.s32b
 
-    def _create_tma_desc(tensor: cute.Tensor, box_dims, swizzle):
+    def _create_tma_desc(tensor: cute.Tensor, box_dims, swizzle, order=stride_order):
         # CUTLASS DSL 4.8's `create_tensor_map_tiled_from_view` scales dynamic strides in i32.
         # Explicitly widen the strides to 64-bit integers to avoid overflow.
         return tmap.create_tensor_map_tiled(
             global_address=tensor.iterator.toint(),
             dtype=tensor.element_type,
-            global_dims=tuple(tensor.shape[i] for i in stride_order),
-            global_strides=tuple(cutlass.Int64(tensor.stride[i]) * tensor.element_type.width // 128 for i in stride_order[1:]),
-            box_dims=tuple(box_dims[i] for i in stride_order),
+            global_dims=tuple(tensor.shape[i] for i in order),
+            global_strides=tuple(cutlass.Int64(tensor.stride[i]) * tensor.element_type.width // 128 for i in order[1:]),
+            box_dims=tuple(box_dims[i] for i in order),
             swizzle=swizzle,
             l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
         )
 
     tma_q_desc = _create_tma_desc(q_tensor, qk_box_q, _tma_swz(CFG.Q_SWZ_BYTES))
-    tma_k_desc = _create_tma_desc(k_tensor, qk_box_k, _tma_swz(CFG.K_SWZ_BYTES))
-    tma_v_desc = _create_tma_desc(v_tensor, vo_box_v, _tma_swz(CFG.V_SWZ_BYTES))
+    tma_k_desc = _create_tma_desc(k_tensor, qk_box_k, _tma_swz(CFG.K_SWZ_BYTES), kv_stride_order)
+    tma_v_desc = _create_tma_desc(v_tensor, vo_box_v, _tma_swz(CFG.V_SWZ_BYTES), kv_stride_order)
     _o_box = list(vo_box_o)
     if _FP32_PARTIALS:
         # fp32 is 4 bytes; scale the box by the O element's own width so
@@ -1864,6 +1995,7 @@ def _host(
             cutlass.Int32(o_tensor.stride[1]),
             cutlass.Int32(CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA),
             n_thd_units,  # persistent cluster count; also seeds the claim counter
+            not PAGED_KV,  # clamp_kv: paged pools have no packed KV total to clamp to
         ).launch(grid=(1, 1, 1), block=(THD_SETUP_THREADS, 1, 1), stream=stream)
         grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
     else:
@@ -1893,6 +2025,9 @@ def _host(
         scale_softmax_log2,
         seq_q_lens_tensor,
         o_partial_f32,
+        block_table_tensor,
+        block_table_v_tensor,
+        paged_hnd,
     ).launch(
         grid=grid_shape,
         block=[CFG.THREADS_PER_CTA, 1, 1],
@@ -1918,6 +2053,8 @@ def compile(  # noqa: A001
     v_stride: Optional[tuple] = None,
     o_stride: Optional[tuple] = None,
     lse_stride: Optional[tuple[int, int, int]] = None,
+    block_table_stride: Optional[tuple[int, int]] = None,
+    block_table_v_stride: Optional[tuple[int, int]] = None,
 ) -> Callable:
     """ENVELOPE: ``d_qk`` / ``d_v`` are the ACTUAL head dims (defaults = full
     TILE_K / TILE_O). TMA descriptors carry these extents while the tile box
@@ -1954,7 +2091,7 @@ def compile(  # noqa: A001
     _o_batch = _fake_batch * SPLIT_KV
     _lse_batch = b * SPLIT_KV
 
-    def _fake_bshd(shape, stride, dtype=STORAGE_DTYPE, bpe=CFG.BPE):
+    def _fake_bshd(shape, stride, dtype=STORAGE_DTYPE, bpe=CFG.BPE, thd_packed=True):
         if stride is None:
             return cute.runtime.make_fake_compact_tensor(dtype, shape, stride_order=(3, 2, 1, 0), assumed_align=16)
         if stride[3] != 1:
@@ -1962,16 +2099,39 @@ def compile(  # noqa: A001
         for axis in (1, 2):  # seq/head global strides feed TMA: 16-byte rule
             if (stride[axis] * bpe) % 16 != 0:
                 raise ValueError(f"declared stride {stride} axis {axis} must be a 16-byte multiple at BPE={bpe} (TMA global-stride rule)")
-        if CFG.THD_VARLEN:
+        if CFG.THD_VARLEN and thd_packed:
             # Extent-1 batch dim: bind the token stride, as _thd_view does at
             # runtime -- T * token_stride is never stepped and overflows the int32
             # stride slot on long packed KV with wide tokens (GitHub #980).
+            # Paged pools are dense tensors and skip this (thd_packed=False).
             return cute.runtime.make_fake_tensor(dtype, shape, (stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
         return cute.runtime.make_fake_tensor(dtype, shape, tuple(stride), assumed_align=16)
 
     fake_q = _fake_bshd((_fake_batch, sq, qh, d_qk), q_stride)
-    fake_k = _fake_bshd((_fake_batch, skv, kh, d_qk), k_stride)
-    fake_v = _fake_bshd((_fake_batch, skv, kh, d_v), v_stride)
+    if PAGED_KV:
+        # [num_pages, page_size, H_kv, D] views of the page pools; the declared
+        # strides ARE the in-page layout (read off by _host) and do not depend
+        # on num_pages, which therefore compiles dynamic. K and V block tables
+        # share one dynamic page-axis symbol.
+        if k_stride is None or v_stride is None:
+            raise ValueError("PAGED_KV: k_stride / v_stride (the pools' strides in [num_pages, page_size, H_kv, D] order) are required")
+        n_pages = cute.sym_int(divisibility=1)
+        fake_k = _fake_bshd((n_pages, PAGE_SIZE, kh, d_qk), k_stride, thd_packed=False)
+        fake_v = _fake_bshd((n_pages, PAGE_SIZE, kh, d_v), v_stride, thd_packed=False)
+        _max_pages = cute.sym_int(divisibility=1)
+
+        def _fake_table(stride):
+            if stride is None:
+                return cute.runtime.make_fake_compact_tensor(cutlass.Int32, (b, _max_pages), stride_order=(1, 0), assumed_align=4)
+            return cute.runtime.make_fake_tensor(cutlass.Int32, (b, _max_pages), tuple(stride), assumed_align=4)
+
+        fake_block_table = _fake_table(block_table_stride)
+        fake_block_table_v = _fake_table(block_table_v_stride)
+    else:
+        fake_k = _fake_bshd((_fake_batch, skv, kh, d_qk), k_stride)
+        fake_v = _fake_bshd((_fake_batch, skv, kh, d_v), v_stride)
+        fake_block_table = None
+        fake_block_table_v = None
     fake_o = _fake_bshd(
         (_o_batch, sq, qh, d_v),
         o_stride,
@@ -2093,7 +2253,10 @@ def compile(  # noqa: A001
         fake_thd_q_lens,
         fake_thd_kv_lens,
         fake_thd_lens_form,
-        *((fake_o,) if _FP32_PARTIALS else ()),
+        # o_partial_f32 slot: the fp32 partial O under a split, else — only
+        # when the paged tables follow it positionally — an explicit None.
+        *((fake_o,) if _FP32_PARTIALS else ((None,) if PAGED_KV else ())),
+        *((fake_block_table, fake_block_table_v) if PAGED_KV else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
     )

--- a/python/cudnn/sdpa/fwd/kernels/thd_helpers.py
+++ b/python/cudnn/sdpa/fwd/kernels/thd_helpers.py
@@ -250,6 +250,9 @@ def build_thd_meta_o_descs_kernel(
     o_row_stride: cutlass.Int32,
     cga_tile_m: cutlass.Int32,
     n_clusters: cutlass.Int32,
+    # False under paged KV: K/V are page pools addressed through block tables,
+    # so no packed-total clamp exists (the descriptors are pool-shaped).
+    clamp_kv: cutlass.Constexpr[bool] = True,
 ) -> None:
     """Per-execute THD setup for the f16/bf16 flavors, one elected thread —
     ``build_thd_meta_o_kv_descs_kernel`` plus the persistent scheduler's
@@ -289,9 +292,10 @@ def build_thd_meta_o_descs_kernel(
         # without touching memory — no fill kernel, and nothing written into
         # the caller's buffer. Mirrors build_thd_meta_o_kv_descs_kernel, which
         # the FP8/MXFP8 flavors have used for this since they were written.
-        t_kv = cutlass.Int32(meta[cutlass.Int32(3) * n_batch + cutlass.Int32(1)])  # cu_k[B]
-        emit_clamped_desc(base_k_desc, o_desc_words, n_batch + cutlass.Int32(1), t_kv, seq_ord=2)
-        emit_clamped_desc(base_v_desc, o_desc_words, n_batch + cutlass.Int32(2), t_kv, seq_ord=2)
+        if cutlass.const_expr(clamp_kv):
+            t_kv = cutlass.Int32(meta[cutlass.Int32(3) * n_batch + cutlass.Int32(1)])  # cu_k[B]
+            emit_clamped_desc(base_k_desc, o_desc_words, n_batch + cutlass.Int32(1), t_kv, seq_ord=2)
+            emit_clamped_desc(base_v_desc, o_desc_words, n_batch + cutlass.Int32(2), t_kv, seq_ord=2)
         nvvm.fence_proxy_release(
             nvvm.MemScope.GPU,
             from_proxy=nvvm.Proxy.GENERIC,

--- a/python/cudnn/sdpa/graph_analyzer.py
+++ b/python/cudnn/sdpa/graph_analyzer.py
@@ -220,6 +220,12 @@ class SdpaGraphFacts:
     has_dropout: bool = False
     has_score_mod: bool = False
     has_paged_kv: bool = False
+    # Paged KV (paged_attention_k_table / v_table): K/V are page pools
+    # [num_pages, H_kv, page_size, D]; ``s_kv`` is the declared
+    # paged_attention_max_seq_len_kv (else what the block tables address). The
+    # in-page layout (HND/NHD) is only the pools' strides, and the tables'
+    # extents live on their IR refs — neither is a separate fact.
+    page_size: int = 0
     has_alibi: bool = False
     has_unfuse_fma: bool = False
     has_block_mask: bool = False
@@ -269,6 +275,10 @@ class SdpaGraphFacts:
     sink_t: Any = None
     seq_kv_t: Any = None
     seq_q_t: Any = None
+    # Paged KV block tables, (B, 1, max_pages, 1) int32; when the graph declares
+    # only one of the pair both refs point at it.
+    paged_k_table_t: Any = None
+    paged_v_table_t: Any = None
     # (B+1,) prefix-sum IR refs (cuDNN 9.24+ cu_seq_len form); None when the
     # graph carries the per-batch seq_len_* form on that side instead.
     cu_seq_q_t: Any = None
@@ -460,12 +470,48 @@ def _extract_facts(rec: dict) -> SdpaGraphFacts:
             v_stride = (v_stride[0], v_stride[1], v_stride[3], v_stride[2])
         dims["k"], dims["v"] = k_dim, v_dim
         strides["k"], strides["v"] = k_stride, v_stride
-    _, h_kv, s_kv, _ = k_dim
+    table_k, table_v = rec.get("paged_attention_k_table"), rec.get("paged_attention_v_table")
+    paged = table_k is not None or table_v is not None
+    page_size = 0
     d_v = v_dim[-1]
-    if k_dim != (b, h_kv, s_kv, d_qk):
-        return _invalid(f"K shape mismatch (q_dim={q_dim}, k_dim={k_dim})")
-    if v_dim != (b, h_kv, s_kv, d_v):
-        return _invalid(f"V shape mismatch (k_dim={k_dim}, v_dim={v_dim})")
+    if paged:
+        # cuDNN paged-cache contract: K/V are page POOLS [num_pages, H_kv,
+        # page_size, D] (the in-page layout rides the strides), addressed
+        # through (B, 1, max_pages, 1) int32 block tables; the logical S_kv is
+        # the declared maximum, else what the tables can address.
+        if is_backward:
+            return _invalid("paged KV caches are forward-only")
+        _, h_kv, page_size, _ = k_dim
+        if k_dim[3] != d_qk:
+            return _invalid(f"paged K container head dim must equal Q's (q_dim={q_dim}, k_dim={k_dim})")
+        if v_dim[:3] != k_dim[:3]:
+            return _invalid(f"paged K/V containers must share [num_pages, H_kv, page_size] (k_dim={k_dim}, v_dim={v_dim})")
+        tables = [t for t in (table_k, table_v) if t is not None]
+        for t in tables:
+            td = tuple(t.get_dim())
+            if len(td) != 4 or td[0] != b or td[1] != 1 or td[3] != 1:
+                return _invalid(f"paged block table must be (B, 1, max_pages, 1) = ({b}, 1, *, 1); got {td}")
+            if t.get_data_type() != cudnn.data_type.INT32:
+                return _invalid(f"paged block table must be int32; got {t.get_data_type()}")
+            if getattr(t, "ragged_offset", None) is not None:
+                return _invalid("packed (ragged-offset) paged block tables are not supported")
+        max_pages = tuple(tables[0].get_dim())[2]
+        if any(tuple(t.get_dim())[2] != max_pages for t in tables):
+            return _invalid("paged K and V block tables must have the same max_pages extent")
+        declared_max = rec.get("paged_attention_max_seq_len_kv")
+        s_kv = int(declared_max) if declared_max is not None else max_pages * page_size
+        if s_kv > max_pages * page_size:
+            return _invalid(f"paged_attention_max_seq_len_kv ({s_kv}) exceeds what the block table addresses ({max_pages} pages x {page_size})")
+        if (k_stride[1] > k_stride[2]) != (v_stride[1] > v_stride[2]):
+            return _invalid("paged K and V containers must share an in-page layout (both HND or both NHD)")
+        table_k = table_k if table_k is not None else table_v
+        table_v = table_v if table_v is not None else table_k
+    else:
+        _, h_kv, s_kv, _ = k_dim
+        if k_dim != (b, h_kv, s_kv, d_qk):
+            return _invalid(f"K shape mismatch (q_dim={q_dim}, k_dim={k_dim})")
+        if v_dim != (b, h_kv, s_kv, d_v):
+            return _invalid(f"V shape mismatch (k_dim={k_dim}, v_dim={v_dim})")
     if o_dim != (b, h_q, s_q, d_v):
         return _invalid(f"O shape mismatch (q_dim={q_dim}, o_dim={o_dim})")
     if is_backward:
@@ -507,7 +553,11 @@ def _extract_facts(rec: dict) -> SdpaGraphFacts:
         _layout_ports += [(dims[name], strides[name]) for name in ("dO", "dQ", "dK", "dV")]
     if is_mxfp8_bwd:
         _layout_ports += [(dims[name], strides[name]) for name in ("q_T", "k_T", "dO_T", "dO_f16")]
-    bshd = all(bshd_layout_ok(d, s) for d, s in _layout_ports)
+    # Paged pools are not BSHD tensors (an HND pool has its head stride above
+    # the row stride); the BSHD fact — what the THD lowering gates on — is
+    # about the ragged Q/O only.
+    _bshd_ports = [(q_dim, q_stride), (o_dim, o_stride)] if paged else _layout_ports
+    bshd = all(bshd_layout_ok(d, s) for d, s in _bshd_ports)
     dense_layout = all(dense_layout_ok(d, s) for d, s in _layout_ports)
 
     # descale_q/k/v are the block-scale SF tensors for MXFP8, or scalar per-tensor
@@ -578,7 +628,9 @@ def _extract_facts(rec: dict) -> SdpaGraphFacts:
     kv_lens_given = seq_len_kv is not None or cu_seq_kv is not None
     seq_q_trim = False
     if thd:
-        if getattr(k, "ragged_offset", None) is None or getattr(v, "ragged_offset", None) is None:
+        # Paged KV: the pools are addressed through the block tables, so only
+        # Q (and O) are ragged — chunked prefill over a paged cache.
+        if not paged and (getattr(k, "ragged_offset", None) is None or getattr(v, "ragged_offset", None) is None):
             return _invalid("THD (ragged) requires ragged Q, K, and V")
         if not q_lens_given or not kv_lens_given:
             return _invalid("THD (ragged) requires seq_len_q/cu_seq_len_q and seq_len_kv/cu_seq_len_kv")
@@ -658,7 +710,10 @@ def _extract_facts(rec: dict) -> SdpaGraphFacts:
         has_bias=rec.get("bias") is not None,
         has_dropout=rec.get("dropout") is not None,
         has_score_mod=rec.get("fn") is not None,
-        has_paged_kv=(rec.get("paged_attention_k_table") is not None or rec.get("paged_attention_v_table") is not None),
+        has_paged_kv=paged,
+        page_size=page_size,
+        paged_k_table_t=table_k,
+        paged_v_table_t=table_v,
         has_alibi=bool(rec.get("use_alibi_mask")),
         has_unfuse_fma=bool(rec.get("unfuse_fma")),
         has_block_mask=rec.get("block_mask") is not None,
@@ -757,6 +812,9 @@ class SdpaBinding:
     # (B+1,) prefix-sum form (cuDNN 9.24+); at most one form per side.
     cu_seq_len_q: Any = None
     cu_seq_len_kv: Any = None
+    # Paged KV block tables.
+    paged_k_table: Any = None
+    paged_v_table: Any = None
     # MXFP8 block-scale (descale) tensors + Amax_O output.
     sf_q: Any = None
     sf_k: Any = None
@@ -819,6 +877,8 @@ class SdpaBinding:
                 self.seq_len_q,
                 self.cu_seq_len_q,
                 self.cu_seq_len_kv,
+                self.paged_k_table,
+                self.paged_v_table,
                 self.sf_q,
                 self.sf_k,
                 self.sf_v,

--- a/test/python/sdpa/frost/test_sdpa_fwd_paged_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_paged_sm100.py
@@ -1,0 +1,600 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Paged KV caches on the FROST SM100 f16/bf16 engine (issue #920).
+
+The graph is cuDNN's own paged-cache contract — ``graph.sdpa(..., k=<page pool>,
+v=<page pool>, use_padding_mask=True, seq_len_q=, seq_len_kv=,
+paged_attention_k_table=, paged_attention_v_table=,
+paged_attention_max_seq_len_kv=)`` — served by ``sdpa_fwd_prefill_sm100``
+through the d128 kernel's ``PAGED_KV`` specialization: block-table indirection on
+the K/V TMA loads, HND and NHD page layouts, per-batch lengths read on device,
+KV split + combine.  The reference gathers each sequence's pages in torch and
+runs fp32 attention over the live tokens.
+
+The second half drives the kernel template directly (like the split-KV suite)
+for the geometry the heuristic would not pick on its own: forced splits with
+empty ranges, cga1, page sizes across the 128-row tile.
+"""
+
+import math
+import os
+
+import pytest
+import torch
+
+from frost_test_utils import requires_dsl, requires_pre_rubin_blackwell, select_engine
+
+pytestmark = [requires_pre_rubin_blackwell, requires_dsl]
+
+D = 128
+
+
+def _ref(q, k_pool, v_pool, block_table, seq_lens, hnd, scale):
+    """q [B, H, D]; pools in their storage layout; returns (O [B, H, D_v], LSE [B, H]) fp32."""
+    B, H, d = q.shape
+    KH = k_pool.shape[1] if hnd else k_pool.shape[2]
+    P = k_pool.shape[2] if hnd else k_pool.shape[1]
+    Dv = v_pool.shape[-1]
+    out = torch.zeros(B, H, Dv, device=q.device, dtype=torch.float32)
+    lse = torch.full((B, H), float("-inf"), device=q.device, dtype=torch.float32)
+    for b, L in enumerate(seq_lens.tolist()):
+        if L == 0:
+            continue
+        pages = block_table[b, : (L + P - 1) // P].long()
+        k, v = k_pool[pages], v_pool[pages]
+        if hnd:
+            k, v = k.permute(0, 2, 1, 3), v.permute(0, 2, 1, 3)
+        k = k.reshape(-1, KH, d)[:L].repeat_interleave(H // KH, dim=1).float()
+        v = v.reshape(-1, KH, Dv)[:L].repeat_interleave(H // KH, dim=1).float()
+        s = torch.einsum("hd,lhd->hl", q[b].float(), k) * scale
+        out[b] = torch.einsum("hl,lhd->hd", torch.softmax(s, -1), v)
+        lse[b] = torch.logsumexp(s, -1)
+    return out, lse
+
+
+def _pools(B, KH, d, P, max_pages, hnd, dtype, seed=0):
+    """Page pools + a scattered block table.  Returns (k_pool, v_pool, k_container,
+    v_container, block_table[B, 1, max_pages, 1]) — the containers are the
+    [num_pages, H_kv, page_size, D]-dim views the graph declares."""
+    torch.manual_seed(seed)
+    dev = "cuda"
+    num_pages = B * max_pages + 5
+    if hnd:
+        k_pool = torch.randn(num_pages, KH, P, d, device=dev, dtype=dtype)
+        v_pool = torch.randn(num_pages, KH, P, d, device=dev, dtype=dtype)
+        k_c, v_c = k_pool, v_pool
+    else:
+        k_pool = torch.randn(num_pages, P, KH, d, device=dev, dtype=dtype)
+        v_pool = torch.randn(num_pages, P, KH, d, device=dev, dtype=dtype)
+        k_c, v_c = k_pool.permute(0, 2, 1, 3), v_pool.permute(0, 2, 1, 3)
+    bt = torch.randperm(num_pages, device=dev)[: B * max_pages].to(torch.int32).view(B, 1, max_pages, 1).contiguous()
+    return k_pool, v_pool, k_c, v_c, bt
+
+
+def _run_graph(B, H, KH, d, P, max_pages, lens, hnd, *, dtype=torch.float16, stats=False, s_q=1, max_seq_len=None, want_split=None):
+    import cudnn
+    import cudnn.sdpa  # noqa: F401 — registers the FROST engines
+    from cudnn.sdpa.fwd.engines import engine_name
+
+    dev = "cuda"
+    scale = 1.0 / math.sqrt(d)
+    k_pool, v_pool, k_c, v_c, bt = _pools(B, KH, d, P, max_pages, hnd, dtype)
+    q_gpu = torch.randn(B, s_q, H, d, device=dev, dtype=dtype).transpose(1, 2)
+    o_gpu = torch.empty(B, s_q, H, d, device=dev, dtype=dtype).transpose(1, 2)
+    seq_lens = torch.tensor(lens, dtype=torch.int32, device=dev)
+    slk = seq_lens.view(B, 1, 1, 1)
+    slq = torch.full((B, 1, 1, 1), s_q, dtype=torch.int32, device=dev)
+
+    io = cudnn.data_type.HALF if dtype == torch.float16 else cudnn.data_type.BFLOAT16
+    g = cudnn.pygraph(io_data_type=io, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    q, k, v = g.tensor_like(q_gpu), g.tensor_like(k_c), g.tensor_like(v_c)
+    tk, tv = g.tensor_like(bt), g.tensor_like(bt)
+    sq_t, sk_t = g.tensor_like(slq), g.tensor_like(slk)
+    o, st = g.sdpa(
+        name="sdpa",
+        q=q,
+        k=k,
+        v=v,
+        generate_stats=stats,
+        attn_scale=scale,
+        use_padding_mask=True,
+        seq_len_q=sq_t,
+        seq_len_kv=sk_t,
+        paged_attention_k_table=tk,
+        paged_attention_v_table=tv,
+        paged_attention_max_seq_len_kv=max_seq_len if max_seq_len is not None else max_pages * P,
+    )
+    o.set_output(True).set_dim(q_gpu.shape).set_stride(q_gpu.stride())
+    stats_gpu = None
+    if stats:
+        stats_gpu = torch.empty(B, H, s_q, 1, device=dev, dtype=torch.float32)
+        st.set_output(True).set_dim(stats_gpu.shape).set_stride(stats_gpu.stride()).set_data_type(cudnn.data_type.FLOAT)
+    g.validate()
+    g.build_operation_graph()
+    g.create_execution_plans([cudnn.heur_mode.A])
+    plan = select_engine(g, engine_name())
+    if want_split is not None:
+        names = [g.get_plan_name_at_index(i) for i in range(len(g.plans))]
+        idx = next((i for i, n in enumerate(names) if n.startswith(engine_name()) and g.plans[i].knobs.split_kv == want_split), None)
+        assert idx is not None, f"no {engine_name()} plan with split_kv={want_split}; knobs={[p.knobs for p in g.plans]}"
+        g.select_plan(idx)
+        plan = g.plans[idx]
+    g.check_support()
+    g.build_plans()
+    ws = torch.empty(max(g.get_workspace_size(), 1), device=dev, dtype=torch.uint8)
+    vp = {q: q_gpu, k: k_c, v: v_c, tk: bt, tv: bt, sq_t: slq, sk_t: slk, o: o_gpu}
+    if stats:
+        vp[st] = stats_gpu
+    # Rule 3: the FROST execute path reads the per-batch lengths on device;
+    # any blocking D2H here is a bug, not a slow path.
+    torch.cuda.set_sync_debug_mode("error")
+    try:
+        g.execute(vp, ws)
+    finally:
+        torch.cuda.set_sync_debug_mode("default")
+    torch.cuda.synchronize()
+
+    ref_o, ref_lse = _ref(q_gpu[:, :, 0, :], k_pool, v_pool, bt.view(B, max_pages), seq_lens, hnd, scale)
+    out = o_gpu[:, :, 0, :].float()
+    assert not torch.isnan(out).any(), "NaN in O"
+    torch.testing.assert_close(out, ref_o, atol=2e-2 if dtype == torch.float16 else 1e-1, rtol=0)
+    live = seq_lens > 0
+    if (~live).any():
+        assert out[~live].abs().max().item() == 0.0, "empty sequence must write O := 0"
+    if stats:
+        got_lse = stats_gpu.view(B, H)
+        torch.testing.assert_close(got_lse[live], ref_lse[live], atol=5e-3, rtol=0)
+        if (~live).any():
+            assert torch.isinf(got_lse[~live]).all() and (got_lse[~live] < 0).all(), "empty sequence must write LSE := -inf"
+    return plan
+
+
+# --- graph API ---------------------------------------------------------------
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("hnd", [False, True], ids=["NHD", "HND"])
+@pytest.mark.parametrize("page_size", [16, 128])
+def test_paged_graph_matches_reference(hnd, page_size):
+    """Mixed lengths incl. 0 and 1, GQA 8:2 (PackGQA), a tile-unaligned tail and a
+    length ending exactly on a page/tile boundary; Stats requested."""
+    _run_graph(5, 8, 2, D, page_size, -(-1100 // page_size), [300, 77, 0, 1, 1024], hnd, stats=True)
+
+
+@pytest.mark.L0
+def test_paged_graph_bf16_mha_no_stats():
+    _run_graph(3, 8, 8, D, 32, 40, [1000, 1279, 33], hnd=False, dtype=torch.bfloat16)
+
+
+@pytest.mark.L0
+def test_paged_graph_long_kv_heuristic_splits():
+    """32k tokens at B=1: a 1-CTA-per-KV-head launch — the split heuristic must
+    engage (the padded exclusion is lifted for paged graphs) and the recombined
+    LSE must match."""
+    plan = _run_graph(1, 8, 1, D, 16, 2048, [32000], hnd=True, stats=True)
+    assert plan.knobs.split_kv > 1, plan.knobs
+
+
+@pytest.mark.L0
+def test_paged_graph_declared_max_seq_len_below_table_reach():
+    """paged_attention_max_seq_len_kv smaller than max_pages * page_size is the
+    common framework case (tables padded to the model's max length)."""
+    _run_graph(2, 8, 2, D, 16, 20, [300, 77], hnd=False, max_seq_len=300, stats=True)
+
+
+@pytest.mark.L0
+def test_paged_graph_d64_envelope_large_batch():
+    """d=64 rides the d128 kernel zero-padded; B=256 GQA 4:4."""
+    torch.manual_seed(3)
+    lens = torch.randint(1, 257, (256,)).tolist()
+    _run_graph(256, 4, 4, 64, 64, 4, lens, hnd=False)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("hnd", [False, True], ids=["NHD", "HND"])
+def test_paged_graph_d256(hnd):
+    """d=256 selects the d256 f16 flavor; same graph contract, Stats out."""
+    _run_graph(3, 8, 2, 256, 32, 40, [1000, 1, 1279], hnd, stats=True)
+
+
+@pytest.mark.L0
+def test_paged_graph_prefill_shaped_s_q():
+    """The same engine serves S_q > 1 over a paged cache (paged prefill / chunked
+    prefill); all q rows attend the whole live KV (no causal mask)."""
+    import cudnn
+    import cudnn.sdpa  # noqa: F401
+    from cudnn.sdpa.fwd.engines import engine_name
+
+    B, H, KH, P, max_pages, s_q = 2, 4, 4, 16, 8, 3
+    dev, dtype = "cuda", torch.float16
+    scale = 1.0 / math.sqrt(D)
+    k_pool, v_pool, k_c, v_c, bt = _pools(B, KH, D, P, max_pages, False, dtype)
+    q_gpu = torch.randn(B, s_q, H, D, device=dev, dtype=dtype).transpose(1, 2)
+    o_gpu = torch.empty(B, s_q, H, D, device=dev, dtype=dtype).transpose(1, 2)
+    lens = torch.tensor([100, 128], dtype=torch.int32, device=dev)
+    g = cudnn.pygraph(io_data_type=cudnn.data_type.HALF, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    q, k, v, tk, tv = g.tensor_like(q_gpu), g.tensor_like(k_c), g.tensor_like(v_c), g.tensor_like(bt), g.tensor_like(bt)
+    slq = torch.full((B, 1, 1, 1), s_q, dtype=torch.int32, device=dev)
+    sq_t, sk_t = g.tensor_like(slq), g.tensor_like(lens.view(B, 1, 1, 1))
+    o, _ = g.sdpa(
+        name="sdpa",
+        q=q,
+        k=k,
+        v=v,
+        generate_stats=False,
+        attn_scale=scale,
+        use_padding_mask=True,
+        seq_len_q=sq_t,
+        seq_len_kv=sk_t,
+        paged_attention_k_table=tk,
+        paged_attention_v_table=tv,
+        paged_attention_max_seq_len_kv=max_pages * P,
+    )
+    o.set_output(True).set_dim(q_gpu.shape).set_stride(q_gpu.stride())
+    g.validate()
+    g.build_operation_graph()
+    g.create_execution_plans([cudnn.heur_mode.A])
+    select_engine(g, engine_name())
+    g.check_support()
+    g.build_plans()
+    ws = torch.empty(max(g.get_workspace_size(), 1), device=dev, dtype=torch.uint8)
+    g.execute({q: q_gpu, k: k_c, v: v_c, tk: bt, tv: bt, sq_t: slq, sk_t: lens.view(B, 1, 1, 1), o: o_gpu}, ws)
+    torch.cuda.synchronize()
+    for r in range(s_q):
+        ref_o, _ = _ref(q_gpu[:, :, r, :], k_pool, v_pool, bt.view(B, max_pages), lens, False, scale)
+        torch.testing.assert_close(o_gpu[:, :, r, :].float(), ref_o, atol=2e-2, rtol=0)
+
+
+@pytest.mark.L0
+def test_paged_graph_declines_off_contract():
+    """Plan-time declines stay plan-time: no engine plan is offered, nothing compiles."""
+    import cudnn
+    import cudnn.sdpa  # noqa: F401
+    from cudnn.sdpa.fwd.engines import engine_name
+    from frost_test_utils import offers_engine
+
+    def _build(P, d=D, H=8, KH=2, hnd=False, padding=True):
+        B, max_pages = 2, 8
+        dev = "cuda"
+        _, _, k_c, v_c, bt = _pools(B, KH, d, P, max_pages, hnd, torch.float16)
+        q_gpu = torch.randn(B, 1, H, d, device=dev, dtype=torch.float16).transpose(1, 2)
+        g = cudnn.pygraph(io_data_type=cudnn.data_type.HALF, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+        q, k, v, tk, tv = g.tensor_like(q_gpu), g.tensor_like(k_c), g.tensor_like(v_c), g.tensor_like(bt), g.tensor_like(bt)
+        lens = torch.full((B, 1, 1, 1), 10, dtype=torch.int32, device=dev)
+        sq_t, sk_t = g.tensor_like(lens), g.tensor_like(lens)
+        o, _ = g.sdpa(
+            name="sdpa",
+            q=q,
+            k=k,
+            v=v,
+            generate_stats=False,
+            attn_scale=0.1,
+            use_padding_mask=padding,
+            seq_len_q=sq_t,
+            seq_len_kv=sk_t,
+            paged_attention_k_table=tk,
+            paged_attention_v_table=tv,
+            paged_attention_max_seq_len_kv=max_pages * P,
+        )
+        o.set_output(True).set_dim(q_gpu.shape).set_stride(q_gpu.stride())
+        try:
+            g.validate()
+            g.build_operation_graph()
+            g.create_execution_plans([cudnn.heur_mode.A])
+        except (cudnn.cudnnGraphNotSupportedError, ValueError):
+            # Rejected upstream of any engine (the validator: paged needs the
+            # padding mask; the backend: page size must be a power of two), so
+            # no plan of any kind exists — the FROST row certainly offered none.
+            return None
+        return g
+
+    def _offers(g):
+        return g is not None and offers_engine(g, engine_name())
+
+    assert _offers(_build(16))
+    assert not _offers(_build(48)), "page_size 48 neither divides nor is a multiple of the 128-row tile"
+    assert not _offers(_build(16, d=512)), "paged KV is wired on the d128 / d256 flavors only"
+    assert not _offers(_build(16, padding=False)), "paged KV requires the padding mask"
+
+
+# --- kernel template, direct -----------------------------------------------
+#
+# What the graph path's heuristic would not choose on its own: forced split
+# counts with EMPTY ranges (more splits than a short batch has tiles), cga1,
+# and page sizes on both sides of the tile.  Mirrors test_sdpa_fwd_split_kv_sm100.
+
+
+def _run_kernel(B, H, KH, P, max_pages, lens, hnd, splits, *, cta_mma=1, dtype=torch.float16, d=128):
+    import cutlass
+    import cuda.bindings.driver as cuda_driver
+
+    from cudnn.frost.template_loader import load_template
+    from cudnn.sdpa.fwd import api_dsl
+    from cudnn.sdpa.fwd.config_sm100 import TemplateParams
+    from cudnn.sdpa.fwd.kernels.sm100 import split_combine as comb
+
+    dev = "cuda"
+    G = H // KH
+    pack = G > 1 and 128 % G == 0
+    scale = 1.0 / math.sqrt(d)
+    k_pool, v_pool, k_c, v_c, bt4 = _pools(B, KH, d, P, max_pages, hnd, dtype)
+    bt = bt4.view(B, max_pages)
+    q = torch.randn(B, 1, H, d, device=dev, dtype=dtype)
+    seq_lens = torch.tensor(lens, dtype=torch.int32, device=dev)
+    # kernel view: [num_pages, page_size, H_kv, d] (a permutation of the container)
+    k_view, v_view = k_c.permute(0, 2, 1, 3), v_c.permute(0, 2, 1, 3)
+
+    path = os.path.join(os.path.dirname(os.path.abspath(api_dsl.__file__)), "kernels", "sm100", f"prefill_d{d}_f16.py")
+    params = TemplateParams(
+        dtype_qkv=3 if dtype == torch.float16 else 2,
+        seq_kv_lens_present=True,
+        paged_kv=True,
+        page_size=P,
+        split_kv=splits,
+        cta_mma=cta_mma,
+        pack_gqa=pack,
+        qh_per_kh=G if pack else 1,
+    )
+    mod = load_template(path, params, tag=f"paged_p{P}_s{splits}_c{cta_mma}_g{G if pack else 1}_{dtype}")
+    # The pools' strides in the kernel's [num_pages, page_size, H_kv, d] order carry the layout (HND vs NHD).
+    fn = mod.compile(b=B, qh=H, kh=KH, sq=1, skv=0, d_qk=d, d_v=d, has_lse=True, k_stride=tuple(k_view.stride()), v_stride=tuple(v_view.stride()))
+    # Split partials are fp32 on SM100 (#891); the combine must be compiled for that width.
+    from test_sdpa_fwd_split_kv_sm100 import _partial_kwargs, _partial_o_dtype, _partial_tag
+
+    o_p = torch.zeros(splits * B, 1, H, d, device=dev, dtype=_partial_o_dtype(splits, dtype))
+    lse_p = torch.zeros(splits * B, H, 1, device=dev, dtype=torch.float32)
+    stream = cuda_driver.CUstream(torch.cuda.current_stream().cuda_stream)
+    fn(
+        q,
+        k_view,
+        v_view,
+        o_p,
+        lse_p,
+        torch.zeros(H, dtype=torch.float32, device=dev),
+        seq_lens,
+        torch.zeros(1, dtype=torch.int64, device=dev),
+        (B, H, KH, 1, 0, 0),
+        cutlass.Float32(scale * math.log2(math.e)),
+        cutlass.Int32(0),
+        None,
+        **_partial_kwargs(splits, o_p),
+        block_table_tensor=bt,
+        block_table_v_tensor=bt,
+        stream=stream,
+    )
+    if splits == 1:
+        o_out, lse_out = o_p, lse_p
+    else:
+        o_out = torch.zeros(B, 1, H, d, device=dev, dtype=dtype)
+        lse_out = torch.zeros(B, H, 1, device=dev, dtype=torch.float32)
+        cfn = comb.compile(
+            b=B, h=H, sq=1, d_v=d, splits=splits, dtype_o="f16" if dtype == torch.float16 else "bf16", has_lse=True, dtype_partial=_partial_tag(splits, dtype)
+        )
+        cfn(o_p, lse_p, o_out, lse_out, None, None, (B, H, 1, d), cutlass.Int32(splits), stream=stream)
+    torch.cuda.synchronize()
+    ref_o, ref_lse = _ref(q[:, 0], k_pool, v_pool, bt, seq_lens, hnd, scale)
+    live = seq_lens > 0
+    torch.testing.assert_close(o_out[:, 0].float(), ref_o, atol=2e-2 if dtype == torch.float16 else 1e-1, rtol=0)
+    torch.testing.assert_close(lse_out.view(B, H)[live], ref_lse[live], atol=5e-3, rtol=0)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("page_size", [32, 64, 256])
+def test_paged_kernel_page_sizes(page_size):
+    """Pages narrower than the tile (several row boxes per tile) and wider than it
+    (one box inside the page, runtime row offset)."""
+    _run_kernel(2, 8, 2, page_size, -(-1100 // page_size), [1000, 77], hnd=page_size == 256, splits=2, cta_mma=2)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("splits", [2, 8])
+def test_paged_kernel_forced_splits_empty_ranges_cga1(splits):
+    """3 batches x 8 heads x 8 splits = 192 CTAs > SM count with [4000, 1, 129]:
+    empty split ranges interleaved with live tiles under the persistent scheduler
+    at cga1 — the Q/O-alias parity regression this PR fixed (see
+    test_split_kv_cga1_empty_splits_multiwave for the dense twin)."""
+    _run_kernel(3, 8, 8, 128, 33, [4000, 1, 129], hnd=True, splits=splits, cta_mma=1)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("page_size", [16, 128])
+def test_paged_kernel_d256(page_size):
+    """The d256 (Qwen) f16 flavor carries the same PAGED_KV specialization: cga2
+    (K box = 64 rows per CTA), forced 4 splits with one empty range."""
+    _run_kernel(2, 8, 2, page_size, -(-1100 // page_size), [1000, 77], hnd=page_size == 16, splits=4, cta_mma=2, d=256)
+
+
+@pytest.mark.L0
+def test_paged_kernel_gqa_group_not_dividing_tile():
+    """H/H_kv = 3 cannot pack a 128-row tile; the unpacked path serves it."""
+    _run_kernel(2, 6, 2, 16, 8, [50, 128], hnd=False, splits=1, cta_mma=2)
+
+
+@pytest.mark.L0
+def test_paged_adapter_cuda_graph_replay_no_host_sync():
+    """The adapter's execute path captured once at fixed B; seq_lens CONTENT
+    changes between replays.  ``set_sync_debug_mode("error")`` during capture
+    makes any blocking D2H raise (python/cudnn/AGENTS.md Rule 3)."""
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm100
+
+    B, H, KH, P, max_pages = 8, 16, 4, 16, 64
+    dev, dtype = "cuda", torch.float16
+    k_pool, v_pool, k_c, v_c, bt4 = _pools(B, KH, D, P, max_pages, False, dtype, seed=1)
+    bt = bt4.view(B, max_pages)
+    q_gpu = torch.randn(B, 1, H, D, device=dev, dtype=dtype).transpose(1, 2)
+    o_gpu = torch.empty(B, 1, H, D, device=dev, dtype=dtype).transpose(1, 2)
+    lse = torch.empty(B, H, 1, device=dev, dtype=torch.float32)
+    seq_lens = torch.full((B,), 1000, dtype=torch.int32, device=dev)
+    seq_q = torch.ones(B, dtype=torch.int32, device=dev)
+    api = SdpaFwdDslSm100(
+        sample_q=q_gpu,
+        sample_k=k_c,
+        sample_v=v_c,
+        sample_o=o_gpu,
+        sample_lse=lse,
+        seq_kv_lens_present=True,
+        seq_q_lens_present=True,
+        paged_page_size=P,
+        paged_max_seq_len_kv=max_pages * P,
+        split_kv=4,
+        pack_gqa=True,
+    )
+    api.check_support()
+    api.compile()
+    ws = torch.empty(max(api.scratch_workspace_bytes(), 1), device=dev, dtype=torch.uint8)
+    s = torch.cuda.Stream()
+    with torch.cuda.stream(s):
+        api.execute(q_gpu, k_c, v_c, o_gpu, lse_tensor=lse, seq_kv_lens=seq_lens, seq_q_lens=seq_q, block_table=bt, workspace=ws)
+    torch.cuda.synchronize()
+    g = torch.cuda.CUDAGraph()
+    torch.cuda.set_sync_debug_mode("error")
+    try:
+        with torch.cuda.graph(g, stream=s):
+            api.execute(q_gpu, k_c, v_c, o_gpu, lse_tensor=lse, seq_kv_lens=seq_lens, seq_q_lens=seq_q, block_table=bt, workspace=ws)
+    finally:
+        torch.cuda.set_sync_debug_mode("default")
+    scale = 1.0 / math.sqrt(D)
+    for new_lens in ([5, 1024, 77, 128, 129, 1, 512, 1000], [1024] * B, [0, 1, 2, 3, 4, 5, 6, 7]):
+        seq_lens.copy_(torch.tensor(new_lens, dtype=torch.int32))
+        g.replay()
+        torch.cuda.synchronize()
+        ref_o, ref_lse = _ref(q_gpu[:, :, 0, :], k_pool, v_pool, bt, seq_lens, False, scale)
+        live = seq_lens > 0
+        torch.testing.assert_close(o_gpu[:, :, 0, :].float(), ref_o, atol=2e-2, rtol=0)
+        torch.testing.assert_close(lse.view(B, H)[live], ref_lse[live], atol=5e-3, rtol=0)
+
+
+# --- THD (ragged) queries over a paged cache: chunked prefill -----------------
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("hnd", [False, True], ids=["NHD", "HND"])
+def test_paged_graph_thd_queries(hnd):
+    """Ragged Q/O (packed [T, H, D] storage + ragged offsets, per-sequence
+    ``seq_len_q``) attending K/V page pools through block tables: each sequence's
+    q tokens see its own live KV pages. Only Q/O are ragged — the pools are
+    ordinary dense tensors — and the THD scheduler walks the Q units while the
+    KV side comes from ``seq_len_kv`` + the tables."""
+    import cudnn
+    import cudnn.sdpa  # noqa: F401
+    from cudnn.sdpa.fwd.engines import engine_name
+
+    dev, dtype = "cuda", torch.float16
+    H, KH, d, P, max_pages = 8, 2, D, 16, 20
+    q_lens = [37, 130, 5]
+    kv_lens = [300, 77, 129]
+    B, T, S_max = len(q_lens), sum(q_lens), max(q_lens)
+    cu = [0]
+    for s in q_lens:
+        cu.append(cu[-1] + s)
+    scale = 1.0 / math.sqrt(d)
+    k_pool, v_pool, k_c, v_c, bt = _pools(B, KH, d, P, max_pages, hnd, dtype)
+    torch.manual_seed(7)
+    q_pk = torch.randn(T, H, d, device=dev, dtype=dtype)
+    stride = (S_max * H * d, d, H * d, 1)
+    q_stor = torch.zeros(B * S_max * H * d, device=dev, dtype=dtype)
+    q_stor[: T * H * d] = q_pk.reshape(-1)
+    q_gpu = q_stor.as_strided((B, H, S_max, d), stride)
+    o_stor = torch.zeros(B * S_max * H * d, device=dev, dtype=dtype)
+    o_gpu = o_stor.as_strided((B, H, S_max, d), stride)
+    slq = torch.tensor(q_lens, dtype=torch.int32, device=dev).view(B, 1, 1, 1)
+    slk = torch.tensor(kv_lens, dtype=torch.int32, device=dev).view(B, 1, 1, 1)
+    ro = (torch.tensor(cu, dtype=torch.int64, device=dev) * H * d).view(B + 1, 1, 1, 1)
+
+    g = cudnn.pygraph(io_data_type=cudnn.data_type.HALF, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    tq = g.tensor(dim=[B, H, S_max, d], stride=list(stride), data_type=cudnn.data_type.HALF, name="q")
+    k, v = g.tensor_like(k_c), g.tensor_like(v_c)
+    tk, tv = g.tensor_like(bt), g.tensor_like(bt)
+    sq_t, sk_t = g.tensor_like(slq), g.tensor_like(slk)
+    qro, oro = g.tensor_like(ro), g.tensor_like(ro)
+    tq.set_ragged_offset(qro)
+    o, _ = g.sdpa(
+        name="sdpa",
+        q=tq,
+        k=k,
+        v=v,
+        generate_stats=False,
+        attn_scale=scale,
+        use_padding_mask=True,
+        seq_len_q=sq_t,
+        seq_len_kv=sk_t,
+        paged_attention_k_table=tk,
+        paged_attention_v_table=tv,
+        paged_attention_max_seq_len_kv=max_pages * P,
+    )
+    o.set_output(True).set_dim([B, H, S_max, d]).set_stride(list(stride))
+    o.set_ragged_offset(oro)
+    g.validate()
+    g.build_operation_graph()
+    g.create_execution_plans([cudnn.heur_mode.A])
+    select_engine(g, engine_name())
+    g.check_support()
+    g.build_plans()
+    ws = torch.empty(max(g.get_workspace_size(), 1), device=dev, dtype=torch.uint8)
+    torch.cuda.set_sync_debug_mode("error")
+    try:
+        g.execute({tq: q_gpu, k: k_c, v: v_c, tk: bt, tv: bt, sq_t: slq, sk_t: slk, qro: ro, oro: ro, o: o_gpu}, ws)
+    finally:
+        torch.cuda.set_sync_debug_mode("default")
+    torch.cuda.synchronize()
+
+    o_out = o_stor[: T * H * d].reshape(T, H, d).float()
+    kv_lens_t = torch.tensor(kv_lens, dtype=torch.int32, device=dev)
+    for b in range(B):
+        for r in range(q_lens[b]):
+            q_row = q_pk[cu[b] + r].unsqueeze(0)  # [1, H, d] -> batch of one
+            ref_o, _ = _ref(q_row, k_pool, v_pool, bt.view(B, max_pages)[b : b + 1], kv_lens_t[b : b + 1], hnd, scale)
+            torch.testing.assert_close(o_out[cu[b] + r], ref_o[0], atol=2e-2, rtol=0)
+
+
+@pytest.mark.L0
+def test_paged_graph_batch_innermost_block_table():
+    """Block tables declared batch-innermost — strides (1, ., B, .) on the
+    (B, 1, max_pages, 1) tensor, the layout test_mhas_v2's harness builds — bind
+    as views: the table strides are part of the compile key, not a contract."""
+    import cudnn
+    import cudnn.sdpa  # noqa: F401
+    from cudnn.sdpa.fwd.engines import engine_name
+
+    dev, dtype = "cuda", torch.float16
+    B, H, KH, P, max_pages = 3, 8, 2, 32, 12
+    k_pool, v_pool, k_c, v_c, _ = _pools(B, KH, D, P, max_pages, False, dtype)
+    num_pages = k_pool.shape[0]
+    # linspace(...).reshape(max_pages, 1, B, 1).transpose(0, 2): batch stride 1, page stride B.
+    bt = torch.randperm(num_pages, device=dev)[: B * max_pages].to(torch.int32).reshape(max_pages, 1, B, 1).transpose(0, 2)
+    assert tuple(bt.stride()) == (1, B, B, 1) or bt.stride()[0] == 1
+    q_gpu = torch.randn(B, 1, H, D, device=dev, dtype=dtype).transpose(1, 2)
+    o_gpu = torch.empty(B, 1, H, D, device=dev, dtype=dtype).transpose(1, 2)
+    lens = torch.tensor([300, 1, 384], dtype=torch.int32, device=dev)
+    g = cudnn.pygraph(io_data_type=cudnn.data_type.HALF, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    q, k, v, tk, tv = g.tensor_like(q_gpu), g.tensor_like(k_c), g.tensor_like(v_c), g.tensor_like(bt), g.tensor_like(bt)
+    slq = torch.ones(B, 1, 1, 1, dtype=torch.int32, device=dev)
+    sq_t, sk_t = g.tensor_like(slq), g.tensor_like(lens.view(B, 1, 1, 1))
+    o, _ = g.sdpa(
+        name="sdpa",
+        q=q,
+        k=k,
+        v=v,
+        generate_stats=False,
+        attn_scale=1.0 / math.sqrt(D),
+        use_padding_mask=True,
+        seq_len_q=sq_t,
+        seq_len_kv=sk_t,
+        paged_attention_k_table=tk,
+        paged_attention_v_table=tv,
+        paged_attention_max_seq_len_kv=max_pages * P,
+    )
+    o.set_output(True).set_dim(q_gpu.shape).set_stride(q_gpu.stride())
+    g.validate()
+    g.build_operation_graph()
+    g.create_execution_plans([cudnn.heur_mode.A])
+    select_engine(g, engine_name())
+    g.check_support()
+    g.build_plans()
+    ws = torch.empty(max(g.get_workspace_size(), 1), device=dev, dtype=torch.uint8)
+    g.execute({q: q_gpu, k: k_c, v: v_c, tk: bt, tv: bt, sq_t: slq, sk_t: lens.view(B, 1, 1, 1), o: o_gpu}, ws)
+    torch.cuda.synchronize()
+    # The reference takes a row-major (B, max_pages) table: materialize the same ids.
+    ref_o, _ = _ref(q_gpu[:, :, 0, :], k_pool, v_pool, bt.reshape(B, max_pages).contiguous(), lens, False, 1.0 / math.sqrt(D))
+    torch.testing.assert_close(o_gpu[:, :, 0, :].float(), ref_o, atol=2e-2, rtol=0)

--- a/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm100.py
@@ -1053,6 +1053,32 @@ def test_split_kv_padded_q_trim(flavor, splits):
     assert (got - ref)[live.expand_as(got)].abs().max().item() <= 2e-2
 
 
+@pytest.mark.L0
+@pytest.mark.parametrize("splits", [8, 16], ids=lambda s: f"split{s}")
+def test_split_kv_cga1_empty_splits_multiwave(splits):
+    """cga1 (Q∪O alias) + more CTAs than SMs + batches whose splits come out EMPTY.
+
+    TMA-STG advances the Q∪O alias gate for every tile, empty ones included;
+    the d128 TMA-LDG warp skipped the empty-tile wait, so after a persistent
+    CTA drained an empty split its alias parity was one behind and the next
+    live tile's Q load raced the previous O drain.  Observed as the LONG batch
+    coming back wrong (max|dO| ~ 2e-2, LSE off by 4e-2) only when
+    B*H*splits > SM count and some other batch has fewer tiles than splits —
+    single-wave, uniform-length and cga2 runs were all clean, which is why the
+    existing split suite never saw it.  Fix: the d192 kernel's return edge
+    (mb_qo_slab_free, PR #575) ported to d128.
+    """
+    from test_sdpa_fwd_dsl_sm100 import _ref_sdpa_full
+
+    B, H, SQ, SKV = 3, 8, 1, 4224
+    lens = torch.tensor([4000, 1, 129], dtype=torch.int32, device="cuda")
+    got, q, k, v, scale = _run_masked(
+        "sm100/prefill_d128_f16.py", 128, 128, splits, B=B, H=H, KH=H, SQ=SQ, SKV=SKV, tp_kwargs=dict(seq_kv_lens_present=True), seq_kv_lens=lens, cta_mma=1
+    )
+    ref = _ref_sdpa_full(_bhsd(q), _bhsd(k), _bhsd(v), scale=scale, seq_kv_lens=lens)
+    assert (got - ref.float().permute(0, 2, 1, 3)).abs().max().item() <= 2e-3
+
+
 # --- the adapter honors the heuristic's split knob ---------------------------
 
 

--- a/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
+++ b/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
@@ -1418,3 +1418,71 @@ def test_bwd_dsink_fact():
     facts = _facts(g)
     assert facts.has_sink and facts.has_dsink
     assert facts.sink_t is not None and facts.dsink_t is not None
+
+
+# --- paged KV caches (issue #920) -------------------------------------------
+
+
+def _mk_paged_graph(*, d=128, page_size=16, max_pages=8, hnd=True, padding=True, max_seq_len=None, one_table=False):
+    """cuDNN's paged-cache contract: K/V page pools [num_pages, H_kv, page_size, D]
+    (HND compact, or NHD storage declared via strides) + (B, 1, max_pages, 1)
+    int32 block tables + per-batch lengths."""
+    g = _mk_graph()
+    b, h, kh = B, H, 2
+    q = g.tensor(dim=(b, h, 1, d), stride=(h * d, d, d, 1), data_type=DTYPE, name="q")
+    num_pages = b * max_pages
+    if hnd:
+        strides = (kh * page_size * d, page_size * d, d, 1)
+    else:
+        strides = (page_size * kh * d, d, kh * d, 1)
+    k = g.tensor(dim=(num_pages, kh, page_size, d), stride=strides, data_type=DTYPE, name="k")
+    v = g.tensor(dim=(num_pages, kh, page_size, d), stride=strides, data_type=DTYPE, name="v")
+    tk = g.tensor(dim=(b, 1, max_pages, 1), stride=(max_pages, max_pages, 1, 1), data_type=cudnn.data_type.INT32, name="tk")
+    tv = tk if one_table else g.tensor(dim=(b, 1, max_pages, 1), stride=(max_pages, max_pages, 1, 1), data_type=cudnn.data_type.INT32, name="tv")
+    slq = g.tensor(dim=(b, 1, 1, 1), stride=(1, 1, 1, 1), data_type=cudnn.data_type.INT32, name="slq")
+    slk = g.tensor(dim=(b, 1, 1, 1), stride=(1, 1, 1, 1), data_type=cudnn.data_type.INT32, name="slk")
+    kw = dict(paged_attention_k_table=tk, paged_attention_v_table=tv)
+    if max_seq_len is not None:
+        kw["paged_attention_max_seq_len_kv"] = max_seq_len
+    o, _ = g.sdpa(name="s", q=q, k=k, v=v, attn_scale=0.1, is_inference=True, use_padding_mask=padding, seq_len_q=slq, seq_len_kv=slk, **kw)
+    _finish_output(o, (b, h, 1, d), (h * d, d, d, 1))
+    return g
+
+
+def test_paged_facts_hnd_and_nhd():
+    for hnd in (True, False):
+        facts = _facts(_mk_paged_graph(hnd=hnd))
+        assert facts.has_paged_kv and facts.page_size == 16
+        assert facts.s_kv == 8 * 16 and facts.h_kv == 2 and facts.padded
+        assert tuple(facts.paged_k_table_t.get_dim()) == (B, 1, 8, 1)
+        assert facts.paged_k_table_t is not None and facts.paged_v_table_t is not None
+        assert engines.engine_name() in _eligible(_mk_paged_graph(hnd=hnd))
+
+
+def test_paged_facts_declared_max_seq_len_and_single_table():
+    facts = _facts(_mk_paged_graph(max_seq_len=100, one_table=True))
+    assert facts.s_kv == 100
+    assert facts.paged_k_table_t is facts.paged_v_table_t
+    assert engines.engine_name() in _eligible(_mk_paged_graph(max_seq_len=100, one_table=True))
+
+
+def test_paged_probe_declines():
+    assert not _eligible(_mk_paged_graph(page_size=48)), "page_size must divide 128 or be a multiple of it"
+    assert engines.engine_name() in _eligible(_mk_paged_graph(d=192)), "d=192 rides the d256 flavor envelope"
+    assert not _eligible(_mk_paged_graph(d=512)), "paged KV rides the d128 / d256 flavors only"
+    assert not _eligible(_mk_paged_graph(padding=False)), "paged KV needs the padding mask (per-batch KV lengths)"
+    facts = ga.analyze(_mk_paged_graph(max_seq_len=8 * 16 + 1))
+    assert facts.invalid is not None, "a declared max S_kv beyond the block table's reach is invalid"
+
+
+def test_paged_split_kv_is_proposed_on_a_decode_launch(monkeypatch):
+    """The padded exclusion on split-KV is lifted for paged graphs: a B=2, H_kv=2
+    decode launch over 128k tokens must be offered a split plan."""
+    monkeypatch.setattr(ga, "_device_sm_count", lambda: 148)
+    from cudnn.sdpa.fwd.heuristics import _knob_sets
+
+    g = _mk_paged_graph(page_size=128, max_pages=1024)
+    spec = next(s for s in engines.ENGINE_SPECS if s.name == engines.engine_name())
+    facts = _facts(g)
+    knob_sets = _knob_sets(spec, facts)
+    assert any(k.split_kv and k.split_kv > 1 for k in knob_sets), knob_sets

--- a/test/python/sdpa/helpers.py
+++ b/test/python/sdpa/helpers.py
@@ -391,9 +391,13 @@ def create_container_and_page_table(tensor, block_size):
 
     reshaped = torch.cat((cat_tensor.clone()).chunk(blocks_per_batch, dim=2), dim=0)
 
+    # Page p of batch b lives at pool index p*B + b (the chunk/cat above). The
+    # table is stored ROW-MAJOR — each batch's page list contiguous, strides
+    # (table_size, table_size, 1, 1) on the (B, 1, table_size, 1) declaration —
+    # which is what every framework hands cuDNN (FlashInfer, vLLM, SGLang,
+    # Megatron/TE, PyTorch all keep [B, max_pages] int32 row-major).
     table_size = math.ceil(S/block_size)
-    page_table = torch.linspace(0, B*table_size-1, B*table_size, device='cuda', dtype=torch.int32).reshape(table_size,1,B,1)
-    page_table = torch.transpose(page_table,0,2)
+    page_table = torch.arange(B*table_size, device='cuda', dtype=torch.int32).reshape(table_size, B).t().contiguous().reshape(B, 1, table_size, 1)
 
     return(reshaped, page_table)
 


### PR DESCRIPTION
## Summary

Deliverable 1 for #920: **paged KV caches served by the existing SDPA graph API and FROST engine** — no new entry point. A graph built with cuDNN's own paged-cache contract

```python
o, stats = graph.sdpa(q=q, k=k_pool, v=v_pool,            # pools: [num_pages, H_kv, page_size, D]
                      use_padding_mask=True, seq_len_q=slq, seq_len_kv=slk,
                      paged_attention_k_table=tk, paged_attention_v_table=tv,   # [B, 1, max_pages, 1] int32
                      paged_attention_max_seq_len_kv=max_seq_len_kv, ...)
```

now lowers through `sdpa_fwd_prefill_sm100` / `SdpaFwdDslSm100` onto the d128 f16/bf16 kernel's new `PAGED_KV` specialization. FlashInfer's `cudnn_batch_decode_with_kv_cache` already builds exactly this graph, so with `CUDNN_FRONTEND_ENABLE_FROST_ENGINES=1` vLLM/SGLang decode reaches the FROST kernel with zero integration work; the follow-ups in #920 (other archs, fp8 KV, MTP `q_len > 1`, sinks/SWA, deterministic merge) are further kernel specializations behind the same graph.

- **HND** (`[num_pages, H_kv, page_size, D]` compact) and **NHD** (`[num_pages, page_size, H_kv, D]` storage) page layouts. The layout is *only* the pool's strides (already in the compile key): the kernel host reads it off the bound strides and swaps the descriptor dim order — no `TemplateParams` field, no analyzer fact.
- **d128 and d256 f16/bf16 flavors** (`d_qk, d_v <= 256`; d=64 rides the d128 envelope, d=192/192 the d256 one).
- **THD (ragged) queries over the paged cache** — chunked prefill: ragged Q/O + `seq_len_q` with K/V pools + block tables, on the same engine (no KV split there).
- Per-batch KV lengths **read in-kernel** (`seq_len_kv`), the static maximum from the block table's page axis (a dynamic extent: `num_pages` / `max_pages` never enter the compile key). `graph.execute` runs clean under `torch.cuda.set_sync_debug_mode("error")`; the adapter path captures under `torch.cuda.graph` with `seq_len_kv` contents changing between replays.
- **KV split + combine** is proposed for paged graphs (the padded exclusion is lifted: paged graphs are padded by construction and the split composes with the per-batch lengths) — e.g. 32 splits at B=1/32k tokens, 2 at B=4/512.
- Any `S_q` (decode or paged prefill), GQA with PackGQA, Stats out. Declined at plan time (no plan offered): fp8/mxfp8 pools, sink, page sizes that neither divide nor are a multiple of the 128-row tile, d > 256 or mixed dims that would select d192×128, missing padding mask, packed (ragged-offset) block tables.

### How it is built

- `prefill_d128_f16_sm100.py` / `prefill_d256_f16_sm100.py`: `PAGED_KV` mode. Only the TMA-LDG warp changes — a K/V tile is issued as `128 / page_size` row boxes (one box inside the page when the page is taller), each box's page id read from the block table on device; boxes past a sequence's `ceil(len / page_size)` pages get page coordinate `-1` (TMA-OOB → exact zeros, mbarrier bytes still credited, the #624 trick). Separate K and V tables, as the graph declares them.
- `graph_analyzer.py`: paged facts (`page_size`, table refs; `s_kv` = `paged_attention_max_seq_len_kv` or what the tables address), table validation, binding slots; THD requires ragged Q/O only when paged.
- `engines.py`: `paged_kv=True` on the SM100 f16 row with the d128/dense/padded/page-geometry conditions in `mismatch()`; `lower_dsl_prefill` threads the page geometry and binds the tables as `(B, max_pages)` views.
- `api_dsl.py` (`SdpaFwdDslSm100`): pool-shaped K/V descriptors, strides compiled in (no copy), `block_table` / `block_table_v` execute args. SM120/SM80 adapters decline.
- `heuristics.py`: `_split_points` exempts paged graphs from the padded no-split rule.

### Pre-existing bug fixed on the way

With `cta_mma=1` (Q∪O SMEM alias) the d128 TMA-LDG warp's empty-tile branch never consumed the alias-gate phase TMA-STG fires for *every* tile, so after a persistent CTA drained an empty split its parity was one behind and the next live tile's Q load raced the previous O drain. Reproduced on the **unmodified dense kernel** (B=3, H=8, `seq_kv_lens=[4000, 1, 129]`, 8 splits, cga1 → long batch off by ~1e-2), only when `B·H·splits > SM count` and another batch has empty splits. Fix = port of the d192 `mb_qo_slab_free` return edge from #575; regression test `test_split_kv_cga1_empty_splits_multiwave`.

### Perf (B200, bf16, H=32/KV=8, d=128, page 16, kernel-level quick timing)

| B | s_kv | splits | µs | eff. KV BW |
|---|---|---|---|---|
| 1 | 4k | 16 | 45 | 0.37 TB/s |
| 1 | 128k | 16 | 310 | 1.7 TB/s |
| 32 | 4k | 1 | 252 | 2.1 TB/s |
| 256 | 4k | 1 | 2062 | 2.1 TB/s |

Functional-first: decode rides the prefill kernel's 128-row Q tile, so it is MMA-heavy per KV byte. The FlashInfer fa2 / trtllm-gen comparison and a decode-shaped tile are next; neither changes the graph contract.

Rebased onto `develop` @ `dc4dca177` and squashed to a single commit; every gate below was re-run on the rebased tree.

## Test plan

- [x] `test_sdpa_fwd_paged_sm100.py` (new, 24 pass on B200): graph API — both layouts × page 16/128 with lengths {300, 77, 0, 1, 1024} + Stats; bf16 MHA; 32k tokens at B=1 (heuristic must split); declared max below table reach; B=256 with d=64; **d=256** (HND/NHD, Stats); paged prefill `S_q=3`; **THD ragged queries** (HND/NHD); plan-time declines. Kernel-level — page 32/64/256, forced 2/8 splits with empty ranges at cga1, d256 page 16/128 forced splits, GQA group 3, adapter CUDA-graph replay under `set_sync_debug_mode("error")`; batch-innermost block tables.
- [x] `test_sdpa_graph_analyzer.py`: +4 paged fact / decline / split-proposal tests (no GPU), 104 pass
- [x] **`test_mhas_v2.py` paged groups with `CUDNN_FRONTEND_ENABLE_FROST_ENGINES=1`** (python plans lead the ranking, so eligible configs run on the FROST kernel): `test_sdpa_fwd_paged_L0` 384/384 passed, 173 routed to `sdpa_fwd_prefill_sm100` (causal / SWA / band / bottom-right masks, random `d_qk≠d_v`, GQA, bf16, S_q up to 64, B up to 8); `test_sdpa_fwd_paged_unified_L0` 60 passed / 68 skipped, 26 on FROST. This sweep found that the harness declared its block tables batch-innermost (a transposed `linspace`); no framework does that — FlashInfer's cuDNN paths, vLLM, SGLang, Megatron-Core/TE and PyTorch's cuDNN SDPA all keep `[B, max_pages]` int32 row-major — so the helper now builds row-major tables (same page ids), and both layouts bind as views of their declared strides. Re-run on row-major: 384/384 (173 on FROST), unified 60 pass / 68 skip (26 on FROST), fp8 paged 26 pass / 6 skip (backend).
- [x] `test_sdpa_fwd_split_kv_sm100.py`: 87 existing + `test_split_kv_cga1_empty_splits_multiwave[8,16]`
- [x] Dense regression after the engine/adapter/THD rework: `test_sdpa_fwd_dsl_sm100.py` + split-KV + heuristics + frontend-integration + execute-is-async suites — 803 passed / 1 skipped on B200 (re-run after the rebase onto `develop` @ dc4dca177, which moved the kernels under `kernels/sm100/` and made split partials fp32 (#891) — the paged block tables are now passed by keyword after `o_partial_f32`)
- [ ] CI Blackwell lanes
- [ ] Perf table vs FlashInfer fa2 / trtllm-gen (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added paged KV-cache support for SM100 f16/bf16 SDPA with d64, d128, d192, and d256 head dimensions.
  - Supports HND/NHD layouts, GQA/MHA, split-KV execution, THD queries, varied page sizes, separate block tables, and CUDA Graph replay.
  - Added validation for page tables, KV lengths, layouts, strides, capacities, and unsupported configurations.

- **Bug Fixes**
  - Improved handling of empty ranges, padded inputs, dynamic KV extents, and nonstandard block-table strides.

- **Tests**
  - Added broad coverage for paged KV correctness, eligibility, statistics, reference matching, and split-KV behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->