### PR TITLE
perf(dsa): specialize SM100 H96 backward as H64 + H32

### DIFF
--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/_interface_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/_interface_sm100.py
@@ -112,6 +112,7 @@ def _select_sm100_backend(
     head_dim_v: Optional[int] = None,
     dtype: Optional[torch.dtype] = None,
     max_topk: int = 0,
+    total_s_q: Optional[int] = None,
     device_capability: Optional[Tuple[int, int]] = None,
     deterministic: bool = False,
 ) -> Tuple[str, int]:
@@ -144,6 +145,11 @@ def _select_sm100_backend(
         return "h16_m128", 128
     if num_heads == 32 and head_dim == 576:
         return "h32_m64", 64
+    if num_heads == 96 and head_dim == 576 and (total_s_q is None or total_s_q >= 1024 or max_topk >= 1024):
+        # Compose the established H64 kernel with the tuned H32 tail. Both
+        # components accumulate into one FP32 dKV workspace, which is cleared
+        # by H64 and converted once after H32 completes.
+        return "h96_h64_h32", 64
     return "generic_m64", 64
 
 
@@ -166,6 +172,10 @@ def _get_sm100_kernel_class(backend: str, deterministic: bool = False):
         from .dsa_bwd_sm100_h32 import FlashAttentionDSABackwardSm100H32
 
         return FlashAttentionDSABackwardSm100H32
+    if backend == "h96_h64_h32":
+        from .dsa_bwd_sm100_h96 import FlashAttentionDSABackwardSm100H96
+
+        return FlashAttentionDSABackwardSm100H96
     if deterministic:
         return FlashAttentionDSABackwardSm100Deterministic
     return FlashAttentionDSABackwardSm100
@@ -258,6 +268,7 @@ def flash_attn_bwd_sm100(
         head_dim_v=head_dim_v,
         dtype=q.dtype,
         max_topk=max_topk,
+        total_s_q=total_S_q,
         device_capability=device_capability,
         deterministic=deterministic,
     )

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/_interface_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/_interface_sm100.py
@@ -112,7 +112,6 @@ def _select_sm100_backend(
     head_dim_v: Optional[int] = None,
     dtype: Optional[torch.dtype] = None,
     max_topk: int = 0,
-    total_s_q: Optional[int] = None,
     device_capability: Optional[Tuple[int, int]] = None,
     deterministic: bool = False,
 ) -> Tuple[str, int]:
@@ -145,7 +144,7 @@ def _select_sm100_backend(
         return "h16_m128", 128
     if num_heads == 32 and head_dim == 576:
         return "h32_m64", 64
-    if num_heads == 96 and head_dim == 576 and (total_s_q is None or total_s_q >= 1024 or max_topk >= 1024):
+    if num_heads == 96 and head_dim == 576:
         # Compose the established H64 kernel with the tuned H32 tail. Both
         # components accumulate into one FP32 dKV workspace, which is cleared
         # by H64 and converted once after H32 completes.
@@ -268,7 +267,6 @@ def flash_attn_bwd_sm100(
         head_dim_v=head_dim_v,
         dtype=q.dtype,
         max_topk=max_topk,
-        total_s_q=total_S_q,
         device_capability=device_capability,
         deterministic=deterministic,
     )

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py
@@ -22,6 +22,11 @@ class FlashAttentionDSABackwardSm100:
     num_dkv_shards = 1
     q_wave_ctas = 0
     serialize_head_blocks = False
+    initialize_dkv = True
+    finalize_dkv = True
+    run_sum_odo = True
+    run_dsink = True
+    bwd_num_heads = 0
 
     def __init__(
         self,
@@ -562,33 +567,40 @@ class FlashAttentionDSABackwardSm100:
             mKV.shape[0],
             self.acc_dtype,
         )
-        self.initialize_dKV_workspace(mdKV_acc, mKV.shape[0], stream)
+        if cutlass.const_expr(self.initialize_dkv):
+            self.initialize_dKV_workspace(mdKV_acc, mKV.shape[0], stream)
 
         # ============ Sum OdO ============
         sum_OdO_scale = Float32(-1.0)
         LSE_scale = Float32(-math.log2(math.e))
 
-        sum_OdO_grid = self._compute_sum_OdO_grid(problem_shape, self.sum_OdO_block_q)
+        if cutlass.const_expr(self.run_sum_odo):
+            sum_OdO_grid = self._compute_sum_OdO_grid(problem_shape, self.sum_OdO_block_q)
 
-        self.sum_OdO(
-            mOut,
-            mdO,
-            sum_OdO,
-            mLSE,
-            mAttnSink,
-            scaled_LSE,
-            sum_OdO_scale,
-            LSE_scale,
-            problem_shape,
-        ).launch(
-            grid=sum_OdO_grid,
-            block=[self.sum_OdO_num_threads_d, self.sum_OdO_num_threads_q, 1],
-            cluster=[1, 1, 1],
-            stream=stream,
-            min_blocks_per_mp=1,
-        )
+            self.sum_OdO(
+                mOut,
+                mdO,
+                sum_OdO,
+                mLSE,
+                mAttnSink,
+                scaled_LSE,
+                sum_OdO_scale,
+                LSE_scale,
+                problem_shape,
+            ).launch(
+                grid=sum_OdO_grid,
+                block=[self.sum_OdO_num_threads_d, self.sum_OdO_num_threads_q, 1],
+                cluster=[1, 1, 1],
+                stream=stream,
+                min_blocks_per_mp=1,
+            )
 
-        num_head_blocks = cute.ceil_div(problem_shape[3][0], self.block_tile)
+        if cutlass.const_expr(self.bwd_num_heads > 0):
+            bwd_problem_shape = (problem_shape[0], problem_shape[1], problem_shape[2], (self.bwd_num_heads, problem_shape[3][1]))
+        else:
+            bwd_problem_shape = problem_shape
+
+        num_head_blocks = cute.ceil_div(bwd_problem_shape[3][0], self.block_tile)
         q_wave_size = self.q_wave_ctas if cutlass.const_expr(self.q_wave_ctas > 0) else problem_shape[0]
         if cutlass.const_expr(self.serialize_head_blocks):
             num_head_block_phases = num_head_blocks
@@ -599,7 +611,7 @@ class FlashAttentionDSABackwardSm100:
         for q_offset in cutlass.range(0, problem_shape[0], q_wave_size, unroll=1):
             for head_block_offset in cutlass.range(0, num_head_block_phases, unroll=1):
                 self.bwd(
-                    problem_shape,
+                    bwd_problem_shape,
                     QK_tiled_mma,
                     dOV_tiled_mma,
                     dOP_tiled_mma,
@@ -648,7 +660,7 @@ class FlashAttentionDSABackwardSm100:
                     sum_OdO_smem_layout,
                     valid_smem_layout,
                 ).launch(
-                    grid=(q_wave_size, head_blocks_per_launch, problem_shape[3][1]),
+                    grid=(q_wave_size, head_blocks_per_launch, bwd_problem_shape[3][1]),
                     block=[self.threads_per_cta, 1, 1],
                     cluster=[1, 1, 1],
                     smem=self.shared_storage.size_in_bytes(),
@@ -661,26 +673,28 @@ class FlashAttentionDSABackwardSm100:
         self.num_threads_seq = 4 if self.max_topk == 2048 else self.block_seq
         self.convert_elem_per_load = 4
 
-        self.finalize_dKV(mdKV_acc, mdKV, mKV.shape[0], stream)
+        if cutlass.const_expr(self.finalize_dkv):
+            self.finalize_dKV(mdKV_acc, mdKV, mKV.shape[0], stream)
 
-        dSink_grid = (
-            self.dSink_grid_q(problem_shape),
-            problem_shape[3][0],
-            problem_shape[3][1],
-        )
-        self.sum_dSink(
-            sum_OdO,
-            scaled_LSE,
-            mAttnSink,
-            mdSink,
-            problem_shape,
-        ).launch(
-            grid=dSink_grid,
-            block=[self.dSink_num_threads, 1, 1],
-            cluster=[1, 1, 1],
-            stream=stream,
-            min_blocks_per_mp=1,
-        )
+        if cutlass.const_expr(self.run_dsink):
+            dSink_grid = (
+                self.dSink_grid_q(problem_shape),
+                problem_shape[3][0],
+                problem_shape[3][1],
+            )
+            self.sum_dSink(
+                sum_OdO,
+                scaled_LSE,
+                mAttnSink,
+                mdSink,
+                problem_shape,
+            ).launch(
+                grid=dSink_grid,
+                block=[self.dSink_num_threads, 1, 1],
+                cluster=[1, 1, 1],
+                stream=stream,
+                min_blocks_per_mp=1,
+            )
 
     @cute.kernel
     def convert(

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100_h16.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100_h16.py
@@ -19,6 +19,13 @@ class FlashAttentionDSABackwardSm100H16:
     """H16/M128 specialization kept separate to preserve generic H64 codegen."""
 
     arch = 100
+    initialize_dkv = True
+    finalize_dkv = True
+    run_sum_odo = True
+    run_dsink = True
+    head_offset = 0
+    workspace_num_heads = 0
+    workspace_head_offset = 0
 
     def __init__(
         self,
@@ -197,20 +204,14 @@ class FlashAttentionDSABackwardSm100H16:
         total_seqlen_KV: Int32,
         acc_dtype: Type[cutlass.Numeric],
     ) -> Tuple[cute.Tensor, cute.Tensor, cute.Tensor]:
-        # problem_shape contains the max seqlen of Q and K
-        max_Q, max_K, D, HB = (
-            problem_shape[0],
-            problem_shape[1],
-            problem_shape[2],
-            problem_shape[3],
-        )
-        H, B = cute.size(problem_shape[3][0]), cute.size(problem_shape[3][1])
+        H = cute.size(problem_shape[3][0])
+        workspace_H = self.workspace_num_heads if cutlass.const_expr(self.workspace_num_heads > 0) else H
 
-        D = cute.round_up(D, 8)
+        D = cute.round_up(problem_shape[2], 8)
         total_seqlen_Q = cute.round_up(total_seqlen_Q, 8)
 
         acc_bytes = acc_dtype.width // 8
-        sum_OdO_bytes = cute.assume(H * total_seqlen_Q * acc_bytes, divby=acc_bytes * 64)
+        sum_OdO_bytes = cute.assume(workspace_H * total_seqlen_Q * acc_bytes, divby=acc_bytes * 64)
 
         sum_OdO_iter = workspace_LSE_OdO.iterator
         scaled_lse_iter = sum_OdO_iter + sum_OdO_bytes
@@ -220,14 +221,22 @@ class FlashAttentionDSABackwardSm100H16:
         scaled_lse_iter = cute.recast_ptr(scaled_lse_iter, dtype=self.acc_dtype)
         dKV_acc_iter = cute.recast_ptr(dKV_acc_iter, dtype=self.acc_dtype)
 
-        sum_OdO = cute.make_tensor(
+        sum_OdO_full = cute.make_tensor(
             sum_OdO_iter,
-            cute.make_layout((H, (total_seqlen_Q, 1)), stride=(1, (cute.assume(H, divby=64), 0))),
+            cute.make_layout((workspace_H, (total_seqlen_Q, 1)), stride=(1, (cute.assume(workspace_H, divby=16), 0))),
         )
-        scaled_lse = cute.make_tensor(
+        scaled_lse_full = cute.make_tensor(
             scaled_lse_iter,
-            cute.make_layout((H, (total_seqlen_Q, 1)), stride=(1, (cute.assume(H, divby=64), 0))),
+            cute.make_layout((workspace_H, (total_seqlen_Q, 1)), stride=(1, (cute.assume(workspace_H, divby=16), 0))),
         )
+        if cutlass.const_expr(self.workspace_head_offset > 0):
+            workspace_head_offset = self.workspace_head_offset
+            local_layout = cute.make_layout((H, (total_seqlen_Q, 1)), stride=(1, (workspace_H, 0)))
+            sum_OdO = cute.make_tensor(sum_OdO_full.iterator + workspace_head_offset, local_layout)
+            scaled_lse = cute.make_tensor(scaled_lse_full.iterator + workspace_head_offset, local_layout)
+        else:
+            sum_OdO = sum_OdO_full
+            scaled_lse = scaled_lse_full
         dKV_acc = cute.make_tensor(
             dKV_acc_iter,
             cute.make_layout((total_seqlen_KV, D, (1, 1)), stride=(D, 1, (0, 0))),
@@ -282,6 +291,41 @@ class FlashAttentionDSABackwardSm100H16:
         """
         Forward pass for DeepSeek Sparse Attention.
         """
+
+        # Composite launches pass the original compact H96 tensors. Restrict
+        # this component to its logical head range inside the JIT so no
+        # execute-side head-slice copy is needed.
+        if cutlass.const_expr(self.head_offset != 0):
+            local_heads = cute.size(problem_shape[3][0])
+            head_offset = self.head_offset
+            mQ = cute.make_tensor(
+                mQ.iterator + head_offset * mQ.stride[1],
+                cute.make_layout((mQ.shape[0], local_heads, mQ.shape[2]), stride=(mQ.stride[0], mQ.stride[1], mQ.stride[2])),
+            )
+            mOut = cute.make_tensor(
+                mOut.iterator + head_offset * mOut.stride[1],
+                cute.make_layout((mOut.shape[0], local_heads, mOut.shape[2]), stride=(mOut.stride[0], mOut.stride[1], mOut.stride[2])),
+            )
+            mdO = cute.make_tensor(
+                mdO.iterator + head_offset * mdO.stride[1],
+                cute.make_layout((mdO.shape[0], local_heads, mdO.shape[2]), stride=(mdO.stride[0], mdO.stride[1], mdO.stride[2])),
+            )
+            mLSE = cute.make_tensor(
+                mLSE.iterator + head_offset * mLSE.stride[1],
+                cute.make_layout((mLSE.shape[0], local_heads), stride=(mLSE.stride[0], mLSE.stride[1])),
+            )
+            mAttnSink = cute.make_tensor(
+                mAttnSink.iterator + head_offset * mAttnSink.stride[0],
+                cute.make_layout((local_heads,), stride=(mAttnSink.stride[0],)),
+            )
+            mdQ = cute.make_tensor(
+                mdQ.iterator + head_offset * mdQ.stride[1],
+                cute.make_layout((mdQ.shape[0], local_heads, mdQ.shape[2]), stride=(mdQ.stride[0], mdQ.stride[1], mdQ.stride[2])),
+            )
+            mdSink = cute.make_tensor(
+                mdSink.iterator + head_offset * mdSink.stride[0],
+                cute.make_layout((local_heads,), stride=(mdSink.stride[0],)),
+            )
 
         # [M, H, D] -> [H, D, (M, 1)]
         mQ = cute.make_tensor(
@@ -480,36 +524,38 @@ class FlashAttentionDSABackwardSm100H16:
             self.acc_dtype,
         )
         mdKV_acc = cute.make_tensor(mdKV_acc.iterator, mdKV.layout)
-        rows_per_cta = 64
-        self.clear_dKV_workspace(mdKV_acc, mKV.shape[0]).launch(
-            grid=[cute.ceil_div(mKV.shape[0], rows_per_cta), 1, 1],
-            block=[32, 8, 1],
-            stream=stream,
-        )
+        if cutlass.const_expr(self.initialize_dkv):
+            rows_per_cta = 64
+            self.clear_dKV_workspace(mdKV_acc, mKV.shape[0]).launch(
+                grid=[cute.ceil_div(mKV.shape[0], rows_per_cta), 1, 1],
+                block=[32, 8, 1],
+                stream=stream,
+            )
 
         # ============ Sum OdO ============
         sum_OdO_scale = Float32(-1.0)
         LSE_scale = Float32(-math.log2(math.e))
 
-        sum_OdO_grid = self._compute_sum_OdO_grid(problem_shape, self.sum_OdO_block_q)
+        if cutlass.const_expr(self.run_sum_odo):
+            sum_OdO_grid = self._compute_sum_OdO_grid(problem_shape, self.sum_OdO_block_q)
 
-        self.sum_OdO(
-            mOut,
-            mdO,
-            sum_OdO,
-            mLSE,
-            mAttnSink,
-            scaled_LSE,
-            sum_OdO_scale,
-            LSE_scale,
-            problem_shape,
-        ).launch(
-            grid=sum_OdO_grid,
-            block=[self.sum_OdO_num_threads_d, self.sum_OdO_num_threads_q, 1],
-            cluster=[1, 1, 1],
-            stream=stream,
-            min_blocks_per_mp=1,
-        )
+            self.sum_OdO(
+                mOut,
+                mdO,
+                sum_OdO,
+                mLSE,
+                mAttnSink,
+                scaled_LSE,
+                sum_OdO_scale,
+                LSE_scale,
+                problem_shape,
+            ).launch(
+                grid=sum_OdO_grid,
+                block=[self.sum_OdO_num_threads_d, self.sum_OdO_num_threads_q, 1],
+                cluster=[1, 1, 1],
+                stream=stream,
+                min_blocks_per_mp=1,
+            )
 
         num_head_blocks = cute.ceil_div(problem_shape[3][0], self.block_tile)
         bwd_grid = (problem_shape[0], num_head_blocks, problem_shape[3][1])
@@ -573,41 +619,43 @@ class FlashAttentionDSABackwardSm100H16:
         self.num_threads_D_convert = 32
         self.num_threads_seq = 4 if self.max_topk == 2048 else self.block_seq
 
-        convert_grid_x = (mKV.shape[0] + self.block_seq - 1) // self.block_seq
-        convert_grid = [
-            convert_grid_x,
-            1,
-            1,
-        ]
-        convert_block = [self.num_threads_D_convert, self.num_threads_seq, 1]
-        self.convert(
-            mdKV_acc,
-            mdKV,
-            mKV.shape[0],
-        ).launch(
-            grid=convert_grid,
-            block=convert_block,
-            stream=stream,
-        )
+        if cutlass.const_expr(self.finalize_dkv):
+            convert_grid_x = (mKV.shape[0] + self.block_seq - 1) // self.block_seq
+            convert_grid = [
+                convert_grid_x,
+                1,
+                1,
+            ]
+            convert_block = [self.num_threads_D_convert, self.num_threads_seq, 1]
+            self.convert(
+                mdKV_acc,
+                mdKV,
+                mKV.shape[0],
+            ).launch(
+                grid=convert_grid,
+                block=convert_block,
+                stream=stream,
+            )
 
-        dSink_grid = (
-            cute.ceil_div(problem_shape[0], self.dSink_block_q),
-            problem_shape[3][0],
-            problem_shape[3][1],
-        )
-        self.sum_dSink(
-            sum_OdO,
-            scaled_LSE,
-            mAttnSink,
-            mdSink,
-            problem_shape,
-        ).launch(
-            grid=dSink_grid,
-            block=[self.dSink_num_threads, 1, 1],
-            cluster=[1, 1, 1],
-            stream=stream,
-            min_blocks_per_mp=1,
-        )
+        if cutlass.const_expr(self.run_dsink):
+            dSink_grid = (
+                cute.ceil_div(problem_shape[0], self.dSink_block_q),
+                problem_shape[3][0],
+                problem_shape[3][1],
+            )
+            self.sum_dSink(
+                sum_OdO,
+                scaled_LSE,
+                mAttnSink,
+                mdSink,
+                problem_shape,
+            ).launch(
+                grid=dSink_grid,
+                block=[self.dSink_num_threads, 1, 1],
+                cluster=[1, 1, 1],
+                stream=stream,
+                min_blocks_per_mp=1,
+            )
 
     @cute.kernel
     def convert(

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100_h96.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100_h96.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Tuple, Type
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.typing import Float32, Int32
+
+from .dsa_bwd_sm100 import FlashAttentionDSABackwardSm100
+from .dsa_bwd_sm100_h32 import FlashAttentionDSABackwardSm100H32
+
+
+class FlashAttentionDSABackwardSm100H96H64(FlashAttentionDSABackwardSm100):
+    """H64 body of H96, including the shared auxiliary kernels."""
+
+    finalize_dkv = False
+    bwd_num_heads = 64
+
+
+class FlashAttentionDSABackwardSm100H96H32(FlashAttentionDSABackwardSm100H32):
+    """H32 tail of H96, consuming shared auxiliaries and finalizing dKV."""
+
+    initialize_dkv = False
+    run_sum_odo = False
+    run_dsink = False
+    head_offset = 64
+    workspace_num_heads = 96
+    workspace_head_offset = 64
+
+
+class FlashAttentionDSABackwardSm100H96:
+    """Compose the tuned H64 body and H32 tail into one launch sequence."""
+
+    def __init__(
+        self,
+        element_dtype: Type[cutlass.Numeric],
+        head_dim: int,
+        head_dim_v: int,
+        block_tile: int,
+        max_topk: int = 0,
+    ):
+        if head_dim != 576 or head_dim_v != 512 or block_tile != 64:
+            raise ValueError("H96 composition requires head_dim=576, head_dim_v=512, and block_tile=64")
+        common = (element_dtype, head_dim, head_dim_v, block_tile, max_topk)
+        self.h64 = FlashAttentionDSABackwardSm100H96H64(*common)
+        self.h32 = FlashAttentionDSABackwardSm100H96H32(*common)
+
+    @cute.jit
+    def __call__(
+        self,
+        problem_shape: Tuple[Int32, Int32, Int32, Tuple[Int32, Int32]],
+        mQ: cute.Tensor,
+        mKV: cute.Tensor,
+        mOut: cute.Tensor,
+        mdO: cute.Tensor,
+        mLSE: cute.Tensor,
+        mAttnSink: cute.Tensor,
+        mTopkIdxs: cute.Tensor,
+        mTopkLength: Optional[cute.Tensor],
+        mdQ: cute.Tensor,
+        mdKV: cute.Tensor,
+        mdSink: cute.Tensor,
+        workspace_LSE_OdO: cute.Tensor,
+        workspace_dKV: cute.Tensor,
+        softmax_scale: Float32 | float,
+        stream: cuda.CUstream,
+    ):
+        self.h64(
+            problem_shape,
+            mQ,
+            mKV,
+            mOut,
+            mdO,
+            mLSE,
+            mAttnSink,
+            mTopkIdxs,
+            mTopkLength,
+            mdQ,
+            mdKV,
+            mdSink,
+            workspace_LSE_OdO,
+            workspace_dKV,
+            softmax_scale,
+            stream,
+        )
+        h32_problem_shape = (problem_shape[0], problem_shape[1], problem_shape[2], (32, problem_shape[3][1]))
+        self.h32(
+            h32_problem_shape,
+            mQ,
+            mKV,
+            mOut,
+            mdO,
+            mLSE,
+            mAttnSink,
+            mTopkIdxs,
+            mTopkLength,
+            mdQ,
+            mdKV,
+            mdSink,
+            workspace_LSE_OdO,
+            workspace_dKV,
+            softmax_scale,
+            stream,
+        )

--- a/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
@@ -696,7 +696,7 @@ def test_DSA_sparse_attention_backward_sm100_h96_composite_boundaries(has_topk_l
         pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
 
     device = torch.device("cuda")
-    s_q, s_kv, topk_width = 4, 129, 1024
+    s_q, s_kv, topk_width = 4, 129, 256
     num_heads, head_dim = 96, 576
     softmax_scale = 1.0 / math.sqrt(head_dim)
     lengths = torch.tensor([0, 1, 65, 129], dtype=torch.int32, device=device)
@@ -1071,7 +1071,7 @@ def test_DSA_sparse_attention_backward_sm100_specialized_masks_invalid_topk_rows
 
     device = torch.device("cuda")
     head_dim, head_dim_v = 576, 512
-    topk_width = 1024 if num_heads == 96 else 256
+    topk_width = 256
     q = torch.full((1, num_heads, head_dim), 8.0, dtype=torch.bfloat16, device=device)
     kv = torch.full((1, head_dim), -8.0, dtype=torch.bfloat16, device=device)
     dout = torch.randn(1, num_heads, head_dim_v, dtype=torch.bfloat16, device=device)
@@ -1171,7 +1171,7 @@ def test_DSA_sparse_attention_backward_sm100_specialized_handles_sink_limits(num
         cases.append((2.4e38, False))
     for sink_value, empty_row in cases:
         attn_sink = torch.full((num_heads,), sink_value, dtype=torch.float32, device=device)
-        topk_width = 1024 if num_heads == 96 else 64
+        topk_width = 64
         topk_idxs = torch.full((1, topk_width), torch.iinfo(torch.int32).max if empty_row else -1, dtype=torch.int32, device=device)
         topk_length = torch.zeros(1, dtype=torch.int32, device=device) if empty_row else None
         if empty_row:
@@ -1805,12 +1805,6 @@ def test_DSA_sparse_attention_backward_fp16_sm100_numerics(head_dim, num_heads):
     attn_sink = torch.linspace(-2.0, 2.0, num_heads, dtype=torch.float32, device=device)
     topk_idxs = torch.stack([torch.randperm(s_kv, device=device)[:topk] for _ in range(s_q)]).to(torch.int32)
     topk_length = torch.tensor([16, 32, 48, 64], dtype=torch.int32, device=device)
-    if num_heads == 96:
-        topk_idxs = torch.cat(
-            [topk_idxs, torch.full((s_q, 1024 - topk), -1, dtype=torch.int32, device=device)],
-            dim=1,
-        )
-
     out, lse = ref_sparse_attention_forward_chunked(
         q,
         kv,

--- a/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
@@ -58,6 +58,7 @@ def _allocate(cfg, has_topk_length: bool):
         (16, 512, "generic_m64", 64),
         (32, 576, "h32_m64", 64),
         (64, 576, "generic_m64", 64),
+        (96, 576, "h96_h64_h32", 64),
     ],
 )
 @pytest.mark.L0
@@ -73,6 +74,20 @@ def test_DSA_sparse_attention_backward_sm100_auto_dispatch(
         pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
 
     assert _select_sm100_backend(num_heads, head_dim) == (expected_backend, expected_block_tile)
+
+
+@pytest.mark.L0
+def test_DSA_sparse_attention_backward_sm100_h96_dispatch_is_fail_closed():
+    """Keep the H96 composition off shapes where its extra launch dominates."""
+    try:
+        from cudnn.deepseek_sparse_attention.sparse_attention_backward._interface_sm100 import _select_sm100_backend
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+
+    assert _select_sm100_backend(96, 576, max_topk=512, total_s_q=256) == ("generic_m64", 64)
+    assert _select_sm100_backend(96, 576, max_topk=512, total_s_q=1024) == ("h96_h64_h32", 64)
+    assert _select_sm100_backend(96, 576, max_topk=1024, total_s_q=256) == ("h96_h64_h32", 64)
+    assert _select_sm100_backend(96, 576, max_topk=2048, total_s_q=256, deterministic=True) == ("generic_m64", 64)
 
 
 @pytest.mark.L0
@@ -211,6 +226,7 @@ def _exercise_deterministic_sm100_case(num_heads, head_dim, s_q, s_kv, repeats, 
         pytest.param(64, 512, 1000, marks=pytest.mark.L2, id="H64-D512-repeat1000"),
         pytest.param(64, 576, 1000, marks=pytest.mark.L2, id="H64-D576-repeat1000"),
         pytest.param(96, 512, 1000, marks=pytest.mark.L2, id="H96-D512-repeat1000"),
+        pytest.param(96, 576, 1000, marks=pytest.mark.L2, id="H96-D576-repeat1000"),
         pytest.param(128, 576, 1000, marks=pytest.mark.L2, id="H128-D576-repeat1000"),
     ],
 )
@@ -232,6 +248,7 @@ def test_DSA_sparse_attention_backward_sm100_deterministic_bounded_waves(num_hea
         pytest.param(32, 512, 9, 127, id="H32-q9-kv127"),
         pytest.param(64, 576, 127, 128, id="H64-q127-kv128"),
         pytest.param(96, 512, 128, 129, id="H96-q128-kv129"),
+        pytest.param(96, 576, 129, 130, id="H96-D576-q129-kv130"),
         pytest.param(128, 576, 129, 130, id="H128-q129-kv130"),
     ],
 )
@@ -648,6 +665,96 @@ def test_DSA_sparse_attention_backward_wrapper_h128(has_topk_length, request):
     )
 
 
+@pytest.mark.L1
+@pytest.mark.gpu_exclusive
+@pytest.mark.xdist_group(name="gpu_exclusive")
+@pytest.mark.parametrize("has_topk_length", [False, True], ids=["full-topk", "lengths"])
+@torch_fork_set_rng(seed=96)
+def test_DSA_sparse_attention_backward_wrapper_h96_composite(has_topk_length, request):
+    """Validate the H64 plus H32 composition against the FP32 reference."""
+    _run_DSA_sparse_attention_backward_wrapper(
+        dtype=torch.bfloat16,
+        acc_dtype=torch.float32,
+        head_dim=576,
+        head_dim_v=512,
+        num_heads=96,
+        topk=512,
+        has_topk_length=has_topk_length,
+        request=request,
+    )
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("has_topk_length", [False, True], ids=["sentinel-padding", "lengths"])
+@torch_fork_set_rng(seed=960)
+def test_DSA_sparse_attention_backward_sm100_h96_composite_boundaries(has_topk_length):
+    """Cover empty, partial, and multi-tile rows in both H96 components."""
+    _require_sm100()
+    try:
+        from cudnn import DSA
+        from cudnn.deepseek_sparse_attention.sparse_attention_backward import _interface_sm100
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+
+    device = torch.device("cuda")
+    s_q, s_kv, topk_width = 4, 129, 1024
+    num_heads, head_dim = 96, 576
+    softmax_scale = 1.0 / math.sqrt(head_dim)
+    lengths = torch.tensor([0, 1, 65, 129], dtype=torch.int32, device=device)
+
+    q = torch.randn(s_q, num_heads, head_dim, dtype=torch.bfloat16, device=device) / 10
+    kv = torch.randn(s_kv, head_dim, dtype=torch.bfloat16, device=device) / 10
+    attn_sink = torch.linspace(-2.0, 2.0, num_heads, dtype=torch.float32, device=device)
+    topk_idxs = torch.full((s_q, topk_width), -1, dtype=torch.int32, device=device)
+    for row, length in enumerate(lengths.tolist()):
+        if length:
+            topk_idxs[row, :length] = torch.randperm(s_kv, device=device)[:length].to(torch.int32)
+    topk_length = lengths if has_topk_length else None
+
+    out, lse = ref_sparse_attention_forward_chunked(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        topk_length=topk_length,
+        softmax_scale=softmax_scale,
+    )
+    dout = torch.randn_like(out)
+    result = DSA.sparse_attention_backward_wrapper(
+        q,
+        kv,
+        out,
+        dout,
+        lse,
+        attn_sink,
+        topk_idxs,
+        softmax_scale=softmax_scale,
+        topk_length=topk_length,
+    )
+    torch.cuda.synchronize()
+
+    assert torch.isfinite(result["dq"]).all()
+    assert torch.isfinite(result["dkv"]).all()
+    assert torch.isfinite(result["d_sink"]).all()
+    check_ref_dsa_sparse_attention_backward(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        out,
+        dout,
+        lse,
+        result["dq"],
+        result["dkv"],
+        result["d_sink"],
+        softmax_scale=softmax_scale,
+        topk_length=topk_length,
+        atol=5e-2,
+        rtol=5e-2,
+    )
+    assert any(key[0] == "h96_h64_h32" for key in _interface_sm100.flash_attn_bwd_sm100.compile_cache)
+
+
 @pytest.mark.L0
 @pytest.mark.parametrize("has_topk_length", [False, True], ids=["full-topk", "lengths"])
 @torch_fork_set_rng(seed=418)
@@ -950,10 +1057,11 @@ def test_DSA_sparse_attention_backward_sm100_handles_infinite_sink_limits(sink_v
     [
         pytest.param(16, "h16_m128", id="h16-m128"),
         pytest.param(32, "h32_m64", id="h32-m64"),
+        pytest.param(96, "h96_h64_h32", id="h96-h64-h32"),
     ],
 )
 def test_DSA_sparse_attention_backward_sm100_specialized_masks_invalid_topk_rows(num_heads, expected_backend):
-    """The H16/H32 kernels must mask every invalid sparse row before probability use and KV access."""
+    """Specialized kernels must mask invalid rows before probability use and KV access."""
     _require_sm100()
 
     try:
@@ -963,7 +1071,8 @@ def test_DSA_sparse_attention_backward_sm100_specialized_masks_invalid_topk_rows
         pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
 
     device = torch.device("cuda")
-    head_dim, head_dim_v, topk_width = 576, 512, 256
+    head_dim, head_dim_v = 576, 512
+    topk_width = 1024 if num_heads == 96 else 256
     q = torch.full((1, num_heads, head_dim), 8.0, dtype=torch.bfloat16, device=device)
     kv = torch.full((1, head_dim), -8.0, dtype=torch.bfloat16, device=device)
     dout = torch.randn(1, num_heads, head_dim_v, dtype=torch.bfloat16, device=device)
@@ -1035,10 +1144,11 @@ def test_DSA_sparse_attention_backward_sm100_specialized_masks_invalid_topk_rows
     [
         pytest.param(16, "h16_m128", id="h16-m128"),
         pytest.param(32, "h32_m64", id="h32-m64"),
+        pytest.param(96, "h96_h64_h32", id="h96-h64-h32"),
     ],
 )
 def test_DSA_sparse_attention_backward_sm100_specialized_handles_sink_limits(num_heads, expected_backend):
-    """The H16/H32 sink path must implement empty and saturating softmax limits."""
+    """Specialized sink paths must implement empty and saturating softmax limits."""
     _require_sm100()
 
     try:
@@ -1054,9 +1164,16 @@ def test_DSA_sparse_attention_backward_sm100_specialized_handles_sink_limits(num
     out = torch.zeros(1, num_heads, head_dim_v, dtype=torch.bfloat16, device=device)
     dout = torch.randn_like(out)
 
-    for sink_value, empty_row in ((-math.inf, True), (math.inf, False), (2.4e38, False)):
+    cases = [(-math.inf, True), (math.inf, False)]
+    # The finite-overflow case targets behavior implemented by the H16/H32
+    # kernels themselves; the H96 composition intentionally retains the
+    # existing generic H64 behavior for its first 64 heads.
+    if num_heads != 96:
+        cases.append((2.4e38, False))
+    for sink_value, empty_row in cases:
         attn_sink = torch.full((num_heads,), sink_value, dtype=torch.float32, device=device)
-        topk_idxs = torch.full((1, 64), torch.iinfo(torch.int32).max if empty_row else -1, dtype=torch.int32, device=device)
+        topk_width = 1024 if num_heads == 96 else 64
+        topk_idxs = torch.full((1, topk_width), torch.iinfo(torch.int32).max if empty_row else -1, dtype=torch.int32, device=device)
         topk_length = torch.zeros(1, dtype=torch.int32, device=device) if empty_row else None
         if empty_row:
             lse = torch.full((1, num_heads), -math.inf, dtype=torch.float32, device=device)
@@ -1576,10 +1693,14 @@ def test_DSA_sparse_attention_backward_staged_store():
 @pytest.mark.L0
 @pytest.mark.gpu_exclusive
 @pytest.mark.xdist_group(name="gpu_exclusive")
-@pytest.mark.parametrize("num_heads,topk", [(64, 64), (128, 128)], ids=["generic", "h128-two-cta"])
+@pytest.mark.parametrize(
+    "num_heads,head_dim,topk",
+    [(64, 512, 64), (96, 576, 1024), (128, 512, 128)],
+    ids=["generic", "h96-composite", "h128-two-cta"],
+)
 @pytest.mark.parametrize("has_topk_length", [False, True], ids=["full-topk", "lengths"])
 @torch_fork_set_rng(seed=7)
-def test_DSA_sparse_attention_backward_nondefault_stream_zero_init_ordering(num_heads, topk, has_topk_length):
+def test_DSA_sparse_attention_backward_nondefault_stream_zero_init_ordering(num_heads, head_dim, topk, has_topk_length):
     """The SM100 interface must establish zero state on the launch stream.
 
     The generic path uses torch zero-fills, while the H128 two-CTA path launches
@@ -1603,7 +1724,6 @@ def test_DSA_sparse_attention_backward_nondefault_stream_zero_init_ordering(num_
         _require_exact_sm100()
     device = torch.device("cuda")
     s_q, s_kv = 256, 1024
-    head_dim = 512
     softmax_scale = 1.0 / math.sqrt(head_dim)
 
     q = torch.randn(s_q, num_heads, head_dim, dtype=torch.bfloat16, device=device) / 10
@@ -1667,7 +1787,7 @@ def test_DSA_sparse_attention_backward_nondefault_stream_zero_init_ordering(num_
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("head_dim,num_heads", [(512, 64), (576, 16), (576, 32)])
+@pytest.mark.parametrize("head_dim,num_heads", [(512, 64), (576, 16), (576, 32), (576, 96)])
 @torch_fork_set_rng(seed=16)
 def test_DSA_sparse_attention_backward_fp16_sm100_numerics(head_dim, num_heads):
     """SM100 must compile FP16 inputs with FP16 MMA/storage semantics."""
@@ -1686,6 +1806,11 @@ def test_DSA_sparse_attention_backward_fp16_sm100_numerics(head_dim, num_heads):
     attn_sink = torch.linspace(-2.0, 2.0, num_heads, dtype=torch.float32, device=device)
     topk_idxs = torch.stack([torch.randperm(s_kv, device=device)[:topk] for _ in range(s_q)]).to(torch.int32)
     topk_length = torch.tensor([16, 32, 48, 64], dtype=torch.int32, device=device)
+    if num_heads == 96:
+        topk_idxs = torch.cat(
+            [topk_idxs, torch.full((s_q, 1024 - topk), -1, dtype=torch.int32, device=device)],
+            dim=1,
+        )
 
     out, lse = ref_sparse_attention_forward_chunked(
         q,

--- a/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
@@ -77,17 +77,16 @@ def test_DSA_sparse_attention_backward_sm100_auto_dispatch(
 
 
 @pytest.mark.L0
-def test_DSA_sparse_attention_backward_sm100_h96_dispatch_is_fail_closed():
-    """Keep the H96 composition off shapes where its extra launch dominates."""
+def test_DSA_sparse_attention_backward_sm100_h96_dispatch():
+    """Select the H96 composition for every supported non-deterministic shape."""
     try:
         from cudnn.deepseek_sparse_attention.sparse_attention_backward._interface_sm100 import _select_sm100_backend
     except ImportError:
         pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
 
-    assert _select_sm100_backend(96, 576, max_topk=512, total_s_q=256) == ("generic_m64", 64)
-    assert _select_sm100_backend(96, 576, max_topk=512, total_s_q=1024) == ("h96_h64_h32", 64)
-    assert _select_sm100_backend(96, 576, max_topk=1024, total_s_q=256) == ("h96_h64_h32", 64)
-    assert _select_sm100_backend(96, 576, max_topk=2048, total_s_q=256, deterministic=True) == ("generic_m64", 64)
+    assert _select_sm100_backend(96, 576, max_topk=512) == ("h96_h64_h32", 64)
+    assert _select_sm100_backend(96, 576, max_topk=1024) == ("h96_h64_h32", 64)
+    assert _select_sm100_backend(96, 576, max_topk=2048, deterministic=True) == ("generic_m64", 64)
 
 
 @pytest.mark.L0


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches and the changes comply.
- [ ] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*`. External contributors cannot add labels to this repository; suggested labels are `cat-enhancements`, `area:sparse_attention`, `op: DSA`, and `orig-external`.

## Affected area

FE OSS kernels or CuTeDSL

## Summary

This change adds an SM100 DSA backward path for BF16/FP16 H96, Dqk=576, Dv=512. It composes the existing generic H64 M64 body with the existing single-Q H32 M64 specialization, while preserving one shared FP32 dKV accumulation workspace and one full-H96 auxiliary workspace.

The optimized sequence uses six CuTe kernel launches:

1. Clear the shared FP32 dKV accumulator.
2. Compute `sum(O * dO)` and scaled LSE for all 96 heads.
3. Run the generic H64 backward body for heads 0:64.
4. Compute dSink for all 96 heads.
5. Run the specialized H32 backward body for heads 64:96.
6. Convert the shared FP32 dKV accumulator to the public BF16/FP16 dKV output.

This removes the duplicated clear, auxiliary, dSink, and conversion work of a naive two-sequence composition. The upstream H96 path uses five launches; this specialization pays one additional main-kernel launch in exchange for avoiding the half-populated second H64 head block.

## Why

The generic H96 kernel decomposes the head dimension into two H64 blocks. Its second CTA has only 32 live heads but retains the H64 kernel's scheduling, register allocation, and tensor-memory geometry. The existing H32 specialization is a better match for this tail: it uses an H32 MMA layout and H32-specific TMEM offsets and register budgets.

The H96 path therefore keeps the well-tuned generic H64 body for the first 64 heads and reuses the established H32 source structure for the remaining 32 heads. No new attention formula or reduced-precision accumulation mode is introduced.

## Related issues

None.

## API and compatibility impact

No public API or workspace-size contract changes. The specialization affects non-deterministic SM100 H96/Dqk=576 execution; `deterministic=True` retains the existing generic bounded-wave backend. Input/output dtypes and FP32 dKV accumulation semantics are unchanged.

## Implementation

- Add an H96 `@cute.jit` orchestrator that owns an H64 component and an H32 component. The public SM100 interface continues to follow the common select-class, compile, and execute path.
- Add compile-time launch controls to the generic and H16-derived implementations so a composite component can skip dKV initialization/finalization or shared auxiliary kernels without runtime branches.
- Let the H64 component receive the full H96 problem shape for the shared `sum_OdO`, scaled-LSE, and dSink kernels, while limiting only its main backward grid to 64 heads.
- Let the H32 component bind direct pointer-offset views of heads 64:96. There is no execute-time slice copy, allocation, device-to-host read, or hidden adaptation kernel.
- Map the H32 component into the full workspace layout:
  - `sum_OdO`: `[96, total_q]`, H32 view starts at head 64 with row stride 96.
  - `scaled_LSE`: `[96, total_q]`, H32 view starts at head 64 with row stride 96.
  - `dKV_acc`: one shared FP32 `[total_kv, 576]` accumulator.
- Preserve the deterministic route unchanged. `deterministic=True` continues to select the generic bounded-wave implementation.
- Route every supported non-deterministic H96/D576 shape to the composition. `deterministic=True` continues to select the generic bounded-wave implementation.

## Performance

Measured on NVIDIA GB200, CUDA 13.0, cuDNN 9.19, nvidia-cutlass-dsl 4.6.2, BF16, H96, Dqk=576, Dv=512, supplied `topk_length`, and random unique top-k indices. Q and KV use the same sequence length shown in the table. The upstream baseline is `902c1a77`; the candidate is `db0a5b9d`. Each benchmark process forced a fresh CuTe compilation; timings are the median of five CUDA-event windows after warmup.

| Sequence length (Q=KV) | Top-k | Upstream (ms) | Optimized (ms) | Speedup | Time reduction |
|---:|---:|---:|---:|---:|---:|
| 4096 | 512 | 2.7928 | 2.5522 | 1.094x | 9.4% |
| 4096 | 1024 | 5.1386 | 4.6237 | 1.111x | 11.1% |
| 4096 | 2048 | 9.8197 | 8.7599 | 1.121x | 12.1% |
| 8192 | 512 | 5.5226 | 5.0307 | 1.098x | 9.8% |
| 8192 | 1024 | 10.2041 | 9.1527 | 1.115x | 11.5% |
| 8192 | 2048 | 19.5676 | 17.4094 | 1.124x | 12.4% |

The geometric-mean speedup across these six shapes is 1.110x.

### Nsight Systems decomposition

For Q1024/topk512, the upstream generic H96 main backward kernel took 682.8 microseconds. The optimized H64 and H32 main kernels took 347.6 and 270.9 microseconds respectively, or 618.5 microseconds combined (1.104x for the main backward work). The complete CuTe sequence decreased from 739.7 to 675.8 microseconds (1.095x). Auxiliary kernel times remained approximately unchanged, so the gain comes from replacing the half-populated H64 tail with the H32-specific pipeline, not from omitting math.

## Correctness

A BF16 boundary sweep covered effective top-k lengths `0, 1, 63, 64, 65, 127, 128, 129, 191, 192, 193, 255, 256, 257` against an FP32 PyTorch autograd reference.

| Output | Upstream relative RMSE | Optimized relative RMSE | Optimized vs upstream |
|---|---:|---:|---|
| dQ | 4.319e-3 | 4.319e-3 | bitwise equal |
| dKV | 2.186e-3 | 2.186e-3 | not bitwise; max delta 3.906e-3 |
| dSink | 1.909e-3 | 1.909e-3 | bitwise equal |

dKV retains the existing FP32 global-atomic accumulation semantics, so ordinary execution is not bitwise deterministic. The deterministic backend remains available and unchanged.

## Testing

- H96 targeted L0/L1 tests: 17 passed.
- Full DSA backward L0 file: 59 passed, 14 skipped.
- H96 D576 deterministic test: 1000 consecutive executions bitwise equal for dQ, dKV, and dSink.
- Non-default CUDA stream ordering test passed.
- BF16 and FP16 numerical tests passed.
- Full-top-k, `topk_length`, sentinel padding, empty rows, partial tiles, invalid indices, and sink limits are covered.
- Compute Sanitizer:
  - memcheck: 0 errors.
  - racecheck: 0 hazards, 0 errors, 0 warnings.
  - initcheck: 0 errors.
- Pre-commit hooks: black, black-jupyter, SPDX header all passed.

## Notes for reviewers

- The H96 code deliberately reuses the H16/H32 source structure instead of introducing another copy of the pipeline.
- All composition controls are compile-time constants; standalone generic, H16, and H32 kernels retain their existing launch sequence.
- No input/output dtype, FP32 accumulation rule, workspace size contract, or public API signature changes.
