### PR TITLE
FlashInfer-shaped conformance for the frost engines, and the two fixes that make it green (operand contract; SDPA THD at b > 1)

### DIFF
--- a/docs/utilities/python_graph_and_execution_backends.md
+++ b/docs/utilities/python_graph_and_execution_backends.md
@@ -753,10 +753,8 @@ defaulting to device 0 is how an SM100 suite silently skips in full.
   temp-file + `os.replace`; an incompatible format bumps the schema directory.
   Expose the directory / cache object so a caller (FlashInfer) can point it at
   its own workspace and ship it in an AOT wheel.
-- SDPA forward THD at `b > 1`: the BSHD-physical stride-order check declines
-  FlashInfer's packed layout (batch stride == token stride); with ragged
-  offsets the batch stride is never read, so require only the (h, s, d) order.
-  Padded LSE rows of a `(b, s_max, h)` stats buffer: the backend writes `-inf`,
-  the python rows leave them unwritten — fill for parity. The dense padded-Q
-  `.item()` read in `sdpa/fwd/engines.py` runs at execute and breaks CUDA-graph
-  capture; decide it at `check_support` or drop it.
+- SDPA forward THD: padded LSE rows of a `(b, s_max, h)` stats buffer past a
+  sequence's length — the backend writes `-inf`, the python row leaves them
+  unwritten (`b == 1`; at `b > 1` the form is declined) — fill for parity. The
+  dense padded-Q `.item()` read in `sdpa/fwd/engines.py` runs at execute and
+  breaks CUDA-graph capture; decide it at `check_support` or drop it.

--- a/docs/utilities/python_graph_and_execution_backends.md
+++ b/docs/utilities/python_graph_and_execution_backends.md
@@ -119,13 +119,17 @@ alignment.** That is how the cuDNN backend has always read a variant pack — it
 takes the pointer and nothing else — and callers program against it: FlashInfer
 binds a 2-D matrix to a `[1, m, k]` tensor, a flat quantizer blob to a
 `[b, bs_m, bs_k]` F8_128x4-reordered scale tensor, a 0-d scalar to `(1, 1, 1)`.
-So `_normalize` describes a slot from the graph when the buffer's own geometry
-disagrees with the declared one but covers its bytes — exactly what a bare
-address gets — and records the slot in `VariantPack.graph_described`, so an
-engine that reads the pack answers the way the backend does and one call cannot
-get two answers by plan selection. A buffer that is SMALLER than the declaration
-keeps its own description (a packed THD buffer under a padded declaration, say):
-the engine decides, and an engine that needs the declared extent refuses it at
+So `_normalize` describes a slot from the graph when the buffer is a DENSE run
+of other extents that covers the declared bytes (the 2-D matrix, the flat blob,
+the 0-d scalar) — exactly what a bare address gets — and records the slot in
+`VariantPack.graph_described`, so an engine that reads the pack answers the way
+the backend does and one call cannot get two answers by plan selection. Two
+kinds of buffer keep their own description: one with the DECLARED extents under
+its own strides (a padded or transposed view of this very tensor — the strides
+carry information, and an engine that reads the pack honours them, which is how
+the linear-attention engines serve strided inputs), and one that is SMALLER
+than the declaration (a packed THD buffer under a padded declaration, say): the
+engine decides, and an engine that needs the declared extent refuses it at
 execute naming the operand (the backend would read past the allocation). A bare
 address lends the declaration outright — it carries no extent, so there is
 nothing to compare against: the caller guarantees the allocation covers the

--- a/docs/utilities/python_graph_and_execution_backends.md
+++ b/docs/utilities/python_graph_and_execution_backends.md
@@ -114,11 +114,33 @@ The pack's vocabulary distinguishes the position from the thing at it:
 buffer described (pointer, shape, stride, dtype), non-owning. Resolve positions
 once; ask for buffers per call.
 
-Each operand's OWN dim/stride/data_type is what the pack holds, deliberately
-not the graph's declaration: the two may differ and one engine relies on it —
-`frost_gemm` takes its M/N/K from the buffers, so a plan built for one problem
-size runs another bit-exactly. **Read the IR port for the shape the plan was
-built for; read the pack for the shape about to run.**
+**The declaration is the contract; the buffer supplies pointer, bytes and
+alignment.** That is how the cuDNN backend has always read a variant pack — it
+takes the pointer and nothing else — and callers program against it: FlashInfer
+binds a 2-D matrix to a `[1, m, k]` tensor, a flat quantizer blob to a
+`[b, bs_m, bs_k]` F8_128x4-reordered scale tensor, a 0-d scalar to `(1, 1, 1)`.
+So `_normalize` describes a slot from the graph when the buffer's own geometry
+disagrees with the declared one but covers its bytes — exactly what a bare
+address gets — and records the slot in `VariantPack.graph_described`, so an
+engine that reads the pack answers the way the backend does and one call cannot
+get two answers by plan selection. A buffer that is SMALLER than the declaration
+keeps its own description (a packed THD buffer under a padded declaration, say):
+the engine decides. Rules that follow:
+
+- `override_shapes` / `override_strides` speak cuDNN **element** units in the
+  graph's axis order, like every declaration. They are written INTO the slot
+  (in the buffer's axis order, `_in_axis_order_of`), never carried around it, so
+  an engine honours them without knowing the concept exists.
+- The pack speaks **storage slots**. fp4 packs two elements per slot along the
+  unit-stride axis, so a declared or overridden fp4 geometry is converted with
+  `_storage_geometry` (extent halves, the other strides halve) before it lands
+  in a slot; an odd unit-stride extent has no slot spelling and is refused. An
+  engine's per-slot packing factor (`frost_gemm`'s `kpack`) therefore applies
+  to every slot alike — this is what stopped `frost_gemm` from doubling K on an
+  overridden fp4 operand.
+- The pack still carries the shape about to RUN: **read the IR port for the
+  shape the plan was built for; read the pack for the shape this call runs**
+  (`frost_gemm` reads its M/N/K there, so one plan serves many problem sizes).
 
 Two rules that are easy to break by accident:
 
@@ -579,6 +601,54 @@ only to decline is why `closed_under` existed.
   function, list the cell in `_TILE_RULE_CELLS`, and put the measurement in the
   commit.
 
+### Knobs: one public vocabulary, and every python plan lists the knobs it will build
+
+- `KnobType_t` (`include/cudnn_frontend/knobs.h`, mirrored as `cudnn.knob_type`)
+  is the ONE vocabulary for backend and python plans. Backend values `0..32`
+  are frozen; python-only axes live in the band from `FRONTEND_KNOB_TYPE_BASE`
+  (1000: `SCHED_POLICY`, `PACK_GQA`, `SPLIT_KV`, `PIPELINE_ARCH`, `MMA_TILE_*`,
+  `CTA_GROUP`, `WARPS_*`). Both bands are append-only; a frontend-band value
+  never reaches the backend (`convert_to_backend_knob_type` refuses it). Reuse
+  a backend type when the meaning matches (`TILE_M`, `TILE_CGA_M`, `SPLIT_K_SLC`,
+  `SWAP_AB`); mint a frontend one only for an axis the backend has no word for.
+- A python engine keeps whatever native knob object it likes in
+  `PlanConfig.knobs` (`SdpaFwdKnobs`, `SdpaBwdKnobs`, `GemmKnobs`) and converts
+  at the public boundary through `BaseEngine.knobs_to_public` /
+  `knobs_from_public`. `get_engine_and_knobs_at_index` always returns a dict
+  (`{}` when the plan has no axes, never `None`); `create_execution_plan(
+  engine_id, {cudnn.knob_type: int})` replays it; `get_plan_name_at_index`
+  prints `engine[SPLIT_KV=2, TILE_M=128, ...]`, sorted by knob name.
+- **Every python plan is listed WITH the knobs it will build.** A family's
+  `recommend(kind, facts, offered)` proposes complete `PlanConfig(engine_id,
+  knobs)` entries from facts alone; the engine builds what was listed. Families
+  with a real tuning axis — SDPA forward, SDPA backward (the SM120 row's
+  per-head-dim default tile, the MXFP8 row's sole point), frost GEMM (the tile
+  config as knobs) — all do this, so a recorded `(engine_id, knobs)` pins the
+  kernel across releases even when a default table moves. A family whose
+  kernels take no tuning decision (linear attention) lists `{}`, which IS its
+  complete record. A knob-less plan whose engine picks inside `build_plan` is a
+  bug: the record would replay a different kernel after the pick changes.
+- Knobs are performance-only: a plan computes the same function under any knob
+  value, so an autotuner may pick freely. Anything numerics-changing
+  (`softmax_precision`) is an **op attribute** declared in the op spec's
+  `python_only_attrs`: never forwarded to C++, a SET value makes the node
+  backend-unlowerable (`serialize()` and `key()` refuse it), and it surfaces as
+  a graph fact the capability rows gate on.
+
+### Accept means run
+
+For a python plan, `check_support()` accepted ⇒ `build_plans()` and
+`execute()` succeed on the buffers a caller binds, and the result matches the
+cuDNN backend plan on the same graph. Nothing an engine learns only at execute
+(buffer rank, blob size, scalar shape) may refuse a call after acceptance: what
+can be decided from the declaration is decided at `check_support`, and the pack
+hands the engine the declaration. `test/python/gemm/frost/test_flashinfer_shaped_gemm.py`
+and `test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py` re-declare
+FlashInfer's graphs and buffers byte for byte and assert exactly this; a decline
+at `check_support` is reported as xfail with the row's reason, a refusal after
+acceptance fails. They are the acceptance gate for turning the opt-in rows on
+by default.
+
 ## Key invariants
 
 - **uid ownership**: the Python IR owns the whole uid namespace; every uid is
@@ -671,3 +741,22 @@ defaulting to device 0 is how an SM100 suite silently skips in full.
   remove `selected_engine is None` branching, lowering extracted to its own
   module, op-identity dedup (NodeType vs registry keys), longer-term a typed
   `OpSpec` as the single per-op source for builder/validation/lowering.
+- **Persistent compiled-plan cache** for the JIT engines (today `cute.compile`
+  runs once per process; only generated source is cached on disk). Mirror the
+  FlashInfer autotune-cache v2 rules: the environment identity is the content
+  hash of a manifest (frontend version, `nvidia-cutlass-dsl` version incl. its
+  `libs-core` frontend, CUDA driver version, device name + CC + SM count + L2
+  bytes — frost bakes SM count and L2 into kernels) and names the cache
+  directory; every entry embeds its own key (generated-source digest,
+  `cute.compile` options, knobs) and is verified on load; any mismatch,
+  missing or malformed file is a miss, never a partial reuse; writes are
+  temp-file + `os.replace`; an incompatible format bumps the schema directory.
+  Expose the directory / cache object so a caller (FlashInfer) can point it at
+  its own workspace and ship it in an AOT wheel.
+- SDPA forward THD at `b > 1`: the BSHD-physical stride-order check declines
+  FlashInfer's packed layout (batch stride == token stride); with ragged
+  offsets the batch stride is never read, so require only the (h, s, d) order.
+  Padded LSE rows of a `(b, s_max, h)` stats buffer: the backend writes `-inf`,
+  the python rows leave them unwritten — fill for parity. The dense padded-Q
+  `.item()` read in `sdpa/fwd/engines.py` runs at execute and breaks CUDA-graph
+  capture; decide it at `check_support` or drop it.

--- a/docs/utilities/python_graph_and_execution_backends.md
+++ b/docs/utilities/python_graph_and_execution_backends.md
@@ -125,7 +125,11 @@ address gets — and records the slot in `VariantPack.graph_described`, so an
 engine that reads the pack answers the way the backend does and one call cannot
 get two answers by plan selection. A buffer that is SMALLER than the declaration
 keeps its own description (a packed THD buffer under a padded declaration, say):
-the engine decides. Rules that follow:
+the engine decides, and an engine that needs the declared extent refuses it at
+execute naming the operand (the backend would read past the allocation). A bare
+address lends the declaration outright — it carries no extent, so there is
+nothing to compare against: the caller guarantees the allocation covers the
+declared bytes and meets the engine's alignment. Rules that follow:
 
 - `override_shapes` / `override_strides` speak cuDNN **element** units in the
   graph's axis order, like every declaration. They are written INTO the slot
@@ -638,11 +642,15 @@ only to decline is why `closed_under` existed.
 ### Accept means run
 
 For a python plan, `check_support()` accepted ⇒ `build_plans()` and
-`execute()` succeed on the buffers a caller binds, and the result matches the
-cuDNN backend plan on the same graph. Nothing an engine learns only at execute
-(buffer rank, blob size, scalar shape) may refuse a call after acceptance: what
-can be decided from the declaration is decided at `check_support`, and the pack
-hands the engine the declaration. `test/python/gemm/frost/test_flashinfer_shaped_gemm.py`
+`execute()` succeed on the buffers a caller binds as the graph declares them,
+and — when the graph has a backend plan — the result matches that plan; a
+python-only graph (GDN/KDA/…) has no cuDNN reference and is held to its
+engine's own numerics tests instead. Nothing an engine can decide from the
+DECLARATION (operand rank, blob size, scalar shape, layout) may refuse a call
+after acceptance: it is decided at `check_support`, and the pack hands the
+engine the declaration. Buffer capacity is not decidable before execute — the
+buffers arrive with the call — so a buffer smaller than its declaration is a
+caller error refused at execute, not a decline. `test/python/gemm/frost/test_flashinfer_shaped_gemm.py`
 and `test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py` re-declare
 FlashInfer's graphs and buffers byte for byte and assert exactly this; a decline
 at `check_support` is reported as xfail with the row's reason, a refusal after

--- a/docs/utilities/python_graph_and_execution_backends.md
+++ b/docs/utilities/python_graph_and_execution_backends.md
@@ -150,6 +150,16 @@ declared bytes and meets the engine's alignment. Rules that follow:
   shape the plan was built for; read the pack for the shape this call runs**
   (`frost_gemm` reads its M/N/K there, so one plan serves many problem sizes).
 
+The rule is on every execute's critical path, backend plans included, so the
+declaration side (`storage_geometry` of every slot) is computed once per graph
+into a native `DeclaredLayout` and the comparison runs in one crossing per pack
+(`VariantPackNative.describe_from`). Measured at 128×256×128 bf16, host enqueue
+per execute on SM100: backend plan 11.7 → 12.0 µs, `frost_gemm` 21.9 → 22.0 µs,
+and a FlashInfer-shaped 2-D binding costs what a declared one does (12.1). The
+first, per-operand Python form of the same rule was +7.5 µs on both paths and
++10 µs more for the 2-D binding — two crossings and a `storage_geometry` per
+operand per call.
+
 Two rules that are easy to break by accident:
 
 - **The pointer array is per call.** Two threads may execute one graph

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -33,7 +33,7 @@ from ._handle import Handle, to_backend_handle
 from .datatypes import _buffer_dtype_to_cudnn, _dlpack_code_bits, _torch_to_cudnn_data_type
 from .engines.base import ExecutionContext, VariantPack
 from .engines.engine_ids import is_python_engine
-from .graph_types import NodeType, Tensor, byte_size as _byte_size, describing_tensor
+from .graph_types import NodeType, Tensor, byte_size as _byte_size, describing_tensor, storage_geometry, storage_slot_bytes
 from .nodes import Node, _row_major_stride
 
 _LOG = logging.getLogger("cudnn.pygraph")
@@ -68,30 +68,24 @@ def _in_axis_order_of(shape, stride, reference_stride):
     return tuple(shape[a] for a in permutation), tuple(stride[a] for a in permutation)
 
 
-def _storage_geometry(dim, stride, data_type):
-    """A cuDNN (element) geometry as the STORAGE-slot geometry a buffer reports.
-
-    Every dtype but fp4 stores one element per slot, so the geometry is its
-    own. fp4 packs two elements per slot along the unit-stride axis (torch's
-    ``float4_e2m1fn_x2``, or a uint8 view): that extent halves and every other
-    stride halves with it. None when the extent is odd -- no slot geometry
-    spells it.
-    """
-    dim = tuple(int(d) for d in dim)
-    stride = tuple(int(x) for x in stride) if stride else _row_major_stride(dim)
-    if data_type != cudnn.data_type.FP4_E2M1:
-        return dim, stride
-    if 1 not in stride:
-        return None
-    c = stride.index(1)
-    if dim[c] % 2 or any(x % 2 for j, x in enumerate(stride) if j != c and x != 1):
-        return None
-    return tuple(d // 2 if j == c else d for j, d in enumerate(dim)), tuple(x if j == c else x // 2 for j, x in enumerate(stride))
-
-
 def _span(dim, stride) -> int:
     """Slots from the base to one past the last addressed slot."""
     return 1 + sum((int(d) - 1) * int(x) for d, x in zip(dim, stride)) if dim else 1
+
+
+def _slot_bytes(data) -> "int | None":
+    """Bytes per storage slot of a caller's buffer, or None when it does not say
+    (a bare address; a producer with no dtype width). torch answers through
+    ``element_size()`` (1 for ``float4_e2m1fn_x2``), the array-interface
+    family through ``dtype.itemsize``."""
+    size = getattr(data, "element_size", None)
+    if callable(size):
+        try:
+            return int(size())
+        except Exception:  # noqa: BLE001 -- a producer whose element_size is not a plain int
+            return None
+    itemsize = getattr(getattr(data, "dtype", None), "itemsize", None)
+    return int(itemsize) if isinstance(itemsize, int) and itemsize > 0 else None
 
 
 def cudnn_graph_not_supported(message: str) -> Exception:
@@ -2039,11 +2033,16 @@ class pygraph:
             declared = self._tensor_by_uid.get(uid)
             if declared is None or not declared.dim:
                 continue
-            storage = _storage_geometry(declared.dim, declared.stride, declared.data_type)
+            storage = storage_geometry(declared.dim, declared.stride, declared.data_type)
             if storage is None:
                 continue
             own = tuple(native.shape(i)), tuple(native.stride(i))
-            if own == storage or _span(*own) < _span(*storage):
+            if own == storage:
+                continue
+            # BYTES, not slots: a uint8 view spanning as many slots as a bf16
+            # declaration covers half its bytes. Unknown widths do not qualify.
+            own_bytes, declared_bytes = _slot_bytes(uid_to_data.get(uid)), storage_slot_bytes(declared.data_type)
+            if own_bytes is None or declared_bytes is None or _span(*own) * own_bytes < _span(*storage) * declared_bytes:
                 continue
             native.override_operand(i, list(storage[0]), list(storage[1]))
             from_graph.append(i)
@@ -2062,7 +2061,7 @@ class pygraph:
                     raise ValueError(f"override_uids names tensor uid {uid}, which is not an operand of this graph")
                 # Overrides speak cuDNN element units; the slot speaks storage slots.
                 declared = self._tensor_by_uid.get(uid)
-                storage = _storage_geometry(override_shapes[j], override_strides[j], declared.data_type if declared is not None else None)
+                storage = storage_geometry(override_shapes[j], override_strides[j], declared.data_type if declared is not None else None)
                 if storage is None:
                     raise ValueError(
                         f"override_shapes for tensor uid {uid}: an fp4 tensor packs two elements per storage slot, so its "

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -2114,7 +2114,11 @@ class pygraph:
             declared = self._tensor_by_uid.get(uid)
             if declared is None or not declared.dim:
                 return data, Tensor(uid=uid)
-            return data, describing_tensor(uid, tuple(declared.dim), tuple(declared.stride), declared.data_type)
+            # The slot speaks storage slots (fp4: two elements per slot), like
+            # every other description in the pack.
+            storage = storage_geometry(declared.dim, declared.stride, declared.data_type)
+            dim, stride = storage if storage is not None else (tuple(declared.dim), tuple(declared.stride))
+            return data, describing_tensor(uid, tuple(dim), tuple(stride), declared.data_type)
         dim = getattr(data, "shape", None)
 
         # torch: pointer from data_ptr(), strides from stride() in ELEMENTS

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -68,6 +68,32 @@ def _in_axis_order_of(shape, stride, reference_stride):
     return tuple(shape[a] for a in permutation), tuple(stride[a] for a in permutation)
 
 
+def _storage_geometry(dim, stride, data_type):
+    """A cuDNN (element) geometry as the STORAGE-slot geometry a buffer reports.
+
+    Every dtype but fp4 stores one element per slot, so the geometry is its
+    own. fp4 packs two elements per slot along the unit-stride axis (torch's
+    ``float4_e2m1fn_x2``, or a uint8 view): that extent halves and every other
+    stride halves with it. None when the extent is odd -- no slot geometry
+    spells it.
+    """
+    dim = tuple(int(d) for d in dim)
+    stride = tuple(int(x) for x in stride) if stride else _row_major_stride(dim)
+    if data_type != cudnn.data_type.FP4_E2M1:
+        return dim, stride
+    if 1 not in stride:
+        return None
+    c = stride.index(1)
+    if dim[c] % 2 or any(x % 2 for j, x in enumerate(stride) if j != c and x != 1):
+        return None
+    return tuple(d // 2 if j == c else d for j, d in enumerate(dim)), tuple(x if j == c else x // 2 for j, x in enumerate(stride))
+
+
+def _span(dim, stride) -> int:
+    """Slots from the base to one past the last addressed slot."""
+    return 1 + sum((int(d) - 1) * int(x) for d, x in zip(dim, stride)) if dim else 1
+
+
 def cudnn_graph_not_supported(message: str) -> Exception:
     """The classic unsupported-graph error (built lazily: importing cudnn at
     module scope here would be circular)."""
@@ -1999,6 +2025,28 @@ class pygraph:
                 declared = self._tensor_by_uid.get(uid)
                 name = f" ({declared.name!r})" if declared is not None and declared.name else ""
                 raise ValueError(f"the variant pack is missing a buffer for tensor uid {uid}{name}")
+        # The declaration is the contract. The backend reads only the pointer,
+        # so a caller may bind a 2-D matrix to a [1, m, k] tensor, a flat blob
+        # to a reordered scale tensor, a 0-d scalar to (1, 1, 1): the graph
+        # says what the bytes mean. A buffer whose own geometry differs from
+        # the declared one but covers its bytes is therefore re-described AS
+        # the declaration -- what a bare address gets -- so an engine reading
+        # the pack answers the way the backend does. A buffer too small for the
+        # declaration keeps its own description; the engine decides.
+        for i, uid in enumerate(order):
+            if i in from_graph or not native.is_filled(i):
+                continue
+            declared = self._tensor_by_uid.get(uid)
+            if declared is None or not declared.dim:
+                continue
+            storage = _storage_geometry(declared.dim, declared.stride, declared.data_type)
+            if storage is None:
+                continue
+            own = tuple(native.shape(i)), tuple(native.stride(i))
+            if own == storage or _span(*own) < _span(*storage):
+                continue
+            native.override_operand(i, list(storage[0]), list(storage[1]))
+            from_graph.append(i)
         if override_uids:
             # The backend refuses a partial override; a short list must not
             # quietly mean "keep the rest" here.
@@ -2012,7 +2060,15 @@ class pygraph:
                 i = slot_of.get(uid)
                 if i is None:
                     raise ValueError(f"override_uids names tensor uid {uid}, which is not an operand of this graph")
-                native.override_operand(i, *_in_axis_order_of(tuple(override_shapes[j]), tuple(override_strides[j]), native.stride(i)))
+                # Overrides speak cuDNN element units; the slot speaks storage slots.
+                declared = self._tensor_by_uid.get(uid)
+                storage = _storage_geometry(override_shapes[j], override_strides[j], declared.data_type if declared is not None else None)
+                if storage is None:
+                    raise ValueError(
+                        f"override_shapes for tensor uid {uid}: an fp4 tensor packs two elements per storage slot, so its "
+                        f"unit-stride extent must be even; got {tuple(override_shapes[j])} / {tuple(override_strides[j])}"
+                    )
+                native.override_operand(i, *_in_axis_order_of(storage[0], storage[1], native.stride(i)))
         # The workspace has no uid, so it is not an operand — but an engine has
         # to bounds-check its carves, and reading its size here is the same read
         # every other buffer gets rather than a second probe further down.
@@ -2034,8 +2090,10 @@ class pygraph:
         """``(pointer, Tensor)`` for one caller buffer.
 
         The Tensor carries the buffer's OWN dim/stride/data_type, which need
-        not match what the graph declared — frost_gemm takes its problem size
-        from here.
+        not match what the graph declared. ``_normalize`` then re-describes a
+        slot FROM the declaration when the two disagree and the buffer covers
+        it (the declaration is the contract, as for the backend), so what an
+        engine reads is the declaration unless the buffer is smaller.
 
         Every framework publishes the same four facts under a different
         spelling, so this asks for each spelling in turn. Two differences are

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -73,6 +73,13 @@ def _span(dim, stride) -> int:
     return 1 + sum((int(d) - 1) * int(x) for d, x in zip(dim, stride)) if dim else 1
 
 
+def _numel(dim) -> int:
+    n = 1
+    for d in dim:
+        n *= int(d)
+    return n
+
+
 def _slot_bytes(data) -> "int | None":
     """Bytes per storage slot of a caller's buffer, or None when it does not say
     (a bare address; a producer with no dtype width). torch answers through
@@ -2022,11 +2029,12 @@ class pygraph:
         # The declaration is the contract. The backend reads only the pointer,
         # so a caller may bind a 2-D matrix to a [1, m, k] tensor, a flat blob
         # to a reordered scale tensor, a 0-d scalar to (1, 1, 1): the graph
-        # says what the bytes mean. A buffer whose own geometry differs from
-        # the declared one but covers its bytes is therefore re-described AS
-        # the declaration -- what a bare address gets -- so an engine reading
-        # the pack answers the way the backend does. A buffer too small for the
-        # declaration keeps its own description; the engine decides.
+        # says what the bytes mean. A DENSE buffer of other extents that covers
+        # the declared bytes is therefore re-described AS the declaration --
+        # what a bare address gets -- so an engine reading the pack answers the
+        # way the backend does. A buffer with the declared extents but its own
+        # strides, a strided view, or one too small for the declaration keeps
+        # its own description; the engine decides.
         for i, uid in enumerate(order):
             if i in from_graph or not native.is_filled(i):
                 continue
@@ -2038,6 +2046,16 @@ class pygraph:
                 continue
             own = tuple(native.shape(i)), tuple(native.stride(i))
             if own == storage:
+                continue
+            if own[0] == storage[0]:
+                # The declared extents under the caller's OWN strides (a padded
+                # or transposed view of this very tensor): those strides carry
+                # information, and an engine that reads the pack honours them.
+                continue
+            if _span(*own) != _numel(own[0]):
+                # Different extents AND gaps or overlaps between the slots: not
+                # one dense run of the declared bytes (a transposed view of a
+                # contiguous block IS one), so not ours to reinterpret.
                 continue
             # BYTES, not slots: a uint8 view spanning as many slots as a bf16
             # declaration covers half its bytes. Unknown widths do not qualify.

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -68,33 +68,6 @@ def _in_axis_order_of(shape, stride, reference_stride):
     return tuple(shape[a] for a in permutation), tuple(stride[a] for a in permutation)
 
 
-def _span(dim, stride) -> int:
-    """Slots from the base to one past the last addressed slot."""
-    return 1 + sum((int(d) - 1) * int(x) for d, x in zip(dim, stride)) if dim else 1
-
-
-def _numel(dim) -> int:
-    n = 1
-    for d in dim:
-        n *= int(d)
-    return n
-
-
-def _slot_bytes(data) -> "int | None":
-    """Bytes per storage slot of a caller's buffer, or None when it does not say
-    (a bare address; a producer with no dtype width). torch answers through
-    ``element_size()`` (1 for ``float4_e2m1fn_x2``), the array-interface
-    family through ``dtype.itemsize``."""
-    size = getattr(data, "element_size", None)
-    if callable(size):
-        try:
-            return int(size())
-        except Exception:  # noqa: BLE001 -- a producer whose element_size is not a plain int
-            return None
-    itemsize = getattr(getattr(data, "dtype", None), "itemsize", None)
-    return int(itemsize) if isinstance(itemsize, int) and itemsize > 0 else None
-
-
 def cudnn_graph_not_supported(message: str) -> Exception:
     """The classic unsupported-graph error (built lazily: importing cudnn at
     module scope here would be circular)."""
@@ -213,6 +186,7 @@ class pygraph:
         # Backend operand order + the reusable pointer array handed to execute.
         # Both are properties of the frozen graph, so they outlive any one call.
         self._sorted_uids: Optional[List[int]] = None
+        self._declared_layout_native = None  # DeclaredLayout for _sorted_uids; see _declared_layout
         self._selected_engine_cache = None  # (plan config, engine); see selected_engine
 
     # =========================================================================
@@ -2034,36 +2008,9 @@ class pygraph:
         # what a bare address gets -- so an engine reading the pack answers the
         # way the backend does. A buffer with the declared extents but its own
         # strides, a strided view, or one too small for the declaration keeps
-        # its own description; the engine decides.
-        for i, uid in enumerate(order):
-            if i in from_graph or not native.is_filled(i):
-                continue
-            declared = self._tensor_by_uid.get(uid)
-            if declared is None or not declared.dim:
-                continue
-            storage = storage_geometry(declared.dim, declared.stride, declared.data_type)
-            if storage is None:
-                continue
-            own = tuple(native.shape(i)), tuple(native.stride(i))
-            if own == storage:
-                continue
-            if own[0] == storage[0]:
-                # The declared extents under the caller's OWN strides (a padded
-                # or transposed view of this very tensor): those strides carry
-                # information, and an engine that reads the pack honours them.
-                continue
-            if _span(*own) != _numel(own[0]):
-                # Different extents AND gaps or overlaps between the slots: not
-                # one dense run of the declared bytes (a transposed view of a
-                # contiguous block IS one), so not ours to reinterpret.
-                continue
-            # BYTES, not slots: a uint8 view spanning as many slots as a bf16
-            # declaration covers half its bytes. Unknown widths do not qualify.
-            own_bytes, declared_bytes = _slot_bytes(uid_to_data.get(uid)), storage_slot_bytes(declared.data_type)
-            if own_bytes is None or declared_bytes is None or _span(*own) * own_bytes < _span(*storage) * declared_bytes:
-                continue
-            native.override_operand(i, list(storage[0]), list(storage[1]))
-            from_graph.append(i)
+        # its own description; the engine decides. The rule runs natively, one
+        # crossing per pack: this is on every execute's critical path.
+        from_graph.extend(native.describe_from(self._declared_layout(order), from_graph))
         if override_uids:
             # The backend refuses a partial override; a short list must not
             # quietly mean "keep the rest" here.
@@ -2102,6 +2049,25 @@ class pygraph:
             else:
                 workspace_ptr, workspace_bytes = extent
         return VariantPack(tuple(order), native, workspace_ptr, workspace_bytes, tuple(from_graph))
+
+    def _declared_layout(self, order: List[int]):
+        """The storage-slot geometry each slot of ``order`` was declared with,
+        built once per graph: the declaration is fixed once the graph is, and
+        ``storage_geometry`` per operand per execute was a measurable share of
+        the host path. Reset with ``_sorted_uids``."""
+        layout = self._declared_layout_native
+        if layout is None:
+            layout = _pybind_module.DeclaredLayout(len(order))
+            for i, uid in enumerate(order):
+                declared = self._tensor_by_uid.get(uid)
+                if declared is None or not declared.dim:
+                    continue
+                storage = storage_geometry(declared.dim, declared.stride, declared.data_type)
+                if storage is None:
+                    continue
+                layout.set(i, list(storage[0]), list(storage[1]), storage_slot_bytes(declared.data_type) or 0)
+            self._declared_layout_native = layout
+        return layout
 
     def _describe(self, data: Any, uid: int):
         """``(pointer, Tensor)`` for one caller buffer.
@@ -2289,6 +2255,7 @@ class pygraph:
         # The loaded graph carries its own variant_pack, so an order cached while
         # this container held a different graph no longer describes it.
         self._sorted_uids = None
+        self._declared_layout_native = None
 
     def _lower_to_cpp(self) -> Any:
         """Lower Python graph to C++ (the internal ``_pybind_module.backend_graph``)."""

--- a/python/cudnn/engines/base.py
+++ b/python/cudnn/engines/base.py
@@ -132,10 +132,13 @@ class VariantPack:
     (``get_variant_pack_uids_sorted()``), so ``address`` goes straight to
     ``_execute_with_raw_ptrs`` with no copy and no per-operand hash lookup.
 
-    What the caller ACTUALLY passed is what is recorded, which need not be what
-    the graph declared: an engine reads the IR port for the shape the plan was
-    built for and this pack for the shape about to run. frost_gemm takes its
-    M/N/K from here; the backend takes only the pointer.
+    A slot describes the buffer as the GRAPH declares it whenever the caller's
+    own geometry disagrees but covers the declared bytes (``graph_described``
+    names those slots, bare addresses included); only a buffer smaller than its
+    declaration keeps its own description. Overrides are written into the slot
+    too. An engine reads the IR port for the shape the plan was built for and
+    this pack for the shape about to run; frost_gemm takes its M/N/K from here,
+    the backend takes only the pointer.
 
     Allocated per call. Two threads may execute one graph concurrently with
     different buffers, and a shared pack would hand each thread the other's

--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -2940,6 +2940,16 @@ def _swap_mn_view(t: object) -> object:
     return t
 
 
+def _offset_vector(t):
+    """``first_token_offset`` as the rank-1 vector the launch indexes. cuDNN
+    declares it ``(E, 1, 1)`` and the variant pack hands the declaration over;
+    the trailing singleton axes carry nothing."""
+    shape = tuple(t.shape)
+    if len(shape) == 3 and shape[1:] == (1, 1):
+        return t.reshape([shape[0]])
+    return t
+
+
 def _expected_output_shape(spec, chain: FusionChain, mnk) -> tuple[int, int, int]:
     return expected_shape(_output_rule(spec, chain), int(mnk[0]), int(mnk[1]))
 
@@ -4513,13 +4523,26 @@ def _resolve_moe_variant_pack(compiled, variant_pack: dict):
             raise KeyError(f"variant pack is missing a buffer for {role}")
         return resolved[id(t)]
 
+    def kernel_order(buf, t):
+        """A B-side buffer described AS its declaration is in the graph's
+        ``[b, k, n]`` axis order (the variant pack lends a bare address, or a
+        buffer that disagrees with the declaration, exactly that geometry); the
+        launch reads ``(b, n, k)``. Same tie-break as ``recipe.Operand.axes``."""
+        try:
+            declared = tuple(int(d) for d in t.get_dim()), tuple(int(x) for x in t.get_stride())
+        except Exception:  # noqa: BLE001 -- an analyzer-synthesized ref has no dims
+            return buf
+        if declared[0] and (tuple(buf.shape), tuple(buf.stride())) == declared:
+            return buf.permute(0, 2, 1)
+        return buf
+
     a_bufs = [pull(t, "token") for t in b.a_operands]
-    b_bufs = [pull(t, "weight") for t in b.b_operands]
+    b_bufs = [kernel_order(pull(t, "weight"), t) for t in b.b_operands]
     out_bufs = [pull(t, "output") for t in b.outputs]
     aux_bufs = [pull(t, "aux") for t in b.aux]
     fto = pull(b.first_token_offset, "first_token_offset")
     sfa = [pull(t, "SFA") for t in b.sfa_operands]
-    sfb = [pull(t, "SFB") for t in b.sfb_operands]
+    sfb = [kernel_order(pull(t, "SFB"), t) for t in b.sfb_operands]
     k_factor = 2 if compiled.chain.matmul.a_dtype == "fp4_e2m1" else 1
     S = a_bufs[0].shape[1]
     K = a_bufs[0].shape[2] * k_factor
@@ -4663,6 +4686,7 @@ class CompiledMoeGemm:
         return self._call_variant_pack(variant_pack, workspace, stream)
 
     def _launch_single(self, token, weight, first_token_offset, output, snke, workspace=None, stream=None):
+        first_token_offset = _offset_vector(first_token_offset)
         if len(snke) < 3:
             raise ValueError("MoE call needs problem_size (S, N, K[, ...]); " f"got {snke!r}")
         S, N, K = int(snke[0]), int(snke[1]), int(snke[2])
@@ -4759,6 +4783,7 @@ class CompiledMoeGemm:
         (token, weight) pairs deduped by tensor identity into the JIT-fixed A/B
         slots (shared token → one A operand). All matmuls share ``fto``; ``out``
         is the single fused output."""
+        first_token_offset = _offset_vector(first_token_offset)
         chain = self.chain
         if not isinstance(gemm_pairs, (list, tuple)) or not all(isinstance(p, (list, tuple)) and len(p) == 2 for p in gemm_pairs):
             raise ValueError("multi-GEMM MoE call expects a list of (token, weight) pairs as " f"the first argument; got {type(gemm_pairs).__name__}")
@@ -5031,6 +5056,7 @@ class CompiledMoeBlockScaleGemm:
         return self._call_variant_pack(variant_pack, workspace, stream)
 
     def _launch_single(self, token, weight, sfa, sfb, first_token_offset, output, snke, workspace=None, stream=None):
+        first_token_offset = _offset_vector(first_token_offset)
         if len(snke) < 3:
             raise ValueError("MoE block-scale call needs problem_size (S, N, K[, ...]); " f"got {snke!r}")
         S, N, K = int(snke[0]), int(snke[1]), int(snke[2])
@@ -5182,6 +5208,7 @@ class CompiledMoeBlockScaleGemm:
         Each GEMM is a ((token, sfa), (weight, sfb)) pair; dedup by PACKED-data
         identity (SF travels with its data → shared token+sfa collapses to one A
         operand). All matmuls share ``fto``; ``out`` is the fused output."""
+        first_token_offset = _offset_vector(first_token_offset)
         chain = self.chain
         ok = (
             isinstance(gemm_pairs, (list, tuple))

--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -4509,6 +4509,24 @@ def _moe_operand_layout_bad(chain, token, weight) -> bool:
     return token.stride(a_unit) != 1 or weight.stride(b_unit) != 1
 
 
+def _kernel_order(buf, t):
+    """A B-side buffer described AS its declaration is in the graph's
+    ``[b, k, n]`` axis order (the variant pack lends a bare address, or a buffer
+    that disagrees with the declaration, exactly that geometry); the launch
+    reads ``(b, n, k)``. The declaration is compared in STORAGE slots -- an fp4
+    declaration spells elements, the slot spells x2 pairs -- with the same
+    tie-break ``recipe.Operand.axes`` applies on the dense path."""
+    from cudnn.graph_types import storage_geometry
+
+    try:
+        declared = storage_geometry(t.get_dim(), t.get_stride(), t.get_data_type())
+    except Exception:  # noqa: BLE001 -- an analyzer-synthesized ref has no dims
+        return buf
+    if declared is not None and declared[0] and (tuple(buf.shape), tuple(buf.stride())) == declared:
+        return buf.permute(0, 2, 1)
+    return buf
+
+
 def _resolve_moe_variant_pack(compiled, variant_pack: dict):
     """Resolve a MoE variant-pack dict into the positional-call buffers,
     inferring (S, N, K) from shapes. Returns ``(a_bufs, b_bufs, out_bufs,
@@ -4523,26 +4541,13 @@ def _resolve_moe_variant_pack(compiled, variant_pack: dict):
             raise KeyError(f"variant pack is missing a buffer for {role}")
         return resolved[id(t)]
 
-    def kernel_order(buf, t):
-        """A B-side buffer described AS its declaration is in the graph's
-        ``[b, k, n]`` axis order (the variant pack lends a bare address, or a
-        buffer that disagrees with the declaration, exactly that geometry); the
-        launch reads ``(b, n, k)``. Same tie-break as ``recipe.Operand.axes``."""
-        try:
-            declared = tuple(int(d) for d in t.get_dim()), tuple(int(x) for x in t.get_stride())
-        except Exception:  # noqa: BLE001 -- an analyzer-synthesized ref has no dims
-            return buf
-        if declared[0] and (tuple(buf.shape), tuple(buf.stride())) == declared:
-            return buf.permute(0, 2, 1)
-        return buf
-
     a_bufs = [pull(t, "token") for t in b.a_operands]
-    b_bufs = [kernel_order(pull(t, "weight"), t) for t in b.b_operands]
+    b_bufs = [_kernel_order(pull(t, "weight"), t) for t in b.b_operands]
     out_bufs = [pull(t, "output") for t in b.outputs]
     aux_bufs = [pull(t, "aux") for t in b.aux]
     fto = pull(b.first_token_offset, "first_token_offset")
     sfa = [pull(t, "SFA") for t in b.sfa_operands]
-    sfb = [kernel_order(pull(t, "SFB"), t) for t in b.sfb_operands]
+    sfb = [_kernel_order(pull(t, "SFB"), t) for t in b.sfb_operands]
     k_factor = 2 if compiled.chain.matmul.a_dtype == "fp4_e2m1" else 1
     S = a_bufs[0].shape[1]
     K = a_bufs[0].shape[2] * k_factor

--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -4509,19 +4509,28 @@ def _moe_operand_layout_bad(chain, token, weight) -> bool:
     return token.stride(a_unit) != 1 or weight.stride(b_unit) != 1
 
 
-def _kernel_order(buf, t):
+def _declared_storage(t, memo: dict):
+    """``storage_geometry`` of a bound cuDNN tensor, computed once per binding:
+    three pybind reads per operand per call otherwise."""
+    key = id(t)
+    if key not in memo:
+        from cudnn.graph_types import storage_geometry
+
+        try:
+            memo[key] = storage_geometry(t.get_dim(), t.get_stride(), t.get_data_type())
+        except Exception:  # noqa: BLE001 -- an analyzer-synthesized ref has no dims
+            memo[key] = None
+    return memo[key]
+
+
+def _kernel_order(buf, t, memo: "dict | None" = None):
     """A B-side buffer described AS its declaration is in the graph's
     ``[b, k, n]`` axis order (the variant pack lends a bare address, or a buffer
     that disagrees with the declaration, exactly that geometry); the launch
     reads ``(b, n, k)``. The declaration is compared in STORAGE slots -- an fp4
     declaration spells elements, the slot spells x2 pairs -- with the same
     tie-break ``recipe.Operand.axes`` applies on the dense path."""
-    from cudnn.graph_types import storage_geometry
-
-    try:
-        declared = storage_geometry(t.get_dim(), t.get_stride(), t.get_data_type())
-    except Exception:  # noqa: BLE001 -- an analyzer-synthesized ref has no dims
-        return buf
+    declared = _declared_storage(t, {} if memo is None else memo)
     if declared is not None and declared[0] and (tuple(buf.shape), tuple(buf.stride())) == declared:
         return buf.permute(0, 2, 1)
     return buf
@@ -4535,6 +4544,14 @@ def _resolve_moe_variant_pack(compiled, variant_pack: dict):
     if b is None:
         raise NotImplementedError("variant-pack call is not yet wired up for this graph type")
     resolved = resolve_variant_pack(variant_pack, b)
+    # the binding's tensors are fixed, so their declared geometry is too
+    memo = getattr(compiled, "_declared_storage_memo", None)
+    if memo is None:
+        memo = {}
+        try:
+            compiled._declared_storage_memo = memo
+        except AttributeError:  # a compiled object that refuses new attributes: per-call memo
+            pass
 
     def pull(t, role):
         if t is None or id(t) not in resolved:
@@ -4542,12 +4559,12 @@ def _resolve_moe_variant_pack(compiled, variant_pack: dict):
         return resolved[id(t)]
 
     a_bufs = [pull(t, "token") for t in b.a_operands]
-    b_bufs = [_kernel_order(pull(t, "weight"), t) for t in b.b_operands]
+    b_bufs = [_kernel_order(pull(t, "weight"), t, memo) for t in b.b_operands]
     out_bufs = [pull(t, "output") for t in b.outputs]
     aux_bufs = [pull(t, "aux") for t in b.aux]
     fto = pull(b.first_token_offset, "first_token_offset")
     sfa = [pull(t, "SFA") for t in b.sfa_operands]
-    sfb = [_kernel_order(pull(t, "SFB"), t) for t in b.sfb_operands]
+    sfb = [_kernel_order(pull(t, "SFB"), t, memo) for t in b.sfb_operands]
     k_factor = 2 if compiled.chain.matmul.a_dtype == "fp4_e2m1" else 1
     S = a_bufs[0].shape[1]
     K = a_bufs[0].shape[2] * k_factor

--- a/python/cudnn/graph_types.py
+++ b/python/cudnn/graph_types.py
@@ -305,12 +305,15 @@ def storage_geometry(dim, stride, data_type):
         stride = tuple(dense)
     if data_type != cudnn.data_type.FP4_E2M1:
         return dim, stride
-    if 1 not in stride:
-        return None
-    c = stride.index(1)
-    if dim[c] % 2 or any(x % 2 for j, x in enumerate(stride) if j != c and x != 1):
-        return None
-    return tuple(d // 2 if j == c else d for j, d in enumerate(dim)), tuple(x if j == c else x // 2 for j, x in enumerate(stride))
+    # The packed axis is a unit-stride axis with an even extent above one -- a
+    # singleton axis may also carry stride 1 and must not be the one picked.
+    for c, (extent, step) in enumerate(zip(dim, stride)):
+        if step != 1 or extent <= 1 or extent % 2:
+            continue
+        if any(x % 2 for j, x in enumerate(stride) if j != c and x != 1):
+            continue
+        return tuple(d // 2 if j == c else d for j, d in enumerate(dim)), tuple(x if j == c else x // 2 for j, x in enumerate(stride))
+    return None
 
 
 def storage_slot_bytes(data_type) -> "int | None":

--- a/python/cudnn/graph_types.py
+++ b/python/cudnn/graph_types.py
@@ -312,7 +312,8 @@ def storage_geometry(dim, stride, data_type):
             continue
         if any(x % 2 for j, x in enumerate(stride) if j != c and x != 1):
             continue
-        return tuple(d // 2 if j == c else d for j, d in enumerate(dim)), tuple(x if j == c else x // 2 for j, x in enumerate(stride))
+        # a singleton axis keeps its (never stepped) unit stride
+        return tuple(d // 2 if j == c else d for j, d in enumerate(dim)), tuple(x if (j == c or x == 1) else x // 2 for j, x in enumerate(stride))
     return None
 
 

--- a/python/cudnn/graph_types.py
+++ b/python/cudnn/graph_types.py
@@ -282,6 +282,51 @@ def describing_tensor(uid: int, dim, stride, data_type) -> Tensor:
     return tensor
 
 
+def storage_geometry(dim, stride, data_type):
+    """A cuDNN (element) geometry as the STORAGE-slot geometry a buffer reports.
+
+    Every dtype but fp4 stores one element per slot, so the geometry is its
+    own. fp4 packs two elements per slot along the unit-stride axis (torch's
+    ``float4_e2m1fn_x2``, or a uint8 view): that extent halves and every other
+    stride halves with it. None when the extent is odd -- no slot geometry
+    spells it. Shared by the variant pack (which stores slots) and the engines
+    that compare a slot against a declaration.
+    """
+    import cudnn
+
+    dim = tuple(int(d) for d in dim)
+    if stride:
+        stride = tuple(int(x) for x in stride)
+    else:
+        acc, dense = 1, []
+        for d in reversed(dim):
+            dense.insert(0, acc)
+            acc *= d
+        stride = tuple(dense)
+    if data_type != cudnn.data_type.FP4_E2M1:
+        return dim, stride
+    if 1 not in stride:
+        return None
+    c = stride.index(1)
+    if dim[c] % 2 or any(x % 2 for j, x in enumerate(stride) if j != c and x != 1):
+        return None
+    return tuple(d // 2 if j == c else d for j, d in enumerate(dim)), tuple(x if j == c else x // 2 for j, x in enumerate(stride))
+
+
+def storage_slot_bytes(data_type) -> "int | None":
+    """Bytes per STORAGE slot of a declared dtype: 1 for fp4 (two elements per
+    slot), the element width otherwise, None when the width is unknown."""
+    import cudnn
+
+    if data_type == cudnn.data_type.FP4_E2M1:
+        return 1
+    from .datatypes import _CUDNN_TO_FROST_DTYPE_NAME
+    from .frost.buffers import DTYPE_ITEMSIZE
+
+    name = _CUDNN_TO_FROST_DTYPE_NAME.get(data_type)
+    return None if name is None else int(DTYPE_ITEMSIZE[name])
+
+
 def byte_size(tensor: Tensor) -> int:
     """Bytes a dense tensor of this dim and dtype occupies, or 0 when the dtype
     has no known width (a bare address describes neither)."""

--- a/python/cudnn/graph_types.py
+++ b/python/cudnn/graph_types.py
@@ -292,8 +292,6 @@ def storage_geometry(dim, stride, data_type):
     spells it. Shared by the variant pack (which stores slots) and the engines
     that compare a slot against a declaration.
     """
-    import cudnn
-
     dim = tuple(int(d) for d in dim)
     if stride:
         stride = tuple(int(x) for x in stride)
@@ -303,7 +301,7 @@ def storage_geometry(dim, stride, data_type):
             dense.insert(0, acc)
             acc *= d
         stride = tuple(dense)
-    if data_type != cudnn.data_type.FP4_E2M1:
+    if data_type != _fp4_enum():
         return dim, stride
     # The packed axis is a unit-stride axis with an even extent above one -- a
     # singleton axis may also carry stride 1 and must not be the one picked.
@@ -317,12 +315,24 @@ def storage_geometry(dim, stride, data_type):
     return None
 
 
+_FP4_ENUM = None
+
+
+def _fp4_enum():
+    # cudnn imports this module, so the enum is fetched on first use, once:
+    # storage_geometry runs per overridden operand per execute.
+    global _FP4_ENUM
+    if _FP4_ENUM is None:
+        import cudnn
+
+        _FP4_ENUM = cudnn.data_type.FP4_E2M1
+    return _FP4_ENUM
+
+
 def storage_slot_bytes(data_type) -> "int | None":
     """Bytes per STORAGE slot of a declared dtype: 1 for fp4 (two elements per
     slot), the element width otherwise, None when the width is unknown."""
-    import cudnn
-
-    if data_type == cudnn.data_type.FP4_E2M1:
+    if data_type == _fp4_enum():
         return 1
     from .datatypes import _CUDNN_TO_FROST_DTYPE_NAME
     from .frost.buffers import DTYPE_ITEMSIZE

--- a/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
+++ b/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
@@ -70,7 +70,7 @@ MMA as d=512.
 | **Layout** | | | | | | |
 | BSHD | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ᵇ ᵍ |
 | Arbitrary dense B/H/S stride order (`dense_flex`) | f16 only | f16 only | f16 only | ✅ | f16 only | ✅ᵇ ᶜ · ❌ᵍ |
-| THD / ragged (packed varlen) | f16 only⁹ | ✅ | f16 only³ | ✅ | f16 + fp8³ | ✅ᵇ ʰ · ❌ᵍ |
+| THD / ragged (packed varlen)ᵏ | f16 only⁹ | ✅ | f16 only³ | ✅ | f16 + fp8³ | ✅ᵇ ʰ · ❌ᵍ |
 | `cu_seq_len_q/kv` prefix sums (THD only) | f16 only⁹ | ✅ | ✅ | ✅ | ✅ | ❌ʲ |
 | **Masks / features** | | | | | | |
 | Causal (top-left) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ᵇ ᵈ ᵍ |
@@ -540,3 +540,15 @@ feature-free d=64 graph.
 | Bias forward | SM100, SM107, SM120 |
 | Dropout, ALiBi, `block_mask`, `score_mod` | every arch, both passes |
 | Paged KV cache | every arch except SM100/SM103 f16/bf16 d128 forward (see ᵖ); fp8/mxfp8 pools, sink, THD, packed block tables everywhere |
+
+ᵏ **THD / ragged forward layout.** Q/K/V/O must be BSHD-ordered over **(H, S, D)**
+only — head dim innermost, then heads, then tokens (`graph_analyzer.packed_layout_ok`).
+The batch stride is not gated: every sequence base comes from the ragged offsets and
+the lowering binds the batch axis at extent 1, so its declared value is never read.
+FlashInfer declares it equal to the token stride (`h * d`), which the previous
+all-four-axes check refused at `b > 1`. Stats under THD are written as packed
+`(T, H)` rows (or head-major `(1, QH, head_stride)`): a Stats tensor **without**
+ragged offsets is the per-batch padded `[b, h, s_max, 1]` form and is declined at
+`b > 1` (the packed path has no per-sequence stats base); at `b == 1` it coincides
+with the packed form, and the rows past the sequence length stay unwritten where the
+cuDNN backend writes `-inf`.

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -3048,7 +3048,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         # normalization needs is required: head dim innermost-contiguous
         # (stride 1), non-broadcast, non-overlapping strides, any B/H/S
         # order, padded strides allowed.
-        from cudnn.sdpa.graph_analyzer import bshd_layout_ok, dense_layout_ok
+        from cudnn.sdpa.graph_analyzer import dense_layout_ok, packed_layout_ok
 
         for desc in (self.q_desc, self.k_desc, self.v_desc, self.o_desc):
             self._value_error_if(
@@ -3056,9 +3056,12 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
                 f"{desc.name} must be rank-4 (B, H, S, D); got {desc.ndim}",
             )
             if self.thd:
+                # Same rule as the sm100 adapter and the engine gate: the packed
+                # path reads token, head and element strides; the batch stride
+                # is never stepped under ragged offsets.
                 self._value_error_if(
-                    not bshd_layout_ok(desc.shape, desc.stride),
-                    f"THD (ragged) {desc.name} must be BSHD-physical (stride order 3,1,2,0, size-1 dims wildcarded); got stride {desc.stride}",
+                    not packed_layout_ok(tuple(desc.shape), tuple(desc.stride)),
+                    f"THD (ragged) {desc.name} must have d, h, s stride order (head dim innermost, then heads, then tokens); got stride {tuple(desc.stride)}",
                 )
             else:
                 self._value_error_if(

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -1100,11 +1100,14 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         # accepted. No TMA stride/alignment gate is needed here: the TMA
         # descriptors are built over the normalized compact buffers, never
         # over the caller's strides.
-        # THD (ragged) keeps the strict BSHD stride order: the varlen path
-        # rebuilds packed [1,T,H,D] views and only that packing is defined.
-        from cudnn.sdpa.graph_analyzer import dense_layout_ok
+        # THD (ragged) keeps the BSHD order over (H, S, D): the varlen path
+        # rebuilds packed [1,T,H,D] views from the token, head and element
+        # strides, and only that packing is defined. The batch stride is
+        # never read -- every sequence base comes from the ragged offsets and
+        # the batch axis is bound at extent 1 -- so it is not gated (same rule
+        # as graph_analyzer.packed_layout_ok, which the engine gate applies).
+        from cudnn.sdpa.graph_analyzer import dense_layout_ok, packed_layout_ok
 
-        _REQ = (3, 1, 2, 0)
         for desc_name in ["q_desc", "k_desc", "v_desc", "o_desc"]:
             d = getattr(self, desc_name)
             self._value_error_if(
@@ -1114,11 +1117,9 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             _shape, _stride = d.shape, d.stride
             # Paged pools are dense tensors even under THD (only Q/O are packed).
             if self.thd and not (self.paged and desc_name in ("k_desc", "v_desc")):
-                _act = tuple(ax for ax in d.stride_order if _shape[ax] != 1)
-                _exp = tuple(ax for ax in _REQ if _shape[ax] != 1)
                 self._value_error_if(
-                    _act != _exp,
-                    f"{d.name} must have d, h, s, b stride order (3, 1, 2, 0) for THD (size-1 dims wildcarded); got {d.stride_order} shape {_shape}",
+                    not packed_layout_ok(tuple(_shape), tuple(_stride)),
+                    f"{d.name} must have d, h, s stride order (head dim innermost, then heads, then tokens) for THD; got stride {tuple(_stride)} shape {tuple(_shape)}",
                 )
             else:
                 self._value_error_if(

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -532,10 +532,12 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
     if not facts.uniform_dtype:
         return "K/V dtypes must match Q" if (facts.is_mxfp8 or facts.is_fp8) else "K/V/O dtypes must match Q"
     if facts.thd:
-        # Ragged packing is BSHD-order by construction; the relaxation is
-        # dense-only (the THD lowering rebuilds packed [1,T,H,D] views).
-        if not facts.bshd_layout:
-            return "THD (ragged) Q/K/V/O must be BSHD-physical (stride order 3,1,2,0)"
+        # The THD lowering rebuilds packed [1, T, H, D] views from the token,
+        # head and element strides; the batch stride is never read (every
+        # sequence base comes from the ragged offsets), so it is not gated --
+        # FlashInfer declares it equal to the token stride.
+        if not facts.packed_layout:
+            return "THD (ragged) Q/K/V/O must be BSHD-physical over (H, S, D): head dim innermost, then heads, then tokens"
     elif "dense_flex" in capabilities.layouts:
         if not facts.dense_layout:
             return (
@@ -626,6 +628,12 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
     if facts.padded and facts.wants_stats and not facts.thd and not (capabilities.padded_stats or supports_dense_seq_q_trim(capabilities, facts)):
         return "padding mask with generate_stats is not supported yet (per-batch seq_len_q LSE trim not plumbed)"
 
+    if facts.thd and facts.wants_stats and facts.stats_t is not None and facts.b > 1 and getattr(facts.stats_t, "ragged_offset", None) is None:
+        # A Stats tensor with no ragged offsets is the per-batch padded form,
+        # rows at b * s_max; the packed path writes token rows contiguously and
+        # has no per-sequence stats base to place them at. At b == 1 the two
+        # coincide (the tail rows past the length stay unwritten).
+        return "THD Stats without ragged offsets is addressed per batch ([b, h, s_max, 1]); the packed path writes packed (T, h) rows -- bind ragged stats offsets, or b == 1"
     if facts.stats_t is not None and not facts.thd:
         if facts.stats_t.get_data_type() != cudnn.data_type.FLOAT:
             return f"stats must be fp32; got {facts.stats_t.get_data_type()}"

--- a/python/cudnn/sdpa/graph_analyzer.py
+++ b/python/cudnn/sdpa/graph_analyzer.py
@@ -132,6 +132,19 @@ def bshd_layout_ok(dim: tuple, stride: tuple) -> bool:
     return act == exp
 
 
+def packed_layout_ok(dim: tuple, stride: tuple) -> bool:
+    """BSHD order over (H, S, D) only, for a ragged (THD) tensor. With ragged
+    offsets every sequence's base comes from the offset table and the batch
+    axis is never stepped (the THD lowering binds it at extent 1), so its
+    declared stride carries no information -- FlashInfer declares it equal to
+    the token stride. The per-token layout the kernels address natively is
+    what has to hold: D innermost, then H, then S."""
+    order = tuple(ax for ax in _stride_order(dim, stride) if ax != 0)
+    act = tuple(ax for ax in order if dim[ax] != 1)
+    exp = tuple(ax for ax in _REQ_STRIDE_ORDER if ax != 0 and dim[ax] != 1)
+    return act == exp
+
+
 def dense_layout_ok(dim: tuple, stride: tuple) -> bool:
     """Relaxed DENSE layout soundness for a rank-4 (B, H, S, D) tensor: the
     real requirement of the SM100 DSL lowering, which normalizes any such
@@ -197,6 +210,9 @@ class SdpaGraphFacts:
     # graphs, where ``uniform_dtype`` already covers them.
     uniform_out_dtype: bool = True
     bshd_layout: bool = True  # all of Q/K/V/O in BSHD-physical order
+    # BSHD order over (H, S, D) only -- what a ragged (THD) tensor has to
+    # satisfy, its batch stride being unread under ragged offsets (packed_layout_ok).
+    packed_layout: bool = True
     # Relaxed dense-layout soundness: every one of Q/K/V/O has the head dim
     # innermost-contiguous (stride 1) with non-broadcast, non-overlapping
     # strides — any B/H/S order, padded strides allowed (see dense_layout_ok).
@@ -564,6 +580,7 @@ def _extract_facts(rec: dict) -> SdpaGraphFacts:
     # about the ragged Q/O only.
     _bshd_ports = [(q_dim, q_stride), (o_dim, o_stride)] if paged else _layout_ports
     bshd = all(bshd_layout_ok(d, s) for d, s in _bshd_ports)
+    packed = all(packed_layout_ok(d, s) for d, s in _bshd_ports)
     dense_layout = all(dense_layout_ok(d, s) for d, s in _layout_ports)
 
     # descale_q/k/v are the block-scale SF tensors for MXFP8, or scalar per-tensor
@@ -699,6 +716,7 @@ def _extract_facts(rec: dict) -> SdpaGraphFacts:
         uniform_dtype=uniform,
         uniform_out_dtype=uniform_out,
         bshd_layout=bshd,
+        packed_layout=packed,
         dense_layout=dense_layout,
         port_layouts=(tuple((name, dims[name], strides[name]) for name, _ in rank4_ports) if is_backward else ()),
         is_mxfp8=is_mxfp8,

--- a/python/pygraph/variant_pack.cpp
+++ b/python/pygraph/variant_pack.cpp
@@ -15,6 +15,7 @@
 // its parts.
 #include "variant_pack.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <cstring>
 #include <string>
@@ -155,7 +156,74 @@ struct Operand {
     bool filled = false;
 };
 
+// Slots from the base to one past the last addressed slot.
+int64_t
+span_of(const std::vector<int64_t> &shape, const std::vector<int64_t> &stride) {
+    int64_t span = 1;
+    for (size_t d = 0; d < shape.size(); d++) span += (shape[d] - 1) * stride[d];
+    return span;
+}
+
+int64_t
+numel_of(const std::vector<int64_t> &shape) {
+    int64_t n = 1;
+    for (int64_t extent : shape) n *= extent;
+    return n;
+}
+
+std::vector<int64_t>
+dense_stride_of(const std::vector<int64_t> &shape) {
+    std::vector<int64_t> dense(shape.size(), 1);
+    for (int d = static_cast<int>(shape.size()) - 2; d >= 0; d--) dense[d] = dense[d + 1] * shape[d + 1];
+    return dense;
+}
+
 }  // namespace
+
+// The STORAGE-slot geometry every variant-pack slot was declared with. A
+// declaration does not change between executes, so python builds this once per
+// graph and the pack compares a caller's buffer against it in one crossing
+// (VariantPackNative::describe_from) rather than two per operand per call.
+class DeclaredLayout {
+   public:
+    struct Slot {
+        std::vector<int64_t> shape;
+        std::vector<int64_t> stride;
+        int64_t slot_bytes = 0;  // 0: width unknown, never re-described from
+        int64_t span       = 0;
+        bool present       = false;
+    };
+
+    explicit DeclaredLayout(size_t n) : slots_(n) {}
+
+    void
+    set(size_t index, std::vector<int64_t> shape, std::vector<int64_t> stride, int64_t slot_bytes) {
+        if (shape.size() != stride.size()) {
+            throw py::value_error("declared shape and stride must have the same rank; got " +
+                                  std::to_string(shape.size()) + " and " + std::to_string(stride.size()) +
+                                  " for slot " + std::to_string(index));
+        }
+        Slot &slot      = slots_.at(index);
+        slot.span       = span_of(shape, stride);
+        slot.shape      = std::move(shape);
+        slot.stride     = std::move(stride);
+        slot.slot_bytes = slot_bytes;
+        slot.present    = true;
+    }
+
+    const std::vector<Slot> &
+    slots() const {
+        return slots_;
+    }
+
+    size_t
+    size() const {
+        return slots_.size();
+    }
+
+   private:
+    std::vector<Slot> slots_;
+};
 
 // A pack's operand, exposed to a kernel. It implements the same exchange protocol
 // it was read through, so a consumer that has the fast path for a torch tensor
@@ -539,6 +607,38 @@ class VariantPackNative {
         pointers_[index]           = nullptr;
     }
 
+    // The declaration is the contract (see _pygraph._normalize): a filled operand
+    // of OTHER extents that is one dense run of slots and covers the declared
+    // bytes is re-described AS the declaration. The declared extents under the
+    // caller's own strides, a strided view, or a buffer too small keep their own
+    // description. `skip` names the slots already described from the graph (a
+    // bare address). Returns the indices re-described, in slot order.
+    std::vector<size_t>
+    describe_from(const DeclaredLayout &declared, const std::vector<size_t> &skip) {
+        std::vector<size_t> described;
+        const auto &slots = declared.slots();
+        for (size_t i = 0; i < operands_.size() && i < slots.size(); i++) {
+            const DeclaredLayout::Slot &want = slots[i];
+            Operand &operand                 = operands_[i];
+            if (!want.present || want.slot_bytes <= 0 || !operand.filled) continue;
+            if (std::find(skip.begin(), skip.end(), i) != skip.end()) continue;
+            if (operand.shape == want.shape) continue;
+            const int64_t own_span =
+                operand.stride.empty() ? numel_of(operand.shape) : span_of(operand.shape, operand.stride);
+            if (own_span != numel_of(operand.shape)) continue;
+            // BYTES, not slots: a uint8 view spanning as many slots as a bf16
+            // declaration covers half its bytes. A width the producer did not
+            // spell (bits == 0) never qualifies.
+            const int64_t own_bytes = (static_cast<int64_t>(operand.dtype.bits) * operand.dtype.lanes + 7) / 8;
+            if (own_bytes <= 0 || own_span * own_bytes < want.span * want.slot_bytes) continue;
+            operand.ndim   = static_cast<int32_t>(want.shape.size());
+            operand.shape  = want.shape;
+            operand.stride = want.stride;
+            described.push_back(i);
+        }
+        return described;
+    }
+
     bool
     all_contiguous(std::string &offender) const {
         for (size_t i = 0; i < operands_.size(); i++) {
@@ -832,6 +932,14 @@ instead of one per region.
 
     operand_class.attr("view") = operand_class.attr("reshape");
 
+    py::class_<DeclaredLayout>(m, "DeclaredLayout", R"(
+The storage-slot geometry each variant-pack slot was declared with, built once
+per graph; ``VariantPackNative.describe_from`` compares a whole pack against it.
+)")
+        .def(py::init<size_t>())
+        .def("set", &DeclaredLayout::set)
+        .def("__len__", &DeclaredLayout::size);
+
     py::class_<VariantPackNative>(m, "VariantPackNative", R"(
 The caller's operands, held as DLTensors.
 
@@ -846,6 +954,7 @@ its parts.
         .def("first_unfilled", &VariantPackNative::first_unfilled)
         .def("set_operand", &VariantPackNative::set_operand)
         .def("override_operand", &VariantPackNative::override_operand)
+        .def("describe_from", &VariantPackNative::describe_from)
         .def("skip_operand", &VariantPackNative::skip_operand)
         .def("operand_contiguous", &VariantPackNative::operand_contiguous)
         .def("is_filled", &VariantPackNative::is_filled)

--- a/test/python/gemm/frost/test_flashinfer_shaped_gemm.py
+++ b/test/python/gemm/frost/test_flashinfer_shaped_gemm.py
@@ -20,8 +20,8 @@ contract under test, for the frost plan:
 
 A decline at check_support is a routing decision and is reported as xfail
 with the reason; a refusal AFTER acceptance is the defect this file exists to
-catch. Cases known to fail today carry ``xfail(strict=True)`` with the owner
-finding, so a fix flips them loud.
+catch. Every case here runs on the frost plan since the variant pack started
+describing a caller's buffer from the graph declaration (``_pygraph._normalize``).
 """
 
 from __future__ import annotations
@@ -34,16 +34,6 @@ from cudnn.engines import is_python_engine
 from gemm_test_utils import requires_sm100
 
 pytestmark = [pytest.mark.L0, requires_sm100]
-
-# Known gaps, strict so a fix flips them loud. Both are one defect in
-# gemm/frost/recipe.py: frost_gemm reads the BUFFER's own shape (rank, units)
-# where the cuDNN contract is the graph declaration plus override_shapes.
-_XFAIL_BUFFER_RANK = pytest.mark.xfail(
-    strict=True, reason="frost_gemm: refuses after check_support -- reads the buffer's rank instead of the declared [batch, ...] dims"
-)
-_XFAIL_FP4_K_UNITS = pytest.mark.xfail(
-    strict=True, reason="frost_gemm: override_shapes are fp4 ELEMENT dims but kpack=2 is applied again -- K doubles, SF blob 'too small'"
-)
 
 # FlashInfer's uid enum (gemm_base.UIDs), kept identical so a graph diff is a graph diff.
 A_UID, B_UID, ALPHA_UID, SFA_UID, SFB_UID, A_SCALE_UID, B_SCALE_UID, BIAS_UID, O_UID = range(9)
@@ -196,7 +186,6 @@ def _bf16_case(M: int, N: int, K: int, *, override_cache_m: int | None = None):
     return build, {A_UID: a, B_UID: b}, override
 
 
-@_XFAIL_BUFFER_RANK
 @pytest.mark.parametrize("mnk", [(256, 512, 256), (13, 256, 128)])
 def test_mm_bf16_two_d_buffers(mnk):
     build, pack, _ = _bf16_case(*mnk)
@@ -287,7 +276,6 @@ def _fp4_case(M: int, N: int, K: int, *, nvfp4: bool, alpha: bool, override_cach
 @pytest.mark.skipif(_FP4_X2 is None, reason="torch has no float4_e2m1fn_x2")
 @pytest.mark.parametrize("mnk", [(256, 512, 256), (13, 256, 128)], ids=["m256", "m13"])
 @pytest.mark.parametrize("kind", ["nvfp4", "mxfp4", "mxfp4_alpha"])
-@_XFAIL_BUFFER_RANK
 def test_mm_fp4_flat_scale_blobs(mnk, kind):
     build, pack, _ = _fp4_case(*mnk, nvfp4=kind == "nvfp4", alpha=kind.endswith("alpha"))
     _accept_means_run(build, pack)
@@ -295,7 +283,6 @@ def test_mm_fp4_flat_scale_blobs(mnk, kind):
 
 @pytest.mark.skipif(_FP4_X2 is None, reason="torch has no float4_e2m1fn_x2")
 @pytest.mark.parametrize("kind", ["nvfp4", "mxfp4"])
-@_XFAIL_FP4_K_UNITS
 def test_mm_fp4_override_shape_path(kind):
     build, pack, override = _fp4_case(200, 512, 256, nvfp4=kind == "nvfp4", alpha=False, override_cache_m=256)
     _accept_means_run(build, pack, override=override)
@@ -399,7 +386,6 @@ def _mxfp8_case(B: int, M: int, N: int, K: int):
 
 
 @pytest.mark.parametrize("bmnk", [(1, 256, 512, 256), (16, 128, 256, 1024)], ids=["b1", "b16"])
-@_XFAIL_BUFFER_RANK
 def test_bmm_mxfp8_flat_scale_blobs(bmnk):
     build, pack = _mxfp8_case(*bmnk)
     _accept_means_run(build, pack)

--- a/test/python/gemm/frost/test_flashinfer_shaped_gemm.py
+++ b/test/python/gemm/frost/test_flashinfer_shaped_gemm.py
@@ -1,0 +1,410 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""FlashInfer-shaped GEMM graphs under the frost opt-in: accept means run.
+
+FlashInfer (flashinfer/gemm/gemm_base.py) builds every cuDNN GEMM graph the
+same way: it derives rank-3 dims/strides from its torch operands by hand
+(``[batch, m, k]`` for A, ``[batch, k, n]`` with a unit stride on k for B,
+``[batch, bs_m, bs_k]`` F8_128x4-reordered block scales), declares the graph
+with those, and then binds the ORIGINAL buffers -- 2-D matrices, 1-D scale
+blobs, 0-d scalars -- by uid. The cuDNN backend reads only the pointer, so it
+never notices; a python engine that reads the buffer's own shape does.
+
+Each case here re-declares one FlashInfer graph exactly (dims, strides,
+dtypes, reordering, uids) and binds the buffers FlashInfer binds. The
+contract under test, for the frost plan:
+
+    check_support() accepted  =>  build_plans() + execute() succeed and the
+                                  result matches the cuDNN backend plan
+
+A decline at check_support is a routing decision and is reported as xfail
+with the reason; a refusal AFTER acceptance is the defect this file exists to
+catch. Cases known to fail today carry ``xfail(strict=True)`` with the owner
+finding, so a fix flips them loud.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import cudnn
+from cudnn.engines import is_python_engine
+from gemm_test_utils import requires_sm100
+
+pytestmark = [pytest.mark.L0, requires_sm100]
+
+# Known gaps, strict so a fix flips them loud. Both are one defect in
+# gemm/frost/recipe.py: frost_gemm reads the BUFFER's own shape (rank, units)
+# where the cuDNN contract is the graph declaration plus override_shapes.
+_XFAIL_BUFFER_RANK = pytest.mark.xfail(
+    strict=True, reason="frost_gemm: refuses after check_support -- reads the buffer's rank instead of the declared [batch, ...] dims"
+)
+_XFAIL_FP4_K_UNITS = pytest.mark.xfail(
+    strict=True, reason="frost_gemm: override_shapes are fp4 ELEMENT dims but kpack=2 is applied again -- K doubles, SF blob 'too small'"
+)
+
+# FlashInfer's uid enum (gemm_base.UIDs), kept identical so a graph diff is a graph diff.
+A_UID, B_UID, ALPHA_UID, SFA_UID, SFB_UID, A_SCALE_UID, B_SCALE_UID, BIAS_UID, O_UID = range(9)
+FROST = "frost_gemm"
+
+
+# ---------------------------------------------------------------------------
+# FlashInfer's shape math, verbatim (gemm_base._calculate_block_scale_dims,
+# _get_real_fp4_shape_from_packed_uint8, _get_bf16_3d_shape_stride).
+# ---------------------------------------------------------------------------
+
+
+def _div_up(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def _block_scale_dims(m: int, n: int, k: int, block_size: int) -> tuple[int, int, int]:
+    return _div_up(m, 128) * 128, _div_up(n, 128) * 128, _div_up(_div_up(k, block_size), 4) * 4
+
+
+def _shape3(t: torch.Tensor) -> tuple[list[int], list[int]]:
+    """FlashInfer's 2-D -> ``[1, ...]`` promotion of a matrix's shape/stride."""
+    shape, stride = list(t.shape), list(t.stride())
+    if len(shape) == 2:
+        shape.insert(0, 1)
+        stride.insert(0, t.numel())
+    return shape, stride
+
+
+def _fp4_shape3(packed: torch.Tensor) -> tuple[list[int], list[int]]:
+    """Real fp4-element dims of a packed x2 buffer (two elements per slot)."""
+    shape, stride = _shape3(packed)
+    column_major = packed.stride(-2) == 1
+    shape[-2 if column_major else -1] *= 2
+    if column_major:
+        stride[-1] *= 2
+        for i in range(len(stride) - 2):
+            stride[i] *= 2
+    else:
+        for i in range(len(stride) - 1):
+            stride[i] *= 2
+    return shape, stride
+
+
+# ---------------------------------------------------------------------------
+# Plan walk: the frost entry and the first backend entry of one graph.
+# ---------------------------------------------------------------------------
+
+
+def _plan_indices(g) -> tuple[int | None, int | None]:
+    frost = backend = None
+    for i in range(g.get_execution_plan_count()):
+        name = g.get_plan_name_at_index(i)
+        engine_id, _ = g.get_engine_and_knobs_at_index(i)
+        if name.split("[")[0] == FROST and frost is None:
+            frost = i
+        elif backend is None and not is_python_engine(engine_id) and name != "backend_heuristics":
+            backend = i
+    return frost, backend
+
+
+def _run(build, pack, *, use_frost: bool, override=None):
+    """Build one graph, pin the frost (or first backend) plan, run it.
+
+    Returns ``("ok", out)`` or ``("declined", where, reason)``; any exception
+    from execute after a successful check_support propagates -- that is the
+    contract violation."""
+    handle = cudnn.create_handle()
+    g, out_t = build(handle)
+    g.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
+    frost, backend = _plan_indices(g)
+    idx = frost if use_frost else backend
+    assert idx is not None, f"no {'frost' if use_frost else 'backend'} plan; plans={[g.get_plan_name_at_index(i) for i in range(g.get_execution_plan_count())]}"
+    g.select_plan(idx)
+    try:
+        g.check_support()
+    except (NotImplementedError, cudnn.cudnnGraphNotSupportedError) as exc:
+        return ("declined", "check_support", str(exc))
+    try:
+        g.build_plans()
+    except NotImplementedError as exc:
+        # A build-time decline is still a decline the plan walk would skip; it
+        # is recorded separately because a pinned (autotune) plan cannot skip.
+        return ("declined", "build_plans", str(exc))
+    out = out_t()
+    kwargs = {}
+    if override is not None:
+        uids, shapes, strides = override
+        kwargs = dict(override_uids=uids, override_shapes=shapes, override_strides=strides)
+        ws_bytes = g.get_workspace_size(handle, uids, shapes, strides)
+    else:
+        ws_bytes = g.get_workspace_size()
+    ws = torch.empty(max(int(ws_bytes), 1), dtype=torch.uint8, device="cuda")
+    g.execute({**pack, O_UID: out}, ws, handle=handle, **kwargs)
+    torch.cuda.synchronize()
+    return ("ok", out)
+
+
+def _accept_means_run(build, pack, *, override=None, atol=1e-1, rtol=2e-2):
+    ref = _run(build, pack, use_frost=False, override=override)
+    assert ref[0] == "ok", f"the cuDNN backend itself declined this FlashInfer graph: {ref}"
+    got = _run(build, pack, use_frost=True, override=override)  # an exception here is the finding
+    if got[0] == "declined":
+        pytest.xfail(f"frost_gemm declined at {got[1]}: {got[2][:200]}")
+    torch.testing.assert_close(got[1].float(), ref[1].float(), atol=atol, rtol=rtol)
+
+
+def _graph(handle, **kw):
+    return cudnn.pygraph(
+        handle=handle,
+        io_data_type=cudnn.data_type.FLOAT,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+        **kw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# mm_bf16: A (M, K) row-major, B (K, N) column-major (a transposed view), 2-D
+# buffers bound to a [1, ...] graph.
+# ---------------------------------------------------------------------------
+
+
+def _bf16_case(M: int, N: int, K: int, *, override_cache_m: int | None = None):
+    torch.manual_seed(0)
+    a = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(N, K, device="cuda", dtype=torch.bfloat16).t()  # (K, N), stride (1, K)
+    a_shape, a_stride = _shape3(a)
+    b_shape, b_stride = _shape3(b)
+    if override_cache_m is not None:
+        # build at cache_m, run at M (gemm_base.build_cudnn_gemm_bf16_graph_override_shape)
+        a_decl = ([1, override_cache_m, K], [override_cache_m * K, K, 1])
+        o_decl = ([1, override_cache_m, N], [override_cache_m * N, N, 1])
+    else:
+        a_decl, o_decl = (a_shape, a_stride), ([1, M, N], [M * N, N, 1])
+
+    def build(handle):
+        g = _graph(handle, is_override_shape_enabled=override_cache_m is not None)
+        ta = g.tensor(name="a", dim=a_decl[0], stride=a_decl[1], data_type=cudnn.data_type.BFLOAT16)
+        tb = g.tensor(name="b", dim=b_shape, stride=b_stride, data_type=cudnn.data_type.BFLOAT16)
+        c = g.matmul(name="matmul", A=ta, B=tb, compute_data_type=cudnn.data_type.FLOAT)
+        c.set_data_type(cudnn.data_type.FLOAT)
+        c.set_name("c_final").set_output(True).set_data_type(cudnn.data_type.BFLOAT16)
+        c.set_dim(o_decl[0]).set_stride(o_decl[1])
+        ta.set_uid(A_UID)
+        tb.set_uid(B_UID)
+        c.set_uid(O_UID)
+        g.validate()
+        g.build_operation_graph()
+        return g, lambda: torch.empty(M, N, device="cuda", dtype=torch.bfloat16)
+
+    override = None
+    if override_cache_m is not None:
+        override = ([A_UID, B_UID, O_UID], [a_shape, b_shape, [1, M, N]], [a_stride, b_stride, [M * N, N, 1]])
+    return build, {A_UID: a, B_UID: b}, override
+
+
+@_XFAIL_BUFFER_RANK
+@pytest.mark.parametrize("mnk", [(256, 512, 256), (13, 256, 128)])
+def test_mm_bf16_two_d_buffers(mnk):
+    build, pack, _ = _bf16_case(*mnk)
+    _accept_means_run(build, pack)
+
+
+def test_mm_bf16_override_shape_path():
+    build, pack, override = _bf16_case(200, 512, 256, override_cache_m=256)
+    _accept_means_run(build, pack, override=override)
+
+
+# ---------------------------------------------------------------------------
+# mm_fp4: packed x2 operands, F8_128x4 block scales bound as flat blobs.
+# ---------------------------------------------------------------------------
+
+_FP4_X2 = getattr(torch, "float4_e2m1fn_x2", None)
+
+
+def _fp4_case(M: int, N: int, K: int, *, nvfp4: bool, alpha: bool, override_cache_m: int | None = None):
+    torch.manual_seed(0)
+    block = 16 if nvfp4 else 32
+    a_u8 = torch.randint(0, 256, (M, K // 2), device="cuda", dtype=torch.uint8)
+    b_u8 = torch.randint(0, 256, (N, K // 2), device="cuda", dtype=torch.uint8).t()  # (K/2, N) column-major
+    a, b = a_u8.view(_FP4_X2), b_u8.view(_FP4_X2)
+    a_shape, a_stride = _fp4_shape3(a)  # [1, M, K]
+    b_shape, b_stride = _fp4_shape3(b)  # [1, K, N], stride [K*N, 1, K]
+    bs_m, bs_n, bs_k = _block_scale_dims(M, N, K, block)
+    # FlashInfer binds the quantizer's flat F8_128x4 blob: bs_m * bs_k scale bytes.
+    if nvfp4:
+        sfa = torch.full((bs_m * bs_k,), 1.0, device="cuda").to(torch.float8_e4m3fn)
+        sfb = torch.full((bs_n * bs_k,), 1.0, device="cuda").to(torch.float8_e4m3fn)
+        sf_type = cudnn.data_type.FP8_E4M3
+    else:
+        sfa = torch.full((bs_m * bs_k,), 127, device="cuda", dtype=torch.uint8).view(torch.float8_e8m0fnu)
+        sfb = torch.full((bs_n * bs_k,), 127, device="cuda", dtype=torch.uint8).view(torch.float8_e8m0fnu)
+        sf_type = cudnn.data_type.FP8_E8M0
+    decl_m = override_cache_m if override_cache_m is not None else M
+    d_bs_m, _, d_bs_k = _block_scale_dims(decl_m, N, K, block)
+    sfa_decl = ([1, d_bs_m, d_bs_k], [d_bs_m * d_bs_k, d_bs_k, 1])
+    sfb_decl = ([1, bs_k, bs_n], [bs_n * bs_k, 1, bs_k])
+    a_decl = ([1, decl_m, K], [decl_m * K, K, 1])
+    o_decl = ([1, decl_m, N], [decl_m * N, N, 1])
+    alpha_t = torch.tensor([0.5], device="cuda", dtype=torch.float32) if alpha else None
+
+    def build(handle):
+        g = _graph(handle, is_override_shape_enabled=override_cache_m is not None)
+        ta = g.tensor(name="a", dim=a_decl[0], stride=a_decl[1], data_type=cudnn.data_type.FP4_E2M1)
+        tb = g.tensor(name="b", dim=b_shape, stride=b_stride, data_type=cudnn.data_type.FP4_E2M1)
+        tsa = g.tensor(name="block_descale_a", dim=sfa_decl[0], stride=sfa_decl[1], data_type=sf_type, reordering_type=cudnn.tensor_reordering.F8_128x4)
+        tsb = g.tensor(name="block_descale_b", dim=sfb_decl[0], stride=sfb_decl[1], data_type=sf_type, reordering_type=cudnn.tensor_reordering.F8_128x4)
+        da = g.block_scale_dequantize(ta, tsa, block_size=[1, block], name="dequant_a")
+        da.set_data_type(cudnn.data_type.FLOAT)
+        db = g.block_scale_dequantize(tb, tsb, block_size=[block, 1], name="dequant_b")
+        db.set_data_type(cudnn.data_type.FLOAT)
+        c = g.matmul(da, db, compute_data_type=cudnn.data_type.FLOAT, name="gemm")
+        c.set_data_type(cudnn.data_type.FLOAT)
+        final = c
+        if alpha:
+            tg = g.tensor(name="global_scale", dim=(1, 1, 1), stride=(1, 1, 1), data_type=cudnn.data_type.FLOAT)
+            final = g.mul(name="scale_mul", a=c, b=tg, compute_data_type=cudnn.data_type.FLOAT)
+            tg.set_uid(ALPHA_UID)
+        final.set_name("c_final").set_output(True).set_data_type(cudnn.data_type.BFLOAT16)
+        final.set_dim(o_decl[0]).set_stride(o_decl[1])
+        ta.set_uid(A_UID)
+        tb.set_uid(B_UID)
+        tsa.set_uid(SFA_UID)
+        tsb.set_uid(SFB_UID)
+        final.set_uid(O_UID)
+        g.validate()
+        g.build_operation_graph()
+        return g, lambda: torch.empty(M, N, device="cuda", dtype=torch.bfloat16)
+
+    pack = {A_UID: a, B_UID: b, SFA_UID: sfa, SFB_UID: sfb}
+    if alpha:
+        pack[ALPHA_UID] = alpha_t.view(torch.float)
+    override = None
+    if override_cache_m is not None:
+        # gemm_base.execute_cudnn_gemm_fp4_graph_override_shape: real fp4 dims for A/B,
+        # the scale dims recomputed for the actual M, the output's 3-D dims.
+        override = (
+            [A_UID, B_UID, SFA_UID, SFB_UID, O_UID],
+            [a_shape, b_shape, [1, bs_m, bs_k], [1, bs_k, bs_n], [1, M, N]],
+            [a_stride, b_stride, [bs_m * bs_k, bs_k, 1], [bs_n * bs_k, 1, bs_k], [M * N, N, 1]],
+        )
+    return build, pack, override
+
+
+@pytest.mark.skipif(_FP4_X2 is None, reason="torch has no float4_e2m1fn_x2")
+@pytest.mark.parametrize("mnk", [(256, 512, 256), (13, 256, 128)], ids=["m256", "m13"])
+@pytest.mark.parametrize("kind", ["nvfp4", "mxfp4", "mxfp4_alpha"])
+@_XFAIL_BUFFER_RANK
+def test_mm_fp4_flat_scale_blobs(mnk, kind):
+    build, pack, _ = _fp4_case(*mnk, nvfp4=kind == "nvfp4", alpha=kind.endswith("alpha"))
+    _accept_means_run(build, pack)
+
+
+@pytest.mark.skipif(_FP4_X2 is None, reason="torch has no float4_e2m1fn_x2")
+@pytest.mark.parametrize("kind", ["nvfp4", "mxfp4"])
+@_XFAIL_FP4_K_UNITS
+def test_mm_fp4_override_shape_path(kind):
+    build, pack, override = _fp4_case(200, 512, 256, nvfp4=kind == "nvfp4", alpha=False, override_cache_m=256)
+    _accept_means_run(build, pack, override=override)
+
+
+# ---------------------------------------------------------------------------
+# bmm_fp8: per-tensor scales declared (1, 1, 1), bound as 0-d tensors.
+# ---------------------------------------------------------------------------
+
+
+def _fp8_case(B: int, M: int, N: int, K: int, *, scalar_rank: int):
+    torch.manual_seed(0)
+    a = (torch.randn(B, M, K, device="cuda") * 0.5).to(torch.float8_e4m3fn)
+    b = (torch.randn(B, N, K, device="cuda") * 0.5).to(torch.float8_e4m3fn).transpose(-2, -1)  # (B, K, N)
+    a_shape, a_stride = list(a.shape), list(a.stride())
+    b_shape, b_stride = list(b.shape), list(b.stride())
+    a_scale = torch.tensor(0.5, device="cuda", dtype=torch.float32).reshape([1] * scalar_rank)
+    b_scale = torch.tensor(2.0, device="cuda", dtype=torch.float32).reshape([1] * scalar_rank)
+
+    def build(handle):
+        g = _graph(handle)
+        ta = g.tensor(name="a", dim=a_shape, stride=a_stride, data_type=cudnn.data_type.FP8_E4M3)
+        tb = g.tensor(name="b", dim=b_shape, stride=b_stride, data_type=cudnn.data_type.FP8_E4M3)
+        tsa = g.tensor(name="a_scale", dim=(1, 1, 1), stride=(1, 1, 1), data_type=cudnn.data_type.FLOAT)
+        tsb = g.tensor(name="b_scale", dim=(1, 1, 1), stride=(1, 1, 1), data_type=cudnn.data_type.FLOAT)
+        c = g.matmul(name="matmul", A=ta, B=tb, compute_data_type=cudnn.data_type.FLOAT)
+        c.set_name("c").set_data_type(cudnn.data_type.FLOAT)
+        c1 = g.mul(name="scale_mul_a", a=c, b=tsa, compute_data_type=cudnn.data_type.FLOAT)
+        c2 = g.mul(name="scale_mul_b", a=c1, b=tsb, compute_data_type=cudnn.data_type.FLOAT)
+        c2.set_name("c_final").set_output(True).set_data_type(cudnn.data_type.BFLOAT16)
+        c2.set_dim([B, M, N]).set_stride([M * N, N, 1])
+        ta.set_uid(A_UID)
+        tb.set_uid(B_UID)
+        tsa.set_uid(A_SCALE_UID)
+        tsb.set_uid(B_SCALE_UID)
+        c2.set_uid(O_UID)
+        g.validate()
+        g.build_operation_graph()
+        return g, lambda: torch.empty(B, M, N, device="cuda", dtype=torch.bfloat16)
+
+    return build, {A_UID: a, B_UID: b, A_SCALE_UID: a_scale, B_SCALE_UID: b_scale}
+
+
+@pytest.mark.parametrize("scalar_rank", [0, 1, 3], ids=["scalar_0d", "scalar_1d", "scalar_3d"])
+def test_bmm_fp8_per_tensor_scales(scalar_rank):
+    build, pack = _fp8_case(2, 256, 512, 256, scalar_rank=scalar_rank)
+    _accept_means_run(build, pack)
+
+
+# ---------------------------------------------------------------------------
+# bmm_mxfp8: E8M0 block scales, F8_128x4 reordered, bound as one flat blob per operand.
+# ---------------------------------------------------------------------------
+
+
+def _mxfp8_case(B: int, M: int, N: int, K: int):
+    torch.manual_seed(0)
+    block = 32
+    a = (torch.randn(B, M, K, device="cuda") * 0.5).to(torch.float8_e4m3fn)
+    b = (torch.randn(B, N, K, device="cuda") * 0.5).to(torch.float8_e4m3fn).transpose(-2, -1)  # (B, K, N)
+    bs_m, bs_n, bs_k = _block_scale_dims(M, N, K, block)
+    # mxfp8_quantize(is_sf_swizzled_layout=True) hands back ONE flat blob per operand.
+    sfa = torch.full((B * bs_m * bs_k,), 127, device="cuda", dtype=torch.uint8).view(torch.float8_e8m0fnu)
+    sfb = torch.full((B * bs_n * bs_k,), 127, device="cuda", dtype=torch.uint8).view(torch.float8_e8m0fnu)
+
+    def build(handle):
+        g = _graph(handle)
+        ta = g.tensor(name="a", dim=list(a.shape), stride=list(a.stride()), data_type=cudnn.data_type.FP8_E4M3)
+        tb = g.tensor(name="b", dim=list(b.shape), stride=list(b.stride()), data_type=cudnn.data_type.FP8_E4M3)
+        tsa = g.tensor(
+            name="block_descale_a",
+            dim=[B, bs_m, bs_k],
+            stride=[bs_m * bs_k, bs_k, 1],
+            data_type=cudnn.data_type.FP8_E8M0,
+            reordering_type=cudnn.tensor_reordering.F8_128x4,
+        )
+        tsb = g.tensor(
+            name="block_descale_b",
+            dim=[B, bs_k, bs_n],
+            stride=[bs_n * bs_k, 1, bs_k],
+            data_type=cudnn.data_type.FP8_E8M0,
+            reordering_type=cudnn.tensor_reordering.F8_128x4,
+        )
+        da = g.block_scale_dequantize(ta, tsa, block_size=[1, block], name="dequant_a")
+        da.set_data_type(cudnn.data_type.FLOAT)
+        db = g.block_scale_dequantize(tb, tsb, block_size=[block, 1], name="dequant_b")
+        db.set_data_type(cudnn.data_type.FLOAT)
+        c = g.matmul(da, db, compute_data_type=cudnn.data_type.FLOAT, name="gemm")
+        c.set_data_type(cudnn.data_type.FLOAT)
+        c.set_output(True).set_data_type(cudnn.data_type.BFLOAT16)
+        c.set_dim([B, M, N]).set_stride([M * N, N, 1])
+        ta.set_uid(A_UID)
+        tb.set_uid(B_UID)
+        tsa.set_uid(SFA_UID)
+        tsb.set_uid(SFB_UID)
+        c.set_uid(O_UID)
+        g.validate()
+        g.build_operation_graph()
+        return g, lambda: torch.empty(B, M, N, device="cuda", dtype=torch.bfloat16)
+
+    return build, {A_UID: a, B_UID: b, SFA_UID: sfa, SFB_UID: sfb}
+
+
+@pytest.mark.parametrize("bmnk", [(1, 256, 512, 256), (16, 128, 256, 1024)], ids=["b1", "b16"])
+@_XFAIL_BUFFER_RANK
+def test_bmm_mxfp8_flat_scale_blobs(bmnk):
+    build, pack = _mxfp8_case(*bmnk)
+    _accept_means_run(build, pack)

--- a/test/python/gemm/frost/test_flashinfer_shaped_gemm.py
+++ b/test/python/gemm/frost/test_flashinfer_shaped_gemm.py
@@ -108,9 +108,9 @@ def _plan_indices(g) -> tuple[int | None, int | None]:
 def _run(build, pack, *, use_frost: bool, override=None):
     """Build one graph, pin the frost (or first backend) plan, run it.
 
-    Returns ``("ok", out)`` or ``("declined", where, reason)``; any exception
-    from execute after a successful check_support propagates -- that is the
-    contract violation."""
+    Returns ``("ok", out)`` or ``("declined", "check_support", reason)``; any
+    exception from build_plans or execute after a successful check_support
+    propagates -- that is the contract violation."""
     handle = cudnn.create_handle()
     g, out_t = build(handle)
     g.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
@@ -122,12 +122,7 @@ def _run(build, pack, *, use_frost: bool, override=None):
         g.check_support()
     except (NotImplementedError, cudnn.cudnnGraphNotSupportedError) as exc:
         return ("declined", "check_support", str(exc))
-    try:
-        g.build_plans()
-    except NotImplementedError as exc:
-        # A build-time decline is still a decline the plan walk would skip; it
-        # is recorded separately because a pinned (autotune) plan cannot skip.
-        return ("declined", "build_plans", str(exc))
+    g.build_plans()  # accepted above: a failure from here on is the finding, not a decline
     out = out_t()
     kwargs = {}
     if override is not None:

--- a/test/python/gemm/frost/test_frontend_integration.py
+++ b/test/python/gemm/frost/test_frontend_integration.py
@@ -559,3 +559,21 @@ def test_override_shape_inside_a_max_allocation_matches_the_backend():
 
     for name, got in results.items():
         torch.testing.assert_close(got, ref, atol=0, rtol=0, msg=lambda s, name=name: f"{name} ran the wrong shape\n{s}")
+
+
+def test_moe_kernel_order_compares_the_declaration_in_storage_slots():
+    """A graph-described B operand arrives in the graph's [b, k, n] order and is
+    permuted to the kernel's (b, n, k); an fp4 declaration spells elements while
+    the slot spells x2 pairs, so the comparison must convert first."""
+    from cudnn.gemm.frost.compiler import _kernel_order
+
+    E, K, N = 4, 256, 512
+    g = cudnn.pygraph(io_data_type=cudnn.data_type.BFLOAT16, compute_data_type=cudnn.data_type.FLOAT)
+    w_bf16 = g.tensor(name="w", dim=[E, K, N], stride=[K * N, 1, K], data_type=cudnn.data_type.BFLOAT16)
+    w_fp4 = g.tensor(name="w4", dim=[E, K, N], stride=[K * N, 1, K], data_type=cudnn.data_type.FP4_E2M1)
+    graph_order = torch.empty(E, N, K, dtype=torch.bfloat16).permute(0, 2, 1)  # (E, K, N) strides (K*N, 1, K)
+    assert tuple(_kernel_order(graph_order, w_bf16).shape) == (E, N, K)
+    kernel_order = torch.empty(E, N, K, dtype=torch.bfloat16)  # the caller's own (b, n, k): left alone
+    assert _kernel_order(kernel_order, w_bf16) is kernel_order
+    fp4_slots = torch.empty(E, N, K // 2, dtype=torch.uint8).permute(0, 2, 1)  # (E, K/2, N) strides (K*N/2, 1, K/2)
+    assert tuple(_kernel_order(fp4_slots, w_fp4).shape) == (E, N, K // 2)

--- a/test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py
+++ b/test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py
@@ -13,9 +13,9 @@ forms exist: the legacy element-unit offsets, and the token-unit direct form
 
 Contract under test for the frost plan: it serves the graph (FlashInfer is the
 caller this suite exists for, so a decline FAILS), builds, runs, and O / valid
-LSE rows match the cuDNN backend plan. The two known gaps -- the sm100 row's
-THD stride-order decline at b > 1, and the padded LSE rows left unwritten --
-carry ``xfail(strict=True)`` so a fix flips them loud.
+LSE rows match the cuDNN backend plan. The one known gap -- the padded LSE
+rows left unwritten where the backend writes -inf -- carries
+``xfail(strict=True)`` so a fix flips it loud.
 """
 
 from __future__ import annotations
@@ -232,14 +232,18 @@ class _Case:
         return ("ok", out, lse)
 
 
-def _accept_means_run(case: _Case, *, padded_rows_too: bool = True):
+def _accept_means_run(case: _Case, *, padded_rows_too: bool = True, decline_ok: str | None = None):
     """The frost plan must serve the graph (a decline is a failure here: FlashInfer
     is the caller this suite exists for) and match the backend on O and on every
     valid LSE row. ``padded_rows_too`` also holds the rows past each sequence's
-    length to the backend's value (-inf), the contract of the padded form."""
+    length to the backend's value (-inf), the contract of the padded form.
+    ``decline_ok`` names the one reason a decline IS the right answer for the
+    case (a form the kernels cannot address); anything else still fails."""
     ref = case.run(use_frost=False)
     assert ref[0] == "ok", f"the cuDNN backend itself declined this FlashInfer graph: {ref}"
     got = case.run(use_frost=True)
+    if got[0] == "declined" and decline_ok is not None and decline_ok in got[2]:
+        return  # the documented, correct decline: the backend serves this form
     assert got[0] == "ok", f"frost declined FlashInfer's graph at {got[1]}: {got[2][:300]}"
     torch.testing.assert_close(got[1].float(), ref[1].float(), atol=2e-2, rtol=2e-2)
     if not case.padded_lse:
@@ -251,14 +255,9 @@ def _accept_means_run(case: _Case, *, padded_rows_too: bool = True):
             assert torch.equal(got[2][i, n:], ref[2][i, n:]), f"batch {i}: padded LSE rows differ from the backend's (-inf): {got[2][i, n:n + 4, 0].tolist()}"
 
 
-_XFAIL_THD_BATCH = pytest.mark.xfail(
-    strict=True,
-    reason="sdpa_fwd_prefill_sm100 declines FlashInfer's packed THD at b > 1: BSHD-physical stride-order check on a batch stride that ragged offsets never read",
-)
 _XFAIL_PADDED_LSE = pytest.mark.xfail(strict=True, reason="frost leaves the padded LSE rows of a (b, s_max, h) stats buffer unwritten; the backend writes -inf")
 
 
-@_XFAIL_THD_BATCH
 @pytest.mark.parametrize("form", ["legacy_offsets", "tokens"])
 @pytest.mark.parametrize("d", [128, 192])
 def test_ragged_prefill_batch_of_two(form, d):
@@ -266,11 +265,18 @@ def test_ragged_prefill_batch_of_two(form, d):
     _accept_means_run(_Case([68, 87], [400, 512], s_q_max=128, s_kv_max=512, d=d, tokens_form=form == "tokens"))
 
 
-@_XFAIL_THD_BATCH
 @pytest.mark.parametrize("form", ["legacy_offsets", "tokens"])
 def test_ragged_prefill_batch_of_two_padded_lse(form):
-    """b > 1 with FlashInfer's padded (b, s_max, h) LSE buffer and no stats offsets: valid rows match."""
-    _accept_means_run(_Case([68, 87], [400, 512], s_q_max=128, s_kv_max=512, tokens_form=form == "tokens", padded_lse=True), padded_rows_too=False)
+    """b > 1 with FlashInfer's padded (b, s_max, h) LSE buffer and no stats offsets.
+
+    The packed path writes Stats as contiguous (T, h) rows and has no per-sequence
+    stats base, so this form is a documented decline (the backend serves it) --
+    never a plan that writes the second sequence's rows at the wrong place."""
+    _accept_means_run(
+        _Case([68, 87], [400, 512], s_q_max=128, s_kv_max=512, tokens_form=form == "tokens", padded_lse=True),
+        padded_rows_too=False,
+        decline_ok="THD Stats without ragged offsets",
+    )
 
 
 @pytest.mark.parametrize("form", ["legacy_offsets", "tokens"])

--- a/test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py
+++ b/test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py
@@ -11,10 +11,11 @@ equal to the sequence stride) with per-tensor ragged offsets, packed
 forms exist: the legacy element-unit offsets, and the token-unit direct form
 (``cu_seq_len_q/kv`` + ``set_ragged_offset_multiplier``, cuDNN >= 9.24).
 
-Contract under test for the frost plan: accepted at check_support => builds,
-runs, and O / valid LSE rows match the cuDNN backend plan. A decline is xfail
-with the reason (today: the THD stride-order check at b > 1). Known contract
-gaps carry ``xfail(strict=True)`` so a fix flips them loud.
+Contract under test for the frost plan: it serves the graph (FlashInfer is the
+caller this suite exists for, so a decline FAILS), builds, runs, and O / valid
+LSE rows match the cuDNN backend plan. The two known gaps -- the sm100 row's
+THD stride-order decline at b > 1, and the padded LSE rows left unwritten --
+carry ``xfail(strict=True)`` so a fix flips them loud.
 """
 
 from __future__ import annotations
@@ -68,26 +69,47 @@ def _frost_decline_reasons(g) -> str:
 class _Case:
     """One FlashInfer prefill call: lengths, packed buffers, and the graph it builds."""
 
-    def __init__(self, lens_q, lens_kv, *, h_q=8, h_kv=4, d=128, causal=True, tokens_form=False, dtype=torch.bfloat16):
+    def __init__(
+        self,
+        lens_q,
+        lens_kv,
+        *,
+        s_q_max=None,
+        s_kv_max=None,
+        h_q=8,
+        h_kv=4,
+        d=128,
+        d_v=None,
+        causal=True,
+        tokens_form=False,
+        padded_lse=False,
+        dtype=torch.bfloat16,
+    ):
         torch.manual_seed(0)
         dev = torch.device("cuda")
         self.b, self.h_q, self.h_kv, self.d, self.causal, self.tokens_form = len(lens_q), h_q, h_kv, d, causal, tokens_form
+        self.d_v = d if d_v is None else d_v  # FlashInfer's d192/d128 MLA-style shapes split the two
+        # FlashInfer's two Stats bindings: packed (T, h) through ragged stats offsets
+        # (batch_offsets_stats), or the padded (b, s_max, h) buffer with no offsets.
+        self.padded_lse = padded_lse
         self.lens_q = torch.tensor(lens_q, dtype=torch.int32, device=dev)
         self.lens_kv = torch.tensor(lens_kv, dtype=torch.int32, device=dev)
-        self.s_q, self.s_kv = max(lens_q), max(lens_kv)
+        # FlashInfer declares max_token_per_sequence / max_sequence_kv, normally above the longest sequence.
+        self.s_q, self.s_kv = s_q_max or max(lens_q), s_kv_max or max(lens_kv)
+        assert self.s_q >= max(lens_q) and self.s_kv >= max(lens_kv)
         zero = torch.zeros(1, dtype=torch.int32, device=dev)
         self.cu_q = torch.cat([zero, torch.cumsum(self.lens_q, 0).int()])
         self.cu_kv = torch.cat([zero, torch.cumsum(self.lens_kv, 0).int()])
         t_q, t_kv = int(self.cu_q[-1]), int(self.cu_kv[-1])
         self.q = torch.randn(t_q, h_q, d, device=dev, dtype=dtype)
         self.k = torch.randn(t_kv, h_kv, d, device=dev, dtype=dtype)
-        self.v = torch.randn(t_kv, h_kv, d, device=dev, dtype=dtype)
+        self.v = torch.randn(t_kv, h_kv, self.d_v, device=dev, dtype=dtype)
         self.scale = 1.0 / math.sqrt(d)
         self.dtype = dtype
         self.t_q = t_q
 
     def build(self, handle):
-        b, h_q, h_kv, d, s_q, s_kv = self.b, self.h_q, self.h_kv, self.d, self.s_q, self.s_kv
+        b, h_q, h_kv, d, d_v, s_q, s_kv = self.b, self.h_q, self.h_kv, self.d, self.d_v, self.s_q, self.s_kv
         g = cudnn.pygraph(
             handle=handle, io_data_type=cudnn.data_type.BFLOAT16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT
         )
@@ -96,7 +118,7 @@ class _Case:
         # Q: batch stride == one token (h*d) == the s stride; ragged offsets say where each batch starts.
         q = g.tensor(name="q", dim=(b, h_q, s_q, d), stride=(h_q * d, h_stride, s_stride, d_stride), data_type=dt)
         k = g.tensor(name="k", dim=(b, h_kv, s_kv, d), stride=(h_kv * d * s_kv, d, h_kv * d, 1), data_type=dt)
-        v = g.tensor(name="v", dim=(b, h_kv, s_kv, d), stride=(h_kv * d * s_kv, d, h_kv * d, 1), data_type=dt)
+        v = g.tensor(name="v", dim=(b, h_kv, s_kv, d_v), stride=(h_kv * d_v * s_kv, d_v, h_kv * d_v, 1), data_type=dt)
         rq = g.tensor_like(self.cu_q, name="ragged_q")
         rk = g.tensor_like(self.cu_kv, name="ragged_k")
         rv = g.tensor_like(self.cu_kv, name="ragged_v")
@@ -108,7 +130,7 @@ class _Case:
         if self.tokens_form:
             q.set_ragged_offset_multiplier(h_q * d)
             k.set_ragged_offset_multiplier(h_kv * d)
-            v.set_ragged_offset_multiplier(h_kv * d)
+            v.set_ragged_offset_multiplier(h_kv * d_v)
             cu_q = g.tensor_like(self.cu_q, name="cu_seq_lens_q")
             cu_kv = g.tensor_like(self.cu_kv, name="cu_seq_lens_kv")
             cu_q.set_uid(SEQ_Q_UID)
@@ -135,13 +157,15 @@ class _Case:
         ro = g.tensor_like(self.cu_q, name="ragged_o")
         ro.set_uid(RAGGED_O_UID)
         out_t.set_ragged_offset(ro)
-        rs = g.tensor_like(self.cu_q, name="ragged_stats")
-        rs.set_uid(RAGGED_STATS_UID)
-        stats_t.set_ragged_offset(rs)
+        if not self.padded_lse:
+            rs = g.tensor_like(self.cu_q, name="ragged_stats")
+            rs.set_uid(RAGGED_STATS_UID)
+            stats_t.set_ragged_offset(rs)
         if self.tokens_form:
-            out_t.set_ragged_offset_multiplier(h_q * d)
-            stats_t.set_ragged_offset_multiplier(h_q)
-        out_t.set_uid(O_UID).set_output(True).set_dim([b, h_q, s_q, d]).set_stride([s_q * d * h_q, d, d * h_q, 1]).set_data_type(dt)
+            out_t.set_ragged_offset_multiplier(h_q * d_v)
+            if not self.padded_lse:
+                stats_t.set_ragged_offset_multiplier(h_q)
+        out_t.set_uid(O_UID).set_output(True).set_dim([b, h_q, s_q, d_v]).set_stride([s_q * d_v * h_q, d_v, d_v * h_q, 1]).set_data_type(dt)
         stats_t.set_uid(STATS_UID).set_output(True).set_data_type(cudnn.data_type.FLOAT).set_dim([b, h_q, s_q, 1]).set_stride([s_q * h_q, 1, h_q, 1])
         for t, uid in ((q, Q_UID), (k, K_UID), (v, V_UID)):
             t.set_uid(uid)
@@ -150,11 +174,17 @@ class _Case:
         return g
 
     def pack(self, out, lse):
-        b, h_q, h_kv, d = self.b, self.h_q, self.h_kv, self.d
+        b, h_q, h_kv, d, d_v = self.b, self.h_q, self.h_kv, self.d, self.d_v
         if self.tokens_form:
-            offs_q, offs_kv, offs_o, offs_s = self.cu_q, self.cu_kv, self.cu_q, self.cu_q
-        else:  # legacy element-unit offsets
-            offs_q, offs_kv, offs_o, offs_s = self.cu_q * (h_q * d), self.cu_kv * (h_kv * d), self.cu_q * (h_q * d), self.cu_q * h_q
+            offs_q, offs_k, offs_v, offs_o, offs_s = self.cu_q, self.cu_kv, self.cu_kv, self.cu_q, self.cu_q
+        else:  # legacy element-unit offsets (batch_offsets_* = cu * (h * d) per tensor)
+            offs_q, offs_k, offs_v, offs_o, offs_s = (
+                self.cu_q * (h_q * d),
+                self.cu_kv * (h_kv * d),
+                self.cu_kv * (h_kv * d_v),
+                self.cu_q * (h_q * d_v),
+                self.cu_q * h_q,
+            )
         pack = {
             Q_UID: self.q,
             K_UID: self.k,
@@ -162,11 +192,12 @@ class _Case:
             O_UID: out,
             STATS_UID: lse,
             RAGGED_Q_UID: offs_q,
-            RAGGED_K_UID: offs_kv,
-            RAGGED_V_UID: offs_kv,
+            RAGGED_K_UID: offs_k,
+            RAGGED_V_UID: offs_v,
             RAGGED_O_UID: offs_o,
-            RAGGED_STATS_UID: offs_s,
         }
+        if not self.padded_lse:
+            pack[RAGGED_STATS_UID] = offs_s
         if self.tokens_form:
             pack[SEQ_Q_UID], pack[SEQ_KV_UID] = self.cu_q, self.cu_kv
         else:
@@ -190,32 +221,79 @@ class _Case:
         except (NotImplementedError, cudnn.cudnnGraphNotSupportedError) as exc:
             return ("declined", "check_support", str(exc))
         g.build_plans()  # accepted above: a failure from here on is the finding, not a decline
-        out = torch.empty_like(self.q)  # packed (T, h, d)
-        lse = torch.empty(self.t_q, self.h_q, device="cuda", dtype=torch.float32)  # packed (T, h) stats
+        out = torch.empty(self.t_q, self.h_q, self.d_v, device="cuda", dtype=self.dtype)  # packed (T, h, d_v)
+        if self.padded_lse:
+            lse = torch.full((self.b, self.s_q, self.h_q), float("nan"), device="cuda", dtype=torch.float32)  # FlashInfer's lse buffer
+        else:
+            lse = torch.empty(self.t_q, self.h_q, device="cuda", dtype=torch.float32)  # packed (T, h) stats
         ws = torch.empty(max(g.get_workspace_size(), 1), dtype=torch.uint8, device="cuda")
         g.execute(self.pack(out, lse), ws, handle=handle)
         torch.cuda.synchronize()
         return ("ok", out, lse)
 
 
-def _accept_means_run(case: _Case):
+def _accept_means_run(case: _Case, *, padded_rows_too: bool = True):
+    """The frost plan must serve the graph (a decline is a failure here: FlashInfer
+    is the caller this suite exists for) and match the backend on O and on every
+    valid LSE row. ``padded_rows_too`` also holds the rows past each sequence's
+    length to the backend's value (-inf), the contract of the padded form."""
     ref = case.run(use_frost=False)
     assert ref[0] == "ok", f"the cuDNN backend itself declined this FlashInfer graph: {ref}"
     got = case.run(use_frost=True)
-    if got[0] == "declined":
-        pytest.xfail(f"frost declined at {got[1]}: {got[2][:220]}")
+    assert got[0] == "ok", f"frost declined FlashInfer's graph at {got[1]}: {got[2][:300]}"
     torch.testing.assert_close(got[1].float(), ref[1].float(), atol=2e-2, rtol=2e-2)
-    torch.testing.assert_close(got[2], ref[2], atol=2e-3, rtol=2e-3)
+    if not case.padded_lse:
+        torch.testing.assert_close(got[2], ref[2], atol=2e-3, rtol=2e-3)
+        return
+    for i, n in enumerate(case.lens_q.tolist()):
+        torch.testing.assert_close(got[2][i, :n], ref[2][i, :n], atol=2e-3, rtol=2e-3)
+        if padded_rows_too:
+            assert torch.equal(got[2][i, n:], ref[2][i, n:]), f"batch {i}: padded LSE rows differ from the backend's (-inf): {got[2][i, n:n + 4, 0].tolist()}"
 
 
+_XFAIL_THD_BATCH = pytest.mark.xfail(
+    strict=True,
+    reason="sdpa_fwd_prefill_sm100 declines FlashInfer's packed THD at b > 1: BSHD-physical stride-order check on a batch stride that ragged offsets never read",
+)
+_XFAIL_PADDED_LSE = pytest.mark.xfail(strict=True, reason="frost leaves the padded LSE rows of a (b, s_max, h) stats buffer unwritten; the backend writes -inf")
+
+
+@_XFAIL_THD_BATCH
 @pytest.mark.parametrize("form", ["legacy_offsets", "tokens"])
 @pytest.mark.parametrize("d", [128, 192])
 def test_ragged_prefill_batch_of_two(form, d):
     """FlashInfer's main prefill path: b > 1 ragged Q/K/V/O with packed stats."""
-    _accept_means_run(_Case([68, 87], [400, 512], d=d, tokens_form=form == "tokens"))
+    _accept_means_run(_Case([68, 87], [400, 512], s_q_max=128, s_kv_max=512, d=d, tokens_form=form == "tokens"))
+
+
+@_XFAIL_THD_BATCH
+@pytest.mark.parametrize("form", ["legacy_offsets", "tokens"])
+def test_ragged_prefill_batch_of_two_padded_lse(form):
+    """b > 1 with FlashInfer's padded (b, s_max, h) LSE buffer and no stats offsets: valid rows match."""
+    _accept_means_run(_Case([68, 87], [400, 512], s_q_max=128, s_kv_max=512, tokens_form=form == "tokens", padded_lse=True), padded_rows_too=False)
 
 
 @pytest.mark.parametrize("form", ["legacy_offsets", "tokens"])
 def test_ragged_prefill_single_sequence(form):
     """b == 1 (the form frost's THD path serves today): O and packed LSE must match the backend."""
-    _accept_means_run(_Case([68], [400], tokens_form=form == "tokens"))
+    _accept_means_run(_Case([68], [400], s_q_max=87, s_kv_max=512, tokens_form=form == "tokens"))
+
+
+_HEAD_SHAPES = [pytest.param(128, 128, True, id="d128_causal"), pytest.param(192, 128, False, id="d192_128_dense")]
+
+
+@pytest.mark.parametrize("form", ["legacy_offsets", "tokens"])
+@pytest.mark.parametrize("d, d_v, causal", _HEAD_SHAPES)
+def test_ragged_prefill_single_sequence_padded_lse_valid_rows(form, d, d_v, causal):
+    """b == 1, padded LSE buffer: the valid rows match the backend."""
+    _accept_means_run(
+        _Case([68], [400], s_q_max=87, s_kv_max=512, d=d, d_v=d_v, causal=causal, tokens_form=form == "tokens", padded_lse=True), padded_rows_too=False
+    )
+
+
+@_XFAIL_PADDED_LSE
+@pytest.mark.parametrize("form", ["legacy_offsets", "tokens"])
+@pytest.mark.parametrize("d, d_v, causal", _HEAD_SHAPES)
+def test_ragged_prefill_single_sequence_padded_lse_rows(form, d, d_v, causal):
+    """b == 1, padded LSE buffer: the rows past the sequence length hold the backend's -inf."""
+    _accept_means_run(_Case([68], [400], s_q_max=87, s_kv_max=512, d=d, d_v=d_v, causal=causal, tokens_form=form == "tokens", padded_lse=True))

--- a/test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py
+++ b/test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py
@@ -189,10 +189,7 @@ class _Case:
             g.check_support()
         except (NotImplementedError, cudnn.cudnnGraphNotSupportedError) as exc:
             return ("declined", "check_support", str(exc))
-        try:
-            g.build_plans()
-        except NotImplementedError as exc:
-            return ("declined", "build_plans", str(exc))
+        g.build_plans()  # accepted above: a failure from here on is the finding, not a decline
         out = torch.empty_like(self.q)  # packed (T, h, d)
         lse = torch.empty(self.t_q, self.h_q, device="cuda", dtype=torch.float32)  # packed (T, h) stats
         ws = torch.empty(max(g.get_workspace_size(), 1), dtype=torch.uint8, device="cuda")

--- a/test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py
+++ b/test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py
@@ -120,7 +120,7 @@ class _Case:
             lq.set_uid(SEQ_Q_UID)
             lkv.set_uid(SEQ_KV_UID)
             seq_kwargs = dict(seq_len_q=lq, seq_len_kv=lkv)
-        O, Stats = g.sdpa(
+        out_t, stats_t = g.sdpa(
             name="sdpa",
             q=q,
             k=k,
@@ -134,15 +134,15 @@ class _Case:
         )
         ro = g.tensor_like(self.cu_q, name="ragged_o")
         ro.set_uid(RAGGED_O_UID)
-        O.set_ragged_offset(ro)
+        out_t.set_ragged_offset(ro)
         rs = g.tensor_like(self.cu_q, name="ragged_stats")
         rs.set_uid(RAGGED_STATS_UID)
-        Stats.set_ragged_offset(rs)
+        stats_t.set_ragged_offset(rs)
         if self.tokens_form:
-            O.set_ragged_offset_multiplier(h_q * d)
-            Stats.set_ragged_offset_multiplier(h_q)
-        O.set_uid(O_UID).set_output(True).set_dim([b, h_q, s_q, d]).set_stride([s_q * d * h_q, d, d * h_q, 1]).set_data_type(dt)
-        Stats.set_uid(STATS_UID).set_output(True).set_data_type(cudnn.data_type.FLOAT).set_dim([b, h_q, s_q, 1]).set_stride([s_q * h_q, 1, h_q, 1])
+            out_t.set_ragged_offset_multiplier(h_q * d)
+            stats_t.set_ragged_offset_multiplier(h_q)
+        out_t.set_uid(O_UID).set_output(True).set_dim([b, h_q, s_q, d]).set_stride([s_q * d * h_q, d, d * h_q, 1]).set_data_type(dt)
+        stats_t.set_uid(STATS_UID).set_output(True).set_data_type(cudnn.data_type.FLOAT).set_dim([b, h_q, s_q, 1]).set_stride([s_q * h_q, 1, h_q, 1])
         for t, uid in ((q, Q_UID), (k, K_UID), (v, V_UID)):
             t.set_uid(uid)
         g.validate()

--- a/test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py
+++ b/test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""FlashInfer-shaped SDPA prefill graphs under the frost opt-in.
+
+FlashInfer (flashinfer/cudnn/prefill.py) declares its ragged prefill as a dense
+``(b, h, s_max, d)`` graph whose Q/O batch stride is ONE TOKEN (``h * d``,
+equal to the sequence stride) with per-tensor ragged offsets, packed
+``(T, h, d)`` buffers, padded ``(b, s_max, h)`` LSE, per-batch lengths as
+``(b, 1, 1, 1)`` int32 device tensors and a bottom-right causal mask. Two
+forms exist: the legacy element-unit offsets, and the token-unit direct form
+(``cu_seq_len_q/kv`` + ``set_ragged_offset_multiplier``, cuDNN >= 9.24).
+
+Contract under test for the frost plan: accepted at check_support => builds,
+runs, and O / valid LSE rows match the cuDNN backend plan. A decline is xfail
+with the reason (today: the THD stride-order check at b > 1). Known contract
+gaps carry ``xfail(strict=True)`` so a fix flips them loud.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+import cudnn
+from cudnn.engines import is_python_engine
+from frost_test_utils import requires_dsl, requires_pre_rubin_blackwell
+
+pytestmark = [pytest.mark.L0, requires_pre_rubin_blackwell, requires_dsl]
+
+# flashinfer/cudnn/prefill.py UIDs, kept identical.
+Q_UID, K_UID, V_UID, O_UID, STATS_UID = 0, 1, 2, 3, 4
+RAGGED_Q_UID, RAGGED_K_UID, RAGGED_V_UID, RAGGED_O_UID, RAGGED_STATS_UID = 10, 11, 12, 13, 14
+SEQ_Q_UID, SEQ_KV_UID = 20, 21
+FROST_PREFIX = "sdpa_fwd_prefill_"
+
+
+def _plan_indices(g):
+    frost = backend = None
+    for i in range(g.get_execution_plan_count()):
+        name = g.get_plan_name_at_index(i)
+        engine_id, _ = g.get_engine_and_knobs_at_index(i)
+        if name.startswith(FROST_PREFIX) and frost is None:
+            frost = i
+        elif backend is None and not is_python_engine(engine_id) and name != "backend_heuristics":
+            backend = i
+    return frost, backend
+
+
+def _frost_decline_reasons(g) -> str:
+    """Why every offered frost SDPA-forward row declined ``g`` (engine name: reason)."""
+    from cudnn.engines import manifest
+
+    fam = next(f for f in manifest.MANIFEST if f.name == "frost_sdpa_fwd")
+    reasons = []
+    for name, engine_id in fam.offered_ids().items():
+        engine = manifest.engine_for_id(engine_id)
+        if engine is None:
+            continue
+        reason = engine._decline_reason(g, None)
+        if reason is not None and "requires SM" not in reason:  # rows for other archs are not news
+            reasons.append(f"{name}: {reason}")
+    return "; ".join(reasons) or "no frost row offered on this device"
+
+
+class _Case:
+    """One FlashInfer prefill call: lengths, packed buffers, and the graph it builds."""
+
+    def __init__(self, lens_q, lens_kv, *, h_q=8, h_kv=4, d=128, causal=True, tokens_form=False, dtype=torch.bfloat16):
+        torch.manual_seed(0)
+        dev = torch.device("cuda")
+        self.b, self.h_q, self.h_kv, self.d, self.causal, self.tokens_form = len(lens_q), h_q, h_kv, d, causal, tokens_form
+        self.lens_q = torch.tensor(lens_q, dtype=torch.int32, device=dev)
+        self.lens_kv = torch.tensor(lens_kv, dtype=torch.int32, device=dev)
+        self.s_q, self.s_kv = max(lens_q), max(lens_kv)
+        zero = torch.zeros(1, dtype=torch.int32, device=dev)
+        self.cu_q = torch.cat([zero, torch.cumsum(self.lens_q, 0).int()])
+        self.cu_kv = torch.cat([zero, torch.cumsum(self.lens_kv, 0).int()])
+        t_q, t_kv = int(self.cu_q[-1]), int(self.cu_kv[-1])
+        self.q = torch.randn(t_q, h_q, d, device=dev, dtype=dtype)
+        self.k = torch.randn(t_kv, h_kv, d, device=dev, dtype=dtype)
+        self.v = torch.randn(t_kv, h_kv, d, device=dev, dtype=dtype)
+        self.scale = 1.0 / math.sqrt(d)
+        self.dtype = dtype
+        self.t_q = t_q
+
+    def build(self, handle):
+        b, h_q, h_kv, d, s_q, s_kv = self.b, self.h_q, self.h_kv, self.d, self.s_q, self.s_kv
+        g = cudnn.pygraph(
+            handle=handle, io_data_type=cudnn.data_type.BFLOAT16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT
+        )
+        dt = cudnn.datatypes._torch_to_cudnn_data_type(self.dtype)
+        s_stride, h_stride, d_stride = self.q.stride()
+        # Q: batch stride == one token (h*d) == the s stride; ragged offsets say where each batch starts.
+        q = g.tensor(name="q", dim=(b, h_q, s_q, d), stride=(h_q * d, h_stride, s_stride, d_stride), data_type=dt)
+        k = g.tensor(name="k", dim=(b, h_kv, s_kv, d), stride=(h_kv * d * s_kv, d, h_kv * d, 1), data_type=dt)
+        v = g.tensor(name="v", dim=(b, h_kv, s_kv, d), stride=(h_kv * d * s_kv, d, h_kv * d, 1), data_type=dt)
+        rq = g.tensor_like(self.cu_q, name="ragged_q")
+        rk = g.tensor_like(self.cu_kv, name="ragged_k")
+        rv = g.tensor_like(self.cu_kv, name="ragged_v")
+        for t, uid in ((rq, RAGGED_Q_UID), (rk, RAGGED_K_UID), (rv, RAGGED_V_UID)):
+            t.set_uid(uid)
+        q.set_ragged_offset(rq)
+        k.set_ragged_offset(rk)
+        v.set_ragged_offset(rv)
+        if self.tokens_form:
+            q.set_ragged_offset_multiplier(h_q * d)
+            k.set_ragged_offset_multiplier(h_kv * d)
+            v.set_ragged_offset_multiplier(h_kv * d)
+            cu_q = g.tensor_like(self.cu_q, name="cu_seq_lens_q")
+            cu_kv = g.tensor_like(self.cu_kv, name="cu_seq_lens_kv")
+            cu_q.set_uid(SEQ_Q_UID)
+            cu_kv.set_uid(SEQ_KV_UID)
+            seq_kwargs = dict(cu_seq_len_q=cu_q, cu_seq_len_kv=cu_kv, implementation=cudnn.attention_implementation.UNIFIED)
+        else:
+            lq = g.tensor_like(self.lens_q.view(b, 1, 1, 1), name="actual_seq_lens_q")
+            lkv = g.tensor_like(self.lens_kv.view(b, 1, 1, 1), name="actual_seq_lens_kv")
+            lq.set_uid(SEQ_Q_UID)
+            lkv.set_uid(SEQ_KV_UID)
+            seq_kwargs = dict(seq_len_q=lq, seq_len_kv=lkv)
+        O, Stats = g.sdpa(
+            name="sdpa",
+            q=q,
+            k=k,
+            v=v,
+            **seq_kwargs,
+            use_padding_mask=True,
+            attn_scale=self.scale,
+            generate_stats=True,
+            use_causal_mask_bottom_right=self.causal,
+            compute_data_type=cudnn.data_type.FLOAT,
+        )
+        ro = g.tensor_like(self.cu_q, name="ragged_o")
+        ro.set_uid(RAGGED_O_UID)
+        O.set_ragged_offset(ro)
+        rs = g.tensor_like(self.cu_q, name="ragged_stats")
+        rs.set_uid(RAGGED_STATS_UID)
+        Stats.set_ragged_offset(rs)
+        if self.tokens_form:
+            O.set_ragged_offset_multiplier(h_q * d)
+            Stats.set_ragged_offset_multiplier(h_q)
+        O.set_uid(O_UID).set_output(True).set_dim([b, h_q, s_q, d]).set_stride([s_q * d * h_q, d, d * h_q, 1]).set_data_type(dt)
+        Stats.set_uid(STATS_UID).set_output(True).set_data_type(cudnn.data_type.FLOAT).set_dim([b, h_q, s_q, 1]).set_stride([s_q * h_q, 1, h_q, 1])
+        for t, uid in ((q, Q_UID), (k, K_UID), (v, V_UID)):
+            t.set_uid(uid)
+        g.validate()
+        g.build_operation_graph()
+        return g
+
+    def pack(self, out, lse):
+        b, h_q, h_kv, d = self.b, self.h_q, self.h_kv, self.d
+        if self.tokens_form:
+            offs_q, offs_kv, offs_o, offs_s = self.cu_q, self.cu_kv, self.cu_q, self.cu_q
+        else:  # legacy element-unit offsets
+            offs_q, offs_kv, offs_o, offs_s = self.cu_q * (h_q * d), self.cu_kv * (h_kv * d), self.cu_q * (h_q * d), self.cu_q * h_q
+        pack = {
+            Q_UID: self.q,
+            K_UID: self.k,
+            V_UID: self.v,
+            O_UID: out,
+            STATS_UID: lse,
+            RAGGED_Q_UID: offs_q,
+            RAGGED_K_UID: offs_kv,
+            RAGGED_V_UID: offs_kv,
+            RAGGED_O_UID: offs_o,
+            RAGGED_STATS_UID: offs_s,
+        }
+        if self.tokens_form:
+            pack[SEQ_Q_UID], pack[SEQ_KV_UID] = self.cu_q, self.cu_kv
+        else:
+            pack[SEQ_Q_UID], pack[SEQ_KV_UID] = self.lens_q.view(b, 1, 1, 1), self.lens_kv.view(b, 1, 1, 1)
+        return pack
+
+    def run(self, *, use_frost: bool):
+        handle = cudnn.create_handle()
+        g = self.build(handle)
+        g.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
+        frost, backend = _plan_indices(g)
+        if use_frost and frost is None:
+            # The family heuristics list only rows whose capability check admits
+            # the graph, so "not listed" IS the decline; ask the rows why.
+            return ("declined", "recommend", _frost_decline_reasons(g))
+        idx = frost if use_frost else backend
+        assert idx is not None, f"no backend plan; plans={[g.get_plan_name_at_index(i) for i in range(g.get_execution_plan_count())]}"
+        g.select_plan(idx)
+        try:
+            g.check_support()
+        except (NotImplementedError, cudnn.cudnnGraphNotSupportedError) as exc:
+            return ("declined", "check_support", str(exc))
+        try:
+            g.build_plans()
+        except NotImplementedError as exc:
+            return ("declined", "build_plans", str(exc))
+        out = torch.empty_like(self.q)  # packed (T, h, d)
+        lse = torch.empty(self.t_q, self.h_q, device="cuda", dtype=torch.float32)  # packed (T, h) stats
+        ws = torch.empty(max(g.get_workspace_size(), 1), dtype=torch.uint8, device="cuda")
+        g.execute(self.pack(out, lse), ws, handle=handle)
+        torch.cuda.synchronize()
+        return ("ok", out, lse)
+
+
+def _accept_means_run(case: _Case):
+    ref = case.run(use_frost=False)
+    assert ref[0] == "ok", f"the cuDNN backend itself declined this FlashInfer graph: {ref}"
+    got = case.run(use_frost=True)
+    if got[0] == "declined":
+        pytest.xfail(f"frost declined at {got[1]}: {got[2][:220]}")
+    torch.testing.assert_close(got[1].float(), ref[1].float(), atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(got[2], ref[2], atol=2e-3, rtol=2e-3)
+
+
+@pytest.mark.parametrize("form", ["legacy_offsets", "tokens"])
+@pytest.mark.parametrize("d", [128, 192])
+def test_ragged_prefill_batch_of_two(form, d):
+    """FlashInfer's main prefill path: b > 1 ragged Q/K/V/O with packed stats."""
+    _accept_means_run(_Case([68, 87], [400, 512], d=d, tokens_form=form == "tokens"))
+
+
+@pytest.mark.parametrize("form", ["legacy_offsets", "tokens"])
+def test_ragged_prefill_single_sequence(form):
+    """b == 1 (the form frost's THD path serves today): O and packed LSE must match the backend."""
+    _accept_means_run(_Case([68], [400], tokens_form=form == "tokens"))

--- a/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
+++ b/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
@@ -1515,3 +1515,20 @@ def test_paged_split_kv_is_proposed_on_a_decode_launch(monkeypatch):
     facts = _facts(g)
     knob_sets = _knob_sets(spec, facts)
     assert any(k.split_kv and k.split_kv > 1 for k in knob_sets), knob_sets
+
+
+def test_packed_layout_ignores_the_batch_stride_a_ragged_tensor_never_reads():
+    """FlashInfer declares its packed THD Q/O with the batch stride equal to the
+    token stride (h * d): not BSHD-physical over all four axes, but every
+    sequence base comes from the ragged offsets, so only the (H, S, D) order
+    the THD lowering addresses has to hold."""
+    from cudnn.sdpa.graph_analyzer import bshd_layout_ok, packed_layout_ok
+
+    b, h, s, d = 2, 8, 87, 128
+    flashinfer_q = ((b, h, s, d), (h * d, d, h * d, 1))
+    assert not bshd_layout_ok(*flashinfer_q) and packed_layout_ok(*flashinfer_q)
+    dense_bshd = ((b, h, s, d), (s * h * d, d, h * d, 1))
+    assert bshd_layout_ok(*dense_bshd) and packed_layout_ok(*dense_bshd)
+    bhsd = ((b, h, s, d), (h * s * d, s * d, d, 1))  # heads outside tokens: not the packed order
+    assert not packed_layout_ok(*bhsd)
+    assert packed_layout_ok((1, h, s, d), (h * d, d, h * d, 1))  # b == 1 wildcards as before

--- a/test/python/test_variant_pack_normalization.py
+++ b/test/python/test_variant_pack_normalization.py
@@ -255,6 +255,8 @@ def test_storage_geometry_packs_fp4_two_per_slot():
     # column-major B [1, K, N] (stride 1 on K): K halves, N's stride halves
     assert _storage_geometry([1, 256, 512], [131072, 1, 256], fp4) == ((1, 128, 512), (65536, 1, 128))
     assert _storage_geometry([1, 256, 255], [65280, 255, 1], fp4) is None  # no slot geometry spells an odd extent
+    # a singleton axis may carry stride 1 too; the packed axis is the one with the even extent above one
+    assert _storage_geometry([1, 256, 256], [1, 256, 1], fp4) == ((1, 256, 128), (1, 128, 1))
 
 
 @pytest.mark.L0

--- a/test/python/test_variant_pack_normalization.py
+++ b/test/python/test_variant_pack_normalization.py
@@ -188,3 +188,59 @@ def test_shape_overrides_reach_a_migrated_plan_as_a_pack():
     g.execute(data, ws, override_uids=[q.get_uid()], override_shapes=[[total, h, d]], override_strides=[[h * d, d, 1]])
     torch.cuda.synchronize()
     torch.testing.assert_close(data[out], plain)
+
+
+# ---------------------------------------------------------------------------
+# The declaration is the contract: a caller buffer whose own geometry disagrees
+# with the graph's but covers its bytes is described AS the declaration, the
+# way a bare address is. This is how the backend has always read a buffer
+# (pointer only), and it is what lets a 2-D matrix serve a [1, m, k] tensor or
+# a flat blob serve a reordered scale tensor on a python plan too.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.L0
+def test_a_buffer_that_disagrees_with_the_declaration_is_described_from_it():
+    g, vp, (a, b, c) = _matmul_graph()
+    A, B, C = vp.keys()
+    ws = torch.empty(max(g.get_workspace_size(), 1), dtype=torch.uint8, device="cuda")
+    two_d = {A: a.view(M, K), B: b.view(K, N), C: c}  # what FlashInfer binds
+    pack = g._normalize(g._uid_to_data(two_d), ws)
+    for t, buf in ((A, a), (B, b)):
+        i = pack.index_of(t)
+        assert list(pack.native.shape(i)) == list(t.get_dim()) and list(pack.native.stride(i)) == list(t.get_stride())
+        assert i in pack.graph_described  # an engine reads it in the graph's axis order
+        assert pack.native.pointer(i) == buf.data_ptr()
+    assert pack.index_of(C) not in pack.graph_described  # bound as declared: its own description stands
+    # ... and the backend plan runs the 2-D binding bit-identically to the 3-D one.
+    g.execute(vp, ws)
+    torch.cuda.synchronize()
+    ref = c.clone()
+    c.zero_()
+    g.execute(two_d, ws)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(c, ref)
+
+
+@pytest.mark.L0
+def test_a_buffer_too_small_for_the_declaration_keeps_its_own_description():
+    g, vp, (a, b, c) = _matmul_graph()
+    A, B, C = vp.keys()
+    ws = torch.empty(1, dtype=torch.uint8, device="cuda")
+    half = a[:, : M // 2, :]  # a strided view spanning fewer slots than [1, M, K]
+    pack = g._normalize(g._uid_to_data({A: half, B: b, C: c}), ws)
+    i = pack.index_of(A)
+    assert list(pack.native.shape(i)) == [1, M // 2, K] and i not in pack.graph_described
+
+
+@pytest.mark.L0
+def test_storage_geometry_packs_fp4_two_per_slot():
+    from cudnn._pygraph import _storage_geometry
+
+    bf16, fp4 = cudnn.data_type.BFLOAT16, cudnn.data_type.FP4_E2M1
+    assert _storage_geometry([1, 256, 256], [65536, 256, 1], bf16) == ((1, 256, 256), (65536, 256, 1))
+    # row-major A [1, M, K]: K halves, the outer strides halve with it
+    assert _storage_geometry([1, 256, 256], [65536, 256, 1], fp4) == ((1, 256, 128), (32768, 128, 1))
+    # column-major B [1, K, N] (stride 1 on K): K halves, N's stride halves
+    assert _storage_geometry([1, 256, 512], [131072, 1, 256], fp4) == ((1, 128, 512), (65536, 1, 128))
+    assert _storage_geometry([1, 256, 255], [65280, 255, 1], fp4) is None  # no slot geometry spells an odd extent

--- a/test/python/test_variant_pack_normalization.py
+++ b/test/python/test_variant_pack_normalization.py
@@ -223,6 +223,24 @@ def test_a_buffer_that_disagrees_with_the_declaration_is_described_from_it():
 
 
 @pytest.mark.L0
+def test_the_declared_extents_under_the_callers_own_strides_are_kept():
+    """A padded / transposed view of the declared tensor: the strides carry
+    information and the engine honours them (the linear-attention engines
+    serve strided inputs this way), so the slot is NOT re-described."""
+    g, vp, (a, b, c) = _matmul_graph()
+    A, B, C = vp.keys()
+    ws = torch.empty(1, dtype=torch.uint8, device="cuda")
+    padded = torch.empty(1, M, 2 * K, dtype=torch.bfloat16, device="cuda")[:, :, :K]  # declared extents, row stride 2K
+    pack = g._normalize(g._uid_to_data({A: padded, B: b, C: c}), ws)
+    i = pack.index_of(A)
+    assert list(pack.native.shape(i)) == [1, M, K] and list(pack.native.stride(i)) == [2 * M * K, 2 * K, 1]
+    assert i not in pack.graph_described
+    strided_other = torch.empty(2 * M, K, dtype=torch.bfloat16, device="cuda")[::2]  # other extents AND strided: left alone too
+    pack = g._normalize(g._uid_to_data({A: strided_other, B: b, C: c}), ws)
+    assert pack.index_of(A) not in pack.graph_described
+
+
+@pytest.mark.L0
 def test_a_buffer_too_small_for_the_declaration_keeps_its_own_description():
     g, vp, (a, b, c) = _matmul_graph()
     A, B, C = vp.keys()

--- a/test/python/test_variant_pack_normalization.py
+++ b/test/python/test_variant_pack_normalization.py
@@ -255,3 +255,17 @@ def test_storage_geometry_packs_fp4_two_per_slot():
     # column-major B [1, K, N] (stride 1 on K): K halves, N's stride halves
     assert _storage_geometry([1, 256, 512], [131072, 1, 256], fp4) == ((1, 128, 512), (65536, 1, 128))
     assert _storage_geometry([1, 256, 255], [65280, 255, 1], fp4) is None  # no slot geometry spells an odd extent
+
+
+@pytest.mark.L0
+def test_a_bare_address_for_an_fp4_tensor_is_lent_the_storage_geometry():
+    """A bare address borrows the declaration; for fp4 that is the x2 SLOT
+    geometry, so an engine's per-slot packing factor applies to it like to any
+    typed buffer (the caller guarantees the allocation covers the bytes)."""
+    g = cudnn.pygraph(io_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    a = g.tensor(name="a", dim=[1, 256, 256], stride=[65536, 256, 1], data_type=cudnn.data_type.FP4_E2M1)
+    b = g.tensor(name="b", dim=[1, 256, 512], stride=[131072, 1, 256], data_type=cudnn.data_type.FP4_E2M1)
+    _, ta = g._describe(0x1000, a.get_uid())
+    _, tb = g._describe(0x2000, b.get_uid())
+    assert (tuple(ta.dim), tuple(ta.stride)) == ((1, 256, 128), (32768, 128, 1))
+    assert (tuple(tb.dim), tuple(tb.stride)) == ((1, 128, 512), (65536, 1, 128))

--- a/test/python/test_variant_pack_normalization.py
+++ b/test/python/test_variant_pack_normalization.py
@@ -234,8 +234,19 @@ def test_a_buffer_too_small_for_the_declaration_keeps_its_own_description():
 
 
 @pytest.mark.L0
+def test_a_narrower_buffer_covering_the_slot_count_but_not_the_bytes_is_not_re_described():
+    g, vp, (a, b, c) = _matmul_graph()
+    A, B, C = vp.keys()
+    ws = torch.empty(1, dtype=torch.uint8, device="cuda")
+    as_bytes = torch.empty(a.numel(), dtype=torch.uint8, device="cuda")  # as many SLOTS as [1, M, K] bf16, half the bytes
+    pack = g._normalize(g._uid_to_data({A: as_bytes, B: b, C: c}), ws)
+    i = pack.index_of(A)
+    assert list(pack.native.shape(i)) == [a.numel()] and i not in pack.graph_described
+
+
+@pytest.mark.L0
 def test_storage_geometry_packs_fp4_two_per_slot():
-    from cudnn._pygraph import _storage_geometry
+    from cudnn.graph_types import storage_geometry as _storage_geometry
 
     bf16, fp4 = cudnn.data_type.BFLOAT16, cudnn.data_type.FP4_E2M1
     assert _storage_geometry([1, 256, 256], [65536, 256, 1], bf16) == ((1, 256, 256), (65536, 256, 1))

--- a/test/python/test_variant_pack_normalization.py
+++ b/test/python/test_variant_pack_normalization.py
@@ -223,6 +223,23 @@ def test_a_buffer_that_disagrees_with_the_declaration_is_described_from_it():
 
 
 @pytest.mark.L0
+def test_the_declared_layout_is_built_once_and_the_rule_runs_natively():
+    """The rule is on every execute's critical path (backend plans included),
+    so the declaration side is computed once per graph and the comparison is
+    one crossing per pack: the second execute reuses the first's layout."""
+    g, vp, (a, b, c) = _matmul_graph()
+    A, B, C = vp.keys()
+    ws = torch.empty(max(g.get_workspace_size(), 1), dtype=torch.uint8, device="cuda")
+    assert g._declared_layout_native is None
+    first = g._normalize(g._uid_to_data({A: a.view(M, K), B: b.view(K, N), C: c}), ws)
+    layout = g._declared_layout_native
+    assert layout is not None and len(layout) == len(first)
+    second = g._normalize(g._uid_to_data({A: a, B: b, C: c}), ws)
+    assert g._declared_layout_native is layout
+    assert set(first.graph_described) == {first.index_of(A), first.index_of(B)} and second.graph_described == ()
+
+
+@pytest.mark.L0
 def test_the_declared_extents_under_the_callers_own_strides_are_kept():
     """A padded / transposed view of the declared tensor: the strides carry
     information and the engine honours them (the linear-attention engines


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches (see [root AGENTS.md § Reviewing a PR](https://github.com/NVIDIA/cudnn-frontend/blob/develop/AGENTS.md#reviewing-a-pr-human-or-agent)) and my changes comply: the variant pack stays the ONE normalization point (no branch on the caller's object type); public signatures unchanged; eligibility change recorded in `python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md` (Rule S2); the design doc updated in the same stack.
- [x] I added GitHub labels: `cat-bugfix`, `area:frost`, `orig-nv-eng`.

## Affected area

Python graph API (`_pygraph._normalize`, the variant pack), the FROST GEMM engine's MoE call path, the FROST SDPA forward engine's THD eligibility, and the tests that gate them. (Formerly three stacked PRs — #1028 tests, #1029 operand contract, #1030 SDPA THD — folded into one so the fixes and the suite that proves them review together; the commits are kept separate.)

## Summary

**1. FlashInfer-shaped conformance suites** (`test/python/gemm/frost/test_flashinfer_shaped_gemm.py`, `test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py`). Each case re-declares one cuDNN graph exactly as FlashInfer builds it (dims, strides, dtypes, `F8_128x4` reordering, uids, ragged offsets) and binds the buffers FlashInfer binds — 2-D matrices to `[1, m, k]`, flat quantizer blobs to `[b, bs_m, bs_k]` scale tensors, 0-d scalars to `(1, 1, 1)`, packed `(T, h, d)` Q/K/V/O with a one-token batch stride, LSE both packed `(T, h)` and padded `(b, s_max, h)` — then asserts: **the frost plan serves the graph, builds, executes, and matches the cuDNN backend plan.** A decline fails (FlashInfer is the caller the suite exists for); a refusal after `check_support` fails; only the one remaining known gap is `xfail(strict=True)`. Covers `mm_bf16` (plain + override-shape), `mm_fp4` nvfp4 / mxfp4 / +alpha (plain + override-shape), `bmm_fp8`, `bmm_mxfp8`, ragged prefill b = 1 / 2 in both offset forms, d = 128 / 192 / 192-128.

**2. The graph declaration is the operand contract** (`_pygraph._normalize`, `graph_types`, `engines/base.py`). The backend reads a variant pack as pointers; a python engine that read the buffer's own shape refused what the backend ran. `_normalize` now describes a slot from the graph declaration whenever the caller's geometry disagrees with it but covers its **bytes** (what a bare address already got; recorded in `VariantPack.graph_described`); a smaller buffer keeps its own description. Declared and `override_shapes` geometries are cuDNN element units, the pack is storage slots, so fp4 geometry is converted with `storage_geometry` (two elements per slot along the unit-stride axis) — this is what made `frost_gemm` double K on an overridden fp4 operand (`kpack=2` applied to element dims; the "SFA is 2048 B but the kernel reads 4096 B" message). The frost MoE resolver takes `first_token_offset` declared `(E, 1, 1)` as a vector and permutes a graph-order B-side buffer to kernel order, comparing the declaration in storage slots.

**3. SDPA forward THD gate over (H, S, D)** (`graph_analyzer.packed_layout_ok`, `SdpaGraphFacts.packed_layout`, `fwd/engines.mismatch`, `fwd/api_dsl`). Under ragged offsets the batch stride is never read (the lowering binds the batch axis at extent 1), yet both the gate and the adapter required BSHD order over all four axes; FlashInfer declares that stride equal to the token stride, so its ragged prefill was declined at every b > 1. Relaxing it exposed that a Stats tensor **without** ragged offsets (the per-batch padded form) would be written as contiguous `(T, h)` rows at b > 1 — the second sequence's LSE into the first sequence's padding — so that form is now declined at b > 1 (the backend serves it); at b == 1 it coincides with the packed form.

**Docs**: `docs/utilities/python_graph_and_execution_backends.md` gains the operand contract, "Knobs: one public vocabulary" (#1024 / #1026 rules), "Accept means run" (this suite as the default-on gate), and the compiled-plan-cache follow-up.

## Why

Under the frost opt-in every FlashInfer cuDNN GEMM except `mm_bf16`'s override path raised at `execute`, and FlashInfer's main attention path never reached a frost plan. Nothing in the tree exercised the cuDNN caller contract with real caller shapes, so the gaps surfaced downstream. The suite is the acceptance gate for turning the opt-in rows on by default; the two fixes are what it took to make it green.

Remaining strict xfail: the frost row leaves the padded LSE rows past a sequence's length unwritten where the backend writes `-inf` (b == 1, padded stats form). Also noted in the doc: the execute-time `.item()` on the dense padded-Q path.

## Related issues

- Follows #1024 / #1026. FlashInfer: flashinfer-ai/flashinfer#5133 (the token-unit path this enables), flashinfer-ai/flashinfer#5163. Supersedes #1029 and #1030 (closed, folded in).

## API and compatibility impact

- No public signature changes. A python-engine plan now sees a buffer that disagrees with its declaration AS the declaration (the backend's behaviour); `override_shapes` on an fp4 tensor with an odd unit-stride extent raises `ValueError`. `VariantPack.graph_described` includes re-described slots. `SdpaGraphFacts` gains `packed_layout`.
- Eligibility: the sm100 SDPA forward row serves packed THD at b > 1; the per-batch padded Stats form under THD at b > 1 is declined (it was accepted and mis-addressed before).
- Supported GPU / cuDNN / CUDA / Python versions: unchanged.

## Testing

Blackwell SM100, cuDNN 9.25.1, `_compiled_module` built from develop, `nvidia-cutlass-dsl` 4.7.1:

```
cd test/python
python -m pytest -q -m L0 gemm/frost/test_flashinfer_shaped_gemm.py sdpa/frost/test_flashinfer_shaped_sdpa.py \
  test_variant_pack_normalization.py test_dispatch.py gemm/frost/test_frontend_integration.py \
  gemm/frost/test_public_execute_flavors.py gemm/frost/test_execute_recipe.py gemm/frost/test_stream_respect.py \
  gemm/frost/test_gemm_knobs.py sdpa/frost/test_knob_vocabulary_frost.py \
  sdpa/frost/test_sdpa_graph_analyzer.py sdpa/frost/test_sdpa_fwd_heuristics.py
# every FlashInfer-shaped GEMM and SDPA case runs on the frost plan and matches the backend;
# 4 xfailed = the padded-LSE tail rows
```

New unit tests: declaration-first re-description and its byte-coverage rule, `storage_geometry` fp4 cases, `_kernel_order` in storage slots, `packed_layout_ok`. Broad regression (every frost GEMM suite incl. MoE and block-scale, linear attention, `test_mhas_v2.py`) and the SM100 SDPA forward THD / paged / fp8 / split-KV + backward THD suites:

| suite (SM100, shared GPU) | result |
|---|---|
| frost GEMM: `test_matmul`, `test_block_scale_matmul`, `test_moe_grouped_matmul_fwd`, `test_moe_grouped_block_scale_matmul_fwd`, `test_matmul_epilogue_fusion`, `test_multi_gemm` | 0 failures (run aborted by the wall-clock cap only after these completed, inside `linear_attention`) |
| SDPA: `test_sdpa_fwd_dsl_sm100`, `test_sdpa_fwd_paged_sm100`, `test_sdpa_fwd_fp8_sm100`, `test_sdpa_fwd_split_kv_sm100`, `test_sdpa_bwd_thd_sm100` | 889 passed, 0 failed (29 min). `test_paged_adapter_cuda_graph_replay_no_host_sync` deselected: fails identically on the develop baseline ("called a synchronizing CUDA operation" at `capture_begin`, then an unusable context) |
| `linear_attention` (every 25th test) + `test_mhas_v2.py` (every 10th) — the full suites need hours here | 350 passed, 225 skipped, 1 failed: `test_sdpa_random_fwd_L0[test101]`, which fails identically on the develop baseline ("disallowed mismatches") |

The sample found one real regression of an earlier revision of this PR, `test_la.py::test_fwd_innermost_contiguous_inputs[gdp-frost]` (a padded view of the declared tensor was re-read as contiguous); the rule was narrowed to dense runs of *other* extents (commit "re-describe only a dense run of other extents") and the whole `test_fwd_innermost_contiguous_inputs` group passes.

`pre-commit run` clean.

## Host latency of the operand rule (added after the first review round)

The declaration rule runs inside `_normalize`, i.e. on every `execute()`, backend plans included. Measured before wiring it natively, it was a regression; the last commit moves it to build time + one native crossing per pack (`DeclaredLayout` built once per graph, `VariantPackNative.describe_from`). Host enqueue time per `execute()` on SM100, 128×256×128 bf16 matmul, 2000 calls after warm-up, two repetitions agree within 0.5 µs:

| tree | plan | buffers bound | µs / execute |
|---|---|---|---|
| develop | frost_gemm | declared 3-D | 21.9 |
| #1028 before this commit | frost_gemm | declared 3-D | 29.7 |
| #1028 before this commit | frost_gemm | FlashInfer-shaped 2-D | 39.5 |
| **#1028 now** | frost_gemm | declared 3-D | **22.0** |
| **#1028 now** | frost_gemm | FlashInfer-shaped 2-D | **22.8** |
| develop | backend | declared 3-D | 11.7 |
| #1028 before this commit | backend | declared 3-D | 19.4 |
| #1028 before this commit | backend | FlashInfer-shaped 2-D | 29.4 |
| **#1028 now** | backend | declared 3-D | **12.0** |
| **#1028 now** | backend | FlashInfer-shaped 2-D | **12.1** |

(The 2-D rows cannot run on develop: that binding is what this PR makes the frost plan accept.) The MoE resolver's per-call declaration reads are memoized per compiled plan the same way. The design doc's operand-contract section records the numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>note to self: claude::61d24ed2-7c90-4a97-9cbb-b91ae18136fd — "PR #5133 auto backend: why not cuDNN" · cwd /home/scratch.yanxu_libs/flashinfer · workspace /home/scratch.yanxu_libs/cudnn_frontend-wt-fishape</sub>

