### PR TITLE
fix(serialization): reject malformed graph blobs and honour the written count

### DIFF
--- a/include/cudnn_frontend/backend/device_properties.h
+++ b/include/cudnn_frontend/backend/device_properties.h
@@ -64,17 +64,29 @@ class DeviceProperties : public detail::backend_descriptor {
                                        error_code_t::CUDNN_BACKEND_API_FAILED,
                                        "CUDNN_ATTR_DEVICEPROP_JSON_REPRESENTATION is only available starting 9.8.");
 
-        int64_t serializationSize;
+        RETURN_CUDNN_FRONTEND_ERROR_IF(get_ptr() == nullptr,
+                                       error_code_t::CUDNN_BACKEND_API_FAILED,
+                                       "DeviceProperties::serialize: descriptor not initialized; call build() first.");
+
+        int64_t serializationSize = 0;
         _CUDNN_CHECK_CUDNN_ERROR(detail::get_attribute(
             get_ptr(), CUDNN_ATTR_DEVICEPROP_JSON_REPRESENTATION, CUDNN_TYPE_CHAR, 0, &serializationSize, nullptr));
         serialization_buf.resize(static_cast<size_t>(serializationSize));
 
+        // The written count is what the buffer holds. A device property descriptor does not
+        // change after finalization, so the two calls agree and no retry is needed here.
+        int64_t written = 0;
         _CUDNN_CHECK_CUDNN_ERROR(detail::get_attribute(get_ptr(),
                                                        CUDNN_ATTR_DEVICEPROP_JSON_REPRESENTATION,
                                                        CUDNN_TYPE_CHAR,
                                                        serializationSize,
-                                                       &serializationSize,
+                                                       &written,
                                                        serialization_buf.data()));
+        RETURN_CUDNN_FRONTEND_ERROR_IF(written < 0 || written > serializationSize,
+                                       error_code_t::CUDNN_BACKEND_API_FAILED,
+                                       "DeviceProperties::serialize: cuDNN reported a written count outside the "
+                                       "buffer.");
+        serialization_buf.resize(static_cast<size_t>(written));
         return {};
 #else
         (void)serialization_buf;

--- a/include/cudnn_frontend/backend/kernel_cache.h
+++ b/include/cudnn_frontend/backend/kernel_cache.h
@@ -79,21 +79,64 @@ class KernelCache : public detail::backend_descriptor {
             error_code_t::CUDNN_BACKEND_API_FAILED,
             "KernelCache::to_json: descriptor not initialized; call build() or from_json() first.");
 
-        int64_t serializationSize;
-        std::vector<char> serialization_buf;
-        _CUDNN_CHECK_CUDNN_ERROR(detail::get_attribute(
-            get_ptr(), CUDNN_ATTR_KERNEL_CACHE_JSON_REPRESENTATION, CUDNN_TYPE_CHAR, 0, &serializationSize, nullptr));
-        serialization_buf.resize(static_cast<size_t>(serializationSize));
+        // cuDNN serves the blob with a size query and then a fill.
+        // mutex_ cannot make the two calls atomic.
+        // ExecutionPlanBuilder_v8::build() hands the raw descriptor to cuDNN.
+        // cuDNN then inserts kernels under its own lock and never takes mutex_.
+        // So the cache can change between the two calls.
+        // The fill can then need a larger buffer, or write fewer bytes than the query reported.
+        // Retry a bounded number of times, and take the length from the written count.
+        // Each attempt asks for the size again.
+        // cuDNN before 9.27 leaves the count untouched on the SIZE_INSUFFICIENT path.
+        // Reading the count back there would repeat the same size.
+        constexpr int max_attempts = 3;
+        for (int attempt = 0; attempt < max_attempts; ++attempt) {
+            int64_t requested_size = 0;
+            _CUDNN_CHECK_CUDNN_ERROR(detail::get_attribute(
+                get_ptr(), CUDNN_ATTR_KERNEL_CACHE_JSON_REPRESENTATION, CUDNN_TYPE_CHAR, 0, &requested_size, nullptr));
 
-        _CUDNN_CHECK_CUDNN_ERROR(detail::get_attribute(get_ptr(),
-                                                       CUDNN_ATTR_KERNEL_CACHE_JSON_REPRESENTATION,
-                                                       CUDNN_TYPE_CHAR,
-                                                       serializationSize,
-                                                       &serializationSize,
-                                                       serialization_buf.data()));
-        std::string json_string(serialization_buf.begin(), serialization_buf.end());
-        str_json = std::move(json_string);
-        return {};
+            // An empty buffer gives a null data() pointer.
+            // cuDNN reads that as the query form of the call, not the fill form.
+            // Nothing is there to copy, so answer with an empty string.
+            if (requested_size <= 0) {
+                return {};
+            }
+
+            std::vector<char> serialization_buf(static_cast<size_t>(requested_size));
+            int64_t written          = 0;
+            auto const attempt_state = detail::get_attribute(get_ptr(),
+                                                             CUDNN_ATTR_KERNEL_CACHE_JSON_REPRESENTATION,
+                                                             CUDNN_TYPE_CHAR,
+                                                             requested_size,
+                                                             &written,
+                                                             serialization_buf.data());
+
+            if (attempt_state == CUDNN_STATUS_SUCCESS) {
+                RETURN_CUDNN_FRONTEND_ERROR_IF(
+                    written < 0 || written > requested_size,
+                    error_code_t::CUDNN_BACKEND_API_FAILED,
+                    "KernelCache::to_json: cuDNN reported a written count outside the buffer.");
+                str_json.assign(serialization_buf.begin(), serialization_buf.begin() + written);
+                return {};
+            }
+
+            // Any status other than a short buffer is a real failure, so do not retry it.
+            if (attempt_state != CUDNN_STATUS_BAD_PARAM_SIZE_INSUFFICIENT) {
+                std::stringstream error_msg;
+                error_msg << "KernelCache::to_json: reading CUDNN_ATTR_KERNEL_CACHE_JSON_REPRESENTATION failed with "
+                          << "message: " << detail::get_last_error_string_()
+                          << ", and code: " << detail::get_error_string(attempt_state);
+                CUDNN_FE_LOG_LABEL_ENDL("ERROR: " << error_msg.str() << " at " << __FILE__ << ":" << __LINE__);
+                return {error_code_t::CUDNN_BACKEND_API_FAILED, error_msg.str()};
+            }
+        }
+
+        {
+            std::string const error_msg =
+                "KernelCache::to_json: cuDNN reported an insufficient buffer on every attempt.";
+            CUDNN_FE_LOG_LABEL_ENDL("ERROR: " << error_msg << " at " << __FILE__ << ":" << __LINE__);
+            return {error_code_t::CUDNN_BACKEND_API_FAILED, error_msg};
+        }
 #else
         (void)str_json;
         return {error_code_t::CUDNN_BACKEND_API_FAILED,

--- a/include/cudnn_frontend/graph_interface.h
+++ b/include/cudnn_frontend/graph_interface.h
@@ -7,7 +7,9 @@
 
 #include <algorithm>
 #include <atomic>
+#include <charconv>
 #include <mutex>
+#include <system_error>
 #include <unordered_map>
 #include <stdexcept>
 #include <string>
@@ -61,6 +63,39 @@ class Graph : public ICudnn, public INode {
                                            j["json_version"].get<std::string>() != GRAPH_JSON_VERSION,
                                        error_code_t::UNSUPPORTED_GRAPH_FORMAT,
                                        "Unsupported graph JSON version. Expected " + std::string(GRAPH_JSON_VERSION));
+        return {error_code_t::OK, ""};
+    }
+
+    // Rejects a serialized graph that lacks a key the deserializer reads unconditionally.
+    // Without this, the read uses the const operator[], which is JSON_ASSERT(it != end()) and
+    // therefore a no-op under NDEBUG: a truncated blob dereferences end() instead of failing.
+    static error_t
+    require_key(json const &j, char const *key) {
+        RETURN_CUDNN_FRONTEND_ERROR_IF(!j.contains(key),
+                                       error_code_t::UNSUPPORTED_GRAPH_FORMAT,
+                                       "Serialized graph is missing the key " + std::string(key) + ".");
+        return {error_code_t::OK, ""};
+    }
+
+    // Parses a uid that was serialized as a json object key.
+    // std::stoll throws std::invalid_argument out of the library for a key that is not a number.
+    // A corrupt key must fail like every other malformed input instead.
+    // A negative value stays valid. uid_t is signed and set_uid() takes any value.
+    // The serializer writes std::to_string(uid), so a blob can carry a negative uid.
+    static error_t
+    parse_uid_key(std::string const &key, uid_t &uid) {
+        long long value        = 0;
+        char const *const last = key.data() + key.size();
+        auto const result      = std::from_chars(key.data(), last, value);
+        // from_chars must consume the whole key.
+        // A partial parse leaves result.ptr short of the end.
+        // This rejects a trailing character, an embedded NUL, a leading space and a leading plus.
+        // The serializer writes none of those.
+        // Two keys that differ only in such a character would otherwise map to one uid.
+        RETURN_CUDNN_FRONTEND_ERROR_IF(result.ec != std::errc() || result.ptr != last,
+                                       error_code_t::UNSUPPORTED_GRAPH_FORMAT,
+                                       "Serialized graph holds a uid key that is not a valid uid: " + key);
+        uid = static_cast<uid_t>(value);
         return {error_code_t::OK, ""};
     }
 #endif
@@ -1720,6 +1755,15 @@ class Graph : public ICudnn, public INode {
                           bool run_warmup) {
         CHECK_CUDNN_FRONTEND_ERROR(check_graph_json_version(j));
 
+        // Test the keys that carry no plan data up front, so a malformed blob fails before this
+        // clears the containers below and before build_plans() does any cuDNN work.
+        // cudnn_backend_data stays at its own read: enforce_precompiled gives it a different
+        // error code, and that difference is part of the API.
+        CHECK_CUDNN_FRONTEND_ERROR(require_key(j, "behavior_notes"));
+        CHECK_CUDNN_FRONTEND_ERROR(require_key(j, "variant_pack_uids"));
+        CHECK_CUDNN_FRONTEND_ERROR(require_key(j, "variant_pack_replacements"));
+        CHECK_CUDNN_FRONTEND_ERROR(require_key(j, "fe_workspace_size"));
+
         // Clear deserialize-owned containers so a re-deserialize on the same Graph
         // does not feed prepare_variant_pack_template() with stale entries from a
         // prior deserialize call.
@@ -1730,6 +1774,8 @@ class Graph : public ICudnn, public INode {
 
         auto const has_graph_structure = j.contains("nodes") || j.contains("tensors");
         if (has_graph_structure) {
+            // has_graph_structure tests nodes and tensors, neither of which implies gid.
+            CHECK_CUDNN_FRONTEND_ERROR(require_key(j, "gid"));
             gid = j["gid"].get<uint64_t>();
 
             RETURN_CUDNN_FRONTEND_ERROR_IF(!j.contains("tensors") || !j["tensors"].is_array(),
@@ -1747,6 +1793,7 @@ class Graph : public ICudnn, public INode {
             error_code_t::GRAPH_EXECUTION_PLAN_CREATION_FAILED,
             "enforce_precompiled requested, but serialized graph has no precompiled execution plan");
 
+        CHECK_CUDNN_FRONTEND_ERROR(require_key(j, "cudnn_backend_data"));
         auto serialized_plan = j["cudnn_backend_data"];
         if (device_prop != nullptr) {
             CHECK_CUDNN_FRONTEND_ERROR(plans.build_plans(device_prop, serialized_plan));
@@ -1761,8 +1808,14 @@ class Graph : public ICudnn, public INode {
         // Deserialize pass_by_values from JSON
         if (j.contains("pass_by_values")) {
             auto pass_by_values_json = j["pass_by_values"];
+            // begin() on a scalar is not end(), so the loop below would run once and it.key()
+            // would throw json::invalid_iterator out of the library.
+            RETURN_CUDNN_FRONTEND_ERROR_IF(!pass_by_values_json.is_object(),
+                                           error_code_t::UNSUPPORTED_GRAPH_FORMAT,
+                                           "Serialized graph pass_by_values must be a map.");
             for (auto it = pass_by_values_json.begin(); it != pass_by_values_json.end(); ++it) {
-                uid_t uid                       = std::stoll(it.key());
+                uid_t uid = 0;
+                CHECK_CUDNN_FRONTEND_ERROR(parse_uid_key(it.key(), uid));
                 pass_by_values_t value          = it.value().get<pass_by_values_t>();
                 deserialized_pass_by_value[uid] = value;
             }
@@ -1771,9 +1824,19 @@ class Graph : public ICudnn, public INode {
         // Deserialize workspace_modifications from JSON
         if (j.contains("workspace_modifications")) {
             auto workspace_modifications_json = j["workspace_modifications"];
+            RETURN_CUDNN_FRONTEND_ERROR_IF(!workspace_modifications_json.is_object(),
+                                           error_code_t::UNSUPPORTED_GRAPH_FORMAT,
+                                           "Serialized graph workspace_modifications must be a map.");
             for (auto it = workspace_modifications_json.begin(); it != workspace_modifications_json.end(); ++it) {
-                uid_t uid                                 = std::stoll(it.key());
-                auto tuple_json                           = it.value();
+                uid_t uid = 0;
+                CHECK_CUDNN_FRONTEND_ERROR(parse_uid_key(it.key(), uid));
+                auto tuple_json = it.value();
+                // The const operator[] on an array holds no assert at all.
+                // A short entry is therefore undefined behaviour in a debug build too.
+                RETURN_CUDNN_FRONTEND_ERROR_IF(!tuple_json.is_array() || tuple_json.size() < 3,
+                                               error_code_t::UNSUPPORTED_GRAPH_FORMAT,
+                                               "Serialized graph holds a workspace_modifications entry that is not a "
+                                               "list of at least three elements.");
                 auto tuple_value                          = std::make_tuple(tuple_json[0].get<int64_t>(),
                                                    tuple_json[1].get<int64_t>(),
                                                    tuple_json[2].get<std::vector<float>>());
@@ -2552,6 +2615,7 @@ class Graph : public ICudnn, public INode {
             }
         }
 
+        CHECK_CUDNN_FRONTEND_ERROR(require_key(j, "gid"));
         gid = j["gid"].get<uint64_t>();
 
         RETURN_CUDNN_FRONTEND_ERROR_IF(!j.contains("tensors") || !j["tensors"].is_array(),

--- a/include/cudnn_frontend/utils/serialize.h
+++ b/include/cudnn_frontend/utils/serialize.h
@@ -635,7 +635,10 @@ from_json(const nlohmann::json& j, Tensor_attributes& ta) {
     ta.reordering_type  = j.at("reordering_type").get<TensorReordering_t>();
     ta.set_uid(j.at("uid").get<Tensor_attributes::uid_t>());
 
-    if (ta.is_pass_by_value && !j["pass_by_value"].is_null()) {
+    // contains(), and not the const operator[].
+    // That overload only checks the key with a JSON_ASSERT, which NDEBUG removes.
+    // A damaged tensor entry would then dereference end().
+    if (ta.is_pass_by_value && j.contains("pass_by_value") && !j["pass_by_value"].is_null()) {
         ta.pass_by_value = j.at("pass_by_value");
     }
     if (j.contains("ragged_offset_uid")) {

--- a/include/cudnn_frontend_ExecutionPlan.h
+++ b/include/cudnn_frontend_ExecutionPlan.h
@@ -105,7 +105,10 @@ class ExecutionPlan_v8 : public BackendDescriptor {
     std::string
     getJsonRepresentation() const {
         auto status = CUDNN_STATUS_SUCCESS;
-        int64_t serializationSize;
+        // Initialized, and every error path returns: set_error_and_throw_exception only throws
+        // when NV_CUDNN_DISABLE_EXCEPTION is undefined, so a build that defines it would
+        // otherwise fall through and size the buffer from an indeterminate value.
+        int64_t serializationSize = 0;
         std::vector<char> serialization_buf;
         status = detail::get_attribute(pointer->get_backend_descriptor(),
                                        CUDNN_ATTR_EXECUTION_PLAN_JSON_REPRESENTATION,
@@ -118,21 +121,34 @@ class ExecutionPlan_v8 : public BackendDescriptor {
                                           status,
                                           "CUDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR: GetAttribute "
                                           "CUDNN_ATTR_EXECUTION_PLAN_JSON_REPRESENTATION Failed");
+            return std::string();
         }
         serialization_buf.resize(static_cast<size_t>(serializationSize));
-        status = detail::get_attribute(pointer->get_backend_descriptor(),
+        // The written count is what the buffer holds. An execution plan does not change after
+        // finalization, so the two calls agree and no retry is needed here.
+        int64_t written = 0;
+        status          = detail::get_attribute(pointer->get_backend_descriptor(),
                                        CUDNN_ATTR_EXECUTION_PLAN_JSON_REPRESENTATION,
                                        CUDNN_TYPE_CHAR,
                                        serializationSize,
-                                       &serializationSize,
+                                       &written,
                                        serialization_buf.data());
         if (status != CUDNN_STATUS_SUCCESS) {
             set_error_and_throw_exception(this,
                                           status,
                                           "CUDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR: GetAttribute "
                                           "CUDNN_ATTR_EXECUTION_PLAN_JSON_REPRESENTATION Failed");
+            return std::string();
         }
-        std::string json_string(serialization_buf.begin(), serialization_buf.end());
+        if (written < 0 || written > serializationSize) {
+            set_error_and_throw_exception(this,
+                                          CUDNN_STATUS_INTERNAL_ERROR,
+                                          "CUDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR: GetAttribute "
+                                          "CUDNN_ATTR_EXECUTION_PLAN_JSON_REPRESENTATION returned a written count "
+                                          "outside the buffer");
+            return std::string();
+        }
+        std::string json_string(serialization_buf.begin(), serialization_buf.begin() + written);
         return json_string;
     }
 

--- a/test/cpp/kernel_cache.cpp
+++ b/test/cpp/kernel_cache.cpp
@@ -473,3 +473,147 @@ TEST_CASE("KernelCache revision() grows with size()", "[kernel_cache][revision]"
         WARN("the shape ladder gave no cache hit or no cache insertion on this configuration");
     }
 }
+
+// ---------------------------------------------------------------------------
+// Test 8 — to_json() content while the cache mutates
+//
+// to_json() reads the blob with a size query and then a fill.  The cache can
+// change between the two calls: ExecutionPlanBuilder_v8::build() copies the raw
+// descriptor out from under mutex_ and hands it to cuDNN, which then inserts
+// kernels under its own lock and never takes mutex_ again.
+//
+// A fill that writes fewer bytes than the query reported used to leave the tail
+// of the buffer as the zeros from resize().  to_json() then returned valid json
+// followed by NUL bytes and reported success.  A json lexer maps NUL to end of
+// input, so parsing alone never detected it.
+//
+// The race is not reachable on demand through the public API, so this case
+// cannot fail on the pre-fix code.  It pins the content contract instead.
+// ---------------------------------------------------------------------------
+TEST_CASE("KernelCache to_json() returns clean json while the cache mutates", "[kernel_cache][thread_safety]") {
+    namespace fe = cudnn_frontend;
+
+    if (fe::detail::get_backend_version() < 91000) {
+        SKIP("KernelCache to_json() requires cuDNN >= 9.10");
+    }
+
+    cudnnHandle_t handle;
+    cudnnCreate(&handle);
+
+    auto kc = std::make_shared<fe::KernelCache>();
+
+    // A read before build() must fail, and must not leave anything behind.
+    {
+        std::string early = "not-empty";
+        auto const status = kc->to_json(early);
+        REQUIRE(status.is_bad());
+        REQUIRE(early.empty());
+    }
+
+    // Finalize the cache and seed one entry.
+    auto seed = make_matmul_graph(handle, kc, revision_shape(16));
+    build_plan(handle, seed);
+    REQUIRE(kc->is_finalized());
+
+    // With nothing racing, the size query and the fill must agree.
+    {
+        std::string first, second;
+        REQUIRE(kc->to_json(first).is_good());
+        REQUIRE(kc->to_json(second).is_good());
+        REQUIRE(first == second);
+    }
+
+    constexpr int NUM_BUILDERS = 3;
+    constexpr int NUM_READS    = 40;
+
+    // Build every graph here.  setup_matmul_graph() and make_matmul_graph() use
+    // REQUIRE, which is not safe to call from a spawned thread.
+    std::vector<std::shared_ptr<fe::graph::Graph>> graphs;
+    for (int i = 0; i < NUM_BUILDERS; ++i) {
+        graphs.push_back(make_matmul_graph(handle, kc, revision_shape(32 + 16 * i)));
+    }
+
+    Barrier barrier(NUM_BUILDERS + 1);
+    std::atomic<int> good_reads{0};
+    std::atomic<bool> saw_padding{false};
+    std::atomic<bool> saw_parse_failure{false};
+    std::atomic<bool> saw_partial_failure{false};
+    std::atomic<bool> builders_ok{true};
+
+    std::vector<std::thread> builders;
+    for (int i = 0; i < NUM_BUILDERS; ++i) {
+        builders.emplace_back([&, i]() {
+            cudnnHandle_t h;
+            cudnnCreate(&h);
+            barrier.wait();
+            auto const& g = graphs[static_cast<size_t>(i)];
+            bool const ok = g->create_execution_plans({fe::HeurMode_t::A, fe::HeurMode_t::FALLBACK}).is_good() &&
+                            g->check_support(h).is_good() &&
+                            g->build_plans(h, fe::BuildPlanPolicy_t::HEURISTICS_CHOICE).is_good();
+            if (!ok) {
+                builders_ok.store(false);
+            }
+            cudnnDestroy(h);
+        });
+    }
+
+    std::thread reader([&]() {
+        barrier.wait();
+        for (int i = 0; i < NUM_READS; ++i) {
+            std::string blob;
+            auto const status = kc->to_json(blob);
+            if (status.is_good()) {
+                // The gate on the padded tail.  Parsing alone does not catch it.
+                if (blob.find('\0') != std::string::npos) {
+                    saw_padding.store(true);
+                }
+                // Bind the result: gcc's warn_unused_result ignores a (void) cast.
+                try {
+                    json const parsed = json::parse(blob);
+                    if (!parsed.is_object()) {
+                        saw_parse_failure.store(true);
+                    }
+                } catch (...) {
+                    saw_parse_failure.store(true);
+                }
+                good_reads.fetch_add(1);
+            } else if (!blob.empty()) {
+                // A failure must never hand back a partial result.
+                saw_partial_failure.store(true);
+            }
+            std::this_thread::yield();
+        }
+    });
+
+    for (auto& t : builders) {
+        t.join();
+    }
+    reader.join();
+
+    REQUIRE(builders_ok.load());
+    REQUIRE_FALSE(saw_padding.load());
+    REQUIRE_FALSE(saw_parse_failure.load());
+    REQUIRE_FALSE(saw_partial_failure.load());
+    REQUIRE(good_reads.load() > 0);
+
+    // A read after every builder stopped must succeed and must round-trip.
+    std::string final_blob;
+    REQUIRE(kc->to_json(final_blob).is_good());
+    REQUIRE_FALSE(final_blob.empty());
+    REQUIRE(final_blob.find('\0') == std::string::npos);
+    json parsed_final;
+    REQUIRE_NOTHROW(parsed_final = json::parse(final_blob));
+    REQUIRE(parsed_final.is_object());
+
+    auto reloaded = std::make_shared<fe::KernelCache>();
+    REQUIRE(reloaded->from_json(final_blob).is_good());
+
+    // The builders must have changed the cache, else the case proves nothing.
+    if (fe::detail::get_backend_version() >= MIN_REVISION_VERSION) {
+        auto const state = read_state(kc);
+        REQUIRE(state.revision > 0);
+        REQUIRE(state.size > 0);
+    }
+
+    cudnnDestroy(handle);
+}

--- a/test/cpp/serialize.cpp
+++ b/test/cpp/serialize.cpp
@@ -865,6 +865,165 @@ TEST_CASE("Plan re-serialize preserves pass-by-value and workspace modifications
     cudnnDestroy(handle);
 }
 
+// A blob that lost a key, or that carries a uid key which is not a number, must come back as
+// UNSUPPORTED_GRAPH_FORMAT. Before the guards below, a missing key reached the const operator[],
+// whose only check is a JSON_ASSERT that a Release build (NDEBUG) removes, and a bad uid key
+// reached std::stoll, which threw std::invalid_argument out of the library.
+TEST_CASE("Malformed serialized graph is rejected", "[graph][serialize][deserialize]") {
+    namespace fe = cudnn_frontend;
+
+    // A pointwise node with a scalar operand, so the blob carries pass_by_values.
+    fe::graph::Graph graph;
+    graph.set_io_data_type(fe::DataType_t::HALF)
+        .set_intermediate_data_type(fe::DataType_t::FLOAT)
+        .set_compute_data_type(fe::DataType_t::FLOAT);
+
+    constexpr int64_t N = 4;
+    auto X              = graph.tensor(fe::graph::Tensor_attributes()
+                              .set_name("X")
+                              .set_dim({N, N, N})
+                              .set_stride({N * N, N, 1})
+                              .set_data_type(fe::DataType_t::HALF)
+                              .set_uid(1));
+    auto scalar         = graph.tensor(5.0f);
+    scalar->set_name("scalar").set_uid(2);
+    auto Y = graph.pointwise(X,
+                             scalar,
+                             fe::graph::Pointwise_attributes()
+                                 .set_name("add")
+                                 .set_mode(fe::PointwiseMode_t::ADD)
+                                 .set_compute_data_type(fe::DataType_t::FLOAT));
+    Y->set_output(true).set_data_type(fe::DataType_t::HALF).set_uid(3);
+
+    cudnnHandle_t handle;
+    cudnnCreate(&handle);
+
+    REQUIRE(graph.build(handle, {fe::HeurMode_t::A}).is_good());
+
+    std::vector<uint8_t> blob;
+    REQUIRE(graph.serialize(blob).is_good());
+
+    json const base = json::from_ubjson(blob);
+
+    // The blob must be well formed to start with, else a section below would pass for the
+    // wrong reason.
+    REQUIRE(base.contains("pass_by_values"));
+    REQUIRE_FALSE(base["pass_by_values"].empty());
+
+    auto expect_rejected = [&handle](json const& j) {
+        fe::graph::Graph reloaded;
+        auto status = reloaded.deserialize(handle, j);
+        CAPTURE(status.get_message());
+        REQUIRE_FALSE(status.is_good());
+        REQUIRE(status.get_code() == fe::error_code_t::UNSUPPORTED_GRAPH_FORMAT);
+    };
+
+    // The positive control. Every section below reaches its guard only after the plan rebuild
+    // succeeds, so without this a broken rebuild would look like a broken guard.
+    SECTION("the unmodified blob is accepted") {
+        fe::graph::Graph ok;
+        auto status = ok.deserialize(handle, base);
+        CAPTURE(status.get_message());
+        REQUIRE(status.is_good());
+    }
+
+    // Every key the deserializer reads unconditionally. gid is reachable because the blob
+    // carries the graph structure; the guard above it tests nodes and tensors, not gid.
+    auto const required_keys = {"gid",
+                                "cudnn_backend_data",
+                                "behavior_notes",
+                                "variant_pack_uids",
+                                "variant_pack_replacements",
+                                "fe_workspace_size"};
+
+    for (auto const& key : required_keys) {
+        SECTION(std::string("a blob with no ") + key + " is rejected") {
+            json j = base;
+            REQUIRE(j.erase(key) == 1);
+            expect_rejected(j);
+        }
+    }
+
+    SECTION("a pass_by_values uid key that is not a number is rejected") {
+        json j              = base;
+        json rekeyed        = json::object();
+        auto const& pbv     = base["pass_by_values"];
+        rekeyed["bad-uid"]  = pbv.begin().value();
+        j["pass_by_values"] = rekeyed;
+        expect_rejected(j);
+    }
+
+    SECTION("a workspace_modifications uid key that is not a number is rejected") {
+        json j                                  = base;
+        j["workspace_modifications"]["bad-uid"] = json::array({0, 0, json::array({1.0})});
+        expect_rejected(j);
+    }
+
+    SECTION("a workspace_modifications entry with fewer than three elements is rejected") {
+        json j                                 = base;
+        j["workspace_modifications"]["999999"] = json::array({0, 0});
+        expect_rejected(j);
+    }
+
+    SECTION("a workspace_modifications entry that is not a list is rejected") {
+        json j                                 = base;
+        j["workspace_modifications"]["999999"] = 7;
+        expect_rejected(j);
+    }
+
+    // uid_t is signed and set_uid() takes any value, so a negative uid key is well formed.
+    // The parser must keep accepting it.
+    SECTION("a negative pass_by_values uid key is accepted") {
+        json j              = base;
+        json rekeyed        = json::object();
+        auto const& pbv     = base["pass_by_values"];
+        rekeyed["-5"]       = pbv.begin().value();
+        j["pass_by_values"] = rekeyed;
+
+        fe::graph::Graph reloaded;
+        auto status = reloaded.deserialize(handle, j);
+        CAPTURE(status.get_message());
+        REQUIRE(status.is_good());
+    }
+
+    // begin() on a scalar is not end(), so without an is_object guard the loop would run once
+    // and it.key() would throw json::invalid_iterator out of the library.
+    SECTION("a pass_by_values that is not a map is rejected") {
+        json j              = base;
+        j["pass_by_values"] = 7;
+        expect_rejected(j);
+    }
+
+    SECTION("a workspace_modifications that is not a map is rejected") {
+        json j                       = base;
+        j["workspace_modifications"] = json::array({1, 2, 3});
+        expect_rejected(j);
+    }
+
+    // A tensor entry that claims a pass-by-value and lost the value reaches the const
+    // operator[] inside from_json(json, Tensor_attributes&), whose only check is a
+    // JSON_ASSERT that NDEBUG removes.
+    SECTION("a tensor that claims a pass-by-value with no value does not crash") {
+        json j = base;
+        REQUIRE(j.contains("tensors"));
+        REQUIRE(j["tensors"].is_array());
+        bool patched = false;
+        for (auto& tensor : j["tensors"]) {
+            tensor["is_pass_by_value"] = true;
+            if (tensor.erase("pass_by_value") == 1) {
+                patched = true;
+            }
+        }
+        REQUIRE(patched);
+        // The parser has no error channel, so the contract is only that it must not read past
+        // the end of the object. Any typed outcome is acceptable.
+        fe::graph::Graph reloaded;
+        REQUIRE_NOTHROW((void)reloaded.deserialize(handle, j));
+    }
+
+    cudnnDestroy(handle);
+}
+
 // ============================================================
 // Helpers shared by handle-less deserialize tests below.
 // ============================================================


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches and my changes comply.
- [x] I added GitHub labels: `cat-bugfix`, `mod-frontend`, `orig-external`.

## Affected area

C++ frontend API or graph construction

## Summary

This PR fixes three issues in the frontend's json handling.

1. `Graph::deserialize_plan_impl` read seven json keys with the const `operator[]`. nlohmann implements that as `JSON_ASSERT(it != end())`, and `JSON_ASSERT` is `assert`. A Release build drops the check, so a blob that lost a key dereferences the end iterator. This is UB. This is fixed now by checking for the keys existence before dereferencing.
2. The same function parses uid keys with `std::stoll` and iterates both uid maps with no shape check. Both throw a `std::` exception out of the library if the key is not an integer. These paths now return `UNSUPPORTED_GRAPH_FORMAT` consistent with the other returns.
3. `KernelCache::to_json`, `ExecutionPlan::getJsonRepresentation` and `DeviceProperties::serialize` built the result from the buffer extent, and dropped the count that the fill call returns. All three now use the count.

## Why

The first two fixes are sanity-checks that avoid UB/exceptions (especially when compiled with no-exceptions mode).

The third change is defensive behavior. cuDNN serves a json blob with a size query and then a bytes fill. A fill that writes fewer bytes than the query reported leaves the tail of the buffer as the zeros from `resize()`. The caller gets valid json, then NUL bytes, and no error. A json lexer maps NUL to end of input, so nothing rejects the padded blob today. But this may change on incrementing JSON versions.

Also, in case of concurrent execution, the kernel cache size may change between the two calls. For example, this happens when cuDNN is compiling new kernels onto one cache and the caller asks for a `to_json` in another thread. Both these operation are individually thread-safe, but in between the to_json size/emit call, we may get different bytes. To workaround this, `KernelCache::to_json` retries the serialization attempt three times. Each attempt repeats the size query, and exits with success if properly filled. An execution plan and a device property descriptor do not change after finalization, so these two dont need such retries.

## Related issues

None.

## API and compatibility impact

No public API change and no new symbol. 

- A malformed blob returns `UNSUPPORTED_GRAPH_FORMAT`. It previously crashed or
  threw a raw `std::` exception.
- `DeviceProperties::serialize` sizes the output vector to the written count.
- `getJsonRepresentation` returns an empty string after a backend failure. It previously sized a buffer from an indeterminate value, because `set_error_and_throw_exception` returns instead of throwing when `NV_CUDNN_DISABLE_EXCEPTION` is defined.
- A negative uid still loads. `uid_t` is signed and the serializer writes `std::to_string(uid)`, so `std::stoll` accepted one. `parse_uid_key` uses std::from_chars` and requires the whole key to be consumed.

## Testing

L40S, cuDNN ToT, CUDA 13.4, GCC with `-Wall -Wextra -Wpedantic -Werror`.

```
    cmake -B build -DCMAKE_BUILD_TYPE=Release -DCUDNN_PATH=$CUDNN_PATH \
          -DCUDAToolkit_ROOT=$(dirname $(dirname $(which nvcc)))
    cmake --build build -j 32 --target tests
    ./build/bin/tests
    # All tests passed (820 assertions in 40 test cases)
```

Two test cases are new. `test/cpp/serialize.cpp` gets twelve sections for the
malformed-blob paths. `test/cpp/kernel_cache.cpp` gets one case that runs three
plan builds against one kernel cache while a reader calls `to_json` in a loop.
Each result must hold no NUL byte, must parse as a json object, and must
round-trip through `from_json`.
