### PR TITLE
fix(frost): clear stale TMA descriptor flags for short varlen tails

### DIFF
--- a/python/cudnn/frost/tile_dsl/thd.py
+++ b/python/cudnn/frost/tile_dsl/thd.py
@@ -37,6 +37,7 @@ from cutlass._mlir.dialects import arith
 
 # int64 words per 128-byte TMA descriptor.
 TENSOR_MAP_QWORDS = 128 // 8
+TENSOR_MAP_BIT21 = 1 << 21  # qword 1: encoder's "tensor >= 128 KiB" flag; tensormap.replace does not update it (issue #1013)
 
 THD_META_WORDS = lambda b: 4 * b + 4  # noqa: E731
 THD_REMAP_OFF = lambda b: 3 * b + 2  # noqa: E731
@@ -294,6 +295,13 @@ def thd_claim_next(meta_t: cute.Tensor, ctr_off: cutlass.Int32, slot, tidx: cutl
 
 
 @cute.jit
+def set_tensor_map_bit21(dptr, new_bytes: cutlass.Int64) -> None:
+    """Recompute bit 21 from the patched extent (as cuTensorMapEncodeTiled would)."""
+    w = (dptr + 1).load() & cutlass.Int64(~TENSOR_MAP_BIT21)
+    (dptr + 1).store((w | cutlass.Int64(TENSOR_MAP_BIT21)) if new_bytes >= cutlass.Int64(128 << 10) else w)
+
+
+@cute.jit
 def emit_seq_descs(
     base_desc,
     desc_words,
@@ -352,6 +360,9 @@ def emit_seq_descs(
             new_value=cute.math.max(s_b, cutlass.Int32(1)),
             ord=seq_ord,
         )
+        set_tensor_map_bit21(
+            dptr, cutlass.Int64(cute.math.max(s_b, cutlass.Int32(1))) * cutlass.Int64(row_stride) * cutlass.Int64(base_ptr.element_type.width // 8)
+        )
 
 
 @cute.jit
@@ -392,6 +403,7 @@ __all__ = [
     "THD_SETUP_THREADS",
     "emit_clamped_desc",
     "emit_seq_descs",
+    "set_tensor_map_bit21",
     "thd_claim_next",
     "thd_decode_unit",
     "write_thd_batch_remap",

--- a/python/cudnn/linear_attention/frost/common/thd.py
+++ b/python/cudnn/linear_attention/frost/common/thd.py
@@ -19,6 +19,14 @@ import cutlass.experimental.primitives as nvvm
 from cutlass.base_dsl.typing import Pointer
 
 TENSOR_MAP_QWORDS = 128 // 8
+TENSOR_MAP_BIT21 = 1 << 21  # qword 1: encoder's "tensor >= 128 KiB" flag; tensormap.replace does not update it (issue #1013)
+
+
+@cute.jit
+def set_tensor_map_bit21(dptr, new_bytes: cutlass.Int64) -> None:
+    """Recompute bit 21 from the patched extent (as cuTensorMapEncodeTiled would)."""
+    w = (dptr + 1).load() & cutlass.Int64(~TENSOR_MAP_BIT21)
+    (dptr + 1).store((w | cutlass.Int64(TENSOR_MAP_BIT21)) if new_bytes >= cutlass.Int64(128 << 10) else w)
 
 
 @cute.jit
@@ -73,6 +81,7 @@ def emit_seq_descs(
             new_value=s_b,
             ord=seq_ord,
         )
+        set_tensor_map_bit21(dptr, cutlass.Int64(s_b) * cutlass.Int64(base_ptr.stride[0]) * cutlass.Int64(base_ptr.element_type.width // 8))
 
 
 @cute.jit
@@ -142,3 +151,4 @@ def emit_checkpoint_seq_descs(
             new_value=cnt,
             ord=seq_ord,
         )
+        set_tensor_map_bit21(dptr, cutlass.Int64(cnt) * cutlass.Int64(base_ptr.stride[0]) * cutlass.Int64(base_ptr.element_type.width // 8))


### PR DESCRIPTION

> **Credit: The idea for this fix comes entirely from [TMA Descriptor Encoding and the Hidden 21st Bit](https://zhuanlan.zhihu.com/p/2037200219700449995).**

## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the applicable Hard Rules in `AGENTS.md` and my changes comply, or I explain the exception below.
- [x] I added the required `cat-*`, `area:*` / `op:*`, and `orig-*` labels.

## Affected area

FE OSS kernels or CuTeDSL — FROST linear attention and shared THD descriptor helpers.

## Summary

Fix an illegal memory access in FROST KDA prefill when a packed variable-length input ends with a short sequence. The reported configuration uses BF16 inputs with `(T, H, D) = (8192, 64, 128)` and `cu_seqlens = [0, 8191, 8192]`; the first forward call fails with `cudaErrorIllegalAddress` before this fix.

Add `copy_tensor_map()` to both FROST THD modules. It clears bit 21 of the second 64-bit descriptor word while copying the 128-byte tensor map. Route `emit_seq_descs`, `emit_checkpoint_seq_descs`, and `emit_clamped_desc` through this helper before applying their descriptor updates.

## Why

Both figures below are from the blog cited above.

<img width="1440" height="390" alt="image" src="https://github.com/user-attachments/assets/3d82bb28-fb15-46fe-98be-2efdaea34bdc" />

On the tested R580 driver, the encoder sets bit 21 when `product(dims) * element_size >= 128 KiB`.

A BF16 descriptor encoded for `(D, H, T) = (128, 64, 8192)` (128 MiB) keeps hidden bit 21 set after `tensormap.replace` rebases and shrinks it to `(128, 64, 1)` (16 KiB), so out-of-bounds loads can fault on unmapped memory.

<img width="1440" height="933" alt="image" src="https://github.com/user-attachments/assets/2d9f0ac1-dd62-4982-a7b8-f57d60e01668" />

B200/300 tests showed that completed loads still zero-filled out-of-bounds rows with bit 21 set; the diagram omits this behavior

**Fix:** Apply `qword[1] &= ~(1 << 21)` during device-side descriptor copies. [CUTLASS clears the same bit during host encoding](https://github.com/NVIDIA/cutlass/blob/cdcf8d86daa9b417840fd99875a1b1af685d389d/include/cute/atom/copy_traits_sm90_tma.hpp#L971), but that check cannot account for later device-side rebasing or shrinking.

## Related issues

Fixes [#1013](https://github.com/NVIDIA/cudnn-frontend/issues/1013).

## API and compatibility impact

No API or dependency changes. The fix only changes how FROST copies TMA descriptors.

## Testing

Tests passed on NVIDIA B200 (SM100, driver 580.126.09) and B300 (SM103, driver 580.95.05), both using PyTorch 2.13.0+cu130 (CUDA 13.0), cuDNN 9.20.0, and CuTeDSL 4.7.1.

- **Reproducer:** The original reproducer now passes. Additional checks passed with tail lengths of 4 at H=64, 2 and 3 at H=128, and 6 at H=32.
- **Numerics:** Packed outputs are bit-identical to separate per-sequence runs. Tail RMS error ratios against FP64 are `3.2e-3`–`3.6e-3`.
- **LA L0, non-exclusive:** 895 passed, 776 skipped, 2 xfailed, 0 failed.
- **LA hang-stress, GPU-exclusive:** 9 passed, 3 skipped, 0 failed.
- **SDPA THD subset:** 301 passed, 0 failed.
- **Performance:** Median latency changed by less than 0.1% across four tested shapes and three alternating A/B rounds. Differences were within run-to-run variation.
