### PR TITLE
Fix NaN when using cuTile engine with `headdim=32` for GDN kernel

### DIFF
--- a/python/cudnn/linear_attention/cutile/kernels/gdn.py
+++ b/python/cudnn/linear_attention/cutile/kernels/gdn.py
@@ -2097,6 +2097,7 @@ def chunk_bwd_kernel_dv_local(
 
     o_t = i_t * BT + r_bt
     m_t = o_t < T
+    m_A = (o_t[:, None] <= o_t[None, :]) & (m_t[:, None] & m_t[None, :])
 
     b_A = ct.zeros((BT, BT), dtype=ct.float32)
     b_g = ct.zeros((BT,), dtype=ct.float32)
@@ -2131,18 +2132,8 @@ def chunk_bwd_kernel_dv_local(
             b_A = b_A + safe_dot(b_k, b_q) * scale
 
         if USE_G or USE_G_GAMMA:
-            if H <= 16:
-                b_g_ref = ct.max(b_g, axis=0)
-                b_A = b_A * (exp2(b_g[None, :] - b_g_ref) * exp2(b_g_ref - b_g[:, None]))
-            elif USE_G:
-                g_base = bos * HV + i_h
-                b_g_ref = ct.astype(gf.load_offset(g_base + i_t * BT * HV).item(), ct.float32)
-                b_A = b_A * (exp2(b_g[None, :] - b_g_ref) * exp2(b_g_ref - b_g[:, None]))
-            else:
-                b_g_ref = b_gamma
-                b_A = b_A * (exp2(b_g[None, :] - b_g_ref) * exp2(b_g_ref - b_g[:, None]))
+            b_A = ct.where(m_A, b_A * exp2(b_g[None, :] - b_g[:, None]), ct.zeros((BT, BT), dtype=ct.float32))
 
-    m_A = (o_t[:, None] <= o_t[None, :]) & (m_t[:, None] & m_t[None, :])
     b_A = ct.astype(ct.where(m_A, b_A, ct.zeros((BT, BT), dtype=ct.float32)), do.dtype)
 
     for i_v in range(ct.cdiv(V, BV)):


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches (see [root AGENTS.md § Reviewing a PR](https://github.com/NVIDIA/cudnn-frontend/blob/develop/AGENTS.md#reviewing-a-pr-human-or-agent)) and my changes comply, or I explain the exception below.
- [x] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

<!-- What changed? Keep the scope concise. -->

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved causal masking in linear attention computations to prevent invalid attention contributions.
  * Updated gate scaling behavior for more consistent gradient calculations across supported hardware configurations.
  * Improved numerical reliability during model training and backpropagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->