### PR TITLE
test: refresh API index from development CI wheel

### DIFF
--- a/test/python/api_index/README.md
+++ b/test/python/api_index/README.md
@@ -19,24 +19,26 @@ AST parser, kernel-template discovery, or broad exposure report.
 
 ## Run
 
-Build the Python bindings first. Use the Linux development build environment
-with its CUDA/cuDNN libraries and optional Python dependencies installed; the
-scan itself needs no GPU.
+Use the wheel artifact from `build:dev:linux:amd64`, in the same Linux
+development CI image with its CUDA/cuDNN libraries and Python dependencies.
+The inspection itself needs no GPU.
 
 ```bash
-CUDA_VISIBLE_DEVICES='' python3 test/python/api_index/api_index.py
-CUDA_VISIBLE_DEVICES='' CUDNN_API_INDEX_PACKAGE_ROOT="$PWD/build/cudnn" \
+python3 -m pip install --no-deps --target api_index_wheel build/wheel/*.whl
+CUDA_VISIBLE_DEVICES='' python3 test/python/api_index/api_index.py --package-root api_index_wheel/cudnn
+CUDA_VISIBLE_DEVICES='' CUDNN_API_INDEX_PACKAGE_ROOT="$PWD/api_index_wheel/cudnn" \
   python3 -m unittest discover -s test/python/api_index -p test_api_index.py -v
 ```
 
-The scanner defaults to `build/cudnn`; `--package-root` selects another build.
+The scanner defaults to `build/cudnn` for local CMake builds; `--package-root`
+selects the installed wheel above.
 It checks that the selected package is used, even with an editable cuDNN install
 present. Run it in a fresh Python process.
 
 After reviewing an intentional API change, in the same environment:
 
 ```bash
-CUDA_VISIBLE_DEVICES='' python3 test/python/api_index/api_index.py --write
+CUDA_VISIBLE_DEVICES='' python3 test/python/api_index/api_index.py --package-root api_index_wheel/cudnn --write
 git diff -- test/python/api_index/api_index_modules.txt test/python/api_index/api_index.txt
 ```
 
@@ -45,14 +47,16 @@ the API baseline, not the module allowlist.
 
 ## CI and tests
 
-The full baseline check runs after compilation in `build:dev:linux:amd64` on a
-CPU runner. This keeps the backend/platform constant; release and Windows
-builds can expose different native bindings. The development image supplies
-PyTorch and CuTeDSL; the job installs JAX for the listed JAX facade.
+`analysis:api_index` downloads the wheel from `build:dev:linux:amd64` and runs
+the checks on a CPU runner with GPU visibility disabled. The analysis stage
+follows build, and the job explicitly needs that build's wheel artifact. The
+development image supplies PyTorch and CuTeDSL; the job installs JAX for the
+listed JAX facade. Release and Windows builds can expose different native names
+and do not define this baseline.
 
 Use `unittest` for CPU execution; the parent `test/python` pytest configuration
-requires a GPU. Fixture tests run before compilation in all build jobs using only Python 3.10+
-and the standard library:
+requires a GPU. Fixture tests also run in the analysis job and can be run locally
+using only Python 3.10+ and the standard library:
 
 ```bash
 python3 -S -m unittest discover -s test/python/api_index -p test_api_index.py -v

--- a/test/python/api_index/api_index.txt
+++ b/test/python/api_index/api_index.txt
@@ -331,6 +331,15 @@ cudnn.gnn.CscGraph.num_dst_nodes
 cudnn.gnn.CscGraph.num_edges
 cudnn.gnn.CscGraph.num_indices
 cudnn.gnn.agg_simple
+cudnn.gnn_agg_op
+cudnn.gnn_agg_op.MAX
+cudnn.gnn_agg_op.MEAN
+cudnn.gnn_agg_op.MIN
+cudnn.gnn_agg_op.SUM
+cudnn.gnn_agg_op.name
+cudnn.gnn_agg_op.value
+cudnn.gnn_agg_simple_backward
+cudnn.gnn_agg_simple_forward
 cudnn.graph
 cudnn.graph_cache
 cudnn.heur_mode
@@ -392,6 +401,7 @@ cudnn.knob_type.STREAM_K
 cudnn.knob_type.SWAP_AB
 cudnn.knob_type.SWIZZLE
 cudnn.knob_type.TILEK
+cudnn.knob_type.TILE_CGA
 cudnn.knob_type.TILE_CGA_M
 cudnn.knob_type.TILE_CGA_N
 cudnn.knob_type.TILE_COLS
@@ -642,6 +652,11 @@ cudnn.scalar_type.name
 cudnn.scalar_type.value
 cudnn.sdpa
 cudnn.sdpa.bwd
+cudnn.sdpa.bwd.Nvfp4AttentionQatBackward
+cudnn.sdpa.bwd.Nvfp4AttentionQatBackward.check_support
+cudnn.sdpa.bwd.Nvfp4AttentionQatBackward.compile
+cudnn.sdpa.bwd.Nvfp4AttentionQatBackward.execute
+cudnn.sdpa.bwd.Nvfp4AttentionQatBackward.scratch_workspace_bytes
 cudnn.sdpa.bwd.SdpaBwdDsl
 cudnn.sdpa.bwd.SdpaBwdDsl.check_support
 cudnn.sdpa.bwd.SdpaBwdDsl.compile
@@ -657,6 +672,7 @@ cudnn.sdpa.bwd.SdpaBwdDslSm80.check_support
 cudnn.sdpa.bwd.SdpaBwdDslSm80.compile
 cudnn.sdpa.bwd.SdpaBwdDslSm80.execute
 cudnn.sdpa.bwd.SdpaBwdDslSm80.scratch_workspace_bytes
+cudnn.sdpa.bwd.nvfp4_attention_qat_backward
 cudnn.sdpa.bwd.sdpa_bwd_wrapper_dsl_sm120
 cudnn.sdpa.bwd.sdpa_bwd_wrapper_sm80
 cudnn.sdpa.fwd


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of LICENSE.txt.
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the applicable AGENTS.md rules.
- [x] I added change-type, area, and originator labels.

## Affected area

CI or test infrastructure.

## Summary

Refresh the API index from the actual development CI wheel: 778 names, up from 762. This records ten native names absent from the original locally built baseline and six recently merged NVFP4 attention names. The module allowlist and inspection rules are unchanged.

Document installation and inspection of regular build-wheel artifacts in the CPU analysis job. Companion CI-only MR: https://gitlab-master.nvidia.com/cudnn/cudnn_frontend/-/merge_requests/2387. Merge and sync this baseline before running that MR.

## Testing

- Used the real wheel from development build job https://gitlab-master.nvidia.com/cudnn/cudnn_frontend/-/jobs/434788527; its Python and binding source matches this branch.
- Ran in the matching development CI image with Docker runtime `runc`, no GPU devices, and GPU visibility disabled. The old baseline failed with exactly these 16 additions; all 9 tests pass with the regenerated baseline.
- Pre-commit and `git diff --check` pass.

@coderabbitai ignore
