### PR TITLE
Fix SM100 2CTA Flex Attention mask slot synchronization

### DIFF
--- a/python/cudnn/flex_attention/kernels/sm100/fwd/forward.py
+++ b/python/cudnn/flex_attention/kernels/sm100/fwd/forward.py
@@ -25,6 +25,7 @@ import cuda.bindings.driver as cuda
 import cudnn.flex_attention.kernels.common.pipeline as pipeline_custom
 from cudnn.flex_attention.kernels.common import device_utils as utils
 from cudnn.flex_attention.plan.kernels.packed_mask import (
+    create_mask_payload_pipeline,
     softmax_arbitrary_forward_sm100,
     softmax_arbitrary_forward_qstage1_n_direction_sm100,
 )
@@ -623,22 +624,18 @@ class _FlexAttentionForwardSm100Base:
         pipeline_mask_s1 = None
         if const_expr(self.use_smem_mask_pipeline):
             # Each N-direction stream owns one independent 2-KB mask slot.
-            # PipelineTmaAsync releases once per consumer warp, so this group
-            # counts warps rather than threads.
+            # Every thread owns different mask words. Release the slot only
+            # after every reader has arrived, not just one lane per warp.
             mask_tx_count = self.m_block_size * SM100_FWD_MASK_PAYLOAD_WORDS * 4
-            pipeline_mask_s0 = cutlass_pipeline.PipelineTmaAsync.create(
+            pipeline_mask_s0 = create_mask_payload_pipeline(
                 barrier_storage=storage.mbar_load_mask_s0.data_ptr(),
-                num_stages=1,
-                producer_group=tma_warp,
-                consumer_group=softmax_warps,
+                consumer_threads=cute.arch.WARP_SIZE * len(self.softmax0_warp_ids),
                 tx_count=mask_tx_count,
                 defer_sync=True,
             )
-            pipeline_mask_s1 = cutlass_pipeline.PipelineTmaAsync.create(
+            pipeline_mask_s1 = create_mask_payload_pipeline(
                 barrier_storage=storage.mbar_load_mask_s1.data_ptr(),
-                num_stages=1,
-                producer_group=tma_warp,
-                consumer_group=softmax_warps,
+                consumer_threads=cute.arch.WARP_SIZE * len(self.softmax1_warp_ids),
                 tx_count=mask_tx_count,
                 defer_sync=True,
             )

--- a/python/cudnn/flex_attention/plan/kernels/packed_mask.py
+++ b/python/cudnn/flex_attention/plan/kernels/packed_mask.py
@@ -271,6 +271,31 @@ def load_mask_payload_to_smem(
 
 
 @cute.jit
+def create_mask_payload_pipeline(
+    barrier_storage: cute.Pointer,
+    consumer_threads: cutlass.Constexpr[int],
+    tx_count: cutlass.Constexpr[int],
+    defer_sync: cutlass.Constexpr[bool] = True,
+):
+    """Create a CTA-local mask slot whose reuse waits for every reader.
+
+    PipelineTmaAsync normally elects one empty-barrier signaller per warp.
+    Mask words are read independently by each lane; count each reader and
+    make every lane signal instead. This also avoids depending on warp-local
+    reconvergence to order the next bulk copy after all shared loads.
+    """
+    return cutlass.pipeline.PipelineTmaAsync.create(
+        barrier_storage=barrier_storage,
+        num_stages=1,
+        producer_group=cutlass.pipeline.CooperativeGroup(cutlass.pipeline.Agent.Thread, 1),
+        consumer_group=cutlass.pipeline.CooperativeGroup(cutlass.pipeline.Agent.Thread, consumer_threads),
+        tidx=Int32(0),  # A local pipeline signals whenever tidx % 32 == 0.
+        tx_count=tx_count,
+        defer_sync=defer_sync,
+    )
+
+
+@cute.jit
 def consume_mask_payload_from_smem(
     s_mask: cute.Tensor,
     payload_group_idx: Int32,
@@ -283,6 +308,9 @@ def consume_mask_payload_from_smem(
     s_mask_thread = s_mask[payload_group_idx, None]
     r_mask = cute.make_rmem_tensor_like(s_mask_thread, Uint32)
     cute.autovec_copy(s_mask_thread, r_mask)
+    # Finish generic-proxy shared reads before allowing the producer to
+    # overwrite this slot through cp.async.bulk (the async proxy).
+    cute.arch.fence_proxy("async.shared", space="cta")
     mask_pipeline.consumer_release(consumer_state)
     consumer_state.advance()
     return r_mask, consumer_state


### PR DESCRIPTION
## Summary

Fix intermittent incorrect mask reads in the SM100 2CTA Flex Attention forward kernel. On B200, a valid row can consume an all-zero mask, producing zero output and `LSE=-inf`, followed by large gradient errors.

Count all 128 mask-reading threads in each slot's empty barrier and issue `fence.proxy.async.shared::cta` after the shared loads and before releasing the slot. The existing 2CTA configuration and backward kernels are preserved.

## Why

Each N-direction stream reuses a single shared-memory mask slot. The original pipeline released once per consumer warp, while individual lanes read different mask words. It also lacked ordering between those generic-proxy shared loads and the next async-proxy bulk copy that overwrites the slot. Waiting for the previous bulk copy to complete covers the producer-to-consumer handoff; safe slot reuse also needs the reverse handoff.

A diagnostic captured `0x03000000` becoming zero for a row with valid keys. The softmax statistics were already incorrect at their producer, and matched the values read by the correction stage. This localizes the observed failure to the forward mask path.

## Affected area

FE OSS kernels / CuTeDSL: Flex Attention shared-mask consumption and SM100 2CTA forward pipeline construction.

## API and compatibility impact

No public API, supported architecture, or dependency-floor changes. The shared-mask consumer helper also gains the fence for its existing callers. GPU validation was performed on B200; SM90 was not tested.

## Testing

B200, CuTe DSL 4.6.2, CUDA 13.2 PyTorch build. Imports were verified to resolve to the modified checkout.

- Fixed-input reproducer: BF16 Q/K `[1,4096,4,192]`, V `[1,4096,4,128]`; 2000 rounds, two complete forward/backward calls per round. Zero accuracy failures or NaN/Inf failures; all 4000 forward outputs were identical. Each call checked output, dQ, dK, and dV against the supplied FP64 reference.
- All 25 existing Flex Attention L0/L1/L2 tests passed, using `cd test/python && pytest fe_api/flex_attention/ -m 'L0 or L1 or L2' -q` with `PYTHONPATH` pointing to this checkout's `python/` directory.
- Standalone mask handoff diagnostic under `compute-sanitizer --tool racecheck --error-exitcode 99`: the original pipeline reports a read/write race; the fixed handoff reports zero errors and warnings. Diagnostic files and the fixed-input data are not part of this PR.
- `pre-commit run --files python/cudnn/flex_attention/kernels/sm100/fwd/forward.py python/cudnn/flex_attention/plan/kernels/packed_mask.py` passed.

## Related issues

None linked.

## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the applicable `AGENTS.md` files and the changes comply.
- [x] I added labels for change type, affected area, and originator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mask processing synchronization during attention operations.
  - Prevented shared-memory data from being overwritten before all reads complete.
  - Improved coordination across participating threads for mask payload transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->