### PR TITLE
frost(sdpa): add a specialized SM120 D512 F16 prefill kernel

### DIFF
--- a/python/cudnn/frost/README.md
+++ b/python/cudnn/frost/README.md
@@ -322,6 +322,7 @@ python/cudnn/
         sm107/prefill_d128_fp8.py     Rubin siblings (dense K=64 MMA, desc v1)
         sm120/prefill_f16.py          general SM120 template (any head dim)
         sm120/prefill_d256_f16.py     d256 flavor
+        sm120/prefill_d512_f16.py     d512 flavor
         sm120/_common.py              SM120-only warp-level primitives
         _common_blackwell.py      SHARED by sm100/ + sm107/ (cc 100-119), so it
                                   sits ABOVE both rather than inside either

--- a/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
+++ b/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
@@ -358,15 +358,21 @@ Engines: `sdpa_fwd_prefill_sm120`, `sdpa_fwd_prefill_sm120_fp8`,
 kernel picks Q/K and V head tiles independently (f16/bf16 head dims it would
 tile at 256 on both sides run a dedicated template, `sm120/prefill_d256_f16.py` with the same support; fp8 has no such flavor).
 
-| Feature | FPROP<br>d ≤ 256, any ×8 | FPROP FP8<br>d ≤ 256, any ×16 | BPROP<br>d ≤ 256, any ×8 |
+D512 FP16/BF16 FPROP (`sm120/prefill_d512_f16.py`) supports **both D_QK and D_V
+in (256, 512]**, in multiples of 8. It uses a 64 x 32 CTA and 512 x 512 head
+tiles: (512, 512) is **native**; smaller shapes are **envelope-served** by
+zero-padding, with the same MMA and on-chip storage cost.
+FP8 FPROP and BPROP remain limited to 256.
+
+| Feature | FPROP<br>d ≤ 256, any ×8;<br>both dims ∈ (256, 512], any ×8 | FPROP FP8<br>d ≤ 256, any ×16 | BPROP<br>d ≤ 256, any ×8 |
 |---|:--:|:--:|:--:|
 | **Data types** | | | |
 | FP16 / BF16 | ✅ | — | ✅ |
 | FP8 E4M3 / E5M2 (per-tensor) | — | ✅ | ❌ |
 | MXFP8 | ❌ | ❌ | ❌ |
 | O dtype ≠ QKV — **FP8 graphs only** (fp16/bf16/fp8 out) | ❌ | ✅ | — |
-| Rectangular head dims (D_QK ≠ D_V) | ✅ (independent) | ✅ (independent) | ✅ (D_QK ≥ D_V) |
-| Head-dim alignment (actual `D_QK`/`D_V`) | ×8, ≤ 256ᵃ | ×16, ≤ 256ᵃ | ×8, ≤ 256 |
+| Rectangular head dims (D_QK ≠ D_V) | ✅ (independent within each served band) | ✅ (independent) | ✅ (D_QK ≥ D_V) |
+| Head-dim alignment (actual `D_QK`/`D_V`) | ×8, both ≤ 256ᵃ; or both ∈ (256, 512] | ×16, ≤ 256ᵃ | ×8, ≤ 256 |
 | **Layout** | | | |
 | BSHD / `dense_flex` | ✅ / ✅ | ✅ / ✅ | ✅ / ✅ |
 | THD / ragged | ✅ | ✅ | ❌ |
@@ -386,8 +392,8 @@ tile at 256 on both sides run a dedicated template, `sm120/prefill_d256_f16.py` 
 | Decode-shaped (`S_q == 1`) | ✅ | ✅ | ✅ |
 
 ᵃ **Head TILE granule and head-DIM alignment are different numbers — the column
-headers quote the head-dim rule.** `SUPPORTED_HEAD_TILES` steps by 16 (f16) /
-32 (FP8), but those are the kernel's native tile sizes; an actual `D_QK`/`D_V`
+headers quote the head-dim rule.** `GENERAL_HEAD_TILES` steps by 16 (f16), and
+`SUPPORTED_HEAD_TILES_FP8` steps by 32. Those are the kernel's native tile sizes; an actual `D_QK`/`D_V`
 only has to satisfy `d_pad_multiple` — **8** on the f16 row, **16** on the FP8
 row (the TMA 16-byte global-stride rule at 2 and 1 bytes/elem) — and is
 zero-padded up to the next tile. So a d=72 f16 graph is eligible and computes

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -42,12 +42,15 @@ from cudnn.sdpa.fwd.config_sm120 import (
     HEAD_TILE_GRANULE as _SM120_HEAD_TILE_GRANULE,
     SEQ_KV_TILES as _SM120_KV_TILES,
     SEQ_Q_TILES as _SM120_Q_TILES,
-    SUPPORTED_HEAD_TILE_MAX as _SM120_HEAD_TILE_MAX,
+    GENERAL_HEAD_TILE_MAX as _SM120_GENERAL_HEAD_TILE_MAX,
+    FP8_SUPPORTED_HEAD_TILE_MAX as _SM120_FP8_HEAD_TILE_MAX,
     FP8_HEAD_TILE_GRANULE as _SM120_FP8_HEAD_TILE_GRANULE,
     TemplateParams as Sm120TemplateParams,
     D256_FLAVOR as _SM120_D256_FLAVOR,
+    D512_FLAVOR as _SM120_D512_FLAVOR,
     pick_flavor as _sm120_pick_flavor,
     smem_bytes as _sm120_smem_bytes,
+    tile_domain as _sm120_tile_domain,
 )
 
 
@@ -151,7 +154,11 @@ _SM100_TILE_N = 128
 
 # Keyed by kernel flavor (config_sm120.F16_FLAVORS / FP8_FLAVORS); None = the general template. The fp8
 # family has no flavor: every head dim runs its general template.
-_SM120_KERNEL_FILES = {_SM120_D256_FLAVOR: "sm120/prefill_d256_f16.py", None: "sm120/prefill_f16.py"}
+_SM120_KERNEL_FILES = {
+    _SM120_D256_FLAVOR: "sm120/prefill_d256_f16.py",
+    _SM120_D512_FLAVOR: "sm120/prefill_d512_f16.py",
+    None: "sm120/prefill_f16.py",
+}
 _SM120_FP8_KERNEL_FILES = {None: "sm120/prefill_fp8.py"}
 
 
@@ -2709,7 +2716,10 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
     FP16/BF16 MHA, GQA, and MQA; head dimensions in multiples of 8 through
     256 (ENVELOPE: the general template compiles at tiles rounded up to 16 and
     TMA zero-fills the pad columns; head dims inside the d256 flavor's envelope
-    run the d256 template instead, ``config_sm120.pick_flavor``); top-left or
+    run the d256 template instead, ``config_sm120.pick_flavor``) plus independently
+    sized Q/K and V/O head dimensions in (256, 512], in multiples of 8
+    (the d512 template: two warps per Q slab split the head dim,
+    CTA tile (64, 32) only); top-left or
     bottom-right causal masks; left sliding
     windows; optional per-batch query and key/value lengths; optional
     per-Q-head attention-sink logits; and THD (ragged / fully packed
@@ -2718,14 +2728,16 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
 
     ``scale_softmax`` is a runtime parameter. Dtype, shape, tile sizes, masks,
     and length-tensor / sink / THD presence are compile-time specializations.
-    ``tile_m`` / ``tile_n`` are honored on both templates; left unset, both run
-    the largest KV tile that fits (the flavor selects the file, not the tiles).
+    ``tile_m`` / ``tile_n`` are honored on every template within its kernel
+    table (``config_sm120.tile_domain``); left unset, each runs the largest KV
+    tile of that table that fits SMEM.
     """
 
     def _initialize_implementation(self) -> None:
         self.q_tile = _SM120_Q_TILES[0] if self.tile_m is None else self.tile_m
         self.kv_tile = _SM120_KV_TILES[0] if self.tile_n is None else self.tile_n
         self.flavor: Optional[tuple[int, int]] = None
+        self._tile_domain: frozenset[tuple[int, int]] = frozenset()
         self.compute_capability: Optional[tuple[int, int]] = None
         self.head_dim_qk: Optional[int] = None
         self.head_dim_v: Optional[int] = None
@@ -2825,19 +2837,36 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             h_q % h_kv != 0,
             f"H_q ({h_q}) must be divisible by H_kv ({h_kv}) for GQA / MQA",
         )
-        self._value_error_if(
-            d_q % 8 != 0 or not 0 < d_q <= _SM120_HEAD_TILE_MAX,
-            f"D_QK ({d_q}) must be a multiple of 8 (TMA 16-byte global-stride rule at 2 B/elem) and <= {_SM120_HEAD_TILE_MAX}",
-        )
-        self._value_error_if(
-            d_v % 8 != 0 or not 0 < d_v <= _SM120_HEAD_TILE_MAX,
-            f"D_V ({d_v}) must be a multiple of 8 (TMA 16-byte global-stride rule at 2 B/elem) and <= {_SM120_HEAD_TILE_MAX}",
-        )
-
         self.dtype = self._check_dtype(self.q_desc, [torch.float16, torch.bfloat16, *_SM100_FP8_DTYPES], name="Q")
         self._fp8 = self.dtype in _SM100_FP8_DTYPES
         # Kernel flavor (config_sm120.F16_FLAVORS / FP8_FLAVORS); None = the general template.
         self.flavor = _sm120_pick_flavor(int(d_q), int(d_v), self._fp8)
+        # Head dims above the general template's cap exist only where a flavor's
+        # tiles reach (d512: both dims in (256, 512]), so the flavor sets the cap.
+        head_tile_max = _SM120_GENERAL_HEAD_TILE_MAX
+        if self._fp8:
+            head_tile_max = _SM120_FP8_HEAD_TILE_MAX
+        elif self.flavor is not None:
+            head_tile_max = max(head_tile_max, *self.flavor)
+        above_cap = (
+            f" (above {_SM120_GENERAL_HEAD_TILE_MAX}, both head dimensions must be in ({_SM120_GENERAL_HEAD_TILE_MAX}, {_SM120_D512_FLAVOR[0]}])"
+            if not self._fp8 and max(int(d_q), int(d_v)) > _SM120_GENERAL_HEAD_TILE_MAX
+            else ""
+        )
+        self._value_error_if(
+            d_q % 8 != 0 or not 0 < d_q <= head_tile_max,
+            f"D_QK ({d_q}) must be a multiple of 8 (TMA 16-byte global-stride rule at 2 B/elem) and <= {head_tile_max}{above_cap}",
+        )
+        self._value_error_if(
+            d_v % 8 != 0 or not 0 < d_v <= head_tile_max,
+            f"D_V ({d_v}) must be a multiple of 8 (TMA 16-byte global-stride rule at 2 B/elem) and <= {head_tile_max}{above_cap}",
+        )
+        # The kernel table bounds the CTA tiles (d512: (64, 32) alone). An unset
+        # tile_m takes the flavor's Q tile here so the checks below see it; the
+        # KV tile is picked by SMEM fit further down.
+        self._tile_domain = _sm120_tile_domain(int(d_q), int(d_v), self._fp8)
+        if self.tile_m is None and not any(m == self.q_tile for m, _ in self._tile_domain):
+            self.q_tile = max(m for m, _ in self._tile_domain)
         if self.pack_gqa:
             self._not_implemented_error_if(
                 self.thd,
@@ -2918,9 +2947,9 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         arch = f"sm_{self.compute_capability[0]}{self.compute_capability[1]}"
         smem_capacity_bytes = cutlass.utils.get_smem_capacity_in_bytes(arch)
 
-        # SMEM tiles are sized at the ENVELOPE-padded head tiles (rounded up
-        # to the head-tile granule), not the actual dims — the kernel stages
-        # full tiles and the TMA zero-fills the pad columns.
+        # General head dims round to the dtype's granule. The SMEM model also
+        # promotes envelope-served dimensions to their flavor's fixed tiles;
+        # TMA zero-fills the pad columns in those full-sized allocations.
         granule = _SM120_FP8_HEAD_TILE_GRANULE if self._fp8 else _SM120_HEAD_TILE_GRANULE
         d_qp = -(-d_q // granule) * granule
         d_vp = -(-d_v // granule) * granule
@@ -2930,14 +2959,18 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             return _sm120_smem_bytes(d_qp, d_vp, self.q_tile, kv_tile, self.dtype.itemsize, 2 if self._fp8 else self.dtype.itemsize)
 
         if self.tile_n is None:
-            # Pick the largest KV tile that fits this device.
-            self.kv_tile = next((t for t in _SM120_KV_TILES if _smem_bytes(t) <= smem_capacity_bytes), self.kv_tile)
+            # Pick the largest KV tile in the kernel table that fits this device.
+            self.kv_tile = next((t for t in _SM120_KV_TILES if (self.q_tile, t) in self._tile_domain and _smem_bytes(t) <= smem_capacity_bytes), self.kv_tile)
         self._not_implemented_error_if(
             _smem_bytes(self.kv_tile) > smem_capacity_bytes,
             (
                 f"SM120 prefill requires {_smem_bytes(self.kv_tile)} bytes of shared memory for D={d_q}, "
                 f"q_tile={self.q_tile}, and kv_tile={self.kv_tile}, but {arch} provides {smem_capacity_bytes} bytes"
             ),
+        )
+        self._not_implemented_error_if(
+            (self.q_tile, self.kv_tile) not in self._tile_domain,
+            f"SM120 prefill has no kernel for q_tile={self.q_tile}, kv_tile={self.kv_tile} at D=({d_q}, {d_v}); supported: {sorted(self._tile_domain)}",
         )
 
         if self.scale_softmax is None or self.scale_softmax == 0.0:
@@ -3209,7 +3242,10 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             None,  # thd_q_lens / thd_kv_lens / thd_lens_form: THD-only, folded out
             None,
             None,
-            cutlass.Int32(0),  # thd_n_ctas: THD-only persistent grid extent
+            # Persistent grid CTA count (one per SM): the d512 template walks the
+            # dense units over it and prefetches each next Q tile; the general and
+            # d256 templates launch one CTA per unit and ignore it on this path.
+            cutlass.Int32(self._persistent_ctas(q_tensor.device) if self.flavor == _SM120_D512_FLAVOR else 0),
             current_stream,
         )
         if self.split_kv > 1:
@@ -3638,12 +3674,12 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             pack.q_lens_dev,
             pack.kv_lens_dev,
             cutlass.Int32(pack.lens_form),
-            cutlass.Int32(self._thd_persistent_ctas(pack.Q.device)),
+            cutlass.Int32(self._persistent_ctas(pack.Q.device)),
             current_stream,
         )
 
-    def _thd_persistent_ctas(self, device) -> int:
-        """CTA count for the persistent THD grid.
+    def _persistent_ctas(self, device) -> int:
+        """CTA count for a persistent grid (THD on every template, dense on d512).
 
         Sized to the MACHINE, not to the work: the live unit total is a
         device-side quantity (issue #552), a CTA with nothing left to claim just

--- a/python/cudnn/sdpa/fwd/config_sm120.py
+++ b/python/cudnn/sdpa/fwd/config_sm120.py
@@ -12,27 +12,44 @@ from typing import Optional
 from cudnn.frost.tile_dsl.constants import DTYPE_BF16, DTYPE_E4M3, DTYPE_E5M2, DTYPE_FP16  # noqa: F401  (DTYPE_E4M3 re-exported for the FP8 template)
 
 SEQ_Q_TILES = (128, 64)
-SEQ_KV_TILES = (128, 64)
+SEQ_KV_TILES = (128, 64, 32)
 HEAD_TILE_GRANULE = 16
 SUPPORTED_HEAD_TILE_MIN = 16
-SUPPORTED_HEAD_TILE_MAX = 256
-SUPPORTED_HEAD_TILES = tuple(range(SUPPORTED_HEAD_TILE_MIN, SUPPORTED_HEAD_TILE_MAX + 1, HEAD_TILE_GRANULE))
+GENERAL_HEAD_TILE_MAX = 256
+SUPPORTED_HEAD_TILE_MAX = 512
+GENERAL_HEAD_TILES = tuple(range(SUPPORTED_HEAD_TILE_MIN, GENERAL_HEAD_TILE_MAX + 1, HEAD_TILE_GRANULE))
 FP8_HEAD_TILE_GRANULE = 32
-SUPPORTED_HEAD_TILES_FP8 = tuple(range(FP8_HEAD_TILE_GRANULE, SUPPORTED_HEAD_TILE_MAX + 1, FP8_HEAD_TILE_GRANULE))
+FP8_SUPPORTED_HEAD_TILE_MAX = 256
+SUPPORTED_HEAD_TILES_FP8 = tuple(range(FP8_HEAD_TILE_GRANULE, FP8_SUPPORTED_HEAD_TILE_MAX + 1, FP8_HEAD_TILE_GRANULE))
 
 
 D256_FLAVOR = (256, 256)
-F16_FLAVORS: frozenset[tuple[int, int]] = frozenset({D256_FLAVOR})
+D512_FLAVOR = (512, 512)
+D512_TILE = (64, 32)
+GENERAL_KV_TILES = (128, 64)
+F16_FLAVORS: frozenset[tuple[int, int]] = frozenset({D256_FLAVOR, D512_FLAVOR})
 FP8_FLAVORS: frozenset[tuple[int, int]] = frozenset()
 
 
 def pick_flavor(d_qk: int, d_v: int, fp8: bool) -> Optional[tuple[int, int]]:
-    """The flavor whose native head tiles the general template would compile
-    ``(d_qk, d_v)`` at (each dim rounded up at the dtype family's head-tile
-    granule), or ``None`` for the general template."""
+    """Select the fixed-tile flavor for the head dimensions, or the general template."""
+    if not fp8 and GENERAL_HEAD_TILE_MAX < d_qk <= D512_FLAVOR[0] and GENERAL_HEAD_TILE_MAX < d_v <= D512_FLAVOR[1]:
+        return D512_FLAVOR
     granule = FP8_HEAD_TILE_GRANULE if fp8 else HEAD_TILE_GRANULE
     tiles = (-(-d_qk // granule) * granule, -(-d_v // granule) * granule)
     return tiles if tiles in (FP8_FLAVORS if fp8 else F16_FLAVORS) else None
+
+
+def tile_domain(d_qk: int, d_v: int, fp8: bool) -> frozenset[tuple[int, int]]:
+    """The (q_tile, kv_tile) pairs the kernel serving these head dims is built for.
+
+    The d512 flavor has one tile; the general and d256 templates take any Q tile
+    with a 128- or 64-key KV tile. The ranking and the adapter intersect their
+    SMEM fit with this set, so no tile is proposed that declines at build.
+    """
+    if pick_flavor(d_qk, d_v, fp8) == D512_FLAVOR:
+        return frozenset({D512_TILE})
+    return frozenset((m, n) for m in SEQ_Q_TILES for n in GENERAL_KV_TILES)
 
 
 # SMEM the SM120 parts expose to a kernel. The adapter asks cutlass for the
@@ -55,20 +72,34 @@ def register_budgets(q_tile: int) -> tuple[int, int]:
 def smem_bytes(d_qk: int, d_v: int, q_tile: int, kv_tile: int, itemsize: int = 2, out_itemsize: Optional[int] = None) -> int:
     """SMEM the SM120 prefill kernel needs for one specialization.
 
-    One K tile (D_QK wide) plus one V tile (D_V wide), aliased with the
-    q_tile x D_V output staging tile. The two terms size INDEPENDENTLY:
+    The general and D=256 kernels alias one K tile (D_QK wide) plus one V
+    tile (D_V wide) with the q_tile x D_V output staging tile. The two terms size independently:
     ``itemsize`` is the QKV element, ``out_itemsize`` the staged output's, and
     FP8 differs on exactly that (1-byte KV, half-precision O). The f16 D=256
-    kernel also keeps half of its Q tile resident in shared memory.
+    kernel also keeps half of its Q tile resident in shared memory. The f16
+    D=512 kernel keeps a quarter of Q there and adds the fp32 partial-S
+    exchange between the two warps that split each Q slab's head dim. Its O
+    epilogue reuses that Q/exchange storage in two rounds, while the K/V slab
+    receives the next Q tile. It needs a third TMA barrier for those Q loads.
+    Every d512 envelope shape uses the full 512-wide storage on both sides.
 
     Lives here rather than in the adapter because the ranking must not propose
     a tile the kernel cannot fit, and two answers to that question is how a plan
     list fills with entries that decline at build.
     """
-    kv_or_o = max(kv_tile * (d_qk + d_v) * itemsize, q_tile * d_v * (itemsize if out_itemsize is None else out_itemsize))
     flavor = pick_flavor(d_qk, d_v, fp8=itemsize == 1)
-    q_resident = q_tile * (flavor[0] // 2) * itemsize if flavor == D256_FLAVOR else 0
-    return kv_or_o + q_resident + 16
+    if flavor == D512_FLAVOR:
+        d_qk, d_v = D512_FLAVOR
+    kv_or_o = max(kv_tile * (d_qk + d_v) * itemsize, q_tile * d_v * (itemsize if out_itemsize is None else out_itemsize))
+    q_resident = 0
+    exchange = 0
+    if flavor == D256_FLAVOR:
+        q_resident = q_tile * (flavor[0] // 2) * itemsize
+    elif flavor == D512_FLAVOR:
+        q_resident = q_tile * (flavor[0] // 4) * itemsize
+        exchange = q_tile * kv_tile * 4 * 2
+    barrier_bytes = 24 if flavor == D512_FLAVOR else 16
+    return kv_or_o + q_resident + exchange + barrier_bytes
 
 
 @dataclass(frozen=True)

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -1050,7 +1050,7 @@ def _sm80_spec() -> EngineSpec:
 
 
 def _sm120_spec() -> EngineSpec:
-    from cudnn.sdpa.fwd.config_sm120 import SUPPORTED_HEAD_TILES
+    from cudnn.sdpa.fwd.config_sm120 import D512_FLAVOR, GENERAL_HEAD_TILE_MAX, GENERAL_HEAD_TILES
 
     return EngineSpec(
         name="sdpa_fwd_prefill_sm120",
@@ -1058,9 +1058,11 @@ def _sm120_spec() -> EngineSpec:
             sm_lo=_BLACKWELL_GEFORCE[0],
             sm_hi=_BLACKWELL_GEFORCE[1],
             phase="prefill",
-            # The kernel picks its Q/K and V head tiles independently, so the
-            # native shapes are the cross product of the supported tiles.
-            d_shapes=frozenset((tq, tv) for tq in SUPPORTED_HEAD_TILES for tv in SUPPORTED_HEAD_TILES),
+            # The general template picks its Q/K and V head tiles independently,
+            # so the native shapes are the cross product of the supported tiles;
+            # the d512 flavor (sm120/prefill_d512_f16.py) adds its (512, 512).
+            d_shapes=frozenset((tq, tv) for tq in GENERAL_HEAD_TILES for tv in GENERAL_HEAD_TILES) | {D512_FLAVOR},
+            d_envelope_floors=((D512_FLAVOR, GENERAL_HEAD_TILE_MAX),),
             dtypes=frozenset({cudnn.data_type.HALF, cudnn.data_type.BFLOAT16}),
             causal=True,
             bottom_right=True,
@@ -1088,7 +1090,8 @@ def _sm120_spec() -> EngineSpec:
             # split sets ride SCHED_NATURAL.
             split_kv_supported=True,
             tile_ms=frozenset({64, 128}),
-            tile_ns=frozenset({64, 128}),
+            # 32 is the d512 flavor's KV tile alone (config_sm120.tile_domain).
+            tile_ns=frozenset({32, 64, 128}),
             cgas=frozenset({1}),
             pack_gqas=frozenset({False, True}),
         ),

--- a/python/cudnn/sdpa/fwd/heuristics.py
+++ b/python/cudnn/sdpa/fwd/heuristics.py
@@ -62,7 +62,7 @@ from cudnn.sdpa.fwd.config_sm100 import (
     d256_square_br_as_tl,
     pack_gqa_supported,
 )
-from cudnn.sdpa.fwd.config_sm120 import FP8_HEAD_TILE_GRANULE, HEAD_TILE_GRANULE, SMEM_CAPACITY_BYTES, smem_bytes
+from cudnn.sdpa.fwd.config_sm120 import D512_FLAVOR, FP8_HEAD_TILE_GRANULE, HEAD_TILE_GRANULE, SMEM_CAPACITY_BYTES, pick_flavor, smem_bytes, tile_domain
 from cudnn.sdpa.fwd.engines import (
     ENGINE_SPECS,
     Capabilities,
@@ -282,7 +282,7 @@ def _sm120_tiles(caps: Capabilities, facts) -> Tuple[int, int]:
         grid //= 2
     kv_tiles = -(-facts.s_kv // 128)
     fine = sm_count > 0 and (grid * 2 <= sm_count or (grid * 2 <= 3 * sm_count and kv_tiles >= 12))
-    tile_m = 64 if fine else 128
+    preferred_tile_m = 64 if fine else 128
     # FP8 stages a byte per KV element but still writes O in half, so the two
     # SMEM terms size differently -- see config_sm120.smem_bytes. The kernel
     # stages ENVELOPE head tiles (actual dims round up to the granule), so
@@ -292,8 +292,21 @@ def _sm120_tiles(caps: Capabilities, facts) -> Tuple[int, int]:
     granule = FP8_HEAD_TILE_GRANULE if facts.is_fp8 else HEAD_TILE_GRANULE
     d_qp = -(-facts.d_qk // granule) * granule
     d_vp = -(-facts.d_v // granule) * granule
-    fits = [n for n in sorted(caps.tile_ns, reverse=True) if smem_bytes(d_qp, d_vp, tile_m, n, qkv_itemsize, o_itemsize) <= SMEM_CAPACITY_BYTES]
-    return tile_m, (fits[0] if fits else min(caps.tile_ns))
+    # Prefer the selected query tile, then larger query and KV tiles.
+    candidate_tiles = sorted(
+        tile_domain(facts.d_qk, facts.d_v, facts.is_fp8),
+        key=lambda tile: (tile[0] == preferred_tile_m, tile[0], tile[1]),
+        reverse=True,
+    )
+    for m, n in candidate_tiles:
+        if m not in caps.tile_ms or n not in caps.tile_ns:
+            continue
+        if smem_bytes(d_qp, d_vp, m, n, qkv_itemsize, o_itemsize) <= SMEM_CAPACITY_BYTES:
+            return m, n
+    # Nothing fits: fall back to the smallest tile the kernel table admits for
+    # the row, so the decline comes from the SMEM check rather than at build.
+    admitted = [(m, n) for m, n in candidate_tiles if m in caps.tile_ms and n in caps.tile_ns] or candidate_tiles
+    return min(admitted, key=lambda tile: (tile[1], tile[0]))
 
 
 def _tile_points(spec: EngineSpec, facts) -> List[Tuple[Optional[int], Optional[int]]]:
@@ -312,7 +325,13 @@ def _tile_points(spec: EngineSpec, facts) -> List[Tuple[Optional[int], Optional[
     granule = FP8_HEAD_TILE_GRANULE if facts.is_fp8 else HEAD_TILE_GRANULE
     d_qp = -(-facts.d_qk // granule) * granule
     d_vp = -(-facts.d_v // granule) * granule
-    domain = [(m, n) for m in caps.tile_ms for n in caps.tile_ns if smem_bytes(d_qp, d_vp, m, n, qkv_itemsize, o_itemsize) <= SMEM_CAPACITY_BYTES]
+    tile_choices = tile_domain(facts.d_qk, facts.d_v, facts.is_fp8)
+    domain = [
+        (m, n)
+        for m in caps.tile_ms
+        for n in caps.tile_ns
+        if (m, n) in tile_choices and smem_bytes(d_qp, d_vp, m, n, qkv_itemsize, o_itemsize) <= SMEM_CAPACITY_BYTES
+    ]
     return sorted(domain or [best], key=lambda mn: (mn != best, mn[1] != best[1], -mn[0]))
 
 
@@ -348,6 +367,12 @@ def _sched_points(caps: Capabilities, facts) -> List[Optional[int]]:
             primary = SCHED_LPT if 1024 <= facts.s_kv <= 16384 else SCHED_NATURAL
         else:
             primary = SCHED_NATURAL
+    elif causal_ish and _sm120_d512_windowed(caps, facts):
+        # Sliding window on the d512 flavor: a unit's K/V working set is a few
+        # tiles whichever head it belongs to, so LPT_L2's per-KV-group batching
+        # has nothing to protect in L2 and its row order only costs; the plain
+        # heads-fastest LPT walk is the faster one for packed and unpacked units.
+        primary = SCHED_LPT
     elif causal_ish:
         # SM100/SM120: balance the triangular load; pick the LPT variant by
         # whether one head's K+V working set fits the L2 budget.
@@ -539,12 +564,37 @@ def _pack_gqa_tile_q(caps: Capabilities, facts, tile_m: Optional[int], cga: Opti
     return cga_tile_m(512, cga)
 
 
+def _sm120_d512_windowed(caps: Capabilities, facts) -> bool:
+    """An f16 sliding-window graph on the SM120 d512 flavor.
+
+    Two rules key on it. Pack the GQA group into the Q tile: a packed unit holds
+    ``tile_m / G`` tokens, so its key span is that many tokens plus the window
+    instead of ``tile_m`` plus the window, fewer K/V tiles through the L2->SMEM
+    path and less masked-out MMA at the same DRAM bytes. And walk the units with
+    plain LPT (see :func:`_sched_points`). Without a window the decode rule
+    alone decides the packing.
+    """
+    return (
+        caps.sm_lo >= 120
+        and caps.sm_hi < 130
+        and not facts.is_fp8
+        and facts.window_left is not None
+        and pick_flavor(facts.d_qk, facts.d_v, fp8=False) == D512_FLAVOR
+    )
+
+
+def _pack_gqa_eligible(caps: Capabilities, facts, tile_m: int) -> bool:
+    """Whether a packed set can be built at ``tile_m``: the row offers packing,
+    the batch is dense, there is a group to pack and the ratio divides the tile."""
+    return True in caps.pack_gqas and not facts.thd and facts.h_q != facts.h_kv and pack_gqa_supported(facts.h_q, facts.h_kv, tile_m)
+
+
 def _pack_gqa_points(caps: Capabilities, facts, tile_m: int, cga: Optional[int] = None) -> Tuple[bool, ...]:
     """The pack_gqa axis, best first: ``(True, False)`` when packing wins,
     ``(False, True)`` when it is only eligible, ``(False,)`` when it is not."""
-    if not (True in caps.pack_gqas and not facts.thd and facts.h_q != facts.h_kv and pack_gqa_supported(facts.h_q, facts.h_kv, tile_m)):
+    if not _pack_gqa_eligible(caps, facts, tile_m):
         return (False,)
-    if _pack_gqa_wins(facts, _pack_gqa_tile_q(caps, facts, tile_m, cga)):
+    if _pack_gqa_wins(facts, _pack_gqa_tile_q(caps, facts, tile_m, cga)) or _sm120_d512_windowed(caps, facts):
         return (True, False)
     return (False, True)
 

--- a/python/cudnn/sdpa/fwd/kernels/__init__.py
+++ b/python/cudnn/sdpa/fwd/kernels/__init__.py
@@ -11,10 +11,11 @@ owns.  Within a package the filename encodes the rest of the coverage matrix:
 ``<phase>_d<dim>_<dtype-family>.py``, e.g. ``sm100/prefill_d512_f16.py``
 (``f16`` covers fp16 and bf16, picked by ``TemplateParams``).
 
-A file omits the dimension when one implementation covers every supported head
-dim: ``sm120/prefill_f16.py`` and ``sm120/prefill_fp8.py`` do, while
+A file omits the dimension when one implementation covers a range of head
+dims: ``sm120/prefill_f16.py`` and ``sm120/prefill_fp8.py`` do, while
 ``sm120/prefill_d256_f16.py`` is the d256 flavor (head dims that tile at 256 on
-both sides).
+both sides). ``sm120/prefill_d512_f16.py`` serves both head dims in (256, 512]
+at multiples of eight, with two warps per Q slab splitting the head dimension.
 
 Modules shared across arch lines stay at THIS level rather than inside one
 arch's package, so the directory a file lives in always names its only owner:

--- a/python/cudnn/sdpa/fwd/kernels/sm120/prefill_d512_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm120/prefill_d512_f16.py
@@ -1,25 +1,46 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: MIT
 
 """
-A fused multi-head attention (FMHA) FP16/BF16 kernel for the NVIDIA Blackwell
-SM120 family (SM120 and SM121) using TMA K/V loads.
+A fused multi-head attention (FMHA) FP16/BF16 kernel for D=512 heads on the
+NVIDIA Blackwell SM120 family (SM120 and SM121) using TMA K/V loads.
 
-This example demonstrates an implementation of fused multi-head attention using
-SM80-era ``mma.sync.aligned.m16n8k16`` tensor cores and TMA loads for K/V tiles.
-The implementation fuses the Q*K^T matrix multiplication, softmax normalization,
-and softmax(Q*K^T)*V into a single kernel, avoiding intermediate data movement
-through global memory.
+This is the D=512 variant of ``prefill_f16.py``: the same fused Q*K^T,
+softmax, and softmax(Q*K^T)*V pipeline on SM80-era ``mma.sync.aligned.m16n8k16``
+tensor cores, with (512, 512) head tiles. A 16-row Q slab's fp32 O accumulator
+is 16 x 512 / 32 lanes = 256 registers per lane, more than the whole register
+budget, so two warps share every slab and split the head dim: warp ``half``
+owns Q/K columns ``[half*256, half*256+256)`` and the same O/V columns. Each
+warp computes a partial ``S = Q_half @ K_half^T`` over its 256 columns, the two
+partials are summed through shared memory, both warps run the (identical)
+online softmax, and each accumulates its own ``O_half += P @ V_half``. The head
+dim doubles the per-tile MMA work, so the CTA tile is (64, 32): 8 warps, and
+the largest K plus V tile that fits SMEM next to the staged Q fragments and the
+exchange buffer.
 
 The kernel implements key optimizations including:
-- A dedicated load warp that streams K/V tiles into shared memory using TMA and
-  mbarrier completion
-- Q fragments loaded directly from global memory into registers to reduce shared
-  memory footprint
+- All warps compute; an elected lane of warp 0 also issues the K/V TMA loads
+- Dense Q tiles arrive by one TMA copy into the K/V slab (free until the first
+  K/V tile); each warp reads its A fragments with ``ldmatrix`` and a CTA
+  barrier hands the slab to the K/V pipeline. PackGQA tiles use a G-heads x
+  T-tokens box that lands token-major, the kernel's packed row order; THD tiles
+  keep the direct per-lane global loads
+- Dense CTAs are persistent: a machine-sized grid walks the (Q tile, batch,
+  head) units, and the next unit's Q tile is issued as soon as a unit's last
+  K/V tile is consumed, so the Q load overlaps the epilogue; O stages through
+  the idle Q-staging / exchange storage meanwhile
+- Twelve of each warp's sixteen Q d-fragments live in registers, the other four
+  in shared memory and are reloaded once per KV tile
+- One fp32 partial-S exchange per KV tile between the two warps of a slab,
+  single-buffered: the write follows the V-tile wait, and the next V tile is
+  issued only after every warp has consumed the current one, so the partner
+  has always finished reading before the buffer is rewritten
+- Lazy O rescale: the running row max only moves when a tile raises it by more
+  than ``RESCALE_THRESHOLD``, so most KV tiles skip the O correction
 - Online softmax fused into the main loop, with per-lane registers and intra-warp
   threadquad shuffles for max/sum reductions across the 4 lanes that share a Q-row
-- Shared-memory epilogue staging that aliases the K/V buffer after compute warps
-  finish reading the last tile
+- Shared-memory epilogue staging that reuses the Q-staging and exchange storage
+  after compute warps finish reading the last tile
 - MHA, GQA, and MQA head mapping
 - Top-left or bottom-right causal masks, sliding windows, and per-batch lengths
 - Per-row natural-log LSE (softmax stats) output
@@ -30,14 +51,14 @@ The kernel implements key optimizations including:
 
 Constraints:
 - Supported input dtypes: Float16 and BFloat16, output dtype must match input dtype
-- Runtime head dimensions must be multiples of 8 up to 256 (TMA 16-byte
-  global-stride rule); the kernel compiles at head TILES rounded up to 16 and
-  TMA zero-fills the pad columns (the head-dim ENVELOPE)
+- Head tiles are (512, 512): each runtime head dimension is independently in
+  (256, 512], in multiples of 8 (TMA 16-byte global-stride rule); TMA zero-fills
+  the pad columns
 - Q heads must be divisible by the number of K/V heads
 - Q/K/V/O use compact BSHD storage
-- Supported CTA Q/KV tiles are 128 or 64
-- K/V pipeline and output staging storage must fit within the target SM120 SMEM
-  capacity
+- The one supported CTA (Q, KV) tile is (64, 32) (``config_sm120.D512_TILE``)
+- K/V pipeline, staged Q, exchange, and output staging storage must fit within
+  the target SM120 SMEM capacity
 """
 
 from functools import lru_cache, partial
@@ -73,13 +94,15 @@ from cudnn.sdpa.fwd.kernels.sm120._common import (
     nvvm_threadquad_reduction_sum,
     pack_to_i32,
 )
+from cudnn.sdpa.fwd.config_sm100 import rescale_threshold
 from cudnn.sdpa.fwd.config_sm120 import (
-    HEAD_TILE_GRANULE,
+    D512_FLAVOR,
+    D512_TILE,
     SEQ_KV_TILES as _SEQ_KV_TILES,
     SEQ_Q_TILES as _SEQ_Q_TILES,
-    GENERAL_HEAD_TILES as _SUPPORTED_HEAD_TILES,
+    GENERAL_HEAD_TILE_MAX,
     TemplateParams,
-    register_budgets,
+    pick_flavor,
     validate_params,
 )
 
@@ -100,11 +123,6 @@ STORAGE_DTYPE = {DTYPE_FP16: cutlass.Float16, DTYPE_BF16: cutlass.BFloat16}[PARA
 THD_PERSISTENT = True
 
 
-def round_up_head_tile(d: int) -> int:
-    """Round a head dim up to the head-tile granule — the ENVELOPE head tile."""
-    return ceil_div(d, HEAD_TILE_GRANULE) * HEAD_TILE_GRANULE
-
-
 fmul2 = partial(prims.mul_packed_f32x2, ftz=False, rnd=prims.FPRoundingMode.RN)
 fma2 = partial(prims.fma_packed_f32x2, ftz=False, rnd=prims.FPRoundingMode.RN)
 
@@ -119,8 +137,18 @@ class SM120FusedMultiHeadAttentionForward:
 
     SEQ_Q_TILES = _SEQ_Q_TILES
     SEQ_KV_TILES = _SEQ_KV_TILES
-    SUPPORTED_HEAD_TILES = _SUPPORTED_HEAD_TILES
+    SUPPORTED_HEAD_TILES = (512,)
     MMA_TILER = (16, 8, 16)  # mma.sync.aligned.m16n8k16
+    # Warps per 16-row Q slab: each owns one head-dim half of Q/K and of V/O
+    # (config_sm120.smem_bytes, the SMEM model the ranking uses, assumes 2).
+    HEAD_SPLIT = 2
+    # Q d-fragments (of each warp's 16) kept in shared memory: with the warp's
+    # O half (128 fp32) resident, 12 register-resident fragments fit under the
+    # 255-register cap; 4 x 512 B per warp is what SMEM has left.
+    Q_SMEM_FRAGS = 4
+    # Lazy rescale: a tile max at most this far (log2 units of the scaled scores)
+    # above the running row max is not adopted, so the O correction stays 1.0.
+    RESCALE_THRESHOLD = rescale_threshold(PARAMS.dtype_qkv)
 
     @staticmethod
     def is_layout_supported(
@@ -200,11 +228,11 @@ class SM120FusedMultiHeadAttentionForward:
             ``(H, head_stride)`` (FlashAttention's ``softmax_lse`` layout; tokens
             contiguous within a head, ``head_stride >= T``) instead of the default
             token-major ``(T, H)``.
-        :param head_tile_qk: Q/K head TILE (the QK^T contraction width). Must
-            be a multiple of 16 between 16 and 256, inclusive. Runtime head
-            dims may be any multiple of 8 that rounds up to this tile — the
-            TMA descriptors keep the actual extents and zero-fill the pad
-            columns (the head-dim ENVELOPE).
+        :param head_tile_qk: Q/K head TILE (the QK^T contraction width): 512,
+            the one tile this kernel is built for. Runtime head dims may be any
+            multiple of 8 in (256, 512] — the TMA descriptors keep the actual
+            extents and zero-fill the pad columns
+            (the head-dim ENVELOPE).
         :param head_tile_v: V/O head TILE (the P@V output width). Same
             constraint as ``head_tile_qk``.
         :param q_tile: Query sequence tile size.
@@ -253,33 +281,37 @@ class SM120FusedMultiHeadAttentionForward:
         self.kv_tile = kv_tile
         self.pack_gqa = pack_gqa
         self.qh_per_kh = qh_per_kh
+        # Dense Q tiles load by TMA: a row block of one head, or under PackGQA a
+        # G-heads x T-tokens box whose token-major landing order is the packed
+        # row order. THD rows ride the packed token base and keep the per-lane
+        # global loads.
+        self.tma_q = not thd_varlen
+        # Rows of a Q tile per token (PackGQA packs qh_per_kh heads per token).
+        self.q_tile_tokens = q_tile // qh_per_kh if pack_gqa else q_tile
         # KV split: SPLIT_KV CTAs per (q_tile, batch, head), each covering a
         # contiguous slice of that tile's KV-tile range.  1 = off (folds away).
         self.split_kv = split_kv
 
-        # Warp roles
-        if self.q_tile == 128:
-            self.compute_warp_ids = (0, 1, 2, 3, 4, 5, 6, 7)
-            self.load_warp_id = 8
-            self.empty_warp_ids = (9, 10, 11)
-            self.num_warps = 12
-        else:
-            self.compute_warp_ids = (0, 1, 2, 3)
-            self.load_warp_id = 4
-            self.empty_warp_ids = (5, 6, 7)
-            self.num_warps = 8
+        if (self.q_tile, self.kv_tile) != D512_TILE:
+            raise ValueError(f"SM120 SDPA d512 kernel: (q_tile, kv_tile) must be {D512_TILE}; got {(self.q_tile, self.kv_tile)}")
+        if (self.head_tile_qk, self.head_tile_v) != D512_FLAVOR:
+            raise ValueError(f"SM120 SDPA d512 kernel: head tiles must be {D512_FLAVOR}; got {(self.head_tile_qk, self.head_tile_v)}")
+
+        # Warp roles: every warp computes; HEAD_SPLIT warps share each 16-row Q
+        # slab, one head-dim half each.
+        self.compute_warp_ids = (0, 1, 2, 3, 4, 5, 6, 7)
+        self.num_warps = 8
         self.num_compute_warps = len(self.compute_warp_ids)
-        self.num_load_warps = 1
-        self.load_regs, self.compute_regs = register_budgets(self.q_tile)
 
         self.bar_compute_sync = 1
         self.bar_k_consumed = 2
         self.bar_v_consumed = 3
+        # One named barrier per Q slab (ids 4..7) for the partial-S exchange.
+        self.bar_pair_base = 4
 
         self.threads_per_cta = cute.arch.WARP_SIZE * self.num_warps
-        self.threads_load = cute.arch.WARP_SIZE * self.num_load_warps
         self.threads_compute = cute.arch.WARP_SIZE * self.num_compute_warps
-        self.threads_kv_pipeline = self.threads_compute + self.threads_load
+        self.threads_kv_pipeline = self.threads_compute
 
         self._setup_attributes()
 
@@ -289,13 +321,26 @@ class SM120FusedMultiHeadAttentionForward:
         # Tiling
         self.k_tile_elems = self.kv_tile * self.head_tile_qk
         self.v_tile_elems = self.kv_tile * self.head_tile_v
-        self.o_tile_elems = self.q_tile * self.head_tile_v
 
-        # MMA
+        # MMA, per warp: its head-dim half of Q/K (QK^T) and of V/O (P@V).
         self.qk_k_frags = self.kv_tile // self.MMA_TILER[1]
-        self.qk_d_frags = self.head_tile_qk // self.MMA_TILER[2]
+        self.qk_d_frags = self.head_tile_qk // self.HEAD_SPLIT // self.MMA_TILER[2]
         self.pv_v_frags = self.kv_tile // self.MMA_TILER[2]
-        self.pv_d_frags = self.head_tile_v // self.MMA_TILER[1]
+        self.pv_d_frags = self.head_tile_v // self.HEAD_SPLIT // self.MMA_TILER[1]
+        # Element offset of a warp's K/V column half inside the swizzled sK/sV
+        # tile: whole swizzle chunks, and the XOR pattern depends on row % 8 only.
+        self.k_half_elems = self.k_tile_elems // self.HEAD_SPLIT
+        self.v_half_elems = self.v_tile_elems // self.HEAD_SPLIT
+        # Q d-fragments past q_reg_frags stay in shared memory.
+        self.q_smem_frags = self.Q_SMEM_FRAGS
+        self.q_reg_frags = self.qk_d_frags - self.q_smem_frags
+        # SMEM: the K + V tile, the staged Q fragments ([warp][frag][lane][4]
+        # Int32) and the partial-S exchange ([warp][k_frag][lane][4] fp32) --
+        # which the epilogue reuses as O staging -- and the TMA mbarriers.
+        # config_sm120.smem_bytes sizes the same storage for the ranking and
+        # the adapter; the kernel does not keep a second copy of that model.
+        self.q_smem_words = self.num_compute_warps * self.q_smem_frags * 32 * 4
+        self.s_smem_words = self.num_compute_warps * self.qk_k_frags * 32 * 4
 
         # TMA
         def get_swizzle(head_tile: int):
@@ -379,6 +424,94 @@ class SM120FusedMultiHeadAttentionForward:
                 )
 
     @cute.jit
+    def load_q_tile_tma(
+        self,
+        s_dst: cutlass.Array,
+        tma_desc: cutlass.GridConstant[cuda.TensorMap],
+        mbar: cutlass.Array,
+        batch_idx: cutlass.Int32,
+        head_idx: cutlass.Int32,
+        seq_coord: cutlass.Int32,
+        envelope: cutlass.Constexpr[bool],
+    ) -> None:
+        """Launch the TMA load(s) for the whole q_tile x head_tile_qk Q tile into
+        the swizzled K/V slab: same chunk geometry and envelope handling as
+        ``load_one_kv_tile``, with ``q_tile`` rows per swizzle chunk."""
+        chunks = self.k_tma_swizzle_chunks
+        chunk_elems = self.k_swizzle_chunk_elems
+        if prims.elect_sync():
+            if cutlass.const_expr(envelope):
+                prims.mbarrier_arrive_expect_tx(mbar, chunks * tma_desc.global_tx_bytes())
+                for i in cutlass.range_constexpr(chunks):
+                    # Packed descriptors place head before sequence.
+                    coords = (i * chunk_elems, head_idx, seq_coord, batch_idx) if self.pack_gqa else (i * chunk_elems, seq_coord, head_idx, batch_idx)
+                    prims.cp_async_bulk_tensor_shared_cta_global(
+                        s_dst.subview(i * self.q_tile * chunk_elems),
+                        tma_desc.get_ptr(),
+                        coords,
+                        mbar,
+                    )
+            else:
+                prims.mbarrier_arrive_expect_tx(mbar, tma_desc.global_tx_bytes())
+                coords = (0, head_idx, seq_coord, 0, batch_idx) if self.pack_gqa else (0, seq_coord, 0, head_idx, batch_idx)
+                prims.cp_async_bulk_tensor_shared_cta_global(
+                    s_dst,
+                    tma_desc.get_ptr(),
+                    coords,
+                    mbar,
+                )
+
+    @cute.jit
+    def load_q_frags_from_smem(
+        self,
+        basic_params: SimpleNamespace,
+        sKV: cutlass.Array,
+    ) -> cutlass.Array:
+        """Read the warp's Q A-fragments from the TMA-staged tile with ``ldmatrix``.
+
+        The tile is chunk-major in the slab, so the warp's column half is a
+        contiguous swizzled q_tile x head_tile_qk/2 block: half 0 at the slab
+        base, half 1 at ``k_tile_elems``. Same register / shared-memory split
+        and layouts as ``load_q_tile``: the first ``q_reg_frags`` d-fragments
+        land in registers, the rest in the warp's ``sQ`` slots (one 16-byte
+        store per fragment).
+
+        :param basic_params: Lane mapping and the warp's row slab / column half.
+        :param sKV: The K/V slab holding the Q tile.
+        :return: Packed Q fragments arranged for ``mma.sync`` A operands.
+        """
+        q_regs = cutlass.Array(
+            cutlass.Int32,
+            (self.q_reg_frags + 1) * 4,
+            alignment=16,
+        )
+        # ldmatrix.x4 address providers for an A fragment: lanes 0-7 rows 0-7 at
+        # column 0, 8-15 rows 8-15 at column 0, 16-23 rows 0-7 at column 8,
+        # 24-31 rows 8-15 at column 8 -> registers (a0a1, a2a3, a4a5, a6a7).
+        row_in_cta = basic_params.q_warp_row0 + basic_params.lane_mod8 + (basic_params.lane_div8 % 2) * 8
+        col_in_frag = basic_params.lane_div16 * 8
+        chunk_elems = self.k_swizzle_chunk_elems
+        q_smem_base = (basic_params.compute_warp_idx * self.q_smem_frags * 32 + basic_params.lane) * 4
+        # The warp's half starts at element offset 0 or k_tile_elems (the upper
+        # half of the swizzle chunks); columns below are relative to the half.
+        half_base = sKV.data_ptr() + basic_params.half * self.k_tile_elems
+        for d_frag in cutlass.range_constexpr(self.qk_d_frags):
+            col_in_half = d_frag * self.MMA_TILER[2] + col_in_frag
+            chunk = col_in_half // chunk_elems
+            col_in_chunk = col_in_half % chunk_elems
+            physical_row = chunk * self.q_tile + row_in_cta
+            q_ptr = half_base + physical_row * chunk_elems + swizzle_xor(physical_row, col_in_chunk, chunk_elems, self.in_dtype.bytes)
+            frag = prims.ldmatrix(q_ptr, 4, prims.MMALayout.ROW)
+            if cutlass.const_expr(d_frag < self.q_reg_frags):
+                q_regs[d_frag * 4 : 4] = frag
+            else:
+                (basic_params.sQ.data_ptr() + q_smem_base + (d_frag - self.q_reg_frags) * 32 * 4).store(
+                    cutlass.Vector.from_elements((frag[0], frag[1], frag[2], frag[3]), cutlass.Int32),
+                    alignment=16,
+                )
+        return q_regs
+
+    @cute.jit
     def load_q_tile(
         self,
         basic_params: SimpleNamespace,
@@ -389,9 +522,11 @@ class SM120FusedMultiHeadAttentionForward:
             offsets.
         :return: Packed Q fragments arranged for ``mma.sync`` A operands.
         """
+        # One spare fragment slot at the end: mma_qk reloads the upper
+        # d-fragments from shared memory into it.
         q_regs = cutlass.Array(
             cutlass.Int32,
-            self.qk_d_frags * 4,
+            (self.q_reg_frags + 1) * 4,
             alignment=16,
         )
 
@@ -400,9 +535,10 @@ class SM120FusedMultiHeadAttentionForward:
         col0 = (basic_params.lane % 4) * 2
 
         row0_in_cta = basic_params.q_warp_row0 + row0
-        col0_in_cta = col0
+        col0_in_cta = basic_params.q_col_half0 + col0
+        q_smem_base = (basic_params.compute_warp_idx * self.q_smem_frags * 32 + basic_params.lane) * 4
         q_regs_offset = 0
-        for _ in cutlass.range_constexpr(self.qk_d_frags):
+        for d_frag in cutlass.range_constexpr(self.qk_d_frags):
             mma_offsets_in_cta = (
                 (row0_in_cta, col0_in_cta),
                 (row0_in_cta + 8, col0_in_cta),
@@ -419,10 +555,15 @@ class SM120FusedMultiHeadAttentionForward:
                 if cur_q_seq_idx < basic_params.seqlen_q and col_in_cta < basic_params.head_dim_qk:
                     q_pair = (basic_params.q_ptr + basic_params.q_head_off + q_row_off + col_in_cta).load(count=2, alignment=4)
                     q_packed = q_pair.bitcast(cutlass.Int32)[0]
-                q_regs[q_regs_offset + i] = q_packed
+                if cutlass.const_expr(d_frag >= self.q_reg_frags):
+                    # The upper q_smem_frags d-fragments go to shared memory; mma_qk reloads them once per KV tile
+                    basic_params.sQ[q_smem_base + (d_frag - self.q_reg_frags) * 32 * 4 + i] = q_packed
+                else:
+                    q_regs[q_regs_offset + i] = q_packed
 
             col0_in_cta += self.MMA_TILER[2]
-            q_regs_offset += 4
+            if cutlass.const_expr(d_frag < self.q_reg_frags):
+                q_regs_offset += 4
 
         return q_regs
 
@@ -462,6 +603,7 @@ class SM120FusedMultiHeadAttentionForward:
             k_physical_row = k_chunk * self.kv_tile + k_row_in_cta
             k_smem_ptr = (
                 mma_params.sK.data_ptr()
+                + basic_params.k_half_off
                 + k_physical_row * self.k_swizzle_chunk_elems
                 + swizzle_xor(
                     k_physical_row,
@@ -472,10 +614,15 @@ class SM120FusedMultiHeadAttentionForward:
             )
             return prims.ldmatrix(k_smem_ptr, 4, prims.MMALayout.ROW)
 
-        for k_frag_pair in cutlass.range_constexpr(self.qk_k_frags // 2):
-            for d_frag in cutlass.range_constexpr(self.qk_d_frags):
+        q_smem_base = (basic_params.compute_warp_idx * self.q_smem_frags * 32 + basic_params.lane) * 4
+        for d_frag in cutlass.range_constexpr(self.qk_d_frags):
+            q_off = d_frag * 4
+            if cutlass.const_expr(d_frag >= self.q_reg_frags):
+                # Upper d-fragment: reload it from shared memory into the spare slot.
+                q_off = self.q_reg_frags * 4
+                q_regs[q_off:4] = (basic_params.sQ.data_ptr() + q_smem_base + (d_frag - self.q_reg_frags) * 32 * 4).load(count=4, alignment=16)
+            for k_frag_pair in cutlass.range_constexpr(self.qk_k_frags // 2):
                 k_vec = load_k_frag_pair(k_frag_pair, d_frag)
-                q_off = d_frag * 4
                 s_off = (k_frag_pair * 2) * 4
                 s_regs[s_off:4] = mma_m16n8k16_f32(
                     q_regs[q_off + 0],
@@ -594,7 +741,14 @@ class SM120FusedMultiHeadAttentionForward:
                 new_max = cur_max
             else:
                 row_max_prev = row_max[row_half]
-                new_max = cute.arch.fmax(row_max_prev, cur_max)
+                # Only adopt a new row max when it exceeds the old one by more
+                # than RESCALE_THRESHOLD; otherwise old_scale stays exactly 1.0.
+                update = (cur_max - row_max_prev) * softmax_scale_log2 > self.RESCALE_THRESHOLD
+                if row_max_prev == -cutlass.Float32.inf:
+                    update = cur_max > -cutlass.Float32.inf
+                new_max = row_max_prev
+                if update:
+                    new_max = cur_max
                 need_correct = True
                 if cutlass.const_expr(in_mask_steps):
                     need_correct = new_max > -cutlass.Float32.inf
@@ -640,12 +794,15 @@ class SM120FusedMultiHeadAttentionForward:
             else:
                 row_sum[row_half] = row_sum[row_half] * old_scale + tile_sum
 
-                for d_frag in cutlass.range_constexpr(self.pv_d_frags):
-                    o_off = d_frag * 4 + row_half * 2
-                    o_regs[o_off + 0], o_regs[o_off + 1] = fmul2(
-                        (o_regs[o_off + 0], o_regs[o_off + 1]),
-                        (old_scale, old_scale),
-                    )
+                # Skip the O rescale when every lane's correction is 1.0.
+                rescale = ~prims.vote_sync(0xFFFFFFFF, old_scale == cutlass.Float32(1.0), prims.VoteSync.ALL)
+                if rescale:
+                    for d_frag in cutlass.range_constexpr(self.pv_d_frags):
+                        o_off = d_frag * 4 + row_half * 2
+                        o_regs[o_off + 0], o_regs[o_off + 1] = fmul2(
+                            (o_regs[o_off + 0], o_regs[o_off + 1]),
+                            (old_scale, old_scale),
+                        )
 
         return s_regs
 
@@ -678,6 +835,7 @@ class SM120FusedMultiHeadAttentionForward:
             v_physical_row = v_chunk * self.kv_tile + v_row_in_cta
             sV_ptr = (
                 mma_params.sV.data_ptr()
+                + basic_params.v_half_off
                 + v_physical_row * self.v_swizzle_chunk_elems
                 + swizzle_xor(
                     v_physical_row,
@@ -725,6 +883,44 @@ class SM120FusedMultiHeadAttentionForward:
                 )
 
     @cute.jit
+    def exchange_partial_s(
+        self,
+        basic_params: SimpleNamespace,
+        s_regs: cutlass.Array,
+    ) -> None:
+        """Sum the two head-dim halves of ``S`` across the warps of a Q slab.
+
+        Each warp publishes its partial scores in its own ``sX`` slots
+        (``[warp][k_frag][lane][4]``, one 16-byte store per fragment), meets its
+        partner on the slab's named barrier, and adds the partner's slots in
+        place. The buffer is single-buffered: the caller runs this after the V
+        tile's mbarrier wait, and the next V tile is issued only after every
+        warp has consumed the current one, so the partner has finished reading
+        this tile's partials before anyone writes the next tile's.
+
+        :param basic_params: Lane mapping, warp-pair indices, and ``sX``.
+        :param s_regs: This warp's partial QK scores; the full scores on return.
+        """
+        # sX is Int32 storage shared with the Q staging; the fp32 partials
+        # travel as bit patterns (16-byte stores / loads with a vector bitcast).
+        own_base = basic_params.sX.data_ptr() + (basic_params.compute_warp_idx * self.qk_k_frags * 32 + basic_params.lane) * 4
+        partner_base = basic_params.sX.data_ptr() + (basic_params.partner_warp_idx * self.qk_k_frags * 32 + basic_params.lane) * 4
+        for k_frag in cutlass.range_constexpr(self.qk_k_frags):
+            s_off = k_frag * 4
+            (own_base + k_frag * 32 * 4).store(
+                cutlass.Vector.from_elements((s_regs[s_off + 0], s_regs[s_off + 1], s_regs[s_off + 2], s_regs[s_off + 3]), cutlass.Float32).bitcast(
+                    cutlass.Int32
+                ),
+                alignment=16,
+            )
+        prims.barrier_cta_sync(self.bar_pair_base + basic_params.slab, thread_count=self.HEAD_SPLIT * cute.arch.WARP_SIZE)
+        for k_frag in cutlass.range_constexpr(self.qk_k_frags):
+            s_off = k_frag * 4
+            partner = (partner_base + k_frag * 32 * 4).load(count=4, alignment=16).bitcast(cutlass.Float32)
+            for i in cutlass.range_constexpr(4):
+                s_regs[s_off + i] = s_regs[s_off + i] + partner[i]
+
+    @cute.jit
     def compute_one_kv_tile(
         self,
         basic_params: SimpleNamespace,
@@ -758,10 +954,30 @@ class SM120FusedMultiHeadAttentionForward:
             pass
 
         s_regs = self.mma_qk(basic_params, mma_params, q_regs)
-        prims.barrier_cta_arrive(self.bar_k_consumed, self.threads_kv_pipeline)
+        # Warp 0 waits until every warp has read sK, then issues the next K tile's
+        # TMA load while the other warps run softmax.
+        if basic_params.compute_warp_idx == 0:
+            prims.barrier_cta_sync(self.bar_k_consumed, thread_count=self.threads_kv_pipeline)
+            if kv_tile_idx - 1 >= basic_params.min_kv_tile:
+                self.load_one_kv_tile(
+                    mma_params.sK,
+                    basic_params.tma_k_desc,
+                    basic_params.k_tma_mbar,
+                    basic_params.tma_batch_idx,
+                    basic_params.kv_head_idx,
+                    basic_params.kv_row_base + (kv_tile_idx - 1) * self.kv_tile,
+                    is_v=False,
+                    envelope=basic_params.k_envelope,
+                )
+        else:
+            prims.barrier_cta_arrive(self.bar_k_consumed, self.threads_kv_pipeline)
 
         while not prims.mbarrier_try_wait_parity(basic_params.v_tma_mbar, tma_phase):
             pass
+
+        # Full scores = this warp's head-dim half + the partner's. After the V
+        # wait on purpose: see exchange_partial_s for why that keeps sX race-free.
+        self.exchange_partial_s(basic_params, s_regs)
 
         p_regs = self.online_softmax(
             basic_params,
@@ -785,7 +1001,100 @@ class SM120FusedMultiHeadAttentionForward:
                 self.v_swizzle_chunk_elems,
             )
         self.mma_pv(basic_params, mma_params, p_regs)
-        prims.barrier_cta_arrive(self.bar_v_consumed, self.threads_kv_pipeline)
+        if basic_params.compute_warp_idx == 0:
+            prims.barrier_cta_sync(self.bar_v_consumed, thread_count=self.threads_kv_pipeline)
+            if kv_tile_idx - 1 >= basic_params.min_kv_tile:
+                self.load_one_kv_tile(
+                    mma_params.sV,
+                    basic_params.tma_v_desc,
+                    basic_params.v_tma_mbar,
+                    basic_params.tma_batch_idx,
+                    basic_params.kv_head_idx,
+                    basic_params.kv_row_base + (kv_tile_idx - 1) * self.kv_tile,
+                    is_v=True,
+                    envelope=basic_params.v_envelope,
+                )
+        else:
+            prims.barrier_cta_arrive(self.bar_v_consumed, self.threads_kv_pipeline)
+
+    @cute.jit
+    def _dense_unit_coords(
+        self,
+        uid: cutlass.Int32,
+        n_q_tiles: cutlass.Int32,
+        n_batch: cutlass.Int32,
+        n_qh: cutlass.Int32,
+        k: cute.Tensor,
+    ):
+        """Decode a linear dense unit id into ``(q_tile_idx, batch_idx, head_idx,
+        split_idx, o_batch_idx)``.
+
+        LPT / LPT_L2 order the whole unit set globally (heaviest causal rows
+        first). NATURAL walks Q tiles fastest, then the composite batch axis
+        (``batch + split * B`` under KV split), then heads, with the causal Q-tile
+        reversal so the longest diagonal rows launch first.
+        """
+        split_idx = cutlass.Int32(0)
+        if cutlass.const_expr(self.sched_policy != SCHED_NATURAL):
+            if cutlass.const_expr(self.sched_policy == SCHED_LPT_L2):
+                q_tile_idx, head_idx, batch_idx = lpt_l2_tile_coords(
+                    uid,
+                    n_qh,
+                    n_batch,
+                    n_q_tiles,
+                    n_qh // cutlass.Int32(k.shape[2]),
+                    cutlass.Int32(k.shape[1]),
+                    (self.head_tile_qk + self.head_tile_v) * self.in_dtype.width // 8,
+                    SCHED_L2_BUDGET_BYTES,
+                )
+            else:
+                q_tile_idx, head_idx, batch_idx = lpt_tile_coords(uid, n_qh, n_batch, n_q_tiles)
+            o_batch_idx = batch_idx
+        else:
+            q_tile_idx = uid % n_q_tiles
+            rest = uid // n_q_tiles
+            n_by = n_batch * cutlass.Int32(self.split_kv)
+            by = rest % n_by
+            head_idx = rest // n_by
+            batch_idx = by
+            o_batch_idx = by
+            if cutlass.const_expr(self.split_kv > 1):
+                split_idx = by // n_batch
+                batch_idx = by % n_batch
+            if cutlass.const_expr(self.is_causal):
+                # Diagonal-bounded work grows with the Q tile: long tiles first.
+                q_tile_idx = n_q_tiles - 1 - q_tile_idx
+        return q_tile_idx, batch_idx, head_idx, split_idx, o_batch_idx
+
+    @cute.jit
+    def _next_dense_unit(self, unit_idx: cutlass.Int32) -> cutlass.Int32:
+        """The unit this CTA takes after ``unit_idx``: one round of G = grid-size
+        units later.
+
+        Without a sliding window unit costs vary and the scheduler order is
+        heaviest-first, so the walk is boustrophedon: round k hands CTA b unit
+        k*G + b on even rounds and k*G + (G-1-b) on odd ones, and each CTA
+        alternates heavy and light units (a plain stride would hand CTA 0 the
+        heaviest unit of every round). Windowed units cost the same, so there
+        the plain stride k*G + b is used.
+        """
+        gdim, _, _ = cute.arch.grid_dim()
+        if cutlass.const_expr(self.window_size_left is None):
+            rnd = unit_idx // gdim
+            pos = unit_idx - rnd * gdim
+            next_unit = (rnd + cutlass.Int32(1)) * gdim + (gdim - cutlass.Int32(1) - pos)
+        else:
+            next_unit = unit_idx + gdim
+        return next_unit
+
+    @cute.jit
+    def _dense_unit_count(self, q: cute.Tensor, n_q_tiles: cutlass.Int32):
+        """``(n_batch, n_heads, n_units)`` of the dense unit space, as the launch
+        computed it: the head axis is the packed group count under PackGQA and
+        the full Q head count otherwise (``qh_per_kh`` is the GQA ratio either way)."""
+        n_batch = cutlass.Int32(q.shape[0])
+        n_qh = cutlass.Int32(q.shape[2] // self.qh_per_kh if self.pack_gqa else q.shape[2])
+        return n_batch, n_qh, n_q_tiles * n_batch * cutlass.Int32(self.split_kv) * n_qh
 
     @cute.jit
     def _run_unit(
@@ -800,12 +1109,16 @@ class SM120FusedMultiHeadAttentionForward:
         seq_kv_lens,
         tma_k_desc,
         tma_v_desc,
+        tma_q_desc,
         softmax_scale_log2,
         sKV,
         sK,
         sV,
+        sQ,
+        sX,
         k_tma_mbar,
         v_tma_mbar,
+        q_tma_mbar,
         lane,
         warp,
         phase_base,
@@ -814,14 +1127,14 @@ class SM120FusedMultiHeadAttentionForward:
         q_tile_idx,
         batch_idx,
         head_idx,
+        unit_idx,
+        n_q_tiles,
     ) -> cutlass.Int32:
-        """One unit of work: the (Q tile, sequence, head) triple named by the
-        last three arguments.
+        """Compute one (Q tile, sequence, head) unit, optionally within a KV split.
 
-        Split out of ``kernel`` so the persistent THD path can call it once per
-        claimed unit. SMEM and the per-warp register budget belong to the CTA,
-        not to the unit, so they stay in the caller and arrive here as
-        arguments — the same convention ``load_one_kv_tile`` already uses.
+        Dense and THD persistent CTAs call this once per assigned unit. SMEM
+        belongs to the CTA and is reused across units; dense units prefetch
+        the next Q tile while storing the current output.
         """
         q_seq_idx = q_tile_idx * (self.q_tile // self.qh_per_kh if self.pack_gqa else self.q_tile)
 
@@ -917,177 +1230,179 @@ class SM120FusedMultiHeadAttentionForward:
             min_kv_tile = _lo
             num_kv_tiles = _lo + _per + _extra
         has_kv_work = num_kv_tiles > 0 and (num_kv_tiles - 1) >= min_kv_tile
-        # Tiles the load warp will push through the K/V mbarriers for this unit.
+        # Tiles warp 0 will push through the K/V mbarriers for this unit.
         # Branchless on purpose: when has_kv_work is false the difference is
         # already <= 0, so this is exactly zero.
         tiles_loaded = cute.math.max(cutlass.Int32(0), num_kv_tiles - min_kv_tile)
 
+        # THD collapses the packed view's batch coordinate to 0; the
+        # per-sequence token base rides the seq coordinate instead. Every
+        # K/V load (including the first) must apply both, or batch >= 1
+        # reads the wrong packed rows.
+        tma_batch_idx = batch_idx
+        if cutlass.const_expr(self.thd_varlen):
+            tma_batch_idx = cutlass.Int32(0)
         # /////////////////////////////////////////////////////////////////////////////
-        #  LOAD K/V
+        #  COMPUTE (every warp)
         # /////////////////////////////////////////////////////////////////////////////
-        if warp == self.load_warp_id:
-            prims.setmaxregister(self.load_regs, prims.SetMaxRegisterAction.DECREASE)
+        compute_warp_idx = warp
+        # Warp pair: slab = the 16-row Q slab, half = the head-dim half of Q/K
+        # and V/O this warp owns; the partner is the slab's other half.
+        slab = warp // self.HEAD_SPLIT
+        half = warp % self.HEAD_SPLIT
+        partner_warp_idx = slab * self.HEAD_SPLIT + (self.HEAD_SPLIT - 1 - half)
+        q_warp_row0 = slab * self.MMA_TILER[0]
+        q_col_half0 = half * (self.head_tile_qk // self.HEAD_SPLIT)
+        v_col_half0 = half * (self.head_tile_v // self.HEAD_SPLIT)
+        k_half_off = half * self.k_half_elems
+        v_half_off = half * self.v_half_elems
 
-            # THD collapses the packed view's batch coordinate to 0; the
-            # per-sequence token base rides the seq coordinate instead. Every
-            # K/V load (including the first) must apply both, or batch >= 1
-            # reads the wrong packed rows.
-            tma_batch_idx = batch_idx
-            if cutlass.const_expr(self.thd_varlen):
-                tma_batch_idx = cutlass.Int32(0)
+        lane_div8 = lane // 8
+        lane_mod8 = lane % 8
+        lane_div16 = lane // 16
 
-            # The attention loop walks K/V tiles right-to-left so causal and
-            # tail-masked tiles are processed before fully unmasked tiles.
+        # Per-lane row_max and row_sum for online softmax. Each lane owns
+        # two Q rows: lane//4 and lane//4 + 8 within this compute warp.
+        row_max = cutlass.Array(cutlass.Float32, 2, alignment=16)
+        row_sum = cutlass.Array(cutlass.Float32, 2, alignment=16)
+        for i in cutlass.range_constexpr(2):
+            row_max[i] = -cutlass.Float32.inf
+            row_sum[i] = 0.0
+
+        # Per-lane fp32 accumulator for O = P @ V.
+        o_regs = cutlass.Array(
+            cutlass.Float32,
+            self.pv_d_frags * 4,
+            alignment=16,
+        )
+        for i in cutlass.range_constexpr(self.pv_d_frags * 4):
+            o_regs[i] = 0.0
+
+        basic_params = SimpleNamespace(
+            phase_base=phase_base,
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            head_dim_qk=head_dim_qk,
+            q_ptr=q_ptr,
+            batch_idx=batch_idx,
+            head_idx=head_idx,
+            q_seq_idx=q_seq_idx,
+            q_head_off=q_head_off,
+            q_seq_stride=q_seq_stride,
+            q_head_stride=q_head_stride,
+            q_warp_row0=q_warp_row0,
+            lane=lane,
+            lane_div8=lane_div8,
+            lane_mod8=lane_mod8,
+            lane_div16=lane_div16,
+            tma_k_desc=tma_k_desc,
+            tma_v_desc=tma_v_desc,
+            k_tma_mbar=k_tma_mbar,
+            v_tma_mbar=v_tma_mbar,
+            sQ=sQ,
+            sX=sX,
+            compute_warp_idx=compute_warp_idx,
+            slab=slab,
+            half=half,
+            partner_warp_idx=partner_warp_idx,
+            q_col_half0=q_col_half0,
+            k_half_off=k_half_off,
+            v_half_off=v_half_off,
+            tma_batch_idx=tma_batch_idx,
+            kv_head_idx=kv_head_idx,
+            kv_row_base=kv_row_base,
+            min_kv_tile=min_kv_tile,
+            k_envelope=k_envelope,
+            v_envelope=v_envelope,
+        )
+        mma_params = SimpleNamespace(
+            sK=sK,
+            sV=sV,
+            o_regs=o_regs,
+        )
+        softmax_params = SimpleNamespace(
+            row_max=row_max,
+            row_sum=row_sum,
+            softmax_scale_log2=softmax_scale_log2,
+        )
+
+        kv_seq_idx = cutlass.Int32(0)
+        if cutlass.const_expr(self.tma_q):
+            # Dense: the Q tile rides the K/V slab, free until the first K/V tile.
+            # Its TMA copy is already in flight, issued by the previous unit's
+            # epilogue (the kernel prologue for a CTA's first unit); every warp
+            # reads its A fragments with ldmatrix, and the CTA barrier hands the
+            # slab to the K/V pipeline.
             kv_seq_idx = (num_kv_tiles - 1) * self.kv_tile
-            if has_kv_work:
-                self.load_one_kv_tile(
-                    sK,
-                    tma_k_desc,
-                    k_tma_mbar,
-                    tma_batch_idx,
-                    kv_head_idx,
-                    kv_row_base + kv_seq_idx,
-                    is_v=False,
-                    envelope=k_envelope,
-                )
-                self.load_one_kv_tile(
-                    sV,
-                    tma_v_desc,
-                    v_tma_mbar,
-                    tma_batch_idx,
-                    kv_head_idx,
-                    kv_row_base + kv_seq_idx,
-                    is_v=True,
-                    envelope=v_envelope,
-                )
+            # The Q mbarrier completes once per unit: its parity is the parity of
+            # the CTA's round (unit_idx // grid size).
+            _gdim, _, _ = cute.arch.grid_dim()
+            q_parity = (unit_idx // _gdim) & cutlass.Int32(1)
+            while not prims.mbarrier_try_wait_parity(q_tma_mbar, q_parity):
+                pass
+            q_regs = self.load_q_frags_from_smem(basic_params, sKV)
+            prims.barrier_cta_sync(self.bar_compute_sync, thread_count=self.threads_compute)
 
-                kv_seq_idx -= self.kv_tile
-                while kv_seq_idx >= min_kv_tile * self.kv_tile:
-                    prims.barrier_cta_sync(
-                        self.bar_k_consumed,
-                        thread_count=self.threads_kv_pipeline,
-                    )
-                    self.load_one_kv_tile(
-                        sK,
-                        tma_k_desc,
-                        k_tma_mbar,
-                        tma_batch_idx,
-                        kv_head_idx,
-                        kv_row_base + kv_seq_idx,
-                        is_v=False,
-                        envelope=k_envelope,
-                    )
+        # Warp 0 issues the first K/V tile's TMA loads; compute_one_kv_tile
+        # issues the rest.
+        if warp == 0 and has_kv_work:
+            if cutlass.const_expr(not self.tma_q):
+                kv_seq_idx = (num_kv_tiles - 1) * self.kv_tile
+            self.load_one_kv_tile(sK, tma_k_desc, k_tma_mbar, tma_batch_idx, kv_head_idx, kv_row_base + kv_seq_idx, is_v=False, envelope=k_envelope)
+            self.load_one_kv_tile(sV, tma_v_desc, v_tma_mbar, tma_batch_idx, kv_head_idx, kv_row_base + kv_seq_idx, is_v=True, envelope=v_envelope)
 
-                    prims.barrier_cta_sync(
-                        self.bar_v_consumed,
-                        thread_count=self.threads_kv_pipeline,
-                    )
-                    self.load_one_kv_tile(
-                        sV,
-                        tma_v_desc,
-                        v_tma_mbar,
-                        tma_batch_idx,
-                        kv_head_idx,
-                        kv_row_base + kv_seq_idx,
-                        is_v=True,
-                        envelope=v_envelope,
-                    )
-                    kv_seq_idx -= self.kv_tile
-                # Consume the LAST tile's consumer arrivals. compute_one_kv_tile
-                # arrives at both barriers for every tile it processes (N), but
-                # the loop above only syncs between tiles (N-1), so without this
-                # each pass leaves one unmatched arrival pending on each barrier.
-                # That is invisible while a CTA runs a single tile range -- the
-                # leftover dies with the CTA -- but a CTA that starts a SECOND
-                # range finds the barrier already part-signalled, satisfies its
-                # first sync immediately, and issues the next
-                # mbarrier.arrive.expect_tx while the previous transaction is
-                # still outstanding.
-                prims.barrier_cta_sync(self.bar_k_consumed, thread_count=self.threads_kv_pipeline)
-                prims.barrier_cta_sync(self.bar_v_consumed, thread_count=self.threads_kv_pipeline)
-        # /////////////////////////////////////////////////////////////////////////////
-        #  COMPUTE
-        # /////////////////////////////////////////////////////////////////////////////
-        elif warp < self.load_warp_id:
-            prims.setmaxregister(self.compute_regs, prims.SetMaxRegisterAction.INCREASE)
-
-            compute_warp_idx = warp
-            q_warp_row0 = compute_warp_idx * self.MMA_TILER[0]
-
-            lane_div8 = lane // 8
-            lane_mod8 = lane % 8
-            lane_div16 = lane // 16
-
-            # Per-lane row_max and row_sum for online softmax. Each lane owns
-            # two Q rows: lane//4 and lane//4 + 8 within this compute warp.
-            row_max = cutlass.Array(cutlass.Float32, 2, alignment=16)
-            row_sum = cutlass.Array(cutlass.Float32, 2, alignment=16)
-            for i in cutlass.range_constexpr(2):
-                row_max[i] = -cutlass.Float32.inf
-                row_sum[i] = 0.0
-
-            # Per-lane fp32 accumulator for O = P @ V.
-            o_regs = cutlass.Array(
-                cutlass.Float32,
-                self.pv_d_frags * 4,
-                alignment=16,
-            )
-            for i in cutlass.range_constexpr(self.pv_d_frags * 4):
-                o_regs[i] = 0.0
-
-            basic_params = SimpleNamespace(
-                phase_base=phase_base,
-                seqlen_q=seqlen_q,
-                seqlen_k=seqlen_k,
-                head_dim_qk=head_dim_qk,
-                q_ptr=q_ptr,
-                batch_idx=batch_idx,
-                head_idx=head_idx,
-                q_seq_idx=q_seq_idx,
-                q_head_off=q_head_off,
-                q_seq_stride=q_seq_stride,
-                q_head_stride=q_head_stride,
-                q_warp_row0=q_warp_row0,
-                lane=lane,
-                lane_div8=lane_div8,
-                lane_mod8=lane_mod8,
-                lane_div16=lane_div16,
-                tma_k_desc=tma_k_desc,
-                tma_v_desc=tma_v_desc,
-                k_tma_mbar=k_tma_mbar,
-                v_tma_mbar=v_tma_mbar,
-            )
-            mma_params = SimpleNamespace(
-                sK=sK,
-                sV=sV,
-                o_regs=o_regs,
-            )
-            softmax_params = SimpleNamespace(
-                row_max=row_max,
-                row_sum=row_sum,
-                softmax_scale_log2=softmax_scale_log2,
-            )
-
-            # Load Q into registers.
+        # Load Q into registers.
+        if cutlass.const_expr(not self.tma_q):
             q_regs = self.load_q_tile(basic_params)
 
-            # Main attention loop.
-            mask_steps = 1
-            if cutlass.const_expr(self.is_causal):
-                mask_steps = ceil_div(self.q_tile // self.qh_per_kh if self.pack_gqa else self.q_tile, self.kv_tile)
-                if cutlass.const_expr(self.diag_shifted):
-                    # A translated diagonal (bottom-right anchoring or a right
-                    # band) can straddle one additional KV tile; the frontier
-                    # width itself is R-independent — the band only translates
-                    # the diagonal.
-                    mask_steps = ceil_div((self.q_tile // self.qh_per_kh if self.pack_gqa else self.q_tile) + self.kv_tile - 1, self.kv_tile)
-            left_mask_steps = 1
-            if cutlass.const_expr(self.window_size_left is not None):
-                left_mask_steps = ceil_div((self.q_tile // self.qh_per_kh if self.pack_gqa else self.q_tile) + self.kv_tile - 1, self.kv_tile)
+        # Main attention loop.
+        mask_steps = 1
+        if cutlass.const_expr(self.is_causal):
+            mask_steps = ceil_div(self.q_tile // self.qh_per_kh if self.pack_gqa else self.q_tile, self.kv_tile)
+            if cutlass.const_expr(self.diag_shifted):
+                # A translated diagonal (bottom-right anchoring or a right
+                # band) can straddle one additional KV tile; the frontier
+                # width itself is R-independent — the band only translates
+                # the diagonal.
+                mask_steps = ceil_div((self.q_tile // self.qh_per_kh if self.pack_gqa else self.q_tile) + self.kv_tile - 1, self.kv_tile)
+        left_mask_steps = 1
+        if cutlass.const_expr(self.window_size_left is not None):
+            left_mask_steps = ceil_div((self.q_tile // self.qh_per_kh if self.pack_gqa else self.q_tile) + self.kv_tile - 1, self.kv_tile)
 
-            kv_tile_idx = num_kv_tiles - 1
-            # Phase 1: potentially masked iterations.
-            for step in cutlass.range_constexpr(mask_steps):
+        kv_tile_idx = num_kv_tiles - 1
+        # Phase 1: potentially masked iterations.
+        for step in cutlass.range_constexpr(mask_steps):
+            if kv_tile_idx >= min_kv_tile:
+                self.compute_one_kv_tile(
+                    basic_params,
+                    mma_params,
+                    softmax_params,
+                    q_regs,
+                    num_kv_tiles,
+                    kv_tile_idx,
+                    in_mask_steps=True,
+                    is_first_kv_tile=(step == 0),
+                )
+            kv_tile_idx -= 1
+
+        # Phase 2: remaining fully unmasked iterations.
+        while kv_tile_idx > min_kv_tile + (left_mask_steps - 1):
+            self.compute_one_kv_tile(
+                basic_params,
+                mma_params,
+                softmax_params,
+                q_regs,
+                num_kv_tiles,
+                kv_tile_idx,
+                in_mask_steps=False,
+                is_first_kv_tile=False,
+            )
+            kv_tile_idx -= 1
+
+        # The sliding-window left edge sweeps across the Q tile and can
+        # therefore cut through more than one K/V tile.
+        if cutlass.const_expr(self.window_size_left is not None):
+            for _ in cutlass.range_constexpr(left_mask_steps):
                 if kv_tile_idx >= min_kv_tile:
                     self.compute_one_kv_tile(
                         basic_params,
@@ -1097,12 +1412,15 @@ class SM120FusedMultiHeadAttentionForward:
                         num_kv_tiles,
                         kv_tile_idx,
                         in_mask_steps=True,
-                        is_first_kv_tile=(step == 0),
+                        is_first_kv_tile=False,
                     )
                 kv_tile_idx -= 1
-
-            # Phase 2: remaining fully unmasked iterations.
-            while kv_tile_idx > min_kv_tile + (left_mask_steps - 1):
+        else:
+            # Guard against the split's START, not 0. Without KV split
+            # min_kv_tile is 0 on this branch so the two agree, but a split
+            # begins partway into the KV range -- and warp 0 bounds the K/V
+            # refills it issues by min_kv_tile.
+            if kv_tile_idx >= min_kv_tile:
                 self.compute_one_kv_tile(
                     basic_params,
                     mma_params,
@@ -1113,186 +1431,174 @@ class SM120FusedMultiHeadAttentionForward:
                     in_mask_steps=False,
                     is_first_kv_tile=False,
                 )
-                kv_tile_idx -= 1
 
-            # The sliding-window left edge sweeps across the Q tile and can
-            # therefore cut through more than one K/V tile.
-            if cutlass.const_expr(self.window_size_left is not None):
-                for _ in cutlass.range_constexpr(left_mask_steps):
-                    if kv_tile_idx >= min_kv_tile:
-                        self.compute_one_kv_tile(
-                            basic_params,
-                            mma_params,
-                            softmax_params,
-                            q_regs,
-                            num_kv_tiles,
-                            kv_tile_idx,
-                            in_mask_steps=True,
-                            is_first_kv_tile=False,
-                        )
-                    kv_tile_idx -= 1
+        # Per-row O normalization factor and natural-log LSE.
+        # The thread-quad reductions left row_max / row_sum replicated across
+        # the four lanes that share a Q row, so every lane finalizes the two
+        # rows it owns without further exchange. row_max holds the raw (unscaled)
+        # score max; the scale is applied in log2 domain and converted with ln(2).
+        # With has_sink, the per-head sink logit joins the softmax denominator
+        # as a virtual column with no V row: it rescales O, enters the LSE,
+        # and gives a row with no visible key a finite LSE (the sink alone).
+        LN2 = cutlass.Float32(0.6931471805599453)
+        row_sum_inv = cutlass.Array(cutlass.Float32, 2, alignment=8)
+        row_lse = cutlass.Array(cutlass.Float32, 2, alignment=8)
+        for row_half in cutlass.range_constexpr(2):
+            row_max_nat = row_max[row_half] * softmax_scale_log2 * LN2
+            if cutlass.const_expr(self.has_sink):
+                sinks_arr = cutlass.make_array_view(sinks)
+                _sink_head = q_head_base if cutlass.const_expr(not self.pack_gqa) else q_head_base + (q_warp_row0 + (lane // 4) + row_half * 8) % self.qh_per_kh
+                sink_logit = cutlass.Float32(sinks_arr[_sink_head])
+                new_max = cute.arch.fmax(row_max_nat, sink_logit)
+                # alpha re-normalizes the loop's accumulator and sum from
+                # row_max_nat to the sink-extended max; it is 0 for a row
+                # with no visible key, so O := 0 falls out.
+                alpha = cute.math.exp(row_max_nat - new_max, fastmath=True)
+                new_sum = row_sum[row_half] * alpha + cute.math.exp(sink_logit - new_max, fastmath=True)
+                row_sum_inv[row_half] = alpha / new_sum
+                row_lse[row_half] = new_max + cute.math.log(new_sum, fastmath=True)
             else:
-                # Guard against the split's START, not 0. Without KV split
-                # min_kv_tile is 0 on this branch so the two agree, but a split
-                # begins partway into the KV range -- and the load warp bounds
-                # its loop by min_kv_tile, so testing >= 0 here makes the compute
-                # warps run one tile the loader never fetches and the CTA
-                # deadlocks on the TMA barrier.
-                if kv_tile_idx >= min_kv_tile:
-                    self.compute_one_kv_tile(
-                        basic_params,
-                        mma_params,
-                        softmax_params,
-                        q_regs,
-                        num_kv_tiles,
-                        kv_tile_idx,
-                        in_mask_steps=False,
-                        is_first_kv_tile=False,
-                    )
+                inv = cutlass.Float32(0.0)
+                if row_sum[row_half] > 0.0:
+                    inv = cute.math.rcp(row_sum[row_half], approx=True, ftz=True)
+                row_sum_inv[row_half] = inv
+                lse_val = row_max_nat + cute.math.log(
+                    cute.math.max(row_sum[row_half], cutlass.Float32(1e-30)),
+                    fastmath=True,
+                )
+                # Rows with no visible key write -inf / O := 0.
+                if row_sum[row_half] <= 0.0:
+                    lse_val = -cutlass.Float32.inf
+                row_lse[row_half] = lse_val
 
-            # Per-row O normalization factor and natural-log LSE.
-            # The thread-quad reductions left row_max / row_sum replicated across
-            # the four lanes that share a Q row, so every lane finalizes the two
-            # rows it owns without further exchange. row_max holds the raw (unscaled)
-            # score max; the scale is applied in log2 domain and converted with ln(2).
-            # With has_sink, the per-head sink logit joins the softmax denominator
-            # as a virtual column with no V row: it rescales O, enters the LSE,
-            # and gives a row with no visible key a finite LSE (the sink alone).
-            LN2 = cutlass.Float32(0.6931471805599453)
-            row_sum_inv = cutlass.Array(cutlass.Float32, 2, alignment=8)
-            row_lse = cutlass.Array(cutlass.Float32, 2, alignment=8)
-            for row_half in cutlass.range_constexpr(2):
-                row_max_nat = row_max[row_half] * softmax_scale_log2 * LN2
-                if cutlass.const_expr(self.has_sink):
-                    sinks_arr = cutlass.make_array_view(sinks)
-                    _sink_head = (
-                        q_head_base if cutlass.const_expr(not self.pack_gqa) else q_head_base + (q_warp_row0 + (lane // 4) + row_half * 8) % self.qh_per_kh
-                    )
-                    sink_logit = cutlass.Float32(sinks_arr[_sink_head])
-                    new_max = cute.arch.fmax(row_max_nat, sink_logit)
-                    # alpha re-normalizes the loop's accumulator and sum from
-                    # row_max_nat to the sink-extended max; it is 0 for a row
-                    # with no visible key, so O := 0 falls out.
-                    alpha = cute.math.exp(row_max_nat - new_max, fastmath=True)
-                    new_sum = row_sum[row_half] * alpha + cute.math.exp(sink_logit - new_max, fastmath=True)
-                    row_sum_inv[row_half] = alpha / new_sum
-                    row_lse[row_half] = new_max + cute.math.log(new_sum, fastmath=True)
-                else:
-                    inv = cutlass.Float32(0.0)
-                    if row_sum[row_half] > 0.0:
-                        inv = cute.math.rcp(row_sum[row_half], approx=True, ftz=True)
-                    row_sum_inv[row_half] = inv
-                    lse_val = row_max_nat + cute.math.log(
-                        cute.math.max(row_sum[row_half], cutlass.Float32(1e-30)),
-                        fastmath=True,
-                    )
-                    # Rows with no visible key write -inf / O := 0.
-                    if row_sum[row_half] <= 0.0:
-                        lse_val = -cutlass.Float32.inf
-                    row_lse[row_half] = lse_val
+        if cutlass.const_expr(lse is not None):
+            # Both warps of a slab hold the same stats; the half-0 warp stores them.
+            if half == 0 and lane % 4 == 0:
+                lse_arr = cutlass.make_array_view(lse)
+                for row_half in cutlass.range_constexpr(2):
+                    _lse_row_in_cta = q_warp_row0 + (lane // 4) + row_half * 8
+                    lse_q_idx = q_seq_idx + (_lse_row_in_cta if cutlass.const_expr(not self.pack_gqa) else _lse_row_in_cta // self.qh_per_kh)
+                    _lse_head = q_head_base if cutlass.const_expr(not self.pack_gqa) else q_head_base + _lse_row_in_cta % self.qh_per_kh
+                    lse_out = cutlass.Float32(row_lse[row_half])
+                    if cutlass.const_expr(self.thd_varlen):
+                        # Packed ragged-Stats LSE, written directly in the
+                        # caller's declared layout: token-major (T, H) or
+                        # head-major (H, head_stride).
+                        # Rows past this sequence's Q length belong to the
+                        # NEXT sequence — never written, and there is no
+                        # padded region to trim.
+                        if lse_q_idx < seqlen_q:
+                            if cutlass.const_expr(self.thd_lse_head_major):
+                                lse_row = lse_arr[_lse_head, :]
+                                lse_row[q_row_base + lse_q_idx] = lse_out
+                            else:
+                                lse_row = lse_arr[q_row_base + lse_q_idx, :]
+                                lse_row[_lse_head] = lse_out
+                    else:
+                        # Rows at/past this batch's Q length trim to -inf.
+                        if lse_q_idx >= seqlen_q:
+                            lse_out = -cutlass.Float32.inf
+                        if lse_q_idx < q.shape[1]:
+                            lse_arr[o_batch_idx, _lse_head, lse_q_idx] = lse_out
 
-            if cutlass.const_expr(lse is not None):
-                if lane % 4 == 0:
-                    lse_arr = cutlass.make_array_view(lse)
-                    for row_half in cutlass.range_constexpr(2):
-                        _lse_row_in_cta = q_warp_row0 + (lane // 4) + row_half * 8
-                        lse_q_idx = q_seq_idx + (_lse_row_in_cta if cutlass.const_expr(not self.pack_gqa) else _lse_row_in_cta // self.qh_per_kh)
-                        _lse_head = q_head_base if cutlass.const_expr(not self.pack_gqa) else q_head_base + _lse_row_in_cta % self.qh_per_kh
-                        lse_out = cutlass.Float32(row_lse[row_half])
-                        if cutlass.const_expr(self.thd_varlen):
-                            # Packed ragged-Stats LSE, written directly in the
-                            # caller's declared layout: token-major (T, H) or
-                            # head-major (H, head_stride).
-                            # Rows past this sequence's Q length belong to the
-                            # NEXT sequence — never written, and there is no
-                            # padded region to trim.
-                            if lse_q_idx < seqlen_q:
-                                if cutlass.const_expr(self.thd_lse_head_major):
-                                    lse_row = lse_arr[_lse_head, :]
-                                    lse_row[q_row_base + lse_q_idx] = lse_out
-                                else:
-                                    lse_row = lse_arr[q_row_base + lse_q_idx, :]
-                                    lse_row[_lse_head] = lse_out
-                        else:
-                            # Rows at/past this batch's Q length trim to -inf.
-                            if lse_q_idx >= seqlen_q:
-                                lse_out = -cutlass.Float32.inf
-                            if lse_q_idx < q.shape[1]:
-                                lse_arr[o_batch_idx, _lse_head, lse_q_idx] = lse_out
+        prims.barrier_cta_sync(self.bar_compute_sync, thread_count=self.threads_compute)
 
-            prims.barrier_cta_sync(self.bar_compute_sync, thread_count=self.threads_compute)
+        if cutlass.const_expr(self.tma_q):
+            # Every warp is past its last K/V wait and no K/V copy is in flight, so
+            # the K/V mbarriers are re-armed for the next unit: its tile parity
+            # restarts at 0 and no phase count crosses the unit boundary. The
+            # unit-end CTA barrier orders the re-arm before the next unit's waits.
+            if compute_warp_idx == 0:
+                if prims.elect_sync():
+                    prims.mbarrier_inval(k_tma_mbar)
+                    prims.mbarrier_inval(v_tma_mbar)
+                    prims.mbarrier_init(k_tma_mbar, 1)
+                    prims.mbarrier_init(v_tma_mbar, 1)
+                prims.fence_mbarrier_init()
+            next_unit = self._next_dense_unit(unit_idx)
+            _n_batch, _n_qh, n_units = self._dense_unit_count(q, n_q_tiles)
+            if compute_warp_idx == 0 and next_unit < n_units:
+                next_q_tile_idx, next_batch_idx, next_head_idx, _, _ = self._dense_unit_coords(next_unit, n_q_tiles, _n_batch, _n_qh, k)
+                next_q_seq_idx = next_q_tile_idx * cutlass.Int32(self.q_tile_tokens)
+                next_q_head_base = next_head_idx * cutlass.Int32(self.qh_per_kh if self.pack_gqa else 1)
+                self.load_q_tile_tma(sKV, tma_q_desc, q_tma_mbar, next_batch_idx, next_q_head_base, next_q_seq_idx, envelope=k_envelope)
 
-            # Epilogue: normalize O, stage it through an stmatrix-friendly SMEM
-            # layout, then store one contiguous 8-element vector per lane to GMEM.
-            sO = sKV
-            row_sum_inv_vec = cutlass.Vector.from_elements(
-                (
-                    row_sum_inv[0],
-                    row_sum_inv[0],
-                    row_sum_inv[1],
-                    row_sum_inv[1],
-                    row_sum_inv[0],
-                    row_sum_inv[0],
-                    row_sum_inv[1],
-                    row_sum_inv[1],
-                ),
-                cutlass.Float32,
-            )
-            for d_frag_pair in cutlass.range_constexpr(self.pv_d_frags // 2):
+        # Epilogue: normalize O, stage it through an stmatrix-friendly SMEM
+        # layout, then store one contiguous 8-element vector per lane to GMEM.
+        # The K/V slab may be receiving the next unit's Q tile, so O stages
+        # through the idle sQ/sX storage: Int32 words, 4 KB per warp, in two
+        # rounds of half the d-fragment pairs (16 x 16 elements = 128 words per
+        # pair, 4 per lane).
+        pairs_per_round = self.pv_d_frags // 4
+        sO = sQ.data_ptr() + compute_warp_idx * (pairs_per_round * 16 * 16 // 2)
+        row_sum_inv_vec = cutlass.Vector.from_elements(
+            (
+                row_sum_inv[0],
+                row_sum_inv[0],
+                row_sum_inv[1],
+                row_sum_inv[1],
+                row_sum_inv[0],
+                row_sum_inv[0],
+                row_sum_inv[1],
+                row_sum_inv[1],
+            ),
+            cutlass.Float32,
+        )
+        store_row = lane_mod8 + ((lane_div8) % 2) * 8
+        store_col = lane_div16 * 8
+        _store_row_in_cta = q_warp_row0 + store_row
+        store_q_seq_idx = q_seq_idx + (_store_row_in_cta if cutlass.const_expr(not self.pack_gqa) else _store_row_in_cta // self.qh_per_kh)
+        store_head_off = o_head_off
+        if cutlass.const_expr(self.pack_gqa and self.qh_per_kh != 1):
+            store_head_off = store_head_off + (_store_row_in_cta % self.qh_per_kh) * o_head_stride
+        for o_round in cutlass.range_constexpr(2):
+            for j in cutlass.range_constexpr(pairs_per_round):
+                d_frag_pair = o_round * pairs_per_round + j
                 o_off = (d_frag_pair * 2) * 4
                 o_scaled = fmul2(o_regs[o_off:8], row_sum_inv_vec)
                 o_packed = o_scaled.to(o.dtype).bitcast(cutlass.Int32)
-                sO_ptr = sO.data_ptr() + (compute_warp_idx * (self.pv_d_frags // 2) + d_frag_pair) * (16 * 16) + lane * 8
+                sO_ptr = sO + j * (16 * 16 // 2) + lane * 4
                 prims.stmatrix(
                     sO_ptr,
                     o_packed,
                     prims.MMALayout.ROW,
                 )
-
-            store_row = lane_mod8 + ((lane_div8) % 2) * 8
-            store_col = lane_div16 * 8
-            _store_row_in_cta = q_warp_row0 + store_row
-            store_q_seq_idx = q_seq_idx + (_store_row_in_cta if cutlass.const_expr(not self.pack_gqa) else _store_row_in_cta // self.qh_per_kh)
-            store_head_off = o_head_off
-            if cutlass.const_expr(self.pack_gqa and self.qh_per_kh != 1):
-                store_head_off = store_head_off + (_store_row_in_cta % self.qh_per_kh) * o_head_stride
-            for d_frag_pair in cutlass.range_constexpr(self.pv_d_frags // 2):
-                store_col_in_cta = d_frag_pair * 16 + store_col
+            prims.bar_warp_sync(0xFFFFFFFF)
+            for j in cutlass.range_constexpr(pairs_per_round):
+                d_frag_pair = o_round * pairs_per_round + j
+                store_col_in_cta = v_col_half0 + d_frag_pair * 16 + store_col
+                sO_ptr = sO + j * (16 * 16 // 2) + lane * 4
                 if cutlass.const_expr(self.thd_varlen):
                     # Packed storage: rows past this sequence's Q length are
                     # the NEXT sequence's tokens — no store, and never the
                     # dense path's zero-fill.
                     if store_q_seq_idx < seqlen_q and store_col_in_cta < head_dim_v:
                         gO_ptr = o_ptr + store_head_off + store_q_seq_idx * o_seq_stride + store_col_in_cta
-                        sO_ptr = sO.data_ptr() + (compute_warp_idx * (self.pv_d_frags // 2) + d_frag_pair) * (16 * 16) + lane * 8
-                        gO_ptr.store(sO_ptr.load(count=8, alignment=16), alignment=16)
-                else:
-                    if store_q_seq_idx < q.shape[1] and store_col_in_cta < head_dim_v:
-                        gO_ptr = o_ptr + store_head_off + store_q_seq_idx * o_seq_stride + store_col_in_cta
-                        if store_q_seq_idx < seqlen_q:
-                            sO_ptr = sO.data_ptr() + (compute_warp_idx * (self.pv_d_frags // 2) + d_frag_pair) * (16 * 16) + lane * 8
-                            gO_ptr.store(sO_ptr.load(count=8, alignment=16), alignment=16)
-                        else:
-                            zero_vec = cutlass.Vector.from_elements(
-                                (
-                                    o.dtype(0.0),
-                                    o.dtype(0.0),
-                                    o.dtype(0.0),
-                                    o.dtype(0.0),
-                                    o.dtype(0.0),
-                                    o.dtype(0.0),
-                                    o.dtype(0.0),
-                                    o.dtype(0.0),
-                                ),
-                                o.dtype,
-                            )
-                            gO_ptr.store(zero_vec, alignment=16)
-
-        # /////////////////////////////////////////////////////////////////////////////
-        #  EMPTY
-        # /////////////////////////////////////////////////////////////////////////////
-        else:
-            prims.setmaxregister(self.load_regs, prims.SetMaxRegisterAction.DECREASE)
+                        gO_ptr.store(sO_ptr.load(count=4, alignment=16).bitcast(o.dtype), alignment=16)
+                elif store_q_seq_idx < q.shape[1] and store_col_in_cta < head_dim_v:
+                    gO_ptr = o_ptr + store_head_off + store_q_seq_idx * o_seq_stride + store_col_in_cta
+                    if store_q_seq_idx < seqlen_q:
+                        gO_ptr.store(sO_ptr.load(count=4, alignment=16).bitcast(o.dtype), alignment=16)
+                    else:
+                        zero_vec = cutlass.Vector.from_elements(
+                            (
+                                o.dtype(0.0),
+                                o.dtype(0.0),
+                                o.dtype(0.0),
+                                o.dtype(0.0),
+                                o.dtype(0.0),
+                                o.dtype(0.0),
+                                o.dtype(0.0),
+                                o.dtype(0.0),
+                            ),
+                            o.dtype,
+                        )
+                        gO_ptr.store(zero_vec, alignment=16)
+            prims.bar_warp_sync(0xFFFFFFFF)
+        # Unit boundary: the next unit's staged Q fragments land over storage the
+        # epilogue is still reading, so no warp may start it before every warp is
+        # done here.
+        prims.barrier_cta_sync(self.bar_compute_sync, thread_count=self.threads_compute)
 
         return tiles_loaded
 
@@ -1309,6 +1615,7 @@ class SM120FusedMultiHeadAttentionForward:
         seq_kv_lens: cute.Tensor,
         tma_k_desc: cutlass.GridConstant[cuda.TensorMap],
         tma_v_desc: cutlass.GridConstant[cuda.TensorMap],
+        tma_q_desc: cutlass.GridConstant[cuda.TensorMap],
         softmax_scale_log2: cutlass.Float32,
         n_q_tiles: cutlass.Int32,
     ) -> None:
@@ -1328,6 +1635,8 @@ class SM120FusedMultiHeadAttentionForward:
         :param seq_kv_lens: Per-batch key/value lengths, or an unused dummy tensor.
         :param tma_k_desc: Tensor map descriptor for K.
         :param tma_v_desc: Tensor map descriptor for V.
+        :param tma_q_desc: Tensor map descriptor for Q (dense path; the K
+            descriptor stands in when Q loads per lane).
         :param softmax_scale_log2: ``softmax_scale * log2(e)``, pre-folded host-side.
         """
         tidx, _, _ = cute.arch.thread_idx()
@@ -1337,29 +1646,42 @@ class SM120FusedMultiHeadAttentionForward:
         # Shared-memory layout:
         #   sK: one kv_tile x head_tile_qk K tile
         #   sV: one kv_tile x head_tile_v V tile
-        # The epilogue later aliases this storage as the q_tile x head_tile_v
-        # sO staging tile after compute warps finish consuming the final K/V
-        # tile.
+        #   sAux: sQ (every warp's staged Q d-fragments) followed by sX (every
+        #         warp's partial-S exchange slots)
+        # The epilogue stages O through sAux (in two rounds) while the K/V
+        # storage may already be receiving the next unit's Q tile.
         sKV = cutlass.Array(
             k.dtype,
-            max(self.k_tile_elems + self.v_tile_elems, self.o_tile_elems),
+            self.k_tile_elems + self.v_tile_elems,
             space=cutlass.AddressSpace.smem,
             alignment=128,
         )
         sK = sKV
         sV = sKV.subview(self.k_tile_elems)
-        tma_mbar = cutlass.Array(cutlass.Int64, 2, space=cutlass.AddressSpace.smem, alignment=8)
+        sAux = cutlass.Array(
+            cutlass.Int32,
+            self.q_smem_words + self.s_smem_words,
+            space=cutlass.AddressSpace.smem,
+            alignment=16,
+        )
+        sQ = sAux
+        sX = sAux.subview(self.q_smem_words)
+        tma_mbar = cutlass.Array(cutlass.Int64, 3, space=cutlass.AddressSpace.smem, alignment=8)
         k_tma_mbar = tma_mbar
         v_tma_mbar = tma_mbar.subview(1)
+        q_tma_mbar = tma_mbar.subview(2)
 
         # Initialize the TMA completion barriers before any load or compute warp
         # can touch the K/V pipeline.
-        if warp == self.load_warp_id:
+        if warp == 0:
             if prims.elect_sync():
                 prims.prefetch_tensormap(tma_k_desc.get_ptr())
                 prims.prefetch_tensormap(tma_v_desc.get_ptr())
+                if cutlass.const_expr(self.tma_q):
+                    prims.prefetch_tensormap(tma_q_desc.get_ptr())
                 prims.mbarrier_init(k_tma_mbar, 1)
                 prims.mbarrier_init(v_tma_mbar, 1)
+                prims.mbarrier_init(q_tma_mbar, 1)
         prims.fence_mbarrier_init()
         prims.barrier_cta_sync(0)
 
@@ -1377,9 +1699,6 @@ class SM120FusedMultiHeadAttentionForward:
             _slot = cutlass.Array(cutlass.Int32, 1, space=cutlass.AddressSpace.smem, alignment=16)
             _bidx, _, _ = cute.arch.block_idx()
             _uid = cutlass.Int32(_bidx)
-            # K/V mbarrier parity is a CTA-lifetime count under a persistent
-            # grid: the barriers are armed once above, so each unit picks the
-            # phase up where the previous one left it.
             _phase = cutlass.Int32(0)
             while _uid < _live:
                 _qt, _b, _h = thd_decode_unit(
@@ -1401,12 +1720,16 @@ class SM120FusedMultiHeadAttentionForward:
                     seq_kv_lens,
                     tma_k_desc,
                     tma_v_desc,
+                    tma_q_desc,
                     softmax_scale_log2,
                     sKV,
                     sK,
                     sV,
+                    sQ,
+                    sX,
                     k_tma_mbar,
                     v_tma_mbar,
+                    q_tma_mbar,
                     lane,
                     warp,
                     _phase,
@@ -1415,78 +1738,64 @@ class SM120FusedMultiHeadAttentionForward:
                     _qt,
                     _b,
                     _h,
+                    cutlass.Int32(0),
+                    n_q_tiles,
                 )
                 _uid = thd_claim_next(seq_kv_lens, cutlass.Int32(4 * _nb + 3), _slot, cutlass.Int32(tidx))
         else:
-            q_tile_idx, batch_idx, head_idx = cute.arch.block_idx()
-            # KV split rides the BATCH axis: grid.y = batch + split*B.  Q/K/V and
-            # the per-batch seqlens must use the REAL batch; only the O/LSE
-            # partial slot uses the composite.  Folds away at split_kv == 1.
-            split_idx = cutlass.Int32(0)
-            o_batch_idx = batch_idx
-            if cutlass.const_expr(self.split_kv > 1):
-                n_batch_real = cutlass.Int32(q.shape[0])
-                split_idx = batch_idx // n_batch_real
-                batch_idx = batch_idx % n_batch_real
-                o_batch_idx = split_idx * n_batch_real + batch_idx
-            if cutlass.const_expr(self.sched_policy != SCHED_NATURAL):
-                _n_qh = cutlass.Int32((q.shape[2] // self.qh_per_kh if self.pack_gqa else q.shape[2]))
-                _n_batch = cutlass.Int32(self.thd_batch if cutlass.const_expr(self.thd_varlen) else q.shape[0])
-                if cutlass.const_expr(self.sched_policy == SCHED_LPT_L2):
-                    q_tile_idx, head_idx, batch_idx = lpt_l2_tile_coords(
-                        q_tile_idx,
-                        _n_qh,
-                        _n_batch,
-                        n_q_tiles,
-                        _n_qh // cutlass.Int32(k.shape[2]),
-                        cutlass.Int32(k.shape[1]),
-                        (self.head_tile_qk + self.head_tile_v) * self.in_dtype.width // 8,
-                        SCHED_L2_BUDGET_BYTES,
-                    )
-                else:
-                    q_tile_idx, head_idx, batch_idx = lpt_tile_coords(q_tile_idx, _n_qh, _n_batch, n_q_tiles)
-                o_batch_idx = batch_idx
-            elif cutlass.const_expr(self.is_causal):
-                # Diagonal-bounded work grows with the Q tile. Launch long tiles
-                # first to avoid leaving a few expensive CTAs in the final
-                # scheduler waves (right-band graphs share the causal shape).
-                grid_q, _, _ = cute.arch.grid_dim()
-                q_tile_idx = grid_q - q_tile_idx - 1
-            if cutlass.const_expr(self.thd_varlen):
-                # blockIdx.y is a RANK, not a batch: the remap puts the longest
-                # sequences on the low CTA ids so they dispatch first, leaving
-                # the ragged tail of the launch to short sequences whose
-                # over-length tiles retire without work.
-                _m = cutlass.make_array_view(seq_kv_lens)
-                _n = (seq_kv_lens.shape[0] - 4) // 4
-                batch_idx = cutlass.Int32(_m[3 * _n + 2 + batch_idx])
-                o_batch_idx = batch_idx
-            self._run_unit(
-                q,
-                k,
-                v,
-                o,
-                lse,
-                sinks,
-                seq_q_lens,
-                seq_kv_lens,
-                tma_k_desc,
-                tma_v_desc,
-                softmax_scale_log2,
-                sKV,
-                sK,
-                sV,
-                k_tma_mbar,
-                v_tma_mbar,
-                lane,
-                warp,
-                cutlass.Int32(0),
-                split_idx,
-                o_batch_idx,
-                q_tile_idx,
-                batch_idx,
-                head_idx,
-            )
+            # Dense: a flat grid over the (Q tile, batch x split, head) units.
+            # Each CTA walks rounds of G = grid-size units. Full attention uses
+            # boustrophedon order (unit k*G + b, then k*G + (G-1-b), ...), which
+            # balances the heaviest-first LPT order; windowed attention uses a
+            # plain grid stride because units have similar costs. One CTA per
+            # unit when the grid is the unit count. Under tma_q the next unit's Q
+            # tile is issued from the current unit's epilogue, the CTA's first
+            # from here.
+            _bidx, _, _ = cute.arch.block_idx()
+            _n_batch, _n_qh, _n_units = self._dense_unit_count(q, n_q_tiles)
+            _uid = cutlass.Int32(_bidx)
+            if cutlass.const_expr(self.tma_q):
+                _q_envelope = q.shape[3] != self.head_tile_qk
+                if warp == 0 and _uid < _n_units:
+                    _qt, _b, _h, _, _ = self._dense_unit_coords(_uid, n_q_tiles, _n_batch, _n_qh, k)
+                    _q_seq = _qt * cutlass.Int32(self.q_tile_tokens)
+                    _q_head_base = _h * cutlass.Int32(self.qh_per_kh if self.pack_gqa else 1)
+                    self.load_q_tile_tma(sKV, tma_q_desc, q_tma_mbar, _b, _q_head_base, _q_seq, envelope=_q_envelope)
+            while _uid < _n_units:
+                q_tile_idx, batch_idx, head_idx, split_idx, o_batch_idx = self._dense_unit_coords(_uid, n_q_tiles, _n_batch, _n_qh, k)
+                self._run_unit(
+                    q,
+                    k,
+                    v,
+                    o,
+                    lse,
+                    sinks,
+                    seq_q_lens,
+                    seq_kv_lens,
+                    tma_k_desc,
+                    tma_v_desc,
+                    tma_q_desc,
+                    softmax_scale_log2,
+                    sKV,
+                    sK,
+                    sV,
+                    sQ,
+                    sX,
+                    k_tma_mbar,
+                    v_tma_mbar,
+                    q_tma_mbar,
+                    lane,
+                    warp,
+                    cutlass.Int32(0),
+                    split_idx,
+                    o_batch_idx,
+                    q_tile_idx,
+                    batch_idx,
+                    head_idx,
+                    _uid,
+                    n_q_tiles,
+                )
+                _uid = self._next_dense_unit(_uid)
 
     kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
@@ -1540,10 +1849,10 @@ class SM120FusedMultiHeadAttentionForward:
         """
         head_dim_qk = q.shape[3]
         head_dim_v = v.shape[3]
-        if cutlass.const_expr(head_dim_qk != k.shape[3] or round_up_head_tile(head_dim_qk) != self.head_tile_qk):
-            raise ValueError("runtime Q/K head dimensions must round up (by the head-tile granule) to the kernel head_tile_qk")
-        if cutlass.const_expr(head_dim_v != o.shape[3] or round_up_head_tile(head_dim_v) != self.head_tile_v):
-            raise ValueError("runtime V/O head dimensions must round up (by the head-tile granule) to the kernel head_tile_v")
+        if cutlass.const_expr(head_dim_qk != k.shape[3] or not GENERAL_HEAD_TILE_MAX < head_dim_qk <= self.head_tile_qk):
+            raise ValueError("runtime Q/K head dimensions must match and be in (256, 512]")
+        if cutlass.const_expr(head_dim_v != o.shape[3] or not GENERAL_HEAD_TILE_MAX < head_dim_v <= self.head_tile_v):
+            raise ValueError("runtime V/O head dimensions must match and be in (256, 512]")
         if cutlass.const_expr(head_dim_qk % 8 != 0 or head_dim_v % 8 != 0):
             raise ValueError("head dimensions must be multiples of 8 (TMA 16-byte global-stride rule at 2 B/elem)")
 
@@ -1577,9 +1886,9 @@ class SM120FusedMultiHeadAttentionForward:
         if cutlass.const_expr(lse is not None):
             if cutlass.const_expr(self.thd_varlen):
                 # The packed token total (q.shape[1]) is DYNAMIC under THD, so
-                # only the static modes are trace-checkable; head_stride >= T
-                # and the (T, H) extent are validated by the adapter at
-                # execute, which builds both views from the same total.
+                # only the static modes are trace-checkable. The adapter builds
+                # the token-major view from that total; head_stride >= T is the
+                # caller's contract for head-major storage.
                 if cutlass.const_expr(self.thd_lse_head_major):
                     if cutlass.const_expr(lse.shape[0] != q.shape[2]):
                         raise ValueError("head-major THD LSE must have shape (H, head_stride) with head_stride >= T")
@@ -1623,20 +1932,22 @@ class SM120FusedMultiHeadAttentionForward:
         # (e.g. a K/V slice of a kv-interleaved [T, 2, H, D] buffer), and TMA
         # encodes it directly (interior strides must be 16-byte multiples;
         # check_support declines declarations TMA cannot express).
-        def kv_tma_desc(t, head_dim, head_tile, swizzle, swizzle_chunks, swizzle_chunk_elems):
+        def kv_tma_desc(t, head_dim, head_tile, swizzle, swizzle_chunks, swizzle_chunk_elems, rows=None):
+            # Q reuses K's geometry with q_tile rows per box; K/V take kv_tile rows and every chunk.
+            rows = self.kv_tile if rows is None else rows
             if cutlass.const_expr(head_dim == head_tile):
                 layout = cute.make_layout(
                     (t.shape[0], t.shape[2], swizzle_chunks, t.shape[1], swizzle_chunk_elems),
                     stride=(t.stride[0], t.stride[2], swizzle_chunk_elems, t.stride[1], 1),
                 )
-                box = (1, 1, swizzle_chunks, self.kv_tile, swizzle_chunk_elems)
+                box = (1, 1, swizzle_chunks, rows, swizzle_chunk_elems)
                 stride_order = (4, 3, 2, 1, 0)
             else:
                 layout = cute.make_layout(
                     (t.shape[0], t.shape[2], t.shape[1], head_dim),
                     stride=(t.stride[0], t.stride[2], t.stride[1], 1),
                 )
-                box = (1, 1, self.kv_tile, swizzle_chunk_elems)
+                box = (1, 1, rows, swizzle_chunk_elems)
                 stride_order = (3, 2, 1, 0)
             return cuda.create_tensor_map_tiled_from_view(
                 cute.make_tensor(t.iterator, layout),
@@ -1647,6 +1958,40 @@ class SM120FusedMultiHeadAttentionForward:
 
         tma_k_desc = kv_tma_desc(k, head_dim_qk, self.head_tile_qk, self.k_tma_swizzle, self.k_tma_swizzle_chunks, self.k_swizzle_chunk_elems)
         tma_v_desc = kv_tma_desc(v, head_dim_v, self.head_tile_v, self.v_tma_swizzle, self.v_tma_swizzle_chunks, self.v_swizzle_chunk_elems)
+        # Dense Q shares K's head tile and swizzle geometry, with all chunks in
+        # one box. Unpacked: q_tile rows of one head. PackGQA:
+        # a G-heads x T-tokens box whose dims are ordered (C, H, S, I, B) so it
+        # lands token-major (row = token * G + head), the kernel's packed row
+        # order. The THD path passes K's descriptor unused.
+        if cutlass.const_expr(self.tma_q and self.pack_gqa):
+            _q_chunks = self.k_tma_swizzle_chunks
+            _q_chunk_elems = self.k_swizzle_chunk_elems
+            if cutlass.const_expr(head_dim_qk == self.head_tile_qk):
+                _q_layout = cute.make_layout(
+                    (q.shape[0], _q_chunks, q.shape[1], q.shape[2], _q_chunk_elems),
+                    stride=(q.stride[0], _q_chunk_elems, q.stride[1], q.stride[2], 1),
+                )
+                _q_box = (1, _q_chunks, self.q_tile_tokens, self.qh_per_kh, _q_chunk_elems)
+                _q_order = (4, 3, 2, 1, 0)
+            else:
+                _q_layout = cute.make_layout(
+                    (q.shape[0], q.shape[1], q.shape[2], head_dim_qk),
+                    stride=(q.stride[0], q.stride[1], q.stride[2], 1),
+                )
+                _q_box = (1, self.q_tile_tokens, self.qh_per_kh, _q_chunk_elems)
+                _q_order = (3, 2, 1, 0)
+            tma_q_desc = cuda.create_tensor_map_tiled_from_view(
+                cute.make_tensor(q.iterator, _q_layout),
+                box_dims=_q_box,
+                stride_order=_q_order,
+                swizzle=self.k_tma_swizzle,
+            )
+        elif cutlass.const_expr(self.tma_q):
+            tma_q_desc = kv_tma_desc(
+                q, head_dim_qk, self.head_tile_qk, self.k_tma_swizzle, self.k_tma_swizzle_chunks, self.k_swizzle_chunk_elems, rows=self.q_tile
+            )
+        else:
+            tma_q_desc = tma_k_desc
         if cutlass.const_expr(self.thd_varlen):
             # Build the [kv|cu_q|cu_k|remap|live|ctr] metadata buffer DEVICE-side
             # from the caller's length tensors (no host cumsum, no H2D — issue
@@ -1674,15 +2019,16 @@ class SM120FusedMultiHeadAttentionForward:
         )
         n_batch = self.thd_batch if cutlass.const_expr(self.thd_varlen) else q.shape[0]
         n_head = q.shape[2] // self.qh_per_kh if self.pack_gqa else q.shape[2]
-        # LPT / LPT_L2 flatten the 3-D grid so the decode can order the whole tile
-        # set globally (heaviest causal rows first); NATURAL keeps the zero-overhead
-        # 3-D grid. The kernel receives n_q_tiles so its decode uses the same value.
-        if cutlass.const_expr(self.sched_policy != SCHED_NATURAL):
-            grid = (n_q_tiles * n_batch * n_head, 1, 1)
-        else:
-            # KV split rides the batch axis: y = batch + split*B (config_sm120
-            # allows split_kv > 1 only under NATURAL, whose 3-D grid has one).
-            grid = (n_q_tiles, n_batch * self.split_kv, n_head)
+        # Dense: a flat grid over the units, capped at thd_n_ctas — the persistent
+        # CTA count the adapter sizes to the machine (0 = one CTA per unit). The
+        # kernel decodes linear unit ids with the same n_q_tiles; KV split rides
+        # the composite batch axis (config_sm120 allows split_kv > 1 only under
+        # NATURAL).
+        n_units = n_q_tiles * n_batch * self.split_kv * n_head
+        n_ctas = cutlass.Int32(thd_n_ctas)
+        if n_ctas <= 0 or n_ctas > n_units:
+            n_ctas = cutlass.Int32(n_units)
+        grid = (n_ctas, cutlass.Int32(1), cutlass.Int32(1))
         # Persistent THD: a flat, machine-sized grid -- the unit a CTA works on
         # comes from the claim counter, not from its block index.
         _persistent = self.thd_varlen and THD_PERSISTENT
@@ -1699,6 +2045,7 @@ class SM120FusedMultiHeadAttentionForward:
             seq_kv_lens,
             tma_k_desc,
             tma_v_desc,
+            tma_q_desc,
             softmax_scale_log2,
             cutlass.Int32(n_q_tiles),
         ).launch(
@@ -1731,7 +2078,7 @@ def compile(  # noqa: A001
     """Compile and cache one architecture-specific compact BSHD shape.
 
     ``d_qk`` is the Q/K head dim (QK^T contraction width) and ``d_v`` the V/O
-    head dim (P@V output width); they are independent, e.g. (192, 128).
+    head dim (P@V output width).
 
     THD specializations pack the batch: ``b`` is the real sequence count and
     ``sq``/``skv`` are IGNORED — the packed token totals are runtime values
@@ -1739,10 +2086,9 @@ def compile(  # noqa: A001
     compile DYNAMIC (``cute.sym_int``) and the cache key stays plan-time-only;
     callers must not pass them. ``max_sq`` (the longest sequence's Q length,
     which sizes the per-sequence grid) is likewise a RUNTIME ``__call__``
-    argument, not a compile parameter. THD strides carry a ZERO batch stride;
-    the fake binds the token stride for the extent-1 batch dim, exactly as
-    ``_thd_view`` does at runtime (``T * token_stride`` is never stepped and
-    overflows the int32 stride slot on long packed KV, GitHub #980).
+    argument, not a compile parameter. THD strides carry a ZERO batch stride
+    (the real view's batch stride is ``t * token_stride``, a runtime value;
+    the fake rebuilds it symbolically — batch extent 1 never steps).
 
     ``has_lse=False`` compiles the LSE store out (the kernel specializes on a
     ``None`` LSE argument) — callers that don't want stats pass no LSE buffer
@@ -1754,6 +2100,8 @@ def compile(  # noqa: A001
     caller-declared head-row stride (``>= T``, a shape — part of the cache key).
     """
 
+    if pick_flavor(d_qk, d_v, fp8=False) != D512_FLAVOR:
+        raise ValueError(f"SM120 SDPA d512 kernel: head dimensions must both be in (256, 512]; got ({d_qk}, {d_v})")
     kernel = SM120FusedMultiHeadAttentionForward(
         in_dtype=STORAGE_DTYPE,
         out_dtype=STORAGE_DTYPE,
@@ -1768,8 +2116,8 @@ def compile(  # noqa: A001
         thd_varlen=PARAMS.thd_varlen,
         thd_batch=b,
         thd_lse_head_major=lse_head_major,
-        head_tile_qk=round_up_head_tile(d_qk),
-        head_tile_v=round_up_head_tile(d_v),
+        head_tile_qk=D512_FLAVOR[0],
+        head_tile_v=D512_FLAVOR[1],
         q_tile=PARAMS.q_tile,
         kv_tile=PARAMS.kv_tile,
         split_kv=PARAMS.split_kv,
@@ -1796,10 +2144,9 @@ def compile(  # noqa: A001
         if stride is None:
             return cute.runtime.make_fake_compact_tensor(STORAGE_DTYPE, shape, stride_order=(3, 2, 1, 0), assumed_align=16)
         if PARAMS.thd_varlen:
-            # Extent-1 batch dim: bind the token stride, as _thd_view does at
-            # runtime -- T * token_stride is never stepped and overflows the int32
-            # stride slot on long packed KV with wide tokens (GitHub #980).
-            return cute.runtime.make_fake_tensor(STORAGE_DTYPE, shape, (stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
+            # Batch stride = tokens * token_stride (`_thd_view`'s envelope),
+            # a runtime value: rebuild it from the dynamic token extent.
+            return cute.runtime.make_fake_tensor(STORAGE_DTYPE, shape, (shape[1] * stride[1], stride[1], stride[2], stride[3]), assumed_align=16)
         return cute.runtime.make_fake_tensor(STORAGE_DTYPE, shape, tuple(stride), assumed_align=16)
 
     fake_q = _fake_bshd((fake_batch, sq, qh, d_qk), q_stride)

--- a/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm120.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm120.py
@@ -943,17 +943,18 @@ def test_dsl_sm120_thd():
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("d_qk,d_v", [(64, 64), (128, 128), (192, 128), (248, 248)], ids=["d64", "d128", "d192x128", "d248"])
+@pytest.mark.parametrize("d_qk,d_v", [(64, 64), (128, 128), (192, 128), (248, 248), (512, 512)], ids=["d64", "d128", "d192x128", "d248", "d512"])
 @torch_fork_set_rng(seed=23)
 def test_dsl_sm120_thd_nan_capacity_tail(d_qk, d_v):
     """THD with a NaN-poisoned capacity tail: O must be finite and correct.
-    (248, 248) runs the d256 kernel with zero-filled pad columns in the tail."""
+    (248, 248) runs the d256 kernel with zero-filled pad columns in the tail;
+    (512, 512) the d512 kernel (two warps per Q slab sanitize the V tail)."""
 
     _run_thd_case(seq_q_lens=[200, 150, 47], seq_kv_lens=[200, 150, 47], head_dim=d_qk, head_dim_v=d_v, is_causal=True, nan_capacity_tail=True)
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("head_dim", [128, 256], ids=["d128", "d256"])
+@pytest.mark.parametrize("head_dim", [128, 256, 512], ids=["d128", "d256", "d512"])
 @torch_fork_set_rng(seed=27)
 def test_dsl_sm120_thd_multi_unit_per_cta(head_dim: int):
     """THD with more live units than the machine has CTAs.
@@ -1024,7 +1025,7 @@ def test_dsl_sm120_thd_gqa_sink(stats_layout: str):
 
 
 @pytest.mark.L1
-@pytest.mark.parametrize("head_dim", [64, 256], ids=["d64", "d256"])
+@pytest.mark.parametrize("head_dim", [64, 256, 512], ids=["d64", "d256", "d512"])
 @torch_fork_set_rng(seed=26)
 def test_dsl_sm120_thd_zero_length_sequence(head_dim: int):
     """A zero-length sequence contributes no tokens and must not perturb its
@@ -1311,6 +1312,8 @@ def test_dsl_sm120_dense_flex_bhsd_contiguous():
         (248, None),  # d256 template, zero-padded 248 -> 256
         (256, None),
         (256, 64),
+        (504, None),  # d512 template, zero-padded 504 -> 512
+        (512, None),
     ],
 )
 @torch_fork_set_rng(seed=2)
@@ -1323,10 +1326,12 @@ def test_dsl_sm120_representative_head_dimensions(head_dim: int, kv_tile: int | 
 def test_dsl_sm120_flavor_routing():
     """The adapter resolves the kernel flavor from the head dims: dims the
     general template would tile at 256 on both sides (f16: above 240) run the
-    d256 template, everything else the general one.
+    d256 template, dimensions independently in (256, 512] the d512
+    template, everything else the general one.
     Unset tile knobs resolve exactly as on the general template; explicit knobs are honored
     on both templates (a geometry that does not fit SMEM declines, as on the
-    general template)."""
+    general template). The d512 template has one CTA tile, (64, 32), and its
+    kv_tile 32 exists for no other head dim."""
 
     _require_dsl()
     from cudnn.sdpa.fwd import sdpa_fwd_wrapper_dsl_sm120
@@ -1351,12 +1356,46 @@ def test_dsl_sm120_flavor_routing():
     assert api.check_support() and (api.q_tile, api.kv_tile) == (128, 64)  # explicit knob honored, default for the rest
     with pytest.raises(NotImplementedError, match="shared memory"):
         _api(256, 256, tile_n=128).check_support()  # a 128-wide KV tile does not fit at d256 in half precision
+    for d_qk, d_v in ((264, 264), (264, 512), (512, 264), (272, 320), (384, 448), (496, 496), (512, 512), (504, 504), (512, 504)):
+        api = _api(d_qk, d_v)
+        assert api.check_support() and api.flavor == (512, 512) and (api.q_tile, api.kv_tile) == (64, 32), (d_qk, d_v)
+    api = _api(512, 512, tile_m=64, tile_n=32)
+    assert api.check_support() and (api.q_tile, api.kv_tile) == (64, 32)  # the one explicit tile the flavor takes
+    with pytest.raises(NotImplementedError, match="shared memory"):
+        _api(512, 512, tile_n=64).check_support()  # a 64-row K plus V tile is 128 KiB at d512
+    with pytest.raises(NotImplementedError, match="shared memory"):
+        _api(512, 512, tile_m=128).check_support()  # the 128 x 512 O staging tile alone is 128 KiB
+    with pytest.raises(NotImplementedError, match="no kernel"):
+        _api(128, 128, tile_n=32).check_support()  # kv_tile 32 is the d512 flavor's alone
+    for d_qk, d_v in ((256, 512), (512, 256), (248, 264), (264, 248), (520, 512), (512, 520)):
+        with pytest.raises(ValueError, match="both head dimensions"):
+            _api(d_qk, d_v).check_support()
     # The general template still takes the knobs.
     api = _api(128, 128, tile_m=64, tile_n=64)
     assert api.check_support() and (api.q_tile, api.kv_tile) == (64, 64)
     q = _bhsd(1, 4, 128, 256, torch.float16)
     with pytest.raises(NotImplementedError, match="shared memory"):
         sdpa_fwd_wrapper_dsl_sm120(q, q, q, q_tile=128, kv_tile=128)
+
+
+@pytest.mark.L0
+def test_dsl_sm120_d512_template_rejects_dims_and_tiles_outside_its_table():
+    """The d512 template's compile() refuses head dims the adapter would never
+    route to it, and its kernel refuses any CTA tile but (64, 32) — routing
+    bugs, not user errors, so they raise."""
+
+    _require_dsl()
+    from cudnn.sdpa.fwd import api_dsl
+    from cudnn.sdpa.fwd.config_sm120 import D512_FLAVOR, TemplateParams
+
+    cc = torch.cuda.get_device_capability()
+    module = api_dsl._load_sm120_kernel_module(D512_FLAVOR, TemplateParams(q_tile=64, kv_tile=32))
+    for d_qk, d_v in ((256, 256), (256, 512), (512, 256), (520, 512), (512, 520)):
+        with pytest.raises(ValueError, match="head dim"):
+            module.compile(compute_capability=cc, b=1, qh=1, kh=1, sq=128, skv=128, d_qk=d_qk, d_v=d_v, has_lse=False)
+    module = api_dsl._load_sm120_kernel_module(D512_FLAVOR, TemplateParams(q_tile=64, kv_tile=64))
+    with pytest.raises(ValueError, match=r"\(q_tile, kv_tile\) must be"):
+        module.compile(compute_capability=cc, b=1, qh=1, kh=1, sq=128, skv=128, d_qk=512, d_v=512, has_lse=False)
 
 
 @pytest.mark.L0
@@ -1759,3 +1798,68 @@ def test_dsl_sm120_bfloat16_and_tile_variants():
         is_causal=True,
         scale=0.5,
     )
+
+
+# --- d512 flavor (MQA / GQA at head_dim 512) -------
+@pytest.mark.L0
+@pytest.mark.parametrize("mask", ["none", "causal", "causal_br", "swa128", "band_right", "padded_qtrim", "sink_swa"])
+@torch_fork_set_rng(seed=40)
+def test_dsl_sm120_d512_features(mask: str):
+    """The d512 flavor x the dense mask / sink / trim envelope, stats checked,
+    on an MQA head layout (many Q heads over one KV head)."""
+    kw: dict = dict(batch=2, h_q=8, h_kv=1, s_q=320, s_kv=320, head_dim=512, check_stats=True)
+    if mask == "causal":
+        kw.update(is_causal=True)
+    elif mask == "causal_br":
+        kw.update(is_causal=True, causal_bottom_right=True, window_size_right=0, s_q=200)
+    elif mask == "swa128":
+        kw.update(is_causal=True, window_size_left=128)
+    elif mask == "band_right":
+        kw.update(window_size_right=8)
+    elif mask == "padded_qtrim":
+        kw.update(
+            seq_q_lens=torch.tensor([37, 290], dtype=torch.int32, device="cuda"),
+            seq_kv_lens=torch.tensor([180, 300], dtype=torch.int32, device="cuda"),
+        )
+    elif mask == "sink_swa":
+        kw.update(is_causal=True, window_size_left=128, with_sink=True)
+    _run_case(**kw)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@torch_fork_set_rng(seed=41)
+def test_dsl_sm120_d512_envelope_504(dtype: torch.dtype):
+    """504 rides the d512 template with TMA zero-filled pad columns, on both
+    sides and on the V side only; the ragged S_kv tail shares the rightmost tile."""
+    _run_case(head_dim=504, head_dim_v=504, s_q=192, s_kv=200, dtype=dtype, is_causal=True, check_stats=True)
+    _run_case(head_dim=512, head_dim_v=504, s_q=128, s_kv=128, dtype=dtype)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=42)
+def test_dsl_sm120_d512_pack_gqa_mqa():
+    """PackGQA on the d512 flavor's q_tile=64: G=64 Q heads x one token per
+    tile (an MQA decode step) and G=8 x 8 tokens."""
+    _run_case(batch=2, h_q=64, h_kv=1, s_q=3, s_kv=512, head_dim=512, is_causal=True, pack_gqa=True, check_stats=True)
+    _run_case(batch=1, h_q=8, h_kv=1, s_q=40, s_kv=256, head_dim=512, is_causal=True, pack_gqa=True, check_stats=True)
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=44)
+def test_dsl_sm120_d512_pack_gqa_sliding_window():
+    """Packed units under a sliding window, the graph path's choice for windowed
+    GQA / MQA on this flavor (plain-LPT walk): G=64 x one token per unit on a
+    grid of 1024 units that the persistent CTAs walk in several rounds, and G=8
+    x 8 tokens on two batches; stats checked."""
+    _run_case(
+        batch=1, h_q=64, h_kv=1, s_q=1024, s_kv=1024, head_dim=512, dtype=torch.bfloat16, is_causal=True, window_size_left=128, pack_gqa=True, check_stats=True
+    )
+    _run_case(batch=2, h_q=8, h_kv=1, s_q=320, s_kv=320, head_dim=512, is_causal=True, window_size_left=128, pack_gqa=True, check_stats=True)
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=43)
+def test_dsl_sm120_d512_long_causal_bf16():
+    """A multi-wave causal grid on an MQA head layout at head_dim 512 (bf16)."""
+    _run_case(batch=1, h_q=16, h_kv=1, s_q=2048, s_kv=2048, head_dim=512, dtype=torch.bfloat16, is_causal=True, check_stats=True)

--- a/test/python/sdpa/frost/test_sdpa_fwd_heuristics.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_heuristics.py
@@ -24,6 +24,7 @@ from cudnn.sdpa.fwd import engines
 from cudnn.engines.heuristics import _assemble
 from cudnn.sdpa.fwd.heuristics import _MAX_SETS_PER_ENGINE, recommend
 from cudnn.sdpa.graph_analyzer import SdpaGraphFacts
+from cudnn.frost.tile_dsl.constants import SCHED_LPT, SCHED_LPT_L2
 
 _F16 = "sdpa_fwd_prefill_sm100"
 _OFFERED = {_F16: 20500, "sdpa_fwd_prefill_sm100_fp8": 20501}
@@ -139,6 +140,57 @@ def test_sm120_d192_keeps_sm120_cga_domain(engine_name, dtype, is_fp8):
     assert all(plan.knobs.cga == 1 for plan in plans)
     spec = next(spec for spec in engines.ENGINE_SPECS if spec.name == engine_name)
     assert all(engines.mismatch(spec.capabilities, facts, plan.knobs) is None for plan in plans)
+
+
+@pytest.mark.L0
+def test_sm120_d512_flavor_pins_its_one_cta_tile():
+    """The d512 flavor is built for (64, 32) alone: the grid rule's tile_m and
+    the largest-fitting tile_n both yield to the kernel table
+    (config_sm120.tile_domain) on full and underfilled grids, and no runner-up
+    proposes another tile. At d128 the same table keeps kv_tile 32 out."""
+    spec = next(spec for spec in engines.ENGINE_SPECS if spec.name == "sdpa_fwd_prefill_sm120")
+    offered = {"sdpa_fwd_prefill_sm120": 20504}
+    for d_qk, d_v in ((264, 264), (264, 512), (512, 264), (272, 320), (384, 448), (496, 504), (512, 512)):
+        for s in (128, 16384):
+            facts = _facts(s_q=s, s_kv=s, h_q=64, h_kv=1, d_qk=d_qk, d_v=d_v, device_cc=(12, 0), device_sm_count=188)
+            plans = recommend("A", facts, offered)
+            assert plans
+            assert {(p.knobs.tile_m, p.knobs.tile_n) for p in plans} == {(64, 32)}
+            assert all(engines.mismatch(spec.capabilities, facts, p.knobs) is None for p in plans)
+    facts = _facts(d_qk=128, d_v=128, device_cc=(12, 0), device_sm_count=188)
+    plans = recommend("A", facts, offered)
+    assert plans and all(p.knobs.tile_n != 32 for p in plans)
+
+
+@pytest.mark.L0
+def test_sm120_d512_sliding_window_packs_gqa():
+    """The d512 flavor packs the GQA group into its 64-row Q tile under a sliding
+    window (the packed unit's key span shrinks from 64 + W to 1 + W tokens for
+    MQA) and walks windowed units, packed or not, with plain LPT; a 128-head
+    group cannot pack into 64 rows, MHA has nothing to pack, and without a
+    window the decode rule (s_q < tile) and the L2 scheduler rule decide as
+    before."""
+    offered = {"sdpa_fwd_prefill_sm120": 20504}
+    spec = next(spec for spec in engines.ENGINE_SPECS if spec.name == "sdpa_fwd_prefill_sm120")
+
+    def primary(**over):
+        facts = _facts(**{**dict(s_q=16384, s_kv=16384, h_q=64, h_kv=1, d_qk=512, d_v=512, device_cc=(12, 0), device_sm_count=188), **over})
+        plans = recommend("A", facts, offered)
+        assert plans and engines.mismatch(spec.capabilities, facts, plans[0].knobs) is None
+        return plans[0].knobs
+
+    packed = primary(window_left=128)
+    assert (packed.pack_gqa, packed.tile_m, packed.sched_policy) == (True, 64, SCHED_LPT)  # packed window units walk plain LPT
+    assert primary(window_left=128, h_q=8, h_kv=1).pack_gqa is True
+    for d_qk, d_v in ((264, 512), (512, 264), (320, 384)):
+        packed = primary(window_left=128, d_qk=d_qk, d_v=d_v)
+        assert (packed.pack_gqa, packed.tile_m, packed.tile_n, packed.sched_policy) == (True, 64, 32, SCHED_LPT)
+    pro = primary(window_left=128, h_q=128, h_kv=1)  # G=128 does not divide the 64-row tile; windowed units still walk LPT
+    assert (pro.pack_gqa, pro.sched_policy) == (False, SCHED_LPT)
+    assert primary(window_left=128, h_q=64, h_kv=64).pack_gqa is False  # MHA
+    full_causal = primary()  # full causal prefill: decode rule only, L2 rule for the scheduler
+    assert (full_causal.pack_gqa, full_causal.sched_policy) == (False, SCHED_LPT_L2)
+    assert primary(window_left=128, d_qk=128, d_v=128).pack_gqa is False  # the rule is the d512 flavor's
 
 
 @pytest.mark.L0

--- a/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm120.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm120.py
@@ -51,12 +51,12 @@ def _expected_split(api):
     )
 
 
-def _sm120_case(h_q, h_kv, s_q, s_kv, *, with_lse=False, workspace=True, causal=False, lse_layout="contiguous", split_kv=None):
+def _sm120_case(h_q, h_kv, s_q, s_kv, *, d=128, with_lse=False, workspace=True, causal=False, lse_layout="contiguous", split_kv=None):
     from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm120
 
     if torch.cuda.get_device_capability()[0] != 12:
         pytest.skip("SM120 part required")
-    b, d, dev = 1, 128, "cuda"
+    b, dev = 1, "cuda"
     torch.manual_seed(0)
     q = torch.randn(b, h_q, s_q, d, device=dev, dtype=torch.float16)
     k = torch.randn(b, h_kv, s_kv, d, device=dev, dtype=torch.float16)
@@ -141,6 +141,14 @@ def test_sm120_split_with_and_without_workspace(workspace):
 def test_sm120_split_writes_the_recombined_lse():
     result = _sm120_case(8, 1, 128, 32768, with_lse=True)
     assert result.split == result.expected_split
+    assert (result.output - result.reference).abs().max().item() <= 2e-2
+
+
+def test_sm120_d512_split_recombines_o_and_lse():
+    """The d512 flavor under a KV split: its fp32 partial O (512 wide) and LSE
+    recombine through the shared combine pass."""
+    result = _sm120_case(8, 1, 64, 8192, d=512, with_lse=True, split_kv=4)
+    assert result.split == 4
     assert (result.output - result.reference).abs().max().item() <= 2e-2
 
 

--- a/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
+++ b/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
@@ -655,10 +655,15 @@ def test_knob_request_pack_gqa_outside_domain_rejects_row():
 _SM120 = engines.engine_name(arch="sm120")
 
 
-def _mk_sm120_graph(d: int = 128, **sdpa_kwargs):
-    """A dense fp16 BSHD graph inside the SM120 row's envelope (D <= 256)."""
+def _mk_sm120_graph(d: int = 128, *, d_v: int | None = None, **sdpa_kwargs):
+    """Build a dense fp16 BSHD graph with independent Q/K and V/O dimensions."""
     g = _mk_graph()
-    q, k, v, dims, strides = _mk_qkv(g, d=d)
+    q_dims, q_strides = (B, H, S, d), (S * H * d, d, H * d, 1)
+    d_v = d if d_v is None else d_v
+    dims, strides = (B, H, S, d_v), (S * H * d_v, d_v, H * d_v, 1)
+    q = g.tensor(dim=q_dims, stride=q_strides, data_type=DTYPE, name="q")
+    k = g.tensor(dim=q_dims, stride=q_strides, data_type=DTYPE, name="k")
+    v = g.tensor(dim=dims, stride=strides, data_type=DTYPE, name="v")
     o, _ = g.sdpa(name="s", q=q, k=k, v=v, attn_scale=0.1, is_inference=True, **sdpa_kwargs)
     _finish_output(o, dims, strides)
     return g
@@ -766,11 +771,25 @@ def test_sm120_probe_rejects_on_sm100_family():
 def test_sm120_probe_head_dim_envelope(monkeypatch):
     # d_envelope: any multiple of 8 up to the 256 cap is served via TMA
     # zero-padding; only sub-8 alignment (TMA 16-byte global-stride rule)
-    # stays ineligible.
+    # stays ineligible. Both dimensions in (256, 512] use the d512 envelope.
     monkeypatch.setattr(ga, "_device_cc", lambda: (12, 0))
     assert _SM120 in _eligible(_mk_sm120_graph(d=192))
     assert _SM120 in _eligible(_mk_sm120_graph(d=136))  # multiple of 8, not of 16
     assert not _eligible(_mk_sm120_graph(d=132))  # multiple of 4, not of 8
+    assert _SM120 in _eligible(_mk_sm120_graph(d=512))
+    assert _SM120 in _eligible(_mk_sm120_graph(d=504))
+    assert _SM120 in _eligible(_mk_sm120_graph(d=264))
+    assert _SM120 in _eligible(_mk_sm120_graph(d=496))
+
+
+def test_sm120_probe_full_d512_envelope_pairs(monkeypatch):
+    """Every 8-aligned Q/K and V/O pair in (256, 512] is independently eligible."""
+    monkeypatch.setattr(ga, "_device_cc", lambda: (12, 0))
+    for d_qk in range(264, 513, 8):
+        for d_v in range(264, 513, 8):
+            assert _SM120 in _eligible(_mk_sm120_graph(d=d_qk, d_v=d_v)), (d_qk, d_v)
+    for d_qk, d_v in ((256, 512), (512, 256), (248, 264), (264, 248), (260, 264), (264, 260), (520, 512), (512, 520)):
+        assert _SM120 not in _eligible(_mk_sm120_graph(d=d_qk, d_v=d_v)), (d_qk, d_v)
 
 
 def test_sm120_probe_accepts_right_band_widening(monkeypatch):


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches (see [root AGENTS.md § Reviewing a PR](https://github.com/NVIDIA/cudnn-frontend/blob/develop/AGENTS.md#reviewing-a-pr-human-or-agent)) and my changes comply, or I explain the exception below.
- [x] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

FE OSS kernels or CuTeDSL

## Summary

Add a dedicated D=512 prefill kernel for SM120, with the following design to allocate register/smem appropriately and improve the performance:
- Tile size is fixed at (64, 32).
- Two warps share each 16-row Q (each owns half of D), sum their partial QK scores before softmax, and accumulate separate 256-column output halves.
- Use TMA Q/K/V loads, partial Q staging in shared memory, persistent dense/THD execution, next-Q prefetch, and output staging that reuses the Q/score-exchange storage.
- Prefer PackGQA for SWA cases (e.g., DeepSeek V4) in the heuristic: all Q rows within a Q tile then share the same K/V tile window, which reduces the number of K/V tiles processed.
- Register the D512 flavor with matching envelope checks, tile selection, shared-memory accounting, windowed-GQA ranking, support documentation, and forward/split-KV tests.

<img width="1755" height="844" alt="image" src="https://github.com/user-attachments/assets/98b87dfb-f768-480a-9028-f4ca202a1c56" />

## Why

The existing SM120 FP16/BF16 forward kernels stop at head dimension 256. D512 attention is needed by workloads such as DeepSeek-V4 and Gemma4.

Extending the D256 warp mapping directly would require 256 FP32 registers per thread for the output accumulator alone. Splitting output ownership across a warp pair reduces that to 128 registers per thread while retaining the existing attention pipeline and feature handling.

## Related issues

Related to #381.

## API and compatibility impact

- No public API signature or dependency changes.
- FP16/BF16 forward now accepts independent QK and V head dimensions in `(256, 512]`, in multiples of eight. Smaller dimensions in this band are zero-padded to the fixed 512×512 head tiles and retain their computation/storage cost. Cross-band pairs such as `(256, 512)` remain unsupported.
- Existing dimensions at or below 256 keep their general/D256 paths. FP8 and backward head-dimension limits remain 256.
- Preserve causal/bottom-right/window masks, padding, sinks, MHA/GQA/MQA, optional LSE, THD, and split-KV support. D512 accepts only the 64×32 CTA tile.

## Performance

```
python -m benchmark.attention_training.runner \
    --config deepseek_v4 \
    --backend cudnn,cudnn_oss \
    --dtype bfloat16 \
    --profile-pass fwd
```

<img width="1485" height="889" alt="image" src="https://github.com/user-attachments/assets/adee515f-2f66-4a72-af3d-bce468b6cafd" />

## Testing

See the pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added SM120 FP16 support for attention head dimensions above 256 through 512, including native 512-dimensional execution.
  - Added support for independent Q/K and V/O head dimensions within the supported range.
  - Added zero-padding for smaller dimensions and expanded support for masks, sinks, sliding windows, GQA/MQA, causal workloads, and split-KV execution.
  - Documented the new D512 kernel coverage and supported dimension ranges.

- **Bug Fixes**
  - Improved tile selection and validation for supported head dimensions and execution configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->