### PR TITLE
frost(sdpa): fix d256 fp8 + mxfp8 masked-softmax TMEM race — aliased P store vs the other warpgroup's S load (#981); mhas_v2 fp8/mxfp8 fwd draw d=256

### DIFF
--- a/python/cudnn/sdpa/AGENTS.md
+++ b/python/cudnn/sdpa/AGENTS.md
@@ -64,7 +64,7 @@ ordered after that read.**
 
 - Some kernels have no spare TMEM and pack P into the tail of the S slot it
   was computed from (`P_EVEN_OFF`/`P_ODD_OFF` inside the `S_ACC_*` column
-  range — e.g. `prefill_d256_fp8_sm100.py`, `P_EVEN_OFF = 96` in a 128-col
+  range — e.g. `sm100/prefill_d256_fp8.py`, `P_EVEN_OFF = 96` in a 128-col
   slot). With a single softmax owner that is safe: all of S is in registers
   before any P store. It is a race the moment a row's keys are split across
   two softmax warpgroups: the half storing into the aliased columns
@@ -76,17 +76,34 @@ ordered after that read.**
   after its `tcgen05.ld` has landed (`tcgen05.wait::ld` first — the
   softmax paths otherwise never wait on loads explicitly), and the storing
   half waits on it right before the aliased store (`mb_softmax_hi_loaded`
-  in `prefill_d256_fp8_sm100.py`, mirroring `mb_softmax_max`). Do NOT try
+  in `sm100/prefill_d256_fp8.py`, mirroring `mb_softmax_max`). Do NOT try
   to fix it by swapping which half owns which keys: the alpha/stats value
   is aliased too (`STATS_*_OFF == S_ACC_*_OFF`, i.e. S column 0), so the
   half that stores alpha must also be the one that owns key 0 — the
   original ownership is forced, only the ordering was missing.
-- Detector: a kernel that matches both
-  `grep -l "mb_softmax_max" python/cudnn/sdpa/fwd/kernels/*.py` and
-  `grep -l "P_EVEN_OFF: int = " python/cudnn/sdpa/fwd/kernels/*.py` with
-  `P_EVEN_OFF < S_ACC_EVEN_OFF + 128` has this hazard class. For each P
-  store, name the warpgroup that still reads the target columns and the
-  barrier that orders the store after that read; if there is none, it is
-  a bug. The symptom in a fuzz suite is `ref == 0, gpu != 0` elements on
-  masked configs with `key mod TILE_N` in the aliased range — recover the
-  leaked keys by matching `O_gpu - O_ref` against `V` rows.
+- The same kernel family can hide the split behind a different role name.
+  `sm100/prefill_d256_mxfp8.py` has no `mb_softmax_max`: its
+  `FUSED_CORR_SPLIT_P` schedule (mxfp8 + strict top-left causal) gives
+  keys 64–127 to the *correction* warpgroup (`_fused_p1_step`), and half 0
+  stored P into cols 96–111 with nothing ordering it after that
+  warpgroup's S-hi load. There the release already existed —
+  `mb_stat_empty` is arrived right after that load — so the fix is to wait
+  on it *before* the aliased store instead of at the end of the iteration.
+  The dense split-P schedule of the same kernel is safe only because both
+  halves meet at a 256-thread named barrier (`barrier_id=8`) after their
+  loads; if that barrier ever moves below the P store, this comes back.
+- Detector: every kernel with `P_EVEN_OFF: int = ` inside the `S_ACC_*`
+  range (`grep -l "P_EVEN_OFF: int = " python/cudnn/sdpa/fwd/kernels/*/*.py`,
+  today the six d256 kernels) whose config can select
+  `SOFTMAX_WARPGROUPS == 2` (`grep -n "SOFTMAX_WARPGROUPS=2\|split_p\|fused_corr_split_p" python/cudnn/sdpa/fwd/config_*.py`)
+  — regardless of which role runs the second half. For each P store, name
+  the warpgroup that still reads the target columns and the barrier that
+  orders the store after that read; if there is none, it is a bug. Random
+  data can hide it: the lagging half usually lags only when it rescales O
+  (alpha ≠ 1), which `RESCALE_THRESHOLD` makes rare — force it with K
+  scaled by `growth ** (key // 128)` (`k_tile_growth` in
+  `test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py`; the pre-fix mxfp8
+  kernel then fails every run with inf/NaN O). The symptom in a fuzz suite
+  is `ref == 0, gpu != 0` elements on masked configs with `key mod TILE_N`
+  in the aliased range — recover the leaked keys by matching
+  `O_gpu - O_ref` against `V` rows.

--- a/python/cudnn/sdpa/AGENTS.md
+++ b/python/cudnn/sdpa/AGENTS.md
@@ -57,3 +57,36 @@ head-major, never dense-padded.**
 - Reviewing: if the diff touches `fwd/engines.py`, `bwd/engines.py` or
   `cudnn/engines/manifest.py` and `python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md` is
   untouched, ask why before approving.
+
+**Rule S3 — When P is aliased into a score slot's TMEM tail, the warpgroup
+that stores into columns another warpgroup still has to read must be
+ordered after that read.**
+
+- Some kernels have no spare TMEM and pack P into the tail of the S slot it
+  was computed from (`P_EVEN_OFF`/`P_ODD_OFF` inside the `S_ACC_*` column
+  range — e.g. `prefill_d256_fp8_sm100.py`, `P_EVEN_OFF = 96` in a 128-col
+  slot). With a single softmax owner that is safe: all of S is in registers
+  before any P store. It is a race the moment a row's keys are split across
+  two softmax warpgroups: the half storing into the aliased columns
+  overwrites the *other* half's unread S whenever that half lags a tile.
+  GitHub #981 was exactly this — garbage weights on keys 96–111, masked
+  paths only, sporadic and data-dependent (the no-mask fast path is
+  single-owner).
+- The fix is an explicit release: the reading half arrives an mbarrier
+  after its `tcgen05.ld` has landed (`tcgen05.wait::ld` first — the
+  softmax paths otherwise never wait on loads explicitly), and the storing
+  half waits on it right before the aliased store (`mb_softmax_hi_loaded`
+  in `prefill_d256_fp8_sm100.py`, mirroring `mb_softmax_max`). Do NOT try
+  to fix it by swapping which half owns which keys: the alpha/stats value
+  is aliased too (`STATS_*_OFF == S_ACC_*_OFF`, i.e. S column 0), so the
+  half that stores alpha must also be the one that owns key 0 — the
+  original ownership is forced, only the ordering was missing.
+- Detector: a kernel that matches both
+  `grep -l "mb_softmax_max" python/cudnn/sdpa/fwd/kernels/*.py` and
+  `grep -l "P_EVEN_OFF: int = " python/cudnn/sdpa/fwd/kernels/*.py` with
+  `P_EVEN_OFF < S_ACC_EVEN_OFF + 128` has this hazard class. For each P
+  store, name the warpgroup that still reads the target columns and the
+  barrier that orders the store after that read; if there is none, it is
+  a bug. The symptom in a fuzz suite is `ref == 0, gpu != 0` elements on
+  masked configs with `key mod TILE_N` in the aliased range — recover the
+  leaked keys by matching `O_gpu - O_ref` against `V` rows.

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d256_fp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d256_fp8.py
@@ -590,6 +590,17 @@ def _kernel(
         init_count=CFG.SOFTMAX_LANES,
         producer=Producer.THREAD,
     )
+    # Half 1 -> half 0: "my S chunk (keys 64-127) is in registers". Half 0's
+    # packed P for keys 0-63 lands in TMEM cols 96-111 of the SAME score slot
+    # -- the S of keys 96-111, which half 1 still has to read -- so that store
+    # must wait for this (GitHub #981: half 1 lagging a tile read clobbered
+    # scores and emitted garbage weights for exactly those keys).
+    mb_softmax_hi_loaded = MBarrier(
+        cutlass.Array(cutlass.Int64, 2, alignment=16, space=cutlass.AddressSpace.smem),
+        stages=2,
+        init_count=CFG.SOFTMAX_LANES,
+        producer=Producer.THREAD,
+    )
 
     sched = Sched(
         **{
@@ -647,6 +658,7 @@ def _kernel(
             if cutlass.const_expr(CFG.SOFTMAX_WARPGROUPS == 2):
                 for p in cutlass.range_constexpr(2):
                     mb_softmax_max[p].init()
+                    mb_softmax_hi_loaded[p].init()
             bars.mb_empty_mainloop.init()
             bars.mb_tmem_dealloc.init()
 
@@ -701,6 +713,7 @@ def _kernel(
             bottom_right_diagonal=bottom_right_diagonal,
             softmax_exchange=softmax_exchange,
             mb_softmax_max=mb_softmax_max,
+            mb_softmax_hi_loaded=mb_softmax_hi_loaded,
         )
 
     elif cutlass.const_expr(CFG.SOFTMAX_WARPGROUPS == 2) and warp_idx >= CFG.SOFTMAX_WG1_BASE and warp_idx < CFG.SOFTMAX_WG1_BASE + CFG.SOFTMAX_WG_WARPS:
@@ -731,6 +744,7 @@ def _kernel(
             bottom_right_diagonal=bottom_right_diagonal,
             softmax_exchange=softmax_exchange,
             mb_softmax_max=mb_softmax_max,
+            mb_softmax_hi_loaded=mb_softmax_hi_loaded,
         )
 
     elif warp_idx >= CFG.CORR_WARP_BASE and warp_idx < CFG.CORR_WARP_BASE + CFG.CORRECTION_WARPS:
@@ -1507,12 +1521,14 @@ def _softmax_warp_group(
     bottom_right_diagonal: cutlass.Constexpr[bool],
     softmax_exchange,
     mb_softmax_max,
+    mb_softmax_hi_loaded,
 ):
     nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
     tmem_base = tmem_ptr_i32.load()
 
     bmm1_done_phase_pair = cutlass.Int32(0)
     softmax_max_phase_pair = cutlass.Int32(0)
+    hi_loaded_phase_pair = cutlass.Int32(0)
     stat_empty_phase = cutlass.Int32(1)
     epilogue_state = cutlass.Int32(1)
 
@@ -1654,6 +1670,10 @@ def _softmax_warp_group(
                         ),
                         size=CHUNK,
                     )
+                    # S(keys 64-127) is in registers: release half 0's P store
+                    # into cols 96-111 (see mb_softmax_hi_loaded, GitHub #981).
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                    mb_softmax_hi_loaded[parity_rt].arrive()
                 if cutlass.const_expr(softmax_half == 1):
                     softmax_max_phase = (softmax_max_phase_pair >> parity_rt) & cutlass.Int32(1)
                     mb_softmax_max[parity_rt].wait(softmax_max_phase)
@@ -1690,6 +1710,12 @@ def _softmax_warp_group(
                     # Keep the multiply adjacent to the subtract so PTXAS can
                     # emit FFMA2 instead of a separate FMUL2/FADD2 pair.
                     reg_S_half = scale_log2 * reg_S_half - total_max_safe
+                if cutlass.const_expr(softmax_half == 0):
+                    # Our P (keys 0-63) overwrites S cols 96-111 = half 1's
+                    # unread keys 96-111; wait until half 1 holds them (#981).
+                    hi_loaded_phase = (hi_loaded_phase_pair >> parity_rt) & cutlass.Int32(1)
+                    mb_softmax_hi_loaded[parity_rt].wait(hi_loaded_phase)
+                    hi_loaded_phase_pair = hi_loaded_phase_pair ^ (cutlass.Int32(1) << parity_rt)
                 chunk_P_a = _exp2_dense_chunk_a(reg_S_half[0:P_SUBCHUNK].vec, softmax_half)
                 new_p_sum_pair = row_reduction_pair(chunk_P_a)
                 nvvm.tcgen05_st(
@@ -1802,6 +1828,10 @@ def _softmax_warp_group(
                             nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(CHUNK), cutlass.Float32),
                             num=CHUNK,
                         )
+                        # S(keys 64-127) is in registers: release half 0's P
+                        # store into cols 96-111 (mb_softmax_hi_loaded, #981).
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                        mb_softmax_hi_loaded[parity_rt].arrive()
                         masked_chunk = apply_mask_chunk(
                             raw_chunk,
                             mask_q_abs - (kv_col_base + cutlass.Int32(CHUNK)),
@@ -1837,6 +1867,12 @@ def _softmax_warp_group(
                         _stat_arrive(bars.mb_stat_full, _STAT_FULL_WARP_ARRIVALS)
 
                     reg_S_half = reg_S_half * scale_log2 - total_max_safe
+                    if cutlass.const_expr(softmax_half == 0):
+                        # Our P (keys 0-63) overwrites S cols 96-111 = half 1's
+                        # unread keys 96-111; wait until half 1 holds them (#981).
+                        hi_loaded_phase = (hi_loaded_phase_pair >> parity_rt) & cutlass.Int32(1)
+                        mb_softmax_hi_loaded[parity_rt].wait(hi_loaded_phase)
+                        hi_loaded_phase_pair = hi_loaded_phase_pair ^ (cutlass.Int32(1) << parity_rt)
                     if cutlass.const_expr(_SMEM_ALPHA_HANDOFF):
                         chunk_P_a = _exp2_masked_tail_chunk_a(reg_S_half[0:P_SUBCHUNK].vec, softmax_half)
                     else:

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d256_mxfp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d256_mxfp8.py
@@ -2199,6 +2199,14 @@ def _softmax_warp_group(
 
                 chunk_P_0a = _exp2_chunk0a_mixed(reg_S[0:P_SUBCHUNK].vec, True)
                 hoisted_sum = row_reduction_pair(chunk_P_0a)
+                if cutlass.const_expr(CFG.FUSED_CORR_SPLIT_P):
+                    # Our P (keys 0-63) lands in S cols 96-111 -- the fused
+                    # warpgroup's UNREAD keys 96-111.  It arrives mb_stat_empty
+                    # only after its S-hi tcgen05.ld has landed, so waiting here
+                    # (instead of at the end of the iteration) orders the aliased
+                    # store after that read (GitHub #981 class, Rule S3).
+                    bars.mb_stat_empty.wait(stat_empty_phase)
+                    stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
                 nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32), chunk_P_0a.to(STORAGE_DTYPE))
                 chunk_P_0b = cute.math.exp2(reg_S[P_SUBCHUNK:CHUNK].vec, fastmath=True)
                 hoisted_sum = hoisted_sum + row_reduction_pair(chunk_P_0b)
@@ -2234,8 +2242,9 @@ def _softmax_warp_group(
                     new_p_sum_pair = new_p_sum_pair + deferred_sum_1
                 alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
                 total_sum = total_sum * alpha_pair + new_p_sum_pair
-                bars.mb_stat_empty.wait(stat_empty_phase)
-                stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+                if cutlass.const_expr(not CFG.FUSED_CORR_SPLIT_P):
+                    bars.mb_stat_empty.wait(stat_empty_phase)
+                    stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
             for kv_loop in cutlass.range(bounds.unmasked_lo, bounds.unmasked_hi, 1, unroll=1):
                 parity_rt = kv_loop & cutlass.Int32(1)
                 parity_is_even = parity_rt == cutlass.Int32(0)
@@ -2298,6 +2307,11 @@ def _softmax_warp_group(
                 chunk_P_0a = _exp2_chunk0a_mixed(reg_S[0:P_SUBCHUNK].vec, False)
                 if cutlass.const_expr(not _E5_STYLE_SOFTMAX):
                     hoisted_sum = row_reduction_pair(chunk_P_0a)
+                if cutlass.const_expr(CFG.FUSED_CORR_SPLIT_P):
+                    # Aliased P store into the fused warpgroup's unread S cols
+                    # 96-111: wait for its post-load mb_stat_empty arrive (#981).
+                    bars.mb_stat_empty.wait(stat_empty_phase)
+                    stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
                 nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32), chunk_P_0a.to(STORAGE_DTYPE))
                 if cutlass.const_expr(_E5_STYLE_SOFTMAX):
                     hoisted_sum = row_reduction_pair(chunk_P_0a)
@@ -2344,8 +2358,9 @@ def _softmax_warp_group(
                     new_p_sum_pair = new_p_sum_pair + deferred_sum_1
                 alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
                 total_sum = total_sum * alpha_pair + new_p_sum_pair
-                bars.mb_stat_empty.wait(stat_empty_phase)
-                stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+                if cutlass.const_expr(not CFG.FUSED_CORR_SPLIT_P):
+                    bars.mb_stat_empty.wait(stat_empty_phase)
+                    stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
             for kv_loop in cutlass.range(bounds.unmasked_hi, bounds.right, 1, unroll=1):
                 tail_active = True
                 if tail_active:
@@ -2431,6 +2446,11 @@ def _softmax_warp_group(
 
                     chunk_P_0a = _exp2_chunk0a_mixed(reg_S[0:P_SUBCHUNK].vec, True)
                     hoisted_sum = row_reduction_pair(chunk_P_0a)
+                    if cutlass.const_expr(CFG.FUSED_CORR_SPLIT_P):
+                        # Aliased P store into the fused warpgroup's unread S
+                        # cols 96-111: wait for its post-load arrive (#981).
+                        bars.mb_stat_empty.wait(stat_empty_phase)
+                        stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
                     nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32), chunk_P_0a.to(STORAGE_DTYPE))
                     chunk_P_0b = cute.math.exp2(reg_S[P_SUBCHUNK:CHUNK].vec, fastmath=True)
                     hoisted_sum = hoisted_sum + row_reduction_pair(chunk_P_0b)
@@ -2466,8 +2486,9 @@ def _softmax_warp_group(
                         new_p_sum_pair = new_p_sum_pair + deferred_sum_1
                     alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
                     total_sum = total_sum * alpha_pair + new_p_sum_pair
-                    bars.mb_stat_empty.wait(stat_empty_phase)
-                    stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
+                    if cutlass.const_expr(not CFG.FUSED_CORR_SPLIT_P):
+                        bars.mb_stat_empty.wait(stat_empty_phase)
+                        stat_empty_phase = stat_empty_phase ^ cutlass.Int32(1)
 
         total_sum_scalar = total_sum[0] + total_sum[1]
         if cutlass.const_expr(CFG.SOFTMAX_WARPGROUPS == 2):
@@ -2636,6 +2657,9 @@ def _correction_warp_group(
             nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(64), cutlass.Float32),
             num=64,
         )
+        # This wait::ld must stay ahead of the mb_stat_empty arrive below: half
+        # 0 waits on that arrive before storing its P into S cols 96-111, which
+        # are our (still unread until here) keys 96-111 (GitHub #981 class).
         nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
         if nvvm.elect_sync():
             nvvm.mbarrier_arrive(mb_qk_sf_reuse_arg.subview(parity_cur_rt))

--- a/test/python/sdpa/frost/frost_test_utils.py
+++ b/test/python/sdpa/frost/frost_test_utils.py
@@ -24,6 +24,14 @@ def _active_sm():
 
 _SM = _active_sm()
 
+# Floor for anything that needs a backend SDPA plan or a DSL kernel: the
+# backend declines SDPA below Ampere and the DSL has no sm_7x target, so a
+# Turing card (the fallback GPU on a runner whose Ampere board has dropped
+# out) must skip these rather than fail them.
+requires_sm80 = pytest.mark.skipif(
+    _SM is None or _SM < 80,
+    reason="needs an SM80+ GPU, have " + ("none" if _SM is None else f"sm_{_SM}"),
+)
 requires_blackwell = pytest.mark.skipif(
     _SM is None or not (100 <= _SM <= 119),
     reason="needs an SM100-line GPU (100 <= SM <= 119), have " + ("none" if _SM is None else f"sm_{_SM}"),
@@ -53,6 +61,8 @@ def _dsl_usable():
     """
     from cudnn.frost.buffers import CUTEDSL_MIN_VERSION, cutedsl_state, cutedsl_too_old
 
+    if _SM is not None and _SM < 80:
+        return False, f"cutedsl has no sm_{_SM} target (needs SM80+)"
     installed, version = cutedsl_state()
     if not installed:
         return False, "needs the cutedsl extra (nvidia-cutlass-dsl)"

--- a/test/python/sdpa/frost/test_sdpa_frontend_integration.py
+++ b/test/python/sdpa/frost/test_sdpa_frontend_integration.py
@@ -15,10 +15,9 @@ import cudnn
 from cudnn.engines import MANIFEST, is_backend_engine, is_python_engine
 
 from cudnn.sdpa.fwd.engines import engine_name
-from frost_test_utils import requires_pre_rubin_blackwell, requires_dsl, _dsl_installed, _is_plan_for
+from frost_test_utils import requires_pre_rubin_blackwell, requires_dsl, requires_sm80, _dsl_installed, _is_plan_for
 
 _FROST = engine_name()  # matches the D=512 graphs below
-_GPU = pytest.mark.skipif(not torch.cuda.is_available(), reason="needs GPU")
 
 
 _SM100 = requires_pre_rubin_blackwell
@@ -76,11 +75,11 @@ def test_engine_family_is_in_the_manifest():
     assert row.id_end > row.engine_id + 1  # a family: a whole id block, one id per cell
 
 
-@_GPU
+@requires_sm80
 def test_ineligible_graph_lists_no_dsl_engine():
-    """ALiBi (a feature no FROST SDPA engine serves) validates on any GPU, so no
-    SM100 needed to check the engine declines it — and a declined graph has no
-    python entry to select at all. (Small head dims are no longer a rejection:
+    """ALiBi (a feature no FROST SDPA engine serves) validates on any SM80+ GPU
+    (the backend still has to plan it), so no SM100 needed to check the engine
+    declines it — and a declined graph has no python entry to select at all. (Small head dims are no longer a rejection:
     the head-dim ENVELOPE serves any d <= flavor via TMA zero-padding.)"""
     g, q, k, v, o = _build_causal_sdpa(use_alibi_mask=True)
     _plan(g)

--- a/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
@@ -199,8 +199,14 @@ def _run(
     stats_layout="contiguous",
     return_lse=False,
     poison_tmem_before_execute: bool = False,
+    k_tile_growth: float = 1.0,
 ):
     """Quantize, build the sdpa_mxfp8 graph, route to the frost engine, execute.
+
+    ``k_tile_growth`` > 1 scales K by ``growth ** (key // 128)`` so every KV
+    tile raises the row max past the kernel's RESCALE_THRESHOLD and the
+    correction path rescales O on every iteration (see
+    ``test_mxfp8_d256_causal_rescale_every_tile``).
 
     Returns ``_RunResult`` or, when ``return_lse`` is set,
     ``_RunWithStatsResult``.
@@ -211,6 +217,8 @@ def _run(
     fp8 = _FP8[in_key]
     Qf = torch.randn(B, H_q, S, d_qk, device=dev) * 0.5
     Kf = torch.randn(B, H_kv, S, d_qk, device=dev) * 0.5
+    if k_tile_growth != 1.0:
+        Kf = Kf * (k_tile_growth ** (torch.arange(S, device=dev) // 128).float()).view(1, 1, S, 1)
     Vf = torch.randn(B, H_kv, S, d_v, device=dev) * 0.5
     Q8, sfq, dqq, (sqp, dsc) = _quantize(Qf, B, H_q, S, d_qk, fp8, columnwise=False)
     K8, sfk, dqk, (skp, _) = _quantize(Kf, B, H_kv, S, d_qk, fp8, columnwise=False)
@@ -427,6 +435,29 @@ def test_mxfp8_d256_masks(in_key, mask):
         d_v=256,
     )
     _check(O, O_ref, torch.float16, in_key, d_qk=256)
+    assert amax.item() > 0.0
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("in_key", _INS)
+@torch_fork_set_rng(seed=981)
+def test_mxfp8_d256_causal_rescale_every_tile(in_key):
+    """Strict top-left causal at d256 runs the FUSED_CORR_SPLIT_P schedule: the
+    correction warpgroup owns keys 64-127 while half 0 stores its P into S cols
+    96-111 (P is aliased into the score slot).  That warpgroup only lags when
+    it rescales O, so scale K by 8 per KV tile to force a rescale every
+    iteration; the unordered kernel then reads clobbered scores and emits
+    inf/NaN or O(1) errors on every run (GitHub #981 class, Rule S3).  Random
+    data almost never rescales (RESCALE_THRESHOLD) and cannot catch this.
+
+    The bound is the block-scale quantization floor of this deliberately
+    extreme input, measured on the (named-barrier ordered) dense schedule:
+    ~0.13-0.16 for e4m3; the racing kernel produced >= 1.75.
+    """
+    O, O_ref, amax = _run(1, 8, 8, 1024, in_key, torch.float16, scale=1.0 / math.sqrt(256), sdpa_kwargs=_MASKS["causal"], d_qk=256, d_v=256, k_tile_growth=8.0)
+    assert torch.isfinite(O.float()).all(), "non-finite O: fused warpgroup read P-clobbered scores"
+    diff = (O.float() - O_ref).abs().max().item()
+    assert diff <= 0.3, f"max|O-ref|={diff:.4f} (quantization floor ~0.15; the unordered kernel gives >= 1.75)"
     assert amax.item() > 0.0
 
 

--- a/test/python/sdpa/frost/test_sdpa_python_validate.py
+++ b/test/python/sdpa/frost/test_sdpa_python_validate.py
@@ -18,6 +18,7 @@ import pytest
 
 import cudnn
 from cudnn.engines import manifest
+from frost_test_utils import requires_sm80
 
 pytestmark = pytest.mark.L0
 
@@ -66,6 +67,7 @@ def test_valid_graph_does_not_lower(frost_candidate):
     assert g._lowered_graph is None, "validate() must not lower to C++ when a python engine is a candidate"
 
 
+@requires_sm80
 def test_classic_path_still_lowers(no_candidates):
     """No python candidate: validate() keeps the classic eager C++ lowering."""
     g, _ = _sdpa_graph(use_causal_mask=True)
@@ -73,6 +75,7 @@ def test_classic_path_still_lowers(no_candidates):
     assert g._lowered_graph is not None, "without python candidates the classic eager lowering must be unchanged"
 
 
+@requires_sm80
 def test_mixed_graph_still_lowers(frost_candidate):
     """A node outside COVERED_NODE_TYPES (pointwise on O) forces the classic eager
     lowering even with a python candidate: the routing rule is every-node-covered."""

--- a/test/python/sdpa/frost/test_tile_dsl_q_loop_bounds.py
+++ b/test/python/sdpa/frost/test_tile_dsl_q_loop_bounds.py
@@ -10,6 +10,7 @@ every kv tile; the reference is plain Python on the same inputs."""
 import pytest
 import torch
 
+from cudnn.frost.tile_dsl.constants import MASK_CAUSAL, MASK_NONE, MASK_SWA
 from frost_test_utils import _dsl_installed, requires_dsl
 
 pytestmark = [pytest.mark.L0, requires_dsl]
@@ -21,7 +22,7 @@ if _dsl_installed():
     from cutlass.base_dsl.typing import Pointer
     from cutlass.cute.runtime import from_dlpack
 
-    from cudnn.frost.tile_dsl.mask import MASK_CAUSAL, MASK_NONE, MASK_SWA, compute_q_loop_bounds, swa_kv_lo_tile
+    from cudnn.frost.tile_dsl.mask import compute_q_loop_bounds, swa_kv_lo_tile
 
     @cute.kernel
     def _probe_kernel(

--- a/test/python/test_mhas_v2.py
+++ b/test/python/test_mhas_v2.py
@@ -953,7 +953,7 @@ def test_sdpa_mxfp8_fwd_L0(env_info, test_no, request, cudnn_handle):
     with RandomizationContext(
         batches=RandomBatchSize(min=1, max=4),
         s_q_s_kv=RandomSequenceLength(s_q_min=128, s_q_max=8192, s_kv_min=128, s_kv_max=8192, s_q_distribution={"s_q=1": 0, "s_q=s_kv": 1, "s_q=random": 1}),
-        d_qk_d_v=RandomHiddenDimSize(d_qk_min=64, d_qk_max=192, d_v_min=64, d_v_max=128, head_dim_distribution={"d_qk=d_v": 1, "d_qk=random": 0}, with_high_probability=[(64, 64), (128, 128), (192, 128)]),
+        d_qk_d_v=RandomHiddenDimSize(d_qk_min=64, d_qk_max=256, d_v_min=64, d_v_max=256, head_dim_distribution={"d_qk=d_v": 1, "d_qk=random": 0}, with_high_probability=[(64, 64), (128, 128), (192, 128), (256, 256)]),
         head_count=RandomHeadGenerator(min=1, max=8, head_group_options=(1, 4, 1)),
         data_type=RandomChoice({torch.float8_e4m3fn: 3, torch.float8_e5m2: 1}),
         output_type=RandomChoice({torch.float16: 2, torch.bfloat16: 1}),  # FP16 more often for tighter tolerance testing

--- a/test/python/test_mhas_v2.py
+++ b/test/python/test_mhas_v2.py
@@ -697,7 +697,10 @@ def test_sdpa_fp8_fwd_L0(env_info, test_no, request, cudnn_handle):
     with RandomizationContext(
         batches=RandomBatchSize(min=1, max=8, with_high_probability=[4]),
         s_q_s_kv=RandomSequenceLength(s_q_min=1, s_q_max=8192, s_kv_min=1, s_kv_max=8192, s_q_distribution={"s_q=1": 2, "s_q=s_kv": 5, "s_q=random": 2}),
-        d_qk_d_v=RandomHiddenDimSize(d_qk_min=64, d_qk_max=192, d_v_min=64, d_v_max=128, head_dim_distribution={"d_qk=d_v": 2, "d_qk=random": 1}, with_high_probability=[(64, 64), (128, 128), (192, 128)]),
+        # d up to 256: the fp8 forward sweep stopped at 192 while the backward
+        # sweep drew 256, which is how the d=256 fp8 forward defect (GitHub
+        # #981, FROST d256 fp8 TMEM race under masking) went unexercised here.
+        d_qk_d_v=RandomHiddenDimSize(d_qk_min=64, d_qk_max=256, d_v_min=64, d_v_max=256, head_dim_distribution={"d_qk=d_v": 2, "d_qk=random": 1}, with_high_probability=[(64, 64), (128, 128), (192, 128), (256, 256)]),
         head_count=RandomHeadGenerator(min=1, max=16, head_group_options=(1, 5, 2)),
         data_type=RandomChoice({torch.float8_e4m3fn: 2, torch.float8_e5m2: 1}),
         output_type=RandomChoice({torch.float8_e4m3fn: 1, torch.float8_e5m2: 1, torch.float16: 2}),


### PR DESCRIPTION
Fixes #981.

## Bug

`sdpa_fwd_prefill_sm100_fp8` at d=256 returned wrong output under any causal mask (TOP_LEFT or BOTTOM_RIGHT, e4m3 or e5m2, MHA or GQA, b≥1): ~0.1% of O elements off by up to ~2.0, sporadic and data-dependent. No-mask configs were always correct.

`sm100/prefill_d256_fp8.py` packs fp8 **P into the tail columns (96–127) of the same TMEM score slot** it was computed from (`P_EVEN_OFF = 96` inside the 128-column S slot — there is no spare TMEM at d=256). That is fine for a single owner (the d256 f16 kernel and this kernel's no-mask fast path load all of S before storing P). The two **masked** variants, however, split each row's 128 keys across the two softmax warpgroups: half 0 loaded everything, published the row max, and immediately stored *its* P (keys 0–63) into cols **96–111 — half 1's still-unread S for keys 96–111**. Whenever half 1 lagged (it can still be finishing the previous tile), it read clobbered scores and produced garbage weights for exactly keys 96–111.

Diagnosed by recovering the corrupted keys from `O_gpu − O_ref` against the sparse-integer `V`: the bad contributions cluster at `key mod 128 ∈ [96, 111]`.

## Fix (fp8)

Add an explicit release, mirroring `mb_softmax_max`: a new per-parity mbarrier `mb_softmax_hi_loaded`. Half 1 arrives it once its S chunk (keys 64–127) has landed in registers (`tcgen05.wait::ld` first — the softmax paths otherwise never wait on loads explicitly), and half 0 waits on it immediately before its first P store, in both masked variants. The fast path, the MMA warp and the correction warp are untouched.

Why not just swap which half owns which keys (so the half storing into cols 96–111 is the one that already waits on the max)? Because alpha/stats is aliased too — `stats_addr` is **S column 0** — so the half that stores alpha must own key 0. The original ownership is forced; only the ordering was missing. (Tried the swap first: it moved the corruption to key 0 instead of removing it.)

## Same hazard in the d256 **mxfp8** kernel (second commit)

Audit of every kernel that aliases P into the score slot (the six d256 kernels): sm107 d256 fp8/mxfp8 and both d256 f16 kernels are single-softmax-owner, the d512 kernels run one softmax warpgroup, and sm107 d128/d192 split the softmax but have dedicated P columns — none can race. `sm100/prefill_d256_mxfp8.py` can, and hides the split behind a different role: its `FUSED_CORR_SPLIT_P` schedule (mxfp8 + strict top-left causal, including padded and left-window) hands keys 64–127 to the **correction** warpgroup (`_fused_p1_step`), and half 0 stored P for keys 0–63 into cols 96–111 with nothing ordering it after that warpgroup's S-hi load. (The kernel's dense split-P schedule is safe: both halves meet at a 256-thread named barrier after their loads.)

Random data hides it: the fused warpgroup only lags when it rescales O, and `RESCALE_THRESHOLD` (4 log2 units) makes that rare — 8 random causal/SWA/BR configs (~90M elements, S up to 4096) were clean. Scaling K by 8 per 128-key tile forces a rescale every iteration, and then **every run** produced inf/NaN O and `max|O−ref| ≈ 2` (12/12 fused-causal runs), while the dense control stayed at that input's ~0.13–0.16 quantization floor.

Fix: the release already exists — `_fused_p1_step` arrives `mb_stat_empty` right after `tcgen05.wait::ld` on S-hi — so under `FUSED_CORR_SPLIT_P` half 0 now waits on it immediately before its first P store instead of at the end of the iteration (all three loop variants). No new barrier; non-fused schedules untouched.

## Verification (B200, cuDNN 9.26, FROST opted in)

fp8:
- All previously failing repros pass: exact CI config family (Qwen3.5 geometry, BR causal, s=1013 padded strides), packed strides, s=384, s=1024, e4m3, TOP_LEFT causal, MHA (was 20,091 bad elements). No-mask control still passes.
- Regression sample (96 tests): `test_mhas_v2::test_sdpa_fp8_fwd_L0[test1..48]` — now drawing d=256 — plus `sdpa/suites` `context.fp8.dense`/`context.fp8.thd` `[test1..24]` each: **56 passed, 39 skipped (envelope waives), 1 failed**.
- The one failure, `fp8_fwd_L0[test42]` (d=256, e5m2 in/out, band window 78/423, BOTTOM_RIGHT): **8 of 1.85M elements**, max abs 0.159 vs 0.125, one query row — and it fails **identically on the pre-fix kernel** (A/B by stashing only the kernel file). That is the known e5m2 P-rounding midpoint class (the forward compare has no mismatch budget yet; see #971 / #947), unrelated to this fix.

mxfp8:
- Forced-rescale causal runs (e4m3/e5m2, MHA, S=1024, 4 seeds each): pre-fix `max|O−ref|` 1.75–2.6 with inf/NaN → post-fix 0.10–0.19, all finite (dense control on the same data: 0.13–0.16).
- Random probes (8 configs, ~90M elements) and the full direct `sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py` module (L0+L1) pass unchanged.
- New `test_mxfp8_d256_causal_rescale_every_tile[e4m3|e5m2]` fails on the pre-fix kernel and passes on the fixed one (A/B by stashing only the kernel file).

## Tests

- `test_sdpa_fp8_fwd_L0` now draws `d_qk/d_v` up to **256** (was 192; only the backward sweep drew 256), with `(256, 256)` in the high-probability list — this is how the fp8 defect went unexercised there; the `sdpa/suites` Qwen3.5 fp8 preset found it. `test_sdpa_mxfp8_fwd_L0` gets the same widening.
- `sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py`: `_run(..., k_tile_growth=)` hook + the deterministic forced-rescale regression above.

## AGENTS.md

**Rule S3** (python/cudnn/sdpa/AGENTS.md): when a kernel aliases P into a score slot's tail, the warpgroup that stores into columns another warpgroup still has to read must be ordered after that read. The second commit records the fused-role variant and widens the detector — it keyed on `mb_softmax_max`, which is exactly why it missed the mxfp8 kernel; it now keys on `P_EVEN_OFF` aliasing + any config that can select `SOFTMAX_WARPGROUPS == 2`, and gives the forced-rescale recipe for surfacing the race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved FP8 and MXFP8 attention stability by preventing synchronization-related errors during probability computation.
  - Fixed edge cases involving masked-tail processing, fused corrections, and repeated score rescaling.
  - Improved reliability for ragged packed sequences, including very large batch strides.

- **Testing**
  - Expanded coverage for single-query, lean-attention, FP8, and MXFP8 scenarios across larger hidden dimensions, including D512.
  - Added regression coverage for causal attention, ragged packed sequences, varied masks, and large-memory stride boundaries.
  - Improved test compatibility checks for supported GPU architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->