### PR TITLE
enable-swap-ab

### DIFF
--- a/benchmark/gemm/frost/benchmark_block_scale_matmul.py
+++ b/benchmark/gemm/frost/benchmark_block_scale_matmul.py
@@ -22,8 +22,10 @@ from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.kernel_registry import candidates as _candidates
 
 from benchmark_utils import (
+    with_workspace,
     add_sweep_args,
     ceil_div,
+    expand_config_variants,
     find_cublas_time,
     kernel_match_token,
     nsys_run_and_parse,
@@ -31,12 +33,13 @@ from benchmark_utils import (
     report_pool,
     resolve_nbuf,
     rotating,
-    select_configs,
+    select_config_variants,
     set_bytes,
     spec_for,
     time_ms_delayed,
     time_ms_events,
     to_blocked,
+    validate_config_variant_args,
 )
 
 
@@ -48,7 +51,7 @@ def _vp_bs(handles, a, b, c, sfa, sfb):
 
 def _build_plan(g, cfg, _name):
     """JIT-compile the recorded graph with a forced tile config."""
-    return jit_from_cudnn_graph(g, config=cfg)
+    return with_workspace(jit_from_cudnn_graph(g, config=cfg))
 
 
 # Combo table (input dtype family + scale dtype + block size)
@@ -112,9 +115,6 @@ def _build_spec_map():
         # A family without the CTA-pair axis (sm120) has no cta_group at all.
         m[cfg.name] = (cfg, getattr(cfg, "cta_group", 1))
     return m
-
-
-_SPEC_MAP = _build_spec_map()
 
 
 def _mkdata(batch: int, M: int, N: int, K: int, combo: str):
@@ -264,7 +264,7 @@ def _make_reference_pool(batch: int, M: int, N: int, K: int, combo: str, ref_mod
 # Worker mode: run the kernels under nsys profile, no Python timing.
 
 
-def _nsys_worker(shape, combo, configs, warmup, iters, ref_mode, nbuf) -> None:
+def _nsys_worker(shape, combo, configs, warmup, iters, ref_mode, nbuf, spec_map) -> None:
     B, M, N, K = (int(x) for x in shape.split(","))
     wset = _mkdata(B, M, N, K, combo)  # dedicated warmup buffer
     pool = _mkdata_pool(B, M, N, K, combo, nbuf)  # rotation pool
@@ -280,9 +280,9 @@ def _nsys_worker(shape, combo, configs, warmup, iters, ref_mode, nbuf) -> None:
     torch.cuda.synchronize()
 
     # 2. each block-scale config.
-    config_names = configs or list(_SPEC_MAP)
+    config_names = configs or list(spec_map)
     for name in config_names:
-        spec = spec_for(name, _SPEC_MAP)
+        spec = spec_for(name, spec_map)
         cfg = spec[0] if spec else None
         if cfg is None:
             continue
@@ -325,6 +325,13 @@ def main() -> int:
     )
     add_sweep_args(parser)
     args = parser.parse_args()
+    validate_config_variant_args(parser, args)
+
+    spec_map = expand_config_variants(
+        _build_spec_map(),
+        sweep_swap_ab=args.sweep_swap_ab,
+        sweep_split_k=args.sweep_split_k,
+    )
 
     if not torch.cuda.is_available():
         print("No CUDA, skipping.")
@@ -340,12 +347,26 @@ def main() -> int:
     nbuf = resolve_nbuf(args.rotate_buffers, per_set)
 
     if args._nsys_worker:
-        configs = select_configs(args.configs, _SPEC_MAP) if args.configs else []
-        _nsys_worker(args.shape, args.combo, configs, args.warmup, args.iters, args.ref, nbuf)
+        configs = (
+            select_config_variants(
+                args.configs,
+                spec_map,
+                sweep_swap_ab=args.sweep_swap_ab,
+                sweep_split_k=args.sweep_split_k,
+            )
+            if args.configs
+            else []
+        )
+        _nsys_worker(args.shape, args.combo, configs, args.warmup, args.iters, args.ref, nbuf, spec_map)
         return 0
 
     flops = 2 * B * M * N * K
-    config_names = select_configs(args.configs, _SPEC_MAP)
+    config_names = select_config_variants(
+        args.configs,
+        spec_map,
+        sweep_swap_ab=args.sweep_swap_ab,
+        sweep_split_k=args.sweep_split_k,
+    )
 
     print(f"\n=== block-scale matmul B={B} {M}x{N}x{K}  (~{flops / 1e9:.1f} GFLOP) — " f"{combo} in / BF16 out ===")
 
@@ -377,7 +398,11 @@ def main() -> int:
             "--rotate-buffers",
             str(nbuf),
         ]
-        if config_names:
+        if args.sweep_swap_ab:
+            inner_args.append("--sweep-swap-ab")
+        if args.sweep_split_k is not None:
+            inner_args += ["--sweep-split-k", str(args.sweep_split_k)]
+        if args.configs:
             inner_args += ["--configs", ",".join(config_names)]
         kern_times = nsys_run_and_parse(__file__, inner_args, tag="bench_bs")
 
@@ -392,7 +417,7 @@ def main() -> int:
             print("  reference kernel: not detected in nsys output")
 
         for name in config_names:
-            spec = spec_for(name, _SPEC_MAP)
+            spec = spec_for(name, spec_map)
             cfg = spec[0] if spec else None
             if cfg is None:
                 rows.append((name, 0.0, float("inf"), "UNKNOWN_CONFIG"))
@@ -436,7 +461,7 @@ def main() -> int:
 
         ctx_dead = False
         for name in config_names:
-            spec = spec_for(name, _SPEC_MAP)
+            spec = spec_for(name, spec_map)
             cfg = spec[0] if spec else None
             if cfg is None:
                 row = (name, 0.0, float("inf"), "UNKNOWN_CONFIG")

--- a/benchmark/gemm/frost/benchmark_block_scale_matmul_swiglu.py
+++ b/benchmark/gemm/frost/benchmark_block_scale_matmul_swiglu.py
@@ -23,12 +23,25 @@ from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
 from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.kernel_registry import candidates as _registry_candidates
 
-from benchmark_utils import add_sweep_args, ceil_div, report_pool, resolve_nbuf, rotating, select_configs, set_bytes, spec_for, time_ms, to_blocked
+from benchmark_utils import (
+    with_workspace,
+    add_sweep_args,
+    ceil_div,
+    expand_config_variants,
+    report_pool,
+    resolve_nbuf,
+    rotating,
+    select_config_variants,
+    set_bytes,
+    spec_for,
+    time_ms,
+    to_blocked,
+)
 
 
 def _build_plan(g, cfg, cta_group):
     """JIT-compile the recorded graph with a forced tile config."""
-    return jit_from_cudnn_graph(g, config=cfg)
+    return with_workspace(jit_from_cudnn_graph(g, config=cfg))
 
 
 def _vp_bs_mg(handles, gemm_pairs, outs, *aux):
@@ -196,6 +209,11 @@ def main() -> int:
     p.add_argument("--shape", default="1,4096,4096,4096", help="B,M,N,K")
     add_sweep_args(p, nsys=False)
     args = p.parse_args()
+    spec_map = expand_config_variants(
+        _SPEC_MAP,
+        sweep_swap_ab=args.sweep_swap_ab,
+        sweep_split_k=args.sweep_split_k,
+    )
 
     if not torch.cuda.is_available():
         print("No CUDA, skipping.")
@@ -228,11 +246,16 @@ def main() -> int:
     )
     print(f"  {'unfused dequant+2xcuBLAS+pointwise':52s} " f"{flops / (bl_ms * 1e-3) / 1e12:8.2f} TFLOP/s  {bl_ms:8.3f} ms   {'1.00×':>8s}")
 
-    config_names = select_configs(args.configs, _SPEC_MAP)
+    config_names = select_config_variants(
+        args.configs,
+        spec_map,
+        sweep_swap_ab=args.sweep_swap_ab,
+        sweep_split_k=args.sweep_split_k,
+    )
 
     best = None
     for name in config_names:
-        spec = spec_for(name, _SPEC_MAP)
+        spec = spec_for(name, spec_map)
         if spec is None:
             print(f"  {name:62s} UNKNOWN (not a sweepable block-scale strategy)")
             continue

--- a/benchmark/gemm/frost/benchmark_matmul.py
+++ b/benchmark/gemm/frost/benchmark_matmul.py
@@ -5,7 +5,10 @@
 
 `--shape` is `B,M,N,K` (B independent same-shape GEMMs; B=1 = plain matmul).
 Timing modes: delayed (default) / nsys / events. `--rotate-buffers` defeats
-hot-L2 inflation on small shapes.
+hot-L2 inflation on small shapes. `--sweep-swap-ab` benchmarks both
+``swap_ab=False`` and ``swap_ab=True`` for every selected geometry.
+`--sweep-split-k N` benchmarks ``split_k_slices=1..N``. When both are
+specified, the two dimensions form a Cartesian product.
 
     python benchmark/gemm/frost/benchmark_matmul.py --shape 1,8192,8192,8192
 """
@@ -25,17 +28,20 @@ from cudnn.gemm.frost.fusion_ir import FusionChain as _FC, MatmulSpec as _MS, Ou
 from cudnn.gemm.frost.kernel_registry import candidates as _candidates
 
 from benchmark_utils import (
+    with_workspace,
     add_sweep_args,
+    expand_config_variants,
     find_cublas_time,
     kernel_match_token,
     nsys_run_and_parse,
     report_pool,
     resolve_nbuf,
     rotating,
-    select_configs,
+    select_config_variants,
     spec_for,
     time_ms_delayed,
     time_ms_events,
+    validate_config_variant_args,
 )
 
 
@@ -58,13 +64,9 @@ def _build_spec_map():
     )
     m = {}
     for t, cfg in _candidates(chain):
-        label = cfg.name
         # A family without the CTA-pair axis (sm120) has no cta_group at all.
-        m[label] = (cfg, getattr(cfg, "cta_group", 1))
+        m[cfg.name] = (cfg, getattr(cfg, "cta_group", 1))
     return m
-
-
-_SPEC_MAP = _build_spec_map()
 
 
 def _vp(handles, a, b, c):
@@ -75,14 +77,7 @@ def _vp(handles, a, b, c):
 
 def _build_plan(g, cfg, _name):
     """JIT-compile the recorded graph with a forced tile config."""
-    compiled = jit_from_cudnn_graph(g, config=cfg)
-    if getattr(compiled, "workspace_bytes", 0):
-        from cudnn.frost.workspace import Workspace
-
-        buf = torch.empty(compiled.workspace_bytes, dtype=torch.uint8, device="cuda")
-        ws = Workspace(buf, compiled.workspace_bytes, "benchmark_matmul")
-        return lambda vp, stream=None: compiled(vp, stream=stream, workspace=ws)
-    return compiled
+    return with_workspace(jit_from_cudnn_graph(g, config=cfg))
 
 
 # ---------------------------------------------------------------------------
@@ -143,6 +138,7 @@ def _nsys_worker(
     warmup: int,
     iters: int,
     nbuf: int,
+    spec_map: dict,
 ) -> None:
     """Inner mode re-exec'd under nsys: run each config (and cuBLAS) for
     warmup+iters launches, no timing — nsys captures it. Timed iters rotate
@@ -162,9 +158,9 @@ def _nsys_worker(
     torch.cuda.synchronize()
 
     # 2. each GEMM config.
-    config_names = configs or list(_SPEC_MAP)
+    config_names = configs or list(spec_map)
     for name in config_names:
-        spec = spec_for(name, _SPEC_MAP)
+        spec = spec_for(name, spec_map)
         if spec is None:
             continue
         cfg = spec[0]
@@ -196,6 +192,13 @@ def main() -> int:
     )
     add_sweep_args(parser)
     args = parser.parse_args()
+    validate_config_variant_args(parser, args)
+
+    spec_map = expand_config_variants(
+        _build_spec_map(),
+        sweep_swap_ab=args.sweep_swap_ab,
+        sweep_split_k=args.sweep_split_k,
+    )
 
     if not torch.cuda.is_available():
         print("No CUDA, skipping.")
@@ -208,12 +211,26 @@ def main() -> int:
     nbuf = resolve_nbuf(args.rotate_buffers, _per_set_bytes(B, M, N, K))
 
     if args._nsys_worker:
-        configs = select_configs(args.configs, _SPEC_MAP) if args.configs else []
-        _nsys_worker(args.shape, configs, args.warmup, args.iters, nbuf)
+        configs = (
+            select_config_variants(
+                args.configs,
+                spec_map,
+                sweep_swap_ab=args.sweep_swap_ab,
+                sweep_split_k=args.sweep_split_k,
+            )
+            if args.configs
+            else []
+        )
+        _nsys_worker(args.shape, configs, args.warmup, args.iters, nbuf, spec_map)
         return 0
 
     flops = 2 * B * M * N * K
-    config_names = select_configs(args.configs, _SPEC_MAP)
+    config_names = select_config_variants(
+        args.configs,
+        spec_map,
+        sweep_swap_ab=args.sweep_swap_ab,
+        sweep_split_k=args.sweep_split_k,
+    )
 
     print(f"\n=== matmul B={B} {M}x{N}x{K}  (~{flops / 1e9:.1f} GFLOP) — BF16 ===")
 
@@ -231,7 +248,11 @@ def main() -> int:
     if args.timing == "nsys":
         print("  [timing: nsys median kernel duration]\n")
         inner_args = ["--shape", args.shape, "--warmup", str(args.warmup), "--iters", str(args.iters), "--rotate-buffers", str(nbuf)]
-        if config_names:
+        if args.sweep_swap_ab:
+            inner_args.append("--sweep-swap-ab")
+        if args.sweep_split_k is not None:
+            inner_args += ["--sweep-split-k", str(args.sweep_split_k)]
+        if args.configs:
             inner_args += ["--configs", ",".join(config_names)]
         kern_times = nsys_run_and_parse(__file__, inner_args, tag="benchmark_matmul")
 
@@ -245,7 +266,7 @@ def main() -> int:
             print("  cuBLAS kernel: not detected in nsys output")
 
         for name in config_names:
-            spec = spec_for(name, _SPEC_MAP)
+            spec = spec_for(name, spec_map)
             cfg = spec[0] if spec else None
             if cfg is None:
                 rows.append((name, 0.0, float("inf"), "UNKNOWN_CONFIG"))
@@ -290,7 +311,7 @@ def main() -> int:
         # first such error, short-circuit the remaining configs as CTX_DEAD.
         ctx_dead = False
         for name in config_names:
-            spec = spec_for(name, _SPEC_MAP)
+            spec = spec_for(name, spec_map)
             cfg = spec[0] if spec else None
             if cfg is None:
                 row = (name, 0.0, float("inf"), "UNKNOWN_CONFIG")

--- a/benchmark/gemm/frost/benchmark_matmul_mixed_input.py
+++ b/benchmark/gemm/frost/benchmark_matmul_mixed_input.py
@@ -25,17 +25,20 @@ from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.kernel_registry import candidates as _candidates
 
 from benchmark_utils import (
+    with_workspace,
     add_sweep_args,
+    expand_config_variants,
     find_cublas_time,
     kernel_match_token,
     nsys_run_and_parse,
     report_pool,
     resolve_nbuf,
     rotating,
-    select_configs,
+    select_config_variants,
     spec_for,
     time_ms_delayed,
     time_ms_events,
+    validate_config_variant_args,
 )
 
 # name -> (cudnn enum, torch dtype, element bytes, is_integer). load = narrow A
@@ -87,9 +90,6 @@ def _build_spec_map():
     return m
 
 
-_SPEC_MAP = _build_spec_map()
-
-
 def _vp(handles, a, b, c):
     """Variant-pack dict {tensor: buffer}; `a` is the narrow (load-dtype) A root operand."""
     A, B, C = handles
@@ -98,7 +98,7 @@ def _vp(handles, a, b, c):
 
 def _build_plan(g, cfg, _name):
     """JIT-compile the graph with a forced tile config -> callable kernel."""
-    return jit_from_cudnn_graph(g, config=cfg)
+    return with_workspace(jit_from_cudnn_graph(g, config=cfg))
 
 
 # ---------------------------------------------------------------------------
@@ -165,7 +165,7 @@ def _per_set_bytes(batch, M, N, K, load_dt, tin_dt, tout_dt) -> int:
 # ---------------------------------------------------------------------------
 
 
-def _nsys_worker(shape, configs, warmup, iters, nbuf, load_dt, tin_dt, tout_dt) -> None:
+def _nsys_worker(shape, configs, warmup, iters, nbuf, load_dt, tin_dt, tout_dt, spec_map) -> None:
     B, M, N, K = (int(x) for x in shape.split(","))
     wa, wb, wc = _mkdata(B, M, N, K, load_dt, tin_dt, tout_dt)
     pool = _mkdata_pool(B, M, N, K, load_dt, tin_dt, tout_dt, nbuf)
@@ -184,9 +184,9 @@ def _nsys_worker(shape, configs, warmup, iters, nbuf, load_dt, tin_dt, tout_dt) 
     torch.cuda.synchronize()
 
     # 2. each GEMM config.
-    config_names = configs or list(_SPEC_MAP)
+    config_names = configs or list(spec_map)
     for name in config_names:
-        spec = spec_for(name, _SPEC_MAP)
+        spec = spec_for(name, spec_map)
         cfg = spec[0] if spec else None
         if cfg is None:
             continue
@@ -217,6 +217,13 @@ def main() -> int:
     parser.add_argument("--tout", default="bf16", help="output dtype (default bf16)")
     add_sweep_args(parser)
     args = parser.parse_args()
+    validate_config_variant_args(parser, args)
+
+    spec_map = expand_config_variants(
+        _build_spec_map(),
+        sweep_swap_ab=args.sweep_swap_ab,
+        sweep_split_k=args.sweep_split_k,
+    )
 
     if not torch.cuda.is_available():
         print("No CUDA, skipping.")
@@ -231,12 +238,26 @@ def main() -> int:
     nbuf = resolve_nbuf(args.rotate_buffers, per_set)
 
     if args._nsys_worker:
-        configs = select_configs(args.configs, _SPEC_MAP) if args.configs else []
-        _nsys_worker(args.shape, configs, args.warmup, args.iters, nbuf, load_dt, tin_dt, tout_dt)
+        configs = (
+            select_config_variants(
+                args.configs,
+                spec_map,
+                sweep_swap_ab=args.sweep_swap_ab,
+                sweep_split_k=args.sweep_split_k,
+            )
+            if args.configs
+            else []
+        )
+        _nsys_worker(args.shape, configs, args.warmup, args.iters, nbuf, load_dt, tin_dt, tout_dt, spec_map)
         return 0
 
     flops = 2 * B * M * N * K
-    config_names = select_configs(args.configs, _SPEC_MAP)
+    config_names = select_config_variants(
+        args.configs,
+        spec_map,
+        sweep_swap_ab=args.sweep_swap_ab,
+        sweep_split_k=args.sweep_split_k,
+    )
 
     print(f"\n=== mixed-input matmul B={B} {M}x{N}x{K}  (~{flops / 1e9:.1f} GFLOP) " f"— A={load_dt} -> {tin_dt} @ {tin_dt} -> {tout_dt} ===")
 
@@ -269,7 +290,11 @@ def main() -> int:
             "--tout",
             tout_dt,
         ]
-        if config_names:
+        if args.sweep_swap_ab:
+            inner_args.append("--sweep-swap-ab")
+        if args.sweep_split_k is not None:
+            inner_args += ["--sweep-split-k", str(args.sweep_split_k)]
+        if args.configs:
             inner_args += ["--configs", ",".join(config_names)]
         kern_times = nsys_run_and_parse(__file__, inner_args, tag="benchmark_mixed")
 
@@ -283,7 +308,7 @@ def main() -> int:
             print("  cuBLAS kernel: not detected in nsys output")
 
         for name in config_names:
-            spec = spec_for(name, _SPEC_MAP)
+            spec = spec_for(name, spec_map)
             if spec is None:
                 rows.append((name, 0.0, float("inf"), "UNKNOWN_CONFIG"))
                 continue
@@ -319,7 +344,7 @@ def main() -> int:
 
         ctx_dead = False
         for name in config_names:
-            spec = spec_for(name, _SPEC_MAP)
+            spec = spec_for(name, spec_map)
             cfg = spec[0] if spec else None
             if cfg is None:
                 row = (name, 0.0, float("inf"), "UNKNOWN_CONFIG")

--- a/benchmark/gemm/frost/benchmark_matmul_swiglu.py
+++ b/benchmark/gemm/frost/benchmark_matmul_swiglu.py
@@ -22,12 +22,23 @@ from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
 from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.kernel_registry import candidates as _registry_candidates
 
-from benchmark_utils import add_sweep_args, report_pool, resolve_nbuf, rotating, select_configs, set_bytes, spec_for, time_ms
+from benchmark_utils import (
+    add_sweep_args,
+    expand_config_variants,
+    report_pool,
+    resolve_nbuf,
+    rotating,
+    select_config_variants,
+    set_bytes,
+    spec_for,
+    time_ms,
+    with_workspace,
+)
 
 
 def _build_plan(g, cfg, cta_group):
     """JIT-compile the recorded graph with a forced tile config."""
-    return jit_from_cudnn_graph(g, config=cfg)
+    return with_workspace(jit_from_cudnn_graph(g, config=cfg))
 
 
 def _vp_mg(handles, gemm_pairs, outs, *aux):
@@ -158,6 +169,11 @@ def main() -> int:
     p.add_argument("--rtol", type=float, default=2e-2)
     p.add_argument("--atol", type=float, default=2e-1)
     args = p.parse_args()
+    spec_map = expand_config_variants(
+        _SPEC_MAP,
+        sweep_swap_ab=args.sweep_swap_ab,
+        sweep_split_k=args.sweep_split_k,
+    )
 
     if not torch.cuda.is_available():
         print("No CUDA, skipping.")
@@ -197,11 +213,16 @@ def main() -> int:
     print(f"  {'unfused 2xcuBLAS + pointwise':52s} {bl_tflops:8.2f} TFLOP/s  " f"{bl_ms:8.3f} ms   {'1.00×':>8s}")
 
     # --- candidate (config, cta_group) strategies ---
-    config_names = select_configs(args.configs, _SPEC_MAP)
+    config_names = select_config_variants(
+        args.configs,
+        spec_map,
+        sweep_swap_ab=args.sweep_swap_ab,
+        sweep_split_k=args.sweep_split_k,
+    )
 
     best = None
     for label in config_names:
-        spec = spec_for(label, _SPEC_MAP)
+        spec = spec_for(label, spec_map)
         if spec is None:
             print(f"  {label:62s} UNKNOWN (not a sweepable swiglu strategy)")
             continue

--- a/benchmark/gemm/frost/benchmark_moe_block_scale_matmul.py
+++ b/benchmark/gemm/frost/benchmark_moe_block_scale_matmul.py
@@ -23,8 +23,10 @@ from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.kernel_registry import candidates as _candidates
 
 from benchmark_utils import (
+    with_workspace,
     add_fto_alignment_arg,
     add_sweep_args,
+    expand_config_variants,
     find_cublas_time,
     fto_alignment,
     group_offsets,
@@ -34,7 +36,7 @@ from benchmark_utils import (
     report_pool,
     resolve_nbuf,
     rotating,
-    select_configs,
+    select_config_variants,
     set_bytes,
     spec_for,
     time_ms_delayed,
@@ -51,7 +53,7 @@ def _vp_moe_bs(handles, token, weight, sfa, sfb, fto, output):
 
 def _build_plan(g, cfg, _name):
     """JIT-compile the recorded graph with a forced tile config -> compiled kernel."""
-    return jit_from_cudnn_graph(g, config=cfg)
+    return with_workspace(jit_from_cudnn_graph(g, config=cfg))
 
 
 # combo : (is_fp4, block_size, a_dtype, sf_dtype)
@@ -199,7 +201,7 @@ def _cublas_launch(buf, S: int, N: int, K: int, E: int) -> None:
 # Worker mode (re-exec'd under nsys).
 
 
-def _nsys_worker(shape, combo, configs, warmup, iters, nbuf, fto_align_spec, no_baseline=False) -> None:
+def _nsys_worker(shape, combo, configs, warmup, iters, nbuf, fto_align_spec, spec_map, no_baseline=False) -> None:
     G, M, N, K = (int(x) for x in shape.split(","))
     S, E = G * M, G
     offsets = group_offsets(S, E)
@@ -221,8 +223,8 @@ def _nsys_worker(shape, combo, configs, warmup, iters, nbuf, fto_align_spec, no_
     pool = _mkdata_pool(S, N, K, E, combo, nbuf)
 
     # 2. each MoE-block-scale config.
-    for name in configs or list(_SPEC_MAP):
-        spec = spec_for(name, _SPEC_MAP)
+    for name in configs or list(spec_map):
+        spec = spec_for(name, spec_map)
         cfg = spec[0] if spec else None
         if cfg is None:
             continue
@@ -259,6 +261,11 @@ def main() -> int:
     add_sweep_args(parser)
     add_fto_alignment_arg(parser)
     args = parser.parse_args()
+    spec_map = expand_config_variants(
+        _SPEC_MAP,
+        sweep_swap_ab=args.sweep_swap_ab,
+        sweep_split_k=args.sweep_split_k,
+    )
 
     if not torch.cuda.is_available():
         print("No CUDA, skipping.")
@@ -275,12 +282,26 @@ def main() -> int:
     nbuf = resolve_nbuf(args.rotate_buffers, per_set_bytes, free_divisor=4)
 
     if args._nsys_worker:
-        configs = select_configs(args.configs, _SPEC_MAP) if args.configs else []
-        _nsys_worker(args.shape, combo, configs, args.warmup, args.iters, nbuf, args.fto_alignment, args.no_baseline)
+        configs = (
+            select_config_variants(
+                args.configs,
+                spec_map,
+                sweep_swap_ab=args.sweep_swap_ab,
+                sweep_split_k=args.sweep_split_k,
+            )
+            if args.configs
+            else []
+        )
+        _nsys_worker(args.shape, combo, configs, args.warmup, args.iters, nbuf, args.fto_alignment, spec_map, args.no_baseline)
         return 0
 
     flops = 2 * S * N * K
-    config_names = select_configs(args.configs, _SPEC_MAP)
+    config_names = select_config_variants(
+        args.configs,
+        spec_map,
+        sweep_swap_ab=args.sweep_swap_ab,
+        sweep_split_k=args.sweep_split_k,
+    )
 
     print(f"\n=== moe_block_scale_matmul G={G} M={M} N={N} K={K}  " f"(S={S} tokens, ~{flops / 1e9:.1f} GFLOP) — {combo} ===")
 
@@ -312,7 +333,11 @@ def main() -> int:
             "--fto-alignment",
             str(args.fto_alignment),
         ]
-        if config_names:
+        if args.sweep_swap_ab:
+            inner.append("--sweep-swap-ab")
+        if args.sweep_split_k is not None:
+            inner += ["--sweep-split-k", str(args.sweep_split_k)]
+        if args.configs:
             inner += ["--configs", ",".join(config_names)]
         if args.no_baseline:
             inner += ["--no-baseline"]
@@ -327,7 +352,7 @@ def main() -> int:
             cublas_tflops, cublas_ms = float("nan"), float("nan")
             print("  cuBLAS kernel: not detected in nsys output")
         for name in config_names:
-            spec = spec_for(name, _SPEC_MAP)
+            spec = spec_for(name, spec_map)
             cfg = spec[0] if spec else None
             if cfg is None:
                 rows.append((name, 0.0, float("inf"), "UNKNOWN_CONFIG"))
@@ -379,7 +404,7 @@ def main() -> int:
 
         ctx_dead = False
         for name in config_names:
-            spec = spec_for(name, _SPEC_MAP)
+            spec = spec_for(name, spec_map)
             cfg = spec[0] if spec else None
             if cfg is None:
                 row = (name, 0.0, float("inf"), "UNKNOWN_CONFIG")

--- a/benchmark/gemm/frost/benchmark_moe_block_scale_matmul_swiglu.py
+++ b/benchmark/gemm/frost/benchmark_moe_block_scale_matmul_swiglu.py
@@ -22,15 +22,17 @@ from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.kernel_registry import candidates as _registry_candidates
 
 from benchmark_utils import (
+    with_workspace,
     add_fto_alignment_arg,
     add_sweep_args,
+    expand_config_variants,
     fto_alignment,
     group_offsets,
     rand_e8m0,
     report_pool,
     resolve_nbuf,
     rotating,
-    select_configs,
+    select_config_variants,
     set_bytes,
     spec_for,
     time_ms,
@@ -40,7 +42,7 @@ from benchmark_utils import (
 
 def _build_plan(g, cfg, cta_group):
     """JIT-compile the recorded graph with a forced tile config."""
-    return jit_from_cudnn_graph(g, config=cfg)
+    return with_workspace(jit_from_cudnn_graph(g, config=cfg))
 
 
 def _vp_moe_bs_mg(handles, gemm_pairs, fto, outs, *aux):
@@ -254,6 +256,11 @@ def main() -> int:
     add_sweep_args(p, nsys=False)
     add_fto_alignment_arg(p)
     args = p.parse_args()
+    spec_map = expand_config_variants(
+        _SPEC_MAP,
+        sweep_swap_ab=args.sweep_swap_ab,
+        sweep_split_k=args.sweep_split_k,
+    )
 
     if not torch.cuda.is_available():
         print("No CUDA, skipping.")
@@ -266,7 +273,12 @@ def main() -> int:
     E, S = G, G * M
     combo = args.combo
 
-    config_names = select_configs(args.configs, _SPEC_MAP)
+    config_names = select_config_variants(
+        args.configs,
+        spec_map,
+        sweep_swap_ab=args.sweep_swap_ab,
+        sweep_split_k=args.sweep_split_k,
+    )
     per_set = set_bytes(_mkdata(S, N, K, E, combo))
     nbuf = resolve_nbuf(args.rotate_buffers, per_set)
 
@@ -302,7 +314,7 @@ def main() -> int:
 
     best = None
     for label in config_names:
-        spec = spec_for(label, _SPEC_MAP)
+        spec = spec_for(label, spec_map)
         if spec is None:
             print(f"  {label:66s} UNKNOWN (not a sweepable MoE block-scale swiglu strategy)")
             continue

--- a/benchmark/gemm/frost/benchmark_moe_block_scale_matmul_swiglu_cutedsl_vs_frost.py
+++ b/benchmark/gemm/frost/benchmark_moe_block_scale_matmul_swiglu_cutedsl_vs_frost.py
@@ -499,10 +499,19 @@ def main() -> int:
         store_modes = {"tma": ["tma"], "stg": ["stg"], "both": ["tma", "stg"]}[args.frost_store]
         offsets = bu.group_offsets(S, E)
         alignment = bu.fto_alignment(args.fto_alignment, offsets)
-        spec_map = _frost_spec_map(args.combo, args.output_mode, alignment)
+        spec_map = bu.expand_config_variants(
+            _frost_spec_map(args.combo, args.output_mode, alignment),
+            sweep_swap_ab=args.sweep_swap_ab,
+            sweep_split_k=args.sweep_split_k,
+        )
         wset = _frost_set(S, N, K, E, args.combo, args.output_mode)
         pool = [wset] + [_frost_set(S, N, K, E, args.combo, args.output_mode) for _ in range(max(0, nbuf - 1))]
-        for cname in bu.select_configs(args.configs, spec_map):
+        for cname in bu.select_config_variants(
+            args.configs,
+            spec_map,
+            sweep_swap_ab=args.sweep_swap_ab,
+            sweep_split_k=args.sweep_split_k,
+        ):
             spec = bu.spec_for(cname, spec_map)
             if spec is None:
                 print(f"  {cname:52s} UNKNOWN config")
@@ -516,7 +525,7 @@ def main() -> int:
                 try:
                     g, h = _frost_graph(S, N, K, E, args.combo, args.output_mode, alignment)
                     with C.force_stg_epi(store == "stg"):
-                        plan = jit_from_cudnn_graph(g, config=cfg)
+                        plan = bu.with_workspace(jit_from_cudnn_graph(g, config=cfg))
                 except (NotImplementedError, ValueError) as e:
                     print(f"  {label:52s} UNSUPPORTED: {type(e).__name__}: {str(e)[:60]}")
                     continue

--- a/benchmark/gemm/frost/benchmark_moe_grouped_matmul.py
+++ b/benchmark/gemm/frost/benchmark_moe_grouped_matmul.py
@@ -28,8 +28,10 @@ from cudnn.gemm.frost.fusion_ir import (
 from cudnn.gemm.frost.kernel_registry import candidates as _candidates
 
 from benchmark_utils import (
+    with_workspace,
     add_fto_alignment_arg,
     add_sweep_args,
+    expand_config_variants,
     find_cublas_time,
     fto_alignment,
     group_offsets,
@@ -38,7 +40,7 @@ from benchmark_utils import (
     report_pool,
     resolve_nbuf,
     rotating,
-    select_configs,
+    select_config_variants,
     spec_for,
     time_ms_delayed,
     time_ms_events,
@@ -53,7 +55,7 @@ def _vp_moe(handles, token, weight, fto, output):
 
 def _build_plan(g, cfg, _name):
     """JIT-compile the recorded graph with a forced tile config."""
-    return jit_from_cudnn_graph(g, config=cfg)
+    return with_workspace(jit_from_cudnn_graph(g, config=cfg))
 
 
 def _build_spec_map():
@@ -172,7 +174,7 @@ def _cublas_launch(buf, S: int, N: int, K: int, E: int) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _nsys_worker(shape, configs, warmup, iters, nbuf, fto_align_spec) -> None:
+def _nsys_worker(shape, configs, warmup, iters, nbuf, fto_align_spec, spec_map) -> None:
     G, M, N, K = (int(x) for x in shape.split(","))
     S, E = G * M, G
     wtok, ww, wout = _mkdata(S, N, K, E)  # dedicated warmup buffer
@@ -189,9 +191,9 @@ def _nsys_worker(shape, configs, warmup, iters, nbuf, fto_align_spec) -> None:
     torch.cuda.synchronize()
 
     # 2. each MoE config.
-    config_names = configs or list(_SPEC_MAP)
+    config_names = configs or list(spec_map)
     for name in config_names:
-        spec = spec_for(name, _SPEC_MAP)
+        spec = spec_for(name, spec_map)
         cfg = spec[0] if spec else None
         if cfg is None:
             continue
@@ -224,6 +226,11 @@ def main() -> int:
     add_sweep_args(parser)
     add_fto_alignment_arg(parser)
     args = parser.parse_args()
+    spec_map = expand_config_variants(
+        _SPEC_MAP,
+        sweep_swap_ab=args.sweep_swap_ab,
+        sweep_split_k=args.sweep_split_k,
+    )
 
     if not torch.cuda.is_available():
         print("No CUDA, skipping.")
@@ -238,12 +245,26 @@ def main() -> int:
     nbuf = resolve_nbuf(args.rotate_buffers, per_set)
 
     if args._nsys_worker:
-        configs = select_configs(args.configs, _SPEC_MAP) if args.configs else []
-        _nsys_worker(args.shape, configs, args.warmup, args.iters, nbuf, args.fto_alignment)
+        configs = (
+            select_config_variants(
+                args.configs,
+                spec_map,
+                sweep_swap_ab=args.sweep_swap_ab,
+                sweep_split_k=args.sweep_split_k,
+            )
+            if args.configs
+            else []
+        )
+        _nsys_worker(args.shape, configs, args.warmup, args.iters, nbuf, args.fto_alignment, spec_map)
         return 0
 
     flops = 2 * S * N * K
-    config_names = select_configs(args.configs, _SPEC_MAP)
+    config_names = select_config_variants(
+        args.configs,
+        spec_map,
+        sweep_swap_ab=args.sweep_swap_ab,
+        sweep_split_k=args.sweep_split_k,
+    )
 
     print(f"\n=== moe_grouped_matmul G={G} M={M} N={N} K={K}  " f"(S={S} tokens, ~{flops / 1e9:.1f} GFLOP) — BF16 ===")
 
@@ -272,7 +293,11 @@ def main() -> int:
             "--fto-alignment",
             str(args.fto_alignment),
         ]
-        if config_names:
+        if args.sweep_swap_ab:
+            inner_args.append("--sweep-swap-ab")
+        if args.sweep_split_k is not None:
+            inner_args += ["--sweep-split-k", str(args.sweep_split_k)]
+        if args.configs:
             inner_args += ["--configs", ",".join(config_names)]
         kern_times = nsys_run_and_parse(__file__, inner_args, tag="bench_moe")
         cublas_hit = find_cublas_time(kern_times)
@@ -284,7 +309,7 @@ def main() -> int:
             cublas_tflops, cublas_ms = float("nan"), float("nan")
             print("  cuBLAS kernel: not detected in nsys output")
         for name in config_names:
-            spec = spec_for(name, _SPEC_MAP)
+            spec = spec_for(name, spec_map)
             cfg = spec[0] if spec else None
             if cfg is None:
                 rows.append((name, 0.0, float("inf"), "UNKNOWN_CONFIG"))
@@ -323,7 +348,7 @@ def main() -> int:
 
         ctx_dead = False
         for name in config_names:
-            spec = spec_for(name, _SPEC_MAP)
+            spec = spec_for(name, spec_map)
             cfg = spec[0] if spec else None
             if cfg is None:
                 row = (name, 0.0, float("inf"), "UNKNOWN_CONFIG")

--- a/benchmark/gemm/frost/benchmark_moe_grouped_matmul_models.py
+++ b/benchmark/gemm/frost/benchmark_moe_grouped_matmul_models.py
@@ -42,16 +42,18 @@ from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.kernel_registry import candidates as _registry_candidates
 
 from benchmark_utils import (
+    with_workspace,
     add_fto_alignment_arg,
     add_sweep_args,
     ceil_div,
     even_offsets,
+    expand_config_variants,
     fto_alignment,
     rand_e8m0,
     report_pool,
     resolve_nbuf,
     rotating,
-    select_configs,
+    select_config_variants,
     set_bytes,
     spec_for,
     time_ms,
@@ -416,8 +418,17 @@ def _run_model(key: str, spec: dict, args) -> tuple | None:
         bl_label = "unfused per-group cuBLAS bf16 + pointwise" + ("" if bl_sets is pool else " [no rotation]")
         print(f"  {bl_label:64s} {flops / (bl_ms * 1e-3) / 1e12:8.2f} TFLOP/s  " f"{bl_ms:8.3f} ms", flush=True)
 
-    spec_map = _build_spec_map(variant, args.dtype)
-    labels = select_configs(args.configs, spec_map)
+    spec_map = expand_config_variants(
+        _build_spec_map(variant, args.dtype),
+        sweep_swap_ab=args.sweep_swap_ab,
+        sweep_split_k=args.sweep_split_k,
+    )
+    labels = select_config_variants(
+        args.configs,
+        spec_map,
+        sweep_swap_ab=args.sweep_swap_ab,
+        sweep_split_k=args.sweep_split_k,
+    )
     print(f"  sweeping {len(labels)} configs (each JITs once, ~15-25 s)", flush=True)
 
     best = None
@@ -431,7 +442,7 @@ def _run_model(key: str, spec: dict, args) -> tuple | None:
             print(f"  ▶ running {label} ...", flush=True)
         try:
             g, h = _graph(S, N, K, E, variant, args.dtype, offsets, alignment)
-            plan = jit_from_cudnn_graph(g, config=cfg)
+            plan = with_workspace(jit_from_cudnn_graph(g, config=cfg))
         except (NotImplementedError, ValueError) as e:
             print(f"  {label:64s} SKIP: {type(e).__name__}: {str(e)[:40]}", flush=True)
             continue

--- a/benchmark/gemm/frost/benchmark_moe_grouped_matmul_swiglu.py
+++ b/benchmark/gemm/frost/benchmark_moe_grouped_matmul_swiglu.py
@@ -24,14 +24,16 @@ from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.kernel_registry import candidates as _registry_candidates
 
 from benchmark_utils import (
+    with_workspace,
     add_fto_alignment_arg,
     add_sweep_args,
+    expand_config_variants,
     fto_alignment,
     group_offsets,
     report_pool,
     resolve_nbuf,
     rotating,
-    select_configs,
+    select_config_variants,
     set_bytes,
     spec_for,
     time_ms,
@@ -40,7 +42,7 @@ from benchmark_utils import (
 
 def _build_plan(g, cfg, cta_group):
     """JIT-compile the graph with a forced tile config → callable kernel."""
-    return jit_from_cudnn_graph(g, config=cfg)
+    return with_workspace(jit_from_cudnn_graph(g, config=cfg))
 
 
 def _vp_moe_mg(handles, gemm_pairs, fto, outs, *aux):
@@ -206,6 +208,11 @@ def main() -> int:
     p.add_argument("--rtol", type=float, default=5e-2)
     p.add_argument("--atol", type=float, default=2e-1)
     args = p.parse_args()
+    spec_map = expand_config_variants(
+        _SPEC_MAP,
+        sweep_swap_ab=args.sweep_swap_ab,
+        sweep_split_k=args.sweep_split_k,
+    )
 
     if not torch.cuda.is_available():
         print("No CUDA, skipping.")
@@ -247,11 +254,16 @@ def main() -> int:
     bl_tflops = flops / (bl_ms * 1e-3) / 1e12
     print(f"  {'unfused 2xcuBLAS batched + pointwise':54s} {bl_tflops:8.2f} TFLOP/s  " f"{bl_ms:8.3f} ms   {'1.00×':>8s}")
 
-    config_names = select_configs(args.configs, _SPEC_MAP)
+    config_names = select_config_variants(
+        args.configs,
+        spec_map,
+        sweep_swap_ab=args.sweep_swap_ab,
+        sweep_split_k=args.sweep_split_k,
+    )
 
     best = None
     for label in config_names:
-        spec = spec_for(label, _SPEC_MAP)
+        spec = spec_for(label, spec_map)
         if spec is None:
             print(f"  {label:64s} UNKNOWN (not a sweepable MoE swiglu strategy)")
             continue

--- a/benchmark/gemm/frost/benchmark_utils.py
+++ b/benchmark/gemm/frost/benchmark_utils.py
@@ -22,11 +22,37 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from dataclasses import replace
 from typing import Callable
 
 import torch
 
 from cudnn.gemm.frost.tile_config import by_name as _by_name
+
+
+class _PlanWithWorkspace:
+    """Own scratch alongside its non-owning Workspace view, outside timing."""
+
+    def __init__(self, compiled):
+        from cudnn.frost.workspace import Workspace
+
+        self.compiled = compiled
+        self.buffer = torch.empty(compiled.workspace_bytes, dtype=torch.uint8, device="cuda")
+        self.workspace = Workspace(self.buffer, compiled.workspace_bytes, "frost benchmark")
+
+    def __call__(self, variant_pack, stream=None):
+        return self.compiled(variant_pack, stream=stream, workspace=self.workspace)
+
+
+def with_workspace(compiled):
+    """Prepare a fixed-shape benchmark plan for warmup and repeated launches.
+
+    Split-K partials and MoE descriptor scratch use the same caller-owned
+    workspace contract. Keep the allocation alive for as long as the callable;
+    Workspace itself only retains a pointer, not the tensor that owns it.
+    """
+    return _PlanWithWorkspace(compiled) if compiled.workspace_bytes else compiled
+
 
 # Config selection
 
@@ -69,6 +95,52 @@ def select_configs(arg, spec_map):
     return list(dict.fromkeys(out))
 
 
+def expand_config_variants(spec_map, *, sweep_swap_ab: bool = False, sweep_split_k: int | None = None):
+    """Expand a base config map over the requested swap-AB / split-K axes."""
+    split_k_values = range(1, sweep_split_k + 1) if sweep_split_k is not None else (1,)
+    swap_ab_values = (False, True) if sweep_swap_ab else (False,)
+    expanded = {}
+    for cfg, _cta_group in spec_map.values():
+        for split_k_slices in split_k_values:
+            for swap_ab in swap_ab_values:
+                variant = replace(cfg, split_k_slices=split_k_slices, swap_ab=swap_ab)
+                expanded[variant.name] = (variant, getattr(variant, "cta_group", 1))
+    return expanded
+
+
+def select_config_variants(arg, spec_map, *, sweep_swap_ab: bool = False, sweep_split_k: int | None = None):
+    """Select labels, expanding explicit selections over enabled variant axes.
+
+    With no ``--configs`` filter, ``spec_map`` already contains the complete
+    Cartesian product produced by :func:`expand_config_variants`.
+    """
+    selected = select_configs(arg, spec_map)
+    if not arg or (not sweep_swap_ab and sweep_split_k is None):
+        return selected
+    expanded = []
+    seen_bases = set()
+    for name in selected:
+        spec = spec_for(name, spec_map)
+        if spec is None:
+            expanded.append(name)
+            continue
+        cfg = spec[0]
+        base = replace(
+            cfg,
+            split_k_slices=1 if sweep_split_k is not None else cfg.split_k_slices,
+            swap_ab=False if sweep_swap_ab else cfg.swap_ab,
+        )
+        if base.name in seen_bases:
+            continue
+        seen_bases.add(base.name)
+        split_k_values = range(1, sweep_split_k + 1) if sweep_split_k is not None else (cfg.split_k_slices,)
+        swap_ab_values = (False, True) if sweep_swap_ab else (cfg.swap_ab,)
+        for split_k_slices in split_k_values:
+            for swap_ab in swap_ab_values:
+                expanded.append(replace(cfg, split_k_slices=split_k_slices, swap_ab=swap_ab).name)
+    return list(dict.fromkeys(expanded))
+
+
 # Argument surface
 
 CONFIGS_HELP = "comma-separated config names or globs, e.g. 'CONFIG_sm100_*' (default: sweep all)"
@@ -102,7 +174,37 @@ def add_sweep_args(parser, *, nsys: bool = True, warmup: int = 10, iters: int = 
     parser.add_argument("--rotate-buffers", default="auto", metavar="N", help=ROTATE_HELP)
     if nsys:
         parser.add_argument("--_nsys-worker", action="store_true", help=argparse.SUPPRESS)
+    add_config_variant_args(parser)
     return parser
+
+
+def add_config_variant_args(parser):
+    """Add the orthogonal tile-config sweep dimensions used by GEMM benches."""
+
+    def positive_int(value: str) -> int:
+        parsed = int(value)
+        if parsed < 1:
+            raise argparse.ArgumentTypeError("must be at least 1")
+        return parsed
+
+    parser.add_argument(
+        "--sweep-swap-ab",
+        action="store_true",
+        help="sweep both the ordinary and swap_ab=True variant of every selected tile config",
+    )
+    parser.add_argument(
+        "--sweep-split-k",
+        type=positive_int,
+        default=None,
+        metavar="N",
+        help="sweep split_k_slices from 1 through N for every selected tile config",
+    )
+    return parser
+
+
+def validate_config_variant_args(parser, args) -> None:
+    if args.sweep_split_k is not None and args.sweep_split_k < 1:
+        parser.error("--sweep-split-k must be at least 1")
 
 
 # Buffer rotation (defeat a hot L2 on small shapes)

--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -80,6 +80,7 @@ from .graph_analyzer import (
     GemmBinding,
     analyze_with_binding,
     resolve_variant_pack,
+    swap_ab_binding,
 )
 from .tile_config import DEFAULT_CONFIG, TileConfig, _sm_count
 
@@ -2936,6 +2937,15 @@ def _reshape_aux_to_fake(t: object, ref: TensorRef) -> object:
     return t.reshape(shape)
 
 
+def _swap_mn_view(t: object) -> object:
+    """Transpose the logical M/N axes without moving the runtime storage."""
+    if len(t.shape) == 3:
+        return t.permute(0, 2, 1)
+    if len(t.shape) == 2:
+        return t.permute(1, 0)
+    return t
+
+
 def _expected_output_shape(spec, chain: FusionChain, mnk) -> tuple[int, int, int]:
     return expected_shape(_output_rule(spec, chain), int(mnk[0]), int(mnk[1]))
 
@@ -3159,6 +3169,11 @@ class CompiledFusedGemm:
         # split-K slices for the kernel
         needs_workspace = bool(r.workspace_bytes)
         split_k_slices = self.config.split_k_slices
+        swap_ab = self.config.swap_ab
+        packed_scale_slots = frozenset(
+            o.index for o in r.outputs if o.role.startswith("quant_scale_") and self.chain.quants[int(o.role.rsplit("_", 1)[1])].scale_reorder == "F8_128x4"
+        )
+        mn_view_slots = (frozenset(o.index for o in r.outputs) | frozenset(x.index for x in r.aux)) - packed_scale_slots
         if needs_workspace:
             cta_k_elems = _cta_k_elems(self.chain, self.config)
             reduce_elems = _splitk_reduce_elems(self.chain)
@@ -3228,7 +3243,7 @@ class CompiledFusedGemm:
                 ):
                     gave_up["output layout"] += 1
                     return refuse(operands, graph_order)
-                problem += (st[1], st[2], st[0])
+                problem += (st[2], st[1], st[0]) if swap_ab and idx in mn_view_slots else (st[1], st[2], st[0])
             for idx, align in auxs:
                 v = operands[idx]
                 if tensor_alignment(tuple(v.shape), tuple(v.stride()), v.element_size(), ptr=v.data_ptr()) < align:
@@ -3307,7 +3322,14 @@ class CompiledFusedGemm:
             return launchable(
                 tuple(problem),
                 *(v.permute(1, 2, 0) for v in vs),
-                *(operands[i].permute(1, 2, 0) if ref is None else _reshape_aux_to_fake(operands[i], ref) for i, ref in tail),
+                *(
+                    (
+                        ((_swap_mn_view(operands[i]) if swap_ab and i in mn_view_slots else operands[i]).permute(1, 2, 0))
+                        if ref is None
+                        else _reshape_aux_to_fake(_swap_mn_view(operands[i]) if swap_ab else operands[i], ref)
+                    )
+                    for i, ref in tail
+                ),
                 *extra,
                 stream=_as_custream(stream),
             )
@@ -3873,8 +3895,6 @@ def _check_block_quant_supported(
         return
     if chain.has_mainloop_fusion:
         raise NotImplementedError("block_scale_quantize epilogue is not supported with mainloop fusion")
-    if any(spec.quant_idx is not None and spec.major != "n" for spec in chain.output_specs):
-        raise NotImplementedError("block_scale_quantize data outputs must be N-major")
     elem_bytes = DTYPE_BYTES[chain.output_dtype]
     vsize = vec_bytes_epi // elem_bytes
     cols_per_acc_stage = _epi_tile_cols(config)
@@ -4258,12 +4278,16 @@ def probe_supported(graph: cudnn.pygraph, config: "TileConfig | None" = None) ->
         want = ".".join(str(v) for v in buffers.CUTEDSL_MIN_VERSION)
         raise NotImplementedError(f"frost_gemm requires nvidia-cutlass-dsl >= {want}; found {version[1]}")
     chain, _binding = analyze_with_binding(graph)
+    if config is None:
+        config = plan_config(chain, dynamic_shapes=_graph_dynamic_shapes(graph))
+    if config.swap_ab:
+        from .fusion_ir import swap_ab
+
+        chain = swap_ab(chain)
     _dtype_reason = dtype_arch_reject(chain, _current_arch())
     if _dtype_reason is not None:
         raise NotImplementedError(_dtype_reason)
     _check_executable(chain)
-    if config is None:
-        config = plan_config(chain, dynamic_shapes=_graph_dynamic_shapes(graph))
     _check_splitk_supported(chain, config)
     if chain.is_multi_gemm and not (chain.has_moe or chain.has_block_scale):
         from .kernel_registry import select_template
@@ -4321,8 +4345,9 @@ def jit_from_cudnn_graph(
 
     `graph` is a ``cudnn.pygraph`` built after ``import cudnn.gemm.frost`` (the
     import installs the op-recording hook). `config` is a PURE-GEOMETRY tile from
-    `tile_config.CATALOG`. Execution strategy: ``cta_group`` ∈ {1, 2} and
-    picks the template (mainloop auto-detected).
+    `tile_config.CATALOG`. ``config.swap_ab`` logically lowers
+    ``C.T = B.T @ A.T`` without changing runtime buffers. Execution strategy:
+    ``cta_group`` ∈ {1, 2} and picks the template (mainloop auto-detected).
 
     Mixed CGA needs no argument and no caller change: where the GPU and the
     template both support it, the launch carries ``config``'s cluster as the
@@ -4331,6 +4356,11 @@ def jit_from_cudnn_graph(
     Everywhere else the launch is the plain fixed cluster it always was.
     """
     chain, binding = analyze_with_binding(graph)
+    if config.swap_ab:
+        from .fusion_ir import swap_ab
+
+        chain = swap_ab(chain)
+        binding = swap_ab_binding(binding)
     _dtype_reason = dtype_arch_reject(chain, _current_arch())
     if _dtype_reason is not None:
         raise NotImplementedError(_dtype_reason)

--- a/python/cudnn/gemm/frost/epilogue_codegen.py
+++ b/python/cudnn/gemm/frost/epilogue_codegen.py
@@ -603,12 +603,14 @@ def _dense_store_offset(i: int, is_fp4: bool, batch: int) -> str:
     return f"(tile_l * out_stride_l_{i} + {base})" if batch > 1 else f"({base})"
 
 
-def _emit_mmajor_scatter(tap_idx: int, i: int, source_var: str, dtype: Dtype, batch: int, vsize: int, *, row_pred: str | None = None) -> list[str]:
+def _emit_mmajor_scatter(
+    tap_idx: int, i: int, source_var: str, dtype: Dtype, batch: int, vsize: int, *, row_pred: str | None = None, converted: bool = False
+) -> list[str]:
     """Per-element scatter for an M-major (or arbitrarily strided) dense
     output: vsize scalar stores through the output's own runtime strides."""
     tap_var = f"_tap_{tap_idx}"
     l_term = f"tile_l * out_stride_l_{i} + " if batch > 1 else ""
-    lines = [f"{tap_var} = {_store_cast_expr(source_var, dtype)}"]
+    lines = [f"{tap_var} = {source_var if converted else _store_cast_expr(source_var, dtype)}"]
     for e in range(vsize):
         store = (
             f"(gC_tap_{tap_idx}_ptr + {l_term}row * out_stride_m_{i} + "
@@ -652,13 +654,14 @@ def _emit_tap_store(
     offset_expr: str = "linear_idx",
     *,
     row_pred: str | None = None,
+    converted: bool = False,
 ) -> list[str]:
     """Store one N-major tap vector: ``offset_expr`` in ``_tap_store_elems``-wide
     chunks (a wide dtype co-materialized with a block-quant splits into <=32B
     sub-stores). An M-major output goes through `_emit_mmajor_scatter`."""
     tap_var = f"_tap_{tap_idx}"
     store_elems = _tap_store_elems(chain, tap_dtype, dim, stride, vsize)
-    lines = [f"{tap_var} = {_store_cast_expr(source_var, tap_dtype)}"]
+    lines = [f"{tap_var} = {source_var if converted else _store_cast_expr(source_var, tap_dtype)}"]
     # The STG arm sits inside `row < M` / `col_j + vsize <= N`; the TMA arm has
     # neither -- its store is clipped by the descriptor's global extent instead.
     # `_tap_store_elems` divides both N and `col_j`, so a sub-chunk is wholly
@@ -1487,35 +1490,9 @@ def generate(
     for si in output_order:
         spec = specs[si]
         src = _parent_value(spec.source_ref)
-        if si in tma_slots:
-            _tma_j = sorted(tma_slots).index(si)
-            _ov = tma_out_value(_tma_j)
-            if spec.quant_idx is not None:
-                body_lines.extend(
-                    _emit_block_quant(
-                        chain.quants[spec.quant_idx],
-                        spec.quant_idx,
-                        src,
-                        spec.dtype,
-                        _ov,
-                        _scale_tap_idx(spec.quant_idx),
-                        quant_batch_expr,
-                        chain.matmul.M,
-                        vsize,
-                        store_row_pred,
-                    )
-                )
-            else:
-                body_lines.append(f"{_ov} = {_store_cast_expr(src, spec.dtype)}")
-            body_lines.append(tma_out_ready_marker(_tma_j))
-            continue
-        tap_idx = _tap_of[si]
-        if spec.major == "m":
-            body_lines.extend(_emit_mmajor_scatter(tap_idx, si, src, spec.dtype, chain.matmul.batch, vsize, row_pred=store_row_pred))
-            continue
-        offset_expr = _dense_store_offset(si, spec.dtype == "fp4_e2m1", chain.matmul.batch)
-        if spec.quant_idx is not None:
-            qv = f"_tap_{tap_idx}"
+        converted = spec.quant_idx is not None
+        if converted:
+            qv = f"_quant_data_{si}"
             body_lines.extend(
                 _emit_block_quant(
                     chain.quants[spec.quant_idx],
@@ -1530,20 +1507,23 @@ def generate(
                     store_row_pred,
                 )
             )
-            _align = max(vsize // 2, 4) if spec.dtype == "fp4_e2m1" else f"VEC_BYTES_TAP_{tap_idx}"
-            # fp4 is packed 2-per-byte, so its tap tensor is Int8 (B, M, N/2).
-            _st = f"(gC_tap_{tap_idx}_ptr + {offset_expr}).store({qv}, alignment={_align})"
-            # A quant tap's DATA store does not go through `_emit_tap_store`, so it
-            # needs the arm's row bound applied here too. Without it a MoE tile,
-            # which overhangs its routed group into the NEXT one, writes rows that
-            # group's own tile also writes -- two tiles racing on the same bytes.
-            if store_row_pred is None:
-                body_lines.append(_st)
-            else:
-                body_lines.append(f"if ({store_row_pred}) & (col_j + {vsize} <= N):")
-                body_lines.append(f"    {_st}")
-        else:
-            body_lines.extend(_emit_tap_store(tap_idx, src, spec.dtype, chain, spec.dim, spec.stride, vsize, offset_expr, row_pred=store_row_pred))
+            src = qv
+        # Quantized values (including packed FP4) are already converted. All
+        # dense outputs use the same layout/store dispatch after this point.
+        if si in tma_slots:
+            _tma_j = sorted(tma_slots).index(si)
+            _ov = tma_out_value(_tma_j)
+            body_lines.append(f"{_ov} = {src if converted else _store_cast_expr(src, spec.dtype)}")
+            body_lines.append(tma_out_ready_marker(_tma_j))
+            continue
+        tap_idx = _tap_of[si]
+        if spec.major == "m":
+            body_lines.extend(_emit_mmajor_scatter(tap_idx, si, src, spec.dtype, chain.matmul.batch, vsize, row_pred=store_row_pred, converted=converted))
+            continue
+        offset_expr = _dense_store_offset(si, spec.dtype == "fp4_e2m1", chain.matmul.batch)
+        body_lines.extend(
+            _emit_tap_store(tap_idx, src, spec.dtype, chain, spec.dim, spec.stride, vsize, offset_expr, row_pred=store_row_pred, converted=converted)
+        )
 
     for red_idx, red in enumerate(chain.reductions):
         red_source = _parent_value(red.source_ref)

--- a/python/cudnn/gemm/frost/fusion_ir.py
+++ b/python/cudnn/gemm/frost/fusion_ir.py
@@ -941,3 +941,118 @@ class FusionChain:
             f"{m.a_dtype}*{m.b_dtype}->{m.accum_dtype} | {mainloop}"
             f"epilogue: {chain} -> {self.output_dtype}{reductions}{quant}]"
         )
+
+
+def swap_ab(chain: FusionChain) -> FusionChain:
+    """Return the logical-transpose view ``C.T = B.T @ A.T`` of ``chain``.
+
+    No runtime storage moves.  Every dense non-virtual tensor swaps its last
+    two logical dimensions and strides, A/B-side metadata trades places, and
+    pointwise operation topology stays unchanged.  The binding performs the
+    corresponding tensor-role swap separately.
+
+    Quantization axes and scale metadata follow the transpose; the ordinary
+    quantization support checks decide whether the resulting layout can run.
+    MoE still requires a scheduler that routes ranges along N instead of M.
+    """
+
+    if chain.has_moe:
+        raise NotImplementedError("swap_ab is not supported for MoE: routed groups partition M, not N")
+
+    def _mn(values):
+        if values is None or len(values) < 2:
+            return values
+        return (*values[:-2], values[-1], values[-2])
+
+    def _bcast(mode):
+        return {"per_row": "per_col", "per_col": "per_row"}.get(mode, mode)
+
+    def _op(op):
+        # gen_index is the only pointwise op whose value depends on an output
+        # axis. Scalar attributes on every other op are transpose-invariant.
+        attrs = tuple((key, 3 - value if key == "axis" and value in (1, 2) else value) for key, value in op.attrs)
+        return dataclasses.replace(op, attrs=attrs) if attrs != op.attrs else op
+
+    mm = chain.matmul
+    swapped_mm = dataclasses.replace(
+        mm,
+        M=mm.N,
+        N=mm.M,
+        a_batch=mm.b_batch,
+        b_batch=mm.a_batch,
+        a_major="k" if mm.b_major == "k" else "m",
+        b_major="k" if mm.a_major == "k" else "n",
+        a_dtype=mm.b_dtype,
+        b_dtype=mm.a_dtype,
+    )
+    swapped_aux = []
+    for t in chain.aux_tensors:
+        dim, stride = t.dim, t.stride
+        if len(dim) == 1:
+            # Rank-1 aux broadcasts as (1, N). Make that axis explicit before
+            # transposing; runtime _reshape_aux_to_fake supplies the same view.
+            dim, stride = (1, dim[0]), (stride[0], stride[0])
+        swapped_aux.append(dataclasses.replace(t, dim=_mn(dim), stride=_mn(stride), bcast_mode=_bcast(t.bcast_mode)))
+    # An unset output stride means compact N-major. Materialize it before the
+    # transpose; leaving it unset would incorrectly remain N-major instead of
+    # becoming the equivalent M-major view.
+    swapped_outputs = [
+        dataclasses.replace(
+            o,
+            dim=_mn(o.dim or (mm.batch, mm.M, mm.N)),
+            stride=_mn(o.stride or (mm.M * mm.N, mm.N, 1)),
+        )
+        for o in chain.output_specs
+    ]
+    swapped_reductions = [dataclasses.replace(r, dim=_mn(r.dim)) for r in chain.reductions]
+    swapped_quants = [
+        dataclasses.replace(
+            q,
+            axis=2 if q.axis == 1 else 1,
+            # transpose=True is an API spelling of axis=1, already resolved
+            # by the analyzer. Use the explicit axis in the transformed IR.
+            transpose=False,
+            # F8_128x4 describes physical atoms, with the blocked axis last
+            # for both row and column quantization. Their storage is unchanged.
+            scale_dim=q.scale_dim if q.scale_reorder == "F8_128x4" else _mn(q.scale_dim),
+        )
+        for q in chain.quants
+    ]
+
+    block_scale = chain.block_scale
+    if block_scale is not None:
+        block_scale = dataclasses.replace(
+            block_scale,
+            a_dtype=block_scale.b_dtype,
+            b_dtype=block_scale.a_dtype,
+            block_size_a=_mn(block_scale.block_size_b),
+            block_size_b=_mn(block_scale.block_size_a),
+            sf_dtype_a=block_scale.sf_dtype_b,
+            sf_dtype_b=block_scale.sf_dtype_a,
+            sfa_reorder=block_scale.sfb_reorder,
+            sfb_reorder=block_scale.sfa_reorder,
+            dequant_compute_a=block_scale.dequant_compute_b,
+            dequant_compute_b=block_scale.dequant_compute_a,
+            dequant_out_a=block_scale.dequant_out_b,
+            dequant_out_b=block_scale.dequant_out_a,
+            fake_dequant_a=block_scale.fake_dequant_b,
+            fake_dequant_b=block_scale.fake_dequant_a,
+        )
+
+    return dataclasses.replace(
+        chain,
+        matmul=swapped_mm,
+        aux_tensors=swapped_aux,
+        ops=[_op(op) for op in chain.ops],
+        output_specs=swapped_outputs,
+        reductions=swapped_reductions,
+        quants=swapped_quants,
+        num_a_operands=chain.num_b_operands,
+        num_b_operands=chain.num_a_operands,
+        gemm_operands=[(b, a) for a, b in chain.gemm_operands],
+        mainloop_a_ops=list(chain.mainloop_b_ops),
+        mainloop_b_ops=list(chain.mainloop_a_ops),
+        mainloop_a_load_dtype=chain.mainloop_b_load_dtype,
+        mainloop_b_load_dtype=chain.mainloop_a_load_dtype,
+        block_scale=block_scale,
+    )

--- a/python/cudnn/gemm/frost/graph_analyzer.py
+++ b/python/cudnn/gemm/frost/graph_analyzer.py
@@ -195,6 +195,21 @@ class GemmBinding:
         return [t for t in ts if t is not None]
 
 
+def swap_ab_binding(binding: "GemmBinding | None") -> "GemmBinding | None":
+    """Trade A/B runtime roles while preserving the original tensor objects."""
+    if binding is None:
+        return None
+    return GemmBinding(
+        a_operands=list(binding.b_operands),
+        b_operands=list(binding.a_operands),
+        outputs=list(binding.outputs),
+        aux=list(binding.aux),
+        sfa_operands=list(binding.sfb_operands),
+        sfb_operands=list(binding.sfa_operands),
+        first_token_offset=binding.first_token_offset,
+    )
+
+
 def _make_multi_binding(
     meta: dict,
     a_ids,

--- a/python/cudnn/gemm/frost/recipe.py
+++ b/python/cudnn/gemm/frost/recipe.py
@@ -101,7 +101,7 @@ def expected_shape(rule, m: int, n: int) -> tuple:
     return tuple(v if s == CONST else (m if s == FROM_M else n // v) for s, v in rule)
 
 
-def _output_rule(spec, chain: FusionChain) -> tuple:
+def _output_rule(spec, chain: FusionChain, *, physical_mn_swapped: bool = False) -> tuple:
     """How one output's shape follows from (M, N), as a per-axis rule.
 
     The single answer to a question that used to be asked in two places and
@@ -110,18 +110,28 @@ def _output_rule(spec, chain: FusionChain) -> tuple:
     """
     batch = chain.matmul.batch
     if spec.is_quant_scale:
-        return tuple((CONST, int(d)) for d in spec.dim)
-    if not spec.is_reduction:
-        return ((CONST, batch), (FROM_M, 0), (FROM_N, 2 if spec.dtype == "fp4_e2m1" else 1))
-    red_idx = int(spec.source.rsplit("_", 1)[1])
-    if chain.reductions[red_idx].grouped_by_moe:
-        return tuple((CONST, int(d)) for d in spec.dim)
-    # A reduced axis collapses to 1; the rest follow the problem size.
-    return (
-        (CONST, 1 if spec.dim[0] == 1 else batch),
-        (CONST, 1) if spec.dim[1] == 1 else (FROM_M, 0),
-        (CONST, 1) if spec.dim[2] == 1 else (FROM_N, 1),
-    )
+        rule = tuple((CONST, int(d)) for d in spec.dim)
+        qi = int(spec.source.rsplit("_", 1)[1])
+        if physical_mn_swapped and chain.quants[qi].scale_reorder == "F8_128x4":
+            # Reordered scales are physical atoms, unchanged by swapping the
+            # logical quantization axis. Compact scale tables do transpose.
+            return rule
+    elif not spec.is_reduction:
+        rule = ((CONST, batch), (FROM_M, 0), (FROM_N, 2 if spec.dtype == "fp4_e2m1" else 1))
+    else:
+        red_idx = int(spec.source.rsplit("_", 1)[1])
+        if chain.reductions[red_idx].grouped_by_moe:
+            rule = tuple((CONST, int(d)) for d in spec.dim)
+        else:
+            # A reduced axis collapses to 1; the rest follow the problem size.
+            rule = (
+                (CONST, 1 if spec.dim[0] == 1 else batch),
+                (CONST, 1) if spec.dim[1] == 1 else (FROM_M, 0),
+                (CONST, 1) if spec.dim[2] == 1 else (FROM_N, 1),
+            )
+    # The transformed IR is [B, new-M, new-N], but the user's unchanged buffer
+    # still presents [B, old-M, old-N] = [B, new-N, new-M].
+    return (rule[0], rule[2], rule[1]) if physical_mn_swapped else rule
 
 
 @dataclass(frozen=True)
@@ -453,8 +463,8 @@ def _declared_layout(tensor) -> tuple:
         return (), ()
 
 
-def _operand(index: int, role: str, tensor, *, major: str, dtype: str, batch: int, is_b: bool) -> Operand:
-    declared = _DECLARED_AXES["b" if is_b else "a"]
+def _operand(index: int, role: str, tensor, *, major: str, dtype: str, batch: int, is_b: bool, declared_is_b: bool | None = None) -> Operand:
+    declared = _DECLARED_AXES["b" if (is_b if declared_is_b is None else declared_is_b) else "a"]
     contiguous = AX_K if major == "k" else AX_MN
     modulus, pack = contiguous_modulus(dtype, contiguous == AX_K)
     return Operand(
@@ -479,14 +489,35 @@ def build(compiled) -> GemmRecipe:
     chain: FusionChain = compiled.chain
     mm = chain.matmul
     binding = compiled.binding
+    swap_ab = compiled.config.swap_ab
     order = {}
     for i, t in enumerate(binding.bound_tensors()):
         order.setdefault(id(t), i)
 
     inputs = [
-        _operand(order[id(t)], f"A operand[{i}]", t, major=mm.a_major, dtype=mm.a_dtype, batch=mm.a_batch, is_b=False) for i, t in enumerate(binding.a_operands)
+        _operand(
+            order[id(t)],
+            f"A operand[{i}]",
+            t,
+            major=mm.a_major,
+            dtype=mm.a_dtype,
+            batch=mm.a_batch,
+            is_b=False,
+            declared_is_b=swap_ab,
+        )
+        for i, t in enumerate(binding.a_operands)
     ] + [
-        _operand(order[id(t)], f"B operand[{i}]", t, major=mm.b_major, dtype=mm.b_dtype, batch=mm.b_batch, is_b=True) for i, t in enumerate(binding.b_operands)
+        _operand(
+            order[id(t)],
+            f"B operand[{i}]",
+            t,
+            major=mm.b_major,
+            dtype=mm.b_dtype,
+            batch=mm.b_batch,
+            is_b=True,
+            declared_is_b=not swap_ab,
+        )
+        for i, t in enumerate(binding.b_operands)
     ]
 
     out_reqs = _output_align_reqs(chain, compiled.tma_slots, vec_bytes=compiled.vec_bytes_epi)
@@ -502,7 +533,7 @@ def build(compiled) -> GemmRecipe:
             Output(
                 index=order[id(t)],
                 role=spec.source,
-                rule=_output_rule(spec, chain),
+                rule=_output_rule(spec, chain, physical_mn_swapped=swap_ab),
                 align=out_reqs[i],
                 raw=bool(spec.is_reduction or spec.is_quant_scale),
                 init=init,

--- a/python/cudnn/gemm/frost/tile_config.py
+++ b/python/cudnn/gemm/frost/tile_config.py
@@ -7,7 +7,7 @@ A ``TileConfig`` describes ONLY dtype-independent tile geometry (cta tile,
 MMA-inst tile, cluster shape, pipeline). It does NOT carry ``cta_group`` /
 ``ab_stages`` — those are execution strategy chosen by the
 kernel template. K is stored in *bytes*, so one config covers every dtype.
-Name: ``CONFIG_<pipeline>_<CTA_M>x<CTA_N>x<K_BYTES>_<MMA_M>x<MMA_N>x<MMA_K_BYTES>_cluster<cgrp_m>x<cgrp_n>``.
+Name: ``CONFIG_<pipeline>_<CTA_M>x<CTA_N>x<K_BYTES>_<MMA_M>x<MMA_N>x<MMA_K_BYTES>_cluster<cgrp_m>x<cgrp_n>[_swapAB]``.
 A warp-scoped family (sm120) additionally ALWAYS names its compute-warp grid
 via a ``_warpsMxN`` suffix — no grid is implied by an unsuffixed spelling.
 See ``kernel_registry`` for the template registry and the support funnel.
@@ -100,8 +100,9 @@ class TileConfig:
     """One pure-geometry tile config. Dtype- AND execution-independent.
 
     Four nested tiles, outermost first -- CGA (a cluster of CTAs), CTA, warp,
-    MMA instruction -- plus the K-split axis. Each level must divide the one
-    above it. K is stored in BYTES throughout, so one config serves every dtype.
+    MMA instruction -- plus the K-split and logical A/B-orientation axes. Each
+    tile level must divide the one above it. K is stored in BYTES throughout,
+    so one config serves every dtype.
 
     NOT here, because they are not choices: `ab_stages` (the device SMEM budget
     decides), the epilogue subtile N (the output dtype and drain width decide),
@@ -142,8 +143,13 @@ class TileConfig:
 
     split_k_slices: int
 
+    swap_ab: bool
+
     def __post_init__(self) -> None:
         name = self.name
+
+        if not isinstance(self.swap_ab, bool):
+            raise ValueError(f"TileConfig {name!r}: swap_ab must be bool; got {self.swap_ab!r}")
 
         for label, v in (
             ("cta_tile_m", self.cta_tile_m),
@@ -247,8 +253,8 @@ class TileConfig:
 
     @property
     def geometry_name(self) -> str:
-        """Geometry token (no ``CONFIG_``/pipeline prefix) used in the kernel symbol."""
-        return self._geometry_base + (f"_splitK{self.split_k_slices}" if self.split_k_slices > 1 else "")
+        """Canonical geometry token used in the TileConfig name."""
+        return self._geometry_base + (f"_splitK{self.split_k_slices}" if self.split_k_slices > 1 else "") + ("_swapAB" if self.swap_ab else "")
 
     @property
     def _geometry_base(self) -> str:
@@ -615,6 +621,7 @@ def _geom_sm100(
         cga_size_k=1,
         warps_per_cta=_TCGEN05_WARPS_PER_CTA,
         split_k_slices=1,
+        swap_ab=False,
         cta_group=cta_group,
     )
 
@@ -641,6 +648,7 @@ def _geom_sm103(cta_tile_m: int, cta_tile_n: int, cga_size_m: int, cga_size_n: i
         cga_size_k=1,
         warps_per_cta=_TCGEN05_WARPS_PER_CTA,
         split_k_slices=1,
+        swap_ab=False,
         cta_group=cta_group,
     )
 
@@ -677,6 +685,7 @@ def _geom_sm120(
         cga_size_k=1,
         warps_per_cta=ConfigSm120.DEFAULT_WARPS_PER_CTA,
         split_k_slices=1,
+        swap_ab=False,
     )
 
 
@@ -767,7 +776,7 @@ _CONFIG_NAME_RE = re.compile(
     r"(?P<cta_m>\d+)x(?P<cta_n>\d+)x(?P<k_bytes>\d+)_"
     r"(?P<mma_m>\d+)x(?P<mma_n>\d+)x(?P<mma_k_bytes>\d+)_"
     r"cluster(?P<cga_m>\d+)x(?P<cga_n>\d+)(?:_(?P<cta_group>\d+)ctamma)?"
-    r"(?:_warps(?P<warps_m>\d+)x(?P<warps_n>\d+))?(?:_splitK(?P<split_k>\d+))?$"
+    r"(?:_warps(?P<warps_m>\d+)x(?P<warps_n>\d+))?(?:_splitK(?P<split_k>\d+))?(?P<swap_ab>_swapAB)?$"
 )
 
 
@@ -809,6 +818,7 @@ def _synthesize_config(name: str) -> TileConfig:
         # Not spelled by the name; a family with its own block size declares it.
         warps_per_cta=getattr(cls, "DEFAULT_WARPS_PER_CTA", _TCGEN05_WARPS_PER_CTA),
         split_k_slices=int(m.group("split_k") or 1),
+        swap_ab=bool(m.group("swap_ab")),
         # Only where the family HAS the axis; a name for one that does not
         # carries no such token either.
         **({"cta_group": int(m.group("cta_group") or 1)} if "cta_group" in cls.__dataclass_fields__ else {}),
@@ -1086,6 +1096,7 @@ def as_pipeline(cfg: TileConfig, pipeline: str) -> TileConfig:
         cga_size_k=cfg.cga_size_k,
         warps_per_cta=getattr(cls, "DEFAULT_WARPS_PER_CTA", cfg.warps_per_cta),
         split_k_slices=cfg.split_k_slices,
+        swap_ab=cfg.swap_ab,
         **({"cta_group": getattr(cfg, "cta_group", 1)} if "cta_group" in cls.__dataclass_fields__ else {}),
     )
 

--- a/test/python/gemm/frost/test_block_scale_matmul.py
+++ b/test/python/gemm/frost/test_block_scale_matmul.py
@@ -1470,6 +1470,7 @@ def test_config_families():
             cga_size_k=1,
             warps_per_cta=8,
             split_k_slices=1,
+            swap_ab=False,
             **({"cta_group": 1} if "cta_group" in cls.__dataclass_fields__ else {}),
         )
 
@@ -1523,6 +1524,7 @@ def test_validate_block_scale_config_arch_fork():
             cga_size_k=1,
             warps_per_cta=8,
             split_k_slices=1,
+            swap_ab=False,
             cta_group=1,
             pipeline="sm103",
         )
@@ -1573,6 +1575,7 @@ def test_select_template_dispatches_on_config_arch():
         cga_size_k=1,
         warps_per_cta=8,
         split_k_slices=1,
+        swap_ab=False,
     )
     imposter = TileConfig(**base_kw)
     # It could not even be asked for sm103's fixed K width: that is a ClassVar
@@ -1967,6 +1970,7 @@ def test_a_pipeline_that_fixes_its_k_width_still_does():
             cga_size_k=1,
             warps_per_cta=8,
             split_k_slices=1,
+            swap_ab=False,
             cta_group=1,
         )
 

--- a/test/python/gemm/frost/test_execute_recipe.py
+++ b/test/python/gemm/frost/test_execute_recipe.py
@@ -35,6 +35,7 @@ from cudnn.engines import is_python_engine
 from cudnn.gemm.frost.compiler import jit_from_cudnn_graph, probe_supported
 from cudnn.gemm.frost.graph_analyzer import resolve_variant_pack
 from cudnn.gemm.frost.recipe import _output_rule, expected_shape
+from cudnn.gemm.frost.tile_config import DEFAULT_CONFIG
 
 pytestmark = pytest.mark.L0
 
@@ -133,6 +134,17 @@ def _aux_graph():
     Y = g.add(a=C, b=bias, name="bias_add")
     Y.set_output(True).set_data_type(BF16)
     return g
+
+
+def _rectangular_aux_graph(m=128, n=256, k=128):
+    g = cudnn.pygraph(io_data_type=BF16, intermediate_data_type=F32, compute_data_type=F32)
+    A = g.tensor(name="A", dim=[1, m, k], stride=[m * k, k, 1])
+    B = g.tensor(name="B", dim=[1, k, n], stride=[k * n, 1, k])
+    bias = g.tensor(name="bias", dim=[1, 1, n], stride=[n, n, 1], data_type=F32)
+    C = g.matmul(A=A, B=B, name="mm")
+    Y = g.add(a=C, b=bias, name="bias_add")
+    Y.set_stride([m * n, n, 1]).set_output(True).set_data_type(BF16)
+    return g, A, B, bias, Y
 
 
 def _epilogue_graph():
@@ -519,6 +531,62 @@ def test_one_buffer_in_two_roles_reads_each_role_s_own_axis_order():
     # The graph declares B [b, K, N], so B's N axis is the buffer's LAST -- which
     # makes the product A @ A, not A @ A.T. Asymmetric by construction.
     torch.testing.assert_close(c.float(), (a.float() @ a.float()), atol=2e-1, rtol=2e-2)
+
+
+@requires_sm100
+def test_swap_ab_transposes_only_the_logical_views():
+    """A rectangular fused graph catches every accidental physical transpose.
+
+    The generated kernel sees B.T @ A.T and an M-major C.T, while the caller
+    keeps the original A/B/C buffers and variant-pack tensor identities.
+    """
+    m, n, k = 128, 256, 128
+    g, A, B, bias, Y = _rectangular_aux_graph(m, n, k)
+    compiled = jit_from_cudnn_graph(g, replace(DEFAULT_CONFIG, swap_ab=True))
+
+    assert (compiled.chain.matmul.M, compiled.chain.matmul.N) == (n, m)
+    assert compiled.chain.out_major == "m"
+    assert compiled.chain.aux_tensors[0].bcast_mode == "per_row"
+    assert compiled.binding.a_operands == [B]
+    assert compiled.binding.b_operands == [A]
+
+    a = torch.randn(1, m, k, dtype=torch.bfloat16, device="cuda")
+    b = torch.randn(1, n, k, dtype=torch.bfloat16, device="cuda")
+    bias_buf = torch.randn(1, 1, n, dtype=torch.float32, device="cuda")
+    out = torch.empty(1, m, n, dtype=torch.bfloat16, device="cuda")
+    compiled({A: a, B: b, bias: bias_buf, Y: out})
+    torch.cuda.synchronize()
+
+    ref = torch.einsum("bmk,bnk->bmn", a.float(), b.float()) + bias_buf
+    torch.testing.assert_close(out.float(), ref, atol=2e-1, rtol=2e-2)
+    assert dict(compiled.deferrals) == {}
+
+
+@requires_sm100
+@pytest.mark.parametrize("scalar,step", [(False, 1), (False, 2), (True, 1)])
+@pytest.mark.parametrize("stg", [False, True])
+def test_swap_ab_rank1_aux_keeps_its_broadcast_axis(scalar, step, stg):
+    from cudnn.gemm.frost.compiler import force_stg_epi
+
+    m, n, k = 128, 256, 128
+    size = 1 if scalar else n
+    g = cudnn.pygraph(io_data_type=BF16, intermediate_data_type=F32, compute_data_type=F32)
+    A = g.tensor(name="A", dim=[1, m, k], stride=[m * k, k, 1])
+    B = g.tensor(name="B", dim=[1, k, n], stride=[n * k, 1, k])
+    bias = g.tensor(name="bias", dim=[size], stride=[step], data_type=F32)
+    Y = g.add(a=g.matmul(A=A, B=B), b=bias).set_output(True).set_data_type(F32)
+    torch.manual_seed(0)
+    a = torch.randint(-2, 3, (1, m, k), device="cuda").to(torch.bfloat16)
+    b = torch.randint(-2, 3, (1, n, k), device="cuda").to(torch.bfloat16)
+    bias_buf = (torch.arange(size * step, device="cuda", dtype=torch.float32) + 0.25)[::step]
+    out = torch.empty(1, m, n, device="cuda", dtype=torch.float32)
+    with force_stg_epi(stg):
+        compiled = jit_from_cudnn_graph(g, replace(DEFAULT_CONFIG, swap_ab=True))
+    compiled({A: a, B: b, bias: bias_buf, Y: out})
+    torch.cuda.synchronize()
+    ref = (a.float() @ b.float().transpose(1, 2)) + bias_buf
+    torch.testing.assert_close(out, ref, atol=0, rtol=0)
+    assert not compiled.deferrals
 
 
 @requires_sm100

--- a/test/python/gemm/frost/test_matmul.py
+++ b/test/python/gemm/frost/test_matmul.py
@@ -1028,6 +1028,54 @@ def test_dense_block_scale_quant_epilogue() -> None:
     torch.testing.assert_close(q.float(), q_ref.float(), atol=0, rtol=0)
 
 
+@requires_sm100
+@pytest.mark.parametrize("mode", ["mmajor", "swap_ab"])
+@pytest.mark.parametrize("reordered", [False, True])
+@pytest.mark.parametrize("stg", [False, True])
+def test_quantized_output_uses_normal_mmajor_store(mode, reordered, stg) -> None:
+    """Quantized data and scales must survive both M-major store paths and swap."""
+    from dataclasses import replace
+    from cudnn.gemm.frost.compiler import force_stg_epi, jit_from_cudnn_graph
+
+    M, N, K, bs = 128, 256, 128, 32
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.BFLOAT16,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
+    B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
+    C = g.matmul(A=A, B=B)
+    Q, SF = g.block_scale_quantize(input=C, block_size=bs, axis=-1)
+    Q.set_output(True).set_data_type(cudnn.data_type.FP8_E4M3)
+    Q.set_dim([1, M, N]).set_stride([M * N, 1, M] if mode == "mmajor" else [M * N, N, 1])
+    SF.set_output(True).set_data_type(cudnn.data_type.FP8_E8M0)
+    SF.set_dim([1, M, N // bs]).set_stride([M * N // bs, N // bs, 1])
+    if reordered:
+        SF.set_reordering_type(cudnn.tensor_reordering.F8_128x4)
+
+    cfg = replace(_resolve("CONFIG_sm100_128x128x128_128x128x32_cluster1x1_1ctamma"), swap_ab=mode == "swap_ab")
+    with force_stg_epi(stg):
+        compiled = jit_from_cudnn_graph(g, config=cfg)
+    assert compiled.chain.out_major == "m"
+    assert bool(compiled.tma_slots) == (not stg)
+
+    a, b, _ = _mkdata(M, N, K, "bf16", "bf16")
+    q = torch.empty((1, N, M) if mode == "mmajor" else (1, M, N), dtype=torch.float8_e4m3fn, device="cuda")
+    if mode == "mmajor":
+        q = q.transpose(1, 2)
+    sf = torch.empty(1, M, N // bs, dtype=torch.float8_e8m0fnu, device="cuda")
+    compiled({A: a, B: b, Q: q, SF: sf})
+    torch.cuda.synchronize()
+    assert not compiled.deferrals
+
+    mm = torch.einsum("bmk,bnk->bmn", a.float(), b.float())
+    q_ref, sf_ref = _block_quant_reference(mm, bs, torch.float8_e4m3fn, torch.float8_e8m0fnu)
+    sf_got = sf.float().flatten()[_f8_row_scale_addr(M, N, bs)].unsqueeze(0) if reordered else sf.float()
+    torch.testing.assert_close(sf_got, sf_ref.float(), atol=0, rtol=0)
+    torch.testing.assert_close(q.float(), q_ref.float(), atol=0, rtol=0)
+
+
 def _col_quant_reference(
     x: torch.Tensor,
     block_size: int,

--- a/test/python/gemm/frost/test_tile_select_analytic.py
+++ b/test/python/gemm/frost/test_tile_select_analytic.py
@@ -16,12 +16,46 @@ Selection is pure geometry, so every invariant is checkable on CPU:
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
-from cudnn.gemm.frost.tile_config import by_name, select_config
+from cudnn.gemm.frost.tile_config import as_pipeline, by_name, select_config
 
 MS = (1, 4, 16, 32, 64, 96, 128, 129, 256, 512, 1024, 4096)
 NS = (32, 64, 128, 256, 512, 1024, 4096, 8192, 10240)
 KS = (256, 1024, 2048, 4096, 8192)
+
+
+def test_swap_ab_is_a_named_tile_config_option():
+    base = by_name("CONFIG_sm100_128x256x128_128x256x32_cluster2x1_2ctamma")
+    swapped = replace(base, swap_ab=True)
+    assert swapped.name == f"{base.name}_swapAB"
+    assert swapped.geometry_name.endswith("_swapAB")
+    assert by_name(swapped.name) == swapped
+    assert as_pipeline(swapped, "sm120").swap_ab is True
+
+
+def test_swap_ab_transforms_the_fusion_ir_without_moving_storage():
+    from cudnn.gemm.frost.fusion_ir import FusionChain, FusionOp, MatmulSpec, OutputSpec, TensorRef, swap_ab
+
+    chain = FusionChain(
+        matmul=MatmulSpec(M=64, N=192, K=128, batch=3, a_batch=1, b_batch=3, a_major="m", b_major="n", a_dtype="fp16", b_dtype="bf16"),
+        aux_tensors=[TensorRef("bias", (1, 1, 192), (192, 192, 1), "fp32", "per_col")],
+        ops=[FusionOp("gen_index", parent_idx=-1, attrs=(("axis", 2.0),))],
+        output_specs=[OutputSpec(source_ref=0, dtype="bf16")],
+        mainloop_a_ops=[FusionOp("relu", parent_idx=-1)],
+    )
+
+    swapped = swap_ab(chain)
+    assert (swapped.matmul.M, swapped.matmul.N, swapped.matmul.a_batch, swapped.matmul.b_batch) == (192, 64, 3, 1)
+    assert (swapped.matmul.a_major, swapped.matmul.b_major) == ("m", "n")
+    assert (swapped.matmul.a_dtype, swapped.matmul.b_dtype) == ("bf16", "fp16")
+    assert swapped.aux_tensors[0].bcast_mode == "per_row"
+    assert swapped.ops[0].attrs == (("axis", 1.0),)
+    assert swapped.output_specs[0].dim == (3, 192, 64)
+    assert swapped.output_specs[0].stride == (64 * 192, 1, 192)
+    assert swapped.out_major == "m"
+    assert not swapped.mainloop_a_ops and swapped.mainloop_b_ops == chain.mainloop_a_ops
 
 
 @pytest.mark.parametrize("block_scale", [False, True])


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches (see [root AGENTS.md § Reviewing a PR](https://github.com/NVIDIA/cudnn-frontend/blob/develop/AGENTS.md#reviewing-a-pr-human-or-agent)) and my changes comply, or I explain the exception below.
- [x] I added GitHub labels: one `cat-*`, one or more `area:*` / `op:*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

Add swap A/B tile config choice for small M problem sizes

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added benchmark sweeps for A/B operand swapping and split-K configurations.
  - Added expanded tile-configuration selection and comparison across matmul and MoE benchmarks.
  - Added A/B-swapped execution for supported GEMM workloads without moving data.
  - Added A/B-swapped tile-configuration naming and validation.

- **Bug Fixes**
  - Improved quantized output handling across store paths and reordered scale formats.
  - Block-scale quantized outputs now support additional output layouts.
  - Improved reliability for repeated benchmark launches requiring workspace memory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->