### PR TITLE
BSA: support logical blk128 forward on SM120

### DIFF
--- a/docs/fe-oss-apis/bsa.md
+++ b/docs/fe-oss-apis/bsa.md
@@ -100,7 +100,7 @@ is consumed. Values in the inactive suffix are ignored.
 - With fixed counts, `block_sparse_num` must be in `[1, K_max]`. The
   SM100/SM103 blk128 path additionally requires an even value, i.e. an even
   `block_sparse_num` in `[2, K_max]`.
-- The `block_sizes` entry for every physical KV block referenced by an active
+- The `block_sizes` entry for every caller-visible KV block referenced by an active
   `q2k_block_index` value must be in `[1, sparse_block_size]`. Entries for
   unreferenced physical KV blocks are ignored. A zero-sized referenced block is
   not supported; use `q2k_block_nums` (or the sparse index prefix) to drop the
@@ -121,10 +121,18 @@ Provide `block_sizes` whenever a referenced final block is only partially
 valid.
 
 `sparse_block_size=None` chooses blk64 on SM90/SM120 and blk128 on
-SM100/SM103. Passing `sparse_block_size=64` explicitly selects the SM100/SM103
-blk64 CuTe DSL path, whose shape support is narrower. `kv_splits` is available
-on SM90 and the explicit Blackwell blk64 path; `use_clc` applies only to the
-explicit Blackwell blk64 path.
+SM100/SM103. Passing `sparse_block_size=128` explicitly on SM120 selects the
+logical-blk128 BF16 path. It requires QK/V dimensions of 128 and `S_kv` to be
+a multiple of 128. Its logical metadata is expanded on the current CUDA stream
+and dispatched through the native SM120 blk64 kernel; Q, K, and V are not
+copied. The path supports MHA, GQA, and MQA with unpacked per-query-head
+metadata, so `pack_gqa` must be `None` or `False`.
+
+Passing `sparse_block_size=64` explicitly selects the SM100/SM103 blk64 CuTe
+DSL path, whose shape support is narrower. `kv_splits` is available on SM90 and
+the explicit Blackwell blk64 path; `use_clc` applies only to the explicit
+Blackwell blk64 path. SM120 logical blk128 requires `kv_splits=1` and
+`use_clc=None`.
 
 `kv_splits=2..256` computes FP32 partial outputs and combines them, with
 workspace growing linearly in the split count. SM90 accepts an explicit integer
@@ -225,6 +233,7 @@ therefore requires full physical KV blocks and `block_sizes=None`.
 | SM100/SM103 | 64 (explicit) | BF16 | QK=128, V=128 | MHA |
 | SM100/SM103 | 64 | BF16 / FP8 E4M3 | QK=128, V=128 | MHA |
 | SM120 | 64 | FP16, BF16 | QK=128, V=128 | MHA, GQA, MQA |
+| SM120 | 128 (logical, explicit) | BF16 | QK=128, V=128 | MHA, GQA, MQA |
 | SM120 | 64 | BF16 / FP8 E4M3 | QK=128, V=128 | MHA |
 
 SM90 currently requires `S_q` to be a multiple of 64. Its fixed count may be
@@ -235,6 +244,8 @@ defaults to `False`; when it is `True`, empty rows (`q2k_block_nums == 0`)
 produce `O = 0` and `LSE = -inf`. SM90 selects the empty-row handling as a
 compile-time specialization, so the default non-empty configuration keeps its
 branch-free fast path. Split-KV execution therefore excludes empty rows.
+Regular SM120 forward accepts `block_sizes` shaped `(N_kv,)`, `(B, N_kv)`, or
+`(B, H_q, N_kv)` for both sparse block sizes.
 
 ### Backward
 

--- a/python/cudnn/block_sparse_attention/api.py
+++ b/python/cudnn/block_sparse_attention/api.py
@@ -208,7 +208,7 @@ def block_sparse_attention_forward(
         if isinstance(kv_splits, str) or not 1 <= int(kv_splits) <= 256:
             raise ValueError("SM90 kv_splits must be an integer in [1, 256]")
 
-    if arch_family in {9, 12} and sparse_block_size != 64:
+    if arch_family == 9 and sparse_block_size != 64:
         raise NotImplementedError(f"SM{arch} only provides a blk64 forward path")
     if arch_family == 9:
         if head_dim not in {64, 96, 128} or value_dim not in {64, 96, 128}:
@@ -218,6 +218,10 @@ def block_sparse_attention_forward(
     elif arch_family == 12:
         if head_dim != 128 or value_dim != 128:
             raise NotImplementedError("SM120 forward requires QK and V dimensions of 128")
+        if sparse_block_size == 128 and q_tensor.dtype != torch.bfloat16:
+            raise NotImplementedError("SM120 blk128 forward requires BF16")
+        if sparse_block_size == 128 and seqlen_k % 128:
+            raise NotImplementedError("SM120 blk128 forward requires seqlen_k to be a multiple of 128")
     elif sparse_block_size == 64:
         if q_tensor.dtype != torch.bfloat16 or head_dim != 128 or value_dim != 128:
             raise NotImplementedError("SM100/SM110 blk64 forward requires BF16 and QK=V=128")
@@ -286,6 +290,21 @@ def block_sparse_attention_forward(
                 raise NotImplementedError("kv_splits is currently exposed only by the SM90 and " "SM100/SM110 blk64 CuTe DSL paths")
             if use_clc is not None:
                 raise NotImplementedError("use_clc is currently exposed only by the SM100/SM110 blk64 CuTe DSL path")
+            if arch_family == 12 and sparse_block_size == 128:
+                from .csrc.fwd.sm120_blk128.metadata import lower_sm120_blk128_metadata
+
+                with torch.cuda.nvtx.range("bsa_sm120_blk128_lower_metadata"):
+                    lowered_metadata = lower_sm120_blk128_metadata(
+                        q2k_block_index,
+                        block_sparse_num,
+                        block_sizes,
+                        q2k_block_nums,
+                        seqlen_q=seqlen_q,
+                    )
+                q2k_block_index = lowered_metadata.q2k_block_index
+                block_sparse_num = lowered_metadata.block_sparse_num
+                block_sizes = lowered_metadata.block_sizes
+                q2k_block_nums = lowered_metadata.q2k_block_nums
             out, lse = _interface.bsa_attn_fwd(
                 q_tensor,
                 k_tensor,

--- a/python/cudnn/block_sparse_attention/csrc/fwd/sm120_blk128/metadata.py
+++ b/python/cudnn/block_sparse_attention/csrc/fwd/sm120_blk128/metadata.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 tiffany940107. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+SM120_BLK128_LOGICAL_BLOCK_SIZE = 128
+SM120_BLK128_BACKEND_BLOCK_SIZE = 64
+
+
+@dataclass(frozen=True)
+class Sm120Blk128LoweredMetadata:
+    """Physical blk64 metadata for the SM120 logical-blk128 forward path."""
+
+    q2k_block_index: torch.Tensor
+    block_sparse_num: int
+    block_sizes: Optional[torch.Tensor]
+    q2k_block_nums: Optional[torch.Tensor]
+
+
+def _ceil_div(value: int, divisor: int) -> int:
+    return (value + divisor - 1) // divisor
+
+
+def _lower_block_sizes(block_sizes: torch.Tensor) -> torch.Tensor:
+    """Split each logical 128-token size into two physical 64-token sizes."""
+    first_half = block_sizes.clamp(min=0, max=SM120_BLK128_BACKEND_BLOCK_SIZE)
+    second_half = (block_sizes - SM120_BLK128_BACKEND_BLOCK_SIZE).clamp(min=0, max=SM120_BLK128_BACKEND_BLOCK_SIZE)
+    return torch.stack((first_half, second_half), dim=-1).flatten(-2).contiguous()
+
+
+def lower_sm120_blk128_metadata(
+    q2k_block_index: torch.Tensor,
+    block_sparse_num: int,
+    block_sizes: Optional[torch.Tensor],
+    q2k_block_nums: Optional[torch.Tensor],
+    *,
+    seqlen_q: int,
+) -> Sm120Blk128LoweredMetadata:
+    """Lower logical blk128 sparse metadata to the native SM120 blk64 ABI.
+
+    Every logical KV block ``j`` becomes physical blocks ``2*j`` and
+    ``2*j + 1``. Each logical Q row is repeated for its two physical Q tiles.
+    The public wrapper validates all shapes and requires complete logical KV
+    blocks before invoking this transform. All operations stay on the metadata
+    device and therefore do not introduce a host synchronization.
+    """
+    physical_index_base = q2k_block_index * 2
+    physical_indices = torch.stack((physical_index_base, physical_index_base + 1), dim=-1).flatten(-2)
+    physical_q_blocks = _ceil_div(seqlen_q, SM120_BLK128_BACKEND_BLOCK_SIZE)
+    physical_indices = physical_indices.repeat_interleave(2, dim=2)[:, :, :physical_q_blocks, :].contiguous()
+
+    physical_block_sizes = _lower_block_sizes(block_sizes) if block_sizes is not None else None
+    if q2k_block_nums is not None:
+        physical_block_nums = (q2k_block_nums * 2).repeat_interleave(2, dim=2)[:, :, :physical_q_blocks].contiguous()
+        physical_block_sparse_num = 0
+    else:
+        physical_block_nums = None
+        physical_block_sparse_num = int(block_sparse_num) * 2
+
+    return Sm120Blk128LoweredMetadata(
+        q2k_block_index=physical_indices,
+        block_sparse_num=physical_block_sparse_num,
+        block_sizes=physical_block_sizes,
+        q2k_block_nums=physical_block_nums,
+    )

--- a/test/python/fe_api/bsa/test_BSA_attention_sm120_blk128.py
+++ b/test/python/fe_api/bsa/test_BSA_attention_sm120_blk128.py
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 tiffany940107. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+
+import pytest
+import torch
+
+from test_utils import torch_fork_set_rng
+from fe_api.bsa.bsa_reference import attention_reference, block_sparse_mask
+from cudnn.block_sparse_attention.csrc.fwd.sm120_blk128.metadata import lower_sm120_blk128_metadata
+
+pytestmark = [pytest.mark.gpu_exclusive, pytest.mark.xdist_group(name="gpu_exclusive")]
+
+
+def _import_bsa():
+    try:
+        from cudnn import BSA
+
+        importlib.import_module("cudnn.block_sparse_attention._interface")
+
+        return BSA
+    except (ImportError, OSError) as error:
+        pytest.skip(f"block sparse attention optional dependencies are unavailable: {error}")
+
+
+def _require_sm120() -> None:
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] != 12:
+        pytest.skip("logical blk128 forward is specific to SM120")
+
+
+@pytest.mark.L0
+def test_sm120_blk128_metadata_lowers_odd_count_and_q_tail():
+    q2k = torch.tensor([[[[0, 2, 3], [3, 1, 0]]]], dtype=torch.int32)
+
+    lowered = lower_sm120_blk128_metadata(
+        q2k,
+        block_sparse_num=3,
+        block_sizes=None,
+        q2k_block_nums=None,
+        seqlen_q=193,
+    )
+
+    expected_first_row = torch.tensor([0, 1, 4, 5, 6, 7], dtype=torch.int32)
+    expected_last_row = torch.tensor([6, 7, 2, 3, 0, 1], dtype=torch.int32)
+    assert lowered.q2k_block_index.shape == (1, 1, 4, 6)
+    torch.testing.assert_close(lowered.q2k_block_index[0, 0, 0], expected_first_row)
+    torch.testing.assert_close(lowered.q2k_block_index[0, 0, 1], expected_first_row)
+    torch.testing.assert_close(lowered.q2k_block_index[0, 0, 2], expected_last_row)
+    torch.testing.assert_close(lowered.q2k_block_index[0, 0, 3], expected_last_row)
+    assert lowered.block_sparse_num == 6
+    assert lowered.block_sizes is None
+    assert lowered.q2k_block_nums is None
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize(
+    "block_sizes",
+    (
+        torch.tensor([128, 96, 64, 1], dtype=torch.int32),
+        torch.tensor([[128, 96, 64, 1], [1, 64, 96, 128]], dtype=torch.int32),
+        torch.tensor(
+            [
+                [[128, 96, 64, 1], [1, 64, 96, 128]],
+                [[65, 80, 127, 128], [128, 127, 80, 65]],
+            ],
+            dtype=torch.int32,
+        ),
+    ),
+)
+def test_sm120_blk128_metadata_lowers_block_sizes(block_sizes):
+    q2k = torch.zeros((2, 2, 1, 1), dtype=torch.int32)
+
+    lowered = lower_sm120_blk128_metadata(
+        q2k,
+        block_sparse_num=1,
+        block_sizes=block_sizes,
+        q2k_block_nums=None,
+        seqlen_q=128,
+    )
+
+    expected_first = block_sizes.clamp(min=0, max=64)
+    expected_second = (block_sizes - 64).clamp(min=0, max=64)
+    expected = torch.stack((expected_first, expected_second), dim=-1).flatten(-2)
+    assert lowered.block_sizes.shape == (*block_sizes.shape[:-1], 2 * block_sizes.shape[-1])
+    torch.testing.assert_close(lowered.block_sizes, expected)
+
+
+@pytest.mark.L0
+def test_sm120_blk128_metadata_lowers_variable_counts():
+    q2k = torch.tensor(
+        [[[[3, 2, 1], [0, 1, 3]], [[1, 3, 2], [2, 0, 1]]]],
+        dtype=torch.int32,
+    )
+    block_nums = torch.tensor([[[1, 3], [2, 1]]], dtype=torch.int32)
+
+    lowered = lower_sm120_blk128_metadata(
+        q2k,
+        block_sparse_num=99,
+        block_sizes=None,
+        q2k_block_nums=block_nums,
+        seqlen_q=191,
+    )
+
+    expected_nums = torch.tensor([[[2, 2, 6], [4, 4, 2]]], dtype=torch.int32)
+    assert lowered.q2k_block_index.shape == (1, 2, 3, 6)
+    assert lowered.block_sparse_num == 0
+    torch.testing.assert_close(lowered.q2k_block_nums, expected_nums)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=120128)
+def test_bsa_attention_forward_sm120_blk128_fixed_odd_count():
+    _require_sm120()
+    BSA = _import_bsa()
+    block_size = 128
+    batch, heads, seqlen_q, seqlen_k, dim = 1, 2, 193, 512, 128
+    q = torch.randn((batch, heads, seqlen_q, dim), device="cuda", dtype=torch.bfloat16)
+    k = torch.randn((batch, heads, seqlen_k, dim), device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    q2k = torch.tensor(
+        [[[[0, 1, 3], [3, 2, 0]], [[2, 1, 0], [1, 3, 2]]]],
+        device="cuda",
+        dtype=torch.int32,
+    )
+    block_sizes = torch.tensor([128, 96, 64, 1], device="cuda", dtype=torch.int32)
+
+    result = BSA.block_sparse_attention_forward(
+        q,
+        k,
+        v,
+        q2k,
+        block_sparse_num=3,
+        block_sizes=block_sizes,
+        sparse_block_size=block_size,
+    )
+    mask = block_sparse_mask(q2k, 3, block_sizes, seqlen_q, seqlen_k, block_size)
+    o_ref, lse_ref = attention_reference(q, k, v, mask)
+
+    torch.testing.assert_close(result["o_tensor"].float(), o_ref, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(result["lse_tensor"], lse_ref, atol=2e-3, rtol=2e-3)
+
+    result_bshd = BSA.block_sparse_attention_forward(
+        q.transpose(1, 2),
+        k.transpose(1, 2),
+        v.transpose(1, 2),
+        q2k,
+        block_sparse_num=3,
+        block_sizes=block_sizes,
+        sparse_block_size=block_size,
+        layout="bshd",
+    )
+    torch.testing.assert_close(result_bshd["o_tensor"].transpose(1, 2), result["o_tensor"], atol=0, rtol=0)
+    torch.testing.assert_close(result_bshd["lse_tensor"], result["lse_tensor"], atol=0, rtol=0)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=120129)
+def test_bsa_attention_forward_sm120_blk128_variable_count_gqa():
+    _require_sm120()
+    BSA = _import_bsa()
+    block_size = 128
+    batch, q_heads, kv_heads, seqlen_q, seqlen_k, dim = 1, 4, 2, 191, 512, 128
+    q = torch.randn((batch, q_heads, seqlen_q, dim), device="cuda", dtype=torch.bfloat16)
+    k = torch.randn((batch, kv_heads, seqlen_k, dim), device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    q2k = torch.tensor(
+        [
+            [
+                [[3, 1, 0], [0, 2, 3]],
+                [[2, 0, 3], [3, 1, 2]],
+                [[1, 2, 3], [2, 0, 1]],
+                [[0, 3, 2], [1, 2, 0]],
+            ]
+        ],
+        device="cuda",
+        dtype=torch.int32,
+    )
+    block_nums = torch.tensor([[[1, 3], [2, 1], [3, 2], [1, 2]]], device="cuda", dtype=torch.int32)
+    reference_block_sizes = torch.full((seqlen_k // block_size,), block_size, device="cuda", dtype=torch.int32)
+
+    result = BSA.block_sparse_attention_forward(
+        q,
+        k,
+        v,
+        q2k,
+        block_sizes=None,
+        q2k_block_nums=block_nums,
+        sparse_block_size=block_size,
+        pack_gqa=False,
+    )
+    mask = block_sparse_mask(q2k, 0, reference_block_sizes, seqlen_q, seqlen_k, block_size, block_nums)
+    o_ref, lse_ref = attention_reference(q, k, v, mask)
+
+    torch.testing.assert_close(result["o_tensor"].float(), o_ref, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(result["lse_tensor"], lse_ref, atol=2e-3, rtol=2e-3)
+
+
+@pytest.mark.L0
+def test_bsa_attention_forward_sm120_blk128_rejects_unsupported_inputs():
+    _require_sm120()
+    BSA = _import_bsa()
+    q = torch.empty((1, 1, 128, 128), dtype=torch.float16, device="cuda")
+    k = torch.empty_like(q)
+    v = torch.empty_like(q)
+    q2k = torch.zeros((1, 1, 1, 1), dtype=torch.int32, device="cuda")
+
+    with pytest.raises(NotImplementedError, match="requires BF16"):
+        BSA.block_sparse_attention_forward(q, k, v, q2k, sparse_block_size=128)
+
+    q = q.to(torch.bfloat16)
+    k = k.to(torch.bfloat16)
+    v = v.to(torch.bfloat16)
+    with pytest.raises(NotImplementedError, match="pack_gqa"):
+        BSA.block_sparse_attention_forward(q, k, v, q2k, sparse_block_size=128, pack_gqa=True)
+
+    partial_k = torch.empty((1, 1, 129, 128), dtype=torch.bfloat16, device="cuda")
+    partial_q2k = torch.zeros((1, 1, 1, 1), dtype=torch.int32, device="cuda")
+    with pytest.raises(NotImplementedError, match="seqlen_k.*multiple of 128"):
+        BSA.block_sparse_attention_forward(q, partial_k, partial_k, partial_q2k, sparse_block_size=128)


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` files for the Python and test directories touched by this PR.
- [x] Please apply `cat-feature`, `mod-cutedsl`, `mod-frontend`, and `orig-external`; fork authors do not have permission to add labels.

## Affected area

FE OSS kernels or CuTeDSL, Python API, tests, and BSA documentation.

## Summary

- Add explicit `sparse_block_size=128` forward support on SM120 for BF16 Q/K/V with QK=V=128.
- Lower logical blk128 sparse metadata on the current CUDA stream to the existing native SM120 blk64 ABI; Q, K, and V are not copied.
- Cover fixed odd Top-K, variable Top-K, MHA/GQA, BHSD/BSHD, Q tails, rank-1/2/3 `block_sizes`, and validation failures.
- Document the support matrix and current restrictions.

## Why

SM120 already has a tuned blk64 BSA forward kernel. A logical metadata adapter reuses that implementation, keeps one kernel source of truth, and exactly preserves each selected 128-token KV block as two adjacent 64-token blocks. It also avoids host reads and device synchronization.

The target workload is BF16 `BHSD=[1, 8, 142720, 128]` at 15% or 20% logical-block density. The public `cudnn.BSA.block_sparse_attention_forward` path exceeds the requested 4.5x speedup at 20% density.

## Related issues

Related to #442. The broader BSA benchmark suite is already being developed in #674, so this PR keeps the functional change focused.

## API and compatibility impact

There is no signature change, and the SM120 default remains blk64. Callers opt in with `sparse_block_size=128`.

The new path is forward-only and currently requires:

- SM120, BF16, QK=V=128;
- `S_kv` divisible by 128;
- unpacked per-query-head metadata (`pack_gqa=None` or `False`);
- `kv_splits=1` and `use_clc=None`.

It supports MHA, GQA, and MQA; fixed or per-query-block counts; and rank-1/2/3 `block_sizes`.

## Testing

- `pre-commit run --from-ref upstream/develop --to-ref HEAD`: passed.
- Full `test/python/fe_api/bsa` suite on SM120: 37 passed, 19 skipped.
- The regression test was observed failing on the base revision with `SM120 only provides a blk64 forward path`, then passing after the change.

Performance was measured through the public cudnn-frontend wrapper with five warmups and the median of 21 CUDA-event samples. Dense is PyTorch cuDNN SDPA; sparse patterns contain unique logical block IDs. Conversion is `measured_speedup / (1 / actual_density)`.

| Pattern | Requested density | Actual density | Dense (ms) | Sparse (ms) | Speedup | Ideal | Conversion |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Strided | 15% | 14.9776% | 224.3058 | 36.0429 | 6.2233x | 6.6766x | 93.2100% |
| Local | 15% | 14.9776% | 224.3058 | 36.0147 | 6.2282x | 6.6766x | 93.2830% |
| Strided | 20% | 20.0000% | 224.3058 | 48.1593 | 4.6576x | 5.0000x | 93.1516% |
| Local | 20% | 20.0000% | 224.3058 | 48.0503 | 4.6681x | 5.0000x | 93.3628% |

Sampled first/last-row FP32 reference checks passed for every case. The largest observed output error was `8.17e-5`; the largest LSE error was `1.91e-6`.

## Provenance and scope

This adapter was first developed and validated in [`tiffany940107/Block-Sparse-Attention`](https://github.com/tiffany940107/Block-Sparse-Attention/tree/sm120_blk128_bf16), based on the original [`NVIDIA-JerryChen/Block-Sparse-Attention`](https://github.com/NVIDIA-JerryChen/Block-Sparse-Attention) implementation. The standalone benchmark scripts and experimental multi-GPU communication/compute-overlap prototype remain in that repository and are intentionally outside this focused PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for SM120 block-sparse attention with 128-token logical blocks.
  - Added BF16 support for this execution path when key sequence lengths are divisible by 128.
  - Added support for regular SM120 batched `block_sizes` shapes and variable-count attention scenarios.

- **Bug Fixes**
  - Improved handling of sparse metadata, including variable block sizes, query tails, and odd block counts.

- **Documentation**
  - Clarified caller-visible KV block sizing and documented SM120 logical block-size behavior and constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->