### PR TITLE
frost(sdpa_bwd_sm80): serve THD / ragged ports at their own token stride

### DIFF
--- a/python/cudnn/AGENTS.md
+++ b/python/cudnn/AGENTS.md
@@ -131,11 +131,13 @@ none is precedent:
   declaration would drop the KV-only-padding population these kernels serve
   correctly. It goes away when the FP8 kernels get the epilogue trim; until
   then the read is what keeps a short length from being silently ignored.
-- `cu_seqlens_{q,k}.to(dtype=..., device="cpu")` in the SM80 packed-THD backward
-  (`sdpa/bwd/kernels/bprop_f16_sm80.py`). Reachable only through the standalone
-  wrapper: the registered `sdpa_bwd_sm80` spec declares `thd=False`, so
-  `graph.execute()` does not route here. Still a violation, and it is the one to
-  fix first if that spec ever gains THD.
+- `cu_k.to(dtype=..., device="cpu")` in the SM80 packed-THD WRAPPER path
+  (`_sm80_thd_backward` in `sdpa/bwd/api_dsl.py`), taken only when the caller
+  passes no `max_s_kv` hint. Reachable only through the standalone wrapper: the
+  `sdpa_bwd_sm80` engine path bounds its kv-tile grid and relay counter from
+  the graph's envelope `S_max` and turns the per-batch lengths into
+  `cu_seqlens` on device, so `graph.execute()` never reads a length. Still a
+  violation on the wrapper surface (a caller contract, documented there).
 
 When auditing this list, grep for the ARGUMENT, not the call shape:
 `device="cpu"` finds `to(dtype=..., device="cpu")`, which `to(device="cpu")`
@@ -170,10 +172,12 @@ not become a compile key.
   execute path's cached call must be a guaranteed hit. Guard it with a
   cache-miss regression test (see
   `test_dsl_sm100_thd_compile_key_plan_time_only`), not by inspection.
-- **Known open cleanup (issue #604)**: the SM80 engines' `_compile_cached`
-  (#493) still keys `SQ`/`SKV` under `THD_VARLEN` — migrate it to dynamic
-  token extents like the SM100/SM120 THD compiles rather than copying its
-  pattern.
+- **Issue #604 is closed**: the SM80 THD compiles (forward and backward) take
+  the packed token extents as `cute.sym_int` and key on `b = 1, sq = skv = 0`
+  plus the plan-time sequence count; the regression tests are
+  `test_sm80_bwd_thd_compile_key_plan_time_only` (wrapper) and
+  `test_graph_thd_compile_key_is_plan_time_only` (graph path). Copy that
+  pattern, not a shape-keyed one.
 - **Key on exactly the contract-relevant set — no more, no less.** Both
   failure modes shipped on PR #553 and were caught in review: *under-keying*
   (the cache keyed only `x.shape`/`w.shape` while `check_support()`

--- a/python/cudnn/sdpa/AGENTS.md
+++ b/python/cudnn/sdpa/AGENTS.md
@@ -26,9 +26,10 @@ head-major, never dense-padded.**
   `_thd_lse_view`'s docstring), not something the adapter verifies:
   `as_strided` bounds-checks storage capacity, never overlap. Do not "fix"
   this with a host-side length read; an in-kernel assert is the only
-  legal detector. See the THD classification sites in `fwd/api_dsl.py`
-  (duplicated at the two THD compile-key call sites — extract rather than
-  re-copy if you touch it, per Rule 3's "suspect duplicated logic first").
+  legal detector. Classify with `graph_analyzer.thd_stats_packing(stride_h,
+  stride_s, h_q)` — the one classifier the fwd adapters, the bwd probe and the
+  bwd lowering share; never re-implement the stride test inline (Rule 3's
+  "suspect duplicated logic first").
 - Covered by `test_fwd_probe_rejects_invalid_stats_metadata` and the
   `stats_layout`-parametrized THD tests (`test_dsl_sm100_thd_stats` and
   siblings) in `test/python/sdpa/frost/`.

--- a/python/cudnn/sdpa/bwd/api_dsl.py
+++ b/python/cudnn/sdpa/bwd/api_dsl.py
@@ -1089,7 +1089,10 @@ def _sm80_thd_backward(
     cu_q_t = cu_q.to(dtype=torch.int32, device=dev).contiguous()
     cu_k_t = cu_k.to(dtype=torch.int32, device=dev).contiguous()
     dq_acc = torch.zeros(1, t_q, h_q, fdqk, dtype=torch.float32, device=dev)
-    dQ_k = torch.empty(1, t_q, h_q, fdqk, dtype=q.dtype, device=dev)
+    # The THD cast writes rows below cu_q[n_seq] only, so the returned dQ's
+    # rows past the packed total read zero (as they did when the cast covered
+    # the whole buffer from the zeroed accumulator).
+    dQ_k = torch.zeros(1, t_q, h_q, fdqk, dtype=q.dtype, device=dev)
     # dK/dV write buffers carry the h_q query heads (one slice per query head);
     # MHA: they ARE the outputs.  GQA: reduced over the group below.
     dk_ws = torch.empty(1, t_kv, h_q, fdqk, dtype=q.dtype, device=dev)
@@ -1152,12 +1155,14 @@ def _sm80_thd_backward(
         grid_batch=n_seq,
         stream=stream,
     )
-    c.cast(_fd_tvm(dq_acc), _fd_tvm(dQ_k), _int32((t_q * h_q * fdqk) // 2), stream)
+    # THD cast / fold ABI: bounded by cu_*[n_seq] on device, at the envelope
+    # width here (the wrapper slices the head-dim padding below).
+    c.cast(_fd_tvm(dq_acc), _fd_tvm(dQ_k), _fd_tvm(cu_q_t), _int32(n_seq), _int32((t_q * h_q * fdqk) // 2), stream)
     if h_q != h_kv:
-        dK_k = torch.empty(1, t_kv, h_kv, fdqk, dtype=q.dtype, device=dev)
-        dV_k = torch.empty(1, t_kv, h_kv, fdv, dtype=q.dtype, device=dev)
-        c.reduce_k(_fd_tvm(dk_ws), _fd_tvm(dK_k), _int32(t_kv * h_kv * fdqk), stream)
-        c.reduce_v(_fd_tvm(dv_ws), _fd_tvm(dV_k), _int32(t_kv * h_kv * fdv), stream)
+        dK_k = torch.zeros(1, t_kv, h_kv, fdqk, dtype=q.dtype, device=dev)
+        dV_k = torch.zeros(1, t_kv, h_kv, fdv, dtype=q.dtype, device=dev)
+        c.reduce_k(_fd_tvm(dk_ws), _fd_tvm(dK_k), _fd_tvm(cu_k_t), _int32(n_seq), _int32(t_kv * h_kv * fdqk), stream)
+        c.reduce_v(_fd_tvm(dv_ws), _fd_tvm(dV_k), _fd_tvm(cu_k_t), _int32(n_seq), _int32(t_kv * h_kv * fdv), stream)
     else:
         dK_k, dV_k = dk_ws, dv_ws
     if pad_qk:
@@ -1184,8 +1189,12 @@ from cudnn.frost.tile_dsl.constants import SCHED_LPT_L2 as _BWD_SCHED_LPT_L2  # 
 from cudnn.frost.tile_dsl.constants import SCHED_NATURAL as _BWD_SCHED_NATURAL  # noqa: E402
 
 
-def _sm80_bwd_sched_policy(*, is_causal: bool, deterministic: bool) -> int:
+def _sm80_bwd_sched_policy(*, is_causal: bool, deterministic: bool, thd: bool = False) -> int:
     """Grid order for the SM80 backward (a ``tile_dsl.constants.SCHED_*``).
+
+    Under THD the grid is the plain 3-D (kv_tile, head, sequence) decode over
+    the envelope's kv-tile count -- the kv-major remaps assume the dense grid,
+    so a packed plan takes the plain order whatever the mask.
 
     Causal takes the kv-major LPT order WITHIN L2-sized head groups.  The plain
     kv-major LPT over every head at once spreads a head's kv-tiles across the
@@ -1196,6 +1205,8 @@ def _sm80_bwd_sched_policy(*, is_causal: bool, deterministic: bool) -> int:
     work is uniform per kv-tile, so the plain 3-D grid stays; the deterministic
     relay REQUIRES the plain decode (kv_tile == blockIdx.x).
     """
+    if thd:
+        return _BWD_SCHED_NATURAL
     return _BWD_SCHED_LPT_L2 if (is_causal and not deterministic) else _BWD_SCHED_NATURAL
 
 
@@ -1311,16 +1322,38 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
     """
 
     def __init__(
-        self, *args, has_bias: bool = False, bias_is_fp32: bool = True, bias_batch: int = 1, has_rope: bool = False, rope_max_s: int = 0, **kwargs
+        self,
+        *args,
+        has_bias: bool = False,
+        bias_is_fp32: bool = True,
+        bias_batch: int = 1,
+        has_rope: bool = False,
+        rope_max_s: int = 0,
+        thd: bool = False,
+        max_total_seq_len_q: Optional[int] = None,
+        max_total_seq_len_kv: Optional[int] = None,
+        thd_stats_token_major: bool = False,
+        thd_stats_head_stride: Optional[int] = None,
+        **kwargs,
     ) -> None:
         # SM80-only plan-time facts (scratch sizing + template identity); the
-        # base contract carries everything else.
+        # base contract carries everything else.  The THD keywords are base
+        # parameters, spelled out here because the lowering forwards a keyword
+        # only when it appears in THIS signature (a bare **kwargs hides them).
         self._has_bias = bool(has_bias)
         self._bias_is_fp32 = bool(bias_is_fp32)
         self._bias_batch = int(bias_batch)
         self._has_rope = bool(has_rope)
         self._rope_max_s = int(rope_max_s)
-        super().__init__(*args, **kwargs)
+        super().__init__(
+            *args,
+            thd=thd,
+            max_total_seq_len_q=max_total_seq_len_q,
+            max_total_seq_len_kv=max_total_seq_len_kv,
+            thd_stats_token_major=thd_stats_token_major,
+            thd_stats_head_stride=thd_stats_head_stride,
+            **kwargs,
+        )
 
     def _initialize_implementation(self) -> None:
         self.flavor: Optional[str] = None
@@ -1331,6 +1364,44 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
         self.right_bound_runtime: int = 0
         self._lse_stride: "Optional[tuple[int, int, int]]" = None
         self._dummy_cache: dict = {}
+        # THD (packed) plan-time state: token capacities the views bind at,
+        # the Stats packing, and the compiled lengths -> cu_seqlens setup launch.
+        self._t_q_cap: int = 0
+        self._t_kv_cap: int = 0
+        self._thd_lse_token_major: bool = False
+        self._thd_lse_head_stride: int = 0
+        self._thd_meta_fn = None
+
+    @staticmethod
+    def _thd_total(capacity: int, declared: Optional[int]) -> int:
+        """Token capacity tightened by the declared packed total (always a MIN,
+        so a stale declaration cannot push a view past the caller's buffer)."""
+        return capacity if declared is None else min(capacity, max(int(declared), 0))
+
+    @property
+    def thd_total_q(self) -> Optional[int]:
+        """Packed Q-token extent the lowering binds the Q/O/dO/dQ views at
+        (``min(B * S_max, max_total_seq_len_q)``), or None when not THD."""
+        return self._t_q_cap if self.thd else None
+
+    @property
+    def thd_total_kv(self) -> Optional[int]:
+        """Packed KV-token extent; see :attr:`thd_total_q`."""
+        return self._t_kv_cap if self.thd else None
+
+    @staticmethod
+    def _compact_bshd(desc: TensorDesc) -> bool:
+        """True when a logical-BHSD desc sits on COMPACT BSHD storage: the packed
+        path binds the caller's buffer to kernels that address rows from H and D
+        alone (head stride D, token stride H*D, element stride 1).  The batch
+        stride is not consulted -- a ragged port's sequences start at the ragged
+        offsets, and the packed view rebuilds that axis from the token extent.
+        The token stride is always checked (the packed view walks every token
+        with it, even when the envelope S_max is 1); the head and element
+        strides wildcard on a size-1 extent (the analyzer's convention)."""
+        _, h, _, d = (int(x) for x in desc.shape)
+        st = tuple(int(x) for x in desc.stride)
+        return (int(desc.shape[1]) == 1 or st[1] == d) and st[2] == h * d and (d == 1 or st[3] == 1)
 
     def _checked_lse_view(self, lse_tensor: torch.Tensor) -> torch.Tensor:
         """Validate a caller-provided Stats/LSE buffer and return the
@@ -1426,6 +1497,58 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
         # Contiguous stats keep the packed compact fake (byte-identical).
         self._lse_stride = None if self.stats_desc.is_contiguous() else tuple(int(st) for st in self.stats_desc.stride[:3])
 
+        if self.thd:
+            # Packed (THD / ragged) plan.  The descs are the ENVELOPE (B, H,
+            # S_max, D); the packed buffers appear at execute as [1, T, H, D]
+            # views (the lowering's _thd_view), bound at the capacities below.
+            self._value_error_if(
+                self.seq_kv_lens_present or self.seq_q_lens_present,
+                "SM80 bwd THD: the per-batch lengths become device cu_seqlens; a compiled padding mask is dense-only",
+            )
+            # The declared totals are REQUIRED because scratch_workspace_bytes()
+            # is a build-time function: the fp32 dQ accumulator, the per-query-
+            # head dK/dV partials and do_dot are all sized from the packed token
+            # totals before any buffer exists.  Undeclared, the capacity is
+            # B * S_max -- far more tokens than a packed buffer holds.
+            self._value_error_if(
+                self.max_total_seq_len_q is None or self.max_total_seq_len_kv is None,
+                "SM80 bwd THD: max_total_seq_len_q and max_total_seq_len_kv must be declared "
+                "(the packed dQ accumulator, dK/dV partials and do_dot scratch are sized from the token totals at build time)",
+            )
+            self._value_error_if(self._has_bias, "SM80 bwd THD: bias / dBias is dense-only (a packed graph has no [B, H, S_q, S_kv] bias)")
+            self._value_error_if(self._has_rope, "SM80 bwd THD: RoPE is dense-only")
+            # No staging leg: the kernels' packed fakes are compact BSHD, so a
+            # port declared as a view into a wider per-token record would be
+            # read at the wrong rows.  A decline here, not a silent mis-bind.
+            for desc in (self.q_desc, self.k_desc, self.v_desc, self.o_desc, self.do_desc, self.dq_desc, self.dk_desc, self.dv_desc):
+                self._value_error_if(
+                    not self._compact_bshd(desc),
+                    f"SM80 bwd THD: {desc.name} must be compact BSHD (stride (S*H*D, D, H*D, 1)); got {tuple(desc.stride)} (the packed path has no staging copy)",
+                )
+            self._t_q_cap = self._thd_total(int(b) * int(s_qo), self.max_total_seq_len_q)
+            self._t_kv_cap = self._thd_total(int(b) * int(s_kv), self.max_total_seq_len_kv)
+            self._value_error_if(self._t_q_cap <= 0 or self._t_kv_cap <= 0, "SM80 bwd THD: the packed token capacities must be > 0")
+            # Stats packing (Rule S1), as the lowering classified it from the
+            # ragged declaration: token-major (T, H) or head-major (1, H,
+            # head_stride), head_stride 0 == compact == the Q-token capacity.
+            # The two are exclusive (Rule 1: overlapping optional declarations
+            # are validated as a set).
+            self._value_error_if(
+                bool(self.thd_stats_token_major) and bool(self.thd_stats_head_stride),
+                "SM80 bwd THD: thd_stats_head_stride is head-major-only (token-major (T, H) Stats is compact)",
+            )
+            self._thd_lse_token_major = bool(self.thd_stats_token_major)
+            self._thd_lse_head_stride = 0 if self._thd_lse_token_major else int(self.thd_stats_head_stride or 0)
+            # A head stride shorter than the bound extent puts the later heads'
+            # rows past the buffer (the kernel reads [0, h, row] at that stride
+            # for every row < t_q_cap).
+            self._value_error_if(
+                bool(self._thd_lse_head_stride) and self._thd_lse_head_stride < self._t_q_cap,
+                f"SM80 bwd THD: Stats head stride {self._thd_lse_head_stride} must cover the packed token capacity {self._t_q_cap}",
+            )
+            # The envelope Stats desc describes the packing, not a dense layout.
+            self._lse_stride = None
+
         self._value_error_if(not torch.cuda.is_available(), "CUDA must be available for SM80 BPROP")
         # Plan-time device parity: the kernels bind the Stats pointer directly
         # (native strided reads), and execute() validates the runtime LSE
@@ -1498,7 +1621,7 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
         self._ensure_support_checked()
         from cudnn.sdpa.bwd.config_sm80 import bwd_params_for_flavor
 
-        sched = _sm80_bwd_sched_policy(is_causal=self.is_causal, deterministic=self.deterministic)
+        sched = _sm80_bwd_sched_policy(is_causal=self.is_causal, deterministic=self.deterministic, thd=self.thd)
         # NOTE: the generic pipeline always ran the llama-swept tile point
         # regardless of flavor (the old backward() defaults); the gptoss
         # wide-Q-tile row stays unwired pending an adapter-level perf gate.
@@ -1518,7 +1641,7 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
             has_sink=self.sink_desc is not None,
             has_rope=self._has_rope,
             deterministic=self.deterministic,
-            thd_varlen=False,
+            thd_varlen=self.thd,
             sched_policy=sched,
         )
         # RoPE preconditions the old backward() asserted (the params validator
@@ -1554,11 +1677,33 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
                 deterministic=self.deterministic,
             ),
         )
-        if self._lse_stride is not None:
-            self._use_d64 = False
+        if self._lse_stride is not None or self.thd:
+            self._use_d64 = False  # the d64 kernel is dense-only with packed LSE reads
         if self._use_d64:
             self._kmod = None
             self._compiled_kernel = True  # d64 self-caches on first execute
+        elif self.thd:
+            # Packed token totals compile as cute.sym_int (never in the key,
+            # issue #604): b = 1, sq = skv = 0; the sequence count sizes the
+            # cu_seqlens ABI and IS plan-time.  The Stats packing is plan-time
+            # too (the fake's shape and strides).
+            self._kmod = _load_sm80_bwd_module(self._params)
+            self._compiled_kernel = self._kmod.compile(
+                b=1,
+                h=self.h_q,
+                h_kv=self.h_kv,
+                sq=0,
+                skv=0,
+                swa_window=int(self.swa_window_runtime),
+                rope_max_s=0,
+                n_batch_logical=self.batch_size,
+                lse_stride=None,
+                lse_token_major=self._thd_lse_token_major,
+                lse_head_stride=self._thd_lse_head_stride,
+                out_d_qk=self.head_dim_qk,
+                out_d_v=self.head_dim_v,
+            )
+            self._thd_meta_fn = self._compile_thd_meta()
         else:
             self._kmod = _load_sm80_bwd_module(self._params)
             self._compiled_kernel = self._kmod.compile(
@@ -1573,6 +1718,34 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
                 lse_stride=self._lse_stride,
             )
         self._logger.debug("compile completed")
+
+    def _compile_thd_meta(self):
+        """Plan-time JIT of the lengths -> cu_seqlens setup launch.
+
+        The backward node carries per-batch ``(B,)`` lengths only (no
+        cu_seq_len port), so the fakes are ``(B,)`` int32 and the metadata is
+        the shared ``[seq_kv(B) | cu_q(B+1) | cu_k(B+1) | ...]`` layout of
+        ``tile_dsl.thd`` (``THD_META_WORDS`` words; the remap / live / ctr tail
+        is unused here).
+        """
+        import cutlass
+        from cutlass.cute.runtime import make_fake_compact_tensor, make_fake_stream
+
+        from cudnn.frost.tile_dsl.thd import THD_META_WORDS
+        from cudnn.sdpa.bwd.kernels.thd_helpers import thd_meta_host
+
+        b = self.batch_size
+        i32 = lambda n: make_fake_compact_tensor(cutlass.Int32, (n,), stride_order=(0,), assumed_align=4)  # noqa: E731
+        return cutlass.cute.compile(
+            thd_meta_host,
+            i32(THD_META_WORDS(b)),
+            i32(b),
+            i32(b),
+            cutlass.Int32(0),
+            cutlass.Int32(0),
+            make_fake_stream(use_tvm_ffi_env_stream=False),
+            options="--enable-tvm-ffi",
+        )
 
     # ------------------------------------------------------------------
     def _bshd_gather_bytes(self, desc) -> int:
@@ -1590,6 +1763,8 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
         kernel's set covers the d64 fast path's). All plan-time state — no
         arguments."""
         self._ensure_support_checked()
+        if self.thd:
+            return self._thd_scratch_bytes()
         from .kernels import bprop_f16_sm80 as _kmod
 
         elem = 2  # fp16/bf16 — check_support admits no other input dtype
@@ -1628,6 +1803,37 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
         )
         return total
 
+    def _thd_scratch_bytes(self) -> int:
+        """Packed-path scratch, sized from the token CAPACITIES (build time):
+        head-dim pad staging at packed extents, then the kernel-internal
+        buffers in execute's carve order, then the cu_seqlens metadata."""
+        from cudnn.frost.tile_dsl.thd import THD_META_WORDS
+        from cudnn.sdpa.bwd.config_sm80 import LLAMA_CFG
+
+        elem = 2
+        b, hq, hkv = self.batch_size, self.h_q, self.h_kv
+        tq, tkv = self._t_q_cap, self._t_kv_cap
+        fdqk, fdv = self.flavor_d_qk, self.flavor_d_v
+        pad_qk = self.head_dim_qk < fdqk
+        pad_v = self.head_dim_v < fdv
+        total = 0
+        for pad, tokens, hh, fd in ((pad_qk, tq, hq, fdqk), (pad_qk, tkv, hkv, fdqk), (pad_v, tkv, hkv, fdv), (pad_v, tq, hq, fdv), (pad_v, tq, hq, fdv)):
+            if pad:
+                total += ws_align(tokens * hh * fd * elem)
+        if self.sink_desc is not None:
+            total += ws_align(hq * 4)  # dSink accumulator
+        total += ws_align(tq * hq * fdqk * 4)  # dQ_acc fp32 (the bounded cast writes the caller's dQ)
+        if self.deterministic:
+            # Relay counter: one int32 per (sequence, head, q-tile), q-tiles
+            # bounded by the envelope S_q_max (plan-time; any upper bound works).
+            sem_q_stride = (self.s_q_max + LLAMA_CFG.TILE_Q - 1) // LLAMA_CFG.TILE_Q
+            total += ws_align(max(b * hq * sem_q_stride, 1) * 4)
+        total += ws_align(tkv * hq * fdqk * elem)  # dK per-query-head partials (the bounded fold writes the caller's dK)
+        total += ws_align(tkv * hq * fdv * elem)  # dV per-query-head partials
+        total += ws_align(hq * tq * 4)  # do_dot fp32
+        total += ws_align(THD_META_WORDS(b) * 4)  # [seq_kv | cu_q | cu_k | ...] int32
+        return total
+
     # ------------------------------------------------------------------
     def execute(
         self,
@@ -1653,18 +1859,24 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
     ) -> None:
         """Run the compiled SM80 backward on the adapter's carved workspace (Rule 1:
         no per-call allocation; the dsink launch passes the dense dummy ``cu``).
+        Under THD the operands are the packed ``[1, H, T, D]`` views and the
+        per-batch lengths, and the chain runs through :meth:`_execute_thd`.
         """
         self._logger.debug("Entering execute")
         if self._compiled_kernel is None:
             raise RuntimeError("SdpaBwdDslSm80 is not compiled")
 
         # Init-time flags are compile-time facts; execute must match them
-        # exactly, in both directions (Hard Rule 1).
+        # exactly, in both directions (Hard Rule 1).  Under THD the length
+        # buffers are the graph's per-batch lengths, consumed by the setup
+        # launch rather than a compiled padding mask, so their presence is
+        # checked there instead.
         self._value_error_if(self._has_bias != (bias_tensor is not None), "bias presence must match the plan (has_bias)")
         self._value_error_if(self._has_rope != (rope_freqs is not None), "rope_freqs presence must match the plan (has_rope)")
         self._value_error_if((self.sink_desc is not None) != (sink_tensor is not None), "sink presence must match the plan")
-        self._value_error_if(self.seq_kv_lens_present != (seq_kv_lens is not None), "seq_kv_lens presence must match the plan")
-        self._value_error_if(self.seq_q_lens_present != (seq_q_lens is not None), "seq_q_lens presence must match the plan")
+        if not self.thd:
+            self._value_error_if(self.seq_kv_lens_present != (seq_kv_lens is not None), "seq_kv_lens presence must match the plan")
+            self._value_error_if(self.seq_q_lens_present != (seq_q_lens is not None), "seq_q_lens presence must match the plan")
 
         scale_val = self.scale_softmax if (scale_softmax is None or scale_softmax == 0.0) else float(scale_softmax)
         device = q_tensor.device
@@ -1689,6 +1901,15 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
         with _torch_stream_context(current_stream, device):
             pad_qk = self.head_dim_qk < self.flavor_d_qk
             pad_v = self.head_dim_v < self.flavor_d_v
+
+            if self.thd:
+                self._execute_thd(
+                    q_tensor, k_tensor, v_tensor, o_tensor, do_tensor, stats_tensor, dq_tensor, dk_tensor, dv_tensor,
+                    seq_q_lens=seq_q_lens, seq_kv_lens=seq_kv_lens, sink_tensor=sink_tensor, dsink_tensor=dsink_tensor,
+                    scale_val=scale_val, take=_take, device=device, launch_stream=launch_stream,
+                )  # fmt: skip
+                self._logger.debug("execute completed (THD)")
+                return
 
             def _stage(t: torch.Tensor, pad: bool, fd: int) -> torch.Tensor:
                 """Kernel-facing BSHD view of BHSD-logical ``t``: zero-copy when
@@ -1861,6 +2082,204 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
             if dsink_tensor is not None and dsink_acc is not None:
                 dsink_tensor.view(-1).copy_(dsink_acc)
         self._logger.debug("execute completed")
+
+    def _execute_thd(
+        self,
+        q_tensor,
+        k_tensor,
+        v_tensor,
+        o_tensor,
+        do_tensor,
+        stats_tensor,
+        dq_tensor,
+        dk_tensor,
+        dv_tensor,
+        *,
+        seq_q_lens,
+        seq_kv_lens,
+        sink_tensor,
+        dsink_tensor,
+        scale_val,
+        take,
+        device,
+        launch_stream,
+    ) -> None:
+        """The packed chain: setup launch (lengths -> cu_seqlens on device) ->
+        do_dot -> [dSink] -> main -> dQ cast -> [GQA reduce].
+
+        Sequence ``b`` starts at token ``cu_*[b] = prefix(lengths)[b]`` on
+        every port: the bound ragged-offset values are not read (the FROST THD
+        contract; padded THD with gaps between sequences is issue #737).
+
+        Operands are the lowering's ``[1, H, T, D]`` views over the caller's
+        packed buffers at the plan's token capacities (compact BSHD, so the
+        ``[1, T, H, D]`` permute is a free view); Stats is the ``(T, H)`` or
+        ``(1, H, head_stride)`` view of its declared packing.  Every bound is
+        plan-time: the kv-tile grid and the relay counter come from the
+        envelope ``S_max`` (short tiles early-out), the token extents from the
+        capacities -- no length is read on the host (Rule 3).
+
+        Nothing past the packed total is written into the caller's buffers:
+        the dQ cast and the dK/dV fold are bounded by ``cu_*[B]`` on device
+        and write the caller's head dim directly, so the capacity tail
+        ``[cu_*[B], capacity)`` keeps whatever the caller left there (cuDNN's
+        own contract, which the ragged sweeps assert with a NaN-filled tail).
+        """
+        from cudnn.frost.tile_dsl.thd import THD_META_WORDS
+
+        p_ = self._params
+        c = self._compiled_kernel
+        b, hq, hkv = self.batch_size, self.h_q, self.h_kv
+        tq, tkv = self._t_q_cap, self._t_kv_cap
+        fdqk, fdv = self.flavor_d_qk, self.flavor_d_v
+        pad_qk = self.head_dim_qk < fdqk
+        pad_v = self.head_dim_v < fdv
+        gqa = hq != hkv
+
+        self._value_error_if(seq_q_lens is None or seq_kv_lens is None, "SM80 bwd THD: seq_q_lens and seq_kv_lens are required")
+        for name, t in (("seq_q_lens", seq_q_lens), ("seq_kv_lens", seq_kv_lens)):
+            # Validated on the INPUT, then flattened with view() (which raises
+            # rather than copies): a reshape() of a non-contiguous buffer would
+            # allocate a copy on the hot path and pass a later contiguity check.
+            self._value_error_if(
+                t.dtype != torch.int32 or not t.is_contiguous() or t.device != device, f"SM80 bwd THD: {name} must be a contiguous int32 tensor on {device}"
+            )
+            # The backward node carries per-batch lengths only; the setup
+            # launch was compiled for exactly B of them.
+            self._value_error_if(t.numel() != b, f"SM80 bwd THD: {name} must hold B = {b} per-batch lengths; got {t.numel()}")
+        ql, kl = seq_q_lens.view(-1), seq_kv_lens.view(-1)
+
+        as_bshd = lambda t: t.permute(0, 2, 1, 3)  # noqa: E731  [1,H,T,D] -> [1,T,H,D]
+
+        def _stage_thd(t: torch.Tensor, tokens: int, nh: int, d: int, pad: bool, fd: int, name: str) -> torch.Tensor:
+            """Kernel-facing [1, T, H, D] view of the lowering's [1, H, T, D] view,
+            checked against the PLAN's geometry (the compiled artifact's static
+            head count, head dim and dtype), padded into carved staging when the
+            head dim sits inside the flavor envelope."""
+            view = as_bshd(t)
+            self._value_error_if(
+                tuple(view.shape) != (1, tokens, nh, d) or t.dtype != self.dtype,
+                f"SM80 bwd THD: {name} must be a packed [1, {nh}, {tokens}, {d}] {self.dtype} view; got {tuple(t.shape)} {t.dtype}",
+            )
+            if pad:
+                dst = take(tokens * nh * fd, self.dtype, shape=(1, tokens, nh, fd))
+                dst[..., :d].copy_(view)
+                dst[..., d:].zero_()
+                return dst
+            self._value_error_if(not view.is_contiguous(), f"SM80 bwd THD: {name} must be compact BSHD (the packed path has no staging copy)")
+            return view
+
+        # Staging in _thd_scratch_bytes()'s order (Q, K, V, O, dO).
+        dqk, dv_ = self.head_dim_qk, self.head_dim_v
+        Q = _stage_thd(q_tensor, tq, hq, dqk, pad_qk, fdqk, "Q")
+        K = _stage_thd(k_tensor, tkv, hkv, dqk, pad_qk, fdqk, "K")
+        V = _stage_thd(v_tensor, tkv, hkv, dv_, pad_v, fdv, "V")
+        O = _stage_thd(o_tensor, tq, hq, dv_, pad_v, fdv, "O")  # noqa: E741
+        dO = _stage_thd(do_tensor, tq, hq, dv_, pad_v, fdv, "dO")
+
+        # Stats in the packing the kernel was compiled for (the lowering shapes
+        # it; the shape check here is what makes a mismatch an error rather than
+        # a mis-read).
+        self._value_error_if(stats_tensor.dtype != torch.float32 or stats_tensor.device != device, f"SM80 bwd THD: stats must be fp32 on {device}")
+        if self._thd_lse_token_major:
+            self._value_error_if(
+                tuple(stats_tensor.shape) != (tq, hq) or not stats_tensor.is_contiguous(),
+                f"SM80 bwd THD: token-major stats must be a contiguous ({tq}, {hq}) view; got {tuple(stats_tensor.shape)} stride {tuple(stats_tensor.stride())}",
+            )
+        else:
+            hs = self._thd_lse_head_stride or tq
+            self._value_error_if(
+                tuple(stats_tensor.shape) != (1, hq, hs) or not stats_tensor.is_contiguous(),
+                f"SM80 bwd THD: head-major stats must be a contiguous (1, {hq}, {hs}) view; got {tuple(stats_tensor.shape)} stride {tuple(stats_tensor.stride())}",
+            )
+        lse = stats_tensor
+
+        # Kernel-internal scratch, in _thd_scratch_bytes()'s order.
+        dsink_acc = take(hq, torch.float32, zero=True) if sink_tensor is not None else None
+        dq_acc = take(tq * hq * fdqk, torch.float32, zero=True, shape=(1, tq, hq, fdqk))
+        if p_.deterministic:
+            # Fresh zeros every call: the relay's equality spin deadlocks on a
+            # stale counter.  Stride = q-tiles of the envelope S_q_max.
+            sem_q_stride = (self.s_q_max + p_.tile_q - 1) // p_.tile_q
+            dq_sem = take(max(b * hq * sem_q_stride, 1), torch.int32, zero=True)
+        else:
+            sem_q_stride = 0
+            dq_sem = self._dummy("zero_i32", device, lambda: torch.zeros(1, dtype=torch.int32, device=device))
+        # dK/dV: MHA at native dims binds the caller's packed views directly
+        # (the kernel epilogue stores rows kv < s_kv[b] only); GQA or a padded
+        # head dim stages per-query-head partials, which the row-bounded fold
+        # below writes into the caller's dK/dV at the caller's head dim.  The
+        # partials' rows past the packed total are never read by that fold, so
+        # they need no zero fill.
+        dk_view, dv_view = as_bshd(dk_tensor), as_bshd(dv_tensor)
+        dk_direct = not gqa and not pad_qk and dk_view.is_contiguous()
+        dv_direct = not gqa and not pad_v and dv_view.is_contiguous()
+        dk_ws = dk_view if dk_direct else take(tkv * hq * fdqk, self.dtype, shape=(1, tkv, hq, fdqk))
+        dv_ws = dv_view if dv_direct else take(tkv * hq * fdv, self.dtype, shape=(1, tkv, hq, fdv))
+        dot = take(hq * tq, torch.float32, shape=(1, hq, tq))
+        meta = take(THD_META_WORDS(b), torch.int32)
+        # [seq_kv(B) | cu_q(B+1) | cu_k(B+1) | ...]: the cu slices the kernels bind.
+        cu_q = meta[b : 2 * b + 1]
+        cu_k = meta[2 * b + 1 : 3 * b + 2]
+        dummy_i32 = self._dummy("zero_i32", device, lambda: torch.zeros(1, dtype=torch.int32, device=device))
+        dummy_f32 = self._dummy("zero_f32", device, lambda: torch.zeros(1, dtype=torch.float32, device=device))
+        if sink_tensor is not None:
+            sinks_b = sink_tensor.reshape(-1)
+            self._value_error_if(sinks_b.dtype != torch.float32 or not sinks_b.is_contiguous(), "sinks must be contiguous fp32")
+
+        # --- launch chain ---------------------------------------------------
+        # lens_form 0: both sides are per-batch lengths (the only form the
+        # backward node carries); the setup launch normalises them to cu.
+        self._thd_meta_fn(_fd_tvm(meta), _fd_tvm(ql), _fd_tvm(kl), _int32(0), _int32(b), launch_stream)
+        c.do_dot(_fd_tvm(O), _fd_tvm(dO), _fd_tvm(dot), _int32(hq * tq), launch_stream)
+        if sink_tensor is not None:
+            c.dsink(_fd_tvm(lse), _fd_tvm(dot), _fd_tvm(sinks_b), _fd_tvm(dsink_acc), _fd_tvm(cu_q), _int32(b * hq), launch_stream)
+        _sm80_bwd_call(
+            c.main,
+            q=Q,
+            k=K,
+            v=V,
+            do=dO,
+            dq_acc=dq_acc,
+            dk_ws=dk_ws,
+            dv_ws=dv_ws,
+            lse=lse,
+            do_dot=dot,
+            seq_kv=dummy_i32,
+            bias=dummy_f32,
+            dbias=dummy_f32,
+            rope_cs=dummy_f32,
+            cu_q=cu_q,
+            cu_k=cu_k,
+            seq_q=dummy_i32,
+            dq_sem=dq_sem,
+            n_q_tiles=(tq + p_.tile_q - 1) // p_.tile_q,
+            scale_log2=scale_val * _BWD_LOG2E,
+            attn_scale=scale_val,
+            right_bound=int(self.right_bound_runtime),
+            inv_scale=1.0 / float(scale_val),
+            bias_bstride=0,
+            sem_q_stride=sem_q_stride,
+            # Envelope-derived kv-tile count: any upper bound on a sequence's
+            # KV length is correct (tiles past it early-out).
+            grid_kv_tiles=(self.s_k_max + p_.tile_kv - 1) // p_.tile_kv,
+            grid_batch=b,
+            stream=launch_stream,
+        )
+        # Row-bounded outputs straight into the caller's packed views: the cast
+        # and the fold stop at cu_*[B] (read on device) and write d_qk / d_v
+        # columns, so no torch copy-back touches the caller's buffers.
+        dq_view = as_bshd(dq_tensor)
+        self._value_error_if(not dq_view.is_contiguous(), "SM80 bwd THD: dQ must be compact BSHD (the packed path has no staging copy)")
+        c.cast(_fd_tvm(dq_acc), _fd_tvm(dq_view), _fd_tvm(cu_q), _int32(b), _int32((tq * hq * dqk) // 2), launch_stream)
+        if not dk_direct:
+            self._value_error_if(not dk_view.is_contiguous(), "SM80 bwd THD: dK must be compact BSHD (the packed path has no staging copy)")
+            c.reduce_k(_fd_tvm(dk_ws), _fd_tvm(dk_view), _fd_tvm(cu_k), _int32(b), _int32(tkv * hkv * dqk), launch_stream)
+        if not dv_direct:
+            self._value_error_if(not dv_view.is_contiguous(), "SM80 bwd THD: dV must be compact BSHD (the packed path has no staging copy)")
+            c.reduce_v(_fd_tvm(dv_ws), _fd_tvm(dv_view), _fd_tvm(cu_k), _int32(b), _int32(tkv * hkv * dv_), launch_stream)
+        if dsink_tensor is not None and dsink_acc is not None:
+            dsink_tensor.view(-1).copy_(dsink_acc)
 
 
 _sm80_bwd_cache: dict = {}

--- a/python/cudnn/sdpa/bwd/api_dsl.py
+++ b/python/cudnn/sdpa/bwd/api_dsl.py
@@ -1370,6 +1370,7 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
         self._t_kv_cap: int = 0
         self._thd_lse_token_major: bool = False
         self._thd_lse_head_stride: int = 0
+        self._thd_token_strides: dict = {}  # port role -> the caller's packed token stride (plan-time)
         self._thd_meta_fn = None
 
     @staticmethod
@@ -1390,18 +1391,23 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
         return self._t_kv_cap if self.thd else None
 
     @staticmethod
-    def _compact_bshd(desc: TensorDesc) -> bool:
-        """True when a logical-BHSD desc sits on COMPACT BSHD storage: the packed
-        path binds the caller's buffer to kernels that address rows from H and D
-        alone (head stride D, token stride H*D, element stride 1).  The batch
-        stride is not consulted -- a ragged port's sequences start at the ragged
-        offsets, and the packed view rebuilds that axis from the token extent.
-        The token stride is always checked (the packed view walks every token
-        with it, even when the envelope S_max is 1); the head and element
+    def _packed_bshd(desc: TensorDesc) -> bool:
+        """True when a logical-BHSD desc sits on PACKED BSHD rows the kernels can
+        bind directly: head stride D, element stride 1, and a token stride that
+        covers the row (``>= H*D``) and keeps every row 16-byte aligned (a
+        multiple of 8 fp16/bf16 elements -- the cp.async loads move 16-byte
+        chunks).  The token stride need not be compact: the kernels address a
+        row as ``token * token_stride + head * D`` with the port's own plan-time
+        stride, so a view into a wider per-token record (a K/V slice of an
+        interleaved ``[T, 2, H, D]`` buffer) is served at that stride.  The
+        batch stride is not consulted -- a ragged port's sequences start at the
+        ragged offsets, and the packed view rebuilds that axis from the token
+        extent.  The token stride is always checked (the packed view walks every
+        token with it, even when the envelope S_max is 1); the head and element
         strides wildcard on a size-1 extent (the analyzer's convention)."""
         _, h, _, d = (int(x) for x in desc.shape)
         st = tuple(int(x) for x in desc.stride)
-        return (int(desc.shape[1]) == 1 or st[1] == d) and st[2] == h * d and (d == 1 or st[3] == 1)
+        return (int(desc.shape[1]) == 1 or st[1] == d) and st[2] >= h * d and st[2] % 8 == 0 and (d == 1 or st[3] == 1)
 
     def _checked_lse_view(self, lse_tensor: torch.Tensor) -> torch.Tensor:
         """Validate a caller-provided Stats/LSE buffer and return the
@@ -1517,14 +1523,28 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
             )
             self._value_error_if(self._has_bias, "SM80 bwd THD: bias / dBias is dense-only (a packed graph has no [B, H, S_q, S_kv] bias)")
             self._value_error_if(self._has_rope, "SM80 bwd THD: RoPE is dense-only")
-            # No staging leg: the kernels' packed fakes are compact BSHD, so a
-            # port declared as a view into a wider per-token record would be
-            # read at the wrong rows.  A decline here, not a silent mis-bind.
-            for desc in (self.q_desc, self.k_desc, self.v_desc, self.o_desc, self.do_desc, self.dq_desc, self.dk_desc, self.dv_desc):
+            # No staging leg: the kernels bind the caller's packed rows directly,
+            # each port at its own plan-time token stride (the compiled fake
+            # carries it).  Anything the row arithmetic cannot express -- a
+            # head stride other than D, a token stride below the row or off
+            # 16-byte alignment -- is a decline here, not a silent mis-bind.
+            self._thd_token_strides = {}
+            for role, desc in (
+                ("q", self.q_desc),
+                ("k", self.k_desc),
+                ("v", self.v_desc),
+                ("o", self.o_desc),
+                ("do", self.do_desc),
+                ("dq", self.dq_desc),
+                ("dk", self.dk_desc),
+                ("dv", self.dv_desc),
+            ):
                 self._value_error_if(
-                    not self._compact_bshd(desc),
-                    f"SM80 bwd THD: {desc.name} must be compact BSHD (stride (S*H*D, D, H*D, 1)); got {tuple(desc.stride)} (the packed path has no staging copy)",
+                    not self._packed_bshd(desc),
+                    f"SM80 bwd THD: {desc.name} must be packed BSHD rows (head stride D, element stride 1, "
+                    f"token stride >= H*D and a multiple of 8 elements); got {tuple(desc.stride)} (the packed path has no staging copy)",
                 )
+                self._thd_token_strides[role] = int(desc.stride[2])
             self._t_q_cap = self._thd_total(int(b) * int(s_qo), self.max_total_seq_len_q)
             self._t_kv_cap = self._thd_total(int(b) * int(s_kv), self.max_total_seq_len_kv)
             self._value_error_if(self._t_q_cap <= 0 or self._t_kv_cap <= 0, "SM80 bwd THD: the packed token capacities must be > 0")
@@ -1702,6 +1722,9 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
                 lse_head_stride=self._thd_lse_head_stride,
                 out_d_qk=self.head_dim_qk,
                 out_d_v=self.head_dim_v,
+                # The caller's token strides, plan-time (compile() keeps the
+                # staged ports and the per-query-head partials compact itself).
+                thd_token_strides=tuple(self._thd_token_strides[r] for r in ("q", "k", "v", "o", "do", "dq", "dk", "dv")),
             )
             self._thd_meta_fn = self._compile_thd_meta()
         else:
@@ -2112,9 +2135,10 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
         contract; padded THD with gaps between sequences is issue #737).
 
         Operands are the lowering's ``[1, H, T, D]`` views over the caller's
-        packed buffers at the plan's token capacities (compact BSHD, so the
-        ``[1, T, H, D]`` permute is a free view); Stats is the ``(T, H)`` or
-        ``(1, H, head_stride)`` view of its declared packing.  Every bound is
+        packed buffers at the plan's token capacities, each at the token stride
+        its port declared (the ``[1, T, H, D]`` permute is a free view; the
+        kernels were compiled against exactly that stride); Stats is the
+        ``(T, H)`` or ``(1, H, head_stride)`` view of its declared packing.  Every bound is
         plan-time: the kv-tile grid and the relay counter come from the
         envelope ``S_max`` (short tiles early-out), the token extents from the
         capacities -- no length is read on the host (Rule 3).
@@ -2150,32 +2174,51 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
         ql, kl = seq_q_lens.view(-1), seq_kv_lens.view(-1)
 
         as_bshd = lambda t: t.permute(0, 2, 1, 3)  # noqa: E731  [1,H,T,D] -> [1,T,H,D]
+        ts = self._thd_token_strides
 
-        def _stage_thd(t: torch.Tensor, tokens: int, nh: int, d: int, pad: bool, fd: int, name: str) -> torch.Tensor:
+        def _kernel_view(view: torch.Tensor, tokens: int, nh: int, d: int, tok_stride: int, name: str) -> torch.Tensor:
+            """The kernel-facing [1, T, H, D] view at the PLAN's token stride.
+            The artifact was compiled against exactly (T*ts, ts, D, 1); the
+            load-bearing strides (token, element, and head when H > 1) are
+            checked here, then the view is rebuilt so a size-1 axis carries the
+            compiled stride too (a view, never a copy)."""
+            st = tuple(view.stride())
+            self._value_error_if(
+                tuple(view.shape) != (1, tokens, nh, d) or view.dtype != self.dtype,
+                f"SM80 bwd THD: {name} must be a packed [1, {nh}, {tokens}, {d}] {self.dtype} view; got {tuple(view.shape)} {view.dtype}",
+            )
+            self._value_error_if(
+                st[1] != tok_stride or (d > 1 and st[3] != 1) or (nh > 1 and st[2] != d),
+                f"SM80 bwd THD: {name} must sit on the plan's packed layout (token stride {tok_stride}, head stride {d}, element stride 1); "
+                f"got stride {st} (the packed path has no staging copy)",
+            )
+            want = (max(tokens, 1) * tok_stride, tok_stride, d, 1)
+            return view if st == want else view.as_strided((1, tokens, nh, d), want, view.storage_offset())
+
+        def _stage_thd(t: torch.Tensor, tokens: int, nh: int, d: int, pad: bool, fd: int, name: str, tok_stride: int) -> torch.Tensor:
             """Kernel-facing [1, T, H, D] view of the lowering's [1, H, T, D] view,
             checked against the PLAN's geometry (the compiled artifact's static
-            head count, head dim and dtype), padded into carved staging when the
-            head dim sits inside the flavor envelope."""
+            head count, head dim, dtype and token stride), padded into carved
+            (compact) staging when the head dim sits inside the flavor envelope."""
             view = as_bshd(t)
-            self._value_error_if(
-                tuple(view.shape) != (1, tokens, nh, d) or t.dtype != self.dtype,
-                f"SM80 bwd THD: {name} must be a packed [1, {nh}, {tokens}, {d}] {self.dtype} view; got {tuple(t.shape)} {t.dtype}",
-            )
             if pad:
+                self._value_error_if(
+                    tuple(view.shape) != (1, tokens, nh, d) or t.dtype != self.dtype,
+                    f"SM80 bwd THD: {name} must be a packed [1, {nh}, {tokens}, {d}] {self.dtype} view; got {tuple(t.shape)} {t.dtype}",
+                )
                 dst = take(tokens * nh * fd, self.dtype, shape=(1, tokens, nh, fd))
                 dst[..., :d].copy_(view)
                 dst[..., d:].zero_()
                 return dst
-            self._value_error_if(not view.is_contiguous(), f"SM80 bwd THD: {name} must be compact BSHD (the packed path has no staging copy)")
-            return view
+            return _kernel_view(view, tokens, nh, d, tok_stride, name)
 
         # Staging in _thd_scratch_bytes()'s order (Q, K, V, O, dO).
         dqk, dv_ = self.head_dim_qk, self.head_dim_v
-        Q = _stage_thd(q_tensor, tq, hq, dqk, pad_qk, fdqk, "Q")
-        K = _stage_thd(k_tensor, tkv, hkv, dqk, pad_qk, fdqk, "K")
-        V = _stage_thd(v_tensor, tkv, hkv, dv_, pad_v, fdv, "V")
-        O = _stage_thd(o_tensor, tq, hq, dv_, pad_v, fdv, "O")  # noqa: E741
-        dO = _stage_thd(do_tensor, tq, hq, dv_, pad_v, fdv, "dO")
+        Q = _stage_thd(q_tensor, tq, hq, dqk, pad_qk, fdqk, "Q", ts["q"])
+        K = _stage_thd(k_tensor, tkv, hkv, dqk, pad_qk, fdqk, "K", ts["k"])
+        V = _stage_thd(v_tensor, tkv, hkv, dv_, pad_v, fdv, "V", ts["v"])
+        O = _stage_thd(o_tensor, tq, hq, dv_, pad_v, fdv, "O", ts["o"])  # noqa: E741
+        dO = _stage_thd(do_tensor, tq, hq, dv_, pad_v, fdv, "dO", ts["do"])
 
         # Stats in the packing the kernel was compiled for (the lowering shapes
         # it; the shape check here is what makes a mismatch an error rather than
@@ -2206,14 +2249,16 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
             sem_q_stride = 0
             dq_sem = self._dummy("zero_i32", device, lambda: torch.zeros(1, dtype=torch.int32, device=device))
         # dK/dV: MHA at native dims binds the caller's packed views directly
-        # (the kernel epilogue stores rows kv < s_kv[b] only); GQA or a padded
-        # head dim stages per-query-head partials, which the row-bounded fold
-        # below writes into the caller's dK/dV at the caller's head dim.  The
-        # partials' rows past the packed total are never read by that fold, so
-        # they need no zero fill.
-        dk_view, dv_view = as_bshd(dk_tensor), as_bshd(dv_tensor)
-        dk_direct = not gqa and not pad_qk and dk_view.is_contiguous()
-        dv_direct = not gqa and not pad_v and dv_view.is_contiguous()
+        # (the kernel epilogue stores rows kv < s_kv[b] only, at the caller's
+        # token stride); GQA or a padded head dim stages compact per-query-head
+        # partials, which the row-bounded fold below writes into the caller's
+        # dK/dV at the caller's head dim and token stride.  The partials' rows
+        # past the packed total are never read by that fold, so they need no
+        # zero fill.  Same direct-bind rule as compile()'s fakes.
+        dk_view = _kernel_view(as_bshd(dk_tensor), tkv, hkv, dqk, ts["dk"], "dK")
+        dv_view = _kernel_view(as_bshd(dv_tensor), tkv, hkv, dv_, ts["dv"], "dV")
+        dk_direct = not gqa and not pad_qk
+        dv_direct = not gqa and not pad_v
         dk_ws = dk_view if dk_direct else take(tkv * hq * fdqk, self.dtype, shape=(1, tkv, hq, fdqk))
         dv_ws = dv_view if dv_direct else take(tkv * hq * fdv, self.dtype, shape=(1, tkv, hq, fdv))
         dot = take(hq * tq, torch.float32, shape=(1, hq, tq))
@@ -2269,14 +2314,11 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
         # Row-bounded outputs straight into the caller's packed views: the cast
         # and the fold stop at cu_*[B] (read on device) and write d_qk / d_v
         # columns, so no torch copy-back touches the caller's buffers.
-        dq_view = as_bshd(dq_tensor)
-        self._value_error_if(not dq_view.is_contiguous(), "SM80 bwd THD: dQ must be compact BSHD (the packed path has no staging copy)")
+        dq_view = _kernel_view(as_bshd(dq_tensor), tq, hq, dqk, ts["dq"], "dQ")
         c.cast(_fd_tvm(dq_acc), _fd_tvm(dq_view), _fd_tvm(cu_q), _int32(b), _int32((tq * hq * dqk) // 2), launch_stream)
         if not dk_direct:
-            self._value_error_if(not dk_view.is_contiguous(), "SM80 bwd THD: dK must be compact BSHD (the packed path has no staging copy)")
             c.reduce_k(_fd_tvm(dk_ws), _fd_tvm(dk_view), _fd_tvm(cu_k), _int32(b), _int32(tkv * hkv * dqk), launch_stream)
         if not dv_direct:
-            self._value_error_if(not dv_view.is_contiguous(), "SM80 bwd THD: dV must be compact BSHD (the packed path has no staging copy)")
             c.reduce_v(_fd_tvm(dv_ws), _fd_tvm(dv_view), _fd_tvm(cu_k), _int32(b), _int32(tkv * hkv * dv_), launch_stream)
         if dsink_tensor is not None and dsink_acc is not None:
             dsink_tensor.view(-1).copy_(dsink_acc)

--- a/python/cudnn/sdpa/bwd/config_sm80.py
+++ b/python/cudnn/sdpa/bwd/config_sm80.py
@@ -100,7 +100,9 @@ class TemplateParams:
     # SCHED_NATURAL; the semaphore is caller scratch — carved on the dense
     # engine path, sized from max_s_q on the THD wrapper path).
     deterministic: bool = False
-    # Packed varlen (wrapper-only today; the engine row declares thd=False).
+    # Packed varlen: the standalone wrapper's cu_seqlens path and the
+    # sdpa_bwd_sm80 engine row's ragged graphs (per-batch lengths turned into
+    # cu_seqlens on device) share this specialization.
     thd_varlen: bool = False
     # Tile-scheduler policy in the SHARED frost vocabulary
     # (tile_dsl.constants.SCHED_*): NATURAL is the plain 3-D grid, LPT the

--- a/python/cudnn/sdpa/bwd/engines.py
+++ b/python/cudnn/sdpa/bwd/engines.py
@@ -173,7 +173,7 @@ class Capabilities:
     # `thd_causal` and `thd_gqa` were both removed on exactly that rule, once
     # sdpa_bwd_sm100 -- then the only row that set `thd` -- served the causal
     # family and then GQA. NOTHING is left here: the packed path's remaining
-    # limits (`thd_declared_totals`, compact BSHD, no bias) are not feature
+    # limits (`thd_declared_totals`, packed BSHD rows, no bias) are not feature
     # conjunctions, they are properties of the path itself and mismatch()
     # applies them to every THD row. Think twice before adding another.
     # True when THD REQUIRES sdpa(max_total_seq_len_q=..., max_total_seq_len_kv=...):
@@ -314,14 +314,18 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", requested: 
                 "the packed workspace is sized from the declared token totals at build time"
             )
         # The packed path binds the caller's buffers straight to kernels whose
-        # operands are compact BSHD; it has no staging copy to fix a layout up.
+        # operands are BSHD rows; it has no staging copy to fix a layout up.
         if not facts.bshd_layout:
             return "Q/K/V/O/dO/dQ/dK/dV must be BSHD-physical under THD (the packed path has no staging copy)"
-        # COMPACT, not just BSHD-ordered: the kernels address packed rows from H
-        # and D alone (head stride D, token stride H*D, element stride 1), so a
-        # port declared as a view into a wider per-token record (a K or V slice
-        # of an interleaved [T, 2, H, D] buffer, token stride 2*H*D) would be
-        # read at the wrong rows. The batch stride is not consulted (a ragged
+        # PACKED rows, not necessarily compact: the kernels address a row as
+        # ``token * token_stride + head * D + col`` with each port's own
+        # plan-time token stride, so a port declared as a view into a wider
+        # per-token record (a K or V slice of an interleaved [T, 2, H, D]
+        # buffer, token stride 2*H*D) is served at that stride. Required: head
+        # stride D (no head stride is read), element stride 1, and a token
+        # stride that covers the row (>= H*D) and keeps every row 16-byte
+        # aligned (a multiple of 8 fp16/bf16 elements -- the cp.async loads
+        # move 16-byte chunks). The batch stride is not consulted (a ragged
         # port's sequences start at its ragged offsets). The TOKEN stride is
         # always checked: the packed view walks every token of every sequence
         # with it, so it is load-bearing even when the envelope S_max is 1.
@@ -330,11 +334,15 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", requested: 
         # keeps the ranked plan list honest.
         for name, dim, stride in facts.port_layouts:
             _, h, _, d = (int(x) for x in dim)
+            ts = int(stride[2])
             head_ok = int(dim[1]) == 1 or int(stride[1]) == d
-            token_ok = int(stride[2]) == h * d
+            token_ok = ts >= h * d and ts % 8 == 0
             elem_ok = d == 1 or int(stride[3]) == 1
             if not (head_ok and token_ok and elem_ok):
-                return f"{name} must be compact BSHD under THD (head stride D, token stride H*D); got stride {tuple(stride)}"
+                return (
+                    f"{name} must be packed BSHD rows under THD (head stride D, element stride 1, "
+                    f"token stride >= H*D and a multiple of 8 elements); got stride {tuple(stride)}"
+                )
         # A packed graph has no [B, H, S_q, S_kv] bias: the per-sequence score
         # rectangles are different sizes, and the kernels' bias read is the
         # dense one. Dense-only on every THD row.
@@ -744,9 +752,10 @@ def _sm80_spec() -> EngineSpec:
     (no tunables wired).  sm80 exactly: the kernels assume the A100's 164 KiB
     opt-in SMEM, which the sm86/sm89 parts do not have.
 
-    THD / ragged: served on the packed ``[1, T, H, D]`` path (compact BSHD
-    ports, per-batch ``seq_len_q/kv`` turned into device ``cu_seqlens`` by a
-    setup launch, Stats read in either packed packing, declared totals sizing
+    THD / ragged: served on the packed ``[1, T, H, D]`` path (BSHD ports each
+    at its own token stride -- a K/V slice of an interleaved record included --
+    per-batch ``seq_len_q/kv`` turned into device ``cu_seqlens`` by a setup
+    launch, Stats read in either packed packing, declared totals sizing
     the carved scratch -- hence ``thd_declared_totals``).  Deterministic dQ,
     sinks, GQA, the causal family and head-dim envelope padding all ride it;
     bias / dBias is dense-only (a path property, see mismatch()).  As on every

--- a/python/cudnn/sdpa/bwd/engines.py
+++ b/python/cudnn/sdpa/bwd/engines.py
@@ -171,11 +171,11 @@ class Capabilities:
     # could not do.
     #
     # `thd_causal` and `thd_gqa` were both removed on exactly that rule, once
-    # sdpa_bwd_sm100 -- the only row that sets `thd` -- served the causal family
-    # and then GQA. NOTHING is left here: the packed path's remaining limits
-    # (`thd_declared_totals`, the BSHD requirement) are not feature
-    # conjunctions, they are properties of the path itself. Think twice before
-    # adding another.
+    # sdpa_bwd_sm100 -- then the only row that set `thd` -- served the causal
+    # family and then GQA. NOTHING is left here: the packed path's remaining
+    # limits (`thd_declared_totals`, compact BSHD, no bias) are not feature
+    # conjunctions, they are properties of the path itself and mismatch()
+    # applies them to every THD row. Think twice before adding another.
     # True when THD REQUIRES sdpa(max_total_seq_len_q=..., max_total_seq_len_kv=...):
     # the row's workspace is sized from the packed token totals at BUILD time,
     # before any buffer exists.
@@ -308,15 +308,38 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", requested: 
             return f"graph uses {label}, which this engine does not support"
 
     if facts.thd and capabilities.thd:
-        if capabilities.thd_declared_totals and (facts.max_total_seq_len_q is None or facts.max_total_seq_len_kv is None):
+        if capabilities.thd_declared_totals and any(t is None or int(t) <= 0 for t in (facts.max_total_seq_len_q, facts.max_total_seq_len_kv)):
             return (
-                "THD requires sdpa_backward(max_total_seq_len_q=..., max_total_seq_len_kv=...): "
+                "THD requires positive sdpa_backward(max_total_seq_len_q=..., max_total_seq_len_kv=...): "
                 "the packed workspace is sized from the declared token totals at build time"
             )
         # The packed path binds the caller's buffers straight to kernels whose
         # operands are compact BSHD; it has no staging copy to fix a layout up.
         if not facts.bshd_layout:
             return "Q/K/V/O/dO/dQ/dK/dV must be BSHD-physical under THD (the packed path has no staging copy)"
+        # COMPACT, not just BSHD-ordered: the kernels address packed rows from H
+        # and D alone (head stride D, token stride H*D, element stride 1), so a
+        # port declared as a view into a wider per-token record (a K or V slice
+        # of an interleaved [T, 2, H, D] buffer, token stride 2*H*D) would be
+        # read at the wrong rows. The batch stride is not consulted (a ragged
+        # port's sequences start at its ragged offsets). The TOKEN stride is
+        # always checked: the packed view walks every token of every sequence
+        # with it, so it is load-bearing even when the envelope S_max is 1.
+        # The head and element strides wildcard on a size-1 extent, as in
+        # bshd_layout_ok. The adapters re-check this at build; declining here
+        # keeps the ranked plan list honest.
+        for name, dim, stride in facts.port_layouts:
+            _, h, _, d = (int(x) for x in dim)
+            head_ok = int(dim[1]) == 1 or int(stride[1]) == d
+            token_ok = int(stride[2]) == h * d
+            elem_ok = d == 1 or int(stride[3]) == 1
+            if not (head_ok and token_ok and elem_ok):
+                return f"{name} must be compact BSHD under THD (head stride D, token stride H*D); got stride {tuple(stride)}"
+        # A packed graph has no [B, H, S_q, S_kv] bias: the per-sequence score
+        # rectangles are different sizes, and the kernels' bias read is the
+        # dense one. Dense-only on every THD row.
+        if facts.has_bias or facts.has_dbias:
+            return "bias / dBias is dense-only under THD (a packed graph has no [B, H, S_q, S_kv] bias)"
 
     if facts.has_dsink and not facts.has_sink:
         return "dSink_token output requires a sink_token input"
@@ -716,10 +739,21 @@ def _sm80_spec() -> EngineSpec:
     (head-dim envelopes up to (256, 256), incl. rectangular 192/128),
     host-side head-dim zero-padding, BHSD<->BSHD normalization, per-shape
     kernel caching, and the dedicated plain-dense d=64 fast path.  The
-    CuTe-DSL JIT happens on the first execute (the kernel modules self-cache
-    per shape).  Knob domains are empty (no tunables wired).  sm80 exactly:
-    the kernels assume the A100's 164 KiB opt-in SMEM, which the sm86/sm89
-    parts do not have."""
+    CuTe-DSL JIT happens at compile(), except for that d=64 fast path, whose
+    module still self-caches on the first execute.  Knob domains are empty
+    (no tunables wired).  sm80 exactly: the kernels assume the A100's 164 KiB
+    opt-in SMEM, which the sm86/sm89 parts do not have.
+
+    THD / ragged: served on the packed ``[1, T, H, D]`` path (compact BSHD
+    ports, per-batch ``seq_len_q/kv`` turned into device ``cu_seqlens`` by a
+    setup launch, Stats read in either packed packing, declared totals sizing
+    the carved scratch -- hence ``thd_declared_totals``).  Deterministic dQ,
+    sinks, GQA, the causal family and head-dim envelope padding all ride it;
+    bias / dBias is dense-only (a path property, see mismatch()).  As on every
+    FROST THD row the packed addressing is ``prefix(lengths) x token stride``
+    and the bound ragged-offset values are not read: sequences must be
+    adjacent (padded THD with inter-sequence gaps is issue #737).
+    """
     return EngineSpec(
         name="sdpa_bwd_sm80",
         capabilities=Capabilities(
@@ -741,6 +775,12 @@ def _sm80_spec() -> EngineSpec:
             swa=True,
             padded=True,
             sink=True,
+            thd=True,
+            # The packed scratch (fp32 dQ accumulator, per-query-head dK/dV
+            # partials, do_dot) is sized from the declared token totals at
+            # build time; B * S_max would be the fallback and is far larger
+            # than any packed buffer.
+            thd_declared_totals=True,
             decode=False,  # prefill kernels only
             layouts=frozenset({"bshd", "dense_flex"}),
             # The kernels READ the declared stats strides natively (the

--- a/python/cudnn/sdpa/bwd/engines.py
+++ b/python/cudnn/sdpa/bwd/engines.py
@@ -350,9 +350,9 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", requested: 
                 # inference below from mis-reading that layout.
                 return "THD stats must be ragged (packed); a dense per-batch stats tensor is not read by the packed path"
             stride_h, stride_s = s_stride[1], s_stride[2]
-            token_major = (stride_h, stride_s) == (1, facts.h_q)
-            head_major = not token_major and stride_s == 1 and stride_h >= 1
-            if not token_major and not head_major:
+            packing = ga.thd_stats_packing(stride_h, stride_s, facts.h_q)
+            head_major = packing == "head_major"
+            if packing is None:
                 return (
                     f"THD stats must be packed token-major (stride_h == 1, stride_s == {facts.h_q}) "
                     f"or head-major (stride_s == 1, stride_h == head stride); got stride {s_stride}"
@@ -521,7 +521,7 @@ def lower_dsl_bwd(spec: EngineSpec, facts: "ga.SdpaGraphFacts", requested: Any =
     # which is what the FROST forward emits natively. mismatch() has already
     # rejected anything that is neither.
     stats_stride_h, stats_stride_s = (int(stats_geom[1][1]), int(stats_geom[1][2])) if thd else (0, 0)
-    stats_token_major = thd and (stats_stride_h, stats_stride_s) == (1, facts.h_q)
+    stats_token_major = thd and ga.thd_stats_packing(stats_stride_h, stats_stride_s, facts.h_q) == "token_major"
     stats_head_stride = stats_stride_h if (thd and not stats_token_major) else 0
     # Sink ports: geometry straight from the IR tensors (fp32 (1, H_q, 1, 1)).
     sink_geom = (tuple(facts.sink_t.get_dim()), tuple(facts.sink_t.get_stride())) if facts.has_sink else None

--- a/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
@@ -78,8 +78,10 @@ ALL barriers are at top level (never inside a divergent ``if sg0`` arm) so the
 per-thread barrier count is identical across both sub-groups.
 
 Envelope: f16/bf16; dense (partial tiles gated by runtime bounds) or packed THD
-(``THD_VARLEN``: ``[1,T,H,D]`` operands, ``CU_Q``/``CU_K`` prefix sums, per-sequence
-bounds and diagonal, LSE in either packed packing -- see ``LSE_TOKEN_MAJOR``);
+(``THD_VARLEN``: ``[1,T,H,D]`` operands each at its own plan-time token stride --
+a port may be a view into a wider per-token record -- ``CU_Q``/``CU_K`` prefix
+sums, per-sequence bounds and diagonal, LSE in either packed packing -- see
+``LSE_TOKEN_MAJOR``);
 causal / bottom-right / band / sliding-window masks; GQA via per-query-head
 dK/dV write buffers reduced by the host; d_qk >= d_v with (d_qk//2) % 16 == 0
 (the flavor envelopes: gptoss 64, llama 128, dsv3 192/128, qwen 256).  do_dot
@@ -414,7 +416,7 @@ def _bprop_kernel(
     p_lane = lane % 4  # 0..3  (mma D-frag col pos)
     is_sg0 = sg_id == cutlass.Int32(0)
 
-    # ---- GMEM views + row strides (BSHD packed) ---------------------------
+    # ---- GMEM views + row strides (BSHD, token stride per operand) ---------
     Q_view = cutlass.make_array_view(Q)
     K_view = cutlass.make_array_view(K)
     V_view = cutlass.make_array_view(V)
@@ -425,10 +427,19 @@ def _bprop_kernel(
     LSE_view = cutlass.make_array_view(LSE)
     DOT_view = cutlass.make_array_view(DO_DOT)
 
-    QK_RS = cutlass.Int32(H) * cutlass.Int32(d_qk)  # Q / dQ / dK_ws row stride (H_q heads)
-    V_RS = cutlass.Int32(H) * cutlass.Int32(d_v)  # dO / dV_ws row stride (H_q heads)
-    K_RS = cutlass.Int32(Hkv) * cutlass.Int32(d_qk)  # K read row stride (H_kv heads)
-    VV_RS = cutlass.Int32(Hkv) * cutlass.Int32(d_v)  # V read row stride (H_kv heads)
+    # Token (row) strides are the operands' COMPILE-TIME token strides: a
+    # compact operand folds to H*D (the dense path's staged operands and the
+    # internal dQ accumulator always are), a packed THD port declared as a view
+    # into a wider per-token record (a K/V slice of an interleaved [T, 2, H, D]
+    # buffer) walks its own stride.  Every row is addressed as
+    # ``row * token_stride + head * D + col`` -- the head stride is D on every
+    # port (the adapters admit nothing else), so no head stride is read here.
+    QK_RS = cutlass.Int32(Q.stride[1])  # Q read row stride
+    V_RS = cutlass.Int32(dO.stride[1])  # dO read row stride
+    K_RS = cutlass.Int32(K.stride[1])  # K read row stride (H_kv heads)
+    VV_RS = cutlass.Int32(V.stride[1])  # V read row stride (H_kv heads)
+    DK_RS = cutlass.Int32(dK.stride[1])  # dK write row stride (per-query-head partials or the caller's dK)
+    DV_RS = cutlass.Int32(dV.stride[1])  # dV write row stride
     kv_base = kv_tile * cutlass.Int32(tile_kv)
 
     # ---- Q-loop bounds (shared tile_dsl arithmetic, the KV-major dual of the
@@ -465,8 +476,8 @@ def _bprop_kernel(
 
     # K/V tile (row 0) GMEM element pointers — at the KV head (GQA-mapped).
     # kv_row_origin = batch*SKV (dense) or cu_k[b] (THD packed).
-    k_tile_base = ((kv_row_origin + kv_base) * cutlass.Int32(Hkv) + kv_head) * cutlass.Int32(d_qk)
-    v_tile_base = ((kv_row_origin + kv_base) * cutlass.Int32(Hkv) + kv_head) * cutlass.Int32(d_v)
+    k_tile_base = (kv_row_origin + kv_base) * K_RS + kv_head * cutlass.Int32(d_qk)
+    v_tile_base = (kv_row_origin + kv_base) * VV_RS + kv_head * cutlass.Int32(d_v)
     k_tile_gmem = K_view.data_ptr() + k_tile_base
     v_tile_gmem = V_view.data_ptr() + v_tile_base
 
@@ -640,10 +651,8 @@ def _bprop_kernel(
     # Q/dO row-gate bound (per-seq under THD) + packed seq origin for the GMEM
     # base (q_row_origin = batch*SQ dense / cu_q[b] THD).
     SQ_rt = q_bound
-    HD_QK = cutlass.Int32(H) * cutlass.Int32(d_qk)
-    HD_V = cutlass.Int32(H) * cutlass.Int32(d_v)
-    bhead_qk = (q_row_origin * cutlass.Int32(H) + head) * cutlass.Int32(d_qk)
-    bhead_v = (q_row_origin * cutlass.Int32(H) + head) * cutlass.Int32(d_v)
+    bhead_qk = q_row_origin * QK_RS + head * cutlass.Int32(d_qk)
+    bhead_v = q_row_origin * V_RS + head * cutlass.Int32(d_v)
 
     # Prologue: prefetch Q/dO tile 0 into ring stage 0.  Predicated row-gate
     # (rows >= SQ → zero-size cp.async) keeps the per-iter group count uniform
@@ -653,7 +662,7 @@ def _bprop_kernel(
     # the dynamic q-loop.)
     load_tile_2d(
         sQ,
-        Q_view.data_ptr() + bhead_qk + q_lo_base * HD_QK,
+        Q_view.data_ptr() + bhead_qk + q_lo_base * QK_RS,
         rows=tile_q,
         elems_per_row=d_qk,
         gmem_row_stride_elems=QK_RS,
@@ -667,7 +676,7 @@ def _bprop_kernel(
     )
     load_tile_2d(
         sdO,
-        dO_view.data_ptr() + bhead_v + q_lo_base * HD_V,
+        dO_view.data_ptr() + bhead_v + q_lo_base * V_RS,
         rows=tile_q,
         elems_per_row=d_v,
         gmem_row_stride_elems=V_RS,
@@ -703,7 +712,7 @@ def _bprop_kernel(
         if cutlass.const_expr(qo_stages == 2):
             load_tile_2d(
                 sQ.subview(stage_nxt * cutlass.Int32(QSTAGE_Q)),
-                Q_view.data_ptr() + bhead_qk + nxt_qbase * HD_QK,
+                Q_view.data_ptr() + bhead_qk + nxt_qbase * QK_RS,
                 rows=tile_q,
                 elems_per_row=d_qk,
                 gmem_row_stride_elems=QK_RS,
@@ -717,7 +726,7 @@ def _bprop_kernel(
             )
             load_tile_2d(
                 sdO.subview(stage_nxt * cutlass.Int32(QSTAGE_O)),
-                dO_view.data_ptr() + bhead_v + nxt_qbase * HD_V,
+                dO_view.data_ptr() + bhead_v + nxt_qbase * V_RS,
                 rows=tile_q,
                 elems_per_row=d_v,
                 gmem_row_stride_elems=V_RS,
@@ -1113,7 +1122,7 @@ def _bprop_kernel(
             if (j + cutlass.Int32(1)) < n_iters:
                 load_tile_2d(
                     sQ,
-                    Q_view.data_ptr() + bhead_qk + nxt_qbase * HD_QK,
+                    Q_view.data_ptr() + bhead_qk + nxt_qbase * QK_RS,
                     rows=tile_q,
                     elems_per_row=d_qk,
                     gmem_row_stride_elems=QK_RS,
@@ -1127,7 +1136,7 @@ def _bprop_kernel(
                 )
                 load_tile_2d(
                     sdO,
-                    dO_view.data_ptr() + bhead_v + nxt_qbase * HD_V,
+                    dO_view.data_ptr() + bhead_v + nxt_qbase * V_RS,
                     rows=tile_q,
                     elems_per_row=d_v,
                     gmem_row_stride_elems=V_RS,
@@ -1162,8 +1171,8 @@ def _bprop_kernel(
         for nf in cutlass.range_constexpr(d_v // 8):
             d0 = cutlass.Int32(nf * 8) + cutlass.Int32(2) * p_lane
             off = nf * 4
-            base_top = ((kv_row_origin + kv_base + kv_row_g) * cutlass.Int32(H) + head) * cutlass.Int32(d_v) + d0
-            base_bot = ((kv_row_origin + kv_base + kv_row_g8) * cutlass.Int32(H) + head) * cutlass.Int32(d_v) + d0
+            base_top = (kv_row_origin + kv_base + kv_row_g) * DV_RS + head * cutlass.Int32(d_v) + d0
+            base_bot = (kv_row_origin + kv_base + kv_row_g8) * DV_RS + head * cutlass.Int32(d_v) + d0
             _vt = fp32_to_fp16(acc_grad[off + 0], acc_grad[off + 1], dtype=io_dtype)
             _vb = fp32_to_fp16(acc_grad[off + 2], acc_grad[off + 3], dtype=io_dtype)
             if cutlass.const_expr(GATE_KV):
@@ -1205,8 +1214,8 @@ def _bprop_kernel(
         for nf in cutlass.range_constexpr(d_qk // 8):
             d0 = cutlass.Int32(nf * 8) + cutlass.Int32(2) * p_lane
             off = nf * 4
-            base_top = ((kv_row_origin + kv_base + kv_row_g) * cutlass.Int32(H) + head) * cutlass.Int32(d_qk) + d0
-            base_bot = ((kv_row_origin + kv_base + kv_row_g8) * cutlass.Int32(H) + head) * cutlass.Int32(d_qk) + d0
+            base_top = (kv_row_origin + kv_base + kv_row_g) * DK_RS + head * cutlass.Int32(d_qk) + d0
+            base_bot = (kv_row_origin + kv_base + kv_row_g8) * DK_RS + head * cutlass.Int32(d_qk) + d0
             _kt = fp32_to_fp16(acc_grad[off + 0], acc_grad[off + 1], dtype=io_dtype)
             _kb = fp32_to_fp16(acc_grad[off + 2], acc_grad[off + 3], dtype=io_dtype)
             if cutlass.const_expr(GATE_KV):
@@ -1303,14 +1312,18 @@ def _do_dot_kernel(
         r = row % HSQ
         h = r // cutlass.Int32(SQ)
         q = r % cutlass.Int32(SQ)
-        in_base = ((b * cutlass.Int32(SQ) + q) * cutlass.Int32(H) + h) * cutlass.Int32(d_v)
+        # Row = token: each operand at ITS compile-time token stride (compact
+        # folds to H*d_v; a packed port may carry a wider per-token record).
+        tok = b * cutlass.Int32(SQ) + q
+        o_base = tok * cutlass.Int32(O.stride[1]) + h * cutlass.Int32(d_v)
+        do_base = tok * cutlass.Int32(dO.stride[1]) + h * cutlass.Int32(d_v)
         Ob = cutlass.make_array_view(O).data_ptr()
         dOb = cutlass.make_array_view(dO).data_ptr()
         acc = cutlass.Float32(0.0)
         for k in cutlass.range_constexpr(d_v // 32):
-            idx = in_base + lane + cutlass.Int32(k * 32)  # coalesced across lanes
-            o = Pointer(Ob + idx, dtype=io_dtype).load()
-            d = Pointer(dOb + idx, dtype=io_dtype).load()
+            col = lane + cutlass.Int32(k * 32)  # coalesced across lanes
+            o = Pointer(Ob + o_base + col, dtype=io_dtype).load()
+            d = Pointer(dOb + do_base + col, dtype=io_dtype).load()
             acc = acc + o.to(cutlass.Float32) * d.to(cutlass.Float32)
         # Warp butterfly reduce → all lanes hold the row sum; lane 0 stores.
         for off in cutlass.range_constexpr(5):
@@ -1425,7 +1438,8 @@ _cast_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 # THD variant: the dQ cast writes the CALLER's packed dQ directly -- only the
 # rows below the packed total cu_q[n_seq] (a device value; the rows past it are
 # the caller's capacity tail and must stay as the caller left them), at the
-# caller's head dim d_out (<= the flavor envelope fd the accumulator carries).
+# caller's head dim d_out (<= the flavor envelope fd the accumulator carries)
+# and the caller's token stride (the fake's; a gap column is never written).
 # One thread per (row, head, column pair).
 @cute.kernel
 def _cast_thd_kernel(
@@ -1451,7 +1465,8 @@ def _cast_thd_kernel(
         t_live = Pointer(cutlass.make_array_view(CU_Q).data_ptr() + n_seq, dtype=cutlass.Int32).load()
         if row < t_live:
             src = cutlass.make_array_view(dQ_acc).data_ptr() + (row * cutlass.Int32(H) + h) * cutlass.Int32(fd) + c
-            dst = cutlass.make_array_view(dQ_out).data_ptr() + (row * cutlass.Int32(H) + h) * cutlass.Int32(d_out) + c
+            # The caller's dQ at ITS token stride (compact folds to H*d_out).
+            dst = cutlass.make_array_view(dQ_out).data_ptr() + row * cutlass.Int32(dQ_out.stride[1]) + h * cutlass.Int32(d_out) + c
             v = Pointer(src, dtype=cutlass.Float32).load(count=2)
             Pointer(dst, dtype=cutlass.Int32).store(fp32_to_fp16(v[0], v[1], dtype=io_dtype), alignment=4)
 
@@ -1528,7 +1543,9 @@ def _dkv_reduce_thd_kernel(
             acc = cutlass.Float32(0.0)
             for g in cutlass.range_constexpr(ratio):
                 acc = acc + Pointer(src + in_base + cutlass.Int32(g * d_in), dtype=io_dtype).load().to(cutlass.Float32)
-            Pointer(cutlass.make_array_view(OUT).data_ptr() + e, dtype=io_dtype).store(acc.to(io_dtype))
+            # The caller's dK/dV at ITS token stride (compact folds to Hk*d_out).
+            out_off = row * cutlass.Int32(OUT.stride[1]) + hk * cutlass.Int32(d_out) + di
+            Pointer(cutlass.make_array_view(OUT).data_ptr() + out_off, dtype=io_dtype).store(acc.to(io_dtype))
 
 
 _dkv_reduce_thd_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
@@ -1840,6 +1857,7 @@ def compile(  # noqa: A001 — the template contract's entry point
     lse_head_stride: int = 0,
     out_d_qk: int = 0,
     out_d_v: int = 0,
+    thd_token_strides: "Optional[tuple[int, ...]]" = None,
 ):
     """Compile (or fetch) this template specialization for one shape.
 
@@ -1871,6 +1889,18 @@ def compile(  # noqa: A001 — the template contract's entry point
     ``(dQ_acc, dQ_out, CU_Q, n_seq, n_pairs, stream)`` and ``reduce_k`` /
     ``reduce_v`` ``(IN, OUT, CU_K, n_seq, n_out, stream)`` (always compiled
     under THD; ratio 1 is the padded-head-dim copy).
+
+    ``thd_token_strides`` (THD only, plan-time): the CALLER's token strides for
+    ``(Q, K, V, O, dO, dQ, dK, dV)``, 0 = compact (``H*D``).  A port declared
+    as a view into a wider per-token record (a K/V slice of an interleaved
+    ``[T, 2, H, D]`` buffer) is addressed at its own stride -- the fake carries
+    it, so the codegen folds it like any other constant; a compact port keeps
+    the compact fake (byte-identical).  Each stride must cover the record
+    (``>= H * d``) and be a multiple of 8 elements (16-byte rows for the
+    cp.async loads).  Ports the host stages (a head dim inside the flavor
+    envelope) are compact at the kernel regardless, as are the per-query-head
+    dK/dV partials (GQA or padded): their caller stride reaches only the
+    bounded fold that writes the caller's buffer.
     """
     p = PARAMS
     if (lse_token_major or lse_head_stride) and not p.thd_varlen:
@@ -1883,6 +1913,29 @@ def compile(  # noqa: A001 — the template contract's entry point
     d_out_v = int(out_d_v) if out_d_v else p.d_v
     if d_out_qk % 2 or d_out_v % 2 or d_out_qk > p.d_qk or d_out_v > p.d_v or d_out_qk <= 0 or d_out_v <= 0:
         raise ValueError(f"sm80 bwd: out head dims must be even and within the envelope ({p.d_qk}, {p.d_v}); got ({out_d_qk}, {out_d_v})")
+    if thd_token_strides is not None and not p.thd_varlen:
+        raise ValueError("sm80 bwd: thd_token_strides describe PACKED (THD) ports; the dense path stages its operands compact")
+    ts_q = ts_k = ts_v = ts_o = ts_do = ts_dq = ts_dk = ts_dv = 0
+    if thd_token_strides is not None:
+        if len(thd_token_strides) != 8:
+            raise ValueError(f"sm80 bwd: thd_token_strides must be the 8 (Q, K, V, O, dO, dQ, dK, dV) token strides; got {thd_token_strides}")
+        ts_q, ts_k, ts_v, ts_o, ts_do, ts_dq, ts_dk, ts_dv = (int(x) for x in thd_token_strides)
+        for name, ts, hh, dd in (
+            ("Q", ts_q, h, d_out_qk),
+            ("K", ts_k, h_kv, d_out_qk),
+            ("V", ts_v, h_kv, d_out_v),
+            ("O", ts_o, h, d_out_v),
+            ("dO", ts_do, h, d_out_v),
+            ("dQ", ts_dq, h, d_out_qk),
+            ("dK", ts_dk, h_kv, d_out_qk),
+            ("dV", ts_dv, h_kv, d_out_v),
+        ):
+            if ts and (ts < hh * dd or ts % 8):
+                raise ValueError(f"sm80 bwd: {name} token stride {ts} must cover the packed row (>= {hh * dd}) and be a multiple of 8 elements")
+    # Ports the host stages into compact scratch (a head dim inside the flavor
+    # envelope) reach the kernels compact whatever the caller declared.
+    pad_qk = d_out_qk < p.d_qk
+    pad_v = d_out_v < p.d_v
     io_dtype = cutlass.BFloat16 if p.io_bf16 else cutlass.Float16
     mask_flags = (MASK_CAUSAL if p.is_causal else MASK_NONE) | (MASK_SWA if p.has_swa else 0) | (MASK_PADDED if p.has_seq_kv_lens else 0)
     # SMEM budget derivations (see the assertions in the device code): drop
@@ -1914,14 +1967,38 @@ def compile(  # noqa: A001 — the template contract's entry point
         return cute.runtime.make_fake_compact_tensor(dtype, shape, stride_order=order, assumed_align=align)
 
     r4 = (3, 2, 1, 0)
-    fq = _fake(io_dtype, (_b, _sq, h, p.d_qk), r4)
-    fk = _fake(io_dtype, (_b, _skv, h_kv, p.d_qk), r4)
-    fv = _fake(io_dtype, (_b, _skv, h_kv, p.d_v), r4)
-    fdo = _fake(io_dtype, (_b, _sq, h, p.d_v), r4)
+
+    def _fake_rows(dtype, tokens, hh, dd, ts):
+        """A ``[1, T, hh, dd]`` operand at token stride ``ts`` (0 = compact): the
+        stride is plan-time and rides the fake, so the kernels' row arithmetic
+        folds it like the compact ``hh * dd`` it replaces."""
+        if not ts:
+            return _fake(dtype, (1, tokens, hh, dd), r4)
+        return cute.runtime.make_fake_tensor(dtype, (1, tokens, hh, dd), (tokens * ts, ts, dd, 1), assumed_align=16)
+
+    if p.thd_varlen:
+        fq = _fake_rows(io_dtype, _sq, h, p.d_qk, 0 if pad_qk else ts_q)
+        fk = _fake_rows(io_dtype, _skv, h_kv, p.d_qk, 0 if pad_qk else ts_k)
+        fv = _fake_rows(io_dtype, _skv, h_kv, p.d_v, 0 if pad_v else ts_v)
+        fdo = _fake_rows(io_dtype, _sq, h, p.d_v, 0 if pad_v else ts_do)
+    else:
+        fq = _fake(io_dtype, (_b, _sq, h, p.d_qk), r4)
+        fk = _fake(io_dtype, (_b, _skv, h_kv, p.d_qk), r4)
+        fv = _fake(io_dtype, (_b, _skv, h_kv, p.d_v), r4)
+        fdo = _fake(io_dtype, (_b, _sq, h, p.d_v), r4)
     fdq_acc = _fake(cutlass.Float32, (_b, _sq, h, p.d_qk), r4)
     # dK/dV WRITE buffers carry H_q heads (per-query-head; GQA reduces after).
-    fdk_ws = _fake(io_dtype, (_b, _skv, h, p.d_qk), r4)
-    fdv_ws = _fake(io_dtype, (_b, _skv, h, p.d_v), r4)
+    # Under THD an MHA graph at the envelope's native head dim binds the
+    # caller's dK/dV directly (at the caller's token stride); GQA or a padded
+    # head dim writes compact per-query-head partials the bounded fold reads.
+    if p.thd_varlen:
+        dk_direct = not gqa and not pad_qk
+        dv_direct = not gqa and not pad_v
+        fdk_ws = _fake_rows(io_dtype, _skv, h, p.d_qk, ts_dk if dk_direct else 0)
+        fdv_ws = _fake_rows(io_dtype, _skv, h, p.d_v, ts_dv if dv_direct else 0)
+    else:
+        fdk_ws = _fake(io_dtype, (_b, _skv, h, p.d_qk), r4)
+        fdv_ws = _fake(io_dtype, (_b, _skv, h, p.d_v), r4)
     if p.thd_varlen and lse_token_major:
         # (T, H) token-major: a compact rank-2 fake over the sym token extent.
         fl = _fake(cutlass.Float32, (_sq, h), (1, 0), align=4)
@@ -1999,17 +2076,18 @@ def compile(  # noqa: A001 — the template contract's entry point
         fstream,
         options="--enable-tvm-ffi",
     )
-    fo = _fake(io_dtype, (_b, _sq, h, p.d_v), r4)
+    fo = _fake_rows(io_dtype, _sq, h, p.d_v, 0 if pad_v else ts_o) if p.thd_varlen else _fake(io_dtype, (_b, _sq, h, p.d_v), r4)
     do_dot = cute.compile(_do_dot_host, fo, fdo, fdt, p.d_v, io_dtype, cutlass.Int32(0), fstream, options="--enable-tvm-ffi")
     fdq_out = _fake(io_dtype, (_b, _sq, h, p.d_qk), r4)
     if p.thd_varlen:
-        # Row-bounded, caller-width outputs (see out_d_qk / out_d_v above).
-        fdq_out = _fake(io_dtype, (1, _sq, h, d_out_qk), r4)
+        # Row-bounded, caller-width outputs at the caller's token strides (see
+        # out_d_qk / out_d_v and thd_token_strides above).
+        fdq_out = _fake_rows(io_dtype, _sq, h, d_out_qk, ts_dq)
         cast = cute.compile(
             _cast_thd_host, fdq_acc, fdq_out, fcuq, io_dtype, h, p.d_qk, d_out_qk, cutlass.Int32(0), cutlass.Int32(0), fstream, options="--enable-tvm-ffi"
         )
-        fdk_out = _fake(io_dtype, (1, _skv, h_kv, d_out_qk), r4)
-        fdv_out = _fake(io_dtype, (1, _skv, h_kv, d_out_v), r4)
+        fdk_out = _fake_rows(io_dtype, _skv, h_kv, d_out_qk, ts_dk)
+        fdv_out = _fake_rows(io_dtype, _skv, h_kv, d_out_v, ts_dv)
         reduce_k = cute.compile(
             _dkv_reduce_thd_host,
             fdk_ws,

--- a/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
@@ -77,10 +77,13 @@ Named-"barrier" table (all ``nvvm.barrier_cta_sync()`` — full 256-thread CTA):
 ALL barriers are at top level (never inside a divergent ``if sg0`` arm) so the
 per-thread barrier count is identical across both sub-groups.
 
-v1 envelope: f16/bf16, dense (no mask), MHA, SQ % TILE_Q == 0, SKV % TILE_KV == 0,
-d_qk == d_v, (d_qk//2) % 16 == 0 (llama d=128, gptoss d=64).  do_dot + LSE fed in
-(computed by the reference / forward kernel for now; on-device do_dot is a
-follow-up).
+Envelope: f16/bf16; dense (partial tiles gated by runtime bounds) or packed THD
+(``THD_VARLEN``: ``[1,T,H,D]`` operands, ``CU_Q``/``CU_K`` prefix sums, per-sequence
+bounds and diagonal, LSE in either packed packing -- see ``LSE_TOKEN_MAJOR``);
+causal / bottom-right / band / sliding-window masks; GQA via per-query-head
+dK/dV write buffers reduced by the host; d_qk >= d_v with (d_qk//2) % 16 == 0
+(the flavor envelopes: gptoss 64, llama 128, dsv3 192/128, qwen 256).  do_dot
+is computed on device by ``_do_dot_kernel``; LSE is the forward's Stats.
 
 The kernel is fully parameterized on d_qk/d_v/tile_kv/tile_q/warps_per_sg — d=64
 (gptoss) and d=128 (llama) run the SAME code; d=64 uses strictly less SMEM /
@@ -247,6 +250,7 @@ def _bprop_kernel(
     has_rope: cutlass.Constexpr[bool],  # rotate Q/K in SMEM; un-rotate dQ/dK
     has_seq_len_q: cutlass.Constexpr[bool],  # read SEQ_LEN_Q[batch] → per-batch q-pad (dense PADDED)
     THD_VARLEN: cutlass.Constexpr[bool],  # packed [1,T,H,D] + CU_Q/CU_K; per-batch S_q/S_kv
+    LSE_TOKEN_MAJOR: cutlass.Constexpr[bool],  # THD Stats packing: (T, H) token-major (True) or (1, H, head_stride) head-major (False)
     deterministic: cutlass.Constexpr[bool],  # gate the dQ semaphore relay (folds out → byte-identical fast path)
     sched_policy: cutlass.Constexpr[int],  # SCHED_DEFAULT / SCHED_LPT / SCHED_LPT_L2 grid decode
     sched_l2_bytes: cutlass.Constexpr[int],  # L2 budget sizing the SCHED_LPT_L2 head groups
@@ -469,12 +473,21 @@ def _bprop_kernel(
     # LSE: STRIDE-AWARE on the dense path (a graph Stats input may carry any
     # dense-compatible [B,H,SQ] layout; the compile-time strides come from the
     # fake — a compact fake folds them to the packed constants, so the packed
-    # case is byte-identical).  THD keeps the packed [1,H,T_q] math (the grid
-    # `batch` is the LOGICAL sequence index, not the tensor's batch-1 dim).
-    # do_dot is an internal packed buffer → packed math always.
+    # case is byte-identical).  THD reads the PACKED Stats in either packing
+    # Rule S1 admits, both plan-time (the fake's shape and strides):
+    #   head-major  (1, H, head_stride): row = head*head_stride + cu_q[b] + q,
+    #               head_stride == the packed extent when compact (the
+    #               wrapper's [1,H,T_q]) or the caller's wider capacity;
+    #   token-major (T, H): row = (cu_q[b] + q)*H + head (cuDNN's ragged recipe).
+    # The grid `batch` is the LOGICAL sequence index, not the tensor's batch-1
+    # dim.  do_dot is an internal packed buffer → packed math always.
     if cutlass.const_expr(THD_VARLEN):
-        lse_head_base = cutlass.Int64(head * cutlass.Int32(SQ) + cu_q_b)
-        LSE_Q_STRIDE = cutlass.Int64(1)
+        if cutlass.const_expr(LSE_TOKEN_MAJOR):
+            lse_head_base = cutlass.Int64(cu_q_b * cutlass.Int32(LSE.stride[0]) + head)
+            LSE_Q_STRIDE = cutlass.Int64(LSE.stride[0])
+        else:
+            lse_head_base = cutlass.Int64(head * cutlass.Int32(LSE.stride[1]) + cu_q_b)
+            LSE_Q_STRIDE = cutlass.Int64(1)
         dot_head_base = head * cutlass.Int32(SQ) + cu_q_b
     else:
         lse_head_base = cutlass.Int64(batch) * cutlass.Int64(LSE.stride[0]) + cutlass.Int64(head) * cutlass.Int64(LSE.stride[1])
@@ -1323,6 +1336,7 @@ def _dsink_kernel(
     DSINK: cute.Tensor,  # [H] fp32 (atomicAdd target; zero-init)
     CU_Q: cute.Tensor,  # THD: [n_seq + 1] int32 cumulative q seqlens; dense: 1-elem dummy
     thd: cutlass.Constexpr[bool],
+    lse_token_major: cutlass.Constexpr[bool],  # THD Stats packing (see _bprop_kernel's LSE_TOKEN_MAJOR)
     n_rows: cutlass.Int32,  # (B or n_seq) * H
 ):
     """dSink[h] = -sum_rows exp(sink[h] - LSE) * (dO . O), one warp per (batch|sequence, head)
@@ -1349,11 +1363,18 @@ def _dsink_kernel(
             q_lo = Pointer(cu_p + b, dtype=cutlass.Int32).load()
             n_q = Pointer(cu_p + b + cutlass.Int32(1), dtype=cutlass.Int32).load() - q_lo
             base = cutlass.Int64(h) * cutlass.Int64(SQ) + cutlass.Int64(q_lo)
-            lse_base = cutlass.Int64(h) * cutlass.Int64(LSE.stride[1]) + cutlass.Int64(q_lo) * cutlass.Int64(LSE.stride[2])
+            if cutlass.const_expr(lse_token_major):
+                # (T, H) packing: token stride is the fake's leading stride.
+                lse_base = cutlass.Int64(q_lo) * cutlass.Int64(LSE.stride[0]) + cutlass.Int64(h) * cutlass.Int64(LSE.stride[1])
+                lse_step = cutlass.Int64(LSE.stride[0])
+            else:
+                lse_base = cutlass.Int64(h) * cutlass.Int64(LSE.stride[1]) + cutlass.Int64(q_lo) * cutlass.Int64(LSE.stride[2])
+                lse_step = cutlass.Int64(LSE.stride[2])
         else:
             n_q = SQ
             base = cutlass.Int64(row) * cutlass.Int64(SQ)
             lse_base = cutlass.Int64(b) * cutlass.Int64(LSE.stride[0]) + cutlass.Int64(h) * cutlass.Int64(LSE.stride[1])
+            lse_step = cutlass.Int64(LSE.stride[2])
         lse_p = cutlass.make_array_view(LSE).data_ptr()
         dot_p = cutlass.make_array_view(DO_DOT).data_ptr()
         acc = cutlass.Float32(0.0)
@@ -1361,7 +1382,7 @@ def _dsink_kernel(
         for kk in cutlass.range(n_chunks, unroll=1):
             q = lane + kk * cutlass.Int32(32)
             if q < n_q:
-                lse_q = Pointer(lse_p + lse_base + cutlass.Int64(q) * cutlass.Int64(LSE.stride[2]), dtype=cutlass.Float32).load()
+                lse_q = Pointer(lse_p + lse_base + cutlass.Int64(q) * lse_step, dtype=cutlass.Float32).load()
                 dd_q = Pointer(dot_p + base + cutlass.Int64(q), dtype=cutlass.Float32).load()
                 # Padded / fully-masked q-rows have LSE = -inf (forward writes -inf
                 # for an empty softmax denom).  exp2((sink - (-inf))·log2e) = +inf →
@@ -1401,6 +1422,43 @@ def _cast_kernel(
 _cast_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
 
+# THD variant: the dQ cast writes the CALLER's packed dQ directly -- only the
+# rows below the packed total cu_q[n_seq] (a device value; the rows past it are
+# the caller's capacity tail and must stay as the caller left them), at the
+# caller's head dim d_out (<= the flavor envelope fd the accumulator carries).
+# One thread per (row, head, column pair).
+@cute.kernel
+def _cast_thd_kernel(
+    dQ_acc: cute.Tensor,  # [1, T_cap, H, fd] fp32
+    dQ_out: cute.Tensor,  # [1, T_cap, H, d_out] io_dtype (the caller's packed dQ)
+    CU_Q: cute.Tensor,  # [n_seq + 1] int32
+    io_dtype: cutlass.Constexpr,
+    H: cutlass.Constexpr[int],
+    fd: cutlass.Constexpr[int],
+    d_out: cutlass.Constexpr[int],
+    n_seq: cutlass.Int32,
+    n_pairs: cutlass.Int32,  # T_cap * H * d_out / 2
+):
+    bx, _, _ = cute.arch.block_idx()
+    tidx, _, _ = cute.arch.thread_idx()
+    gid = bx * cutlass.Int32(256) + tidx
+    if gid < n_pairs:
+        per_row = cutlass.Int32(H * (d_out // 2))
+        row = gid // per_row
+        r = gid % per_row
+        h = r // cutlass.Int32(d_out // 2)
+        c = (r % cutlass.Int32(d_out // 2)) * cutlass.Int32(2)
+        t_live = Pointer(cutlass.make_array_view(CU_Q).data_ptr() + n_seq, dtype=cutlass.Int32).load()
+        if row < t_live:
+            src = cutlass.make_array_view(dQ_acc).data_ptr() + (row * cutlass.Int32(H) + h) * cutlass.Int32(fd) + c
+            dst = cutlass.make_array_view(dQ_out).data_ptr() + (row * cutlass.Int32(H) + h) * cutlass.Int32(d_out) + c
+            v = Pointer(src, dtype=cutlass.Float32).load(count=2)
+            Pointer(dst, dtype=cutlass.Int32).store(fp32_to_fp16(v[0], v[1], dtype=io_dtype), alignment=4)
+
+
+_cast_thd_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
 # ===========================================================================
 # GQA dK/dV head reduction: sum the per-query-head workspace over each
 # query-head group → [B, SKV, Hk, d].  IN[B,SKV,H,d] (io_dtype) → OUT[B,SKV,Hk,d].
@@ -1435,6 +1493,45 @@ def _dkv_reduce_kernel(
 
 
 _dkv_reduce_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
+# THD variant: folds the per-query-head partials IN[1, T_cap, H, d_in] onto the
+# CALLER's packed dK / dV OUT[1, T_cap, Hk, d_out] -- ratio H // Hk (1 = a plain
+# copy, the padded-head-dim MHA case), rows below the packed total cu_k[n_seq]
+# only, at the caller's head dim d_out (<= d_in, the flavor envelope).
+@cute.kernel
+def _dkv_reduce_thd_kernel(
+    IN: cute.Tensor,  # [1, T_cap, H, d_in] io_dtype (per-query-head dK/dV)
+    OUT: cute.Tensor,  # [1, T_cap, Hk, d_out] io_dtype (the caller's packed dK/dV)
+    CU_K: cute.Tensor,  # [n_seq + 1] int32
+    d_in: cutlass.Constexpr[int],
+    d_out: cutlass.Constexpr[int],
+    H: cutlass.Constexpr[int],
+    Hk: cutlass.Constexpr[int],
+    io_dtype: cutlass.Constexpr,
+    n_seq: cutlass.Int32,
+    n_out: cutlass.Int32,  # T_cap * Hk * d_out
+):
+    ratio = H // Hk
+    bx, _, _ = cute.arch.block_idx()
+    tidx, _, _ = cute.arch.thread_idx()
+    e = bx * cutlass.Int32(256) + tidx
+    if e < n_out:
+        di = e % cutlass.Int32(d_out)
+        rest = e // cutlass.Int32(d_out)
+        hk = rest % cutlass.Int32(Hk)
+        row = rest // cutlass.Int32(Hk)
+        t_live = Pointer(cutlass.make_array_view(CU_K).data_ptr() + n_seq, dtype=cutlass.Int32).load()
+        if row < t_live:
+            in_base = (row * cutlass.Int32(H) + hk * cutlass.Int32(ratio)) * cutlass.Int32(d_in) + di
+            src = cutlass.make_array_view(IN).data_ptr()
+            acc = cutlass.Float32(0.0)
+            for g in cutlass.range_constexpr(ratio):
+                acc = acc + Pointer(src + in_base + cutlass.Int32(g * d_in), dtype=io_dtype).load().to(cutlass.Float32)
+            Pointer(cutlass.make_array_view(OUT).data_ptr() + e, dtype=io_dtype).store(acc.to(io_dtype))
+
+
+_dkv_reduce_thd_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
 
 
 # ===========================================================================
@@ -1476,6 +1573,7 @@ def _bprop_host(
     has_rope: cutlass.Constexpr[bool],
     has_seq_len_q: cutlass.Constexpr[bool],
     thd_varlen: cutlass.Constexpr[bool],
+    lse_token_major: cutlass.Constexpr[bool],
     deterministic: cutlass.Constexpr[bool],
     sched_policy: cutlass.Constexpr[int],
     sched_l2_bytes: cutlass.Constexpr[int],
@@ -1540,6 +1638,7 @@ def _bprop_host(
         has_rope,
         has_seq_len_q,
         thd_varlen,
+        lse_token_major,
         deterministic,
         sched_policy,
         sched_l2_bytes,
@@ -1580,6 +1679,41 @@ def _cast_host(
 
 
 @cute.jit
+def _cast_thd_host(
+    dQ_acc: cute.Tensor,
+    dQ_out: cute.Tensor,
+    CU_Q: cute.Tensor,
+    io_dtype: cutlass.Constexpr,
+    H: cutlass.Constexpr[int],
+    fd: cutlass.Constexpr[int],
+    d_out: cutlass.Constexpr[int],
+    n_seq: cutlass.Int32,
+    n_pairs: cutlass.Int32,
+    stream: cuda.CUstream,
+):
+    n_blocks = (n_pairs + 255) // 256
+    _cast_thd_kernel(dQ_acc, dQ_out, CU_Q, io_dtype, H, fd, d_out, n_seq, n_pairs).launch(grid=(n_blocks, 1, 1), block=(256, 1, 1), stream=stream)
+
+
+@cute.jit
+def _dkv_reduce_thd_host(
+    IN: cute.Tensor,
+    OUT: cute.Tensor,
+    CU_K: cute.Tensor,
+    d_in: cutlass.Constexpr[int],
+    d_out: cutlass.Constexpr[int],
+    H: cutlass.Constexpr[int],
+    Hk: cutlass.Constexpr[int],
+    io_dtype: cutlass.Constexpr,
+    n_seq: cutlass.Int32,
+    n_out: cutlass.Int32,
+    stream: cuda.CUstream,
+):
+    n_blocks = (n_out + 255) // 256
+    _dkv_reduce_thd_kernel(IN, OUT, CU_K, d_in, d_out, H, Hk, io_dtype, n_seq, n_out).launch(grid=(n_blocks, 1, 1), block=(256, 1, 1), stream=stream)
+
+
+@cute.jit
 def _dkv_reduce_host(
     IN: cute.Tensor,
     OUT: cute.Tensor,
@@ -1602,12 +1736,13 @@ def _dsink_host(
     DSINK: cute.Tensor,
     CU_Q: cute.Tensor,
     thd: cutlass.Constexpr[bool],
+    lse_token_major: cutlass.Constexpr[bool],
     n_rows: cutlass.Int32,
     stream: cuda.CUstream,
 ):
     """Host launcher for :func:`_dsink_kernel`: ``n_rows`` = (batch|n_seq) * H warps."""
     n_blocks = (n_rows + _DODOT_WARPS - 1) // _DODOT_WARPS
-    _dsink_kernel(LSE, DO_DOT, SINKS, DSINK, CU_Q, thd, n_rows).launch(grid=(n_blocks, 1, 1), block=(_DODOT_WARPS * 32, 1, 1), stream=stream)
+    _dsink_kernel(LSE, DO_DOT, SINKS, DSINK, CU_Q, thd, lse_token_major, n_rows).launch(grid=(n_blocks, 1, 1), block=(_DODOT_WARPS * 32, 1, 1), stream=stream)
 
 
 # ===========================================================================
@@ -1701,6 +1836,10 @@ def compile(  # noqa: A001 — the template contract's entry point
     rope_max_s: int = 0,
     n_batch_logical: int = 0,
     lse_stride: "Optional[tuple[int, int, int]]" = None,
+    lse_token_major: bool = False,
+    lse_head_stride: int = 0,
+    out_d_qk: int = 0,
+    out_d_v: int = 0,
 ):
     """Compile (or fetch) this template specialization for one shape.
 
@@ -1716,8 +1855,34 @@ def compile(  # noqa: A001 — the template contract's entry point
     non-contiguous Stats input — the kernels then READ the LSE natively at
     that layout (the #712 analogue for the backward's loads; ``None`` keeps
     the packed compact fake, byte-identical codegen).
+
+    ``lse_token_major`` / ``lse_head_stride`` (THD only, plan-time): the packed
+    Stats packing (Rule S1).  Default = head-major with the compact head
+    stride (the ``[1, H, T_q]`` the SM80 forward wrapper emits; byte-identical
+    codegen).  ``lse_head_stride > 0`` binds head-major Stats at the caller's
+    wider head stride (the FROST forwards' 64-token-rounded capacity);
+    ``lse_token_major`` binds cuDNN's ``(T, H)`` ragged recipe.
+
+    ``out_d_qk`` / ``out_d_v`` (THD only, plan-time; 0 = the envelope): the
+    CALLER's head dims.  Under THD the dQ cast and the dK/dV fold write the
+    caller's packed gradients directly, rows below the packed total only and
+    at these widths, so nothing past ``cu_*[B]`` and no padded column is ever
+    written into the caller's buffers.  ``CompiledBwd.cast`` then takes
+    ``(dQ_acc, dQ_out, CU_Q, n_seq, n_pairs, stream)`` and ``reduce_k`` /
+    ``reduce_v`` ``(IN, OUT, CU_K, n_seq, n_out, stream)`` (always compiled
+    under THD; ratio 1 is the padded-head-dim copy).
     """
     p = PARAMS
+    if (lse_token_major or lse_head_stride) and not p.thd_varlen:
+        raise ValueError("sm80 bwd: lse_token_major / lse_head_stride describe PACKED (THD) Stats; dense Stats pass lse_stride")
+    if lse_token_major and lse_head_stride:
+        raise ValueError("sm80 bwd: lse_head_stride is head-major-only (token-major (T, H) Stats is compact)")
+    if (out_d_qk or out_d_v) and not p.thd_varlen:
+        raise ValueError("sm80 bwd: out_d_qk / out_d_v are THD-only (the dense path slices the padded gradient on the host)")
+    d_out_qk = int(out_d_qk) if out_d_qk else p.d_qk
+    d_out_v = int(out_d_v) if out_d_v else p.d_v
+    if d_out_qk % 2 or d_out_v % 2 or d_out_qk > p.d_qk or d_out_v > p.d_v or d_out_qk <= 0 or d_out_v <= 0:
+        raise ValueError(f"sm80 bwd: out head dims must be even and within the envelope ({p.d_qk}, {p.d_v}); got ({out_d_qk}, {out_d_v})")
     io_dtype = cutlass.BFloat16 if p.io_bf16 else cutlass.Float16
     mask_flags = (MASK_CAUSAL if p.is_causal else MASK_NONE) | (MASK_SWA if p.has_swa else 0) | (MASK_PADDED if p.has_seq_kv_lens else 0)
     # SMEM budget derivations (see the assertions in the device code): drop
@@ -1757,11 +1922,17 @@ def compile(  # noqa: A001 — the template contract's entry point
     # dK/dV WRITE buffers carry H_q heads (per-query-head; GQA reduces after).
     fdk_ws = _fake(io_dtype, (_b, _skv, h, p.d_qk), r4)
     fdv_ws = _fake(io_dtype, (_b, _skv, h, p.d_v), r4)
-    fl = (
-        cute.runtime.make_fake_tensor(cutlass.Float32, (_b, h, _sq), lse_stride, assumed_align=4)
-        if lse_stride is not None and not p.thd_varlen
-        else _fake(cutlass.Float32, (_b, h, _sq), (2, 1, 0))
-    )
+    if p.thd_varlen and lse_token_major:
+        # (T, H) token-major: a compact rank-2 fake over the sym token extent.
+        fl = _fake(cutlass.Float32, (_sq, h), (1, 0), align=4)
+    elif p.thd_varlen and lse_head_stride:
+        # (1, H, head_stride) head-major at the caller's plan-time head stride
+        # (the third EXTENT of a compact fake, never a stride).
+        fl = _fake(cutlass.Float32, (1, h, int(lse_head_stride)), (2, 1, 0), align=4)
+    elif lse_stride is not None and not p.thd_varlen:
+        fl = cute.runtime.make_fake_tensor(cutlass.Float32, (_b, h, _sq), lse_stride, assumed_align=4)
+    else:
+        fl = _fake(cutlass.Float32, (_b, h, _sq), (2, 1, 0))
     fdt = _fake(cutlass.Float32, (_b, h, _sq), (2, 1, 0))
     fsk = _fake(cutlass.Int32, (b if p.has_seq_kv_lens else 1,), (0,), align=4)
     bias_dtype = cutlass.Float32 if p.bias_is_fp32 else io_dtype
@@ -1812,6 +1983,7 @@ def compile(  # noqa: A001 — the template contract's entry point
         bool(p.has_rope),
         bool(p.has_seq_q_lens),
         bool(p.thd_varlen),
+        bool(lse_token_major),
         bool(p.deterministic),
         int(p.sched_policy),
         int(p.sched_l2_mib) * 1024 * 1024,
@@ -1830,16 +2002,57 @@ def compile(  # noqa: A001 — the template contract's entry point
     fo = _fake(io_dtype, (_b, _sq, h, p.d_v), r4)
     do_dot = cute.compile(_do_dot_host, fo, fdo, fdt, p.d_v, io_dtype, cutlass.Int32(0), fstream, options="--enable-tvm-ffi")
     fdq_out = _fake(io_dtype, (_b, _sq, h, p.d_qk), r4)
-    cast = cute.compile(_cast_host, fdq_acc, fdq_out, io_dtype, cutlass.Int32(0), fstream, options="--enable-tvm-ffi")
-    reduce_k = reduce_v = None
-    if gqa:
-        fdk_out = _fake(io_dtype, (_b, _skv, h_kv, p.d_qk), r4)
-        fdv_out = _fake(io_dtype, (_b, _skv, h_kv, p.d_v), r4)
-        reduce_k = cute.compile(_dkv_reduce_host, fdk_ws, fdk_out, p.d_qk, h, h_kv, io_dtype, cutlass.Int32(0), fstream, options="--enable-tvm-ffi")
-        reduce_v = cute.compile(_dkv_reduce_host, fdv_ws, fdv_out, p.d_v, h, h_kv, io_dtype, cutlass.Int32(0), fstream, options="--enable-tvm-ffi")
+    if p.thd_varlen:
+        # Row-bounded, caller-width outputs (see out_d_qk / out_d_v above).
+        fdq_out = _fake(io_dtype, (1, _sq, h, d_out_qk), r4)
+        cast = cute.compile(
+            _cast_thd_host, fdq_acc, fdq_out, fcuq, io_dtype, h, p.d_qk, d_out_qk, cutlass.Int32(0), cutlass.Int32(0), fstream, options="--enable-tvm-ffi"
+        )
+        fdk_out = _fake(io_dtype, (1, _skv, h_kv, d_out_qk), r4)
+        fdv_out = _fake(io_dtype, (1, _skv, h_kv, d_out_v), r4)
+        reduce_k = cute.compile(
+            _dkv_reduce_thd_host,
+            fdk_ws,
+            fdk_out,
+            fcuk,
+            p.d_qk,
+            d_out_qk,
+            h,
+            h_kv,
+            io_dtype,
+            cutlass.Int32(0),
+            cutlass.Int32(0),
+            fstream,
+            options="--enable-tvm-ffi",
+        )
+        reduce_v = cute.compile(
+            _dkv_reduce_thd_host,
+            fdv_ws,
+            fdv_out,
+            fcuk,
+            p.d_v,
+            d_out_v,
+            h,
+            h_kv,
+            io_dtype,
+            cutlass.Int32(0),
+            cutlass.Int32(0),
+            fstream,
+            options="--enable-tvm-ffi",
+        )
+    else:
+        cast = cute.compile(_cast_host, fdq_acc, fdq_out, io_dtype, cutlass.Int32(0), fstream, options="--enable-tvm-ffi")
+        reduce_k = reduce_v = None
+        if gqa:
+            fdk_out = _fake(io_dtype, (b, skv, h_kv, p.d_qk), r4)
+            fdv_out = _fake(io_dtype, (b, skv, h_kv, p.d_v), r4)
+            reduce_k = cute.compile(_dkv_reduce_host, fdk_ws, fdk_out, p.d_qk, h, h_kv, io_dtype, cutlass.Int32(0), fstream, options="--enable-tvm-ffi")
+            reduce_v = cute.compile(_dkv_reduce_host, fdv_ws, fdv_out, p.d_v, h, h_kv, io_dtype, cutlass.Int32(0), fstream, options="--enable-tvm-ffi")
     dsink = None
     if p.has_sink:
         fsinks = _fake(cutlass.Float32, (h,), (0,), align=4)
         fdsink = _fake(cutlass.Float32, (h,), (0,), align=4)
-        dsink = cute.compile(_dsink_host, fl, fdt, fsinks, fdsink, fcuq, bool(p.thd_varlen), cutlass.Int32(0), fstream, options="--enable-tvm-ffi")
+        dsink = cute.compile(
+            _dsink_host, fl, fdt, fsinks, fdsink, fcuq, bool(p.thd_varlen), bool(lse_token_major), cutlass.Int32(0), fstream, options="--enable-tvm-ffi"
+        )
     return CompiledBwd(main=main, do_dot=do_dot, cast=cast, reduce_k=reduce_k, reduce_v=reduce_v, dsink=dsink, sem_q_stride=sem_q_stride)

--- a/python/cudnn/sdpa/bwd/kernels/thd_helpers.py
+++ b/python/cudnn/sdpa/bwd/kernels/thd_helpers.py
@@ -37,7 +37,15 @@ from cudnn.frost.tile_dsl.thd import (
     write_thd_row_offsets,
 )
 
-__all__ = ["THD_BWD_META_WORDS", "THD_ROWOFF_OFF", "THD_SETUP_THREADS", "build_thd_bwd_setup_kernel", "thd_bwd_setup_host"]
+__all__ = [
+    "THD_BWD_META_WORDS",
+    "THD_ROWOFF_OFF",
+    "THD_SETUP_THREADS",
+    "build_thd_bwd_setup_kernel",
+    "thd_bwd_setup_host",
+    "build_thd_meta_kernel",
+    "thd_meta_host",
+]
 
 
 @cute.kernel
@@ -93,3 +101,34 @@ def thd_bwd_setup_host(meta_t, q_lens_t, kv_lens_t, lens_form, n_qh, n_batch, ws
     build_thd_bwd_setup_kernel(meta_t, q_lens_t, kv_lens_t, lens_form, n_qh, n_batch, ws_gran, cga_tile_m, n_clusters).launch(
         grid=(1, 1, 1), block=(THD_SETUP_THREADS, 1, 1), stream=stream
     )
+
+
+@cute.kernel
+def build_thd_meta_kernel(
+    meta_t: cute.Tensor,
+    q_lens_t: cute.Tensor,
+    kv_lens_t: cute.Tensor,
+    lens_form: cutlass.Int32,
+    n_batch: cutlass.Int32,
+) -> None:
+    """Lengths -> ``[seq_kv_lens(B) | cu_seqlens_q(B+1) | cu_seqlens_k(B+1)]`` only.
+
+    The metadata a kernel that takes ``cu_seqlens`` on device needs and
+    nothing else: no blocked-workspace row offsets, no batch ranking, no claim
+    counter.  One thread does the serial cumsum (B is small); no warp
+    primitives, so it runs on every architecture the SDPA kernels do -- the
+    SM80 backward reads ``cu_q`` / ``cu_k`` straight out of this buffer.
+    """
+    tidx, _, _ = cute.arch.thread_idx()
+    if tidx == cutlass.Int32(0):
+        write_thd_meta(cutlass.make_array_view(meta_t), cutlass.make_array_view(q_lens_t), cutlass.make_array_view(kv_lens_t), lens_form, n_batch)
+
+
+build_thd_meta_kernel.set_name_prefix("cudnn", remove_cutlass_symbol=True)
+
+
+@cute.jit
+def thd_meta_host(meta_t, q_lens_t, kv_lens_t, lens_form, n_batch, stream=None):
+    """One-warp launch of :func:`build_thd_meta_kernel` (see ``thd_bwd_setup_host``
+    for why the launch wrapper lives at module level)."""
+    build_thd_meta_kernel(meta_t, q_lens_t, kv_lens_t, lens_form, n_batch).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)

--- a/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
+++ b/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
@@ -465,7 +465,8 @@ on the 80-wide tile.
 Engines: `sdpa_fwd_prefill_sm80`, `sdpa_bwd_sm80`. Both use `mma.sync` (no
 tcgen05) and assume the A100's 164 KiB opt-in SMEM — sm86/sm89 are declined.
 Head dims below a flavor's native shape are zero-padded **host-side**, so there
-is no alignment rule.
+is no alignment rule. The backward serves packed THD graphs (ᵏ); the forward
+does not yet.
 
 | Feature | d64 (GPT-OSS) | d128 (Llama) | d192×d128 (DSv3) | d256 (Qwen) |
 |---|:--:|:--:|:--:|:--:|
@@ -475,8 +476,8 @@ is no alignment rule.
 | FP8 / MXFP8 | ❌ / ❌ | ❌ / ❌ | ❌ / ❌ | ❌ / ❌ |
 | **Layout** | | | | |
 | BSHD / `dense_flex` | ✅ / ✅ | ✅ / ✅ | ✅ / ✅ | ✅ / ✅ |
-| THD / ragged | ❌ / ❌ | ❌ / ❌ | ❌ / ❌ | ❌ / ❌ |
-| `cu_seq_len_q/kv` | ❌ / ❌ | ❌ / ❌ | ❌ / ❌ | ❌ / ❌ |
+| THD / ragged | ❌ / ✅ᵏ | ❌ / ✅ᵏ | ❌ / ✅ᵏ | ❌ / ✅ᵏ |
+| `cu_seq_len_q/kv` | ❌ / ❌ʲ | ❌ / ❌ʲ | ❌ / ❌ʲ | ❌ / ❌ʲ |
 | Strided / permuted Stats | ✅ / ✅ | ✅ / ✅ | ✅ / ✅ | ✅ / ✅ |
 | **Masks / features** | | | | |
 | Causal (top-left) | ✅ / ✅ | ✅ / ✅ | ✅ / ✅ | ✅ / ✅ |
@@ -495,6 +496,32 @@ The SM80 backward additionally has a dedicated plain-dense **d=64 fast path**
 (~2× on A100) that supports **no** features — it is selected only for a
 feature-free d=64 graph.
 
+ᵏ **THD / ragged backward** (`sdpa_bwd_sm80`). Q/K/V/O/dO and the gradients are
+PACKED `[1, T, H, D]` and must be **compact BSHD** (token stride `H*D`, head
+stride `D` — a K/V view into an interleaved `[T, 2, H, D]` record is declined at
+plan time; the SM80 kernels address packed rows from `H` and `D` alone).
+Lengths arrive as the graph's per-batch `seq_len_q/kv` (`use_padding_mask=True`)
+and become `cu_seqlens` on device in a one-warp setup launch. Like every FROST
+THD row, the packed addressing is `prefix(lengths) × token stride`: the bound
+ragged-offset VALUES are not read, so sequences must be adjacent (TE-style
+padded THD with gaps between sequences, `cu_seqlens_padded != cu_seqlens`, is
+not served and is runtime data that cannot be declined at plan time — issue
+#737 tracks reading the offsets on device). **Declared
+`max_total_seq_len_q/kv` are required** (the fp32 dQ accumulator, the
+per-query-head dK/dV partials and do_dot are sized from them at build time).
+Ragged Stats is read in either packed packing — token-major `(T, H)` or
+head-major `(1, H, head_stride)` with any head stride covering the packed
+capacity (the compact `[1, H, T_q]` the SM80 forward wrapper emits, or the
+FROST forwards' 64-rounded one). The kv-tile grid and the deterministic relay
+counter are bounded by the envelope `S_max` (short tiles early-out; no length is
+read on the host); the dQ cast and the dK/dV fold stop at `cu_*[B]` on device and
+write the caller's head dim, so nothing past the packed total is ever written into
+the caller's gradients (the ragged sweeps assert this with a NaN-filled tail). Served under THD: the causal family, GQA/MQA, sinks/dSink,
+deterministic dQ, head-dim envelope padding (carved staging at the packed
+capacities), zero-length and one-sided-empty sequences. Bias/dBias is dense-only (a packed graph has no `[B, H, S_q, S_kv]` bias); RoPE is a
+wrapper-only fusion no engine row admits. The forward row
+still declines THD (the wrapper's `cu_seqlen` path serves it).
+
 ---
 
 ## Gaps at a glance
@@ -512,7 +539,7 @@ feature-free d=64 graph.
 | MXFP8 forward | SM120, SM80 (SM107 is served — see the SM107 table; d512 is ⚠️ⁱᵛ, correct but with no test module) |
 | Per-tensor FP8 backward | every arch |
 | MXFP8 backward outside SM100/SM103 d = 256 | every arch |
-| THD / ragged backward | SM80, SM120, and the SM100/SM103 MXFP8 row (the SM100/SM103 f16/bf16 row serves it — see ʰ) |
+| THD / ragged backward | SM120, and the SM100/SM103 MXFP8 row (the SM100/SM103 f16/bf16 row serves it — see ʰ; SM80 — see ᵏ) |
 | THD forward | SM80 |
 | **Native d=64 (GPT-OSS) forward kernel** | **SM100, SM107** — served via the d128 envelope at ~2× MMA cost |
 | d=64 MXFP8 / d=64 quantized THD | SM100, SM107 (exact-shape gates) |

--- a/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
+++ b/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
@@ -497,9 +497,13 @@ The SM80 backward additionally has a dedicated plain-dense **d=64 fast path**
 feature-free d=64 graph.
 
 ᵏ **THD / ragged backward** (`sdpa_bwd_sm80`). Q/K/V/O/dO and the gradients are
-PACKED `[1, T, H, D]` and must be **compact BSHD** (token stride `H*D`, head
-stride `D` — a K/V view into an interleaved `[T, 2, H, D]` record is declined at
-plan time; the SM80 kernels address packed rows from `H` and `D` alone).
+PACKED `[1, T, H, D]` **BSHD rows, each at its own token stride**: head stride
+`D`, element stride 1, token stride `>= H*D` and a multiple of 8 elements
+(16-byte rows for the `cp.async` loads). A compact port is the common case; a
+K/V view into an interleaved `[T, 2, H, D]` record (token stride `2*H*D`, the
+fused-KV slicing layout) is served at that stride, the gap columns never read or
+written. The strides are plan-time (the compiled fakes carry them); a compact
+port keeps the compact fake, byte-identical codegen.
 Lengths arrive as the graph's per-batch `seq_len_q/kv` (`use_padding_mask=True`)
 and become `cu_seqlens` on device in a one-warp setup launch. Like every FROST
 THD row, the packed addressing is `prefix(lengths) × token stride`: the bound

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -1075,7 +1075,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         # over the caller's strides.
         # THD (ragged) keeps the strict BSHD stride order: the varlen path
         # rebuilds packed [1,T,H,D] views and only that packing is defined.
-        from cudnn.sdpa.graph_analyzer import dense_layout_ok
+        from cudnn.sdpa.graph_analyzer import dense_layout_ok, thd_stats_packing
 
         _REQ = (3, 1, 2, 0)
         for desc_name in ["q_desc", "k_desc", "v_desc", "o_desc"]:
@@ -1172,10 +1172,10 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             self._check_tensor_shape(self.lse_desc, (b, h_qo, s_qo), name="LSE")
             if self.thd:
                 stride_h, stride_s = tuple(self.lse_desc.stride[1:])
-                token_major = (stride_h, stride_s) == (1, h_qo)
-                head_major = not token_major and stride_s == 1 and stride_h >= 1
+                packing = thd_stats_packing(stride_h, stride_s, h_qo)
+                head_major = packing == "head_major"
                 self._value_error_if(
-                    not token_major and not head_major,
+                    packing is None,
                     f"THD LSE must be packed token-major (stride_h == 1, stride_s == H) "
                     f"or head-major (stride_s == 1, stride_h == head_stride); got stride {self.lse_desc.stride}",
                 )
@@ -2884,7 +2884,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         # normalization needs is required: head dim innermost-contiguous
         # (stride 1), non-broadcast, non-overlapping strides, any B/H/S
         # order, padded strides allowed.
-        from cudnn.sdpa.graph_analyzer import bshd_layout_ok, dense_layout_ok
+        from cudnn.sdpa.graph_analyzer import bshd_layout_ok, dense_layout_ok, thd_stats_packing
 
         for desc in (self.q_desc, self.k_desc, self.v_desc, self.o_desc):
             self._value_error_if(
@@ -2920,10 +2920,10 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             self._check_tensor_shape(self.lse_desc, (b, h_q, s_q), name="LSE")
             if self.thd:
                 stride_h, stride_s = tuple(self.lse_desc.stride[1:])
-                token_major = (stride_h, stride_s) == (1, h_q)
-                head_major = not token_major and stride_s == 1 and stride_h >= 1
+                packing = thd_stats_packing(stride_h, stride_s, h_q)
+                head_major = packing == "head_major"
                 self._value_error_if(
-                    not token_major and not head_major,
+                    packing is None,
                     f"THD LSE must be packed token-major (stride_h == 1, stride_s == H) "
                     f"or head-major (stride_s == 1, stride_h == head_stride); got stride {self.lse_desc.stride}",
                 )

--- a/python/cudnn/sdpa/graph_analyzer.py
+++ b/python/cudnn/sdpa/graph_analyzer.py
@@ -119,6 +119,28 @@ def _stride_order(dim: tuple, stride: tuple) -> tuple:
     return tuple(i for i, _ in sorted(enumerate(stride), key=lambda x: (x[1], dim[x[0]])))
 
 
+def thd_stats_packing(stride_h: int, stride_s: int, h_q: int) -> Optional[str]:
+    """Classify a ragged (packed) Stats declaration by its strides (Rule S1).
+
+    ``"token_major"``: ``(stride_h, stride_s) == (1, H_q)`` -- cuDNN's ragged
+    Stats recipe, ``(T, H)`` in memory.  ``"head_major"``: ``stride_s == 1``
+    with ``stride_h >= 1`` the declared head stride, ``(H, head_stride)`` in
+    memory -- what the FROST forwards emit, rounded up to a 64-token capacity.
+    ``None`` is a packing no FROST row reads.  The head stride must cover the
+    packed token total; that total is a device value, so callers can only
+    bound it against a plan-time capacity (see bwd/engines.py mismatch()).
+
+    One classifier for every probe and adapter site, so the two packings
+    cannot drift apart between the forward that writes Stats and the
+    backward that reads it.
+    """
+    if (int(stride_h), int(stride_s)) == (1, int(h_q)):
+        return "token_major"
+    if int(stride_s) == 1 and int(stride_h) >= 1:
+        return "head_major"
+    return None
+
+
 def bshd_layout_ok(dim: tuple, stride: tuple) -> bool:
     """Strict BSHD physical stride order for a rank-4 (B, H, S, D) tensor:
     axes sorted by ascending stride must come out D, H, S, B, with size-1

--- a/test/python/fe_api/sdpa/test_sdpa_bwd_sm80.py
+++ b/test/python/fe_api/sdpa/test_sdpa_bwd_sm80.py
@@ -154,18 +154,21 @@ def test_sdpa_bwd_sm80_wrapper(dtype, d_qk, d_v, mask, gqa):
 
 @pytest.mark.L0
 @pytest.mark.parametrize(
-    "is_causal,deterministic,expected", [(True, False, "lpt_l2"), (True, True, "natural"), (False, False, "natural")], ids=["causal", "causal-det", "dense"]
+    "is_causal,deterministic,thd,expected",
+    [(True, False, False, "lpt_l2"), (True, True, False, "natural"), (False, False, False, "natural"), (True, False, True, "natural")],
+    ids=["causal", "causal-det", "dense", "causal-thd"],
 )
-def test_sm80_bwd_sched_policy_resolution(is_causal, deterministic, expected):
-    """Causal takes the L2-grouped kv-major order; the deterministic relay and
-    non-causal work keep the plain 3-D grid (host-only: no compile)."""
+def test_sm80_bwd_sched_policy_resolution(is_causal, deterministic, thd, expected):
+    """Causal takes the L2-grouped kv-major order; the deterministic relay,
+    non-causal work and the packed (THD) grid keep the plain 3-D decode
+    (host-only: no compile)."""
     try:
         from cudnn.sdpa.bwd import api_dsl as api_sm80
         from cudnn.frost.tile_dsl.constants import SCHED_LPT_L2, SCHED_NATURAL
     except ImportError as e:
         pytest.skip(f"SM80 SDPA API not available: {e}")
     want = {"lpt_l2": SCHED_LPT_L2, "natural": SCHED_NATURAL}[expected]
-    assert api_sm80._sm80_bwd_sched_policy(is_causal=is_causal, deterministic=deterministic) == want
+    assert api_sm80._sm80_bwd_sched_policy(is_causal=is_causal, deterministic=deterministic, thd=thd) == want
 
 
 @pytest.mark.L1

--- a/test/python/sdpa/frost/test_sdpa_bwd_thd_sm80.py
+++ b/test/python/sdpa/frost/test_sdpa_bwd_thd_sm80.py
@@ -323,25 +323,60 @@ def _plan_index(g, name=_ENGINE):
     return None
 
 
-def _build_thd_bwd_graph(case, *, stats_layout="head_major", declare_totals=True, token_gap=0, sink=None, **sdpa_kwargs):
+_GAP_ROLES = ("q", "k", "v", "o", "do", "dq", "dk", "dv")
+
+
+def _gapped(x, gap, fill=float("nan")):
+    """``x`` ([1, cap, nh, dd] compact) re-homed in a per-token record ``gap``
+    elements wider: the returned view has token stride ``nh*dd + gap`` and the
+    gap columns hold ``fill`` (NaN by default -- a read of a gap column would
+    poison the result, a write would show up in the storage).  ``gap <= 0``
+    returns ``x`` itself (a negative gap declares OVERLAPPING rows, a
+    probe-only decline that never binds data)."""
+    if gap <= 0:
+        return x
+    _, cap, nh, dd = x.shape
+    ts = nh * dd + gap
+    stor = torch.full((cap, ts), fill, device=x.device, dtype=x.dtype)
+    view = stor.as_strided((1, cap, nh, dd), (cap * ts, ts, dd, 1))
+    view.copy_(x)
+    return view
+
+
+def _gap_columns(view):
+    """The gap columns of a ``_gapped`` view's per-token records (empty for a
+    compact tensor)."""
+    _, cap, nh, dd = view.shape
+    ts = view.stride(1)
+    if ts == nh * dd:
+        return view.new_empty(0)
+    return view.as_strided((cap, ts - nh * dd), (ts, 1), view.storage_offset() + nh * dd)
+
+
+def _build_thd_bwd_graph(case, *, stats_layout="head_major", declare_totals=True, gaps=None, sink=None, **sdpa_kwargs):
     """A ragged backward graph over ``case``'s packed buffers.
 
     Everything is declared as the ENVELOPE (B, H, S_max, D) plus a per-tensor
-    ragged offset -- cuDNN's spelling of a packed tensor.  ``token_gap`` widens
-    the K/V token stride past ``H_kv * D`` (a view into an interleaved
-    per-token record), which the SM80 packed path DECLINES.  ``sink`` adds the
-    ``sink_token`` / ``dSink_token`` ports ((1, H, 1, 1) fp32); the graph's
+    ragged offset -- cuDNN's spelling of a packed tensor.  ``gaps`` maps a port
+    role (``q k v o do dq dk dv``) to extra elements on its token stride: the
+    port is then a view into a wider per-token record (``k``/``v`` at
+    ``H_kv * D`` is the fused-KV interleaved layout), which the SM80 packed
+    path serves at that stride.  The bound input buffers are re-homed in such
+    records with NaN in the gap columns.  ``sink`` adds the ``sink_token`` /
+    ``dSink_token`` ports ((1, H, 1, 1) fp32); the graph's
     ``_thd_test_ports["dsink"]`` handle finds the dSink buffer in the pack.
     """
     b, h, hkv, d, d_v, dev = case.b, case.h, case.hkv, case.d, case.d_v, "cuda"
+    gaps = dict(gaps or {})
+    assert set(gaps) <= set(_GAP_ROLES), gaps
     io = cudnn.data_type.HALF if case.dtype == torch.float16 else cudnn.data_type.BFLOAT16
     s_max_q, s_max_kv = max(max(case.lens_q), 1), max(max(case.lens_kv), 1)
     g = cudnn.pygraph(io_data_type=io, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
     vp, t, geom = {}, {}, {}
 
     def _port(name, s_max, nh, dd, cu, gap=0):
-        """Envelope (B, nh, s_max, dd) with compact BSHD strides (token stride
-        widened by ``gap``) and an element ragged offset of cu * token stride."""
+        """Envelope (B, nh, s_max, dd) with packed BSHD strides (token stride
+        ``nh*dd`` widened by ``gap``) and an element ragged offset of cu * token stride."""
         ts = nh * dd + gap
         stride = [s_max * ts, dd, ts, 1]
         ro_t = (torch.tensor(cu, dtype=torch.int64, device=dev) * ts).view(b + 1, 1, 1, 1)
@@ -352,11 +387,33 @@ def _build_thd_bwd_graph(case, *, stats_layout="head_major", declare_totals=True
         vp[ro] = ro_t
         return x
 
-    t["q"] = _port("q", s_max_q, h, d, case.cu_q)
-    t["o"] = _port("o", s_max_q, h, d_v, case.cu_q)
-    t["do"] = _port("do", s_max_q, h, d_v, case.cu_q)
-    t["k"] = _port("k", s_max_kv, hkv, d, case.cu_k, token_gap)
-    t["v"] = _port("v", s_max_kv, hkv, d_v, case.cu_k, token_gap)
+    t["q"] = _port("q", s_max_q, h, d, case.cu_q, gaps.get("q", 0))
+    t["o"] = _port("o", s_max_q, h, d_v, case.cu_q, gaps.get("o", 0))
+    t["do"] = _port("do", s_max_q, h, d_v, case.cu_q, gaps.get("do", 0))
+    t["k"] = _port("k", s_max_kv, hkv, d, case.cu_k, gaps.get("k", 0))
+    t["v"] = _port("v", s_max_kv, hkv, d_v, case.cu_k, gaps.get("v", 0))
+    # The gradients' own records (declared below, once the node exists).
+    geom["dq"] = (
+        s_max_q,
+        [s_max_q * (h * d + gaps.get("dq", 0)), d, h * d + gaps.get("dq", 0), 1],
+        h,
+        d,
+        torch.tensor(case.cu_q, dtype=torch.int64, device=dev).view(b + 1, 1, 1, 1) * (h * d + gaps.get("dq", 0)),
+    )
+    geom["dk"] = (
+        s_max_kv,
+        [s_max_kv * (hkv * d + gaps.get("dk", 0)), d, hkv * d + gaps.get("dk", 0), 1],
+        hkv,
+        d,
+        torch.tensor(case.cu_k, dtype=torch.int64, device=dev).view(b + 1, 1, 1, 1) * (hkv * d + gaps.get("dk", 0)),
+    )
+    geom["dv"] = (
+        s_max_kv,
+        [s_max_kv * (hkv * d_v + gaps.get("dv", 0)), d_v, hkv * d_v + gaps.get("dv", 0), 1],
+        hkv,
+        d_v,
+        torch.tensor(case.cu_k, dtype=torch.int64, device=dev).view(b + 1, 1, 1, 1) * (hkv * d_v + gaps.get("dv", 0)),
+    )
 
     # Packed Stats in one of the layouts a forward emits.  head_major is
     # (1, H, head_stride) with a 64-rounded token capacity (WIDER than the
@@ -410,14 +467,16 @@ def _build_thd_bwd_graph(case, *, stats_layout="head_major", declare_totals=True
         kw.update(max_total_seq_len_q=case.cap_q, max_total_seq_len_kv=case.cap_kv)
     kw.update(sdpa_kwargs)
     dq_t, dk_t, dv_t = g.sdpa_backward(**kw)
-    for out, like in ((dq_t, "q"), (dk_t, "k"), (dv_t, "v")):
-        s_max, stride, nh, dd, ro_t = geom[like]
+    for out, role in ((dq_t, "dq"), (dk_t, "dk"), (dv_t, "dv")):
+        s_max, stride, nh, dd, ro_t = geom[role]
         out.set_output(True).set_data_type(io).set_dim([b, nh, s_max, dd]).set_stride(stride)
         ro = g.tensor(name=f"{out.get_name()}_ro", dim=[b + 1, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT64)
         out.set_ragged_offset(ro)
         vp[ro] = ro_t
-    vp.update({t["q"]: case.q, t["k"]: case.k, t["v"]: case.v, t["o"]: case.o, t["do"]: case.do})
+    # Inputs re-homed in their declared records (NaN gap columns: never read).
+    vp.update({t[r]: _gapped(getattr(case, r), gaps.get(r, 0)) for r in ("q", "k", "v", "o", "do")})
     g._thd_test_ports = t  # the sink/dSink handles, for the sinks test
+    g._thd_test_gaps = gaps  # the gradients' records, for _run_graph
     return g, vp, (dq_t, dk_t, dv_t)
 
 
@@ -458,9 +517,12 @@ def _run_graph(lens_q, lens_kv, *, h=2, hkv=None, d=_D, d_v=None, dtype=torch.bf
     )
     g, vp, (dq_t, dk_t, dv_t) = _build_thd_bwd_graph(case, stats_layout=stats_layout, **kw)
     _plan_graph(g)
-    dq = torch.full_like(case.q, float("nan"))
-    dk = torch.full((1, case.cap_kv, case.hkv, case.d), float("nan"), device="cuda", dtype=dtype)
-    dv = torch.full((1, case.cap_kv, case.hkv, case.d_v), float("nan"), device="cuda", dtype=dtype)
+    gaps = g._thd_test_gaps
+    # NaN-filled gradient records at the declared token strides: a gap column
+    # that stops being NaN was written, a live row that stays NaN was skipped.
+    dq = _gapped(torch.full_like(case.q, float("nan")), gaps.get("dq", 0))
+    dk = _gapped(torch.full((1, case.cap_kv, case.hkv, case.d), float("nan"), device="cuda", dtype=dtype), gaps.get("dk", 0))
+    dv = _gapped(torch.full((1, case.cap_kv, case.hkv, case.d_v), float("nan"), device="cuda", dtype=dtype), gaps.get("dv", 0))
     vp.update({dq_t: dq, dk_t: dk, dv_t: dv})
     ws = torch.empty(max(g.get_workspace_size(), 1), device="cuda", dtype=torch.uint8)
     g.execute(vp, ws)
@@ -468,6 +530,7 @@ def _run_graph(lens_q, lens_kv, *, h=2, hkv=None, d=_D, d_v=None, dtype=torch.bf
     for name, x in (("dQ", dq), ("dK", dk), ("dV", dv)):
         live = x[0, : case.t_q] if name == "dQ" else x[0, : case.t_kv]
         assert torch.isfinite(live).all(), f"{name} has non-finite values in the packed region"
+        assert torch.isnan(_gap_columns(x)).all(), f"{name}: a gap column of the per-token record was written"
     _check(case, dq, dk, dv)
     return case, g, vp, ws, (dq, dk, dv)
 
@@ -538,6 +601,49 @@ def test_graph_thd_capacity_tail_left_untouched(variant):
     for name, x, t in (("dQ", dq, case.t_q), ("dK", dk, case.t_kv), ("dV", dv, case.t_kv)):
         assert torch.isfinite(x[0, :t]).all(), f"{name}: live rows must be finite"
         assert torch.isnan(x[0, t:]).all(), f"{name}: rows past the packed total were written"
+
+
+_GAP_CASES = {
+    # K/V (and dK/dV) as slices of an interleaved [T, 2, H_kv, D] record: the
+    # fused-KV layout torch.nn.attention.varlen users produce.
+    "kv_interleaved": dict(gaps={"k": 2 * _D, "v": 2 * _D, "dk": 2 * _D, "dv": 2 * _D}),
+    # The Q side only: Q/O/dO/dQ each in a different record.
+    "q_side": dict(gaps={"q": 8, "o": 16, "do": 24, "dq": 32}),
+    # Every port in a record of its own width.
+    "all_ports": dict(gaps={r: 8 * (i + 1) for i, r in enumerate(_GAP_ROLES)}),
+    # GQA: the dK/dV fold writes the caller's record at its stride.
+    "gqa": dict(h=4, hkv=2, gaps={r: 8 * (i + 1) for i, r in enumerate(_GAP_ROLES)}),
+    # MQA: the size-1 KV head axis wildcards its stride.
+    "mqa": dict(h=4, hkv=1, gaps={"k": 2 * _D, "v": 2 * _D, "dk": 16, "dv": 8}),
+    # A head dim inside the envelope: the staging copy reads the record, the
+    # cast and fold write it.
+    "padded_d": dict(d=96, gaps={r: 8 * (i + 1) for i, r in enumerate(_GAP_ROLES)}),
+    # The causal + deterministic relay with interleaved K/V.
+    "causal_det": dict(use_causal_mask=True, use_deterministic_algorithm=True, gaps={"k": 2 * _D, "v": 2 * _D}),
+}
+
+
+@pytest.mark.parametrize("variant", sorted(_GAP_CASES), ids=sorted(_GAP_CASES))
+def test_graph_thd_gapped_token_strides(variant):
+    """Ports declared as views into wider per-token records are read and
+    written at their own token stride: the reference matches per sequence, the
+    NaN gap columns of the inputs were never read (they would poison the
+    result) and those of the gradients never written."""
+    _run_graph((300, 128, 200), (300, 128, 200), **_GAP_CASES[variant])
+
+
+def test_graph_thd_gapped_capacity_tail_left_untouched():
+    """The capacity-tail contract on gapped records: rows past the packed total
+    and the gap columns both stay NaN, on the direct-bound MHA epilogue."""
+    gaps = {r: 8 * (i + 1) for i, r in enumerate(_GAP_ROLES)}
+    case, g, vp, ws, (dq, dk, dv) = _run_graph((256, 128), (256, 128), poison=True, pad_cap=384, gaps=gaps)
+    ws.fill_(0xFF)
+    g.execute(vp, ws)
+    torch.cuda.synchronize()
+    for name, x, t in (("dQ", dq, case.t_q), ("dK", dk, case.t_kv), ("dV", dv, case.t_kv)):
+        assert torch.isfinite(x[0, :t]).all(), f"{name}: live rows must be finite"
+        assert torch.isnan(x[0, t:]).all(), f"{name}: rows past the packed total were written"
+        assert torch.isnan(_gap_columns(x)).all(), f"{name}: a gap column was written"
 
 
 def test_graph_thd_nan_capacity_tail_unaligned_last_sequence():
@@ -832,12 +938,30 @@ def test_reject_thd_without_declared_totals():
     assert reason is not None and "max_total_seq_len" in reason
 
 
-def test_reject_thd_gapped_token_stride():
-    """K/V declared as views into a wider per-token record (token stride
-    2*H_kv*D, the fused-KV slicing layout): the SM80 packed path addresses rows
-    from H and D alone, so this is a typed plan-time decline, not a mis-read."""
-    reason = _thd_mismatch(token_gap=2 * _D)
-    assert reason is not None and "compact BSHD" in reason, reason
+def test_accept_thd_gapped_token_strides():
+    """Ports declared as views into a wider per-token record are served at
+    their own token stride: K/V at 2*H_kv*D (the fused-KV slicing layout, the
+    one the ragged sweeps draw most), and every port at once."""
+    assert _thd_mismatch(gaps={"k": 2 * _D, "v": 2 * _D}) is None
+    assert _thd_mismatch(gaps={r: 8 * (i + 1) for i, r in enumerate(_GAP_ROLES)}) is None
+    assert _thd_mismatch(h=4, hkv=2, gaps={"k": 2 * _D, "v": 2 * _D, "dk": 8, "dv": 16}) is None
+
+
+def test_reject_thd_misaligned_token_stride():
+    """A token stride off 16-byte alignment (4 fp16 elements past the row) is a
+    typed plan-time decline: the cp.async loads move 16-byte chunks."""
+    reason = _thd_mismatch(gaps={"k": 4})
+    assert reason is not None and "multiple of 8" in reason, reason
+    reason = _thd_mismatch(gaps={"dq": 12})
+    assert reason is not None and "multiple of 8" in reason, reason
+
+
+def test_reject_thd_token_stride_below_the_row():
+    """A token stride shorter than H*D (overlapping rows) never reaches the
+    packed-row rule: the layout envelope's non-overlap check (or the node)
+    declines it first."""
+    reason = _thd_mismatch(gaps={"q": -8})
+    assert reason is not None and ("refused by the node" in reason or "overlapping" in reason or ">= H*D" in reason), reason
 
 
 def test_reject_thd_bias():

--- a/test/python/sdpa/frost/test_sdpa_bwd_thd_sm80.py
+++ b/test/python/sdpa/frost/test_sdpa_bwd_thd_sm80.py
@@ -1,0 +1,888 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``sdpa_bwd_sm80`` THD / varlen through the graph API: the packed backward, end to end.
+
+Two surfaces, deliberately both (the shape of ``test_sdpa_bwd_thd_sm100.py``):
+
+* ``_run`` drives ``SdpaBwdDslSm80`` DIRECTLY with ``thd=True`` -- the adapter's
+  packed chain (setup launch -> do_dot -> main -> cast -> reduce) over packed
+  buffers, one layer below the plan machinery.
+* ``_run_graph`` goes through a ragged GRAPH and pins the engine -- the lowering:
+  packed views over the caller's buffers at the declared capacities, the
+  per-batch length binding, and the Stats packing inference.
+
+The reference is per-sequence dense attention in fp64, compared gradient by
+gradient and sequence by sequence: a THD bug that leaks across a sequence
+boundary shows up as one sequence contaminated by its neighbour, which a
+whole-tensor cosine would average away.
+"""
+
+from __future__ import annotations
+
+import math
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from frost_test_utils import _SM, requires_dsl
+
+import cudnn
+
+_SM80 = pytest.mark.skipif(_SM != 80, reason="needs an SM80 (A100) GPU, have " + ("none" if _SM is None else f"sm_{_SM}"))
+pytestmark = [pytest.mark.L0, _SM80, requires_dsl]
+
+_ENGINE = "sdpa_bwd_sm80"
+_D = 128
+_TOL_COS = 0.999
+
+
+def _causal_bias(s_q, s_kv, device, bottom_right=False, window_left=None, window_right=None):
+    """Additive -inf mask for ONE sequence, in that sequence's OWN geometry.
+
+    Under THD the diagonal is per sequence: ``bottom_right`` anchors it at
+    ``S_kv[b] - S_q[b]``, a per-sequence offset.  ``window_left`` is cuDNN's
+    inclusive column count (``kv > q + diag - window_left``), ``window_right``
+    an offset that widens the upper bound.
+    """
+    q_i = torch.arange(s_q, device=device).view(-1, 1)
+    kv_i = torch.arange(s_kv, device=device).view(1, -1)
+    diag = (s_kv - s_q) if bottom_right else 0
+    keep = kv_i <= q_i + diag + (window_right or 0)
+    if window_left is not None:
+        keep = keep & (kv_i > q_i + diag - window_left)
+    return torch.where(keep, 0.0, float("-inf")).double()
+
+
+def _ref_bwd(q, k, v, do, scale, causal=False, bottom_right=False, window_left=None, window_right=None):
+    """fp64 reference backward for ONE sequence (K/V already broadcast to the Q heads)."""
+    q, k, v, do = (t.detach().double().requires_grad_(t is not do) for t in (q, k, v, do))
+    s = (q @ k.transpose(-1, -2)) * scale
+    if causal:
+        s = s + _causal_bias(q.shape[-2], k.shape[-2], q.device, bottom_right, window_left, window_right)
+    p = torch.softmax(s, dim=-1)
+    o = p @ v
+    o.backward(do)
+    return q.grad, k.grad, v.grad
+
+
+def _cos(a, b):
+    a, b = a.double().flatten(), b.double().flatten()
+    if a.norm() == 0 and b.norm() == 0:
+        return 1.0
+    return float((a @ b) / (a.norm() * b.norm() + 1e-30))
+
+
+def _below_tol(msg):
+    # ``not (x > tol)``: a NaN cosine must FAIL, and every comparison against NaN is False.
+    return not (float(msg.split("cos ")[1].split(" ")[0]) > _TOL_COS)
+
+
+def _thd_case(
+    lens_q,
+    lens_kv,
+    h,
+    d,
+    dtype,
+    cap_q=None,
+    cap_kv=None,
+    poison=False,
+    seed=7,
+    causal=False,
+    bottom_right=False,
+    window_left=None,
+    window_right=None,
+    hkv=None,
+    d_v=None,
+):
+    """Packed Q/K/V/dO plus the forward's O and packed LSE, per sequence in fp64.
+
+    ``cap_*`` over-allocates the packed buffers past the live totals; with
+    ``poison`` the slack is NaN.  The declared totals only bound the buffers, so
+    the rows between ``cu_*[B]`` and the capacity have to stay out of every
+    MMA through the kernel's own per-sequence row gating (issue #624).
+    """
+    dev, b = "cuda", len(lens_q)
+    d_v = d if d_v is None else d_v  # Q/K/dQ/dK carry d; V/O/dO/dV carry d_v
+    t_q, t_kv = sum(lens_q), sum(lens_kv)
+    cap_q, cap_kv = cap_q or t_q, cap_kv or t_kv
+    cu_q, cu_k = [0], [0]
+    for a, c in zip(lens_q, lens_kv, strict=True):
+        cu_q.append(cu_q[-1] + a)
+        cu_k.append(cu_k[-1] + c)
+    g = torch.Generator(device=dev).manual_seed(seed)
+    hkv = h if hkv is None else hkv
+    grp = h // hkv
+
+    def _pk(cap, live, nh, dd):
+        x = torch.randn(1, cap, nh, dd, generator=g, device=dev, dtype=dtype) * 0.3
+        if poison and cap > live:
+            x[0, live:] = float("nan")
+        return x
+
+    q_p, do_p = _pk(cap_q, t_q, h, d), _pk(cap_q, t_q, h, d_v)
+    k_p, v_p = _pk(cap_kv, t_kv, hkv, d), _pk(cap_kv, t_kv, hkv, d_v)
+    o_p = torch.full_like(do_p, float("nan") if poison else 0.0)
+    lse_p = torch.full((1, h, cap_q), float("nan") if poison else 0.0, device=dev, dtype=torch.float32)
+    scale = 1.0 / math.sqrt(d)
+    for i in range(b):
+        if lens_q[i] == 0 or lens_kv[i] == 0:
+            continue
+        qs, ks, vs = (
+            x[0, cu[i] : cu[i] + L].transpose(0, 1).double() for x, cu, L in ((q_p, cu_q, lens_q[i]), (k_p, cu_k, lens_kv[i]), (v_p, cu_k, lens_kv[i]))
+        )
+        if grp > 1:  # kv_head = q_head // grp: heads 0..grp-1 share KV head 0
+            ks, vs = ks.repeat_interleave(grp, dim=0), vs.repeat_interleave(grp, dim=0)
+        sc = (qs @ ks.transpose(-1, -2)) * scale
+        if causal:
+            sc = sc + _causal_bias(lens_q[i], lens_kv[i], dev, bottom_right, window_left, window_right)
+        lse_p[0, :, cu_q[i] : cu_q[i] + lens_q[i]] = torch.logsumexp(sc, dim=-1).float()
+        o_p[0, cu_q[i] : cu_q[i] + lens_q[i]] = (torch.softmax(sc, dim=-1) @ vs).transpose(0, 1).to(dtype)
+    return SimpleNamespace(
+        b=b, h=h, hkv=hkv, d=d, d_v=d_v, dtype=dtype, scale=scale, causal=causal, bottom_right=bottom_right, window_left=window_left, window_right=window_right,
+        lens_q=list(lens_q), lens_kv=list(lens_kv), cu_q=cu_q, cu_k=cu_k, t_q=t_q, t_kv=t_kv, cap_q=cap_q, cap_kv=cap_kv,
+        q=q_p, k=k_p, v=v_p, do=do_p, o=o_p, lse=lse_p,
+    )  # fmt: skip
+
+
+def _check(case, dq, dk, dv):
+    """Per-sequence comparison against the fp64 reference; collected, then asserted."""
+    bad = []
+    for i in range(case.b):
+        if case.lens_q[i] == 0 or case.lens_kv[i] == 0:
+            continue
+        sl_q = slice(case.cu_q[i], case.cu_q[i] + case.lens_q[i])
+        sl_k = slice(case.cu_k[i], case.cu_k[i] + case.lens_kv[i])
+        grp = case.h // case.hkv
+        rep = (lambda x: x.repeat_interleave(grp, dim=0)) if grp > 1 else (lambda x: x)
+        rq, rk, rv = _ref_bwd(
+            case.q[0, sl_q].transpose(0, 1),
+            rep(case.k[0, sl_k].transpose(0, 1)),
+            rep(case.v[0, sl_k].transpose(0, 1)),
+            case.do[0, sl_q].transpose(0, 1),
+            case.scale,
+            causal=case.causal,
+            bottom_right=case.bottom_right,
+            window_left=case.window_left,
+            window_right=case.window_right,
+        )
+        if grp > 1:  # the kernel folds the per-Q-head partials onto the KV heads
+            rk = rk.reshape(case.hkv, grp, *rk.shape[1:]).sum(1)
+            rv = rv.reshape(case.hkv, grp, *rv.shape[1:]).sum(1)
+        for name, got, want in (("dQ", dq[0, sl_q].transpose(0, 1), rq), ("dK", dk[0, sl_k].transpose(0, 1), rk), ("dV", dv[0, sl_k].transpose(0, 1), rv)):
+            bad.append(f"seq {i} {name}: cos {_cos(got, want):.6f} (lens q={case.lens_q[i]} kv={case.lens_kv[i]})")
+    failures = [m for m in bad if _below_tol(m)]
+    assert not failures, "\n".join(bad)
+
+
+# ---------------------------------------------------------------------------
+# The adapter, directly
+# ---------------------------------------------------------------------------
+
+
+def _run(lens_q, lens_kv, h=2, hkv=None, d=_D, dtype=torch.bfloat16, token_major_stats=False, head_stride=0, deterministic=False):
+    from cudnn.sdpa.bwd.api_dsl import SdpaBwdDslSm80
+
+    case = _thd_case(lens_q, lens_kv, h, d, dtype, hkv=hkv)
+    dev, b = "cuda", case.b
+    view = lambda t: t.permute(0, 2, 1, 3)  # noqa: E731  [1,T,H,D] -> logical [1,H,T,D]
+    # The SAMPLES declare the ENVELOPE (B, H, S_max, D), the way a ragged graph
+    # does; the packed buffers only show up at execute.
+    s_max_q, s_max_kv = max(lens_q), max(lens_kv)
+    env = lambda n, s, nh: torch.empty(1, n, s, nh, d, device=dev, dtype=dtype)[0].permute(0, 2, 1, 3)  # noqa: E731
+    eq, ekv = env(b, s_max_q, h), env(b, s_max_kv, case.hkv)
+    e_stats = torch.empty(b, h, s_max_q, 1, device=dev, dtype=torch.float32)
+    dq, dk, dv = torch.zeros_like(case.q), torch.zeros_like(case.k), torch.zeros_like(case.v)
+    if token_major_stats:
+        stats = case.lse[0].transpose(0, 1).contiguous()  # (T, H)
+    elif head_stride:
+        stats = torch.zeros(1, h, head_stride, device=dev, dtype=torch.float32)
+        stats[..., : case.t_q] = case.lse
+    else:
+        stats = case.lse  # compact head-major [1, H, T]
+    api = SdpaBwdDslSm80(
+        sample_q=eq,
+        sample_k=ekv,
+        sample_v=ekv,
+        sample_o=eq,
+        sample_do=eq,
+        sample_stats=e_stats,
+        sample_dq=eq,
+        sample_dk=ekv,
+        sample_dv=ekv,
+        scale_softmax=case.scale,
+        deterministic=deterministic,
+        thd=True,
+        max_total_seq_len_q=case.t_q,
+        max_total_seq_len_kv=case.t_kv,
+        thd_stats_token_major=token_major_stats,
+        thd_stats_head_stride=head_stride,
+    )
+    assert api.check_support()
+    api.compile()
+    ws = torch.empty(api.scratch_workspace_bytes(), dtype=torch.uint8, device=dev)
+    api.execute(
+        view(case.q), view(case.k), view(case.v), view(case.o), view(case.do), stats, view(dq), view(dk), view(dv),
+        workspace=ws,
+        seq_q_lens=torch.tensor(lens_q, dtype=torch.int32, device=dev),
+        seq_kv_lens=torch.tensor(lens_kv, dtype=torch.int32, device=dev),
+    )  # fmt: skip
+    torch.cuda.synchronize()
+    _check(case, dq, dk, dv)
+
+
+@pytest.mark.parametrize("dt", (torch.bfloat16, torch.float16), ids=("bf16", "fp16"))
+def test_thd_self_attention(dt):
+    """Three sequences of unequal length, none a tile multiple."""
+    _run((300, 128, 200), (300, 128, 200), dtype=dt)
+
+
+def test_thd_cross_attention():
+    """Unequal Q and KV lengths, and unequal packed totals with them."""
+    _run((256, 100), (180, 300))
+
+
+def test_thd_single_sequence_matches_dense_shape():
+    _run((512,), (512,))
+
+
+@pytest.mark.parametrize("layout", ("token_major", "head_major_wide"))
+def test_thd_stats_packings(layout):
+    """Both packed Stats layouts Rule S1 admits, beyond the wrapper's compact
+    head-major one: cuDNN's ``(T, H)`` recipe, and head-major at a head stride
+    WIDER than the packed total (the FROST forwards' 64-token-rounded capacity)."""
+    if layout == "token_major":
+        _run((300, 128), (300, 128), token_major_stats=True)
+    else:
+        _run((300, 128), (300, 128), head_stride=512)
+
+
+def test_thd_gqa_direct():
+    _run((300, 128, 200), (300, 128, 200), h=4, hkv=2)
+
+
+def test_thd_deterministic_direct():
+    """The kv-ordered dQ relay under THD, its counter carved from the workspace."""
+    _run((300, 128, 200), (300, 128, 200), deterministic=True)
+
+
+def test_thd_requires_declared_totals():
+    """THD without max_total_seq_len_* is DECLINED, not silently mis-sized:
+    the packed fp32 dQ accumulator, the dK/dV partials and do_dot are sized
+    from the token totals at build time."""
+    from cudnn.sdpa.bwd.api_dsl import SdpaBwdDslSm80
+
+    dev, b, h, s_max = "cuda", 2, 2, 256
+    env = torch.empty(b, s_max, h, _D, device=dev, dtype=torch.bfloat16).permute(0, 2, 1, 3)
+    e_stats = torch.empty(b, h, s_max, 1, device=dev, dtype=torch.float32)
+    kw = dict(
+        sample_q=env,
+        sample_k=env,
+        sample_v=env,
+        sample_o=env,
+        sample_do=env,
+        sample_stats=e_stats,
+        sample_dq=env,
+        sample_dk=env,
+        sample_dv=env,
+        scale_softmax=1.0 / math.sqrt(_D),
+        thd=True,
+    )
+    with pytest.raises(ValueError, match="max_total_seq_len"):
+        SdpaBwdDslSm80(**kw).check_support()
+    assert SdpaBwdDslSm80(**kw, max_total_seq_len_q=400, max_total_seq_len_kv=400).check_support()
+
+
+def test_thd_rejects_bias_and_padding_mask():
+    """Dense-only features under THD are typed declines at check_support."""
+    from cudnn.sdpa.bwd.api_dsl import SdpaBwdDslSm80
+
+    dev, b, h, s_max = "cuda", 2, 2, 256
+    env = torch.empty(b, s_max, h, _D, device=dev, dtype=torch.bfloat16).permute(0, 2, 1, 3)
+    e_stats = torch.empty(b, h, s_max, 1, device=dev, dtype=torch.float32)
+    kw = dict(
+        sample_q=env, sample_k=env, sample_v=env, sample_o=env, sample_do=env, sample_stats=e_stats, sample_dq=env, sample_dk=env, sample_dv=env,
+        scale_softmax=1.0 / math.sqrt(_D), thd=True, max_total_seq_len_q=400, max_total_seq_len_kv=400,
+    )  # fmt: skip
+    with pytest.raises(ValueError, match="dense-only"):
+        SdpaBwdDslSm80(**kw, has_bias=True).check_support()
+    with pytest.raises(ValueError, match="dense-only"):
+        SdpaBwdDslSm80(**kw, seq_kv_lens_present=True).check_support()
+
+
+# ---------------------------------------------------------------------------
+# The graph path: ragged tensors -> lower_dsl_bwd -> packed views
+# ---------------------------------------------------------------------------
+
+
+def _plan_index(g, name=_ENGINE):
+    for i in range(g.get_execution_plan_count()):
+        if name in g.get_plan_name_at_index(i):
+            return i
+    return None
+
+
+def _build_thd_bwd_graph(case, *, stats_layout="head_major", declare_totals=True, token_gap=0, sink=None, **sdpa_kwargs):
+    """A ragged backward graph over ``case``'s packed buffers.
+
+    Everything is declared as the ENVELOPE (B, H, S_max, D) plus a per-tensor
+    ragged offset -- cuDNN's spelling of a packed tensor.  ``token_gap`` widens
+    the K/V token stride past ``H_kv * D`` (a view into an interleaved
+    per-token record), which the SM80 packed path DECLINES.  ``sink`` adds the
+    ``sink_token`` / ``dSink_token`` ports ((1, H, 1, 1) fp32); the graph's
+    ``_thd_test_ports["dsink"]`` handle finds the dSink buffer in the pack.
+    """
+    b, h, hkv, d, d_v, dev = case.b, case.h, case.hkv, case.d, case.d_v, "cuda"
+    io = cudnn.data_type.HALF if case.dtype == torch.float16 else cudnn.data_type.BFLOAT16
+    s_max_q, s_max_kv = max(max(case.lens_q), 1), max(max(case.lens_kv), 1)
+    g = cudnn.pygraph(io_data_type=io, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    vp, t, geom = {}, {}, {}
+
+    def _port(name, s_max, nh, dd, cu, gap=0):
+        """Envelope (B, nh, s_max, dd) with compact BSHD strides (token stride
+        widened by ``gap``) and an element ragged offset of cu * token stride."""
+        ts = nh * dd + gap
+        stride = [s_max * ts, dd, ts, 1]
+        ro_t = (torch.tensor(cu, dtype=torch.int64, device=dev) * ts).view(b + 1, 1, 1, 1)
+        geom[name] = (s_max, stride, nh, dd, ro_t)
+        x = g.tensor(name=name, dim=[b, nh, s_max, dd], stride=stride, data_type=io)
+        ro = g.tensor(name=f"{name}_ro", dim=[b + 1, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT64)
+        x.set_ragged_offset(ro)
+        vp[ro] = ro_t
+        return x
+
+    t["q"] = _port("q", s_max_q, h, d, case.cu_q)
+    t["o"] = _port("o", s_max_q, h, d_v, case.cu_q)
+    t["do"] = _port("do", s_max_q, h, d_v, case.cu_q)
+    t["k"] = _port("k", s_max_kv, hkv, d, case.cu_k, token_gap)
+    t["v"] = _port("v", s_max_kv, hkv, d_v, case.cu_k, token_gap)
+
+    # Packed Stats in one of the layouts a forward emits.  head_major is
+    # (1, H, head_stride) with a 64-rounded token capacity (WIDER than the
+    # packed total -- the FROST forwards); head_major_compact has head stride
+    # == the declared capacity exactly (the SM80 forward wrapper); token_major
+    # is (T, H) (cuDNN's ragged recipe).  Sized on the DECLARED capacity: the
+    # adapter binds the Stats view at min(B * S_max, declared).
+    if stats_layout in ("head_major", "head_major_compact"):
+        t_cap = max(64, -(-case.cap_q // 64) * 64) if stats_layout == "head_major" else case.cap_q
+        stats_stride = [h * t_cap, t_cap, 1, 1]
+        stats_stor = torch.zeros(h * t_cap, dtype=torch.float32, device=dev)
+        stats_stor.as_strided((1, h, case.cap_q), (h * t_cap, t_cap, 1)).copy_(case.lse[:, :, : case.cap_q])
+        stats_ro_t = torch.tensor(case.cu_q, dtype=torch.int64, device=dev).view(b + 1, 1, 1, 1)
+    else:
+        stats_stride = [s_max_q * h, 1, h, 1]
+        stats_stor = case.lse[0].transpose(0, 1).contiguous().reshape(-1)
+        stats_ro_t = (torch.tensor(case.cu_q, dtype=torch.int64, device=dev) * h).view(b + 1, 1, 1, 1)
+    st = g.tensor(name="stats", dim=[b, h, s_max_q, 1], stride=stats_stride, data_type=cudnn.data_type.FLOAT)
+    st_ro = g.tensor(name="stats_ro", dim=[b + 1, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT64)
+    st.set_ragged_offset(st_ro)
+    vp[st_ro] = stats_ro_t
+    vp[st] = stats_stor
+
+    slq = torch.tensor(case.lens_q, dtype=torch.int32, device=dev).view(b, 1, 1, 1)
+    slk = torch.tensor(case.lens_kv, dtype=torch.int32, device=dev).view(b, 1, 1, 1)
+    tq_len = g.tensor(name="seq_len_q", dim=[b, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT32)
+    tk_len = g.tensor(name="seq_len_kv", dim=[b, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT32)
+    vp[tq_len], vp[tk_len] = slq, slk
+
+    kw = dict(
+        name="bwd",
+        q=t["q"],
+        k=t["k"],
+        v=t["v"],
+        o=t["o"],
+        dO=t["do"],
+        stats=st,
+        attn_scale=case.scale,
+        use_padding_mask=True,
+        seq_len_q=tq_len,
+        seq_len_kv=tk_len,
+    )
+    if sink is not None:
+        sink_t = g.tensor(name="sink", dim=[1, h, 1, 1], stride=[h, 1, 1, 1], data_type=cudnn.data_type.FLOAT)
+        dsink_t = g.tensor(name="dSink", dim=[1, h, 1, 1], stride=[h, 1, 1, 1], data_type=cudnn.data_type.FLOAT)
+        vp[sink_t] = sink.view(1, h, 1, 1).contiguous()
+        vp[dsink_t] = torch.zeros(1, h, 1, 1, device=dev, dtype=torch.float32)
+        t["dsink"] = dsink_t
+        kw.update(sink_token=sink_t, dSink_token=dsink_t)
+    if declare_totals:
+        kw.update(max_total_seq_len_q=case.cap_q, max_total_seq_len_kv=case.cap_kv)
+    kw.update(sdpa_kwargs)
+    dq_t, dk_t, dv_t = g.sdpa_backward(**kw)
+    for out, like in ((dq_t, "q"), (dk_t, "k"), (dv_t, "v")):
+        s_max, stride, nh, dd, ro_t = geom[like]
+        out.set_output(True).set_data_type(io).set_dim([b, nh, s_max, dd]).set_stride(stride)
+        ro = g.tensor(name=f"{out.get_name()}_ro", dim=[b + 1, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT64)
+        out.set_ragged_offset(ro)
+        vp[ro] = ro_t
+    vp.update({t["q"]: case.q, t["k"]: case.k, t["v"]: case.v, t["o"]: case.o, t["do"]: case.do})
+    g._thd_test_ports = t  # the sink/dSink handles, for the sinks test
+    return g, vp, (dq_t, dk_t, dv_t)
+
+
+def _plan_graph(g):
+    g.validate()
+    g.build_operation_graph()
+    g.create_execution_plans([cudnn.heur_mode.A])
+    idx = _plan_index(g)
+    assert idx is not None, f"{_ENGINE} not offered; plans = {[g.get_plan_name_at_index(i) for i in range(g.get_execution_plan_count())]}"
+    g.select_plan(idx)
+    g.check_support()
+    g.build_plans()
+
+
+def _run_graph(lens_q, lens_kv, *, h=2, hkv=None, d=_D, d_v=None, dtype=torch.bfloat16, stats_layout="head_major", poison=False, pad_cap=0, **kw):
+    """Build the ragged graph, PIN the engine, execute, compare per sequence.
+
+    The gradient buffers are pre-filled with NaN, not zeros: a live row the
+    kernels fail to write then shows up in the ``isfinite`` check (and a
+    skipped zero-store in the one-sided-empty test), instead of hiding behind
+    a zero the caller happened to put there.
+    """
+    case = _thd_case(
+        lens_q,
+        lens_kv,
+        h,
+        d,
+        dtype,
+        cap_q=sum(lens_q) + pad_cap,
+        cap_kv=sum(lens_kv) + pad_cap,
+        poison=poison,
+        causal=bool(kw.get("use_causal_mask") or kw.get("use_causal_mask_bottom_right") or kw.get("diagonal_band_right_bound") is not None),
+        bottom_right=bool(kw.get("use_causal_mask_bottom_right")),
+        window_left=kw.get("sliding_window_length"),
+        window_right=kw.get("diagonal_band_right_bound"),
+        hkv=hkv,
+        d_v=d_v,
+    )
+    g, vp, (dq_t, dk_t, dv_t) = _build_thd_bwd_graph(case, stats_layout=stats_layout, **kw)
+    _plan_graph(g)
+    dq = torch.full_like(case.q, float("nan"))
+    dk = torch.full((1, case.cap_kv, case.hkv, case.d), float("nan"), device="cuda", dtype=dtype)
+    dv = torch.full((1, case.cap_kv, case.hkv, case.d_v), float("nan"), device="cuda", dtype=dtype)
+    vp.update({dq_t: dq, dk_t: dk, dv_t: dv})
+    ws = torch.empty(max(g.get_workspace_size(), 1), device="cuda", dtype=torch.uint8)
+    g.execute(vp, ws)
+    torch.cuda.synchronize()
+    for name, x in (("dQ", dq), ("dK", dk), ("dV", dv)):
+        live = x[0, : case.t_q] if name == "dQ" else x[0, : case.t_kv]
+        assert torch.isfinite(live).all(), f"{name} has non-finite values in the packed region"
+    _check(case, dq, dk, dv)
+    return case, g, vp, ws, (dq, dk, dv)
+
+
+@pytest.mark.parametrize("dt", (torch.bfloat16, torch.float16), ids=("bf16", "fp16"))
+def test_graph_thd_self_attention(dt):
+    """The whole point: a ragged graph reaches the SM80 kernel through the engine."""
+    _run_graph((300, 128, 200), (300, 128, 200), dtype=dt)
+
+
+def test_graph_thd_cross_attention():
+    _run_graph((256, 100), (180, 300))
+
+
+@pytest.mark.parametrize("layout", ("head_major", "head_major_compact", "token_major"))
+def test_graph_thd_stats_packings(layout):
+    """Every packed Stats layout the row reads, each its own accept test: the
+    FROST forwards' 64-rounded head-major, the SM80 forward wrapper's compact
+    head-major, and cuDNN's token-major recipe."""
+    _run_graph((300, 128), (300, 128), stats_layout=layout)
+
+
+def test_graph_thd_zero_length_sequence():
+    """A sequence with no tokens must not corrupt its neighbours."""
+    _run_graph((256, 0, 128), (256, 0, 128))
+
+
+@pytest.mark.parametrize("lens_q,lens_kv", (((0, 128, 256), (192, 128, 256)), ((192, 128, 256), (0, 128, 256))), ids=("empty_q_side", "empty_kv_side"))
+def test_graph_thd_one_sided_empty_sequence(lens_q, lens_kv):
+    """Empty on ONE side only: the other side's rows exist and must read zero.
+
+    ``empty_q_side``: the sequence's kv tiles run zero Q-iterations, so the
+    epilogue must store zero dK/dV from untouched accumulators.  ``empty_kv_side``:
+    no kv tile touches the sequence's dQ rows, which stay at the accumulator's
+    zero fill.  The explicit zero check is the detector (residue is finite).
+    """
+    case, _, _, _, (dq, dk, dv) = _run_graph(lens_q, lens_kv)
+    i = 0
+    sl_q = slice(case.cu_q[i], case.cu_q[i] + case.lens_q[i])
+    sl_k = slice(case.cu_k[i], case.cu_k[i] + case.lens_kv[i])
+    for name, got in (("dQ", dq[0, sl_q]), ("dK", dk[0, sl_k]), ("dV", dv[0, sl_k])):
+        assert got.numel() == 0 or not got.any(), f"{name} of a one-sided-empty sequence must be exactly zero, got max |{got.abs().max().item()}|"
+
+
+def test_graph_thd_nan_capacity_tail():
+    """Declared totals larger than the live packing, with a NaN tail (#624):
+    the rows between ``cu_*[B]`` and the capacity are inside every packed view,
+    and only the kernel's per-sequence row gating keeps them out of the MMAs."""
+    _run_graph((256, 128), (256, 128), poison=True, pad_cap=384)
+
+
+@pytest.mark.parametrize("variant", ("mha_native", "gqa", "padded_d"), ids=("mha_native", "gqa", "padded_d"))
+def test_graph_thd_capacity_tail_left_untouched(variant):
+    """cuDNN's contract, which test_mhas_v2's ragged sweeps assert with a
+    NaN-filled tail: nothing past the packed total is written into the caller's
+    dQ/dK/dV, on every output path -- the direct-bound MHA epilogue, the GQA
+    fold and the padded-head-dim fold are all bounded by ``cu_*[B]`` on device.
+    The workspace is poisoned too, so a fold reading past the live rows would
+    show up as well."""
+    kw = {"gqa": dict(h=4, hkv=2), "padded_d": dict(d=96)}.get(variant, {})
+    lens = (256, 128)
+    case, g, vp, ws, (dq, dk, dv) = _run_graph(lens, lens, poison=True, pad_cap=384, **kw)
+    ws.fill_(0xFF)
+    g.execute(vp, ws)
+    torch.cuda.synchronize()
+    # _run_graph pre-fills the gradient buffers with NaN: every row past the
+    # packed total must still be NaN, every live row finite.
+    for name, x, t in (("dQ", dq, case.t_q), ("dK", dk, case.t_kv), ("dV", dv, case.t_kv)):
+        assert torch.isfinite(x[0, :t]).all(), f"{name}: live rows must be finite"
+        assert torch.isnan(x[0, t:]).all(), f"{name}: rows past the packed total were written"
+
+
+def test_graph_thd_nan_capacity_tail_unaligned_last_sequence():
+    """The capacity tail reached by a TILE OVERSHOOT of the last sequence: 100
+    tokens is not a tile multiple on either side, so the last q- and kv-tiles
+    of the last sequence straddle the packed total."""
+    _run_graph((256, 100), (256, 100), poison=True, pad_cap=384)
+
+
+def test_graph_thd_b1_matches_dense_shape():
+    _run_graph((512,), (512,))
+
+
+@pytest.mark.parametrize("hkv", (2, 1), ids=("gqa_group2", "mqa"))
+def test_graph_thd_gqa(hkv):
+    """Packed GQA / MQA: per-Q-head dK/dV partials over the packed kv axis,
+    folded onto the KV heads by the reduce."""
+    _run_graph((300, 128, 200), (300, 128, 200), h=4, hkv=hkv)
+
+
+def test_graph_thd_gqa_causal():
+    _run_graph((256, 100), (256, 100), h=4, hkv=2, use_causal_mask=True)
+
+
+def test_graph_thd_gqa_cross_attention_and_zero_length():
+    _run_graph((256, 0, 100), (180, 0, 300), h=4, hkv=2)
+
+
+@pytest.mark.parametrize("dt", (torch.bfloat16, torch.float16), ids=("bf16", "fp16"))
+def test_graph_thd_causal(dt):
+    _run_graph((300, 128, 200), (300, 128, 200), dtype=dt, use_causal_mask=True)
+
+
+def test_graph_thd_causal_zero_length_sequence():
+    _run_graph((256, 0, 128), (256, 0, 128), use_causal_mask=True)
+
+
+def test_graph_thd_causal_cross_attention():
+    _run_graph((256, 100), (180, 300), use_causal_mask=True)
+
+
+def test_graph_thd_causal_bottom_right():
+    """Bottom-right alignment: the diagonal offset ``S_kv[b] - S_q[b]`` IS per
+    sequence (56 and 200 here); S_kv >= S_q on purpose so no reference row is
+    fully masked."""
+    _run_graph((200, 100), (256, 300), use_causal_mask_bottom_right=True)
+
+
+def test_graph_thd_causal_swa():
+    _run_graph((300, 128, 200), (300, 128, 200), use_causal_mask=True, sliding_window_length=64)
+
+
+def test_graph_thd_causal_right_band():
+    _run_graph((300, 128, 200), (300, 128, 200), diagonal_band_right_bound=64)
+
+
+def test_graph_thd_causal_nan_capacity_tail():
+    _run_graph((256, 128), (256, 128), poison=True, pad_cap=384, use_causal_mask=True)
+
+
+def test_graph_thd_deterministic():
+    """The kv-ordered dQ relay through the graph API, its counter carved and
+    zeroed per execute; bitwise identical across executes."""
+    _, g, vp, ws, (dq, dk, dv) = _run_graph((300, 128, 200), (300, 128, 200), use_causal_mask=True, use_deterministic_algorithm=True)
+    first = tuple(x.clone() for x in (dq, dk, dv))
+    g.execute(vp, ws)
+    torch.cuda.synchronize()
+    for a, b_ in zip(first, (dq, dk, dv), strict=True):
+        torch.testing.assert_close(a, b_, rtol=0, atol=0, equal_nan=True)  # NaN only in the untouched prefill past the packed total
+
+
+def _ref_bwd_sink(q, k, v, do, sink_h, scale, causal, s_q, s_kv):
+    """fp64 reference for ONE sequence with an attention sink: a virtual column
+    holding the per-head sink logit joins the softmax and receives no value."""
+    q, k, v = (t.detach().double().requires_grad_(True) for t in (q, k, v))
+    sk = sink_h.detach().double().clone().requires_grad_(True)
+    s = (q @ k.transpose(-1, -2)) * scale
+    if causal:
+        s = s + _causal_bias(s_q, s_kv, q.device)
+    s_ext = torch.cat([s, sk.view(-1, 1, 1).expand(s.shape[0], s.shape[1], 1)], dim=-1)
+    p = torch.softmax(s_ext, dim=-1)[..., :-1]
+    (p @ v).backward(do.double())
+    return q.grad, k.grad, v.grad, sk.grad
+
+
+@pytest.mark.parametrize("stats_layout", ("head_major", "token_major"))
+@pytest.mark.parametrize("causal", (False, True), ids=("plain", "causal"))
+def test_graph_thd_sinks(causal, stats_layout):
+    """Attention sinks under THD through the graph: the dSink kernel walks each
+    (sequence, head) row over ``cu_q`` and reads the packed Stats in either
+    packing; dSink is the sum over every sequence's rows and must be re-zeroed
+    per execute (the carved accumulator)."""
+    lens_q, lens_kv, h, d, dtype, dev = (300, 128, 200), (300, 128, 200), 2, _D, torch.bfloat16, "cuda"
+    case = _thd_case(lens_q, lens_kv, h, d, dtype, causal=causal)
+    sink = torch.randn(h, generator=torch.Generator(device=dev).manual_seed(11), device=dev, dtype=torch.float32) * 0.5
+    # Re-derive O and the LSE with the sink column in the softmax, per sequence.
+    for i in range(case.b):
+        sq_, sk_ = slice(case.cu_q[i], case.cu_q[i] + lens_q[i]), slice(case.cu_k[i], case.cu_k[i] + lens_kv[i])
+        qs, ks, vs = (x[0, sl].transpose(0, 1).double() for x, sl in ((case.q, sq_), (case.k, sk_), (case.v, sk_)))
+        s = (qs @ ks.transpose(-1, -2)) * case.scale
+        if causal:
+            s = s + _causal_bias(lens_q[i], lens_kv[i], dev)
+        s_ext = torch.cat([s, sink.double().view(h, 1, 1).expand(h, lens_q[i], 1)], dim=-1)
+        case.lse[0, :, sq_] = torch.logsumexp(s_ext, dim=-1).float()
+        case.o[0, sq_] = (torch.softmax(s_ext, dim=-1)[..., :-1] @ vs).transpose(0, 1).to(dtype)
+    g, vp, (dq_t, dk_t, dv_t) = _build_thd_bwd_graph(case, sink=sink, stats_layout=stats_layout, **({"use_causal_mask": True} if causal else {}))
+    _plan_graph(g)
+    dq, dk, dv = torch.zeros_like(case.q), torch.zeros_like(case.k), torch.zeros_like(case.v)
+    vp.update({dq_t: dq, dk_t: dk, dv_t: dv})
+    ws = torch.empty(max(g.get_workspace_size(), 1), device=dev, dtype=torch.uint8)
+    g.execute(vp, ws)
+    torch.cuda.synchronize()
+    dsink = vp[g._thd_test_ports["dsink"]].view(-1)
+    first = dsink.clone()
+    g.execute(vp, ws)  # the carved dSink accumulator is re-zeroed, so a second run agrees (atomic order aside)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(dsink, first, rtol=1e-5, atol=1e-6)
+    bad, dsink_ref = [], torch.zeros(h, dtype=torch.float64, device=dev)
+    for i in range(case.b):
+        sq_, sk_ = slice(case.cu_q[i], case.cu_q[i] + lens_q[i]), slice(case.cu_k[i], case.cu_k[i] + lens_kv[i])
+        rq, rk, rv, rs = _ref_bwd_sink(
+            case.q[0, sq_].transpose(0, 1),
+            case.k[0, sk_].transpose(0, 1),
+            case.v[0, sk_].transpose(0, 1),
+            case.do[0, sq_].transpose(0, 1),
+            sink,
+            case.scale,
+            causal,
+            lens_q[i],
+            lens_kv[i],
+        )
+        dsink_ref += rs
+        for name, got, want in (("dQ", dq[0, sq_].transpose(0, 1), rq), ("dK", dk[0, sk_].transpose(0, 1), rk), ("dV", dv[0, sk_].transpose(0, 1), rv)):
+            bad.append(f"seq {i} {name}: cos {_cos(got, want):.6f}")
+    failures = [m for m in bad if _below_tol(m)]
+    assert not failures, "\n".join(bad)
+    # dSink is a per-head scalar pair: compare values, not a scale-blind cosine.
+    torch.testing.assert_close(dsink.double(), dsink_ref, rtol=2e-2, atol=1e-4)
+
+
+def test_thd_rejects_prefix_sum_lengths():
+    """The backward node carries per-batch lengths only; a (B+1,) prefix sum at
+    execute is a contract violation the adapter names, not a silent mis-read."""
+    from cudnn.sdpa.bwd.api_dsl import SdpaBwdDslSm80
+
+    lens_q = lens_kv = (256, 128)
+    case = _thd_case(lens_q, lens_kv, 2, _D, torch.bfloat16)
+    dev, b, h = "cuda", case.b, case.h
+    view = lambda t: t.permute(0, 2, 1, 3)  # noqa: E731
+    env = torch.empty(b, 256, h, _D, device=dev, dtype=torch.bfloat16).permute(0, 2, 1, 3)
+    e_stats = torch.empty(b, h, 256, 1, device=dev, dtype=torch.float32)
+    api = SdpaBwdDslSm80(
+        sample_q=env, sample_k=env, sample_v=env, sample_o=env, sample_do=env, sample_stats=e_stats, sample_dq=env, sample_dk=env, sample_dv=env,
+        scale_softmax=case.scale, thd=True, max_total_seq_len_q=case.t_q, max_total_seq_len_kv=case.t_kv,
+    )  # fmt: skip
+    assert api.check_support()
+    api.compile()
+    ws = torch.empty(api.scratch_workspace_bytes(), dtype=torch.uint8, device=dev)
+    dq, dk, dv = torch.zeros_like(case.q), torch.zeros_like(case.k), torch.zeros_like(case.v)
+    cu = torch.tensor(case.cu_q, dtype=torch.int32, device=dev)
+    with pytest.raises(ValueError, match="per-batch lengths"):
+        api.execute(
+            view(case.q),
+            view(case.k),
+            view(case.v),
+            view(case.o),
+            view(case.do),
+            case.lse,
+            view(dq),
+            view(dk),
+            view(dv),
+            workspace=ws,
+            seq_q_lens=cu,
+            seq_kv_lens=cu,
+        )
+
+
+@pytest.mark.parametrize(
+    "d,d_v", ((64, 64), (96, 96), (192, 128), (160, 128), (256, 256)), ids=("gptoss_native", "llama_padded", "dsv3_native", "dsv3_padded", "qwen_native")
+)
+def test_graph_thd_head_dim_envelope(d, d_v):
+    """Every flavor the row serves, under THD: native (64, 128 via the other
+    tests, 192x128, 256) and padded onto the next envelope (96 -> llama,
+    160x128 -> dsv3) through carved staging at the packed token capacities
+    (the wrapper pads with allocations; the engine must not).  The rectangular
+    flavors carve distinct d_qk / d_v buffers, in a fixed order."""
+    _run_graph((300, 128), (300, 128), d=d, d_v=d_v)
+
+
+def test_graph_thd_execute_does_not_allocate():
+    """Issue #514 on the packed path: after the warm run, re-executing must not
+    touch the CUDA caching allocator (the cu_seqlens metadata, the relay
+    counter and every scratch buffer are carved from the caller's workspace)."""
+    _, g, vp, ws, (dq, dk, dv) = _run_graph((300, 128, 200), (300, 128, 200), h=4, hkv=2, d=96, use_causal_mask=True, use_deterministic_algorithm=True)
+    ref = tuple(x.clone() for x in (dq, dk, dv))
+    before = torch.cuda.memory_stats()["allocation.all.allocated"]
+    for _ in range(3):
+        g.execute(vp, ws)
+    torch.cuda.synchronize()
+    after = torch.cuda.memory_stats()["allocation.all.allocated"]
+    assert after == before, f"execute allocated {after - before} times; the packed path must carve from the workspace only"
+    for a, b_ in zip(ref, (dq, dk, dv), strict=True):
+        torch.testing.assert_close(a, b_, rtol=0, atol=0, equal_nan=True)
+
+
+def test_graph_thd_execute_does_not_sync():
+    """Rule 3 on the packed path: after the warm run, execute performs no
+    device->host read (the lengths become cu_seqlens on device; the grid and
+    relay bounds are plan-time).  torch's sync debug mode turns any
+    synchronizing call into an error; the ``.item()`` probe first proves the
+    mode is armed (the check is RED against a deliberate read)."""
+    _, g, vp, ws, _ = _run_graph((300, 128, 200), (300, 128, 200), h=4, hkv=2, use_causal_mask=True, use_deterministic_algorithm=True)
+    torch.cuda.synchronize()
+    torch.cuda.set_sync_debug_mode("error")
+    try:
+        with pytest.raises(RuntimeError):
+            torch.zeros(1, device="cuda").item()
+        g.execute(vp, ws)
+    finally:
+        torch.cuda.set_sync_debug_mode("default")
+    torch.cuda.synchronize()
+
+
+def test_graph_thd_compile_key_is_plan_time_only():
+    """Issue #604 on the graph path: two ragged graphs with the same envelope,
+    sequence count and Stats packing but different packed totals share ONE
+    compiled artifact (the bprop template's per-shape lru sees a hit, no miss).
+
+    Token-major Stats on purpose: the head-major packing's head stride is
+    plan-time tensor geometry that legitimately keys the artifact (it is the
+    fake's extent), and the 64-rounded capacity differs between the two runs.
+    """
+    from cudnn.frost import template_loader
+
+    def cache_totals():
+        modules = [m for (path, _params), m in template_loader._MODULES.items() if "bprop" in str(path)]
+        infos = [m.compile.cache_info() for m in modules if hasattr(m.compile, "cache_info")]
+        return sum(i.misses for i in infos), sum(i.hits for i in infos)
+
+    _run_graph((300, 128), (300, 128), stats_layout="token_major")
+    n_modules = len(template_loader._MODULES)
+    misses_0, hits_0 = cache_totals()
+    # Same S_max envelope (300) and B (2), different totals and lengths.
+    _run_graph((300, 64), (300, 64), stats_layout="token_major")
+    misses_1, hits_1 = cache_totals()
+    assert misses_1 == misses_0, "different packed totals minted a compile (runtime data leaked into the key)"
+    assert hits_1 > hits_0, "expected the same-envelope re-plan to cache-hit"
+    assert len(template_loader._MODULES) == n_modules
+
+
+# --- probe: accepts and rejects -----------------------------------------------
+
+
+def _thd_mismatch(lens_q=(256, 128), lens_kv=(256, 128), *, h=2, hkv=None, stats_layout="head_major", d=_D, **kw):
+    """``mismatch()`` for a ragged backward graph on the SM80 row, or None if served."""
+    from cudnn.sdpa import graph_analyzer as ga
+    from cudnn.sdpa.bwd.engines import ENGINE_SPECS, mismatch
+
+    case = _thd_case(lens_q, lens_kv, h, d, torch.bfloat16, hkv=hkv)
+    g, _, _ = _build_thd_bwd_graph(case, stats_layout=stats_layout, **kw)
+    try:
+        g.validate()
+        g.build_operation_graph()
+    except cudnn.cudnnGraphNotSupportedError as exc:
+        return f"refused by the node: {exc}"
+    facts = ga.analyze(g)
+    spec = next(s for s in ENGINE_SPECS if s.name == _ENGINE)
+    assert facts is not None
+    return mismatch(spec.capabilities, facts)
+
+
+def test_graph_thd_accepts_the_plain_case():
+    assert _thd_mismatch() is None
+
+
+def test_accept_thd_features():
+    """Every THD conjunction the row serves, each on its own line so a
+    regression names the feature."""
+    assert _thd_mismatch(use_causal_mask=True) is None
+    assert _thd_mismatch(use_causal_mask_bottom_right=True) is None
+    assert _thd_mismatch(use_causal_mask=True, sliding_window_length=64) is None
+    assert _thd_mismatch(diagonal_band_right_bound=64) is None
+    assert _thd_mismatch(h=4, hkv=2) is None
+    assert _thd_mismatch(h=4, hkv=1) is None
+    assert _thd_mismatch(use_deterministic_algorithm=True) is None
+    assert _thd_mismatch(stats_layout="token_major") is None
+    assert _thd_mismatch(d=96) is None
+
+
+def test_reject_thd_without_declared_totals():
+    reason = _thd_mismatch(declare_totals=False)
+    assert reason is not None and "max_total_seq_len" in reason
+
+
+def test_reject_thd_gapped_token_stride():
+    """K/V declared as views into a wider per-token record (token stride
+    2*H_kv*D, the fused-KV slicing layout): the SM80 packed path addresses rows
+    from H and D alone, so this is a typed plan-time decline, not a mis-read."""
+    reason = _thd_mismatch(token_gap=2 * _D)
+    assert reason is not None and "compact BSHD" in reason, reason
+
+
+def test_reject_thd_bias():
+    """Bias / dBias under THD is a path property every THD row declines at plan
+    time (a packed graph has no [B, H, S_q, S_kv] bias)."""
+    from cudnn.sdpa import graph_analyzer as ga
+    from cudnn.sdpa.bwd.engines import ENGINE_SPECS, mismatch
+
+    case = _thd_case((256, 128), (256, 128), 2, _D, torch.bfloat16)
+    g, _, _ = _build_thd_bwd_graph(case)
+    node = g.nodes[0]
+    s_q, s_kv = max(case.lens_q), max(case.lens_kv)
+    bias_t = g.tensor(name="bias", dim=[1, case.h, s_q, s_kv], stride=[case.h * s_q * s_kv, s_q * s_kv, s_kv, 1], data_type=cudnn.data_type.FLOAT)
+    node.inputs["bias"] = bias_t
+    try:
+        g.validate()
+        g.build_operation_graph()
+    except cudnn.cudnnGraphNotSupportedError:
+        return  # refused by the node itself: also a decline before engine selection
+    facts = ga.analyze(g)
+    spec = next(s for s in ENGINE_SPECS if s.name == _ENGINE)
+    reason = mismatch(spec.capabilities, facts)
+    assert reason is not None and "dense-only" in reason, reason
+
+
+def test_reject_thd_dense_stats():
+    """A ragged graph with a DENSE per-batch Stats tensor (no ragged offset,
+    per-sequence stride ``[H*S_max, S_max, 1, 1]``) reads as head-major with
+    head stride S_max while its storage is per-batch rectangles: the row must
+    decline it rather than infer a packing from that stride."""
+    from cudnn.sdpa import graph_analyzer as ga
+    from cudnn.sdpa.bwd.engines import ENGINE_SPECS, mismatch
+
+    case = _thd_case((256, 128), (256, 128), 2, _D, torch.bfloat16)
+    g, _, _ = _build_thd_bwd_graph(case)
+    node = g.nodes[0]
+    s_max_q = max(case.lens_q)
+    node.inputs["stats"].set_ragged_offset(None)
+    node.inputs["stats"].set_stride([case.h * s_max_q, s_max_q, 1, 1])
+    try:
+        g.validate()
+        g.build_operation_graph()
+    except cudnn.cudnnGraphNotSupportedError:
+        return
+    facts = ga.analyze(g)
+    spec = next(s for s in ENGINE_SPECS if s.name == _ENGINE)
+    reason = mismatch(spec.capabilities, facts)
+    assert reason is not None and "dense per-batch stats" in reason, reason

--- a/test/python/sdpa/frost/test_sdpa_execute_is_async.py
+++ b/test/python/sdpa/frost/test_sdpa_execute_is_async.py
@@ -18,9 +18,11 @@ angles here, because each catches what the other misses:
   itself. test_sdpa_stream_respect.py captures the handle-carrying path; this
   file captures the one where the fallback picks the stream.
 
-Scoped to the dense f16 rows, which are clean. The THD and per-tensor FP8 rows
-still read device memory back; each needs a kernel-side change and is listed
-under Rule 3 in python/cudnn/AGENTS.md. Widen the parametrization as they land.
+Scoped to the dense f16 rows, which are clean. The per-tensor FP8 rows still
+read device memory back (listed under Rule 3 in python/cudnn/AGENTS.md). The
+SM80 backward's THD path is asserted sync-free by
+``test_sdpa_bwd_thd_sm80.py::test_graph_thd_execute_does_not_sync``; widen the
+parametrization here as the other rows land.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

`sdpa_bwd_sm80` serves THD / ragged ports at **their own token stride**. A port declared as a view into a wider per-token record — a K or V slice of an interleaved `[T, 2, H_kv, D]` buffer (token stride `2*H_kv*D`, the fused-KV slicing layout), or any Q/O/dO/dQ/dK/dV in a record of its own width — no longer has to be compact BSHD.

Follow-up to PR #950, which landed the engine-path THD backward with a compact-only rule.

## Why

In `test_sdpa_random_bwd_ragged_L0` the harness draws a per-tensor token-stride gap on Q/K/V/O (0–3 extra rows of `H*D`). On A100 the cuDNN backend declines every ragged backward it is offered (`hidden_dim <= 128`, deterministic THD, packed LSE), and with the compact rule the SM80 row declined 382 of 384 draws — so those graphs ran nowhere. With this change the whole sweep routes to `sdpa_bwd_sm80`.

## How

- **Strides are plan-time and ride the compiled fakes.** `compile(..., thd_token_strides=(Q, K, V, O, dO, dQ, dK, dV))` builds each THD operand's fake as `[1, T_sym, H, D]` with strides `(T_sym*ts, ts, D, 1)`; the kernels read `.stride[1]` and address a row as `token * token_stride + head * D + col`. A compact port keeps the compact fake, so the dense path and compact THD graphs are byte-identical.
- **Every kernel that touches a caller buffer** honours it: the main kernel's Q/K/V/dO loads and direct-bound dK/dV stores, the O·dO dot, the bounded dQ cast and the bounded dK/dV fold. Ports the host stages (head dim inside the flavor envelope) and the GQA per-query-head partials stay compact inside `compile()`.
- **Rule** (`mismatch()` and the adapter, same words): head stride `D`, element stride 1, token stride `>= H*D` and a multiple of 8 elements (16-byte rows for the `cp.async` loads). Overlapping strides are already declined by the layout envelope.
- The adapter's execute view check compares the load-bearing strides against the plan and rebuilds the view (never a copy) so size-1 axes carry the compiled stride.

## Testing

`test_sdpa_bwd_thd_sm80.py` builder takes `gaps={role: extra_elements}`; bound inputs are re-homed in records with **NaN gap columns** (a read would poison the result), gradient records are NaN-filled and their gap columns asserted untouched.

- `test_graph_thd_gapped_token_strides[kv_interleaved|q_side|all_ports|gqa|mqa|padded_d|causal_det]`
- `test_graph_thd_gapped_capacity_tail_left_untouched` (tail + gap columns on gapped records)
- probes: `test_accept_thd_gapped_token_strides`, `test_reject_thd_misaligned_token_stride`, `test_reject_thd_token_stride_below_the_row`

Local, A100 (`CUDNN_FRONTEND_ENABLE_FROST_ENGINES=1`):

| suite | result |
|---|---|
| `test_sdpa_bwd_thd_sm80.py` | 67 passed |
| SM80 bwd / integration / stream / gate / q-loop-bounds | all passed |
| `test_mhas_v2.py::test_sdpa_random_bwd_ragged_L0` | 384 passed, all 384 on `frost:sdpa_bwd_sm80` (was 2 of 384) |

Tracker Rule S2: footnote ᵏ updated.

## Labels

`cat-feature` · `area:frost` · `area:global_attention` · `orig-nv-eng`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
