### PR TITLE
test(frost fp8): update the one _ref() caller #971 left on the old signature

### DIFF
--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -1516,7 +1516,7 @@ def test_fp8_sm100_execute_lse_contract():
         api.execute(lse_tensor=lse, **ex)
     api.execute(**ex)
     torch.cuda.synchronize()
-    o_ref = _ref(q8.float() * dq, q8.float() * dq, q8.float() * dq, scale=api.scale_softmax, is_causal=True)
+    o_ref = _ref(q8, q8, q8, dq, dq, dq, "e4m3", scale=api.scale_softmax, is_causal=True)
     torch.testing.assert_close(o.float(), o_ref, atol=5e-2, rtol=3e-2)
 
 


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches and my changes comply.
- [x] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*`.

## Affected area

- Tests (`test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py`)

## Summary

#971 (`f30ed974e`) changed this file's `_ref()` to take the fp8 tensors, their descales and the input dtype key so the reference casts P the way the kernel does. One caller was left on the old signature: `test_fp8_sm100_execute_lse_contract` fails on develop with `TypeError: _ref() missing 4 required positional arguments: 'dq', 'dk', 'dv', and 'in_key'` — first seen on the #985 mirror lane `frost-sdpa:cutlass-rel:sm100` (1 failed / 4573 passed, [job 434564281](https://gitlab-master.nvidia.com/cudnn/cudnn_frontend/-/jobs/434564281)); develop's own nightlies had not yet run past the merge.

One-line fix: pass `q8` (the test uses it for Q, K and V), its descale three times, and `"e4m3"`.

Verified on B200: `sdpa/frost/test_sdpa_fwd_fp8_sm100.py -m "L0 or L1"` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated FP8 attention contract testing to validate reference computations using FP8 tensors and their associated scaling factors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->