### PR TITLE
frost(sdpa): SM107 honours SCHED_LPT, and STAGES_KV is a knob again

### DIFF
--- a/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
+++ b/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
@@ -332,15 +332,44 @@ PackGQA and THD families this line declines per-feature, not per-shape.
 kernel's KV loop bound is a floor division, so an un-synthesized ragged `S_kv`
 would silently drop the tail tile.
 
-**Scheduler policy — NATURAL only on every Rubin row.** `SCHED_LPT_L2` was
-dropped first (the ported decode sites never thread `qh_per_kh` / `seqlen_kv`,
-so `_common_blackwell._decode_initial` raises); plain `SCHED_LPT` followed on
-2026-09-08 once a heuristics fallback fix let a causal graph actually reach it —
-it is silently WRONG on the ported kernels (causal d512 FP8 → NaN, masked d128
-MXFP8 → max|O-ref| ≈ 1.9). A knob is honored or the engine is ineligible. The
-SHIPPED d128 FP8 kernel does honor both and loses them here too, because
-`sched_policies` is row-wide; recovering that needs a per-shape domain
-(`sched_policies_by_d_shape`, mirroring `cgas_by_d_shape`).
+**Scheduler policy — `SCHED_LPT` now served on the f16 (256, 256) Rubin
+flavor; NATURAL elsewhere.**
+
+The earlier reading — "the ported decode does not honor SCHED_LPT" — had the
+symptom right and the cause wrong. Every SM100 kernel calls
+`make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units=True)`; the SM107 port omitted
+that argument on 9 of 11 flavors. Without it the LPT linearization walks a row
+range `CTA_MMA`× too large, no tile is ever claimed and the kernel writes
+**nothing** (cosine 0.0000, dense and causal). The two flavors that kept it,
+d128 FP8 and d192 FP8, are exactly the ones previously described as working.
+
+The argument is restored on every 2-CTA SM107 flavor. It is a **no-op under
+`SCHED_NATURAL`** (that decode branch never reads `q_tiles`), so the shipped
+path is unchanged.
+
+Only what is validated is advertised, via the new per-shape
+`sched_policies_by_d_shape` (mirroring `cgas_by_d_shape`): the f16 row serves
+`SCHED_LPT` at **(256, 256)** only. Validation: cos 1.0000 at n_kv 2/3/4/8,
+dense and causal. Measured causal SOL on Rubin at S = 4096/8192/32768:
+53.0/71.1/76.7 % under NATURAL → **62.6/79.3/77.5 %** under LPT
+(+18.2/+11.6/+1.1 %), recovering 40/51/29 % of the causal-vs-dense gap; dense is
+neutral. The decay with S is the signature of scheduler imbalance.
+
+Still declined, and why: d128/d512 f16 and every FP8/MXFP8 flavor are
+**unvalidated** under LPT rather than known-broken (d512 is cga4×1 role-split,
+a different scheduler shape). `SCHED_LPT_L2` is declined by **every** flavor —
+its decode needs `qh_per_kh` and `seqlen_kv`, which the SM107 call sites do not
+pass, so it raises rather than miscomputes. Both are follow-ups.
+
+**`STAGES_KV` on the d256 flavors is 2..4, not pinned to 2.** The old pin blamed
+a body that conflated the KV ring index with the 2-slot `S_acc` parity; the body
+in fact derives parity from the absolute `kv_loop & 1` and is depth-agnostic.
+The real constraint was the >256 KiB tcgen05 descriptor wrap: at depth 4 the last
+two V stages start at 256/288 KiB and a version-0 descriptor truncates
+`start_address` to 14 bits. `prefill_d256_f16.DESC_VERSION` is now **derived**
+from the layout, so every depth in range is correct by construction (cos 1.0000
+at 2/3/4, dense and causal). Depth is perf-neutral — dense SOL moves 0.3 points
+across all three — so the default stays 2.
 
 **Coverage.** The Rubin cells above are exercised by the SM100 suites running on
 cc 10.7 with an arch-aware engine pin — `test_sdpa_fwd_dsl_sm100.py` (f16/bf16),

--- a/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
+++ b/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
@@ -356,7 +356,7 @@ dense and causal. Measured causal SOL on Rubin at S = 4096/8192/32768:
 neutral. The decay with S is the signature of scheduler imbalance.
 
 Still declined, and why: d128/d512 f16 and every FP8/MXFP8 flavor are
-**unvalidated** under LPT rather than known-broken (d512 is cga4×1 role-split,
+**unvalidated** under LPT rather than known-incorrect (d512 is cga4×1 role-split,
 a different scheduler shape). `SCHED_LPT_L2` is declined by **every** flavor —
 its decode needs `qh_per_kh` and `seqlen_kv`, which the SM107 call sites do not
 pass, so it raises rather than miscomputes. Both are follow-ups.

--- a/python/cudnn/sdpa/fwd/config_sm107.py
+++ b/python/cudnn/sdpa/fwd/config_sm107.py
@@ -740,26 +740,30 @@ def _make_cfg_d256_family(params: TemplateParams, *, flavor: str, mxfp8: bool):
     b, b_o = bpe(params.dtype_qkv), bpe(dtype_o)
     tile_k = tile_o = 256
     tile_n = 128
-    # STAGES_KV is a BODY CONSTRAINT here, not a tuning knob -- pin it to 2.
+    # STAGES_KV is a TUNING KNOB again (2..4), and the note that said otherwise
+    # was WRONG about why.
     #
-    # This pipeline runs a Q.K(i+1) -> S.V(i) lookahead against TWO parity
-    # S_acc TMEM slots, and the body conflates the KV ring index with that
-    # parity.  At depth 2 the two coincide and everything is consistent; at
-    # depth 4 they diverge and the MMA consumes the wrong K/V tile from the
-    # third KV iteration onward -- the first time parity slot 0 is REUSED.
+    # It used to be pinned to 2, blaming a body that "conflates the KV ring
+    # index with the 2-slot S_acc parity". That diagnosis does not survive
+    # reading the body: every parity site derives parity from the ABSOLUTE
+    # `kv_loop & 1`, and K/V ride separate PipelineStates advanced in lockstep
+    # with the TMA warp, so the body is depth-agnostic.
     #
-    # Measured on Rubin (d256 FP8 e4m3, cos vs an fp32 reference), n_kv =
-    # 2/3/4/8:  depth 4 -> 0.9996 / 0.6493 / 0.5448 / --  ;
-    #           depth 2 -> 0.9996 / 0.9996 / 0.9996 / 0.9997.
-    # The f16 sibling breaks identically at depth 4, which is how this was
-    # caught: it had been green at depth 2 and regressed when the SM107 config
-    # first adopted the pre-upstream value of 4 wholesale.
+    # The real cause was the >256 KiB tcgen05 descriptor wrap. Buffers are laid
+    # out sQO | sK[stages] | sV[stages]; at depth 4 the last two V stages start
+    # at 256 KiB and 288 KiB, and a VERSION-0 descriptor truncates
+    # `start_address` to 14 bits, so those stages alias the bottom of SMEM. The
+    # answer goes wrong from the KV iteration that first touches a wrapped
+    # stage -- which is why it looked like a ring bug and why it only shows up
+    # at S_kv > 256.
     #
-    # So do NOT "restore" 4 to match the pre-upstream config or to deepen the
-    # ring for latency -- that is a silent-wrong-answer change, and it only
-    # shows up at S_kv > 256.  Deepening it needs the body's parity indexing
-    # decoupled from the ring index first.
-    stages_kv = 2
+    # Measured on Rubin, d256 f16, cos vs an fp32 reference, n_kv = 2/3/4/8:
+    #   depth 4, desc v0:  1.0000 / 0.6806 / 0.4980 / 0.4640   <- the old data
+    #   depth 4, desc v1:  1.0000 / 1.0000 / 1.0000 / 1.0000   dense AND causal
+    #   depth 3, desc v0:  1.0000 / 1.0000 / 1.0000 / 1.0000   (stays under)
+    # `prefill_d256_f16.DESC_VERSION` is now DERIVED from the layout, so any
+    # depth that fits SMEM is correct by construction. Do not re-literal it.
+    stages_kv = params.stages_kv if getattr(params, "stages_kv", None) else 2
     mask_flags, win_l, win_r, bottom_right, has_sink = _band_fields(params)
     arrivers = _d256_read_tile_arrivers(cta_mma)
 
@@ -828,10 +832,10 @@ def _make_cfg_d256_family(params: TemplateParams, *, flavor: str, mxfp8: bool):
             (cfg.TILES_Q == 1, f"{flavor}: the d256 pipeline mandates TILES_Q == 1"),
             (cfg.SOFTMAX_WARPGROUPS == 1, f"{flavor}: the d256 pipeline mandates SOFTMAX_WARPGROUPS == 1"),
             (
-                cfg.STAGES_KV == 2,
-                f"{flavor}: the d256 body ties its KV ring index to the 2-slot S_acc parity, so "
-                f"STAGES_KV must be 2 (got {cfg.STAGES_KV}); a deeper ring returns WRONG RESULTS "
-                f"from the third KV iteration on, silently, and only at S_kv > 256",
+                2 <= cfg.STAGES_KV <= 4,
+                f"{flavor}: STAGES_KV must be in 2..4 (got {cfg.STAGES_KV}); the upper bound is the "
+                f"{SMEM_USABLE_BYTES // 1024} KiB Rubin carveout, and the kernel derives its tcgen05 "
+                f"descriptor version from the resulting layout so every depth in range is correct",
             ),
         ]
     )

--- a/python/cudnn/sdpa/fwd/config_sm107.py
+++ b/python/cudnn/sdpa/fwd/config_sm107.py
@@ -763,7 +763,11 @@ def _make_cfg_d256_family(params: TemplateParams, *, flavor: str, mxfp8: bool):
     #   depth 3, desc v0:  1.0000 / 1.0000 / 1.0000 / 1.0000   (stays under)
     # `prefill_d256_f16.DESC_VERSION` is now DERIVED from the layout, so any
     # depth that fits SMEM is correct by construction. Do not re-literal it.
-    stages_kv = params.stages_kv if getattr(params, "stages_kv", None) else 2
+    # `is not None`, NOT a truth test: a truthiness check maps an explicit
+    # stages_kv=0 onto the default 2, which is a knob SUBSTITUTION -- the one
+    # thing the engine contract forbids (honored or ineligible). Out-of-domain
+    # values must reach the 2..4 check below and raise there.
+    stages_kv = params.stages_kv if getattr(params, "stages_kv", None) is not None else 2
     mask_flags, win_l, win_r, bottom_right, has_sink = _band_fields(params)
     arrivers = _d256_read_tile_arrivers(cta_mma)
 

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -945,7 +945,7 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
             # flavors that have been validated under it.
             #
             # The ROOT CAUSE of "the ported kernels do not honor LPT" was a
-            # dropped argument, not a broken decode: every SM100 kernel calls
+            # dropped argument, not an incorrect decode: every SM100 kernel calls
             # `make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units=True)` and the
             # SM107 port omitted it on 9 of 11 flavors. Without it the LPT
             # linearization walks a row range CTA_MMA times too large, no tile

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -256,6 +256,12 @@ class Capabilities:
     # Shape-specific CGA domains for rows that lower several native flavors.
     # ``cgas`` remains the default. A split-specific entry further narrows the
     # domain for split-KV plans without changing the unsplit public domain.
+    # Per-d-shape scheduler domain, mirroring cgas_by_d_shape. Needed because
+    # sched_policies is row-wide while LPT support is per-KERNEL: the SM107 port
+    # dropped `lpt_q_tiles_in_cga_units=True` on most flavors, so a row-wide
+    # claim would advertise LPT for kernels that write nothing under it.
+    # An entry here OVERRIDES sched_policies for that flavor.
+    sched_policies_by_d_shape: tuple[tuple[tuple[int, int], frozenset[int]], ...] = ()
     cgas_by_d_shape: tuple[tuple[tuple[int, int], frozenset[int]], ...] = ()
     split_cgas_by_d_shape: tuple[tuple[tuple[int, int], frozenset[int]], ...] = ()
     pack_gqas: frozenset[bool] = frozenset({False})
@@ -315,6 +321,21 @@ def _selected_d_shape(capabilities: Capabilities, facts: "ga.SdpaGraphFacts") ->
     return min(covering, key=lambda shape: (shape[0], shape[1])) if covering else None
 
 
+def effective_sched_policies(capabilities: Capabilities, facts: "ga.SdpaGraphFacts") -> frozenset[int]:
+    """Scheduler domain of the native flavor the lowering will pick.
+
+    Row-wide `sched_policies` is the floor; a `sched_policies_by_d_shape` entry
+    for the selected flavor replaces it. That is what lets one Rubin row serve a
+    d256 kernel that honours LPT next to flavors that do not.
+    """
+    selected = _selected_d_shape(capabilities, facts)
+    if selected is not None:
+        for shape, shape_domain in capabilities.sched_policies_by_d_shape:
+            if shape == selected:
+                return shape_domain
+    return capabilities.sched_policies
+
+
 def effective_cgas(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", split_kv: Optional[int] = None) -> frozenset[int]:
     """CGA domain of the native flavor and split leg selected by the graph."""
 
@@ -358,7 +379,7 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
         if not isinstance(knobs, SdpaFwdKnobs):
             return f"knob request is a {type(knobs).__name__}, not SdpaFwdKnobs — wrong operation's vocabulary"
         for value, domain, label in (
-            (knobs.sched_policy, capabilities.sched_policies, "sched_policy"),
+            (knobs.sched_policy, effective_sched_policies(capabilities, facts), "sched_policy"),
             (knobs.tile_m, capabilities.tile_ms, "tile_m"),
             (knobs.tile_n, capabilities.tile_ns, "tile_n"),
             (knobs.cga, effective_cgas(capabilities, facts, knobs.split_kv), "cga"),
@@ -702,12 +723,36 @@ def _sm107_spec() -> EngineSpec:
             thd=True,
             thd_d_shapes=SM107_F16_THD_SHAPES,
             cu_seq_len=True,
-            # NATURAL ONLY -- same finding as the FP8 and MXFP8 Rubin rows:
-            # every kernel this row serves is a PORT, and the ported decode
-            # sites do not honor SCHED_LPT (measured on the d512 FP8 and d128
-            # MXFP8 siblings; no SM107 f16 numerics suite exists yet to measure
-            # this one, so the row claims the conservative domain).
+            # NATURAL row-wide; LPT advertised PER D-SHAPE for what is validated.
+            #
+            # The old note here said the ported decode "does not honor
+            # SCHED_LPT". The cause was narrower than that: every SM100 kernel
+            # calls `make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units=True)` and
+            # the SM107 port omitted the argument on 9 of 11 flavors. Without
+            # it the LPT linearization walks a row range CTA_MMA times too
+            # large, no tile is ever claimed, and the kernel writes NOTHING --
+            # cosine 0.0000, which reads like a dead kernel rather than a
+            # scheduling bug. The two flavors that kept it (d128 FP8, d192 FP8)
+            # are exactly the ones previously described as working.
+            #
+            # Restored on every 2-CTA SM107 flavor. It is a NO-OP under
+            # SCHED_NATURAL -- that decode branch never reads q_tiles -- so the
+            # shipped path is unchanged.
+            #
+            # Validated on d256 f16: cos 1.0000 at n_kv 2/3/4/8, dense AND
+            # causal. Measured causal SOL on Rubin at S=4096/8192/32768:
+            # 53.0/71.1/76.7% under NATURAL -> 62.6/79.3/77.5% under LPT
+            # (+18.2/+11.6/+1.1%), recovering 40%/51%/29% of the causal-vs-dense
+            # gap; dense itself is neutral. The decay with S is the signature of
+            # scheduler imbalance, which is what LPT exists to fix.
+            #
+            # Only (256, 256) is claimed: d128 and d512 are unvalidated under
+            # LPT here, and d512 is cga4x1 role-split with a different scheduler
+            # shape. SCHED_LPT_L2 is claimed by NO flavor -- its decode needs
+            # `qh_per_kh` and `seqlen_kv`, which the SM107 call sites do not
+            # pass, so it raises rather than miscomputes. Both are follow-ups.
             sched_policies=frozenset({SCHED_NATURAL}),
+            sched_policies_by_d_shape=(((256, 256), frozenset({SCHED_NATURAL, SCHED_LPT})),),
             tile_ms=frozenset({128}),
             tile_ns=frozenset({128}),
             cgas=frozenset({2}),
@@ -896,21 +941,42 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
             # this domain (heuristics.py:329), so narrowing means those graphs
             # get LPT instead of going unserved: a scheduling trade, not a
             # correctness one.  Re-widen once the args are threaded everywhere.
-            # Rubin: NATURAL ONLY.  SCHED_LPT is not honored by the PORTED
-            # SM107 kernels (d256 / d512 here) -- a causal d512 FP8 graph under
-            # LPT returns NaN, and all 12 masked d512 cases go green the moment
-            # the row stops claiming it.  Session 6 had already dropped
-            # SCHED_LPT_L2 for the same reason; LPT survived only because
-            # heuristics could not REACH it (the causal primary is LPT_L2, and
-            # the old out-of-domain fallback dropped to NATURAL -- fixed in
-            # heuristics._sched_points, which is what surfaced this).
-            # KNOWN COST: the SHIPPED d128 FP8 kernel *does* honor LPT and loses
-            # that plan here, because sched_policies is row-wide.  Recovering it
-            # needs a per-d-shape domain (a `sched_policies_by_d_shape` mirroring
-            # `cgas_by_d_shape`), or the ported decode sites threaded and
-            # validated.  Correctness first: a knob is honored or the engine is
-            # ineligible, and a user could already request LPT explicitly.
+            # Rubin: NATURAL row-wide, with LPT advertised per-d-shape for the
+            # flavors that have been validated under it.
+            #
+            # The ROOT CAUSE of "the ported kernels do not honor LPT" was a
+            # dropped argument, not a broken decode: every SM100 kernel calls
+            # `make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units=True)` and the
+            # SM107 port omitted it on 9 of 11 flavors. Without it the LPT
+            # linearization walks a row range CTA_MMA times too large, no tile
+            # is claimed, and the kernel writes NOTHING (cosine 0.0000). The two
+            # flavors that kept it -- d128 FP8 and d192 FP8 -- are exactly the
+            # ones this comment used to single out as working.
+            #
+            # Restored on every 2-CTA SM107 flavor; it is a no-op under
+            # SCHED_NATURAL, so the shipped path is unchanged (SM107 suite 56
+            # passed, block suite 89 passed). Validated under LPT on d256 f16:
+            # cos 1.0000 at n_kv 2/3/4/8, dense AND causal. Measured causal SOL
+            # on Rubin, S=4096/8192/32768: 53.0/71.1/76.7% NATURAL ->
+            # 62.6/79.3/77.5% LPT (+18.2/+11.6/+1.1%); dense is neutral.
+            #
+            # d512 (cga4x1 role-split) is deliberately untouched: different
+            # scheduler shape, and the old NaN report there is unexplained.
+            #
+            # SCHED_LPT_L2 stays off on Rubin for a DIFFERENT and still-open
+            # reason: its decode needs `qh_per_kh` and `seqlen_kv` at every call
+            # site and the SM107 kernels pass neither, so it raises rather than
+            # miscomputes. Threading those two arguments is the follow-up.
+            #
+            # The "KNOWN COST" this note used to carry -- that the d128 FP8
+            # kernel honours LPT but loses the plan because sched_policies is
+            # row-wide -- is what `sched_policies_by_d_shape` below now fixes.
+            # d128 FP8 is not listed yet only because it is unvalidated here.
             sched_policies=(frozenset({SCHED_NATURAL}) if rubin_row else frozenset({SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2})),
+            # NOT claimed here. `lpt_q_tiles_in_cga_units=True` is restored on the
+            # SM107 FP8 kernels too, so LPT should work, but it has not been
+            # validated on them -- and a row claims only what it can demonstrate.
+            # The f16 row (`_sm107_spec`) carries the validated (256, 256) entry.
             tile_ms=frozenset({128}),
             tile_ns=frozenset({128}),
             cgas=frozenset({2}),

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d128_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d128_f16.py
@@ -207,7 +207,14 @@ vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
 CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
 
 
-_sdpa_h = make_sdpa_helpers(CFG)
+# lpt_q_tiles_in_cga_units=True is REQUIRED under any non-NATURAL scheduler:
+# the LPT linearization needs q_tiles in CGA units (n_q_supers // CTA_MMA).
+# Without it the decode walks a row range CTA_MMA times too large, no tile is
+# ever claimed, and the kernel writes NOTHING -- cosine 0.0000 at every shape.
+# It is a NO-OP under SCHED_NATURAL (that decode branch never reads q_tiles),
+# so restoring it cannot change today's shipped path. Every SM100 kernel passes
+# it; the SM107 port dropped it on most flavors. Verified on d256 f16.
+_sdpa_h = make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units=True)
 _decode_initial = _sdpa_h.decode_initial
 _decode_payload = _sdpa_h.decode_payload
 _bounds_for_tile = _sdpa_h.bounds_for_tile

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d128_mxfp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d128_mxfp8.py
@@ -211,7 +211,14 @@ vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
 CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
 
 
-_sdpa_h = make_sdpa_helpers(CFG)
+# lpt_q_tiles_in_cga_units=True is REQUIRED under any non-NATURAL scheduler:
+# the LPT linearization needs q_tiles in CGA units (n_q_supers // CTA_MMA).
+# Without it the decode walks a row range CTA_MMA times too large, no tile is
+# ever claimed, and the kernel writes NOTHING -- cosine 0.0000 at every shape.
+# It is a NO-OP under SCHED_NATURAL (that decode branch never reads q_tiles),
+# so restoring it cannot change today's shipped path. Every SM100 kernel passes
+# it; the SM107 port dropped it on most flavors. Verified on d256 f16.
+_sdpa_h = make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units=True)
 _decode_initial = _sdpa_h.decode_initial
 _decode_payload = _sdpa_h.decode_payload
 _bounds_for_tile = _sdpa_h.bounds_for_tile

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d192_d128_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d192_d128_f16.py
@@ -211,7 +211,14 @@ vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
 CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
 
 
-_sdpa_h = make_sdpa_helpers(CFG)
+# lpt_q_tiles_in_cga_units=True is REQUIRED under any non-NATURAL scheduler:
+# the LPT linearization needs q_tiles in CGA units (n_q_supers // CTA_MMA).
+# Without it the decode walks a row range CTA_MMA times too large, no tile is
+# ever claimed, and the kernel writes NOTHING -- cosine 0.0000 at every shape.
+# It is a NO-OP under SCHED_NATURAL (that decode branch never reads q_tiles),
+# so restoring it cannot change today's shipped path. Every SM100 kernel passes
+# it; the SM107 port dropped it on most flavors. Verified on d256 f16.
+_sdpa_h = make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units=True)
 _decode_initial = _sdpa_h.decode_initial
 _decode_payload = _sdpa_h.decode_payload
 _bounds_for_tile = _sdpa_h.bounds_for_tile

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d192_d128_mxfp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d192_d128_mxfp8.py
@@ -255,7 +255,14 @@ vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
 CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
 
 
-_sdpa_h = make_sdpa_helpers(CFG)
+# lpt_q_tiles_in_cga_units=True is REQUIRED under any non-NATURAL scheduler:
+# the LPT linearization needs q_tiles in CGA units (n_q_supers // CTA_MMA).
+# Without it the decode walks a row range CTA_MMA times too large, no tile is
+# ever claimed, and the kernel writes NOTHING -- cosine 0.0000 at every shape.
+# It is a NO-OP under SCHED_NATURAL (that decode branch never reads q_tiles),
+# so restoring it cannot change today's shipped path. Every SM100 kernel passes
+# it; the SM107 port dropped it on most flavors. Verified on d256 f16.
+_sdpa_h = make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units=True)
 _decode_initial = _sdpa_h.decode_initial
 _decode_payload = _sdpa_h.decode_payload
 _bounds_for_tile = _sdpa_h.bounds_for_tile

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d256_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d256_f16.py
@@ -50,14 +50,41 @@ CFG, _TMA = make_cfg_d256(PARAMS)
 # per-tile literal.  A version-0 descriptor's ``start_address`` is 14 bits = a
 # 256 KiB window; Rubin raises the per-CTA SMEM cap to 327 KiB, so an operand
 # buffer at or above 256 KiB wraps to offset 0 and the MMA multiplies whatever
-# sits at the bottom of SMEM.  This flavor's buffers all stay below the line.
+# sits at the bottom of SMEM.
+#
+# DERIVED, not a literal, because STAGES_KV moves the last operand's offset:
+# the buffers are laid out sQO | sK[stages] | sV[stages], so the LAST V stage
+# starts at (qBufferElems + stages*kBufferElems + (stages-1)*vBufferElems)*BPE
+# and crosses 256 KiB at STAGES_KV=4.  A hardcoded 0 there is a SILENT wrong
+# answer, and this was shipped: `config_sm107` pinned STAGES_KV to 2 and blamed
+# a ring/parity conflation in the body, but the body derives parity from the
+# absolute `kv_loop & 1` and is depth-agnostic.  Measured on Rubin (cos vs an
+# fp32 reference, n_kv = 2/3/4/8): depth 4 with v0 gives 1.0000/0.6806/0.4980/
+# 0.4640 -- wrong exactly from the KV iteration that first touches the wrapped
+# V stage -- and depth 4 with v1 gives 1.0000 across the board, dense AND
+# causal.  Depth 2 and 3 stay under the line and are correct at v0.
 #
 # Do NOT re-literal this at a call site: the d512 MXFP8 sibling shipped NaN on
 # 100% of cells because its scale-factor tiles were declared UNDER a comment
 # claiming "every operand tile here carries desc_version=1" -- without the
 # kwarg.  A single constant makes that class of drift impossible, and
 # test_sm107_descriptor_version_matches_the_smem_budget asserts it.
-DESC_VERSION: int = 0
+_TCGEN05_V0_ADDR_LIMIT = 262144  # 14-bit start_address window
+
+
+def _needs_desc_v1(cfg) -> bool:
+    """True when any MMA-operand buffer starts at or past the v0 address limit.
+
+    Uses the START of the last V stage, not the total: a buffer that merely
+    ENDS past the line is fine, it is the start address that gets truncated.
+    """
+    last_v_start = (
+        cfg.TILE_M * cfg.TILE_K + cfg.STAGES_KV * (cfg.TILE_N * cfg.TILE_K // cfg.CTA_MMA) + (cfg.STAGES_KV - 1) * (cfg.TILE_O * cfg.TILE_N // cfg.CTA_MMA)
+    ) * cfg.BPE
+    return last_v_start >= _TCGEN05_V0_ADDR_LIMIT
+
+
+DESC_VERSION: int = 1 if _needs_desc_v1(CFG) else 0
 Cfg = type(CFG)
 TMA_QK_ITERS = _TMA.QK_ITERS
 TMA_VO_ITERS = _TMA.VO_ITERS
@@ -162,7 +189,20 @@ N_O_CHUNKS = (CFG.TILE_O * CFG.BPE_O + 127) // 128
 
 CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
 
-_sdpa_h = make_sdpa_helpers(CFG)
+# lpt_q_tiles_in_cga_units=True is REQUIRED, not optional: under a non-NATURAL
+# policy the LPT linearization needs q_tiles in CGA units, i.e. n_q_supers //
+# CTA_MMA. Without it the decode walks a row range CTA_MMA times too large, no
+# valid tile is ever claimed, and the kernel writes NOTHING -- cosine 0.0000 at
+# every shape, dense and causal, which reads like a dead kernel rather than a
+# scheduling bug.
+#
+# Every SM100 kernel passes it. The SM107 port dropped it on most flavors, and
+# `sdpa/fwd/engines.py` then narrowed the whole Rubin row to
+# sched_policies={SCHED_NATURAL} and blamed the ported decode -- while noting
+# that the d128 FP8 kernel "DOES honor LPT" and loses the plan anyway. That
+# kernel is one of the only two SM107 flavors that kept this argument, which is
+# the actual explanation.
+_sdpa_h = make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units=True)
 _decode_initial = _sdpa_h.decode_initial
 _decode_payload = _sdpa_h.decode_payload
 _bounds_for_tile = _sdpa_h.bounds_for_tile

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d256_fp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d256_fp8.py
@@ -167,7 +167,14 @@ N_O_CHUNKS = (CFG.TILE_O * CFG.BPE_O + 127) // 128
 
 CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
 
-_sdpa_h = make_sdpa_helpers(CFG)
+# lpt_q_tiles_in_cga_units=True is REQUIRED under any non-NATURAL scheduler:
+# the LPT linearization needs q_tiles in CGA units (n_q_supers // CTA_MMA).
+# Without it the decode walks a row range CTA_MMA times too large, no tile is
+# ever claimed, and the kernel writes NOTHING -- cosine 0.0000 at every shape.
+# It is a NO-OP under SCHED_NATURAL (that decode branch never reads q_tiles),
+# so restoring it cannot change today's shipped path. Every SM100 kernel passes
+# it; the SM107 port dropped it on most flavors. Verified on d256 f16.
+_sdpa_h = make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units=True)
 _decode_initial = _sdpa_h.decode_initial
 _decode_payload = _sdpa_h.decode_payload
 _bounds_for_tile = _sdpa_h.bounds_for_tile

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d256_mxfp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d256_mxfp8.py
@@ -258,7 +258,14 @@ N_O_CHUNKS = (CFG.TILE_O * CFG.BPE_O + 127) // 128
 
 CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
 
-_sdpa_h = make_sdpa_helpers(CFG)
+# lpt_q_tiles_in_cga_units=True is REQUIRED under any non-NATURAL scheduler:
+# the LPT linearization needs q_tiles in CGA units (n_q_supers // CTA_MMA).
+# Without it the decode walks a row range CTA_MMA times too large, no tile is
+# ever claimed, and the kernel writes NOTHING -- cosine 0.0000 at every shape.
+# It is a NO-OP under SCHED_NATURAL (that decode branch never reads q_tiles),
+# so restoring it cannot change today's shipped path. Every SM100 kernel passes
+# it; the SM107 port dropped it on most flavors. Verified on d256 f16.
+_sdpa_h = make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units=True)
 _decode_initial = _sdpa_h.decode_initial
 _decode_payload = _sdpa_h.decode_payload
 _bounds_for_tile = _sdpa_h.bounds_for_tile

--- a/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm107.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm107.py
@@ -619,3 +619,45 @@ def test_sm107_d256_desc_version_follows_the_stages_kv_layout(depth):
     cfg = replace(kern.CFG, STAGES_KV=depth)
     want = 1 if depth >= 4 else 0
     assert int(kern._needs_desc_v1(cfg)) == want, f"STAGES_KV={depth} must select desc_version {want}"
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("bad_depth", [0, 1, 5])
+def test_sm107_d256_rejects_an_out_of_domain_stages_kv(bad_depth):
+    """An out-of-domain STAGES_KV must RAISE, never be silently defaulted.
+
+    `make_cfg_d256` reads `stages_kv` as an OPTIONAL attribute, because the
+    shared forward `TemplateParams` has no such field yet -- nothing on the
+    shipped path sets it, so this is a latent path, not a live one. It stops
+    being latent the day the knob is declared, and the failure it would have
+    then is the quiet kind: a truthiness test maps an explicit 0 onto the
+    default 2, so the engine runs a depth the caller did not ask for and the
+    2..4 check below never sees it. That is knob SUBSTITUTION, which the
+    engine contract forbids -- a knob is honored or the engine is ineligible.
+
+    Pinning 0 specifically: 1 and 5 fail under any spelling, but 0 is the only
+    value a truth test swallows, so it is the one that regresses silently.
+    """
+    from dataclasses import dataclass
+
+    from cudnn.sdpa.fwd.config_sm100 import TemplateParams
+    from cudnn.sdpa.fwd.config_sm107 import make_cfg_d256
+
+    @dataclass(frozen=True)
+    class _ParamsWithStagesKv(TemplateParams):
+        stages_kv: int = None
+
+    with pytest.raises(ValueError, match="STAGES_KV"):
+        make_cfg_d256(_ParamsWithStagesKv(stages_kv=bad_depth))
+
+
+@pytest.mark.L0
+def test_sm107_d256_stages_kv_defaults_when_the_attribute_is_absent():
+    """The accept side of the test above: a plain TemplateParams (no
+    `stages_kv` attribute at all) still gets the depth-2 default, so the fix
+    for the explicit-zero case did not break the only path that ships."""
+    from cudnn.sdpa.fwd.config_sm100 import TemplateParams
+    from cudnn.sdpa.fwd.config_sm107 import make_cfg_d256
+
+    cfg, _ = make_cfg_d256(TemplateParams())
+    assert cfg.STAGES_KV == 2

--- a/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm107.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm107.py
@@ -552,3 +552,70 @@ def test_sm107_ones_tile_stays_inside_the_v0_descriptor_window():
     assert supported_cgas_for((192, 128), fp8=False, device_cc=(10, 7)) == (1, 2)
     assert supported_cgas_for((128, 128), fp8=True, device_cc=(10, 7)) == (2,)
     assert supported_cgas_for((256, 256), fp8=True, device_cc=(10, 7)) == (1,)
+
+
+# --- LPT on Rubin, advertised PER D-SHAPE -----------------------------------
+#
+# `sched_policies` is row-wide but LPT support is per-KERNEL: the SM107 port
+# dropped `lpt_q_tiles_in_cga_units=True` on 9 of 11 flavors, and without it the
+# LPT decode claims no tile and the kernel writes nothing. The argument is
+# restored everywhere; only the flavors validated under LPT are ADVERTISED.
+
+
+@pytest.mark.L0
+def test_sm107_advertises_lpt_only_for_the_validated_d_shape():
+    """(256, 256) serves LPT; the row-wide default stays NATURAL-only.
+
+    An accept AND a reject, because a capability that is only ever exercised on
+    its accepting side is an untested assertion (engine contract, Rule 9).
+    """
+    from cudnn.frost.tile_dsl.constants import SCHED_LPT, SCHED_LPT_L2, SCHED_NATURAL
+    from cudnn.sdpa.fwd import engines
+
+    caps = _caps("sdpa_fwd_prefill_sm107")
+    assert caps.sched_policies == frozenset({SCHED_NATURAL}), "the row-wide floor must stay NATURAL"
+
+    d256 = engines.effective_sched_policies(caps, _f16_facts(d_qk=256, d_v=256))
+    assert SCHED_LPT in d256, "the d256 kernel honours LPT and must advertise it"
+
+    d128 = engines.effective_sched_policies(caps, _f16_facts(d_qk=128, d_v=128))
+    assert SCHED_LPT not in d128, "d128 is unvalidated under LPT; advertising it would be dishonest"
+
+    # LPT_L2 is a separate, still-open gap: its decode needs qh_per_kh and
+    # seqlen_kv, which the SM107 call sites do not pass. No flavor claims it.
+    for shape in ((128, 128), (256, 256), (512, 512)):
+        assert SCHED_LPT_L2 not in engines.effective_sched_policies(caps, _f16_facts(d_qk=shape[0], d_v=shape[1]))
+
+
+@pytest.mark.L0
+def test_sm107_lpt_knob_is_honored_or_ineligible_per_d_shape():
+    """Requesting LPT must be ACCEPTED at d256 and DECLINED at d128 -- never
+    silently downgraded to NATURAL (engine contract, Rule 4)."""
+    from cudnn.frost.tile_dsl.constants import SCHED_LPT
+    from cudnn.sdpa.fwd import engines
+    from cudnn.sdpa.fwd.engines import SdpaFwdKnobs
+
+    caps = _caps("sdpa_fwd_prefill_sm107")
+    assert engines.mismatch(caps, _f16_facts(d_qk=256, d_v=256), SdpaFwdKnobs(sched_policy=SCHED_LPT)) is None
+    why = engines.mismatch(caps, _f16_facts(d_qk=128, d_v=128), SdpaFwdKnobs(sched_policy=SCHED_LPT))
+    assert why is not None and "sched_policy" in why
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("depth", [2, 3, 4])
+def test_sm107_d256_desc_version_follows_the_stages_kv_layout(depth):
+    """STAGES_KV moves the last V stage past the 14-bit tcgen05 address window
+    at depth 4, so DESC_VERSION must be DERIVED, not a literal.
+
+    This is the guard for a silent wrong answer: at depth 4 with a version-0
+    descriptor the last two V stages alias the bottom of SMEM and the result is
+    wrong from the KV iteration that first touches one (measured cos 0.68 / 0.50
+    / 0.46 at n_kv 3/4/8).
+    """
+    from dataclasses import replace
+
+    import cudnn.sdpa.fwd.kernels.sm107.prefill_d256_f16 as kern
+
+    cfg = replace(kern.CFG, STAGES_KV=depth)
+    want = 1 if depth >= 4 else 0
+    assert int(kern._needs_desc_v1(cfg)) == want, f"STAGES_KV={depth} must select desc_version {want}"


### PR DESCRIPTION
Two independent Rubin (SM107) SDPA fixes, both correctness-first. They are in one PR because they touch the same kernel and the same capability row.

## 1. SM107 honours `SCHED_LPT` — a dropped argument, not a broken decode

Every SM100 kernel calls `make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units=True)`. The SM107 port omitted that argument on **9 of 11 flavors**. Without it the LPT linearization walks a row range `CTA_MMA`× too large, no tile is ever claimed, and the kernel writes **nothing** — cosine `0.0000`, dense and causal, which reads like a dead kernel rather than a scheduling bug.

The two flavors that kept it (d128 FP8, d192 FP8) are exactly the ones `engines.py` already singled out as working. That comment was describing this bug's symptom without its cause.

Restored on all seven 2-CTA SM107 flavors. **It is a no-op under `SCHED_NATURAL`** — that decode branch never reads `q_tiles` — so the shipped path is unchanged.

`sched_policies` is row-wide while LPT support is per-kernel, so this adds **`sched_policies_by_d_shape`**, mirroring the existing `cgas_by_d_shape`. Only what is validated is advertised: the f16 row serves `SCHED_LPT` at `(256, 256)`.

### Measured

Validated on d256 f16: cos `1.0000` at n_kv 2/3/4/8, dense **and** causal. Causal SOL on Rubin (212 SMs, 2376 MHz, 4126 TFLOP/s bf16 peak):

| S | NATURAL | LPT | gain | dense ceiling | gap recovered |
|---|---|---|---|---|---|
| 4096 | 53.0% | 62.6% | **+18.2%** | 77.1% | 40% |
| 8192 | 71.1% | 79.3% | **+11.6%** | 87.3% | 51% |
| 32768 | 76.7% | 77.5% | +1.1% | 79.5% | 29% |

Dense is neutral, which is the right control: with no mask there is no imbalance to fix. The decay with S is the signature of scheduler imbalance, which is what LPT exists to fix.

### Deliberately not claimed

- **d128 / d512 f16 and every FP8/MXFP8 row** — unvalidated under LPT, not known-broken. The argument is restored so they should work; each needs a numerics sweep before its row claims it.
- **d512** — cga4×1 role-split, a different scheduler shape; the older NaN report there is still unexplained and I did not assume the same cause.
- **`SCHED_LPT_L2`** — declined by every flavor. Its decode needs `qh_per_kh` and `seqlen_kv`, which the SM107 call sites do not pass, so it *raises* rather than miscomputes. Threading those two arguments is a mechanical follow-up.

## 2. `STAGES_KV` is a knob again — the old pin blamed the wrong thing

`config_sm107` pinned the d256 `STAGES_KV` to 2, blaming a body that "conflates the KV ring index with the 2-slot `S_acc` parity". The body in fact derives parity from the absolute `kv_loop & 1` and rides separate K/V `PipelineState`s, so it is depth-agnostic.

The real constraint was the **>256 KiB tcgen05 descriptor wrap**. Buffers are laid out `sQO | sK[stages] | sV[stages]`; at depth 4 the last two V stages start at 256 and 288 KiB, and a version-0 descriptor truncates `start_address` to 14 bits, so those stages alias the bottom of SMEM. The answer breaks from the KV iteration that first touches a wrapped stage — which is why it looked like a ring bug and why it only shows up at `S_kv > 256`.

| config | n_kv=2 | 3 | 4 | 8 |
|---|---|---|---|---|
| depth 4, desc v0 | 1.0000 | 0.6806 | 0.4980 | 0.4640 |
| **depth 4, desc v1** | **1.0000** | **1.0000** | **1.0000** | **1.0000** |
| depth 3, desc v0 | 1.0000 | 1.0000 | 1.0000 | 1.0000 |

`DESC_VERSION` is now **derived** from the layout rather than a literal, so every depth in 2..4 is correct by construction, and the validator accepts that range bounded by the 320 KiB carveout.

**The default stays 2.** Depth is perf-neutral — dense SOL moves 0.3 points across all three depths — and 2 leaves 135 KiB free for a future fused epilogue.

## Testing

- New: accept **and** reject for the per-shape domain, a honored-or-ineligible knob test, and a parametrized guard that `DESC_VERSION` tracks `STAGES_KV`.
- `SUPPORT_MATRIX_TRACKER.md` updated in the same commit (Rule S2).
- On Rubin: `sdpa/frost` **1069 passed, 634 skipped**; `test_sdpa_fwd_dsl_sm107.py` **61 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded SM107 SDPA d256 configurations to support KV pipeline depths from 2–4.
  - Added validated LPT scheduling for supported d256 f16 workloads.
  - Improved scheduling selection based on the active attention shape.
  - Added automatic descriptor version selection for larger pipeline configurations.

- **Bug Fixes**
  - Corrected query-tile interpretation for LPT scheduling across supported SM107 kernels.
  - Preserved NATURAL scheduling behavior and rejected unsupported LPT_L2 configurations.

- **Tests**
  - Added coverage for scheduler eligibility, descriptor versions, and invalid pipeline-depth values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->