### PR TITLE
frost(sdpa): bound the THD view batch stride — fixes d=192 THD decode int32 overflow (#980); mhas_v2 decode sweeps draw THD

### DIFF
--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -1805,8 +1805,9 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         The packed token totals are runtime values and compile as DYNAMIC
         extents; everything here (logical batch, heads, head dims, the Stats
         specialization, the declared strides with the batch stride zeroed —
-        ``_thd_view``'s batch stride is ``t * token_stride``, a runtime value
-        that never steps at batch extent 1) is known when the graph is built,
+        ``_thd_view`` binds the token stride for the extent-1 batch dim, which
+        never steps; ``t * token_stride`` would overflow the int32 stride slot
+        on long packed KV, GitHub #980) is known when the graph is built,
         so ``compile()`` compiles eagerly and ``_execute_thd``'s lru-cached
         call re-binds the same artifact for every packed total."""
 

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -689,7 +689,14 @@ class SdpaFwdDsl(APIBase):
             buf.data_ptr() % 16 != 0,
             f"{desc.name}: runtime buffer base address must be 16-byte aligned (TMA global-address rule); got data_ptr() % 16 == {buf.data_ptr() % 16}",
         )
-        return buf.as_strided((1, tokens, h, d), (max(tokens, 1) * ts, ts, hs, es), buf.storage_offset())
+        # The batch dim has extent 1, so its stride is never stepped — but the
+        # kernel ABI checks every stride against the int32 range, and the
+        # natural value ``tokens * ts`` overflows it on long packed KV with
+        # wide tokens (h=128, d=192, ~57k tokens -> 5.7e9; GitHub #980). Bind
+        # the token stride instead: any value is semantically equivalent at
+        # extent 1, this one is always in range, and the compile key already
+        # zeroes it (``_thd_compile_kwargs``).
+        return buf.as_strided((1, tokens, h, d), (ts, ts, hs, es), buf.storage_offset())
 
     def _amax_slot(self, tensor, name: str, device: torch.device) -> torch.Tensor:
         """The caller's 1-element amax storage, or a cached dummy.
@@ -3497,7 +3504,10 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             return None
 
         def _packed(buf, tokens, heads, d):
-            return buf.as_strided((1, tokens, heads, d), (tokens * heads * d, heads * d, d, 1), buf.storage_offset())
+            # Extent-1 batch dim: bind the token stride, not tokens * heads * d,
+            # which overflows the kernel ABI's int32 stride check on long packed
+            # KV with wide tokens (GitHub #980; same fix as _thd_view).
+            return buf.as_strided((1, tokens, heads, d), (heads * d, heads * d, d, 1), buf.storage_offset())
 
         def _view(buf, desc, tokens, heads, d):
             # declared_views: the f16 kernel addresses declared strides

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d128_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d128_f16.py
@@ -2291,9 +2291,10 @@ def compile(  # noqa: A001
     values (they change every step under continuous batching), so the token
     extents compile DYNAMIC (``cute.sym_int``) and the cache key stays
     plan-time-only; callers must not pass them (a stray value would only mint
-    a redundant cache entry). THD ``q_stride``/... carry a ZERO batch stride
-    (the real view's batch stride is ``t_q * token_stride``, a runtime value;
-    the fake rebuilds it symbolically — batch extent is 1, it never steps).
+    a redundant cache entry). THD ``q_stride``/... carry a ZERO batch stride;
+    the fake binds the token stride for the extent-1 batch dim, exactly as
+    ``_thd_view`` does at runtime (``T * token_stride`` is never stepped and
+    overflows the int32 stride slot on long packed KV, GitHub #980).
     ``has_lse=False`` compiles the LSE store out (the kernel specializes on a
     ``None`` LSE argument) — callers without a Stats output pass no LSE buffer
     at all. THD Stats layouts: token-major packed rank-2 (T, H) by default
@@ -2343,9 +2344,10 @@ def compile(  # noqa: A001
             if (stride[axis] * bpe) % 16 != 0:
                 raise ValueError(f"declared stride {stride} axis {axis} must be a 16-byte multiple at BPE={bpe} (TMA global-stride rule)")
         if CFG.THD_VARLEN:
-            # Batch stride = tokens * token_stride (`_thd_view`'s envelope),
-            # a runtime value: rebuild it from the dynamic token extent.
-            return cute.runtime.make_fake_tensor(dtype, shape, (shape[1] * stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
+            # Extent-1 batch dim: bind the token stride, as _thd_view does at
+            # runtime -- T * token_stride is never stepped and overflows the int32
+            # stride slot on long packed KV with wide tokens (GitHub #980).
+            return cute.runtime.make_fake_tensor(dtype, shape, (stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
         return cute.runtime.make_fake_tensor(dtype, shape, tuple(stride), assumed_align=16)
 
     fake_q = _fake_bshd((_fake_batch, sq, qh, d_qk), q_stride)

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d192_d128_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d192_d128_f16.py
@@ -2808,9 +2808,10 @@ def compile(  # noqa: A001
     values (they change every step under continuous batching), so the token
     extents compile DYNAMIC (``cute.sym_int``) and the cache key stays
     plan-time-only; callers must not pass them (a stray value would only mint
-    a redundant cache entry). THD ``q_stride``/... carry a ZERO batch stride
-    (the real view's batch stride is ``t_q * token_stride``, a runtime value;
-    the fake rebuilds it symbolically — batch extent is 1, it never steps).
+    a redundant cache entry). THD ``q_stride``/... carry a ZERO batch stride;
+    the fake binds the token stride for the extent-1 batch dim, exactly as
+    ``_thd_view`` does at runtime (``T * token_stride`` is never stepped and
+    overflows the int32 stride slot on long packed KV, GitHub #980).
 
     ENVELOPE: ``d_qk`` / ``d_v`` are the ACTUAL head dims (defaults = the
     flavor's full TILE_K / TILE_O). The Q/K/V/O TMA descriptors are built from
@@ -2851,9 +2852,10 @@ def compile(  # noqa: A001
             if (stride[axis] * bpe) % 16 != 0:
                 raise ValueError(f"declared stride {stride} axis {axis} must be a 16-byte multiple at BPE={bpe} (TMA global-stride rule)")
         if CFG.THD_VARLEN:
-            # Batch stride = tokens * token_stride (`_thd_view`'s envelope),
-            # a runtime value: rebuild it from the dynamic token extent.
-            return cute.runtime.make_fake_tensor(dtype, shape, (shape[1] * stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
+            # Extent-1 batch dim: bind the token stride, as _thd_view does at
+            # runtime -- T * token_stride is never stepped and overflows the int32
+            # stride slot on long packed KV with wide tokens (GitHub #980).
+            return cute.runtime.make_fake_tensor(dtype, shape, (stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
         return cute.runtime.make_fake_tensor(dtype, shape, tuple(stride), assumed_align=16)
 
     fake_q = _fake_bshd((_fake_batch, sq, qh, d_qk), q_stride)

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d256_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d256_f16.py
@@ -1887,9 +1887,10 @@ def compile(  # noqa: A001
     THD/varlen: ``sq``/``skv`` are IGNORED — the packed token totals are
     runtime values (they change every step under continuous batching), so the
     token extents compile DYNAMIC (``cute.sym_int``) and the cache key stays
-    plan-time-only; callers must not pass them. THD strides carry a ZERO batch
-    stride (the real view's batch stride is ``t_q * token_stride``, a runtime
-    value; the fake rebuilds it symbolically — batch extent 1 never steps)."""
+    plan-time-only; callers must not pass them. THD ``q_stride``/... carry a ZERO batch stride;
+    the fake binds the token stride for the extent-1 batch dim, exactly as
+    ``_thd_view`` does at runtime (``T * token_stride`` is never stepped and
+    overflows the int32 stride slot on long packed KV, GitHub #980)."""
     if not (0 < d_qk <= CFG.TILE_K and 0 < d_v <= CFG.TILE_O):
         raise ValueError(f"d256 envelope: need 0 < d_qk <= {CFG.TILE_K} and 0 < d_v <= {CFG.TILE_O}; got ({d_qk}, {d_v})")
     if (d_qk * CFG.BPE) % 16 != 0 or (d_v * CFG.BPE_O) % 16 != 0:
@@ -1921,9 +1922,10 @@ def compile(  # noqa: A001
             if (stride[axis] * bpe) % 16 != 0:
                 raise ValueError(f"declared stride {stride} axis {axis} must be a 16-byte multiple at BPE={bpe} (TMA global-stride rule)")
         if CFG.THD_VARLEN:
-            # Batch stride = tokens * token_stride (`_thd_view`'s envelope),
-            # a runtime value: rebuild it from the dynamic token extent.
-            return cute.runtime.make_fake_tensor(dtype, shape, (shape[1] * stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
+            # Extent-1 batch dim: bind the token stride, as _thd_view does at
+            # runtime -- T * token_stride is never stepped and overflows the int32
+            # stride slot on long packed KV with wide tokens (GitHub #980).
+            return cute.runtime.make_fake_tensor(dtype, shape, (stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
         return cute.runtime.make_fake_tensor(dtype, shape, tuple(stride), assumed_align=16)
 
     fake_q = _fake_bshd((_fake_batch, sq, qh, d_qk), q_stride)

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d512_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d512_f16.py
@@ -2090,9 +2090,10 @@ def compile(  # noqa: A001
     THD/varlen: ``sq``/``skv`` are IGNORED — the packed token totals are
     runtime values (they change every step under continuous batching), so the
     token extents compile DYNAMIC (``cute.sym_int``) and the cache key stays
-    plan-time-only; callers must not pass them. THD strides carry a ZERO batch
-    stride (the real view's batch stride is ``t_q * token_stride``, a runtime
-    value; the fake rebuilds it symbolically — batch extent 1 never steps)."""
+    plan-time-only; callers must not pass them. THD ``q_stride``/... carry a ZERO batch stride;
+    the fake binds the token stride for the extent-1 batch dim, exactly as
+    ``_thd_view`` does at runtime (``T * token_stride`` is never stepped and
+    overflows the int32 stride slot on long packed KV, GitHub #980)."""
     if not (0 < d_qk <= CFG.TILE_K and 0 < d_v <= CFG.TILE_O):
         raise ValueError(f"d512 envelope: need 0 < d_qk <= {CFG.TILE_K} and 0 < d_v <= {CFG.TILE_O}; got ({d_qk}, {d_v})")
     if (d_qk * CFG.BPE) % 16 != 0 or (d_v * CFG.BPE_O) % 16 != 0:
@@ -2120,9 +2121,10 @@ def compile(  # noqa: A001
             if (stride[axis] * bpe) % 16 != 0:
                 raise ValueError(f"declared stride {stride} axis {axis} must be a 16-byte multiple at BPE={bpe} (TMA global-stride rule)")
         if CFG.THD_VARLEN:
-            # Batch stride = tokens * token_stride (`_thd_view`'s envelope),
-            # a runtime value: rebuild it from the dynamic token extent.
-            return cute.runtime.make_fake_tensor(dtype, shape, (shape[1] * stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
+            # Extent-1 batch dim: bind the token stride, as _thd_view does at
+            # runtime -- T * token_stride is never stepped and overflows the int32
+            # stride slot on long packed KV with wide tokens (GitHub #980).
+            return cute.runtime.make_fake_tensor(dtype, shape, (stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
         return cute.runtime.make_fake_tensor(dtype, shape, tuple(stride), assumed_align=16)
 
     fake_q = _fake_bshd((_fake_batch, sq, qh, d_qk), q_stride)

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d512_fp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d512_fp8.py
@@ -2312,9 +2312,10 @@ def compile(  # noqa: A001
     THD/varlen: ``sq``/``skv`` are IGNORED — the packed token totals are
     runtime values (they change every step under continuous batching), so the
     token extents compile DYNAMIC (``cute.sym_int``) and the cache key stays
-    plan-time-only; callers must not pass them. THD strides carry a ZERO batch
-    stride (the real view's batch stride is ``t_q * token_stride``, a runtime
-    value; the fake rebuilds it symbolically — batch extent 1 never steps)."""
+    plan-time-only; callers must not pass them. THD ``q_stride``/... carry a ZERO batch stride;
+    the fake binds the token stride for the extent-1 batch dim, exactly as
+    ``_thd_view`` does at runtime (``T * token_stride`` is never stepped and
+    overflows the int32 stride slot on long packed KV, GitHub #980)."""
     if not (0 < d_qk <= CFG.TILE_K and 0 < d_v <= CFG.TILE_O):
         raise ValueError(f"d512 envelope: need 0 < d_qk <= {CFG.TILE_K} and 0 < d_v <= {CFG.TILE_O}; got ({d_qk}, {d_v})")
     if (d_qk * CFG.BPE) % 16 != 0 or (d_v * CFG.BPE_O) % 16 != 0:
@@ -2342,9 +2343,10 @@ def compile(  # noqa: A001
             if (stride[axis] * bpe) % 16 != 0:
                 raise ValueError(f"declared stride {stride} axis {axis} must be a 16-byte multiple at BPE={bpe} (TMA global-stride rule)")
         if CFG.THD_VARLEN:
-            # Batch stride = tokens * token_stride (`_thd_view`'s envelope),
-            # a runtime value: rebuild it from the dynamic token extent.
-            return cute.runtime.make_fake_tensor(dtype, shape, (shape[1] * stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
+            # Extent-1 batch dim: bind the token stride, as _thd_view does at
+            # runtime -- T * token_stride is never stepped and overflows the int32
+            # stride slot on long packed KV with wide tokens (GitHub #980).
+            return cute.runtime.make_fake_tensor(dtype, shape, (stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
         return cute.runtime.make_fake_tensor(dtype, shape, tuple(stride), assumed_align=16)
 
     fake_q = _fake_bshd((_fake_batch, sq, qh, d_qk), q_stride)

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d128_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d128_f16.py
@@ -2155,9 +2155,10 @@ def compile(  # noqa: A001
 
         Mirrors sm100/prefill_d128_f16.py: the head dim must be
         innermost-contiguous, and the seq/head global strides feed TMA, so they
-        obey the 16-byte global-stride rule.  Under THD the batch stride is
-        tokens * token_stride -- a RUNTIME value -- so it is rebuilt from the
-        dynamic token extent rather than taken from the declaration."""
+        obey the 16-byte global-stride rule.  Under THD the
+        fake binds the token stride for the extent-1 batch dim, as _thd_view
+        does at runtime: tokens * token_stride is never stepped and overflows
+        the int32 stride slot on long packed KV (GitHub #980)."""
         if stride is None:
             return cute.runtime.make_fake_compact_tensor(dtype, shape, stride_order=(3, 2, 1, 0), assumed_align=16)
         if stride[3] != 1:
@@ -2166,7 +2167,10 @@ def compile(  # noqa: A001
             if (stride[axis] * bpe) % 16 != 0:
                 raise ValueError(f"declared stride {stride} axis {axis} must be a 16-byte multiple at BPE={bpe} (TMA global-stride rule)")
         if CFG.THD_VARLEN:
-            return cute.runtime.make_fake_tensor(dtype, shape, (shape[1] * stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
+            # Extent-1 batch dim: bind the token stride, as _thd_view does at
+            # runtime -- T * token_stride is never stepped and overflows the int32
+            # stride slot on long packed KV with wide tokens (GitHub #980).
+            return cute.runtime.make_fake_tensor(dtype, shape, (stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
         return cute.runtime.make_fake_tensor(dtype, shape, tuple(stride), assumed_align=16)
 
     fake_q = _fake_bshd((_fake_batch, sq, qh, d_qk), q_stride)

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d192_d128_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d192_d128_f16.py
@@ -2159,9 +2159,10 @@ def compile(  # noqa: A001
 
         Mirrors sm100/prefill_d128_f16.py: the head dim must be
         innermost-contiguous, and the seq/head global strides feed TMA, so they
-        obey the 16-byte global-stride rule.  Under THD the batch stride is
-        tokens * token_stride -- a RUNTIME value -- so it is rebuilt from the
-        dynamic token extent rather than taken from the declaration."""
+        obey the 16-byte global-stride rule.  Under THD the
+        fake binds the token stride for the extent-1 batch dim, as _thd_view
+        does at runtime: tokens * token_stride is never stepped and overflows
+        the int32 stride slot on long packed KV (GitHub #980)."""
         if stride is None:
             return cute.runtime.make_fake_compact_tensor(dtype, shape, stride_order=(3, 2, 1, 0), assumed_align=16)
         if stride[3] != 1:
@@ -2170,7 +2171,10 @@ def compile(  # noqa: A001
             if (stride[axis] * bpe) % 16 != 0:
                 raise ValueError(f"declared stride {stride} axis {axis} must be a 16-byte multiple at BPE={bpe} (TMA global-stride rule)")
         if CFG.THD_VARLEN:
-            return cute.runtime.make_fake_tensor(dtype, shape, (shape[1] * stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
+            # Extent-1 batch dim: bind the token stride, as _thd_view does at
+            # runtime -- T * token_stride is never stepped and overflows the int32
+            # stride slot on long packed KV with wide tokens (GitHub #980).
+            return cute.runtime.make_fake_tensor(dtype, shape, (stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
         return cute.runtime.make_fake_tensor(dtype, shape, tuple(stride), assumed_align=16)
 
     fake_q = _fake_bshd((_fake_batch, sq, qh, d_qk), q_stride)

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d256_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d256_f16.py
@@ -1907,8 +1907,9 @@ def compile(  # noqa: A001
 
         The head dim must be innermost-contiguous, and the seq/head global
         strides feed TMA so they obey the 16-byte global-stride rule.  Under THD
-        the batch stride is tokens * token_stride -- a RUNTIME value -- so it is
-        rebuilt from the dynamic token extent."""
+        the fake binds the token stride for the extent-1 batch dim, as _thd_view
+        does at runtime: tokens * token_stride is never stepped and overflows
+        the int32 stride slot on long packed KV (GitHub #980)."""
         if stride is None:
             return cute.runtime.make_fake_compact_tensor(dtype, shape, stride_order=(3, 2, 1, 0), assumed_align=16)
         if stride[3] != 1:
@@ -1917,7 +1918,10 @@ def compile(  # noqa: A001
             if (stride[axis] * bpe) % 16 != 0:
                 raise ValueError(f"declared stride {stride} axis {axis} must be a 16-byte multiple at BPE={bpe} (TMA global-stride rule)")
         if CFG.THD_VARLEN:
-            return cute.runtime.make_fake_tensor(dtype, shape, (shape[1] * stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
+            # Extent-1 batch dim: bind the token stride, as _thd_view does at
+            # runtime -- T * token_stride is never stepped and overflows the int32
+            # stride slot on long packed KV with wide tokens (GitHub #980).
+            return cute.runtime.make_fake_tensor(dtype, shape, (stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
         return cute.runtime.make_fake_tensor(dtype, shape, tuple(stride), assumed_align=16)
 
     fake_q = _fake_bshd((_fake_batch, sq, qh, d_qk), q_stride)

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d256_fp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d256_fp8.py
@@ -1984,9 +1984,10 @@ def compile(  # noqa: A001
         """BSHD fake tensor, compact or at the caller's DECLARED strides.
 
         The head dim must be innermost-contiguous, and the seq/head global
-        strides feed TMA so they obey the 16-byte global-stride rule.  Under
-        THD the batch stride is tokens * token_stride -- a RUNTIME value -- so
-        it is rebuilt from the dynamic token extent."""
+        strides feed TMA so they obey the 16-byte global-stride rule.  Under THD
+        the fake binds the token stride for the extent-1 batch dim, as _thd_view
+        does at runtime: tokens * token_stride is never stepped and overflows
+        the int32 stride slot on long packed KV (GitHub #980)."""
         if stride is None:
             return cute.runtime.make_fake_compact_tensor(dtype, shape, stride_order=(3, 2, 1, 0), assumed_align=16)
         if stride[3] != 1:
@@ -1995,7 +1996,10 @@ def compile(  # noqa: A001
             if (stride[axis] * bpe) % 16 != 0:
                 raise ValueError(f"declared stride {stride} axis {axis} must be a 16-byte multiple at BPE={bpe} (TMA global-stride rule)")
         if CFG.THD_VARLEN:
-            return cute.runtime.make_fake_tensor(dtype, shape, (shape[1] * stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
+            # Extent-1 batch dim: bind the token stride, as _thd_view does at
+            # runtime -- T * token_stride is never stepped and overflows the int32
+            # stride slot on long packed KV with wide tokens (GitHub #980).
+            return cute.runtime.make_fake_tensor(dtype, shape, (stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
         return cute.runtime.make_fake_tensor(dtype, shape, tuple(stride), assumed_align=16)
 
     fake_q = _fake_bshd((_fake_batch, sq, qh, d_qk), q_stride)

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d512_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d512_f16.py
@@ -2567,9 +2567,10 @@ def compile(  # noqa: A001
         """BSHD fake tensor, compact or at the caller's DECLARED strides.
 
         The head dim must be innermost-contiguous, and the seq/head global
-        strides feed TMA so they obey the 16-byte global-stride rule.  Under
-        THD the batch stride is tokens * token_stride -- a RUNTIME value -- so
-        it is rebuilt from the dynamic token extent."""
+        strides feed TMA so they obey the 16-byte global-stride rule.  Under THD
+        the fake binds the token stride for the extent-1 batch dim, as _thd_view
+        does at runtime: tokens * token_stride is never stepped and overflows
+        the int32 stride slot on long packed KV (GitHub #980)."""
         if stride is None:
             return cute.runtime.make_fake_compact_tensor(dtype, shape, stride_order=(3, 2, 1, 0), assumed_align=16)
         if stride[3] != 1:
@@ -2578,7 +2579,10 @@ def compile(  # noqa: A001
             if (stride[axis] * bpe) % 16 != 0:
                 raise ValueError(f"declared stride {stride} axis {axis} must be a 16-byte multiple at BPE={bpe} (TMA global-stride rule)")
         if CFG.THD_VARLEN:
-            return cute.runtime.make_fake_tensor(dtype, shape, (shape[1] * stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
+            # Extent-1 batch dim: bind the token stride, as _thd_view does at
+            # runtime -- T * token_stride is never stepped and overflows the int32
+            # stride slot on long packed KV with wide tokens (GitHub #980).
+            return cute.runtime.make_fake_tensor(dtype, shape, (stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
         return cute.runtime.make_fake_tensor(dtype, shape, tuple(stride), assumed_align=16)
 
     fake_q = _fake_bshd((_fake_batch, sq, qh, d_qk), q_stride)

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d512_fp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d512_fp8.py
@@ -2641,9 +2641,10 @@ def compile(  # noqa: A001
         """BSHD fake tensor, compact or at the caller's DECLARED strides.
 
         The head dim must be innermost-contiguous, and the seq/head global
-        strides feed TMA so they obey the 16-byte global-stride rule.  Under
-        THD the batch stride is tokens * token_stride -- a RUNTIME value -- so
-        it is rebuilt from the dynamic token extent."""
+        strides feed TMA so they obey the 16-byte global-stride rule.  Under THD
+        the fake binds the token stride for the extent-1 batch dim, as _thd_view
+        does at runtime: tokens * token_stride is never stepped and overflows
+        the int32 stride slot on long packed KV (GitHub #980)."""
         if stride is None:
             return cute.runtime.make_fake_compact_tensor(dtype, shape, stride_order=(3, 2, 1, 0), assumed_align=16)
         if stride[3] != 1:
@@ -2652,7 +2653,10 @@ def compile(  # noqa: A001
             if (stride[axis] * bpe) % 16 != 0:
                 raise ValueError(f"declared stride {stride} axis {axis} must be a 16-byte multiple at BPE={bpe} (TMA global-stride rule)")
         if CFG.THD_VARLEN:
-            return cute.runtime.make_fake_tensor(dtype, shape, (shape[1] * stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
+            # Extent-1 batch dim: bind the token stride, as _thd_view does at
+            # runtime -- T * token_stride is never stepped and overflows the int32
+            # stride slot on long packed KV with wide tokens (GitHub #980).
+            return cute.runtime.make_fake_tensor(dtype, shape, (stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
         return cute.runtime.make_fake_tensor(dtype, shape, tuple(stride), assumed_align=16)
 
     fake_q = _fake_bshd((_fake_batch, sq, qh, d_qk), q_stride)

--- a/python/cudnn/sdpa/fwd/kernels/sm120/prefill_d256_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm120/prefill_d256_f16.py
@@ -1727,9 +1727,10 @@ def compile(  # noqa: A001
     compile DYNAMIC (``cute.sym_int``) and the cache key stays plan-time-only;
     callers must not pass them. ``max_sq`` (the longest sequence's Q length,
     which sizes the per-sequence grid) is likewise a RUNTIME ``__call__``
-    argument, not a compile parameter. THD strides carry a ZERO batch stride
-    (the real view's batch stride is ``t * token_stride``, a runtime value;
-    the fake rebuilds it symbolically — batch extent 1 never steps).
+    argument, not a compile parameter. THD strides carry a ZERO batch stride;
+    the fake binds the token stride for the extent-1 batch dim, exactly as
+    ``_thd_view`` does at runtime (``T * token_stride`` is never stepped and
+    overflows the int32 stride slot on long packed KV, GitHub #980).
 
     ``has_lse=False`` compiles the LSE store out (the kernel specializes on a
     ``None`` LSE argument) — callers that don't want stats pass no LSE buffer

--- a/python/cudnn/sdpa/fwd/kernels/sm120/prefill_d256_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm120/prefill_d256_f16.py
@@ -1786,9 +1786,10 @@ def compile(  # noqa: A001
         if stride is None:
             return cute.runtime.make_fake_compact_tensor(STORAGE_DTYPE, shape, stride_order=(3, 2, 1, 0), assumed_align=16)
         if PARAMS.thd_varlen:
-            # Batch stride = tokens * token_stride (`_thd_view`'s envelope),
-            # a runtime value: rebuild it from the dynamic token extent.
-            return cute.runtime.make_fake_tensor(STORAGE_DTYPE, shape, (shape[1] * stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
+            # Extent-1 batch dim: bind the token stride, as _thd_view does at
+            # runtime -- T * token_stride is never stepped and overflows the int32
+            # stride slot on long packed KV with wide tokens (GitHub #980).
+            return cute.runtime.make_fake_tensor(STORAGE_DTYPE, shape, (stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
         return cute.runtime.make_fake_tensor(STORAGE_DTYPE, shape, tuple(stride), assumed_align=16)
 
     fake_q = _fake_bshd((fake_batch, sq, qh, d_qk), q_stride)

--- a/python/cudnn/sdpa/fwd/kernels/sm120/prefill_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm120/prefill_f16.py
@@ -1739,9 +1739,10 @@ def compile(  # noqa: A001
     compile DYNAMIC (``cute.sym_int``) and the cache key stays plan-time-only;
     callers must not pass them. ``max_sq`` (the longest sequence's Q length,
     which sizes the per-sequence grid) is likewise a RUNTIME ``__call__``
-    argument, not a compile parameter. THD strides carry a ZERO batch stride
-    (the real view's batch stride is ``t * token_stride``, a runtime value;
-    the fake rebuilds it symbolically — batch extent 1 never steps).
+    argument, not a compile parameter. THD strides carry a ZERO batch stride;
+    the fake binds the token stride for the extent-1 batch dim, exactly as
+    ``_thd_view`` does at runtime (``T * token_stride`` is never stepped and
+    overflows the int32 stride slot on long packed KV, GitHub #980).
 
     ``has_lse=False`` compiles the LSE store out (the kernel specializes on a
     ``None`` LSE argument) — callers that don't want stats pass no LSE buffer

--- a/python/cudnn/sdpa/fwd/kernels/sm120/prefill_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm120/prefill_f16.py
@@ -1795,9 +1795,10 @@ def compile(  # noqa: A001
         if stride is None:
             return cute.runtime.make_fake_compact_tensor(STORAGE_DTYPE, shape, stride_order=(3, 2, 1, 0), assumed_align=16)
         if PARAMS.thd_varlen:
-            # Batch stride = tokens * token_stride (`_thd_view`'s envelope),
-            # a runtime value: rebuild it from the dynamic token extent.
-            return cute.runtime.make_fake_tensor(STORAGE_DTYPE, shape, (shape[1] * stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
+            # Extent-1 batch dim: bind the token stride, as _thd_view does at
+            # runtime -- T * token_stride is never stepped and overflows the int32
+            # stride slot on long packed KV with wide tokens (GitHub #980).
+            return cute.runtime.make_fake_tensor(STORAGE_DTYPE, shape, (stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
         return cute.runtime.make_fake_tensor(STORAGE_DTYPE, shape, tuple(stride), assumed_align=16)
 
     fake_q = _fake_bshd((fake_batch, sq, qh, d_qk), q_stride)

--- a/test/python/test_mhas_v2.py
+++ b/test/python/test_mhas_v2.py
@@ -1115,6 +1115,60 @@ def test_sdpa_mixed_seq_len_forms_L0(env_info, cu_sides, diag_align, right_bound
     exec_sdpa(test.cfg, request, cudnn_handle)
 
 
+@pytest.mark.L0
+def test_sdpa_thd_batch_stride_int32_overflow_L0(env_info, request, cudnn_handle):
+    """Packed-THD decode whose whole-buffer size exceeds INT32_MAX elements.
+
+    The FROST THD views bound the extent-1 batch dim with ``T * token_stride``;
+    the kernel ABI checks every stride against the int32 range, so a packed KV
+    buffer of more than 2^31 elements failed at execute with "Out of bound
+    k_tensor.strides[0]" (GitHub #980, found by the dsv3/kimi_k3 model suites:
+    h=128, d_qk=192, ~57k packed KV tokens). The random sweeps in this file
+    cannot reach that boundary within their memory budget (their largest packed
+    stride is 32 * 8192 * 32 * 192 = 1.6e9), so this pins it deterministically:
+    128 heads x d_qk=192 x 90,800 packed KV tokens = 2.23e9 > 2^31. K alone is
+    4.4 GiB -- that size is the bug's precondition, not a knob.
+    """
+    if torch.cuda.get_device_properties(0).total_memory < 16 * 2**30:
+        pytest.skip("needs a >4 GiB packed K buffer (plus V and reference)")
+    seq_len_kv = [11400] * 4 + [11300] * 4  # 90,800 tokens; each K token is 128*192 elements
+    test = SDPATestConfig(**env_info, implementation=cudnn.attention_implementation.AUTO)
+    test.cfg = ExecConfig(
+        data_type=torch.bfloat16,
+        rng_data_seed=980,
+        rng_geom_seed=980,
+        is_alibi=False,
+        is_infer=True,
+        is_paged=False,
+        is_bias=False,
+        is_block_mask=False,
+        is_padding=True,
+        is_cu_seq_len=False,
+        is_ragged=True,
+        with_ragged_token_gap=False,  # packed contract: token stride = h*d exactly
+        is_dropout=False,
+        is_determin=False,
+        batches=len(seq_len_kv),
+        d_qk=192,
+        d_v=64,  # keeps V at ~1.5 GiB; only K needs to cross the boundary
+        s_q=1,
+        s_kv=max(seq_len_kv),
+        h_q=128,
+        h_k=128,
+        h_v=128,
+        diag_align=cudnn.diagonal_alignment.TOP_LEFT,
+        left_bound=None,
+        right_bound=None,
+        seq_len_q=[1] * len(seq_len_kv),
+        seq_len_kv=seq_len_kv,
+    )
+    test.cfg.fill_derived_fields()
+    assert sum(seq_len_kv) * test.cfg.h_k * test.cfg.d_qk > 2**31, "config must cross the int32 element boundary"
+    test.showConfig((request.node.name, 1), request)
+
+    exec_sdpa(test.cfg, request, cudnn_handle)
+
+
 @pytest.mark.skipif("not config.getoption('--repro')", reason="used with '--repro' only")
 @pytest.mark.L0
 @pytest.mark.L1

--- a/test/python/test_mhas_v2.py
+++ b/test/python/test_mhas_v2.py
@@ -221,7 +221,9 @@ def test_sdpa_random_sq1_L0(env_info, test_no, request, cudnn_handle):
         data_type=RandomChoice({torch.float16 : 1, torch.bfloat16 : 2}),
         with_sliding_mask=SlidingWindowMaskGenerator(no_mask=10),
         diag_align=RandomChoice({cudnn.diagonal_alignment.TOP_LEFT : 1, cudnn.diagonal_alignment.BOTTOM_RIGHT : 1}),
-        is_ragged_or_padded_or_full=RandomChoice({"ragged" : 0, "padded" : 0, "full" : 1}),
+        # ragged = packed-THD decode (the serving shape); was never drawn here,
+        # which is how the d=192 THD-decode view overflow (GitHub #980) hid.
+        is_ragged_or_padded_or_full=RandomChoice({"ragged" : 1, "padded" : 1, "full" : 1}),
         # sink_token not supported with s_q==1
         # dropout not supported with s_q==1
     ) as randomization_ctx:
@@ -288,7 +290,8 @@ def test_sdpa_random_lean_attn_L0(env_info, test_no, request, cudnn_handle):
         data_type=RandomChoice({torch.float16 : 1, torch.bfloat16 : 2}),
         with_sliding_mask=SlidingWindowMaskGenerator(no_mask=10),
         diag_align=RandomChoice({cudnn.diagonal_alignment.TOP_LEFT : 1, cudnn.diagonal_alignment.BOTTOM_RIGHT : 1}),
-        is_ragged_or_padded_or_full=RandomChoice({"ragged" : 0, "padded" : 1, "full" : 1}),
+        # ragged = packed-THD decode against a long KV (GitHub #980 coverage).
+        is_ragged_or_padded_or_full=RandomChoice({"ragged" : 1, "padded" : 1, "full" : 1}),
         # sink_token not supported with s_q==1
         # dropout not supported with s_q==1
     ) as randomization_ctx:


### PR DESCRIPTION
Fixes #980.

## Bug

The packed-THD `(1, T, H, D)` views the FROST forward engines bind (`_thd_view`, and the fp8 `_packed` twin) give the extent-1 batch dim the stride `T * token_stride`. The kernel ABI checks every stride against the **int32** range, so long packed KV with wide tokens overflows it and the engine fails at execute instead of serving:

```
ValueError: Out of bound k_tensor.strides[0] on argument #1 when calling: `_host(q_tensor: Tensor([1, n0, 128, 192], float16), k_tensor: Tensor([1, n1, 128, 192], float16), ...)`, expected to be in int32 range [-2147483648, 2147483647]
```

For the DeepSeek-V3 / Kimi-K3 THD decode configs (h=128, d_qk=192, ~57k packed KV tokens) that stride is ~5.7e9. d=128 / 8-head configs stay around 1e8, which is why only the d=192 model presets tripped it in the `sdpa/suites` CI lane.

## Fix

An extent-1 dim's stride is never stepped, and the THD compile key already zeroes it (`_thd_compile_kwargs`), so bind the **token stride** instead — always in range and semantically identical. Same one-line change in the fp8 THD `_packed` view.

The kernel `compile()` fakes (`_fake_bshd`) described the same THD batch stride as `shape[1] * stride[1]` — the overflowing formula — so they now bind the token stride too; compile-time and runtime layouts describe the same tensor. Covers sm100 (5 kernels), sm120 (2) and, after rebasing over #974, the 6 sm107 prefill kernels. Docstrings that still called the batch stride "`tokens * token_stride`, rebuilt from the dynamic token extent" now say what is bound and why.

## Why not 64-bit strides?

- The **real** THD strides are bounded by construction: token stride `h·d·(1+gap)` (≤ ~2¹⁷ here), head stride `d`, elem stride 1; per-token addressing goes through TMA coordinates (int32 tokens) with 64-bit descriptor math. The exact CI config is an 11 GB buffer (`T·ts` = 5.7e9 elements) and runs correctly under the fix — the kernels are fine with >2³¹-element buffers. The only value that grows with the buffer is the extent-1 batch stride, which nothing reads.
- CuTeDSL does support 64-bit dynamic strides (`from_dlpack(use_32bit_stride=...)`, `cute.sym_int64`), but these kernels are compiled from fakes whose token extent is a 32-bit `cute.sym_int`, and the batch stride was derived from it — so the ABI slot is int32 by construction. Widening it means a 64-bit token extent (64-bit loop bounds and tile math in the hot loop) to carry a number nobody consumes.
- Other head dims share `_thd_view` and are not exempt — h=128 at d=128 overflows at ~32k packed tokens; the 128-head presets were simply the first sweep to draw such sizes.

## Verification (B200, cuDNN 9.26, FROST opted in)

- Exact CI config (`b=27, h=128, d_qk=192, d_v=128, total_kv=57664`, gapped token stride 4·h·d): **fails before / passes after**.
- Minimal repro (~90k packed KV tokens, packed strides): fails before / passes after.
- THD f16 regression sample (context THD, THD chunked, THD decode) green under the fix (32/32 after the rebase).
- New `test_sdpa_thd_batch_stride_int32_overflow_L0` passes (fails before the fix with the `k_tensor.strides[0] ... int32 range` error).

## test_mhas_v2

The decode sweeps (`random_sq1_L0`, `lean_attn_L0`) now draw **ragged (packed-THD) decode** alongside padded/full — they were dense-only, which is how this combination went unexercised there; the new `sdpa/suites` model-generation suites found it.

Those sweeps are RNG-drawn and their maximum packed stride stays below 2³¹, so the PR also adds a **deterministic** pin, `test_sdpa_thd_batch_stride_int32_overflow_L0`: f16 ragged packed-THD decode, `s_q=1`, `h=128`, `d_qk=192`, 90,800 packed KV tokens → `T·h·d = 2.23e9 > 2³¹` (asserted in the test). Skips on GPUs under 16 GiB (the packed K buffer alone is >4 GiB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed long packed-sequence attention cases that could trigger stride overflow errors.
  - Improved handling of variable-length and packed tensor layouts across supported GPU architectures.
  - Corrected stride behavior for THD attention to better match runtime execution.

- **New Features**
  - Expanded Rubin THD support for configured FP8, FP16, and BF16 shapes.
  - Added architecture-specific kernel selection and broader packed-attention coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->