### PR TITLE
enable-mxfp4-mxfp8-mixed-input

### DIFF
--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -1753,22 +1753,27 @@ def _render_block_scale_tile_constants_sm100(
 
     bs = chain.block_scale
     assert bs is not None
-    is_fp4 = bs.is_fp4
+    both_fp4 = bs.both_fp4
+    mixed_width = bs.mixed_width
     is_sm103 = cfg.pipeline == "sm103"
     # The 64-byte block-scale MMA. A pipeline no longer implies it: sm100
     # configs carry both widths and the ACTIVE arch decides (validate_block_scale_config_sm100).
     mma_k64 = cfg.mma_tile_k_bytes == 64
-    if is_sm103 and not is_fp4:
+    if is_sm103 and not both_fp4:
         raise NotImplementedError("the sm103 block-scale pipeline is fp4-only; " f"{bs.a_dtype} data with {bs.sf_dtype} scales runs the sm100 templates")
+    # Baseline SM100 mixed UTCQMMA uses K32 and the padded E2M1 SMEM format
+    # (16 FP4 lanes in 8 payload bytes + 8 padding bytes). Rubin's K64 form
+    # consumes native packed FP4 instead.
+    padded_fp4 = mixed_width and not mma_k64
 
-    # data_elem_bits / sA-sB bytes / B's TMA stride encoding all take one packed
-    # width, read off A alone — a mixed-width combo would mis-size B, not fail.
-    if DTYPE_BITS[bs.a_dtype] != DTYPE_BITS[bs.b_dtype]:
-        raise NotImplementedError(
-            f"block-scale A and B must share an element width; got {bs.a_dtype} " f"({DTYPE_BITS[bs.a_dtype]}b) x {bs.b_dtype} ({DTYPE_BITS[bs.b_dtype]}b)"
-        )
-
-    data_elem_bits = 4 if is_fp4 else 8
+    a_data_elem_bits = DTYPE_BITS[bs.a_dtype]
+    b_data_elem_bits = DTYPE_BITS[bs.b_dtype]
+    a_smem_elem_bits = 8 if padded_fp4 and a_data_elem_bits == 4 else a_data_elem_bits
+    b_smem_elem_bits = 8 if padded_fp4 and b_data_elem_bits == 4 else b_data_elem_bits
+    # K_BYTES names the byte width of the widest operand.  In a mixed UTCQMMA
+    # both sides span the same logical K, while the native packed FP4 SMEM row
+    # occupies half the bytes of its FP8 peer.
+    data_elem_bits = max(a_data_elem_bits, b_data_elem_bits)
     cta_k_elems = cfg.cta_tile_k_bytes * 8 // data_elem_bits
     validate_block_scale_config_sm100(cfg, bs.block_size, cta_k_elems)
 
@@ -1779,6 +1784,10 @@ def _render_block_scale_tile_constants_sm100(
     mma_inst_k_bytes = cfg.mma_tile_k_bytes
     mma_inst_k_elems = mma_inst_k_bytes * 8 // data_elem_bits
     num_kblocks = cta_k_elems // mma_inst_k_elems
+    a_cta_k_bytes = cta_k_elems * a_smem_elem_bits // 8
+    b_cta_k_bytes = cta_k_elems * b_smem_elem_bits // 8
+    a_mma_inst_k_bytes = mma_inst_k_elems * a_smem_elem_bits // 8
+    b_mma_inst_k_bytes = mma_inst_k_elems * b_smem_elem_bits // 8
 
     # --- Operand major (K- / M- / N-major) -----------------------------------
     # FP4 (nvfp4/mxfp4) is K-major only — sub-byte (Float4E2M1FNx2) packing
@@ -1786,17 +1795,19 @@ def _render_block_scale_tile_constants_sm100(
     # (A) / N-major (B). SF layout is unchanged regardless of data major.
     a_major = chain.matmul.a_major
     b_major = chain.matmul.b_major
-    if is_fp4 and (a_major != "k" or b_major != "k"):
-        raise ValueError(f"FP4 block-scaled inputs must be K-major (got A={a_major}-major, " f"B={b_major}-major); only mxfp8 supports M/N-major operands.")
+    if (a_data_elem_bits == 4 and a_major != "k") or (b_data_elem_bits == 4 and b_major != "k"):
+        raise ValueError(
+            f"FP4 block-scaled inputs must be K-major (got A={a_major}-major, " f"B={b_major}-major); only an MXFP8 side supports M/N-major layout."
+        )
     # Major-dependent SMEM descriptor params, mirroring _smem_desc_params.
-    ab_elem_bytes = 1  # FP8; FP4 rejected above for non-K
-    mn_group_elems = cfg.cta_tile_k_bytes // ab_elem_bytes
     cta_smem_m = cta_m
     cta_smem_n = cta_n // cta_group
 
-    def _bs_smem_desc_params(is_mn_major, mn_extent, name):
+    def _bs_smem_desc_params(is_mn_major, mn_extent, name, cta_k_bytes, inst_k_bytes, elem_bits):
         if not is_mn_major:
-            return 16, 8 * min(cfg.cta_tile_k_bytes, 128), mma_inst_k_bytes, 1
+            return 16, 8 * min(cta_k_bytes, 128), inst_k_bytes, 1
+        elem_bytes = elem_bits // 8
+        mn_group_elems = cta_k_bytes // elem_bytes
         if mn_extent < mn_group_elems or mn_extent % mn_group_elems != 0:
             raise ValueError(
                 f"block-scale config {cfg.name!r} cannot use {name}-major input: "
@@ -1805,20 +1816,22 @@ def _render_block_scale_tile_constants_sm100(
             )
         g = mn_group_elems
         return (
-            cfg.cta_tile_k_bytes * g,
-            8 * g * ab_elem_bytes,
-            mma_inst_k_bytes * g,
+            cta_k_bytes * g,
+            8 * g * elem_bytes,
+            inst_k_bytes * g,
             g,
         )
 
-    a_lbo, a_sbo, a_k_step, a_tma_group_elems = _bs_smem_desc_params(a_major == "m", cta_smem_m, "M")
-    b_lbo, b_sbo, b_k_step, b_tma_group_elems = _bs_smem_desc_params(b_major == "n", cta_smem_n, "N")
+    a_lbo, a_sbo, a_k_step, a_tma_group_elems = _bs_smem_desc_params(a_major == "m", cta_smem_m, "M", a_cta_k_bytes, a_mma_inst_k_bytes, a_data_elem_bits)
+    b_lbo, b_sbo, b_k_step, b_tma_group_elems = _bs_smem_desc_params(b_major == "n", cta_smem_n, "N", b_cta_k_bytes, b_mma_inst_k_bytes, b_data_elem_bits)
 
     # Packed (Float4E2M1FNx2 / Float8) element count per row for SMEM.
-    pack = 2 if is_fp4 else 1
-    ab_packed_per_row = cta_k_elems // pack  # ab_dtype elems per K-row
-    sA_packed_elems = cta_m * ab_packed_per_row
-    sB_packed_elems = (cta_n // cta_group) * ab_packed_per_row
+    a_pack = 8 // a_smem_elem_bits
+    b_pack = 8 // b_smem_elem_bits
+    a_packed_per_row = cta_k_elems // a_pack
+    b_packed_per_row = cta_k_elems // b_pack
+    sA_packed_elems = cta_m * a_packed_per_row
+    sB_packed_elems = (cta_n // cta_group) * b_packed_per_row
 
     # --- Scale factors --------------------------------------------------------
     sf_k = cta_k_elems // bs.block_size  # SF values along K per tile
@@ -1999,7 +2012,7 @@ def _render_block_scale_tile_constants_sm100(
             )
     else:
         # One stage covers a whole K-tile: packed data + SF per DISTINCT operand.
-        per_stage = na * (sA_packed_elems + sfa_smem_bytes) + nb * (sB_packed_elems + sfb_smem_bytes)
+        per_stage = na * (cta_m * a_cta_k_bytes + sfa_smem_bytes) + nb * ((cta_n // cta_group) * b_cta_k_bytes + sfb_smem_bytes)
         ab_stages = max(1, smem_ab_stages(per_stage, smem_fixed_reserve=tmpl.smem_fixed_reserve, extra_smem_bytes=ab_reserved))
 
     out_dt = chain.output_dtype
@@ -2009,16 +2022,37 @@ def _render_block_scale_tile_constants_sm100(
     # Instruction-descriptor operand dtype. On sm100 the fp4 MMA rides
     # Tcgen05MxInstrDesc with the E5M2 piggy-back; the K=64B fp4 MMA is an
     # OMMA and takes the real fp4 dtype. fp8 always uses its real dtype.
-    if is_fp4 and not mma_k64:
+    if both_fp4 and not mma_k64:
         idesc_a = idesc_b = "cutlass.Float8E5M2"
-    elif is_fp4:
+    elif both_fp4:
         idesc_a = idesc_b = "cutlass.Float4E2M1FN"
     else:
         idesc_a = DTYPE_TO_CUTLASS[bs.a_dtype]
         idesc_b = DTYPE_TO_CUTLASS[bs.b_dtype]
 
-    # FP4 needs explicit B4X16 (4-bit packed) TMA format; FP8 auto-derives.
-    ab_tma_format = "_tma.TensorMapDataFormat.B4X16" if is_fp4 else "None"
+    def _tma_side(dtype):
+        is_fp4 = dtype == "fp4_e2m1"
+        if is_fp4 and padded_fp4:
+            return DTYPE_TO_CUTLASS[dtype], "_tma.TensorMapDataFormat.B4X16_P64"
+        return (
+            "cutlass.Float4E2M1FN" if is_fp4 else DTYPE_TO_CUTLASS[dtype],
+            "_tma.TensorMapDataFormat.B4X16" if is_fp4 else "None",
+        )
+
+    a_tma_desc_dtype, a_tma_format = _tma_side(bs.a_dtype)
+    b_tma_desc_dtype, b_tma_format = _tma_side(bs.b_dtype)
+
+    def _swizzle_side(row_bytes):
+        if row_bytes % 128 == 0:
+            return "s128b", "SWIZZLE_128B"
+        if row_bytes % 64 == 0:
+            return "s64b", "SWIZZLE_64B"
+        if row_bytes % 32 == 0:
+            return "s32b", "SWIZZLE_32B"
+        return "none", "NONE"
+
+    a_tma_swizzle, a_smem_swizzle = _swizzle_side(a_cta_k_bytes)
+    b_tma_swizzle, b_smem_swizzle = _swizzle_side(b_cta_k_bytes)
 
     lines = [
         f"# Block-scale config: {cfg.name} data={bs.a_dtype}x{bs.b_dtype} sf={bs.sf_dtype} block={bs.block_size}",
@@ -2070,22 +2104,35 @@ def _render_block_scale_tile_constants_sm100(
         f"ab_empty_full_mask = {bs_ab_empty_full_mask}",
         "",
         f"# packed data SMEM",
-        # ab_dtype is the width BOTH operands are sized by (sA/sB bytes, B's TMA
-        # stride encoding, ab_stride_elems); it is only spelled as A's dtype.
-        f"ab_dtype = {DTYPE_TO_CUTLASS[bs.a_dtype]}",
+        f"a_dtype = {DTYPE_TO_CUTLASS[bs.a_dtype]}",
+        f"b_dtype = {DTYPE_TO_CUTLASS[bs.b_dtype]}",
+        f"a_smem_dtype = {'cutlass.Float4E2M1FN_unpack' if padded_fp4 and a_data_elem_bits == 4 else DTYPE_TO_CUTLASS[bs.a_dtype]}",
+        f"b_smem_dtype = {'cutlass.Float4E2M1FN_unpack' if padded_fp4 and b_data_elem_bits == 4 else DTYPE_TO_CUTLASS[bs.b_dtype]}",
+        f"ab_max_data_bits = {data_elem_bits}",
         # Fake-tensor dtypes: A and B may differ (mxfp8 e4m3xe5m2); NOT idesc_a/b (fp4 forces E5M2).
         f"a_fake_dtype = {DTYPE_TO_CUTLASS[bs.a_dtype]}",
         f"b_fake_dtype = {DTYPE_TO_CUTLASS[bs.b_dtype]}",
-        f"ab_packed_per_row = {ab_packed_per_row}",
+        f"a_packed_per_row = {a_packed_per_row}",
+        f"b_packed_per_row = {b_packed_per_row}",
         f"sA_packed_elems = {sA_packed_elems}",
         f"sB_packed_elems = {sB_packed_elems}",
-        # TMA-descriptor element dtype. FP4 uses the NATIVE 4-bit Float4E2M1FN
-        # (not the packed-pair Float4E2M1FNx2) so cute scales the descriptor by
-        # width=4 itself (no manual stride halving). FP8 same as ab_tma_dtype.
-        f"ab_tma_desc_dtype = {'cutlass.Float4E2M1FN' if is_fp4 else DTYPE_TO_CUTLASS[bs.a_dtype]}",
-        f"ab_tma_format = {ab_tma_format}",
-        "ab_tma_swizzle = _tma.TensorMapSwizzle.s128b",
-        "ab_smem_swizzle = cutlass.experimental.primitives.Tcgen05SmemSwizzle.SWIZZLE_128B",
+        # TMA completion counts GMEM payload bytes, not the padded SMEM
+        # footprint.  They differ for B4X16_P64: 128 logical FP4 values read
+        # 64 bytes from GMEM but occupy 128 bytes in SMEM.
+        f"sA_tma_bytes = {cta_m * cta_k_elems * a_data_elem_bits // 8}",
+        f"sB_tma_bytes = {(cta_n // cta_group) * cta_k_elems * b_data_elem_bits // 8}",
+        # Native FP4 TMA uses logical-width Float4E2M1FN + B4X16.  Padded FP4
+        # uses packed-pair Float4E2M1FNx2 + B4X16_P64, whose builder derives
+        # logical FP4 strides while expanding the SMEM destination. FP8 uses
+        # its ordinary data dtype/format.
+        f"a_tma_desc_dtype = {a_tma_desc_dtype}",
+        f"b_tma_desc_dtype = {b_tma_desc_dtype}",
+        f"a_tma_format = {a_tma_format}",
+        f"b_tma_format = {b_tma_format}",
+        f"a_tma_swizzle = _tma.TensorMapSwizzle.{a_tma_swizzle}",
+        f"b_tma_swizzle = _tma.TensorMapSwizzle.{b_tma_swizzle}",
+        f"a_smem_swizzle = cutlass.experimental.primitives.Tcgen05SmemSwizzle.{a_smem_swizzle}",
+        f"b_smem_swizzle = cutlass.experimental.primitives.Tcgen05SmemSwizzle.{b_smem_swizzle}",
         f"a_smem_desc_leading_byte_offset = {a_lbo}",
         f"a_smem_desc_stride_byte_offset = {a_sbo}",
         f"a_smem_k_step_bytes = {a_k_step}",
@@ -2147,7 +2194,7 @@ def _render_block_scale_tile_constants_sm100(
         # Byte step from one MMA M sub-block to the next inside the SMEM tile.
         # sm103 stages ONE 128-B K chunk per AB stage, not the whole K-tile, so
         # its per-M-row width is the chunk's, not cta_tile_k_bytes.
-        f"a_smem_m_step_bytes = {(cta_m // mma_size_m) * (128 if is_sm103 else cfg.cta_tile_k_bytes)}",
+        f"a_smem_m_step_bytes = {(cta_m // mma_size_m) * (128 if is_sm103 else a_cta_k_bytes)}",
         f"registers_per_atom = {_REGISTERS_PER_ATOM}",
         f"sf_atom_desc_stride = {sf_atom_desc_stride}",
         f"sf_block_desc_stride = {sf_block_desc_stride}",
@@ -2165,6 +2212,18 @@ def _render_block_scale_tile_constants_sm100(
         spi = scales_per_inst
         sf_groups = 4 if bs.block_size == 16 else 2  # 12 SFs/row per group either way
         lines += [
+            "",
+            # The sm103 template is homogeneous FP4-only and still uses the
+            # shared AB names.  Keep those aliases local to that pipeline; the
+            # sm100 templates intentionally consume the side-specific names so
+            # a mixed-width operand cannot accidentally inherit its peer's
+            # packing, descriptor dtype, or swizzle.
+            "ab_dtype = a_dtype",
+            "ab_packed_per_row = a_packed_per_row",
+            "ab_tma_desc_dtype = a_tma_desc_dtype",
+            "ab_tma_format = a_tma_format",
+            "ab_tma_swizzle = a_tma_swizzle",
+            "ab_smem_swizzle = a_smem_swizzle",
             "",
             f"# sm103 K=48B UTCOMMA pipeline: {num_kblocks} MMAs per K-tile; an AB " f"stage is one 128-B chunk (3 per K-tile); SF rides its own ring",
             f"chunks_per_ktile = {cfg.cta_tile_k_bytes // 128}",
@@ -2193,8 +2252,8 @@ def _render_block_scale_tile_constants_sm100(
     lines += [
         "",
         f"# block-scale MMA: {num_kblocks} MMAs per K-tile at mma_inst_k_bytes={cfg.mma_tile_k_bytes}",
-        f"idesc_is_omma = {is_fp4 and mma_k64}",
-        f"mma_k_dim_mode = {(2 if is_fp4 else 1) if mma_k64 else 0}",
+        f"idesc_is_omma = {both_fp4 and mma_k64}",
+        f"mma_k_dim_mode = {(2 if both_fp4 else 1) if mma_k64 else 0}",
     ]
     # MoE grouped block-scale: grouped persistent scheduler launches a FIXED
     # cluster count (≈ NUM_SMS / cluster_size); host grid and stride share it.

--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -2106,8 +2106,8 @@ def _render_block_scale_tile_constants_sm100(
         f"# packed data SMEM",
         f"a_dtype = {DTYPE_TO_CUTLASS[bs.a_dtype]}",
         f"b_dtype = {DTYPE_TO_CUTLASS[bs.b_dtype]}",
-        f"a_smem_dtype = {'cutlass.Float4E2M1FN_unpack' if padded_fp4 and a_data_elem_bits == 4 else DTYPE_TO_CUTLASS[bs.a_dtype]}",
-        f"b_smem_dtype = {'cutlass.Float4E2M1FN_unpack' if padded_fp4 and b_data_elem_bits == 4 else DTYPE_TO_CUTLASS[bs.b_dtype]}",
+        f"a_smem_dtype = {'cutlass.Uint8' if padded_fp4 and a_data_elem_bits == 4 else DTYPE_TO_CUTLASS[bs.a_dtype]}",
+        f"b_smem_dtype = {'cutlass.Uint8' if padded_fp4 and b_data_elem_bits == 4 else DTYPE_TO_CUTLASS[bs.b_dtype]}",
         f"ab_max_data_bits = {data_elem_bits}",
         # Fake-tensor dtypes: A and B may differ (mxfp8 e4m3xe5m2); NOT idesc_a/b (fp4 forces E5M2).
         f"a_fake_dtype = {DTYPE_TO_CUTLASS[bs.a_dtype]}",

--- a/python/cudnn/gemm/frost/fusion_ir.py
+++ b/python/cudnn/gemm/frost/fusion_ir.py
@@ -500,7 +500,10 @@ class BlockScaleSpec:
     Currently runs (both sides): fp4 with any of e4m3 / e8m0 / e5m3 scales at
     either K-block (16 or 32) — the two axes are orthogonal, so nvfp4 and mxfp4
     are just the two best-known corners — plus fp8 (e4m3/e5m2) with e8m0 scales
-    at block 32. E5M3 scales additionally require SM 10.7+.
+    at block 32. Mixed mxfp8/mxfp4 is supported in either operand order (shared
+    e8m0 scale format, block 32): SM100 uses the K32 UTCQMMA padded-E2M1 layout,
+    while Rubin additionally provides a native-packed K64 form. E5M3 scales
+    require SM 10.7+.
 
     SF tensors are runtime-positional (not ``TensorRef``s), fully described here
     by per-side scalars; their logical dims derive from M/N/K/block_size. Passed
@@ -558,12 +561,26 @@ class BlockScaleSpec:
 
     @property
     def is_fp4(self) -> bool:
-        return self.a_dtype == "fp4_e2m1"
+        # Kept as the homogeneous-combo predicate it represented before mixed
+        # input widths were admitted.  Callers that need one side must inspect
+        # that side's dtype explicitly.
+        return self.both_fp4
+
+    @property
+    def both_fp4(self) -> bool:
+        return self.a_dtype == "fp4_e2m1" and self.b_dtype == "fp4_e2m1"
+
+    @property
+    def mixed_width(self) -> bool:
+        return (self.a_dtype == "fp4_e2m1") != (self.b_dtype == "fp4_e2m1")
 
     @property
     def mma_block_scale_kind(self) -> str:
         """GEMM ``nvvm.MMABlockScaleKind`` member name."""
-        return "MXF4NVF4" if self.is_fp4 else "MXF8F6F4"
+        # Rubin's mixed FP8/FP4 instruction is a UTCQMMA (MXF8F6F4), whose
+        # per-side format fields independently encode FP8 or E2M1.  MXF4NVF4
+        # is the UTCOMMA path and requires FP4 on both sides.
+        return "MXF4NVF4" if self.both_fp4 else "MXF8F6F4"
 
     @property
     def scale_vec_size(self) -> str:

--- a/python/cudnn/gemm/frost/kernel_registry.py
+++ b/python/cudnn/gemm/frost/kernel_registry.py
@@ -150,6 +150,10 @@ _BLOCK_SCALE_CASES = frozenset(
         _bs_key("fp8_e4m3", "fp8_e8m0", "fp8_e5m2", "fp8_e8m0", 32),
         _bs_key("fp8_e5m2", "fp8_e8m0", "fp8_e4m3", "fp8_e8m0", 32),
         _bs_key("fp8_e5m2", "fp8_e8m0", "fp8_e5m2", "fp8_e8m0", 32),
+        _bs_key("fp4_e2m1", "fp8_e8m0", "fp8_e4m3", "fp8_e8m0", 32),
+        _bs_key("fp4_e2m1", "fp8_e8m0", "fp8_e5m2", "fp8_e8m0", 32),
+        _bs_key("fp8_e4m3", "fp8_e8m0", "fp4_e2m1", "fp8_e8m0", 32),
+        _bs_key("fp8_e5m2", "fp8_e8m0", "fp4_e2m1", "fp8_e8m0", 32),
     }
 )
 
@@ -348,7 +352,7 @@ class KernelTemplate:
 
                 bs = chain.block_scale
                 assert bs is not None
-                data_elem_bits = 4 if bs.is_fp4 else 8
+                data_elem_bits = max(C.DTYPE_BITS[bs.a_dtype], C.DTYPE_BITS[bs.b_dtype])
                 cta_k_elems = config.cta_tile_k_bytes * 8 // data_elem_bits
                 validate_block_scale_config(config, bs.block_size, cta_k_elems)
             else:

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-"""sm100 block-scale GEMM kernel (nvfp4 / mxfp4 / mxfp8): persistent + CLC scheduler.
+"""sm100 block-scale GEMM kernel (nvfp4 / mxfp4 / mxfp8, including mixed
+MXFP8/MXFP4 on baseline SM100 K32 and Rubin K64): persistent + CLC scheduler.
 
 Serves both MMA modes; ``cta_group`` is an injected tile constant.
 
@@ -22,7 +23,8 @@ K-tile takes half as many MMAs, each consuming ``sf_scales_per_inst`` scales;
 when that outgrows a 128x4 utccp atom one SF word spans ``word_atoms`` atoms,
 and SFA is then laid out block-major while SFB is atom-major. At 32 every word
 is one atom and both collapse to the same addresses. fp4 rides the OMMA
-descriptor only at 64; at 32 it keeps the Mx descriptor's E5M2 piggy-back.
+descriptor only at 64. At 32 homogeneous fp4 keeps the Mx descriptor's E5M2
+piggy-back, while mixed fp8/fp4 uses the padded E2M1 operand encoding.
 
 Warp layout (8 warps × 32 = 256 threads/CTA):
   warps 0–3 : epilogue (warp 0 also allocates TMEM)  — setmaxnreg.inc 216
@@ -108,7 +110,7 @@ def _auto_swizzle_w(m, n, k, nt_n):
     if cutlass.const_expr(tile_swizzle_n > 0):
         return tile_swizzle_n
     budget = cutlass.Int64(swizzle_l2_budget_bytes)
-    row_bytes = (cutlass.Int64(ab_dtype.width) * k) // 8
+    row_bytes = (cutlass.Int64(ab_max_data_bits) * k) // 8
     cap = cutlass.max(budget // (row_bytes * cgrp_tile_mnk[1]), cutlass.Int64(1))
     w = cutlass.min(cutlass.Int64(nt_n), cap)
     if cutlass.min(m, n) * row_bytes <= budget and m <= n:
@@ -344,7 +346,7 @@ def _kernel(
     sB_elems = sB_packed_elems
     smem_a_list = [
         cutlass.Array(
-            ab_dtype,
+            a_smem_dtype,
             sA_elems * ab_stages,
             space=cutlass.AddressSpace.smem,
             alignment=1024,
@@ -353,7 +355,7 @@ def _kernel(
     ]
     smem_b_list = [
         cutlass.Array(
-            ab_dtype,
+            b_smem_dtype,
             sB_elems * ab_stages,
             space=cutlass.AddressSpace.smem,
             alignment=1024,
@@ -457,13 +459,13 @@ def _kernel(
     else:
         nvvm.barrier_cluster_arrive_relaxed()
 
-    sA_bytes = sA_elems * (ab_dtype.width // 8)
-    sB_bytes = sB_elems * (ab_dtype.width // 8)
+    sA_bytes = sA_elems * (a_smem_dtype.width // 8)
+    sB_bytes = sB_elems * (b_smem_dtype.width // 8)
     if cutlass.const_expr(cta_group == 1):
-        ab_only_copy_bytes = num_a_operands * sA_bytes + num_b_operands * sB_bytes
+        ab_only_copy_bytes = num_a_operands * sA_tma_bytes + num_b_operands * sB_tma_bytes
         sf_only_copy_bytes = num_a_operands * sfa_smem_bytes + num_b_operands * sfb_smem_bytes
     else:
-        ab_only_copy_bytes = (num_a_operands * sA_bytes + num_b_operands * sB_bytes) * 2
+        ab_only_copy_bytes = (num_a_operands * sA_tma_bytes + num_b_operands * sB_tma_bytes) * 2
         sf_only_copy_bytes = (num_a_operands * sfa_smem_bytes + num_b_operands * sfb_smem_bytes) * 2
 
     if cutlass.const_expr(cta_group == 2):
@@ -692,7 +694,7 @@ def _kernel(
                         if cutlass.const_expr(fallback_cluster_shape_mnk is None):
                             if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
-                                    sA_stage.subview(n_rank * _a_rows * ab_packed_per_row),
+                                    sA_stage.subview(n_rank * _a_rows * a_packed_per_row),
                                     tma_a_desc.get_ptr(),
                                     (coord_k, coord_m_per_cta + n_rank * _a_rows, tile_l_a),
                                     ab_full_mbar_ptr.subview(stage),
@@ -708,7 +710,7 @@ def _kernel(
                                 _a_idx = n_rank * _a_per_cta + _asl
                                 if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
-                                        sA_stage.subview(_a_idx * _a_rows * ab_packed_per_row),
+                                        sA_stage.subview(_a_idx * _a_rows * a_packed_per_row),
                                         tma_a_desc.get_ptr(),
                                         (coord_k, coord_m_per_cta + _a_idx * _a_rows, tile_l_a),
                                         ab_full_mbar_ptr.subview(stage),
@@ -785,7 +787,7 @@ def _kernel(
                         if cutlass.const_expr(fallback_cluster_shape_mnk is None):
                             if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
-                                    sB_stage.subview(pair_m_idx * _b_rows * ab_packed_per_row),
+                                    sB_stage.subview(pair_m_idx * _b_rows * b_packed_per_row),
                                     tma_b_desc.get_ptr(),
                                     (coord_k, coord_n_per_cta + pair_m_idx * _b_rows, tile_l_b),
                                     ab_full_mbar_ptr.subview(stage),
@@ -801,7 +803,7 @@ def _kernel(
                                 _b_idx = pair_m_idx * _b_per_cta + _bsl
                                 if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
-                                        sB_stage.subview(_b_idx * _b_rows * ab_packed_per_row),
+                                        sB_stage.subview(_b_idx * _b_rows * b_packed_per_row),
                                         tma_b_desc.get_ptr(),
                                         (coord_k, coord_n_per_cta + _b_idx * _b_rows, tile_l_b),
                                         ab_full_mbar_ptr.subview(stage),
@@ -1030,7 +1032,7 @@ def _kernel(
                     start_address=smem_a_list[i],
                     leading_byte_offset=a_smem_desc_leading_byte_offset,
                     stride_byte_offset=a_smem_desc_stride_byte_offset,
-                    layout=ab_smem_swizzle,
+                    layout=a_smem_swizzle,
                 )
                 for i in range(num_a_operands)
             ]
@@ -1039,7 +1041,7 @@ def _kernel(
                     start_address=smem_b_list[j],
                     leading_byte_offset=b_smem_desc_leading_byte_offset,
                     stride_byte_offset=b_smem_desc_stride_byte_offset,
-                    layout=ab_smem_swizzle,
+                    layout=b_smem_swizzle,
                 )
                 for j in range(num_b_operands)
             ]
@@ -1528,30 +1530,30 @@ def _host(
             tma_a_desc_list.append(
                 _tma.create_tensor_map_tiled(
                     global_address=_a_op.iterator.toint(),
-                    dtype=ab_tma_desc_dtype,
+                    dtype=a_tma_desc_dtype,
                     global_dims=[m, k_sym, a_batch],
                     global_strides=[
-                        a_stride_k * ab_dtype.width // 128,
-                        a_stride_l * ab_dtype.width // 128,
+                        a_stride_k * a_dtype.width // 128,
+                        a_stride_l * a_dtype.width // 128,
                     ],
                     box_dims=[a_tma_group_elems, cta_tile_mnk[2], 1],
-                    swizzle=ab_tma_swizzle,
-                    tma_format=ab_tma_format,
+                    swizzle=a_tma_swizzle,
+                    tma_format=a_tma_format,
                 )
             )
         else:
             tma_a_desc_list.append(
                 _tma.create_tensor_map_tiled(
                     global_address=_a_op.iterator.toint(),
-                    dtype=ab_tma_desc_dtype,
+                    dtype=a_tma_desc_dtype,
                     global_dims=[k_sym, m, a_batch],
                     global_strides=[
-                        a_stride_m * ab_dtype.width // 128,
-                        a_stride_l * ab_dtype.width // 128,
+                        a_stride_m * a_dtype.width // 128,
+                        a_stride_l * a_dtype.width // 128,
                     ],
                     box_dims=[cta_tile_mnk[2], cta_tile_mnk[0] // a_mcast_slices, 1],
-                    swizzle=ab_tma_swizzle,
-                    tma_format=ab_tma_format,
+                    swizzle=a_tma_swizzle,
+                    tma_format=a_tma_format,
                 )
             )
         sfa_fp16_tensor = cute.make_tensor(
@@ -1582,30 +1584,30 @@ def _host(
             tma_b_desc_list.append(
                 _tma.create_tensor_map_tiled(
                     global_address=_b_op.iterator.toint(),
-                    dtype=ab_tma_desc_dtype,
+                    dtype=b_tma_desc_dtype,
                     global_dims=[n, k_sym, b_batch],
                     global_strides=[
-                        b_stride_k * ab_dtype.width // 128,
-                        b_stride_l * ab_dtype.width // 128,
+                        b_stride_k * b_dtype.width // 128,
+                        b_stride_l * b_dtype.width // 128,
                     ],
                     box_dims=[b_tma_group_elems, cta_tile_mnk[2], 1],
-                    swizzle=ab_tma_swizzle,
-                    tma_format=ab_tma_format,
+                    swizzle=b_tma_swizzle,
+                    tma_format=b_tma_format,
                 )
             )
         else:
             tma_b_desc_list.append(
                 _tma.create_tensor_map_tiled(
                     global_address=_b_op.iterator.toint(),
-                    dtype=ab_tma_desc_dtype,
+                    dtype=b_tma_desc_dtype,
                     global_dims=[k_sym, n, b_batch],
                     global_strides=[
-                        b_stride_n * ab_dtype.width // 128,
-                        b_stride_l * ab_dtype.width // 128,
+                        b_stride_n * b_dtype.width // 128,
+                        b_stride_l * b_dtype.width // 128,
                     ],
                     box_dims=[cta_tile_mnk[2], cta_tile_mnk[1] // b_mcast_slices, 1],
-                    swizzle=ab_tma_swizzle,
-                    tma_format=ab_tma_format,
+                    swizzle=b_tma_swizzle,
+                    tma_format=b_tma_format,
                 )
             )
         sfb_fp16_tensor = cute.make_tensor(
@@ -1716,7 +1718,8 @@ def _host(
 @lru_cache(maxsize=None)
 def compile() -> Callable:
     out_vec_elems = vec_bytes_epi // (cd_dtype.width // 8)
-    ab_stride_elems = 128 // ab_dtype.width
+    a_stride_elems = 128 // a_dtype.width
+    b_stride_elems = 128 // b_dtype.width
     sym_m = cute.sym_int64()
     sym_n = cute.sym_int64(divisibility=out_vec_elems)
     # K tails are supported: the K loop is ceil_div and the TMA descriptor's global K
@@ -1724,7 +1727,8 @@ def compile() -> Callable:
     # TMA contiguous-extent one, already gated by _tma_alignment_reject.
     sym_k = cute.sym_int64()
     # Packed K extent: same reasoning as sym_k -- no CTA-tile multiple is required.
-    sym_kp = cute.sym_int64()
+    sym_akp = cute.sym_int64()
+    sym_bkp = cute.sym_int64()
     sym_l = cute.sym_int64()
     if matmul_a_batch == 1:
         sym_a_l = 1
@@ -1738,7 +1742,7 @@ def compile() -> Callable:
     def _make_fake_a():
         return make_fake_compact_tensor(
             a_fake_dtype,
-            (sym_m, sym_kp, sym_a_l),
+            (sym_m, sym_akp, sym_a_l),
             stride_order=(0, 1, 2) if a_is_m_major else (1, 0, 2),
             assumed_align=16,
         )
@@ -1746,7 +1750,7 @@ def compile() -> Callable:
     def _make_fake_b():
         return make_fake_compact_tensor(
             b_fake_dtype,
-            (sym_n, sym_kp, sym_b_l),
+            (sym_n, sym_bkp, sym_b_l),
             stride_order=(0, 1, 2) if b_is_n_major else (1, 0, 2),
             assumed_align=16,
         )
@@ -1784,12 +1788,12 @@ def compile() -> Callable:
     # @@INJECT_COMPILE_AB_FAKES@@
 
     # The operand's unit stride (m/n when MN-major, k when K-major) never reaches TMA, so it carries no 16B contract.
-    sym_a_stride_m = cute.sym_int64() if a_is_m_major else cute.sym_int64(divisibility=ab_stride_elems)
-    sym_a_stride_k = cute.sym_int64(divisibility=ab_stride_elems) if a_is_m_major else cute.sym_int64()
-    sym_a_stride_l = cute.sym_int64(divisibility=ab_stride_elems)
-    sym_b_stride_n = cute.sym_int64() if b_is_n_major else cute.sym_int64(divisibility=ab_stride_elems)
-    sym_b_stride_k = cute.sym_int64(divisibility=ab_stride_elems) if b_is_n_major else cute.sym_int64()
-    sym_b_stride_l = cute.sym_int64(divisibility=ab_stride_elems)
+    sym_a_stride_m = cute.sym_int64() if a_is_m_major else cute.sym_int64(divisibility=a_stride_elems)
+    sym_a_stride_k = cute.sym_int64(divisibility=a_stride_elems) if a_is_m_major else cute.sym_int64()
+    sym_a_stride_l = cute.sym_int64(divisibility=a_stride_elems)
+    sym_b_stride_n = cute.sym_int64() if b_is_n_major else cute.sym_int64(divisibility=b_stride_elems)
+    sym_b_stride_k = cute.sym_int64(divisibility=b_stride_elems) if b_is_n_major else cute.sym_int64()
+    sym_b_stride_l = cute.sym_int64(divisibility=b_stride_elems)
 
     # @@INJECT_COMPILE_REDUCTION_STRIDE_DECLS@@
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-"""sm100 MoE grouped block-scale matmul fwd (nvfp4 / mxfp4 / mxfp8).
+"""sm100 MoE grouped block-scale matmul fwd (nvfp4 / mxfp4 / mxfp8,
+including mixed MXFP8/MXFP4 on baseline SM100 K32 and Rubin K64).
 
 Serves both MMA modes; ``cta_group`` is an injected tile constant.
 
@@ -82,7 +83,7 @@ def _moe_auto_swizzle_w(group_rows, n, k, nt_n):
     if cutlass.const_expr(tile_swizzle_n > 0):
         return tile_swizzle_n
     budget = cutlass.Int64(swizzle_l2_budget_bytes)
-    row_bytes = (cutlass.Int64(ab_dtype.width) * k) // 8
+    row_bytes = (cutlass.Int64(ab_max_data_bits) * k) // 8
     cap = cutlass.max(budget // (row_bytes * cgrp_tile_mnk[1]), cutlass.Int64(1))
     w = cutlass.min(cutlass.Int64(nt_n), cap)
     rows = cutlass.Int64(group_rows)
@@ -302,7 +303,7 @@ def _kernel(
     sB_elems = sB_packed_elems
     smem_a_list = [
         cutlass.Array(
-            ab_dtype,
+            a_smem_dtype,
             sA_elems * ab_stages,
             space=cutlass.AddressSpace.smem,
             alignment=1024,
@@ -311,7 +312,7 @@ def _kernel(
     ]
     smem_b_list = [
         cutlass.Array(
-            ab_dtype,
+            b_smem_dtype,
             sB_elems * ab_stages,
             space=cutlass.AddressSpace.smem,
             alignment=1024,
@@ -408,10 +409,10 @@ def _kernel(
     else:
         nvvm.barrier_cluster_arrive_relaxed()
 
-    sA_bytes = sA_elems * (ab_dtype.width // 8)
-    sB_bytes = sB_elems * (ab_dtype.width // 8)
+    sA_bytes = sA_elems * (a_smem_dtype.width // 8)
+    sB_bytes = sB_elems * (b_smem_dtype.width // 8)
     # The pair leader issues ONE expect_tx for both CTAs, so it counts twice.
-    ab_only_copy_bytes = (num_a_operands * sA_bytes + num_b_operands * sB_bytes) * cta_group
+    ab_only_copy_bytes = (num_a_operands * sA_tma_bytes + num_b_operands * sB_tma_bytes) * cta_group
     sf_only_copy_bytes = (num_a_operands * sfa_smem_bytes + num_b_operands * sfb_smem_bytes) * cta_group
     if cutlass.const_expr(cta_group == 2):
         pair_n_size = cgrp_tile_mnk[1] // cluster_n
@@ -806,7 +807,7 @@ def _kernel(
                         _fence_tensormap_acquire(a_desc_tma_ptr_list[_ai])
                     for _ai in cutlass.range_constexpr(num_a_operands):
                         if elect_one:
-                            row_base = mA_list[_ai].iterator.raw_ptr().toint() + ((group_begin * a_stride_m_list[_ai] * ab_dtype.width) >> 3)
+                            row_base = mA_list[_ai].iterator.raw_ptr().toint() + ((group_begin * a_stride_m_list[_ai] * a_dtype.width) >> 3)
                             _replace_tensormap_global_address(tma_a_desc_smem_list[_ai], row_base)
                             _replace_tensormap_global_dim_1(tma_a_desc_smem_list[_ai], group_end - group_begin)
                         nvvm.bar_warp_sync(0xFFFFFFFF)
@@ -896,7 +897,7 @@ def _kernel(
                         for _ai in cutlass.range_constexpr(num_a_operands):
                             if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
-                                    smem_a_list[_ai].subview(sA_elems * stage + _a_off * ab_packed_per_row),
+                                    smem_a_list[_ai].subview(sA_elems * stage + _a_off * a_packed_per_row),
                                     a_desc_load_list[_ai],
                                     (coord_k, coord_m_desc + _a_off, cutlass.Int32(0)),
                                     ab_full_mbar_ptr.subview(stage),
@@ -926,7 +927,7 @@ def _kernel(
                             else:
                                 if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
-                                        sB_stage.subview(_b_off * ab_packed_per_row),
+                                        sB_stage.subview(_b_off * b_packed_per_row),
                                         tma_b_descs[_bj].get_ptr(),
                                         (coord_k, coord_n_per_cta + _b_off, coord_expert),
                                         ab_full_mbar_ptr.subview(stage),
@@ -1054,7 +1055,7 @@ def _kernel(
                     start_address=smem_a_list[i],
                     leading_byte_offset=a_smem_desc_leading_byte_offset,
                     stride_byte_offset=a_smem_desc_stride_byte_offset,
-                    layout=ab_smem_swizzle,
+                    layout=a_smem_swizzle,
                 )
                 for i in range(num_a_operands)
             ]
@@ -1063,7 +1064,7 @@ def _kernel(
                     start_address=smem_b_list[j],
                     leading_byte_offset=b_smem_desc_leading_byte_offset,
                     stride_byte_offset=b_smem_desc_stride_byte_offset,
-                    layout=ab_smem_swizzle,
+                    layout=b_smem_swizzle,
                 )
                 for j in range(num_b_operands)
             ]
@@ -1334,7 +1335,7 @@ def _kernel(
                         start_address=smem_a_list[i],
                         leading_byte_offset=a_smem_desc_leading_byte_offset,
                         stride_byte_offset=a_smem_desc_stride_byte_offset,
-                        layout=ab_smem_swizzle,
+                        layout=a_smem_swizzle,
                     )
                     for i in range(num_a_operands)
                 ]
@@ -1343,7 +1344,7 @@ def _kernel(
                         start_address=smem_b_list[j],
                         leading_byte_offset=b_smem_desc_leading_byte_offset,
                         stride_byte_offset=b_smem_desc_stride_byte_offset,
-                        layout=ab_smem_swizzle,
+                        layout=b_smem_swizzle,
                     )
                     for j in range(num_b_operands)
                 ]
@@ -1843,15 +1844,15 @@ def _host(
         tma_a_desc_list.append(
             _tma.create_tensor_map_tiled(
                 global_address=_a_op.iterator.toint(),
-                dtype=ab_tma_desc_dtype,
+                dtype=a_tma_desc_dtype,
                 global_dims=[k_sym, m, 1],
                 global_strides=[
-                    a_stride_m * ab_dtype.width // 128,
-                    a_stride_l * ab_dtype.width // 128,
+                    a_stride_m * a_dtype.width // 128,
+                    a_stride_l * a_dtype.width // 128,
                 ],
                 box_dims=[cta_tile_mnk[2], cta_tile_mnk[0] // a_mcast_slices, 1],
-                swizzle=ab_tma_swizzle,
-                tma_format=ab_tma_format,
+                swizzle=a_tma_swizzle,
+                tma_format=a_tma_format,
             )
         )
     tma_b_desc_list = []
@@ -1861,30 +1862,30 @@ def _host(
             tma_b_desc_list.append(
                 _tma.create_tensor_map_tiled(
                     global_address=_b_op.iterator.toint(),
-                    dtype=ab_tma_desc_dtype,
+                    dtype=b_tma_desc_dtype,
                     global_dims=[n, k_sym, num_experts],
                     global_strides=[
-                        b_stride_k * ab_dtype.width // 128,
-                        b_stride_l * ab_dtype.width // 128,
+                        b_stride_k * b_dtype.width // 128,
+                        b_stride_l * b_dtype.width // 128,
                     ],
                     box_dims=[b_tma_group_elems, cta_tile_mnk[2], 1],
-                    swizzle=ab_tma_swizzle,
-                    tma_format=ab_tma_format,
+                    swizzle=b_tma_swizzle,
+                    tma_format=b_tma_format,
                 )
             )
         else:
             tma_b_desc_list.append(
                 _tma.create_tensor_map_tiled(
                     global_address=_b_op.iterator.toint(),
-                    dtype=ab_tma_desc_dtype,
+                    dtype=b_tma_desc_dtype,
                     global_dims=[k_sym, n, num_experts],
                     global_strides=[
-                        b_stride_n * ab_dtype.width // 128,
-                        b_stride_l * ab_dtype.width // 128,
+                        b_stride_n * b_dtype.width // 128,
+                        b_stride_l * b_dtype.width // 128,
                     ],
                     box_dims=[cta_tile_mnk[2], cta_tile_mnk[1] // b_mcast_slices, 1],
-                    swizzle=ab_tma_swizzle,
-                    tma_format=ab_tma_format,
+                    swizzle=b_tma_swizzle,
+                    tma_format=b_tma_format,
                 )
             )
     rest_k = ((k_sym // block_size) + 3) // 4
@@ -1969,7 +1970,8 @@ def _host(
 @lru_cache(maxsize=None)
 def compile() -> Callable:
     out_vec_elems = vec_bytes_epi // (cd_dtype.width // 8)
-    ab_stride_elems = 16 // (ab_dtype.width // 8)
+    a_stride_elems = 16 // (a_dtype.width // 8)
+    b_stride_elems = 16 // (b_dtype.width // 8)
     sym_m = cute.sym_int64()
     sym_n = cute.sym_int64(divisibility=out_vec_elems)
     # K tails are supported: the K loop is ceil_div and the TMA descriptor's global K
@@ -1977,14 +1979,15 @@ def compile() -> Callable:
     # TMA contiguous-extent one, already gated by _tma_alignment_reject.
     sym_k = cute.sym_int64()
     # Packed K extent: same reasoning as sym_k -- no CTA-tile multiple is required.
-    sym_kp = cute.sym_int64()
+    sym_akp = cute.sym_int64()
+    sym_bkp = cute.sym_int64()
     sym_e = cute.sym_int64()
     sym_g = cute.sym_int64()
 
     def _make_fake_a():
         return make_fake_compact_tensor(
             a_fake_dtype,
-            (sym_m, sym_kp, 1),
+            (sym_m, sym_akp, 1),
             stride_order=(1, 0, 2),
             assumed_align=16,
         )
@@ -1992,7 +1995,7 @@ def compile() -> Callable:
     def _make_fake_b():
         return make_fake_compact_tensor(
             b_fake_dtype,
-            (sym_n, sym_kp, sym_e),
+            (sym_n, sym_bkp, sym_e),
             stride_order=(0, 1, 2) if b_is_n_major else (1, 0, 2),
             assumed_align=16,
         )
@@ -2032,17 +2035,17 @@ def compile() -> Callable:
         assumed_align=128,
     )
 
-    def _sym_operand_strides(is_mn_major: bool) -> tuple:
+    def _sym_operand_strides(is_mn_major: bool, stride_elems: int) -> tuple:
         # Operand is permuted to (M|N, K, L): the unit stride is mode 0 when MN-major, mode 1 when K-major, and never reaches TMA.
         unit = 0 if is_mn_major else 1
-        return tuple(cute.sym_int64() if i == unit else cute.sym_int64(divisibility=ab_stride_elems) for i in range(3))
+        return tuple(cute.sym_int64() if i == unit else cute.sym_int64(divisibility=stride_elems) for i in range(3))
 
     sym_a_strides = []
     for _ in range(num_a_operands):
-        sym_a_strides.extend(_sym_operand_strides(a_is_m_major))
+        sym_a_strides.extend(_sym_operand_strides(a_is_m_major, a_stride_elems))
     sym_b_strides = []
     for _ in range(num_b_operands):
-        sym_b_strides.extend(_sym_operand_strides(b_is_n_major))
+        sym_b_strides.extend(_sym_operand_strides(b_is_n_major, b_stride_elems))
 
     # @@INJECT_COMPILE_REDUCTION_STRIDE_DECLS@@
 

--- a/test/python/gemm/frost/test_block_scale_matmul.py
+++ b/test/python/gemm/frost/test_block_scale_matmul.py
@@ -265,16 +265,27 @@ def test_block_scale_matmul_gate_accepts_supported(a_dt, sf_dt, b_dt, bs):
 
 
 @pytest.mark.parametrize("a_dt,b_dt", [(_DT_FP4, _DT_E4M3), (_DT_FP4, _DT_E5M2), (_DT_E4M3, _DT_FP4), (_DT_E5M2, _DT_FP4)])
-def test_block_scale_matmul_gate_accepts_mixed_mxfp8_mxfp4(a_dt, b_dt):
-    from cudnn.gemm.frost.compiler import _check_block_scale_supported
+def test_block_scale_matmul_gate_accepts_mixed_mxfp8_mxfp4(a_dt, b_dt, monkeypatch):
+    from cudnn.gemm.frost import compiler as C
 
     chain = analyze(_build_nvfp4_graph(256, 256, 512, block_size=32, sf_dt=_DT_E8M0, a_dt=a_dt, b_dt=b_dt))
-    _check_block_scale_supported(chain, "sm100")
+    C._check_block_scale_supported(chain, "sm100")
     assert chain.block_scale.mma_block_scale_kind == "MXF8F6F4"
     cfg32 = by_name("CONFIG_sm100_128x128x128_128x128x32_cluster1x1_1ctamma")
     cfg64 = by_name(_SM107_128 + "_1ctamma")
+    monkeypatch.setattr(C, "_current_arch", lambda: 100)
     assert select_template(chain, cfg32).accepts(chain, cfg32) is None
+    src32 = C._render_block_scale_tile_constants(cfg32, chain, select_template(chain, cfg32))
+    assigned32 = dict(re.findall(r"^(\w+) = (.*)$", src32, re.M))
+    assert assigned32["a_smem_dtype"] == ("cutlass.Uint8" if a_dt == _DT_FP4 else C.DTYPE_TO_CUTLASS[_DTYPE_FROM_CUDNN[a_dt]])
+    assert assigned32["b_smem_dtype"] == ("cutlass.Uint8" if b_dt == _DT_FP4 else C.DTYPE_TO_CUTLASS[_DTYPE_FROM_CUDNN[b_dt]])
+    assert "Float4E2M1FN_unpack" not in src32
+    monkeypatch.setattr(C, "_current_arch", lambda: 107)
     assert select_template(chain, cfg64).accepts(chain, cfg64) is None
+    src64 = C._render_block_scale_tile_constants(cfg64, chain, select_template(chain, cfg64))
+    assigned64 = dict(re.findall(r"^(\w+) = (.*)$", src64, re.M))
+    assert assigned64["a_smem_dtype"] == C.DTYPE_TO_CUTLASS[_DTYPE_FROM_CUDNN[a_dt]]
+    assert assigned64["b_smem_dtype"] == C.DTYPE_TO_CUTLASS[_DTYPE_FROM_CUDNN[b_dt]]
 
 
 def test_block_scale_matmul_gate_rejects_mismatches():

--- a/test/python/gemm/frost/test_block_scale_matmul.py
+++ b/test/python/gemm/frost/test_block_scale_matmul.py
@@ -245,7 +245,7 @@ _DT_FP4, _DT_E4M3, _DT_E5M2, _DT_E8M0 = (
     cudnn.data_type.FP8_E5M2,
     cudnn.data_type.FP8_E8M0,
 )
-# (a_dt, sf_dt, b_dt, block_size) for the 6 supported cases.
+# (a_dt, sf_dt, b_dt, block_size) for the supported cases.
 _SUPPORTED_BS_CASES = [
     (_DT_FP4, _DT_E4M3, _DT_FP4, 16),  # 1 nvfp4
     (_DT_FP4, _DT_E8M0, _DT_FP4, 32),  # 2 mxfp4
@@ -264,6 +264,19 @@ def test_block_scale_matmul_gate_accepts_supported(a_dt, sf_dt, b_dt, bs):
     _check_block_scale_supported(chain, "sm100")
 
 
+@pytest.mark.parametrize("a_dt,b_dt", [(_DT_FP4, _DT_E4M3), (_DT_FP4, _DT_E5M2), (_DT_E4M3, _DT_FP4), (_DT_E5M2, _DT_FP4)])
+def test_block_scale_matmul_gate_accepts_mixed_mxfp8_mxfp4(a_dt, b_dt):
+    from cudnn.gemm.frost.compiler import _check_block_scale_supported
+
+    chain = analyze(_build_nvfp4_graph(256, 256, 512, block_size=32, sf_dt=_DT_E8M0, a_dt=a_dt, b_dt=b_dt))
+    _check_block_scale_supported(chain, "sm100")
+    assert chain.block_scale.mma_block_scale_kind == "MXF8F6F4"
+    cfg32 = by_name("CONFIG_sm100_128x128x128_128x128x32_cluster1x1_1ctamma")
+    cfg64 = by_name(_SM107_128 + "_1ctamma")
+    assert select_template(chain, cfg32).accepts(chain, cfg32) is None
+    assert select_template(chain, cfg64).accepts(chain, cfg64) is None
+
+
 def test_block_scale_matmul_gate_rejects_mismatches():
     from cudnn.gemm.frost.compiler import _check_block_scale_supported
 
@@ -273,7 +286,7 @@ def test_block_scale_matmul_gate_rejects_mismatches():
     # FP8 data at block 16 — the fp8 rows are block-32 only, on every pipeline.
     with pytest.raises(NotImplementedError, match="does not support"):
         _check_block_scale_supported(analyze(_build_nvfp4_graph(256, 256, 512, block_size=16, sf_dt=_DT_E8M0, a_dt=_DT_E4M3)), "sm100")
-    # mixed FP4 A / FP8 B (cross-family) — unsupported.
+    # Mixed width with a non-E8 scale has no UTCQMMA encoding.
     with pytest.raises(NotImplementedError, match="does not support"):
         _check_block_scale_supported(
             analyze(
@@ -282,7 +295,7 @@ def test_block_scale_matmul_gate_rejects_mismatches():
                     256,
                     512,
                     block_size=32,
-                    sf_dt=_DT_E8M0,
+                    sf_dt=_DT_E4M3,
                     a_dt=_DT_FP4,
                     b_dt=_DT_E4M3,
                 )
@@ -1456,6 +1469,13 @@ def test_mma_gpu_arch_special_cases(monkeypatch):
     for ok_sm in (100, 110):
         monkeypatch.setattr(C, "_current_arch", lambda v=ok_sm: v)
         assert kr.mma_arch_reject(int8_chain, kr.GraphType.MATMUL, "sm100") is None
+    # Mixed MXFP8/MXFP4 is a baseline SM100 UTCQMMA encoding (K32); Rubin adds
+    # a K64 form, but the MMA type itself needs no narrow arch exception.
+    mixed_chain = analyze(_build_nvfp4_graph(256, 256, 512, block_size=32, sf_dt=_DT_E8M0, a_dt=_DT_FP4, b_dt=_DT_E4M3))
+    monkeypatch.setattr(C, "_current_arch", lambda: 100)
+    assert kr.mma_arch_reject(mixed_chain, kr.GraphType.BLOCK_SCALE_MATMUL, "sm100") is None
+    monkeypatch.setattr(C, "_current_arch", lambda: 107)
+    assert kr.mma_arch_reject(mixed_chain, kr.GraphType.BLOCK_SCALE_MATMUL, "sm100") is None
     # A family-portable combo is arch-free at this gate (stage 0 handles GPUs).
     bf16_chain = SimpleNamespace(matmul=SimpleNamespace(a_dtype="bf16", b_dtype="bf16", accum_dtype="fp32"))
     monkeypatch.setattr(C, "_current_arch", lambda: 90)
@@ -1855,6 +1875,81 @@ def test_k64_is_rejected_on_older_blackwell(monkeypatch):
 )
 def test_sm107_block_scale_matmul_numerics(combo, config_name, cta_group):
     _run_bs_numeric(combo, config_name, 256, 256, 512)
+
+
+@requires_sm100
+@pytest.mark.parametrize("fp8_on_a", [True, False], ids=["mxfp8_x_mxfp4", "mxfp4_x_mxfp8"])
+@pytest.mark.parametrize("fp8_torch_dt,fp8_cudnn_dt", [(torch.float8_e4m3fn, _DT_E4M3), (torch.float8_e5m2, _DT_E5M2)])
+@pytest.mark.parametrize("fp8_mn_major", [False, True], ids=["k_major", "mn_major"])
+@pytest.mark.parametrize(
+    "config_name",
+    [
+        "CONFIG_sm100_128x128x128_128x128x32_cluster1x1_1ctamma",
+        "CONFIG_sm100_128x256x128_128x256x32_cluster2x1_2ctamma",
+        pytest.param(_SM107_128 + "_1ctamma", marks=requires_sm107),
+        pytest.param("CONFIG_sm100_128x256x128_128x256x64_cluster2x1_2ctamma", marks=requires_sm107),
+    ],
+)
+def test_mixed_mxfp8_mxfp4_numerics(fp8_on_a, fp8_torch_dt, fp8_cudnn_dt, fp8_mn_major, config_name):
+    """K32 padded and Rubin K64 native-packed UTCQMMA, both operand orders."""
+    dev = "cuda"
+    torch.manual_seed(0)
+    M = N = 256
+    K = 512
+    bs = 32
+    sf_k = K // bs
+    lut = torch.tensor(_E2M1, dtype=torch.float32, device=dev)
+
+    fp8_a = (torch.randn(1, M, K, device=dev) * 0.5).to(fp8_torch_dt)
+    fp8_b = (torch.randn(1, N, K, device=dev) * 0.5).to(fp8_torch_dt)
+    fp4_a_u8 = torch.randint(0, 256, (1, M, K // 2), dtype=torch.uint8, device=dev)
+    fp4_b_u8 = torch.randint(0, 256, (1, N, K // 2), dtype=torch.uint8, device=dev)
+    fp4_a = fp4_a_u8.view(torch.float4_e2m1fn_x2)
+    fp4_b = fp4_b_u8.view(torch.float4_e2m1fn_x2)
+
+    if fp8_on_a:
+        a_rt, a_ref, a_dt = fp8_a, fp8_a.float().view(M, K), fp8_cudnn_dt
+        b_rt, b_ref, b_dt = fp4_b, _unpack_fp4(fp4_b_u8, lut).view(N, K), _DT_FP4
+        if fp8_mn_major:
+            a_rt = a_rt.transpose(1, 2).contiguous().transpose(1, 2)
+    else:
+        a_rt, a_ref, a_dt = fp4_a, _unpack_fp4(fp4_a_u8, lut).view(M, K), _DT_FP4
+        b_rt, b_ref, b_dt = fp8_b, fp8_b.float().view(N, K), fp8_cudnn_dt
+        if fp8_mn_major:
+            b_rt = b_rt.transpose(1, 2).contiguous().transpose(1, 2)
+
+    sfa_log = _rand_e8m0((M, sf_k), dev)
+    sfb_log = _rand_e8m0((N, sf_k), dev)
+    g = _build_nvfp4_graph(
+        M,
+        N,
+        K,
+        block_size=bs,
+        sf_dt=_DT_E8M0,
+        a_dt=a_dt,
+        b_dt=b_dt,
+        a_major="m" if fp8_on_a and fp8_mn_major else "k",
+        b_major="n" if not fp8_on_a and fp8_mn_major else "k",
+    )
+    compiled = _plan(g, **_kw(config_name))
+    assert compiled.chain.block_scale.mma_block_scale_kind == "MXF8F6F4"
+
+    c = torch.zeros(1, M, N, dtype=torch.float16, device=dev)
+    compiled(
+        _vp_bs(
+            compiled,
+            a_rt,
+            b_rt,
+            c,
+            _to_blocked(sfa_log).view(1, M, sf_k),
+            _to_blocked(sfb_log).view(1, N, sf_k),
+        )
+    )
+    torch.cuda.synchronize()
+
+    a_deq = a_ref * sfa_log.float().repeat_interleave(bs, 1)
+    b_deq = b_ref * sfb_log.float().repeat_interleave(bs, 1)
+    torch.testing.assert_close(c[0], (a_deq @ b_deq.t()).to(torch.float16), atol=2e-1, rtol=2e-2)
 
 
 @requires_sm107

--- a/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
@@ -175,8 +175,12 @@ def _build_graph(
     quant_axis=None,
     quant_group_offset=False,
     weight_major="k",
+    a_dt_override=None,
+    b_dt_override=None,
 ):
-    block_size, a_dt, sf_dt = _COMBOS[combo]
+    block_size, default_dt, sf_dt = _COMBOS[combo]
+    a_dt = default_dt if a_dt_override is None else a_dt_override
+    b_dt = default_dt if b_dt_override is None else b_dt_override
     sf_k = K // block_size
     g = cudnn.pygraph(
         io_data_type=cudnn.data_type.BFLOAT16,
@@ -184,7 +188,7 @@ def _build_graph(
         compute_data_type=cudnn.data_type.FLOAT,
     )
     tok = g.tensor(name="token", dim=[1, S, K], stride=[S * K, K, 1], data_type=a_dt)
-    w = g.tensor(name="weight", dim=[E, K, N], stride=[K * N, 1, K] if weight_major == "k" else [K * N, N, 1], data_type=a_dt)
+    w = g.tensor(name="weight", dim=[E, K, N], stride=[K * N, 1, K] if weight_major == "k" else [K * N, N, 1], data_type=b_dt)
     SFA = g.tensor(
         name="SFA",
         dim=[1, S, sf_k],
@@ -264,6 +268,18 @@ def test_analyzer_detects_moe_grouped_block_scale_matmul_fwd() -> None:
     assert chain.matmul.b_dtype == "fp4_e2m1"
     assert (chain.matmul.M, chain.matmul.N, chain.matmul.K) == (S, N, K)
     assert chain.output_dtype == "bf16"
+
+
+def test_build_graph_keeps_one_sided_dtype_overrides_independent() -> None:
+    """An override on one MMA operand must not change the other's combo default."""
+    shape = dict(E=2, S=256, N=128, K=256, num_groups=2, combo="mxfp4")
+    fp8 = cudnn.data_type.FP8_E4M3
+
+    a_mixed = analyze(_build_graph(**shape, a_dt_override=fp8))
+    assert (a_mixed.matmul.a_dtype, a_mixed.matmul.b_dtype) == ("fp8_e4m3", "fp4_e2m1")
+
+    b_mixed = analyze(_build_graph(**shape, b_dt_override=fp8))
+    assert (b_mixed.matmul.a_dtype, b_mixed.matmul.b_dtype) == ("fp4_e2m1", "fp8_e4m3")
 
 
 def test_analyzer_offset_dtype_int64() -> None:
@@ -646,6 +662,69 @@ def test_e2e_split_m_tile(cfg_name, cta_group) -> None:
 def test_e2e_mx_combos(combo) -> None:
     # mxfp4 (FP4 + E8M0, block32) / mxfp8 (FP8 E4M3 + E8M0, block32), K-major.
     _run_e2e(E=2, S=1024, N=256, K=512, offsets_list=[0, 256, 384, 512], combo=combo)
+
+
+@requires_sm100
+@pytest.mark.parametrize("fp8_on_a", [True, False], ids=["mxfp8_x_mxfp4", "mxfp4_x_mxfp8"])
+@pytest.mark.parametrize(
+    "config_name",
+    [
+        "CONFIG_sm100_128x128x128_128x128x32_cluster1x1_1ctamma",
+        pytest.param("CONFIG_sm100_128x128x128_128x128x64_cluster1x1_1ctamma", marks=requires_sm107),
+    ],
+)
+def test_e2e_mixed_mxfp8_mxfp4(fp8_on_a, config_name) -> None:
+    """Grouped K32 padded and Rubin K64 native-packed mixed UTCQMMA."""
+    dev = "cuda"
+    torch.manual_seed(0)
+    E, S, N, K = 2, 256, 128, 256
+    offsets_list = [0, 128]
+    bs, sf_k = 32, K // 32
+    fp4, fp8 = cudnn.data_type.FP4_E2M1, cudnn.data_type.FP8_E4M3
+    a_dt, b_dt = (fp8, fp4) if fp8_on_a else (fp4, fp8)
+    lut = torch.tensor(_E2M1, dtype=torch.float32, device=dev)
+
+    tok_fp8 = (torch.randn(1, S, K, device=dev) * 0.5).to(torch.float8_e4m3fn)
+    w_fp8 = (torch.randn(E, N, K, device=dev) * 0.5).to(torch.float8_e4m3fn)
+    tok_u8 = torch.randint(0, 256, (1, S, K // 2), dtype=torch.uint8, device=dev)
+    w_u8 = torch.randint(0, 256, (E, N, K // 2), dtype=torch.uint8, device=dev)
+    if fp8_on_a:
+        tok_rt, tok_ref = tok_fp8, tok_fp8.float().view(S, K)
+        w_rt, w_ref = w_u8.view(torch.float4_e2m1fn_x2), _unpack_fp4(w_u8, lut).view(E, N, K)
+    else:
+        tok_rt, tok_ref = tok_u8.view(torch.float4_e2m1fn_x2), _unpack_fp4(tok_u8, lut).view(S, K)
+        w_rt, w_ref = w_fp8, w_fp8.float().view(E, N, K)
+
+    sfa_log = _rand_e8m0((S, sf_k), dev)
+    sfb_log = _rand_e8m0((E, N, sf_k), dev)
+    g = _build_graph(
+        E,
+        S,
+        N,
+        K,
+        len(offsets_list),
+        combo="mxfp8",
+        a_dt_override=a_dt,
+        b_dt_override=b_dt,
+    )
+    compiled = _plan(g, config=by_name(config_name))
+    assert compiled.chain.block_scale.mma_block_scale_kind == "MXF8F6F4"
+
+    sfa_blk = torch.cat([_to_blocked(sfa_log[b : offsets_list[i + 1] if i + 1 < len(offsets_list) else S]) for i, b in enumerate(offsets_list)])
+    sfa_blk = _with_static_segmented_capacity(sfa_blk, S, len(offsets_list), sf_k)
+    sfb_blk = torch.cat([_to_blocked(sfb_log[e]) for e in range(E)]).view(E, sf_k, N)
+    offsets = torch.tensor(offsets_list, dtype=torch.int32, device=dev)
+    output = torch.zeros(1, S, N, dtype=torch.bfloat16, device=dev)
+    compiled(_vp_bs(compiled, tok_rt, w_rt, output, sfa_blk, sfb_blk, fto=offsets))
+    torch.cuda.synchronize()
+
+    tok_deq = tok_ref * sfa_log.float().repeat_interleave(bs, 1)
+    w_deq = w_ref * sfb_log.float().repeat_interleave(bs, 2)
+    ref = torch.zeros(S, N, dtype=torch.float32, device=dev)
+    for i, begin in enumerate(offsets_list):
+        end = offsets_list[i + 1] if i + 1 < len(offsets_list) else S
+        ref[begin:end] = tok_deq[begin:end] @ w_deq[i % E].T
+    torch.testing.assert_close(output[0], ref.to(torch.bfloat16), atol=2e-1, rtol=2e-2)
 
 
 @pytest.mark.parametrize("cfg_name,cta_group", [(_CFG, 2), (_CFG_1CTA, 1)])


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches (see [root AGENTS.md § Reviewing a PR](https://github.com/NVIDIA/cudnn-frontend/blob/develop/AGENTS.md#reviewing-a-pr-human-or-agent)) and my changes comply, or I explain the exception below.
- [x] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

Enable mxfp4/mxfp8 mixed block scale matmul

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for mixed FP8 and FP4 operands in block-scale matrix multiplication on supported GPU architectures.
  - Supports FP8×FP4 and FP4×FP8 combinations, including applicable K-major and M/N-major layouts.
  - Added split-K execution and reduction support for eligible block-scale workloads.
  - Added support for relevant FP8 formats and K-width configurations.

- **Bug Fixes**
  - Improved operand-specific memory layout, packing, descriptors, and data transfer handling for mixed-precision operations.

- **Tests**
  - Added numerical, compilation, and end-to-end coverage for mixed FP8/FP4 and split-K matrix multiplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->