### PR TITLE
enable-fp8-mxfp8/nvfp4-mixed-gemm

### DIFF
--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -1911,6 +1911,8 @@ def _render_block_scale_tile_constants_sm100(
     epi_cols_per_mma_m = _epi_tile_cols(cfg)
     acc_cols_per_stage = mma_size_m * epi_cols_per_mma_m
     na, nb = chain.num_a_operands, chain.num_b_operands
+    real_na = 0 if bs.fake_dequant_a else na
+    real_nb = 0 if bs.fake_dequant_b else nb
     sf_total_cols = na * sfa_tmem_cols + nb * sfb_tmem_cols
     # Columns each instruction reads from its scale base -- ISA opUTCHMMA,
     # "Load A/B scale factors" (sf{a,b}_tmem_cols).
@@ -2012,7 +2014,7 @@ def _render_block_scale_tile_constants_sm100(
             )
     else:
         # One stage covers a whole K-tile: packed data + SF per DISTINCT operand.
-        per_stage = na * (cta_m * a_cta_k_bytes + sfa_smem_bytes) + nb * ((cta_n // cta_group) * b_cta_k_bytes + sfb_smem_bytes)
+        per_stage = na * cta_m * a_cta_k_bytes + nb * (cta_n // cta_group) * b_cta_k_bytes + real_na * sfa_smem_bytes + real_nb * sfb_smem_bytes
         ab_stages = max(1, smem_ab_stages(per_stage, smem_fixed_reserve=tmpl.smem_fixed_reserve, extra_smem_bytes=ab_reserved))
 
     out_dt = chain.output_dtype
@@ -2082,6 +2084,10 @@ def _render_block_scale_tile_constants_sm100(
         f"num_gemms = {num_gemms}",
         f"num_a_operands = {na}",
         f"num_b_operands = {nb}",
+        f"num_sfa_operands = {real_na}",
+        f"num_sfb_operands = {real_nb}",
+        f"fake_dequant_a = {bs.fake_dequant_a}",
+        f"fake_dequant_b = {bs.fake_dequant_b}",
         f"gemm_a_idx = {tuple(a for a, _ in chain.gemm_operands)}",
         f"gemm_b_idx = {tuple(b for _, b in chain.gemm_operands)}",
         f"acc_region_cols = {acc_region_cols}",
@@ -2090,6 +2096,8 @@ def _render_block_scale_tile_constants_sm100(
         f"acc_gemm_stride = {acc_gemm_stride}",
         f"sfa_col_bases = {tuple(sfa_col_bases)}",
         f"sfb_col_bases = {tuple(sfb_col_bases)}",
+        f"sfa_tmem_cols = {sfa_tmem_cols}",
+        f"sfb_tmem_cols = {sfb_tmem_cols}",
         # Mixed CGA pins the walk to the identity map: the super-block
         # rasterization is not invariant across the two cluster shapes.
         f"tile_swizzle_n = {1 if fallback_cluster is not None else 0}",
@@ -2173,6 +2181,10 @@ def _render_block_scale_tile_constants_sm100(
         f"idesc_a_dtype = {idesc_a}",
         f"idesc_b_dtype = {idesc_b}",
         f"sf_scale_format = {bs.sf_scale_format}",
+        # Four packed copies of the scale format's identity byte. E4M3 uses
+        # bias 7 (0x38), E8M0 bias 127 (0x7f), and unsigned E5M3 bias 15
+        # (0x78).  The MMA consumes these as opaque scale bytes from TMEM.
+        f"sf_one_word = { {'fp8_e4m3': 0x38383838, 'fp8_e8m0': 0x7F7F7F7F, 'fp8_e5m3': 0x78787878}[bs.sf_dtype] }",
         # The idesc M/N are the INSTRUCTION's, not the CTA tile's. They agreed while
         # one instruction covered the tile; with mma_size_m > 1 a CTA-tile M of 256 would
         # encode the M=256 enum on a 1-CTA MMA, which does not exist -> illegal instruction.
@@ -2585,58 +2597,62 @@ def _render_block_scale_template(
     # with its data). GROUPED BY KIND — all A, all B, all SFA, all SFB — so
     # single-GEMM (na=nb=1) is exactly (a, b, sfa, sfb), the legacy call order.
     na, nb = chain.num_a_operands, chain.num_b_operands
+    bs = chain.block_scale
+    assert bs is not None
+    nsa = 0 if bs.fake_dequant_a else na
+    nsb = 0 if bs.fake_dequant_b else nb
     _G = "cutlass.GridConstant[_tma.TensorMap]"
     kernel_ab_desc_params = (
         ",\n".join(
             [f"tma_a_desc_{i}: {_G}" for i in range(na)]
             + [f"tma_b_desc_{j}: {_G}" for j in range(nb)]
-            + [f"tma_sfa_desc_{i}: {_G}" for i in range(na)]
-            + [f"tma_sfb_desc_{j}: {_G}" for j in range(nb)]
+            + [f"tma_sfa_desc_{i}: {_G}" for i in range(nsa)]
+            + [f"tma_sfb_desc_{j}: {_G}" for j in range(nsb)]
         )
         + ","
     )
     ab_desc_lists = (
         "tma_a_descs = [" + ", ".join(f"tma_a_desc_{i}" for i in range(na)) + "]\n"
         "tma_b_descs = [" + ", ".join(f"tma_b_desc_{j}" for j in range(nb)) + "]\n"
-        "tma_sfa_descs = [" + ", ".join(f"tma_sfa_desc_{i}" for i in range(na)) + "]\n"
-        "tma_sfb_descs = [" + ", ".join(f"tma_sfb_desc_{j}" for j in range(nb)) + "]"
+        "tma_sfa_descs = [" + ", ".join(f"tma_sfa_desc_{i}" for i in range(nsa)) + "]\n"
+        "tma_sfb_descs = [" + ", ".join(f"tma_sfb_desc_{j}" for j in range(nsb)) + "]"
     )
     host_ab_params = (
         ",\n".join(
             [f"a_{i}: cute.Tensor" for i in range(na)]
             + [f"b_{j}: cute.Tensor" for j in range(nb)]
-            + [f"sfa_{i}: cute.Tensor" for i in range(na)]
-            + [f"sfb_{j}: cute.Tensor" for j in range(nb)]
+            + [f"sfa_{i}: cute.Tensor" for i in range(nsa)]
+            + [f"sfb_{j}: cute.Tensor" for j in range(nsb)]
         )
         + ","
     )
     host_ab_lists = (
         "_a_operands = [" + ", ".join(f"a_{i}" for i in range(na)) + "]\n"
         "_b_operands = [" + ", ".join(f"b_{j}" for j in range(nb)) + "]\n"
-        "_sfa_operands = [" + ", ".join(f"sfa_{i}" for i in range(na)) + "]\n"
-        "_sfb_operands = [" + ", ".join(f"sfb_{j}" for j in range(nb)) + "]"
+        "_sfa_operands = [" + ", ".join(f"sfa_{i}" for i in range(nsa)) + "]\n"
+        "_sfb_operands = [" + ", ".join(f"sfb_{j}" for j in range(nsb)) + "]"
     )
     host_kernel_desc_pass = (
         ",\n".join(
             [f"tma_a_desc_list[{i}]" for i in range(na)]
             + [f"tma_b_desc_list[{j}]" for j in range(nb)]
-            + [f"tma_sfa_desc_list[{i}]" for i in range(na)]
-            + [f"tma_sfb_desc_list[{j}]" for j in range(nb)]
+            + [f"tma_sfa_desc_list[{i}]" for i in range(nsa)]
+            + [f"tma_sfb_desc_list[{j}]" for j in range(nsb)]
         )
         + ","
     )
     compile_ab_fakes = "\n".join(
         [f"fake_a_{i} = _make_fake_a()" for i in range(na)]
         + [f"fake_b_{j} = _make_fake_b()" for j in range(nb)]
-        + [f"fake_sfa_{i} = _make_fake_sfa()" for i in range(na)]
-        + [f"fake_sfb_{j} = _make_fake_sfb()" for j in range(nb)]
+        + [f"fake_sfa_{i} = _make_fake_sfa()" for i in range(nsa)]
+        + [f"fake_sfb_{j} = _make_fake_sfb()" for j in range(nsb)]
     )
     compile_ab_pass = (
         ",\n".join(
             [f"fake_a_{i}" for i in range(na)]
             + [f"fake_b_{j}" for j in range(nb)]
-            + [f"fake_sfa_{i}" for i in range(na)]
-            + [f"fake_sfb_{j}" for j in range(nb)]
+            + [f"fake_sfa_{i}" for i in range(nsa)]
+            + [f"fake_sfb_{j}" for j in range(nsb)]
         )
         + ","
     )
@@ -2650,11 +2666,11 @@ def _render_block_scale_template(
     moe_host_ma_pass = ",\n".join([f"a_{i}" for i in range(na)] + [f"_a_stride_sets[{i}][0]" for i in range(na)])
     if moe_host_ma_pass:
         moe_host_ma_pass += ","
-    moe_kernel_msfa_params = ",\n".join(f"mSFA_{i}: cute.Tensor" for i in range(na))
+    moe_kernel_msfa_params = ",\n".join(f"mSFA_{i}: cute.Tensor" for i in range(nsa))
     if moe_kernel_msfa_params:
         moe_kernel_msfa_params += ","
-    moe_msfa_list = "mSFA_list = [" + ", ".join(f"mSFA_{i}" for i in range(na)) + "]"
-    moe_host_msfa_pass = ",\n".join(f"_sfa_operands[{i}]" for i in range(na))
+    moe_msfa_list = "mSFA_list = [" + ", ".join(f"mSFA_{i}" for i in range(nsa)) + "]"
+    moe_host_msfa_pass = ",\n".join(f"_sfa_operands[{i}]" for i in range(nsa))
     if moe_host_msfa_pass:
         moe_host_msfa_pass += ","
 
@@ -4911,14 +4927,16 @@ class CompiledMoeBlockScaleGemm:
 
     @property
     def workspace_bytes(self) -> int:
-        """Per-CTA A-descriptor scratch: one 128-byte tensormap slot per CTA per
-        distinct A operand. The persistent grid is shape-independent, so this is
-        constant for the plan — which is why override-shape needs no re-query."""
+        """Per-CTA scratch for dynamic A, real-SFA, and output tensormaps.
+
+        A fake SFA needs no slot. The persistent grid is shape-independent, so
+        this is constant for the plan and override-shape needs no re-query.
+        """
         return (self._grid_ctas * self._desc_slots_per_cta + _MOE_SCHED_COUNTER_SLOTS) * _MOE_DESC_SLOT_BYTES
 
     def _make_workspace(self, n_slots, caller=None):
-        """The per-CTA A-descriptor GMEM workspace (16 int64/slot, 128-byte
-        aligned). ``n_slots`` = grid_ctas * num_a_operands. Carved from the
+        """The per-CTA dynamic-descriptor workspace (16 int64/slot, 128-byte
+        aligned). ``n_slots`` covers every dynamic descriptor. Carved from the
         CALLER's buffer when execute() supplied one; otherwise from one this plan
         owns (the direct jit_from_cudnn_graph path passes no workspace)."""
         if caller is None:
@@ -4949,13 +4967,16 @@ class CompiledMoeBlockScaleGemm:
                 f"({[o.source for o in outputs_spec]}); got {len(outputs)}. "
                 "Pass outputs in slot order."
             )
-        for name, t, rank in (
+        ranked_inputs = [
             ("token", token, 3),
             ("weight", weight, 3),
-            ("sfa", sfa, 3),
-            ("sfb", sfb, 3),
             ("first_token_offset", first_token_offset, 1),
-        ):
+        ]
+        if sfa is not None:
+            ranked_inputs.append(("sfa", sfa, 3))
+        if sfb is not None:
+            ranked_inputs.append(("sfb", sfb, 3))
+        for name, t, rank in ranked_inputs:
             if len(t.shape) != rank:
                 raise ValueError(f"MoE block-scale {name} must be rank-{rank}; " f"got shape {tuple(t.shape)}")
         for spec, t in zip(outputs_spec, outputs):
@@ -5009,8 +5030,11 @@ class CompiledMoeBlockScaleGemm:
             (_wrap_raw_tensor(ci) if (spec.is_reduction or spec.is_quant_scale) else _maybe_wrap_layout(ci, _LEADING_DIM_C))
             for spec, ci in zip(outputs_spec, c_perms)
         ]
-        msfa = _maybe_wrap_layout(sfa.permute(1, 2, 0), _LEADING_DIM_AUX)
-        msfb = _maybe_wrap_layout(sfb.permute(1, 2, 0), _LEADING_DIM_AUX)
+        sf_args = []
+        if sfa is not None:
+            sf_args.append(_maybe_wrap_layout(sfa.permute(1, 2, 0), _LEADING_DIM_AUX))
+        if sfb is not None:
+            sf_args.append(_maybe_wrap_layout(sfb.permute(1, 2, 0), _LEADING_DIM_AUX))
         workspace = self._make_workspace(self._grid_ctas * self._desc_slots_per_cta + _MOE_SCHED_COUNTER_SLOTS, workspace)
         _moe_reset_sched_counter(workspace, self._grid_ctas * self._desc_slots_per_cta, stream)
         return self._launchable(
@@ -5019,8 +5043,7 @@ class CompiledMoeBlockScaleGemm:
             workspace,
             a,
             b,
-            msfa,
-            msfb,
+            *sf_args,
             *_moe_launch_tail(cs, tma_slots=self.tma_slots),
             stream=_as_custream(stream),
         )
@@ -5051,12 +5074,30 @@ class CompiledMoeBlockScaleGemm:
             if _r_sf is not None:
                 raise ValueError(_r_sf)
         out = out_bufs if len(out_bufs) > 1 else out_bufs[0]
+        fake_a = self.chain.block_scale.fake_dequant_a
+        fake_b = self.chain.block_scale.fake_dequant_b
         if self.chain.is_multi_gemm or self.chain.ops:
-            pairs = [((a_bufs[ai], sfa[ai]), (b_bufs[bi], sfb[bi])) for ai, bi in self.chain.gemm_operands]
+            pairs = [
+                (
+                    (a_bufs[ai], None if fake_a else sfa[ai]),
+                    (b_bufs[bi], None if fake_b else sfb[bi]),
+                )
+                for ai, bi in self.chain.gemm_operands
+            ]
             r = self._call_multi_gemm(pairs, fto, out, snk, *aux_bufs, workspace=workspace, stream=stream)
             _finalize_reductions(self.chain, out_bufs)
             return r
-        return self._launch_single(a_bufs[0], b_bufs[0], sfa[0], sfb[0], fto, out, snk, workspace=workspace, stream=stream)
+        return self._launch_single(
+            a_bufs[0],
+            b_bufs[0],
+            None if fake_a else sfa[0],
+            None if fake_b else sfb[0],
+            fto,
+            out,
+            snk,
+            workspace=workspace,
+            stream=stream,
+        )
 
     def _call_multi_gemm(self, gemm_pairs, first_token_offset, output, snke, *aux, workspace=None, stream=None):
         """Multi-GEMM MoE block-scale call:
@@ -5145,8 +5186,8 @@ class CompiledMoeBlockScaleGemm:
         # Grouped by kind (all A, all B, all SFA, all SFB); single-GEMM → a,b,sfa,sfb.
         a_wrapped = [_maybe_wrap_layout(t.permute(1, 2, 0), _LEADING_DIM_A) for (t, _sf) in a_slots]
         b_wrapped = [_maybe_wrap_layout(t.permute(1, 2, 0), _LEADING_DIM_B) for (t, _sf) in b_slots]
-        sfa_wrapped = [_maybe_wrap_layout(sf.permute(1, 2, 0), _LEADING_DIM_AUX) for (_t, sf) in a_slots]
-        sfb_wrapped = [_maybe_wrap_layout(sf.permute(1, 2, 0), _LEADING_DIM_AUX) for (_t, sf) in b_slots]
+        sfa_wrapped = [_maybe_wrap_layout(sf.permute(1, 2, 0), _LEADING_DIM_AUX) for (_t, sf) in a_slots if sf is not None]
+        sfb_wrapped = [_maybe_wrap_layout(sf.permute(1, 2, 0), _LEADING_DIM_AUX) for (_t, sf) in b_slots if sf is not None]
         cs = [
             (_wrap_raw_tensor(ci) if (spec.is_reduction or spec.is_quant_scale) else _maybe_wrap_layout(ci, _LEADING_DIM_C))
             for spec, ci in zip(outputs_spec, c_perms)
@@ -5213,7 +5254,9 @@ def _jit_moe_block_scale(
         _grid_ctas=grid_ctas,
         binding=binding,
         vec_bytes_epi=_epi_chunk_bytes(chain, config, use_tma),
-        _desc_slots_per_cta=chain.num_a_operands * 2 + len([m for m in store_modes if m == "tma"]),
+        _desc_slots_per_cta=chain.num_a_operands
+        + (0 if chain.block_scale.fake_dequant_a else chain.num_a_operands)
+        + len([m for m in store_modes if m == "tma"]),
         store_modes=store_modes,
         use_tma_store=use_tma,
     )

--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -1761,7 +1761,7 @@ def _render_block_scale_tile_constants_sm100(
     mma_k64 = cfg.mma_tile_k_bytes == 64
     if is_sm103 and not both_fp4:
         raise NotImplementedError("the sm103 block-scale pipeline is fp4-only; " f"{bs.a_dtype} data with {bs.sf_dtype} scales runs the sm100 templates")
-    # Baseline SM100 mixed UTCQMMA uses K32 and the padded E2M1 SMEM format
+    # Baseline SM100 mixed block-scale MMA uses K32 and the padded E2M1 SMEM format
     # (16 FP4 lanes in 8 payload bytes + 8 padding bytes). Rubin's K64 form
     # consumes native packed FP4 instead.
     padded_fp4 = mixed_width and not mma_k64
@@ -1770,7 +1770,7 @@ def _render_block_scale_tile_constants_sm100(
     b_data_elem_bits = DTYPE_BITS[bs.b_dtype]
     a_smem_elem_bits = 8 if padded_fp4 and a_data_elem_bits == 4 else a_data_elem_bits
     b_smem_elem_bits = 8 if padded_fp4 and b_data_elem_bits == 4 else b_data_elem_bits
-    # K_BYTES names the byte width of the widest operand.  In a mixed UTCQMMA
+    # K_BYTES names the byte width of the widest operand.  In a mixed-width MMA
     # both sides span the same logical K, while the native packed FP4 SMEM row
     # occupies half the bytes of its FP8 peer.
     data_elem_bits = max(a_data_elem_bits, b_data_elem_bits)

--- a/python/cudnn/gemm/frost/fusion_ir.py
+++ b/python/cudnn/gemm/frost/fusion_ir.py
@@ -501,7 +501,7 @@ class BlockScaleSpec:
     either K-block (16 or 32) — the two axes are orthogonal, so nvfp4 and mxfp4
     are just the two best-known corners — plus fp8 (e4m3/e5m2) with e8m0 scales
     at block 32. Mixed mxfp8/mxfp4 is supported in either operand order (shared
-    e8m0 scale format, block 32): SM100 uses the K32 UTCQMMA padded-E2M1 layout,
+    e8m0 scale format, block 32): SM100 uses the K32 padded-E2M1 layout,
     while Rubin additionally provides a native-packed K64 form. E5M3 scales
     require SM 10.7+.
 
@@ -589,7 +589,7 @@ class BlockScaleSpec:
     @property
     def mma_block_scale_kind(self) -> str:
         """GEMM ``nvvm.MMABlockScaleKind`` member name."""
-        # Rubin's mixed FP8/FP4 instruction is a UTCQMMA (MXF8F6F4), whose
+        # Rubin's mixed FP8/FP4 instruction is MXF8F6F4, whose
         # per-side format fields independently encode FP8 or E2M1.  MXF4NVF4
         # is the UTCOMMA path and requires FP4 on both sides.
         return "MXF4NVF4" if self.both_fp4 else "MXF8F6F4"

--- a/python/cudnn/gemm/frost/fusion_ir.py
+++ b/python/cudnn/gemm/frost/fusion_ir.py
@@ -492,12 +492,12 @@ class BlockScaleSpec:
     (FP4/FP8) A/B each dequantized by a per-block K scale inside the MMA
     (``tcgen05.mma.kind::mx*.block_scale``).
 
-    Detected by a purely STRUCTURAL match in the analyzer: if A and/or B is the
-    output of a ``block_scale_dequantize`` node, dequant(s) + matmul fold into
-    one block-scale matmul (three shapes: dequant(A)@B, A@dequant(B),
-    dequant(A)@dequant(B); ``sfa``/``sfb`` present only for the scaled side(s)).
-    No dtype/block/arch rules here — runnability is decided at compile time.
-    Currently runs (both sides): fp4 with any of e4m3 / e8m0 / e5m3 scales at
+    Detected by a purely STRUCTURAL match in the analyzer.  Two real dequants
+    fold directly.  If exactly one side is dequantized and its peer is raw FP8,
+    the peer is normalized to a logical dequant whose scale is one; only the
+    real side has a runtime SF tensor.  No dtype/block/arch rules live here —
+    runnability is decided at compile time from the same normalized MMA key in
+    both cases.  Currently runs: fp4 with any of e4m3 / e8m0 / e5m3 scales at
     either K-block (16 or 32) — the two axes are orthogonal, so nvfp4 and mxfp4
     are just the two best-known corners — plus fp8 (e4m3/e5m2) with e8m0 scales
     at block 32. Mixed mxfp8/mxfp4 is supported in either operand order (shared
@@ -511,9 +511,10 @@ class BlockScaleSpec:
 
     a_dtype: Dtype  # packed data dtype of A (mirror of matmul.a_dtype)
     b_dtype: Dtype  # packed data dtype of B
-    # Per-side scale info, kept SEPARATE for future asymmetric block-scale. A
-    # non-dequantized side has all None fields. `block_size_*` is 2D (A=[non_K,
-    # K], B=[K, non_K]); only 1D K-scaling used today (2D form is headroom).
+    # Per-side scale info, kept SEPARATE for asymmetric block-scale.  An
+    # unnormalized non-dequantized side has all None fields; a fake side has
+    # logical scale metadata plus its fake_dequant mark. `block_size_*` is 2D
+    # (A=[non_K, K], B=[K, non_K]); only 1D K-scaling is used today.
     block_size_a: "tuple[int, ...] | None" = None
     block_size_b: "tuple[int, ...] | None" = None
     sf_dtype_a: "Dtype | None" = None  # A's scale-factor dtype (None if A not scaled)
@@ -528,6 +529,14 @@ class BlockScaleSpec:
     dequant_compute_b: "Dtype | None" = None
     dequant_out_a: "Dtype | None" = None  # = MMA input type for A
     dequant_out_b: "Dtype | None" = None  # = MMA input type for B
+    # A raw FP8 operand opposite one real block-scale dequant is represented as
+    # a logical dequant by a scale of one.  These marks are deliberately NOT
+    # part of the registry's MMA-type key: capability is decided from the
+    # normalized fields above, exactly like a graph with two real dequants.
+    # Codegen uses them only to elide the runtime SF tensor / TMA / SMEM path
+    # and seed that side's still-reserved TMEM scale region with packed 1.0.
+    fake_dequant_a: bool = False
+    fake_dequant_b: bool = False
     # matmul-level dtypes (accum/output/tap) are NOT duplicated here — read
     # chain.matmul / chain.output_dtype. Only input-side info lives here.
 
@@ -539,8 +548,11 @@ class BlockScaleSpec:
 
     @property
     def both_sided(self) -> bool:
-        """True iff BOTH operands were dequantized (a side is dequantized iff
-        its scale-factor dtype is set) — the runnable case today."""
+        """True iff both operands have logical scale metadata.
+
+        Either side may be a fake dequant backed by a constant-one TMEM scale
+        region instead of a runtime scale-factor tensor.
+        """
         return self.sf_dtype_a is not None and self.sf_dtype_b is not None
 
     # Convenience scalars for the symmetric both-sided path (only valid when the

--- a/python/cudnn/gemm/frost/graph_analyzer.py
+++ b/python/cudnn/gemm/frost/graph_analyzer.py
@@ -213,7 +213,10 @@ def _make_multi_binding(
         objs = []
         for i in ids:
             sid = caps[i].get("sf_id")
-            objs.append(meta[sid].tensor if sid is not None else None)
+            # A fake-dequant side has complete logical SF metadata (so the
+            # ordinary registry key decides support) but no runtime SF tensor.
+            if sid is not None:
+                objs.append(meta[sid].tensor)
         return objs
 
     return GemmBinding(
@@ -800,6 +803,43 @@ def _dedup_operand(pid: int, cap: dict, ids: list[int], caps: dict[int, dict], s
     return ids.index(pid)
 
 
+def _normalize_one_sided_block_scale(
+    operand_pairs: "list[tuple[int, int]]",
+    a_ids: "list[int]",
+    b_ids: "list[int]",
+    a_caps: "dict[int, dict]",
+    b_caps: "dict[int, dict]",
+) -> None:
+    """Give a raw-FP8 peer logical scale metadata copied from one real dequant.
+
+    This is shared by dense and MoE analysis.  The fake mark is intentionally
+    codegen-only; registry support continues to be decided from the normalized
+    ordinary block-scale MMA key.
+    """
+    raw_fp8_dtypes = {"fp8_e4m3", "fp8_e5m2"}
+
+    def _fake_from(peer: dict, *, is_a: bool) -> dict:
+        # A block shape is [non-K,K], B is [K,non-K].
+        kblock = int(peer["block_size_2d"][0 if is_a else -1])
+        return dict(
+            block_size_2d=(1, kblock) if is_a else (kblock, 1),
+            sf_dtype=peer["sf_dtype"],
+            sf_reorder=peer["sf_reorder"],
+            deq_compute=peer["deq_compute"],
+            deq_out=peer["deq_out"],
+            sf_id=None,
+            fake_dequant=True,
+        )
+
+    for ai, bi in operand_pairs:
+        ac = a_caps[a_ids[ai]]
+        bc = b_caps[b_ids[bi]]
+        if ac["sf_dtype"] is None and bc["sf_dtype"] is not None and not bc["fake_dequant"] and ac["data_dtype"] in raw_fp8_dtypes:
+            ac.update(_fake_from(bc, is_a=True))
+        elif bc["sf_dtype"] is None and ac["sf_dtype"] is not None and not ac["fake_dequant"] and bc["data_dtype"] in raw_fp8_dtypes:
+            bc.update(_fake_from(ac, is_a=False))
+
+
 def _build_multi_moe_chain(
     moe_ops: list[_RecordedOp],
     ops: list[_RecordedOp],
@@ -855,6 +895,7 @@ def _build_multi_moe_chain(
                 deq_compute=None,
                 deq_out=None,
                 sf_id=None,
+                fake_dequant=False,
             )
         data_id, sf_id = deq.inputs
         sf_meta = meta[sf_id]
@@ -869,6 +910,7 @@ def _build_multi_moe_chain(
             deq_compute=deq_compute,
             deq_out=deq_out,
             sf_id=sf_id,
+            fake_dequant=False,
         )
 
     a_ids: list[int] = []  # distinct PACKED token (A) data ids
@@ -886,6 +928,7 @@ def _build_multi_moe_chain(
             )
         )
 
+    _normalize_one_sided_block_scale(gemm_operands, a_ids, b_ids, a_caps, b_caps)
     is_block_scale = any(c["sf_dtype"] is not None for c in (*a_caps.values(), *b_caps.values()))
 
     def _moe_geometry(token_id: int, weight_id: int):
@@ -929,6 +972,7 @@ def _build_multi_moe_chain(
                 cap["sf_reorder"],
                 cap["deq_compute"],
                 cap["deq_out"],
+                cap["fake_dequant"],
             )
 
         for cap in a_caps.values():
@@ -950,6 +994,8 @@ def _build_multi_moe_chain(
             dequant_compute_b=b0["deq_compute"],
             dequant_out_a=a0["deq_out"],
             dequant_out_b=b0["deq_out"],
+            fake_dequant_a=a0["fake_dequant"],
+            fake_dequant_b=b0["fake_dequant"],
         )
     mm_compute = moe_ops[0].compute_dtype if moe_ops[0].compute_dtype is not None else compute_dtype
 
@@ -1447,6 +1493,7 @@ def _build_multi_gemm_chain(
                 deq_compute=None,
                 deq_out=None,
                 sf_id=None,
+                fake_dequant=False,
             )
         data_id, sf_id = deq.inputs
         sf_meta = meta[sf_id]
@@ -1461,6 +1508,7 @@ def _build_multi_gemm_chain(
             deq_compute=deq_compute,
             deq_out=deq_out,
             sf_id=sf_id,
+            fake_dequant=False,
         )
 
     aux_tensors: list[TensorRef] = []
@@ -1511,6 +1559,7 @@ def _build_multi_gemm_chain(
             )
         )
 
+    _normalize_one_sided_block_scale(gemm_operands, a_ids, b_ids, a_caps, b_caps)
     is_block_scale = any(c["sf_dtype"] is not None for c in (*a_caps.values(), *b_caps.values()))
 
     # Validate every GEMM shares shape / layout / dtype.
@@ -1561,6 +1610,7 @@ def _build_multi_gemm_chain(
                 cap["sf_reorder"],
                 cap["deq_compute"],
                 cap["deq_out"],
+                cap["fake_dequant"],
             )
 
         for cap in a_caps.values():
@@ -1582,6 +1632,8 @@ def _build_multi_gemm_chain(
             dequant_compute_b=b0["deq_compute"],
             dequant_out_a=a0["deq_out"],
             dequant_out_b=b0["deq_out"],
+            fake_dequant_a=a0["fake_dequant"],
+            fake_dequant_b=b0["fake_dequant"],
         )
     mm_compute = matmuls[0].compute_dtype if matmuls[0].compute_dtype is not None else compute_dtype
     matmul_out_dim = (batch, M, N)

--- a/python/cudnn/gemm/frost/kernel_registry.py
+++ b/python/cudnn/gemm/frost/kernel_registry.py
@@ -262,6 +262,19 @@ def mma_arch_reject(chain: FusionChain, graph_type: GraphType, template_pipeline
             mm = chain.matmul
             return f"the {template_pipeline} {graph_type.value} pipeline does not support " f"input/acc dtype combo {mm.a_dtype}x{mm.b_dtype}->{mm.accum_dtype}"
         return f"the {template_pipeline} {graph_type.value} pipeline does not support " f"this configuration: mma type {key}"
+    # One-sided block-scale graphs are normalized to an ordinary two-sided MMA
+    # type, with the raw FP8 operand carrying a fake-dequant marker.  Keep that
+    # marker out of the generic MMA-type key: it is a renderer capability, not a
+    # new instruction combination.  The sm120 renderer does not yet synthesize
+    # the identity scale-factor operand, however, and unconditionally indexes
+    # both TMA descriptor lists.  Reject it here before rendering/compilation.
+    if (
+        template_pipeline == "sm120"
+        and base_type is GraphType.BLOCK_SCALE_MATMUL
+        and chain.block_scale is not None
+        and (chain.block_scale.fake_dequant_a or chain.block_scale.fake_dequant_b)
+    ):
+        return "the sm120 block_scale_matmul pipeline does not support one-sided " "dequantization: fake scale-factor identity handling is not implemented"
     special = MMA_GPU_ARCH_SPECIAL_CASES.get((template_pipeline, key))
     if special is not None:
         arch = C._current_arch()

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul.py
@@ -18,6 +18,12 @@ instruction that reads it, and the MMA is ``tcgen05_mma_block_scale``. When the
 accumulator cannot double-buffer, ``use_acc_overlap`` overlaps the two regions
 and drains the shared columns first.
 
+For a one-sided-dequant GEMM, the raw FP8 peer is represented by a fake scale
+factor.  Its TMEM region is still reserved, but it has no SF kernel argument or
+SMEM/TMA/``tcgen05_cp`` path.  The four epilogue warps seed the same 32-row
+image in the four TMEM warp partitions, emulating the real copy's ``WARPX4``
+coverage, before the MMA warp proceeds.
+
 ``mma_inst_k_bytes`` selects the MMA-inst K width. At 64 (SM 10.7+ silicon) the
 K-tile takes half as many MMAs, each consuming ``sf_scales_per_inst`` scales;
 when that outgrows a 128x4 utccp atom one SF word spans ``word_atoms`` atoms,
@@ -96,6 +102,9 @@ EPI_SYNC_BAR_ID = 1
 # Named barrier id for the TMEM-alloc handoff
 TMEM_ALLOC_BARRIER_ID = 2
 
+# Five-warp handoff after epilogue warps seed all fake-SF TMEM partitions.
+TMEM_SCALE_ONE_BARRIER_ID = 3
+
 
 @cute.jit
 def _auto_swizzle_w(m, n, k, nt_n):
@@ -136,6 +145,27 @@ def _b_collector_op(mi):
     if cutlass.const_expr(mi == mma_size_m - 1):
         return nvvm.Tcgen05MMACollectorOp.LASTUSE
     return nvvm.Tcgen05MMACollectorOp.USE
+
+
+@cute.jit
+def _fill_scale_one(tmem_base, num_cols):
+    """Fill one logical SF region with the selected format's encoded 1.0.
+
+    The F8_128x4 layout uses 32 scale rows and a 32-bit cell carries four
+    identical scale bytes.  One warp-wide ``32x32b`` store fills those rows in
+    only the issuing warp's TMEM partition.  Calling this from warp positions
+    0..3 supplies the same four-partition coverage as an SF
+    ``tcgen05.cp(..., WARPX4)``.
+    """
+    one = cutlass.Uint32(sf_one_word)
+    one_vec = cutlass.Vector.from_elements((one,), cutlass.Uint32)
+    for col in cutlass.range_constexpr(num_cols):
+        nvvm.tcgen05_st(
+            "32x32b",
+            nvvm.make_tmem_ptr(tmem_base + col, cutlass.Uint32),
+            one_vec,
+        )
+    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
 
 
 # @@SPLITK_ONLY:BEGIN@@
@@ -255,9 +285,11 @@ def _kernel(
     if warp_idx == mma_warp_id:
         for _i in cutlass.range_constexpr(num_a_operands):
             nvvm.prefetch_tensormap(tma_a_descs[_i].get_ptr())
+        for _i in cutlass.range_constexpr(num_sfa_operands):
             nvvm.prefetch_tensormap(tma_sfa_descs[_i].get_ptr())
         for _j in cutlass.range_constexpr(num_b_operands):
             nvvm.prefetch_tensormap(tma_b_descs[_j].get_ptr())
+        for _j in cutlass.range_constexpr(num_sfb_operands):
             nvvm.prefetch_tensormap(tma_sfb_descs[_j].get_ptr())
 
         # @@TMA_STORE_ONLY:BEGIN@@
@@ -369,7 +401,7 @@ def _kernel(
             space=cutlass.AddressSpace.smem,
             alignment=1024,
         )
-        for _ in range(num_a_operands)
+        for _ in range(num_sfa_operands)
     ]
     smem_sfb_list = [
         cutlass.Array(
@@ -378,7 +410,7 @@ def _kernel(
             space=cutlass.AddressSpace.smem,
             alignment=1024,
         )
-        for _ in range(num_b_operands)
+        for _ in range(num_sfb_operands)
     ]
 
     # @@TMA_STORE_ONLY:BEGIN@@
@@ -463,10 +495,10 @@ def _kernel(
     sB_bytes = sB_elems * (b_smem_dtype.width // 8)
     if cutlass.const_expr(cta_group == 1):
         ab_only_copy_bytes = num_a_operands * sA_tma_bytes + num_b_operands * sB_tma_bytes
-        sf_only_copy_bytes = num_a_operands * sfa_smem_bytes + num_b_operands * sfb_smem_bytes
+        sf_only_copy_bytes = num_sfa_operands * sfa_smem_bytes + num_sfb_operands * sfb_smem_bytes
     else:
         ab_only_copy_bytes = (num_a_operands * sA_tma_bytes + num_b_operands * sB_tma_bytes) * 2
-        sf_only_copy_bytes = (num_a_operands * sfa_smem_bytes + num_b_operands * sfb_smem_bytes) * 2
+        sf_only_copy_bytes = (num_sfa_operands * sfa_smem_bytes + num_sfb_operands * sfb_smem_bytes) * 2
 
     if cutlass.const_expr(cta_group == 2):
         # Per-CTA logical tile — the cluster cancels out, so these stay compile-time
@@ -622,9 +654,7 @@ def _kernel(
                         if elect_one:
                             nvvm.mbarrier_arrive_expect_tx(sf_full_mbar_ptr.subview(stage), sf_only_copy_bytes)
 
-                for _ai in cutlass.range_constexpr(num_a_operands):
-                    sA_stage = smem_a_list[_ai].subview(sA_elems * stage)
-                    tma_a_desc = tma_a_descs[_ai]
+                for _ai in cutlass.range_constexpr(num_sfa_operands):
                     sSFA_stage = smem_sfa_list[_ai].subview(sfa_smem_bytes * stage)
                     tma_sfa_desc = tma_sfa_descs[_ai]
                     sfa_m_block = coord_m_per_cta // 128
@@ -652,9 +682,7 @@ def _kernel(
                                 group=_CTA_GROUP,
                             )
 
-                for _bj in cutlass.range_constexpr(num_b_operands):
-                    sB_stage = smem_b_list[_bj].subview(sB_elems * stage)
-                    tma_b_desc = tma_b_descs[_bj]
+                for _bj in cutlass.range_constexpr(num_sfb_operands):
                     sSFB_stage = smem_sfb_list[_bj].subview(sfb_smem_bytes * stage)
                     tma_sfb_desc = tma_sfb_descs[_bj]
                     if cutlass.const_expr(cta_group == 1):
@@ -686,9 +714,6 @@ def _kernel(
                 for _ai in cutlass.range_constexpr(num_a_operands):
                     sA_stage = smem_a_list[_ai].subview(sA_elems * stage)
                     tma_a_desc = tma_a_descs[_ai]
-                    sSFA_stage = smem_sfa_list[_ai].subview(sfa_smem_bytes * stage)
-                    tma_sfa_desc = tma_sfa_descs[_ai]
-                    sfa_m_block = coord_m_per_cta // 128
                     if cutlass.const_expr(a_mcast_slices > 1):
                         _a_rows = cta_tile_mnk[0] // a_mcast_slices
                         if cutlass.const_expr(fallback_cluster_shape_mnk is None):
@@ -778,10 +803,6 @@ def _kernel(
                 for _bj in cutlass.range_constexpr(num_b_operands):
                     sB_stage = smem_b_list[_bj].subview(sB_elems * stage)
                     tma_b_desc = tma_b_descs[_bj]
-                    sSFB_stage = smem_sfb_list[_bj].subview(sfb_smem_bytes * stage)
-                    tma_sfb_desc = tma_sfb_descs[_bj]
-                    if cutlass.const_expr(cta_group == 1):
-                        sfb_n_block = coord_n_per_cta // 128
                     if cutlass.const_expr(b_mcast_slices > 1):
                         _b_rows = cta_tile_mnk[1] // b_mcast_slices
                         if cutlass.const_expr(fallback_cluster_shape_mnk is None):
@@ -951,6 +972,11 @@ def _kernel(
         tmem_raw_addr = tmem_ptr_i32.load()
         base_col_id_root = tmem_raw_addr & 0xFFFF
         base_row_id = tmem_raw_addr >> 16
+        if cutlass.const_expr(fake_dequant_a or fake_dequant_b):
+            nvvm.barrier_cta_sync(
+                barrier_id=TMEM_SCALE_ONE_BARRIER_ID,
+                thread_count=tmem_alloc_bar_count,
+            )
         if cutlass.const_expr(cta_group == 2):
             peer_cta_rank = cta_rank_in_cluster ^ 1
         if is_pair_leader:
@@ -1052,7 +1078,7 @@ def _kernel(
                     stride_byte_offset=128,
                     layout=cutlass.experimental.primitives.Tcgen05SmemSwizzle.NONE,
                 )
-                for i in range(num_a_operands)
+                for i in range(num_sfa_operands)
             ]
             desc_sfb_roots = [
                 cutlass.experimental.primitives.Tcgen05SmemDesc.build(
@@ -1061,7 +1087,7 @@ def _kernel(
                     stride_byte_offset=128,
                     layout=cutlass.experimental.primitives.Tcgen05SmemSwizzle.NONE,
                 )
-                for j in range(num_b_operands)
+                for j in range(num_sfb_operands)
             ]
             while is_valid != 0:
                 acc_stage = tile_iter % acc_stages
@@ -1110,8 +1136,8 @@ def _kernel(
 
                     desc_a_bases = [desc_a_roots[i].advance_start_address(sA_bytes * stage) for i in range(num_a_operands)]
                     desc_b_bases = [desc_b_roots[j].advance_start_address(sB_bytes * stage) for j in range(num_b_operands)]
-                    desc_sfa_bases = [desc_sfa_roots[i].advance_start_address(sfa_smem_bytes * stage) for i in range(num_a_operands)]
-                    desc_sfb_bases = [desc_sfb_roots[j].advance_start_address(sfb_smem_bytes * stage) for j in range(num_b_operands)]
+                    desc_sfa_bases = [desc_sfa_roots[i].advance_start_address(sfa_smem_bytes * stage) for i in range(num_sfa_operands)]
+                    desc_sfb_bases = [desc_sfb_roots[j].advance_start_address(sfb_smem_bytes * stage) for j in range(num_sfb_operands)]
 
                     # One SF word per group of MMAs, refreshed right before they
                     # read it. A word spans word_atoms consecutive K-atoms in SMEM.
@@ -1123,7 +1149,7 @@ def _kernel(
                         pass
 
                     for sf_word in cutlass.range_constexpr(num_sf_atoms):
-                        for _bj in cutlass.range_constexpr(num_b_operands):
+                        for _bj in cutlass.range_constexpr(num_sfb_operands):
                             for block_n in cutlass.range_constexpr(num_blocks_n):
                                 for _a in cutlass.range_constexpr(word_atoms):
                                     if elect_one:
@@ -1150,7 +1176,7 @@ def _kernel(
                                 desc_a_k = desc_a_bases[_ai].advance_start_address(a_smem_k_step_bytes * mma_k)
                                 desc_b = desc_b_bases[_bj].advance_start_address(b_smem_k_step_bytes * mma_k)
                                 for mma_m in cutlass.range_constexpr(mma_size_m):
-                                    if cutlass.const_expr(mma_k_in_word == 0 and _ai not in gemm_a_idx[:gemm_i]):
+                                    if cutlass.const_expr(not fake_dequant_a and mma_k_in_word == 0 and _ai not in gemm_a_idx[:gemm_i]):
                                         for _a in cutlass.range_constexpr(word_atoms):
                                             if elect_one:
                                                 nvvm.tcgen05_cp(
@@ -1301,6 +1327,19 @@ def _kernel(
         tmem_raw_addr = tmem_ptr_i32.load()
         base_col_id_root = tmem_raw_addr & 0xFFFF
         base_row_id = tmem_raw_addr >> 16
+
+        if cutlass.const_expr(fake_dequant_a):
+            for i in cutlass.range_constexpr(num_a_operands):
+                _fill_scale_one((base_row_id << 16) | (base_col_id_root + sfa_col_bases[i]), sfa_tmem_cols)
+        if cutlass.const_expr(fake_dequant_b):
+            for j in cutlass.range_constexpr(num_b_operands):
+                _fill_scale_one((base_row_id << 16) | (base_col_id_root + sfb_col_bases[j]), sfb_tmem_cols)
+        if cutlass.const_expr(fake_dequant_a or fake_dequant_b):
+            nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
+            nvvm.barrier_cta_sync(
+                barrier_id=TMEM_SCALE_ONE_BARRIER_ID,
+                thread_count=tmem_alloc_bar_count,
+            )
 
         if cutlass.const_expr(USE_PDL):
             nvvm.griddepcontrol("wait")
@@ -1525,7 +1564,7 @@ def _host(
     rest_n = (n + 127) // 128
     tma_a_desc_list = []
     tma_sfa_desc_list = []
-    for _a_op, _sfa_op in zip(_a_operands, _sfa_operands):
+    for _a_op in _a_operands:
         if cutlass.const_expr(a_is_m_major):
             tma_a_desc_list.append(
                 _tma.create_tensor_map_tiled(
@@ -1556,6 +1595,7 @@ def _host(
                     tma_format=a_tma_format,
                 )
             )
+    for _sfa_op in _sfa_operands:
         sfa_fp16_tensor = cute.make_tensor(
             cute.recast_ptr(_sfa_op.iterator, dtype=cutlass.Float16),
             cute.make_layout(
@@ -1579,7 +1619,7 @@ def _host(
         )
     tma_b_desc_list = []
     tma_sfb_desc_list = []
-    for _b_op, _sfb_op in zip(_b_operands, _sfb_operands):
+    for _b_op in _b_operands:
         if cutlass.const_expr(b_is_n_major):
             tma_b_desc_list.append(
                 _tma.create_tensor_map_tiled(
@@ -1610,6 +1650,7 @@ def _host(
                     tma_format=b_tma_format,
                 )
             )
+    for _sfb_op in _sfb_operands:
         sfb_fp16_tensor = cute.make_tensor(
             cute.recast_ptr(_sfb_op.iterator, dtype=cutlass.Float16),
             cute.make_layout(

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd.py
@@ -4,6 +4,10 @@
 """sm100 MoE grouped block-scale matmul fwd (nvfp4 / mxfp4 / mxfp8,
 including mixed MXFP8/MXFP4 on baseline SM100 K32 and Rubin K64).
 
+A one-sided-dequant graph keeps the ordinary block-scale MMA.  Its raw FP8
+side has no runtime SF/SMEM/TMA path; four epilogue warps seed the fake side's
+32-row TMEM image across the four warp partitions before MMA starts.
+
 Serves both MMA modes; ``cta_group`` is an injected tile constant.
 
   cta_group=1  single-CTA MMA — every CTA runs its own MMA on its own
@@ -52,9 +56,9 @@ from cuda.bindings import driver as _cuda
 # it to the per-CTA GMEM workspace the TMA reads.
 # @@INJECT_TILE_CONSTANTS@@
 
-# Tensormap workspace slots per CTA: the A operands, plus the output descriptor
-# when the TMA-store epilogue re-dimensions it per routed group.
-moe_desc_slots = num_a_operands * 2 + n_tma_outputs
+# Tensormap workspace slots per CTA: every A operand, each real SFA, plus the
+# output descriptors that are re-dimensioned per routed group.
+moe_desc_slots = num_a_operands + num_sfa_operands + n_tma_outputs
 _CTA_GROUP = nvvm.CTAGroup.CTA_2 if cta_group == 2 else nvvm.CTAGroup.CTA_1
 
 if use_acc_overlap and any(_w != epi_n for _, _w in _epi_subtile_spans(epi_cols_per_mma_m, epi_n)):
@@ -70,6 +74,7 @@ USE_PDL = True
 EPI_SMEM_STAGES = 2
 EPI_SYNC_BAR_ID = 1
 TMEM_ALLOC_BARRIER_ID = 2
+TMEM_SCALE_ONE_BARRIER_ID = 3
 
 
 @cute.jit
@@ -110,6 +115,20 @@ def _b_collector_op(mi):
     if cutlass.const_expr(mi == mma_size_m - 1):
         return nvvm.Tcgen05MMACollectorOp.LASTUSE
     return nvvm.Tcgen05MMACollectorOp.USE
+
+
+@cute.jit
+def _fill_scale_one(tmem_base, num_cols):
+    """Seed one 32-row SF image in the issuing warp's TMEM partition."""
+    one = cutlass.Uint32(sf_one_word)
+    one_vec = cutlass.Vector.from_elements((one,), cutlass.Uint32)
+    for col in cutlass.range_constexpr(num_cols):
+        nvvm.tcgen05_st(
+            "32x32b",
+            nvvm.make_tmem_ptr(tmem_base + col, cutlass.Uint32),
+            one_vec,
+        )
+    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
 
 
 @cute.kernel
@@ -184,9 +203,11 @@ def _kernel(
     if warp_idx == mma_warp_id:
         for _i in cutlass.range_constexpr(num_a_operands):
             nvvm.prefetch_tensormap(tma_a_descs[_i].get_ptr())
+        for _i in cutlass.range_constexpr(num_sfa_operands):
             nvvm.prefetch_tensormap(tma_sfa_descs[_i].get_ptr())
         for _j in cutlass.range_constexpr(num_b_operands):
             nvvm.prefetch_tensormap(tma_b_descs[_j].get_ptr())
+        for _j in cutlass.range_constexpr(num_sfb_operands):
             nvvm.prefetch_tensormap(tma_sfb_descs[_j].get_ptr())
 
         # @@TMA_STORE_ONLY:BEGIN@@
@@ -277,7 +298,7 @@ def _kernel(
             space=cutlass.AddressSpace.smem,
             alignment=128,
         )
-        for _ in range(num_a_operands)
+        for _ in range(num_sfa_operands)
     ]
 
     # @@TMA_STORE_ONLY:BEGIN@@
@@ -326,7 +347,7 @@ def _kernel(
             space=cutlass.AddressSpace.smem,
             alignment=1024,
         )
-        for _ in range(num_a_operands)
+        for _ in range(num_sfa_operands)
     ]
     smem_sfb_list = [
         cutlass.Array(
@@ -335,7 +356,7 @@ def _kernel(
             space=cutlass.AddressSpace.smem,
             alignment=1024,
         )
-        for _ in range(num_b_operands)
+        for _ in range(num_sfb_operands)
     ]
 
     if cutlass.const_expr(cta_group == 2):
@@ -413,7 +434,7 @@ def _kernel(
     sB_bytes = sB_elems * (b_smem_dtype.width // 8)
     # The pair leader issues ONE expect_tx for both CTAs, so it counts twice.
     ab_only_copy_bytes = (num_a_operands * sA_tma_bytes + num_b_operands * sB_tma_bytes) * cta_group
-    sf_only_copy_bytes = (num_a_operands * sfa_smem_bytes + num_b_operands * sfb_smem_bytes) * cta_group
+    sf_only_copy_bytes = (num_sfa_operands * sfa_smem_bytes + num_sfb_operands * sfb_smem_bytes) * cta_group
     if cutlass.const_expr(cta_group == 2):
         pair_n_size = cgrp_tile_mnk[1] // cluster_n
     # Per-CTA output rows one MMA-M block covers. The pair splits M, so this is
@@ -737,7 +758,7 @@ def _kernel(
             for _ai in range(num_a_operands)
         ]
         sfa_desc_base_list = [
-            a_tma_workspace.iterator.raw_ptr() + (block_linear * moe_desc_slots + num_a_operands + _ai) * TENSOR_MAP_QWORDS for _ai in range(num_a_operands)
+            a_tma_workspace.iterator.raw_ptr() + (block_linear * moe_desc_slots + num_a_operands + _ai) * TENSOR_MAP_QWORDS for _ai in range(num_sfa_operands)
         ]
         sfa_desc_tma_ptr_list = [
             cute.make_ptr(
@@ -745,20 +766,20 @@ def _kernel(
                 sfa_desc_base_list[_ai].toint(),
                 mem_space=cute.AddressSpace.generic,
             )
-            for _ai in range(num_a_operands)
+            for _ai in range(num_sfa_operands)
         ]
         sfa_block_bytes = 512 * (((k // block_size) + 3) // 4)
         previous_group_begin = cutlass.Int32(-1)
         if cutlass.const_expr(moe_aligned_offsets):
             a_desc_load_list = [tma_a_descs[_ai].get_ptr() for _ai in range(num_a_operands)]
-            sfa_desc_load_list = [tma_sfa_descs[_ai].get_ptr() for _ai in range(num_a_operands)]
+            sfa_desc_load_list = [tma_sfa_descs[_ai].get_ptr() for _ai in range(num_sfa_operands)]
         else:
             a_desc_load_list = a_desc_tma_ptr_list
             sfa_desc_load_list = sfa_desc_tma_ptr_list
         if elect_one and cutlass.const_expr(not moe_aligned_offsets):
             for _ai in cutlass.range_constexpr(num_a_operands):
                 _copy_tensormap_to_workspace(tma_a_descs[_ai].get_ptr(), tma_a_desc_smem_list[_ai])
-            for _ai in cutlass.range_constexpr(num_a_operands):
+            for _ai in cutlass.range_constexpr(num_sfa_operands):
                 _copy_tensormap_to_workspace(tma_sfa_descs[_ai].get_ptr(), tma_sfa_desc_smem_list[_ai])
         nvvm.bar_warp_sync(0xFFFFFFFF)
 
@@ -815,9 +836,9 @@ def _kernel(
                             (cta_desc_base_list[_ai] + lane).store((tma_a_desc_smem_list[_ai].subview(lane)).load())
                         nvvm.bar_warp_sync(0xFFFFFFFF)
                         _fence_tensormap_release()
-                    for _ai in cutlass.range_constexpr(num_a_operands):
+                    for _ai in cutlass.range_constexpr(num_sfa_operands):
                         _fence_tensormap_acquire(sfa_desc_tma_ptr_list[_ai])
-                    for _ai in cutlass.range_constexpr(num_a_operands):
+                    for _ai in cutlass.range_constexpr(num_sfa_operands):
                         if elect_one:
                             sfa_base = mSFA_list[_ai].iterator.raw_ptr().toint() + start_sf_block_m * sfa_block_bytes
                             _replace_tensormap_global_address(tma_sfa_desc_smem_list[_ai], sfa_base)
@@ -869,7 +890,7 @@ def _kernel(
                         b_data_issue = b_issue
                         _b_off = 0
                     if a_issue:
-                        for _ai in cutlass.range_constexpr(num_a_operands):
+                        for _ai in cutlass.range_constexpr(num_sfa_operands):
                             if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     smem_sfa_list[_ai].subview(sfa_smem_bytes * stage),
@@ -881,7 +902,7 @@ def _kernel(
                                     group=_CTA_GROUP,
                                 )
                     if b_issue:
-                        for _bj in cutlass.range_constexpr(num_b_operands):
+                        for _bj in cutlass.range_constexpr(num_sfb_operands):
                             if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     smem_sfb_list[_bj].subview(sfb_smem_bytes * stage),
@@ -978,6 +999,11 @@ def _kernel(
         tmem_raw_addr = tmem_ptr_i32.load()
         base_col_id_root = tmem_raw_addr & 0xFFFF
         base_row_id = tmem_raw_addr >> 16
+        if cutlass.const_expr(fake_dequant_a or fake_dequant_b):
+            nvvm.barrier_cta_sync(
+                barrier_id=TMEM_SCALE_ONE_BARRIER_ID,
+                thread_count=tmem_alloc_bar_count,
+            )
         if cutlass.const_expr(cta_group == 1):
             ab_full_phase_bit = cutlass.Int32(0)
             ab_iter = cutlass.Int32(0)
@@ -1075,7 +1101,7 @@ def _kernel(
                     stride_byte_offset=128,
                     layout=cutlass.experimental.primitives.Tcgen05SmemSwizzle.NONE,
                 )
-                for i in range(num_a_operands)
+                for i in range(num_sfa_operands)
             ]
             desc_sfb_roots = [
                 cutlass.experimental.primitives.Tcgen05SmemDesc.build(
@@ -1084,7 +1110,7 @@ def _kernel(
                     stride_byte_offset=128,
                     layout=cutlass.experimental.primitives.Tcgen05SmemSwizzle.NONE,
                 )
-                for j in range(num_b_operands)
+                for j in range(num_sfb_operands)
             ]
             while is_valid != 0:
                 while not nvvm.mbarrier_try_wait_parity(
@@ -1139,8 +1165,8 @@ def _kernel(
 
                         desc_a_bases = [desc_a_roots[i].advance_start_address(sA_bytes * stage) for i in range(num_a_operands)]
                         desc_b_bases = [desc_b_roots[j].advance_start_address(sB_bytes * stage) for j in range(num_b_operands)]
-                        desc_sfa_bases = [desc_sfa_roots[i].advance_start_address(sfa_smem_bytes * stage) for i in range(num_a_operands)]
-                        desc_sfb_bases = [desc_sfb_roots[j].advance_start_address(sfb_smem_bytes * stage) for j in range(num_b_operands)]
+                        desc_sfa_bases = [desc_sfa_roots[i].advance_start_address(sfa_smem_bytes * stage) for i in range(num_sfa_operands)]
+                        desc_sfb_bases = [desc_sfb_roots[j].advance_start_address(sfb_smem_bytes * stage) for j in range(num_sfb_operands)]
 
                         # One SF word per group of MMAs, refreshed right before they
                         # read it. A word spans word_atoms consecutive K-atoms in SMEM.
@@ -1152,7 +1178,7 @@ def _kernel(
                             pass
 
                         for sf_word in cutlass.range_constexpr(num_sf_atoms):
-                            for _bj in cutlass.range_constexpr(num_b_operands):
+                            for _bj in cutlass.range_constexpr(num_sfb_operands):
                                 for block_n in cutlass.range_constexpr(num_blocks_n):
                                     for _a in cutlass.range_constexpr(word_atoms):
                                         if elect_one:
@@ -1179,7 +1205,7 @@ def _kernel(
                                     desc_a_k = desc_a_bases[_ai].advance_start_address(a_smem_k_step_bytes * mma_k)
                                     desc_b = desc_b_bases[_bj].advance_start_address(b_smem_k_step_bytes * mma_k)
                                     for mma_m in cutlass.range_constexpr(mma_size_m):
-                                        if cutlass.const_expr(mma_k_in_word == 0 and _ai not in gemm_a_idx[:gemm_i]):
+                                        if cutlass.const_expr(not fake_dequant_a and mma_k_in_word == 0 and _ai not in gemm_a_idx[:gemm_i]):
                                             for _a in cutlass.range_constexpr(word_atoms):
                                                 if elect_one:
                                                     nvvm.tcgen05_cp(
@@ -1355,7 +1381,7 @@ def _kernel(
                         stride_byte_offset=128,
                         layout=cutlass.experimental.primitives.Tcgen05SmemSwizzle.NONE,
                     )
-                    for i in range(num_a_operands)
+                    for i in range(num_sfa_operands)
                 ]
                 desc_sfb_roots = [
                     cutlass.experimental.primitives.Tcgen05SmemDesc.build(
@@ -1364,7 +1390,7 @@ def _kernel(
                         stride_byte_offset=128,
                         layout=cutlass.experimental.primitives.Tcgen05SmemSwizzle.NONE,
                     )
-                    for j in range(num_b_operands)
+                    for j in range(num_sfb_operands)
                 ]
                 while is_valid != 0:
                     while not nvvm.mbarrier_try_wait_parity(
@@ -1419,8 +1445,8 @@ def _kernel(
 
                             desc_a_bases = [desc_a_roots[i].advance_start_address(sA_bytes * stage) for i in range(num_a_operands)]
                             desc_b_bases = [desc_b_roots[j].advance_start_address(sB_bytes * stage) for j in range(num_b_operands)]
-                            desc_sfa_bases = [desc_sfa_roots[i].advance_start_address(sfa_smem_bytes * stage) for i in range(num_a_operands)]
-                            desc_sfb_bases = [desc_sfb_roots[j].advance_start_address(sfb_smem_bytes * stage) for j in range(num_b_operands)]
+                            desc_sfa_bases = [desc_sfa_roots[i].advance_start_address(sfa_smem_bytes * stage) for i in range(num_sfa_operands)]
+                            desc_sfb_bases = [desc_sfb_roots[j].advance_start_address(sfb_smem_bytes * stage) for j in range(num_sfb_operands)]
 
                             # One SF word per group of MMAs, refreshed right before they
                             # read it. A word spans word_atoms consecutive K-atoms in SMEM.
@@ -1432,7 +1458,7 @@ def _kernel(
                                 pass
 
                             for sf_word in cutlass.range_constexpr(num_sf_atoms):
-                                for _bj in cutlass.range_constexpr(num_b_operands):
+                                for _bj in cutlass.range_constexpr(num_sfb_operands):
                                     for block_n in cutlass.range_constexpr(num_blocks_n):
                                         for _a in cutlass.range_constexpr(word_atoms):
                                             if elect_one:
@@ -1459,7 +1485,7 @@ def _kernel(
                                         desc_a_k = desc_a_bases[_ai].advance_start_address(a_smem_k_step_bytes * mma_k)
                                         desc_b = desc_b_bases[_bj].advance_start_address(b_smem_k_step_bytes * mma_k)
                                         for mma_m in cutlass.range_constexpr(mma_size_m):
-                                            if cutlass.const_expr(mma_k_in_word == 0 and _ai not in gemm_a_idx[:gemm_i]):
+                                            if cutlass.const_expr(not fake_dequant_a and mma_k_in_word == 0 and _ai not in gemm_a_idx[:gemm_i]):
                                                 for _a in cutlass.range_constexpr(word_atoms):
                                                     if elect_one:
                                                         nvvm.tcgen05_cp(
@@ -1582,6 +1608,19 @@ def _kernel(
         base_col_id_root = tmem_raw_addr & 0xFFFF
         base_row_id = tmem_raw_addr >> 16
 
+        if cutlass.const_expr(fake_dequant_a):
+            for i in cutlass.range_constexpr(num_a_operands):
+                _fill_scale_one((base_row_id << 16) | (base_col_id_root + sfa_col_bases[i]), sfa_tmem_cols)
+        if cutlass.const_expr(fake_dequant_b):
+            for j in cutlass.range_constexpr(num_b_operands):
+                _fill_scale_one((base_row_id << 16) | (base_col_id_root + sfb_col_bases[j]), sfb_tmem_cols)
+        if cutlass.const_expr(fake_dequant_a or fake_dequant_b):
+            nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
+            nvvm.barrier_cta_sync(
+                barrier_id=TMEM_SCALE_ONE_BARRIER_ID,
+                thread_count=tmem_alloc_bar_count,
+            )
+
         if cutlass.const_expr(USE_PDL):
             nvvm.griddepcontrol("wait")
 
@@ -1606,7 +1645,7 @@ def _kernel(
         tile_l = cutlass.Int32(0)
         epi_block_linear = bidx + bidy * gridx
         d_desc_base_list = [
-            a_tma_workspace.iterator.raw_ptr() + (epi_block_linear * moe_desc_slots + num_a_operands * 2 + _di) * TENSOR_MAP_QWORDS
+            a_tma_workspace.iterator.raw_ptr() + (epi_block_linear * moe_desc_slots + num_a_operands + num_sfa_operands + _di) * TENSOR_MAP_QWORDS
             for _di in range(n_tma_outputs)
         ]
         d_desc_ptr_list = [cute.make_ptr(cutlass.Int64, _b.toint(), mem_space=cute.AddressSpace.generic) for _b in d_desc_base_list]

--- a/test/python/gemm/frost/test_block_scale_matmul.py
+++ b/test/python/gemm/frost/test_block_scale_matmul.py
@@ -41,7 +41,7 @@ from gemm_test_utils import (
 from cudnn.gemm.frost import compiler as C
 from cudnn.gemm.frost.dtypes import DTYPE_FROM_CUDNN as _DTYPE_FROM_CUDNN
 from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
-from cudnn.gemm.frost.graph_analyzer import analyze
+from cudnn.gemm.frost.graph_analyzer import analyze, analyze_with_binding
 from cudnn.gemm.frost.kernel_registry import GraphType, TEMPLATES, select_template
 from cudnn.gemm.frost.tile_config import (
     CATALOG,
@@ -108,6 +108,32 @@ def _build_nvfp4_graph(
         C.set_stride([M * N, 1, M])
     C.set_output(True).set_data_type(cudnn.data_type.HALF)
     return g
+
+
+def _build_one_sided_block_scale_graph(*, fake_a, raw_dt, scaled_dt, sf_dt, block_size):
+    """Dense GEMM with one real block_scale_dequantize and one raw FP8 side."""
+    M = N = 256
+    K = 512
+    sf_k = K // block_size
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.HALF,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1], data_type=raw_dt if fake_a else scaled_dt)
+    B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K], data_type=scaled_dt if fake_a else raw_dt)
+    sf_kw = dict(reordering_type=cudnn.tensor_reordering.F8_128x4)
+    if fake_a:
+        SF = g.tensor(name="SFB", dim=[1, sf_k, N], stride=[sf_k * N, 1, sf_k], data_type=sf_dt, **sf_kw)
+        lhs = A
+        rhs = g.block_scale_dequantize(input=B, descale=SF, block_size=[block_size, 1])
+    else:
+        SF = g.tensor(name="SFA", dim=[1, M, sf_k], stride=[M * sf_k, sf_k, 1], data_type=sf_dt, **sf_kw)
+        lhs = g.block_scale_dequantize(input=A, descale=SF, block_size=[1, block_size])
+        rhs = B
+    C = g.matmul(A=lhs, B=rhs, name="mm")
+    C.set_output(True).set_data_type(cudnn.data_type.HALF)
+    return g, A, B, SF, C
 
 
 def _build_block_scale_reduction_graph(
@@ -286,6 +312,113 @@ def test_block_scale_matmul_gate_accepts_mixed_mxfp8_mxfp4(a_dt, b_dt, monkeypat
     assigned64 = dict(re.findall(r"^(\w+) = (.*)$", src64, re.M))
     assert assigned64["a_smem_dtype"] == C.DTYPE_TO_CUTLASS[_DTYPE_FROM_CUDNN[a_dt]]
     assert assigned64["b_smem_dtype"] == C.DTYPE_TO_CUTLASS[_DTYPE_FROM_CUDNN[b_dt]]
+
+
+@pytest.mark.parametrize("fake_a", [True, False], ids=["raw_fp8_a", "raw_fp8_b"])
+def test_one_sided_dequant_normalizes_to_existing_block_scale_case(fake_a):
+    g, A, B, SF, C_out = _build_one_sided_block_scale_graph(
+        fake_a=fake_a,
+        raw_dt=_DT_E4M3,
+        scaled_dt=_DT_E5M2,
+        sf_dt=_DT_E8M0,
+        block_size=32,
+    )
+    chain, binding = analyze_with_binding(g)
+    bs = chain.block_scale
+    assert bs is not None
+    assert (bs.fake_dequant_a, bs.fake_dequant_b) == ((True, False) if fake_a else (False, True))
+    assert (bs.block_size_a, bs.block_size_b) == ((1, 32), (32, 1))
+    assert (bs.sf_dtype_a, bs.sf_dtype_b) == ("fp8_e8m0", "fp8_e8m0")
+    assert (bs.sfa_reorder, bs.sfb_reorder) == ("F8_128x4", "F8_128x4")
+    assert binding.a_operands == [A]
+    assert binding.b_operands == [B]
+    assert binding.sfa_operands == ([] if fake_a else [SF])
+    assert binding.sfb_operands == ([SF] if fake_a else [])
+    assert binding.outputs == [C_out]
+    C._check_block_scale_supported(chain, "sm100")
+
+
+def test_one_sided_dequant_does_not_expand_the_registry_cases():
+    # Normalizing raw FP8 x NVFP4 creates a full per-side key, but that key is
+    # intentionally absent from _BLOCK_SCALE_CASES.  The fake mark must not
+    # bypass or broaden the existing support table.
+    g, *_ = _build_one_sided_block_scale_graph(
+        fake_a=True,
+        raw_dt=_DT_E4M3,
+        scaled_dt=_DT_FP4,
+        sf_dt=_DT_E4M3,
+        block_size=16,
+    )
+    chain = analyze(g)
+    assert chain.block_scale.fake_dequant_a
+    with pytest.raises(NotImplementedError, match="does not support this configuration"):
+        C._check_block_scale_supported(chain, "sm100")
+
+
+@requires_sm100
+@pytest.mark.parametrize("fake_a", [True, False], ids=["raw_fp8_a", "raw_fp8_b"])
+@pytest.mark.parametrize("scaled_kind", ["mxfp8", "mxfp4"])
+@pytest.mark.parametrize(
+    "config_name",
+    [
+        "CONFIG_sm100_128x128x128_128x128x32_cluster1x1_1ctamma",
+        "CONFIG_sm100_128x128x128_128x128x32_cluster2x1_2ctamma",
+        pytest.param(
+            "CONFIG_sm100_128x128x128_128x128x64_cluster1x1_1ctamma",
+            marks=requires_sm107,
+        ),
+        pytest.param(
+            "CONFIG_sm100_128x128x128_128x128x64_cluster2x1_2ctamma",
+            marks=requires_sm107,
+        ),
+    ],
+)
+def test_one_sided_dequant_e2e(fake_a, scaled_kind, config_name):
+    """The fake side consumes a persistent TMEM unity scale and no SF buffer."""
+    dev = "cuda"
+    torch.manual_seed(0)
+    M = N = 256
+    K = 512
+    block_size = 32
+    raw_dt = cudnn.data_type.FP8_E4M3
+    scaled_dt = cudnn.data_type.FP8_E5M2 if scaled_kind == "mxfp8" else cudnn.data_type.FP4_E2M1
+    g, A, B, SF, C_out = _build_one_sided_block_scale_graph(
+        fake_a=fake_a,
+        raw_dt=raw_dt,
+        scaled_dt=scaled_dt,
+        sf_dt=cudnn.data_type.FP8_E8M0,
+        block_size=block_size,
+    )
+    compiled = _plan(g, config=by_name(config_name))
+    raw_a = (torch.randn(1, M, K, device=dev) * 0.25).to(torch.float8_e4m3fn)
+    raw_b = (torch.randn(1, N, K, device=dev) * 0.25).to(torch.float8_e4m3fn)
+    if scaled_kind == "mxfp8":
+        scaled_a = (torch.randn(1, M, K, device=dev) * 0.25).to(torch.float8_e5m2)
+        scaled_b = (torch.randn(1, N, K, device=dev) * 0.25).to(torch.float8_e5m2)
+        scaled_a_ref = scaled_a.float().view(M, K)
+        scaled_b_ref = scaled_b.float().view(N, K)
+    else:
+        lut = torch.tensor(_E2M1, dtype=torch.float32, device=dev)
+        scaled_a_u8 = torch.randint(0, 256, (1, M, K // 2), dtype=torch.uint8, device=dev)
+        scaled_b_u8 = torch.randint(0, 256, (1, N, K // 2), dtype=torch.uint8, device=dev)
+        scaled_a = scaled_a_u8.view(torch.float4_e2m1fn_x2)
+        scaled_b = scaled_b_u8.view(torch.float4_e2m1fn_x2)
+        scaled_a_ref = _unpack_fp4(scaled_a_u8, lut).view(M, K)
+        scaled_b_ref = _unpack_fp4(scaled_b_u8, lut).view(N, K)
+    a, b = (raw_a, scaled_b) if fake_a else (scaled_a, raw_b)
+    sf_log = _rand_e8m0((N if fake_a else M, K // block_size), dev)
+    sf = _to_blocked(sf_log).view(1, N if fake_a else M, K // block_size)
+    out = torch.empty(1, M, N, dtype=torch.float16, device=dev)
+    compiled({A: a, B: b, SF: sf, C_out: out})
+    torch.cuda.synchronize()
+
+    a_ref = raw_a.float().view(M, K) if fake_a else scaled_a_ref
+    b_ref = scaled_b_ref if fake_a else raw_b.float().view(N, K)
+    if fake_a:
+        b_ref = b_ref * sf_log.float().repeat_interleave(block_size, 1)
+    else:
+        a_ref = a_ref * sf_log.float().repeat_interleave(block_size, 1)
+    torch.testing.assert_close(out.float().view(M, N), a_ref @ b_ref.T, rtol=2e-2, atol=2e-1)
 
 
 def test_block_scale_matmul_gate_rejects_mismatches():

--- a/test/python/gemm/frost/test_block_scale_matmul.py
+++ b/test/python/gemm/frost/test_block_scale_matmul.py
@@ -430,7 +430,7 @@ def test_block_scale_matmul_gate_rejects_mismatches():
     # FP8 data at block 16 — the fp8 rows are block-32 only, on every pipeline.
     with pytest.raises(NotImplementedError, match="does not support"):
         _check_block_scale_supported(analyze(_build_nvfp4_graph(256, 256, 512, block_size=16, sf_dt=_DT_E8M0, a_dt=_DT_E4M3)), "sm100")
-    # Mixed width with a non-E8 scale has no UTCQMMA encoding.
+    # Mixed width with a non-E8 scale has no mixed block-scale MMA encoding.
     with pytest.raises(NotImplementedError, match="does not support"):
         _check_block_scale_supported(
             analyze(
@@ -1613,7 +1613,7 @@ def test_mma_gpu_arch_special_cases(monkeypatch):
     for ok_sm in (100, 110):
         monkeypatch.setattr(C, "_current_arch", lambda v=ok_sm: v)
         assert kr.mma_arch_reject(int8_chain, kr.GraphType.MATMUL, "sm100") is None
-    # Mixed MXFP8/MXFP4 is a baseline SM100 UTCQMMA encoding (K32); Rubin adds
+    # Mixed MXFP8/MXFP4 is a baseline SM100 block-scale MMA encoding (K32); Rubin adds
     # a K64 form, but the MMA type itself needs no narrow arch exception.
     mixed_chain = analyze(_build_nvfp4_graph(256, 256, 512, block_size=32, sf_dt=_DT_E8M0, a_dt=_DT_FP4, b_dt=_DT_E4M3))
     monkeypatch.setattr(C, "_current_arch", lambda: 100)
@@ -2035,7 +2035,7 @@ def test_sm107_block_scale_matmul_numerics(combo, config_name, cta_group):
     ],
 )
 def test_mixed_mxfp8_mxfp4_numerics(fp8_on_a, fp8_torch_dt, fp8_cudnn_dt, fp8_mn_major, config_name):
-    """K32 padded and Rubin K64 native-packed UTCQMMA, both operand orders."""
+    """K32 padded and Rubin K64 native-packed mixed block-scale MMA, both operand orders."""
     dev = "cuda"
     torch.manual_seed(0)
     M = N = 256
@@ -2693,6 +2693,7 @@ def test_sm120_block_scale_registry_wiring():
     # Only the active-GPU gates may refuse -- the family range (sm < 100) or the
     # block-scale MMA special case (100 <= sm < 120) -- never the wiring itself.
     assert reason is None or "runs only on" in reason or "exists only on 120 <= SM < 130" in reason, reason
+
     # fp4 + e8m0 at block 16 is refused by the MMA-type table ...
     chain16 = analyze(_build_nvfp4_graph(256, 256, 512, block_size=16, sf_dt=cudnn.data_type.FP8_E8M0))
     assert "does not support" in mma_arch_reject(chain16, GraphType.BLOCK_SCALE_MATMUL, "sm120")
@@ -2704,6 +2705,37 @@ def test_sm120_block_scale_registry_wiring():
         _build_nvfp4_graph(256, 256, 512, block_size=32, sf_dt=cudnn.data_type.FP8_E8M0, a_dt=cudnn.data_type.FP8_E4M3, a_major="m", b_major="n")
     )
     assert tmpl._extra_reject(chain_mn, cfg) is None
+
+
+@pytest.mark.parametrize("fake_a", [True, False], ids=["raw-a", "raw-b"])
+def test_sm120_rejects_one_sided_mxfp8_without_identity_scale(fake_a):
+    """The normalized MMA key stays generic, but sm120 cannot yet materialize
+    the fake side's all-one scale factors required by a one-sided graph."""
+    from cudnn.gemm.frost.kernel_registry import mma_arch_reject
+
+    g, *_ = _build_one_sided_block_scale_graph(
+        fake_a=fake_a,
+        raw_dt=cudnn.data_type.FP8_E4M3,
+        scaled_dt=cudnn.data_type.FP8_E5M2,
+        sf_dt=cudnn.data_type.FP8_E8M0,
+        block_size=32,
+    )
+    chain = analyze(g)
+
+    # This is still an existing block-scale MMA combination.  sm100 supports
+    # the renderer-level fake-dequant path; sm120 must fail before it indexes a
+    # missing scale-factor descriptor.
+    assert mma_arch_reject(chain, GraphType.BLOCK_SCALE_MATMUL, "sm100") is None
+    reason = mma_arch_reject(chain, GraphType.BLOCK_SCALE_MATMUL, "sm120")
+    assert reason is not None
+    assert "one-sided dequantization" in reason
+    assert "identity handling is not implemented" in reason
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(C, "_current_arch", lambda: 120)
+        assert _sm120_bs_template().accepts(chain, by_name(_SM120_BS_128)) == reason
+        with pytest.raises(NotImplementedError, match="one-sided dequantization"):
+            jit_from_cudnn_graph(g, config=by_name(_SM120_BS_128))
 
 
 def test_sm120_block_scale_config_rules():

--- a/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
@@ -30,9 +30,10 @@ from gemm_test_utils import (
 )
 
 from cudnn.gemm.frost.dtypes import DTYPE_FROM_CUDNN as _DTYPE_FROM_CUDNN
+from cudnn.gemm.frost import compiler as C
 from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
 from cudnn.gemm.frost.fusion_ir import segmented_row_scale_capacity_rows
-from cudnn.gemm.frost.graph_analyzer import analyze
+from cudnn.gemm.frost.graph_analyzer import analyze, analyze_with_binding
 from cudnn.gemm.frost.tile_config import by_name
 from test_matmul import _f8_row_scale_addr
 
@@ -177,6 +178,9 @@ def _build_graph(
     weight_major="k",
     a_dt_override=None,
     b_dt_override=None,
+    dequant_a=True,
+    dequant_b=True,
+    epilogue_relu=False,
 ):
     block_size, default_dt, sf_dt = _COMBOS[combo]
     a_dt = default_dt if a_dt_override is None else a_dt_override
@@ -209,8 +213,8 @@ def _build_graph(
         stride=[1, 1, 1],
         data_type=offset_dt,
     )
-    tok_d = g.block_scale_dequantize(input=tok, descale=SFA, block_size=[1, block_size])
-    w_d = g.block_scale_dequantize(input=w, descale=SFB, block_size=[block_size, 1])
+    tok_d = g.block_scale_dequantize(input=tok, descale=SFA, block_size=[1, block_size]) if dequant_a else tok
+    w_d = g.block_scale_dequantize(input=w, descale=SFB, block_size=[block_size, 1]) if dequant_b else w
     out = g.moe_grouped_matmul(
         tok_d,
         w_d,
@@ -219,6 +223,8 @@ def _build_graph(
         compute_data_type=cudnn.data_type.FLOAT,
         name="moe",
     )
+    if epilogue_relu:
+        out = g.relu(input=out, name="relu")
     if reduction_mode is not None:
         red_kwargs = {}
         if reduction_compute_dt is not None:
@@ -280,6 +286,43 @@ def test_build_graph_keeps_one_sided_dtype_overrides_independent() -> None:
 
     b_mixed = analyze(_build_graph(**shape, b_dt_override=fp8))
     assert (b_mixed.matmul.a_dtype, b_mixed.matmul.b_dtype) == ("fp4_e2m1", "fp8_e4m3")
+
+
+@pytest.mark.parametrize("fake_a", [True, False], ids=["raw_fp8_token", "raw_fp8_weight"])
+def test_analyzer_normalizes_one_sided_moe_dequant(fake_a) -> None:
+    kwargs = dict(E=2, S=256, N=128, K=256, num_groups=2, combo="mxfp4")
+    fp8 = cudnn.data_type.FP8_E4M3
+    if fake_a:
+        kwargs.update(a_dt_override=fp8, dequant_a=False)
+    else:
+        kwargs.update(b_dt_override=fp8, dequant_b=False)
+    chain, binding = analyze_with_binding(_build_graph(**kwargs))
+    bs = chain.block_scale
+    assert chain.has_moe and bs is not None
+    assert (bs.fake_dequant_a, bs.fake_dequant_b) == ((True, False) if fake_a else (False, True))
+    assert (bs.block_size_a, bs.block_size_b) == ((1, 32), (32, 1))
+    assert (bs.sf_dtype_a, bs.sf_dtype_b) == ("fp8_e8m0", "fp8_e8m0")
+    assert len(binding.sfa_operands) == (0 if fake_a else 1)
+    assert len(binding.sfb_operands) == (1 if fake_a else 0)
+    C._check_block_scale_supported(chain, "sm100")
+
+
+def test_one_sided_moe_dequant_does_not_expand_registry_cases() -> None:
+    chain = analyze(
+        _build_graph(
+            E=2,
+            S=256,
+            N=128,
+            K=256,
+            num_groups=2,
+            combo="nvfp4",
+            a_dt_override=cudnn.data_type.FP8_E4M3,
+            dequant_a=False,
+        )
+    )
+    assert chain.block_scale.fake_dequant_a
+    with pytest.raises(NotImplementedError, match="does not support this configuration"):
+        C._check_block_scale_supported(chain, "sm100")
 
 
 def test_analyzer_offset_dtype_int64() -> None:
@@ -724,6 +767,105 @@ def test_e2e_mixed_mxfp8_mxfp4(fp8_on_a, config_name) -> None:
     for i, begin in enumerate(offsets_list):
         end = offsets_list[i + 1] if i + 1 < len(offsets_list) else S
         ref[begin:end] = tok_deq[begin:end] @ w_deq[i % E].T
+    torch.testing.assert_close(output[0], ref.to(torch.bfloat16), atol=2e-1, rtol=2e-2)
+
+
+@requires_sm100
+@pytest.mark.parametrize("fake_a", [True, False], ids=["raw_fp8_token", "raw_fp8_weight"])
+@pytest.mark.parametrize("scaled_kind", ["mxfp8", "mxfp4"])
+@pytest.mark.parametrize("epilogue_relu", [False, True], ids=["direct", "relu"])
+@pytest.mark.parametrize(
+    "config_name",
+    [
+        "CONFIG_sm100_128x128x128_128x128x32_cluster1x1_1ctamma",
+        "CONFIG_sm100_128x128x128_128x128x32_cluster2x1_2ctamma",
+        pytest.param(
+            "CONFIG_sm100_128x128x128_128x128x64_cluster1x1_1ctamma",
+            marks=requires_sm107,
+        ),
+        pytest.param(
+            "CONFIG_sm100_128x128x128_128x128x64_cluster2x1_2ctamma",
+            marks=requires_sm107,
+        ),
+    ],
+)
+def test_e2e_one_sided_dequant(fake_a, scaled_kind, epilogue_relu, config_name) -> None:
+    """MoE fake SF has no runtime tensor or dynamic descriptor workspace."""
+    dev = "cuda"
+    torch.manual_seed(0)
+    E, S, N, K = 2, 256, 128, 256
+    offsets_list = [0, 128]
+    sf_k = K // 32
+    raw_dt = cudnn.data_type.FP8_E4M3
+    scaled_dt = cudnn.data_type.FP8_E5M2 if scaled_kind == "mxfp8" else cudnn.data_type.FP4_E2M1
+
+    raw_tok = (torch.randn(1, S, K, device=dev) * 0.25).to(torch.float8_e4m3fn)
+    raw_w = (torch.randn(E, N, K, device=dev) * 0.25).to(torch.float8_e4m3fn)
+    if scaled_kind == "mxfp8":
+        scaled_tok = (torch.randn(1, S, K, device=dev) * 0.25).to(torch.float8_e5m2)
+        scaled_w = (torch.randn(E, N, K, device=dev) * 0.25).to(torch.float8_e5m2)
+        scaled_tok_ref = scaled_tok.float().view(S, K)
+        scaled_w_ref = scaled_w.float().view(E, N, K)
+    else:
+        lut = torch.tensor(_E2M1, dtype=torch.float32, device=dev)
+        tok_u8 = torch.randint(0, 256, (1, S, K // 2), dtype=torch.uint8, device=dev)
+        w_u8 = torch.randint(0, 256, (E, N, K // 2), dtype=torch.uint8, device=dev)
+        scaled_tok = tok_u8.view(torch.float4_e2m1fn_x2)
+        scaled_w = w_u8.view(torch.float4_e2m1fn_x2)
+        scaled_tok_ref = _unpack_fp4(tok_u8, lut).view(S, K)
+        scaled_w_ref = _unpack_fp4(w_u8, lut).view(E, N, K)
+
+    tok_rt, w_rt = (raw_tok, scaled_w) if fake_a else (scaled_tok, raw_w)
+    tok_ref = raw_tok.float().view(S, K) if fake_a else scaled_tok_ref
+    w_ref = scaled_w_ref if fake_a else raw_w.float().view(E, N, K)
+    g = _build_graph(
+        E,
+        S,
+        N,
+        K,
+        len(offsets_list),
+        combo="mxfp4",
+        a_dt_override=raw_dt if fake_a else scaled_dt,
+        b_dt_override=scaled_dt if fake_a else raw_dt,
+        dequant_a=not fake_a,
+        dequant_b=fake_a,
+        epilogue_relu=epilogue_relu,
+    )
+    compiled = _plan(g, config=by_name(config_name))
+    bs = compiled.chain.block_scale
+    assert (bs.fake_dequant_a, bs.fake_dequant_b) == (fake_a, not fake_a)
+    assert compiled._compiled._desc_slots_per_cta == (compiled.chain.num_a_operands + len(compiled.binding.sfa_operands) + len(compiled._compiled.tma_slots))
+
+    sf_log = _rand_e8m0(((E, N, sf_k) if fake_a else (S, sf_k)), dev)
+    offsets = torch.tensor(offsets_list, dtype=torch.int32, device=dev)
+    output = torch.zeros(1, S, N, dtype=torch.bfloat16, device=dev)
+    bd = compiled.binding
+    variant_pack = {
+        bd.a_operands[0]: tok_rt,
+        bd.b_operands[0]: w_rt,
+        bd.first_token_offset: offsets,
+        bd.outputs[0]: output,
+    }
+    if fake_a:
+        sfb_blk = torch.cat([_to_blocked(sf_log[e]) for e in range(E)]).view(E, sf_k, N)
+        variant_pack[bd.sfb_operands[0]] = sfb_blk
+    else:
+        sfa_parts = [_to_blocked(sf_log[b : offsets_list[i + 1] if i + 1 < len(offsets_list) else S]) for i, b in enumerate(offsets_list)]
+        sfa_blk = _with_static_segmented_capacity(torch.cat(sfa_parts), S, len(offsets_list), sf_k)
+        variant_pack[bd.sfa_operands[0]] = sfa_blk
+    compiled(variant_pack)
+    torch.cuda.synchronize()
+
+    if fake_a:
+        w_ref = w_ref * sf_log.float().repeat_interleave(32, 2)
+    else:
+        tok_ref = tok_ref * sf_log.float().repeat_interleave(32, 1)
+    ref = torch.zeros(S, N, dtype=torch.float32, device=dev)
+    for i, begin in enumerate(offsets_list):
+        end = offsets_list[i + 1] if i + 1 < len(offsets_list) else S
+        ref[begin:end] = tok_ref[begin:end] @ w_ref[i % E].T
+    if epilogue_relu:
+        ref = torch.relu(ref)
     torch.testing.assert_close(output[0], ref.to(torch.bfloat16), atol=2e-1, rtol=2e-2)
 
 

--- a/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
@@ -717,7 +717,7 @@ def test_e2e_mx_combos(combo) -> None:
     ],
 )
 def test_e2e_mixed_mxfp8_mxfp4(fp8_on_a, config_name) -> None:
-    """Grouped K32 padded and Rubin K64 native-packed mixed UTCQMMA."""
+    """Grouped K32 padded and Rubin K64 native-packed mixed block-scale MMA."""
     dev = "cuda"
     torch.manual_seed(0)
     E, S, N, K = 2, 256, 128, 256


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches (see [root AGENTS.md § Reviewing a PR](https://github.com/NVIDIA/cudnn-frontend/blob/develop/AGENTS.md#reviewing-a-pr-human-or-agent)) and my changes comply, or I explain the exception below.
- [x] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

Enable fp8 global scale + mxfp8/fp4 block scale mixed gemm

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for one-sided block-scale dequantization when combining raw FP8 operands with genuinely dequantized operands.
  * Expanded MXFP8 and MXFP4 support across GEMM and grouped MoE operations, including different operand positions and configurations.
  * Added support for optional ReLU epilogues in applicable MoE operations.

* **Bug Fixes**
  * Improved scale handling, workspace allocation, and descriptor management for mixed dequantization scenarios.
  * Added validation for unsupported one-sided dequantization configurations on SM120.
  * Expanded numerical correctness and operand-binding validation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->