### PR TITLE
build: remove obsolete NumPy upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ triton = [
 [dependency-groups]
 dev = [
     "jupyter",
-    "numpy<2.0.0",
+    "numpy",
     "pybind11[global]>=2.13,<3",
     "pytest",
     "pytest-xdist",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jupyter
-numpy<2.0.0
+numpy
 pybind11[global]>=2.13,<3
 pytest
 pytest-xdist


### PR DESCRIPTION
The `numpy<2` development constraint forces downgrades and conflicts with JAX 0.7.2, which requires NumPy >=2. Keep NumPy as a dependency but remove its upper bound in both `pyproject.toml` and `requirements.txt`.

## Before submitting

- [x] I agree to license this contribution under LICENSE.txt.
- [x] Ran pre-commit on the changed files (all hooks skipped: no applicable source files).
- [x] Reviewed applicable AGENTS.md rules.
- [x] Added change-type, affected-area, and originator labels.

## Affected area

Build, packaging, or installation.

## Why

The original pybind11 compatibility restriction is no longer needed by the configured build: NumPy 2 support starts at pybind11 2.12, and this project requires >=2.13,<3 with CMake fetching 2.13.6. See the [pybind11 upgrade guide](https://pybind11.readthedocs.io/en/stable/upgrade.html#v2-12).

## API and compatibility impact

Allows NumPy 2 without requiring it. No runtime API changes.

## Testing

- `pip install --dry-run --group dev "jax[cuda13-local]==0.7.2"`: succeeds and retains installed NumPy 2.5.2. Restoring the old cap reproduces ResolutionImpossible.
- Confirmed the two dependency lists remain identical; `git diff --check` passed.
- `uvx pre-commit run --files pyproject.toml requirements.txt`: all hooks skipped (no applicable source files).
- Existing Blackwell validation with NumPy 2: 57 JAX tests passed, 2 known xfails. Full Python bindings/sample suites not rerun for this metadata-only change.

@coderabbitai ignore
