### PR TITLE
docs: move the docs site base path to /cudnn

### DIFF
--- a/.github/workflows/docs-fern-publish.yml
+++ b/.github/workflows/docs-fern-publish.yml
@@ -39,8 +39,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  PROD_INSTANCE: nvidia-cudnn.docs.buildwithfern.com/deeplearning/cudnn
-  STAGING_INSTANCE: nvidia-cudnn-staging.docs.buildwithfern.com/deeplearning/cudnn
+  PROD_INSTANCE: nvidia-cudnn.docs.buildwithfern.com/cudnn
+  STAGING_INSTANCE: nvidia-cudnn-staging.docs.buildwithfern.com/cudnn
 
 jobs:
   publish:

--- a/docs/fern/docs.yml
+++ b/docs/fern/docs.yml
@@ -3,12 +3,12 @@
 instances:
   # Production. Fronted by docs.nvidia.com via Akamai once the routing is in place.
   # TODO(fern-onboarding): confirm both Fern-hosted URLs with #cdd-fern before publishing.
-  - url: nvidia-cudnn.docs.buildwithfern.com/deeplearning/cudnn
-    custom-domain: docs.nvidia.com/deeplearning/cudnn
+  - url: nvidia-cudnn.docs.buildwithfern.com/cudnn
+    custom-domain: docs.nvidia.com/cudnn
     multi-source: true
   # Staging. Published from develop on every docs change. No custom-domain:
   # nothing about this instance should be reachable from docs.nvidia.com.
-  - url: nvidia-cudnn-staging.docs.buildwithfern.com/deeplearning/cudnn
+  - url: nvidia-cudnn-staging.docs.buildwithfern.com/cudnn
     multi-source: true
 
 title: NVIDIA cuDNN
@@ -16,7 +16,7 @@ title: NVIDIA cuDNN
 global-theme: nvidia
 
 logo:
-  href: /deeplearning/cudnn/latest
+  href: /cudnn/latest
   right-text: cuDNN
 
 navbar-links:
@@ -30,46 +30,46 @@ versions:
 
 redirects:
   # Legacy Sphinx URLs. Sources are relative to the instance path
-  # (docs.nvidia.com/deeplearning/cudnn); destinations are absolute.
+  # (docs.nvidia.com/cudnn); destinations are absolute.
   # Order matters: specific rules first, generic .html rules last.
 
   # Installation guide used to be a separate Sphinx book at /installation/latest/.
   - source: "/installation/latest"
-    destination: "/deeplearning/cudnn/latest/installation/backend"
+    destination: "/cudnn/latest/installation/backend"
   - source: "/installation/latest/index.html"
-    destination: "/deeplearning/cudnn/latest/installation/backend"
+    destination: "/cudnn/latest/installation/backend"
   # Pages that are now nested under the backend / frontend sections.
   - source: "/installation/latest/prerequisites.html"
-    destination: "/deeplearning/cudnn/latest/installation/backend/prerequisites"
+    destination: "/cudnn/latest/installation/backend/prerequisites"
   - source: "/installation/latest/linux.html"
-    destination: "/deeplearning/cudnn/latest/installation/backend/linux"
+    destination: "/cudnn/latest/installation/backend/linux"
   - source: "/installation/latest/windows.html"
-    destination: "/deeplearning/cudnn/latest/installation/backend/windows"
+    destination: "/cudnn/latest/installation/backend/windows"
   - source: "/installation/latest/frontend-dependencies.html"
-    destination: "/deeplearning/cudnn/latest/installation/frontend/frontend-dependencies"
+    destination: "/cudnn/latest/installation/frontend/frontend-dependencies"
   - source: "/installation/latest/python-frontend-install.html"
-    destination: "/deeplearning/cudnn/latest/installation/frontend/python-frontend-install"
+    destination: "/cudnn/latest/installation/frontend/python-frontend-install"
   - source: "/installation/latest/cpp-frontend-install.html"
-    destination: "/deeplearning/cudnn/latest/installation/frontend/cpp-frontend-install"
+    destination: "/cudnn/latest/installation/frontend/cpp-frontend-install"
   - source: "/installation/latest/frontend-next-steps.html"
-    destination: "/deeplearning/cudnn/latest/installation/frontend/frontend-next-steps"
+    destination: "/cudnn/latest/installation/frontend/frontend-next-steps"
   - source: "/installation/latest/:path*.html"
-    destination: "/deeplearning/cudnn/latest/installation/:path*"
+    destination: "/cudnn/latest/installation/:path*"
   - source: "/installation/latest/:path*"
-    destination: "/deeplearning/cudnn/latest/installation/:path*"
+    destination: "/cudnn/latest/installation/:path*"
 
   # Unified cuDNN book at /latest/.
   - source: "/index.html"
-    destination: "/deeplearning/cudnn/latest"
+    destination: "/cudnn/latest"
   - source: "/index"
-    destination: "/deeplearning/cudnn/latest"
+    destination: "/cudnn/latest"
   - source: "/latest/index.html"
-    destination: "/deeplearning/cudnn/latest"
+    destination: "/cudnn/latest"
   - source: "/latest/:path*/index.html"
-    destination: "/deeplearning/cudnn/latest/:path*"
+    destination: "/cudnn/latest/:path*"
   - source: "/latest/:path*.html"
-    destination: "/deeplearning/cudnn/latest/:path*"
+    destination: "/cudnn/latest/:path*"
   - source: "/:path*/index.html"
-    destination: "/deeplearning/cudnn/:path*"
+    destination: "/cudnn/:path*"
   - source: "/:path*.html"
-    destination: "/deeplearning/cudnn/:path*"
+    destination: "/cudnn/:path*"

--- a/docs/operations/Resampling.md
+++ b/docs/operations/Resampling.md
@@ -46,7 +46,7 @@ auto set_generate_index(bool const value) -> Resample_attributes&;
 auto set_is_inference(bool const value) -> Resample_attributes&;
 ```
 
-For more information on exact support surfaces across different versions, refer to [ResampleFwd runtime fusion engine](https://docs.nvidia.com/deeplearning/cudnn/latest/developer/graph-api#resamplefwd) in the *Frontend Developer Guide*.
+For more information on exact support surfaces across different versions, refer to [ResampleFwd runtime fusion engine](https://docs.nvidia.com/cudnn/latest/developer/graph-api#resamplefwd) in the *Frontend Developer Guide*.
 
 Python API for resampling forward will be supported soon.
 


### PR DESCRIPTION
Follow-up to #1006. Moves the docs site base path:

```
docs.nvidia.com/deeplearning/cudnn  ->  docs.nvidia.com/cudnn
```

## What changed

- both instances (production and staging) and the production `custom-domain`
- all 18 `redirects:` destinations
- `logo.href`
- `PROD_INSTANCE` / `STAGING_INSTANCE` in the publish workflow — `fern generate --instance`
  is matched by **exact string equality** against the instance `url`, so these cannot drift
  from `docs.yml` or every publish fails with *"No docs instance found with URL"*
- one in-content link that pointed at this site (`operations/Resampling.md`)

## Deliberately not changed

The 35 cross-links into the cuDNN **backend** book (`/deeplearning/cudnn/backend/...`) and
the one `/deeplearning/cudnn/archives/` link. Those are separately-published books that keep
their existing paths — a blanket find-and-replace would have broken all 36.

## Verification

`fern check` passes, and all **86 pages return HTTP 200** under the new base path with
`fern docs dev`; root redirects to `/cudnn/overview`.

## Requires an Akamai redirect to ship safely

The `redirects:` block in `docs.yml` exists to preserve the legacy Sphinx URLs, and its
**sources are relative to the instance base path**. With the base now `/cudnn`, those rules
cover `/cudnn/*` and no longer match `/deeplearning/cudnn/*` — in production those requests
never reach this site at all.

So the cutover needs `/deeplearning/cudnn/*` -> `/cudnn/*` at the Akamai layer, excluding
`/deeplearning/cudnn/backend/*` and `/deeplearning/cudnn/archives/*`. Without it, every
currently-published cuDNN docs URL 404s when the custom domain is switched over. Fern cannot
express this itself — it can only redirect within its own base path.

This is being raised with #cdd-fern alongside the instance provisioning, which is still
outstanding: the first staging publish from develop failed with
`User does not belong to organization` (run 34559350262), so neither instance is live yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated cuDNN documentation URLs to use the `/cudnn` path.
  * Updated cuDNN logo and redirect destinations while preserving existing page mappings.
  * Corrected the ResampleFwd link to the current developer guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->