### PR TITLE
frost(sdpa): Rubin per-tensor FP8 claims SCHED_LPT at d256 / d192x128; heuristics rank from the flavor's domain

### DIFF
--- a/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
+++ b/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
@@ -384,7 +384,7 @@ e2e `test_fp8_lpt_is_bit_identical_to_natural_on_the_claimed_flavors`.
 
 Still declined, and why: d128/d512 f16, d128 FP8 (tolerance, above) and every
 MXFP8 flavor are **unvalidated** under LPT rather than known-incorrect; d512
-(f16, FP8, MXFP8) is **known-broken** under LPT until the d512 kernels get the
+(f16, FP8, MXFP8) **does not produce output** under LPT until the d512 kernels get the
 `lpt_q_tiles_in_cga_units` argument and are re-validated (cga4×1 role-split, a
 different scheduler shape — `prefill_d512_fp8.py:2533` notes the LPT range is
 `q_clusters * CTA_MMA`). `SCHED_LPT_L2` is declined by **every** flavor —

--- a/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
+++ b/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
@@ -355,9 +355,39 @@ dense and causal. Measured causal SOL on Rubin at S = 4096/8192/32768:
 (+18.2/+11.6/+1.1 %), recovering 40/51/29 % of the causal-vs-dense gap; dense is
 neutral. The decay with S is the signature of scheduler imbalance.
 
-Still declined, and why: d128/d512 f16 and every FP8/MXFP8 flavor are
-**unvalidated** under LPT rather than known-incorrect (d512 is cga4×1 role-split,
-a different scheduler shape). `SCHED_LPT_L2` is declined by **every** flavor —
+**FP8 (256, 256) and (192, 128) join the LPT claim (2026-09-11).** Validated
+through the standalone adapter on Rubin (E4M3 per-tensor scales, bf16 O, causal,
+dense and padded, (B, S) ∈ {(1,256), (2,1000), (1,4096)}) against the fp64
+kernel-mirroring `fp8_ref.compute_ref`: (256, 256) max|O−ref| 0.0078 causal /
+≤ 0.0019 dense (tol 0.075); (192, 128) 0.0397 causal / ≤ 0.0060 dense (tol
+0.04). On both flavors O and LSE under LPT are **bit-identical** to NATURAL (the
+scheduler reorders whole (batch, head, q-tile) work items; each tile's KV loop is
+unchanged), sentinel 0, two-launch 0. Perf node, d256 causal H32/2, LPT vs
+NATURAL launch-interleaved: +5.2/+5.9/+5.6/+2.0/+2.3 % at S = 2K..32K (control
+pair within 1.9 %). The FP8 row now carries
+`sched_policies_by_d_shape = (((256, 256), {NATURAL, LPT}), ((192, 128), {NATURAL, LPT}))`.
+Two FP8 flavors stay out: **(128, 128)** is also bit-identical under LPT, but
+its causal path reads 0.041–0.048 against the suite's 0.04 under NATURAL as
+well, so it gets its own look before it is claimed; **(512, 512)** — the cga4×1
+role-split kernel still calls `make_sdpa_helpers(CFG)` without
+`lpt_q_tiles_in_cga_units` (the #1001 argument, left on the d512 line), so under
+LPT it writes *nothing* (sentinel on 100 % of cells; the earlier "causal d512
+FP8 → NaN" report was that unwritten output being read). In the same
+change `heuristics._sched_points` ranks from the FLAVOR's effective domain
+(`effective_sched_policies`) rather than the row-wide floor — before it, a
+per-shape LPT claim was honoured only when a caller REQUESTED the knob and was
+never proposed for the first plan (this also makes the f16 d256 claim reach
+the graph path's ranking). Pinned by
+`test_sm107_fp8_advertises_lpt_only_for_the_validated_d_shape`,
+`test_sm107_fp8_lpt_knob_is_honored_or_ineligible_per_d_shape` and the Rubin
+e2e `test_fp8_lpt_is_bit_identical_to_natural_on_the_claimed_flavors`.
+
+Still declined, and why: d128/d512 f16, d128 FP8 (tolerance, above) and every
+MXFP8 flavor are **unvalidated** under LPT rather than known-incorrect; d512
+(f16, FP8, MXFP8) is **known-broken** under LPT until the d512 kernels get the
+`lpt_q_tiles_in_cga_units` argument and are re-validated (cga4×1 role-split, a
+different scheduler shape — `prefill_d512_fp8.py:2533` notes the LPT range is
+`q_clusters * CTA_MMA`). `SCHED_LPT_L2` is declined by **every** flavor —
 its decode needs `qh_per_kh` and `seqlen_kv`, which the SM107 call sites do not
 pass, so it raises rather than miscomputes. Both are follow-ups.
 

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -1460,18 +1460,20 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             # tile space, while a ragged batch carries its own scheduler,
             # which walks the live units through batch_remap.
             #
-            # Rubin is excluded for a different reason: the PORTED SM107
-            # kernels do not honor either LPT decode.  LPT_L2 raises outright
-            # ("SCHED_LPT_L2 decode requires qh_per_kh and seqlen_kv at every
-            # call site" -- the ported decode sites never thread them), and
-            # plain LPT is silently WRONG (measured 2026-09-08: causal d512 FP8
-            # -> NaN, masked d128 MXFP8 -> max|O-ref| ~ 1.9).  The three SM107
-            # engine rows already declare sched_policies={SCHED_NATURAL}; this
-            # is the STANDALONE-wrapper twin of that decline, which the row
-            # cannot cover because the wrapper never consults it.
-            # NOTE: the SHIPPED d128 FP8 SM107 kernel does honor both, and
-            # loses them here too -- recovering that needs a per-flavor domain
-            # (see the sched_policies_by_d_shape follow-up).
+            # Rubin is excluded for a different reason.  `_causal_sched_policy`
+            # can pick SCHED_LPT_L2, which NO SM107 kernel honours (its decode
+            # needs qh_per_kh / seqlen_kv, which the ported call sites do not
+            # pass), and plain LPT is claimed PER FLAVOR on the SM107 rows
+            # (`sched_policies_by_d_shape`: f16 (256, 256); FP8 (256, 256) and
+            # (192, 128) -- validated bit-identical to NATURAL, 2026-09-11),
+            # not row-wide: the d512 role-split kernels still lack the
+            # `lpt_q_tiles_in_cga_units` argument (#1001) and write nothing
+            # under LPT.  The wrapper never consults a row, so this derivation
+            # stays NATURAL on Rubin and a standalone caller REQUESTS
+            # `sched_policy=SCHED_LPT` for a validated flavor (the gated
+            # attention block does).  Folding the rows' per-flavor domain into
+            # this derivation is the follow-up.  (The 2026-09-08 "causal d512
+            # FP8 -> NaN" this comment used to cite was that missing argument.)
             _rubin = self._device_cc == (10, 7)
             if self.window_right is not None and not self.thd and not _rubin:
                 # Causal: balance the triangular load; pick the LPT variant by working set.

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -968,12 +968,31 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
             # The "KNOWN COST" this note used to carry -- that the d128 FP8
             # kernel honours LPT but loses the plan because sched_policies is
             # row-wide -- is what `sched_policies_by_d_shape` below now fixes.
-            # d128 FP8 is not listed yet only because it is unvalidated here.
+            # d128 FP8 is not listed yet for the tolerance reason given there.
             sched_policies=(frozenset({SCHED_NATURAL}) if rubin_row else frozenset({SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2})),
-            # NOT claimed here. `lpt_q_tiles_in_cga_units=True` is restored on the
-            # SM107 FP8 kernels too, so LPT should work, but it has not been
-            # validated on them -- and a row claims only what it can demonstrate.
-            # The f16 row (`_sm107_spec`) carries the validated (256, 256) entry.
+            # Rubin: LPT is claimed PER FLAVOR, like the f16 row (`_sm107_spec`).
+            # `lpt_q_tiles_in_cga_units=True` is restored on every 2-CTA SM107 FP8
+            # kernel (#1001).  VALIDATED under LPT on Rubin (2026-09-11), standalone
+            # adapter, E4M3 per-tensor scales, bf16 O, causal + dense + padded,
+            # (B, S) in {(1,256), (2,1000), (1,4096)}, against the fp64
+            # kernel-mirroring `fp8_ref.compute_ref`:
+            #   (256, 256): max|O-ref| 0.0078 causal / <= 0.0019 dense (tol 0.075)
+            #   (192, 128): max|O-ref| 0.0397 causal / <= 0.0060 dense (tol 0.04)
+            # and on BOTH, O and LSE under LPT are BIT-IDENTICAL to NATURAL (the
+            # scheduler reorders whole (batch, head, q-tile) work items; each
+            # tile's KV loop is unchanged), sentinel 0, two-launch 0.  Perf node,
+            # d256 causal H32/2, LPT vs NATURAL launch-interleaved: +5.2/+5.9/
+            # +5.6/+2.0/+2.3 % at S=2K..32K (control pair within 1.9 %).
+            # NOT claimed: (128, 128) -- also bit-identical, but its causal path
+            # sits at 0.041-0.048 vs the suite's 0.04 under NATURAL too, so it
+            # gets its own look first; (512, 512) -- the cga4x1 role-split kernel
+            # still calls make_sdpa_helpers(CFG) WITHOUT lpt_q_tiles_in_cga_units
+            # (the #1001 bug, left on the d512 line), so under LPT it writes
+            # NOTHING (sentinel on 100 % of cells; the old "NaN" report was that
+            # unwritten output being read).
+            sched_policies_by_d_shape=(
+                (((256, 256), frozenset({SCHED_NATURAL, SCHED_LPT})), ((192, 128), frozenset({SCHED_NATURAL, SCHED_LPT}))) if rubin_row else ()
+            ),
             tile_ms=frozenset({128}),
             tile_ns=frozenset({128}),
             cgas=frozenset({2}),

--- a/python/cudnn/sdpa/fwd/heuristics.py
+++ b/python/cudnn/sdpa/fwd/heuristics.py
@@ -71,6 +71,7 @@ from cudnn.sdpa.fwd.engines import (
     _band_covers_kv_tail,
     _selected_d_shape,
     effective_cgas,
+    effective_sched_policies,
     mismatch,
 )
 
@@ -360,7 +361,11 @@ def _sched_points(caps: Capabilities, facts) -> List[Optional[int]]:
     the graph path — the adapters keep a None-input derivation only for
     standalone wrapper users who bypass ranking.
     """
-    domain = caps.sched_policies
+    # The FLAVOR's domain, not the row-wide floor: a `sched_policies_by_d_shape`
+    # claim (the Rubin f16 / FP8 (256, 256) LPT entries) must reach the ranking,
+    # or LPT is only ever honoured when a caller REQUESTS the knob and is never
+    # proposed for the first plan -- which is the whole point of claiming it.
+    domain = effective_sched_policies(caps, facts)
     if len(domain) <= 1:
         return [_sole(domain)]
     if facts.thd and SCHED_NATURAL in domain:

--- a/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
+++ b/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
@@ -114,12 +114,16 @@ def test_per_tensor_fp8_rows_split_per_arch_line():
     # so the sched domain is the same on both rows.
     assert sm107.split_kv_supported is True
     assert sm100.split_kv_supported is True
-    # INVERTED: BOTH remap policies came off the Rubin row.  LPT_L2 went first
-    # (the ported decode sites never thread qh_per_kh / seqlen_kv); plain LPT
-    # followed once heuristics could actually reach it -- a causal d512 FP8
-    # graph under LPT returns NaN, and all 12 masked d512 cases go green with
-    # the row narrowed.  A knob is honored or the engine is ineligible.
+    # The Rubin ROW-WIDE floor is NATURAL: LPT_L2 is honoured by no SM107
+    # kernel (the ported decode sites never thread qh_per_kh / seqlen_kv), and
+    # plain LPT is claimed PER FLAVOR through `sched_policies_by_d_shape` --
+    # (256, 256) and (192, 128) since 2026-09-11, validated bit-identical to
+    # NATURAL; d512 stays out (its role-split kernel still lacks the #1001
+    # `lpt_q_tiles_in_cga_units` argument and writes nothing under LPT, which
+    # is what the old "causal d512 FP8 under LPT returns NaN" report was).
     assert sm107.sched_policies == frozenset({SCHED_NATURAL})
+    assert dict(sm107.sched_policies_by_d_shape) == {(256, 256): frozenset({SCHED_NATURAL, SCHED_LPT}), (192, 128): frozenset({SCHED_NATURAL, SCHED_LPT})}
+    assert sm100.sched_policies_by_d_shape == ()
     assert sm100.sched_policies == frozenset({SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2})
 
     # Both d128 cells carry the write_thd_meta THD leg.
@@ -128,13 +132,12 @@ def test_per_tensor_fp8_rows_split_per_arch_line():
 
 def test_sm107_row_ranks_natural_only_for_causal():
     """The LPT/LPT_L2 remap (issue #653) is an SM100-row property.  A causal
-    per-tensor FP8 graph ranks [LPT_L2, LPT, NATURAL] there, but the Rubin row
-    declares a SINGLE-element domain -- its ported kernels raise on the L2
-    decode and do not honor LPT -- so ranking must offer exactly [NATURAL] and
-    never bolt a fallback on beside it.  The LPT specialization still
-    template-LOADS; it is the decode that is unvalidated, which is why the ROW
-    declines rather than the template raising.  Pure — facts pin the device,
-    and nothing here compiles."""
+    per-tensor FP8 graph ranks [LPT_L2, LPT, NATURAL] there.  On the Rubin row
+    the d128 FLAVOR's effective domain is the row-wide floor, {NATURAL} (LPT is
+    claimed per flavor, at (256, 256) and (192, 128) only), so ranking must
+    offer exactly [NATURAL] there and never bolt a fallback on beside it.  The
+    d256 ranking is pinned in test_sdpa_fwd_dsl_sm107.py.  Pure -- facts pin
+    the device, and nothing here compiles."""
     import cudnn as _c
     from cudnn.frost.tile_dsl.constants import SCHED_LPT, SCHED_LPT_L2, SCHED_NATURAL
     from cudnn.sdpa import graph_analyzer as ga
@@ -172,9 +175,9 @@ def test_sm107_row_ranks_natural_only_for_causal():
     assert heuristics._sched_points(sm107, facts((10, 7))) == [SCHED_NATURAL]
     assert heuristics._sched_points(sm100, facts((10, 0))) == [SCHED_LPT_L2, SCHED_LPT, SCHED_NATURAL]
 
-    # The LPT specialization still template-LOADS -- it is the decode that is
-    # unvalidated on the ported kernels, which is why the ROW declines it rather
-    # than the template raising.
+    # The d128 LPT specialization template-LOADS (the decode is correct since
+    # #1001 and bit-identical to NATURAL); the ROW withholds the claim until the
+    # d128 causal path clears the suite tolerance under NATURAL too.
     assert _load(rubin=True, sched_policy=SCHED_LPT).CFG.SCHEDULER_POLICY == SCHED_LPT
 
 
@@ -563,3 +566,58 @@ def test_sm107_split_matches_unsplit_on_rubin():
         ref = torch.softmax(qf @ kf.transpose(-1, -2) / math.sqrt(d), dim=-1) @ vf
         assert (got.double() - ref).abs().max().item() <= 5e-2, f"split={split}: off the oracle"
         assert (got - base).abs().max().item() <= 5e-2, f"split={split}: diverges from unsplit"
+
+
+@requires_dsl
+@pytest.mark.parametrize("d_qk, d_v", [(256, 256), (192, 128)])
+@pytest.mark.parametrize("causal, b, s", [(True, 2, 1000), (False, 1, 1024)])
+def test_fp8_lpt_is_bit_identical_to_natural_on_the_claimed_flavors(d_qk, d_v, causal, b, s):
+    """Rubin e2e for the FP8 (256, 256) and (192, 128) LPT claims: the same
+    quantized problem under SCHED_LPT and SCHED_NATURAL.  The scheduler only
+    reorders whole (batch, head, q-tile) work items -- each tile's KV loop is
+    unchanged -- so O must be BIT-IDENTICAL across the two policies (measured
+    0.0 on every case, 2026-09-11), and both stay within the module's fp32
+    oracle bound.  S=1000 causal covers a KV tail; dense needs S % 128 == 0."""
+    import torch
+    import cudnn as _c
+
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (10, 7):
+        pytest.skip("the sm107 FP8 kernels serve cc10.7 only")
+    from cudnn.frost.tile_dsl.constants import SCHED_LPT, SCHED_NATURAL
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm100
+
+    torch.manual_seed(0)
+    hq, hkv = 8, 2
+    dev = "cuda"
+    fmax = 448.0
+
+    def quant(x):
+        dsc = (x.abs().amax().clamp_min(1e-8) / fmax).item()
+        return (x / dsc).clamp(-fmax, fmax).to(torch.float8_e4m3fn), torch.full((1,), dsc, device=dev, dtype=torch.float32)
+
+    q8, dq = quant(torch.randn(b, hq, s, d_qk, device=dev) * 0.5)
+    k8, dk = quant(torch.randn(b, hkv, s, d_qk, device=dev) * 0.5)
+    v8, dv = quant(torch.randn(b, hkv, s, d_v, device=dev) * 0.5)
+    outs = {}
+    for pol in (SCHED_NATURAL, SCHED_LPT):
+        out = torch.full((b, hq, s, d_v), 1.5e30, device=dev, dtype=torch.bfloat16)  # sentinel: an unclaimed tile stays visible
+        api = SdpaFwdDslSm100(
+            sample_q=q8, sample_k=k8, sample_v=v8, sample_o=out, scale_softmax=d_qk**-0.5, is_causal=causal, pertensor_fp8=True, sched_policy=pol
+        )
+        assert api.check_support()
+        api.compile()
+        api.execute(q_tensor=q8, k_tensor=k8, v_tensor=v8, o_tensor=out, descale_q=dq, descale_k=dk, descale_v=dv)
+        torch.cuda.synchronize()
+        outs[pol] = out.clone()
+    rep = hq // hkv
+    qf, kf, vf = q8.float() * dq, (k8.float() * dk).repeat_interleave(rep, 1), (v8.float() * dv).repeat_interleave(rep, 1)
+    logits = qf @ kf.transpose(-1, -2) * d_qk**-0.5
+    if causal:
+        logits = logits.masked_fill(~torch.tril(torch.ones(s, s, dtype=torch.bool, device=dev)), float("-inf"))
+    ref = torch.softmax(logits, dim=-1) @ vf
+    scale = ref.abs().max().item()
+    for pol, out in outs.items():
+        assert torch.isfinite(out).all(), f"policy {pol}: non-finite / unwritten cells"
+        err = (out.float() - ref).abs().max().item()
+        assert err <= 0.1 * scale, f"policy {pol}: max err {err} vs fp32 reference (scale {scale})"
+    assert torch.equal(outs[SCHED_LPT], outs[SCHED_NATURAL]), "LPT must be bit-identical to NATURAL -- a different tile walk, the same per-tile math"

--- a/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm107.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm107.py
@@ -327,15 +327,15 @@ def test_sm107_f16_declines_the_stats_trim_it_lacks():
 
 
 def test_sm107_rows_serve_natural_scheduling_only():
-    """SCHED_LPT is NOT honored by the ported Rubin kernels: with the row
-    claiming it, a causal graph picks LPT and comes back with max|O-ref| ~ 1.9
-    (dense stays correct).  Session 6 had already dropped SCHED_LPT_L2 for the
-    same reason -- the ported decode sites never thread qh_per_kh / seqlen_kv --
-    and LPT only stayed hidden because heuristics could not REACH it (its causal
-    primary is LPT_L2, and the old out-of-domain fallback dropped to NATURAL).
+    """The ROW-WIDE floor of every Rubin row stays NATURAL-only: LPT is claimed
+    per flavor (`sched_policies_by_d_shape`) where it is validated -- the f16
+    and, since 2026-09-11, the FP8 (256, 256) kernels -- and nowhere else.
+    SCHED_LPT_L2 is claimed by no Rubin flavor (its decode needs qh_per_kh /
+    seqlen_kv, which the SM107 call sites do not pass).
 
-    A knob is honored or the engine is ineligible.  INVERTS-WHEN the LPT decode
-    is threaded and validated on the ported Rubin kernels."""
+    (This test used to assert LPT was "not honored" by the ported kernels; the
+    cause was the dropped `lpt_q_tiles_in_cga_units` argument, fixed in #1001.
+    The per-flavor claims are pinned by the *_advertises_lpt_only_* tests.)"""
     from cudnn.frost.tile_dsl.constants import SCHED_LPT, SCHED_LPT_L2, SCHED_NATURAL
 
     for row in ("sdpa_fwd_prefill_sm107", "sdpa_fwd_prefill_sm107_fp8", "sdpa_fwd_prefill_sm107_mxfp8"):
@@ -343,6 +343,9 @@ def test_sm107_rows_serve_natural_scheduling_only():
         assert caps.sched_policies == frozenset({SCHED_NATURAL}), row
         assert SCHED_LPT not in caps.sched_policies, row
         assert SCHED_LPT_L2 not in caps.sched_policies, row
+        for _shape, dom in caps.sched_policies_by_d_shape:
+            assert SCHED_LPT_L2 not in dom, row
+    assert _caps("sdpa_fwd_prefill_sm107_mxfp8").sched_policies_by_d_shape == (), "MXFP8 is unvalidated under LPT"
 
 
 def test_sched_points_falls_back_along_the_preference_order():
@@ -361,9 +364,18 @@ def test_sched_points_falls_back_along_the_preference_order():
     points = heuristics._sched_points(rubin_fp8, facts)
     assert len(points) == len(set(points)), points
     assert SCHED_LPT_L2 not in rubin_fp8.sched_policies
-    # Single-element domain today (see the row): the ranking must still be that
-    # one element, never a NATURAL fallback bolted on beside it.
+    # d128 FP8 has a single-element domain (LPT is claimed at (256, 256) only):
+    # the ranking must still be that one element, never a NATURAL fallback
+    # bolted on beside it.
     assert points == [SCHED_NATURAL], points
+
+    # The per-flavor claim must REACH the ranking: at (256, 256) the FP8 row's
+    # effective domain is {NATURAL, LPT}, the causal primary (LPT_L2) is out of
+    # domain, so the fallback walks the preference order -- LPT first, NATURAL
+    # as the autotune alternative.  Before the heuristics read the flavor's
+    # domain this returned [NATURAL] and LPT was never proposed.
+    facts256 = facts.__class__(**{**facts.__dict__, "d_qk": 256, "d_v": 256})
+    assert heuristics._sched_points(rubin_fp8, facts256) == [SCHED_LPT, SCHED_NATURAL]
 
     # ...and the multi-element case, which is the branch the single-element
     # shortcut above skips: with a causal primary (LPT_L2) OUT of domain, the
@@ -584,6 +596,45 @@ def test_sm107_advertises_lpt_only_for_the_validated_d_shape():
     # seqlen_kv, which the SM107 call sites do not pass. No flavor claims it.
     for shape in ((128, 128), (256, 256), (512, 512)):
         assert SCHED_LPT_L2 not in engines.effective_sched_policies(caps, _f16_facts(d_qk=shape[0], d_v=shape[1]))
+
+
+def test_sm107_fp8_advertises_lpt_only_for_the_validated_d_shape():
+    """The FP8 twin of the f16 test above: (256, 256) and (192, 128) serve LPT
+    (validated 2026-09-11 through the standalone adapter, bit-identical to
+    NATURAL -- see the row's comment); d128 and d512 do not; the row-wide floor
+    stays NATURAL; LPT_L2 nowhere."""
+    import cudnn
+    from cudnn.frost.tile_dsl.constants import SCHED_LPT, SCHED_LPT_L2, SCHED_NATURAL
+    from cudnn.sdpa.fwd import engines
+
+    caps = _caps("sdpa_fwd_prefill_sm107_fp8")
+    assert caps.sched_policies == frozenset({SCHED_NATURAL}), "the row-wide floor must stay NATURAL"
+    fp8 = dict(dtype=cudnn.data_type.FP8_E4M3, dtype_o=cudnn.data_type.BFLOAT16, is_fp8=True)
+    for shape in ((256, 256), (192, 128)):
+        assert SCHED_LPT in engines.effective_sched_policies(caps, _f16_facts(d_qk=shape[0], d_v=shape[1], **fp8)), shape
+    for shape in ((128, 128), (512, 512)):
+        assert SCHED_LPT not in engines.effective_sched_policies(caps, _f16_facts(d_qk=shape[0], d_v=shape[1], **fp8)), shape
+    for shape in ((128, 128), (192, 128), (256, 256), (512, 512)):
+        assert SCHED_LPT_L2 not in engines.effective_sched_policies(caps, _f16_facts(d_qk=shape[0], d_v=shape[1], **fp8)), shape
+
+
+@pytest.mark.L0
+def test_sm107_fp8_lpt_knob_is_honored_or_ineligible_per_d_shape():
+    """Requesting LPT on the FP8 row: ACCEPTED at d256 and d192xd128, DECLINED
+    (typed, naming the knob) at d128 and d512 -- never silently downgraded
+    (engine contract, Rule 4)."""
+    import cudnn
+    from cudnn.frost.tile_dsl.constants import SCHED_LPT
+    from cudnn.sdpa.fwd import engines
+    from cudnn.sdpa.fwd.engines import SdpaFwdKnobs
+
+    caps = _caps("sdpa_fwd_prefill_sm107_fp8")
+    fp8 = dict(dtype=cudnn.data_type.FP8_E4M3, dtype_o=cudnn.data_type.BFLOAT16, is_fp8=True)
+    for shape in ((256, 256), (192, 128)):
+        assert engines.mismatch(caps, _f16_facts(d_qk=shape[0], d_v=shape[1], **fp8), SdpaFwdKnobs(sched_policy=SCHED_LPT)) is None, shape
+    for shape in ((128, 128), (512, 512)):
+        why = engines.mismatch(caps, _f16_facts(d_qk=shape[0], d_v=shape[1], **fp8), SdpaFwdKnobs(sched_policy=SCHED_LPT))
+        assert why is not None and "sched_policy" in why, shape
 
 
 @pytest.mark.L0


### PR DESCRIPTION
## Summary

Two things had to move for `SCHED_LPT` to actually run on the Rubin per-tensor FP8 SDPA, and one of them is a bug the f16 row (#1001) was already sitting on.

1. **`heuristics._sched_points` ranked from the row-wide `sched_policies`, not the flavor's effective domain.** A `sched_policies_by_d_shape` claim therefore never reached the ranking: LPT was honoured only when a caller *requested* the knob and was never *proposed* for the first plan — for the f16 (256, 256) claim from #1001 as much as for the FP8 one added here. `_sched_points` now ranks from `effective_sched_policies(caps, facts)`, the same function `mismatch()` already uses to judge a request.
2. **The Rubin FP8 row claims LPT per flavor**, mirroring the f16 row: `sched_policies_by_d_shape = (((256, 256), {NATURAL, LPT}), ((192, 128), {NATURAL, LPT}))`. The row-wide floor stays `{NATURAL}`; `SCHED_LPT_L2` is still claimed by no Rubin flavor.

The kernels needed no change: `lpt_q_tiles_in_cga_units=True` was restored on every 2-CTA SM107 FP8 kernel in #1001.

## Validation (Rubin, `w2u1g-lc-0030`, standalone adapter, E4M3 per-tensor scales, bf16 O)

Each flavor, causal + dense + padded, (B, S) ∈ {(1,256), (2,1000), (1,4096)}, LPT and NATURAL on the same inputs, sentinel-filled O, against the fp64 kernel-mirroring `fp8_ref.compute_ref`:

| flavor | LPT max\|O−ref\| causal / dense | suite tol | LPT vs NATURAL | claimed |
|---|---|---|---|---|
| (256, 256) | 0.0078 / ≤ 0.0019 | 0.075 | **bit-identical** (O and LSE), sentinel 0, two-launch 0 | yes |
| (192, 128) | 0.0397 / ≤ 0.0060 | 0.04 | **bit-identical** | yes |
| (128, 128) | 0.041–0.048 / ≤ 0.0048 | 0.04 | bit-identical | no — its causal path is over the tolerance under NATURAL too; separate look |
| (512, 512) | writes nothing (sentinel on 100 % of cells) | — | NATURAL exact | no — the d512 role-split kernels still call `make_sdpa_helpers(CFG)` without `lpt_q_tiles_in_cga_units`; that is the #1001 argument left on the d512 line, and it is what the old "causal d512 FP8 → NaN" report was |

Bit-identical is the expected result: the scheduler reorders whole (batch, head, q-tile) work items; each tile's KV loop is unchanged.

## Perf (Rubin perf node, 212 SMs, SM clock locked 2376 MHz, FP8 d256 causal, H_q=32 / H_kv=2, B=1, LPT vs NATURAL interleaved by launch, same-config control pair)

| S | NATURAL ms | LPT ms | LPT vs NATURAL | control |
|---|---|---|---|---|
| 2048 | 0.0993 | 0.0941 | +5.2 % | −1.9 % |
| 4096 | 0.1435 | 0.1350 | +5.9 % | −1.1 % |
| 8192 | 0.2871 | 0.2710 | +5.6 % | −0.0 % |
| 16384 | 0.8704 | 0.8530 | +2.0 % | −0.0 % |
| 32768 | 3.3088 | 3.2316 | +2.3 % | −0.1 % |

## Tests

- `test_sdpa_fwd_dsl_sm107.py`: `test_sm107_rows_serve_natural_scheduling_only` now pins the row-wide floor and the absence of LPT_L2 per flavor; new `test_sm107_fp8_advertises_lpt_only_for_the_validated_d_shape` and `test_sm107_fp8_lpt_knob_is_honored_or_ineligible_per_d_shape` (accept d256 / d192x128, typed decline at d128 / d512); `test_sched_points_falls_back_along_the_preference_order` additionally asserts the FP8 d256 causal ranking is `[LPT, NATURAL]` — the heuristics fix, which returned `[NATURAL]` before.
- `test_sdpa_fp8_sm107.py`: `test_fp8_lpt_is_bit_identical_to_natural_on_the_claimed_flavors` (Rubin e2e, 4 cases: {d256, d192x128} × {causal 2×1000, dense 1×1024}, sentinel-filled, `torch.equal` across policies + the module's fp32 oracle bound); stale comments about "LPT returns NaN" corrected.
- `SUPPORT_MATRIX_TRACKER.md` updated (Rule S2). The standalone adapter's `None`-policy derivation keeps Rubin on NATURAL (it could pick LPT_L2); its comment now states why accurately, and a standalone caller requests `sched_policy=SCHED_LPT` for a claimed flavor.

Ran on the Rubin dev node: `sdpa/frost/test_sdpa_fwd_dsl_sm107.py sdpa/frost/test_sdpa_fp8_sm107.py` — 86 passed.

Not in this PR (follow-ups): the d512 `lpt_q_tiles_in_cga_units` argument on the three SM107 d512 kernels (needs its own validation of the cga4x1 decode), the d128 FP8 causal tolerance excess, folding the rows' per-flavor domain into the adapter's `None` derivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added shape-specific LPT scheduling support for SM107 FP8 workloads with d256×256 and d192×128 dimensions.
  - LPT is prioritized for supported shapes while NATURAL scheduling remains the default elsewhere.

- **Bug Fixes**
  - Improved scheduler selection to honor shape-specific policies and avoid unsupported LPT configurations.

- **Documentation**
  - Clarified supported and unsupported scheduler combinations, including LPT_L2 and unvalidated FP8 shapes.

- **Tests**
  - Added coverage confirming LPT and NATURAL produce accurate, finite, bit-identical results for supported cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->