### PR TITLE
sdpa fwd: serve FlashInfer's packed THD at b > 1 (gate on the (H, S, D) order the packed path reads)

### DIFF
--- a/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
+++ b/python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md
@@ -70,7 +70,7 @@ MMA as d=512.
 | **Layout** | | | | | | |
 | BSHD | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ᵇ ᵍ |
 | Arbitrary dense B/H/S stride order (`dense_flex`) | f16 only | f16 only | f16 only | ✅ | f16 only | ✅ᵇ ᶜ · ❌ᵍ |
-| THD / ragged (packed varlen) | f16 only⁹ | ✅ | f16 only³ | ✅ | f16 + fp8³ | ✅ᵇ ʰ · ❌ᵍ |
+| THD / ragged (packed varlen)ᵏ | f16 only⁹ | ✅ | f16 only³ | ✅ | f16 + fp8³ | ✅ᵇ ʰ · ❌ᵍ |
 | `cu_seq_len_q/kv` prefix sums (THD only) | f16 only⁹ | ✅ | ✅ | ✅ | ✅ | ❌ʲ |
 | **Masks / features** | | | | | | |
 | Causal (top-left) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ᵇ ᵈ ᵍ |
@@ -540,3 +540,15 @@ feature-free d=64 graph.
 | Bias forward | SM100, SM107, SM120 |
 | Dropout, ALiBi, `block_mask`, `score_mod` | every arch, both passes |
 | Paged KV cache | every arch except SM100/SM103 f16/bf16 d128 forward (see ᵖ); fp8/mxfp8 pools, sink, THD, packed block tables everywhere |
+
+ᵏ **THD / ragged forward layout.** Q/K/V/O must be BSHD-ordered over **(H, S, D)**
+only — head dim innermost, then heads, then tokens (`graph_analyzer.packed_layout_ok`).
+The batch stride is not gated: every sequence base comes from the ragged offsets and
+the lowering binds the batch axis at extent 1, so its declared value is never read.
+FlashInfer declares it equal to the token stride (`h * d`), which the previous
+all-four-axes check refused at `b > 1`. Stats under THD are written as packed
+`(T, H)` rows (or head-major `(1, QH, head_stride)`): a Stats tensor **without**
+ragged offsets is the per-batch padded `[b, h, s_max, 1]` form and is declined at
+`b > 1` (the packed path has no per-sequence stats base); at `b == 1` it coincides
+with the packed form, and the rows past the sequence length stay unwritten where the
+cuDNN backend writes `-inf`.

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -1100,11 +1100,14 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         # accepted. No TMA stride/alignment gate is needed here: the TMA
         # descriptors are built over the normalized compact buffers, never
         # over the caller's strides.
-        # THD (ragged) keeps the strict BSHD stride order: the varlen path
-        # rebuilds packed [1,T,H,D] views and only that packing is defined.
-        from cudnn.sdpa.graph_analyzer import dense_layout_ok
+        # THD (ragged) keeps the BSHD order over (H, S, D): the varlen path
+        # rebuilds packed [1,T,H,D] views from the token, head and element
+        # strides, and only that packing is defined. The batch stride is
+        # never read -- every sequence base comes from the ragged offsets and
+        # the batch axis is bound at extent 1 -- so it is not gated (same rule
+        # as graph_analyzer.packed_layout_ok, which the engine gate applies).
+        from cudnn.sdpa.graph_analyzer import dense_layout_ok, packed_layout_ok
 
-        _REQ = (3, 1, 2, 0)
         for desc_name in ["q_desc", "k_desc", "v_desc", "o_desc"]:
             d = getattr(self, desc_name)
             self._value_error_if(
@@ -1114,11 +1117,9 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             _shape, _stride = d.shape, d.stride
             # Paged pools are dense tensors even under THD (only Q/O are packed).
             if self.thd and not (self.paged and desc_name in ("k_desc", "v_desc")):
-                _act = tuple(ax for ax in d.stride_order if _shape[ax] != 1)
-                _exp = tuple(ax for ax in _REQ if _shape[ax] != 1)
                 self._value_error_if(
-                    _act != _exp,
-                    f"{d.name} must have d, h, s, b stride order (3, 1, 2, 0) for THD (size-1 dims wildcarded); got {d.stride_order} shape {_shape}",
+                    not packed_layout_ok(tuple(_shape), tuple(_stride)),
+                    f"{d.name} must have d, h, s stride order (head dim innermost, then heads, then tokens) for THD; got stride {tuple(_stride)} shape {tuple(_shape)}",
                 )
             else:
                 self._value_error_if(

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -532,10 +532,12 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
     if not facts.uniform_dtype:
         return "K/V dtypes must match Q" if (facts.is_mxfp8 or facts.is_fp8) else "K/V/O dtypes must match Q"
     if facts.thd:
-        # Ragged packing is BSHD-order by construction; the relaxation is
-        # dense-only (the THD lowering rebuilds packed [1,T,H,D] views).
-        if not facts.bshd_layout:
-            return "THD (ragged) Q/K/V/O must be BSHD-physical (stride order 3,1,2,0)"
+        # The THD lowering rebuilds packed [1, T, H, D] views from the token,
+        # head and element strides; the batch stride is never read (every
+        # sequence base comes from the ragged offsets), so it is not gated --
+        # FlashInfer declares it equal to the token stride.
+        if not facts.packed_layout:
+            return "THD (ragged) Q/K/V/O must be BSHD-physical over (H, S, D): head dim innermost, then heads, then tokens"
     elif "dense_flex" in capabilities.layouts:
         if not facts.dense_layout:
             return (
@@ -626,6 +628,12 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
     if facts.padded and facts.wants_stats and not facts.thd and not (capabilities.padded_stats or supports_dense_seq_q_trim(capabilities, facts)):
         return "padding mask with generate_stats is not supported yet (per-batch seq_len_q LSE trim not plumbed)"
 
+    if facts.thd and facts.wants_stats and facts.stats_t is not None and facts.b > 1 and getattr(facts.stats_t, "ragged_offset", None) is None:
+        # A Stats tensor with no ragged offsets is the per-batch padded form,
+        # rows at b * s_max; the packed path writes token rows contiguously and
+        # has no per-sequence stats base to place them at. At b == 1 the two
+        # coincide (the tail rows past the length stay unwritten).
+        return "THD Stats without ragged offsets is addressed per batch ([b, h, s_max, 1]); the packed path writes packed (T, h) rows -- bind ragged stats offsets, or b == 1"
     if facts.stats_t is not None and not facts.thd:
         if facts.stats_t.get_data_type() != cudnn.data_type.FLOAT:
             return f"stats must be fp32; got {facts.stats_t.get_data_type()}"

--- a/python/cudnn/sdpa/graph_analyzer.py
+++ b/python/cudnn/sdpa/graph_analyzer.py
@@ -132,6 +132,19 @@ def bshd_layout_ok(dim: tuple, stride: tuple) -> bool:
     return act == exp
 
 
+def packed_layout_ok(dim: tuple, stride: tuple) -> bool:
+    """BSHD order over (H, S, D) only, for a ragged (THD) tensor. With ragged
+    offsets every sequence's base comes from the offset table and the batch
+    axis is never stepped (the THD lowering binds it at extent 1), so its
+    declared stride carries no information -- FlashInfer declares it equal to
+    the token stride. The per-token layout the kernels address natively is
+    what has to hold: D innermost, then H, then S."""
+    order = tuple(ax for ax in _stride_order(dim, stride) if ax != 0)
+    act = tuple(ax for ax in order if dim[ax] != 1)
+    exp = tuple(ax for ax in _REQ_STRIDE_ORDER if ax != 0 and dim[ax] != 1)
+    return act == exp
+
+
 def dense_layout_ok(dim: tuple, stride: tuple) -> bool:
     """Relaxed DENSE layout soundness for a rank-4 (B, H, S, D) tensor: the
     real requirement of the SM100 DSL lowering, which normalizes any such
@@ -197,6 +210,9 @@ class SdpaGraphFacts:
     # graphs, where ``uniform_dtype`` already covers them.
     uniform_out_dtype: bool = True
     bshd_layout: bool = True  # all of Q/K/V/O in BSHD-physical order
+    # BSHD order over (H, S, D) only -- what a ragged (THD) tensor has to
+    # satisfy, its batch stride being unread under ragged offsets (packed_layout_ok).
+    packed_layout: bool = True
     # Relaxed dense-layout soundness: every one of Q/K/V/O has the head dim
     # innermost-contiguous (stride 1) with non-broadcast, non-overlapping
     # strides — any B/H/S order, padded strides allowed (see dense_layout_ok).
@@ -564,6 +580,7 @@ def _extract_facts(rec: dict) -> SdpaGraphFacts:
     # about the ragged Q/O only.
     _bshd_ports = [(q_dim, q_stride), (o_dim, o_stride)] if paged else _layout_ports
     bshd = all(bshd_layout_ok(d, s) for d, s in _bshd_ports)
+    packed = all(packed_layout_ok(d, s) for d, s in _bshd_ports)
     dense_layout = all(dense_layout_ok(d, s) for d, s in _layout_ports)
 
     # descale_q/k/v are the block-scale SF tensors for MXFP8, or scalar per-tensor
@@ -699,6 +716,7 @@ def _extract_facts(rec: dict) -> SdpaGraphFacts:
         uniform_dtype=uniform,
         uniform_out_dtype=uniform_out,
         bshd_layout=bshd,
+        packed_layout=packed,
         dense_layout=dense_layout,
         port_layouts=(tuple((name, dims[name], strides[name]) for name, _ in rank4_ports) if is_backward else ()),
         is_mxfp8=is_mxfp8,

--- a/test/python/gemm/frost/test_flashinfer_shaped_gemm.py
+++ b/test/python/gemm/frost/test_flashinfer_shaped_gemm.py
@@ -1,0 +1,410 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""FlashInfer-shaped GEMM graphs under the frost opt-in: accept means run.
+
+FlashInfer (flashinfer/gemm/gemm_base.py) builds every cuDNN GEMM graph the
+same way: it derives rank-3 dims/strides from its torch operands by hand
+(``[batch, m, k]`` for A, ``[batch, k, n]`` with a unit stride on k for B,
+``[batch, bs_m, bs_k]`` F8_128x4-reordered block scales), declares the graph
+with those, and then binds the ORIGINAL buffers -- 2-D matrices, 1-D scale
+blobs, 0-d scalars -- by uid. The cuDNN backend reads only the pointer, so it
+never notices; a python engine that reads the buffer's own shape does.
+
+Each case here re-declares one FlashInfer graph exactly (dims, strides,
+dtypes, reordering, uids) and binds the buffers FlashInfer binds. The
+contract under test, for the frost plan:
+
+    check_support() accepted  =>  build_plans() + execute() succeed and the
+                                  result matches the cuDNN backend plan
+
+A decline at check_support is a routing decision and is reported as xfail
+with the reason; a refusal AFTER acceptance is the defect this file exists to
+catch. Cases known to fail today carry ``xfail(strict=True)`` with the owner
+finding, so a fix flips them loud.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import cudnn
+from cudnn.engines import is_python_engine
+from gemm_test_utils import requires_sm100
+
+pytestmark = [pytest.mark.L0, requires_sm100]
+
+# Known gaps, strict so a fix flips them loud. Both are one defect in
+# gemm/frost/recipe.py: frost_gemm reads the BUFFER's own shape (rank, units)
+# where the cuDNN contract is the graph declaration plus override_shapes.
+_XFAIL_BUFFER_RANK = pytest.mark.xfail(
+    strict=True, reason="frost_gemm: refuses after check_support -- reads the buffer's rank instead of the declared [batch, ...] dims"
+)
+_XFAIL_FP4_K_UNITS = pytest.mark.xfail(
+    strict=True, reason="frost_gemm: override_shapes are fp4 ELEMENT dims but kpack=2 is applied again -- K doubles, SF blob 'too small'"
+)
+
+# FlashInfer's uid enum (gemm_base.UIDs), kept identical so a graph diff is a graph diff.
+A_UID, B_UID, ALPHA_UID, SFA_UID, SFB_UID, A_SCALE_UID, B_SCALE_UID, BIAS_UID, O_UID = range(9)
+FROST = "frost_gemm"
+
+
+# ---------------------------------------------------------------------------
+# FlashInfer's shape math, verbatim (gemm_base._calculate_block_scale_dims,
+# _get_real_fp4_shape_from_packed_uint8, _get_bf16_3d_shape_stride).
+# ---------------------------------------------------------------------------
+
+
+def _div_up(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def _block_scale_dims(m: int, n: int, k: int, block_size: int) -> tuple[int, int, int]:
+    return _div_up(m, 128) * 128, _div_up(n, 128) * 128, _div_up(_div_up(k, block_size), 4) * 4
+
+
+def _shape3(t: torch.Tensor) -> tuple[list[int], list[int]]:
+    """FlashInfer's 2-D -> ``[1, ...]`` promotion of a matrix's shape/stride."""
+    shape, stride = list(t.shape), list(t.stride())
+    if len(shape) == 2:
+        shape.insert(0, 1)
+        stride.insert(0, t.numel())
+    return shape, stride
+
+
+def _fp4_shape3(packed: torch.Tensor) -> tuple[list[int], list[int]]:
+    """Real fp4-element dims of a packed x2 buffer (two elements per slot)."""
+    shape, stride = _shape3(packed)
+    column_major = packed.stride(-2) == 1
+    shape[-2 if column_major else -1] *= 2
+    if column_major:
+        stride[-1] *= 2
+        for i in range(len(stride) - 2):
+            stride[i] *= 2
+    else:
+        for i in range(len(stride) - 1):
+            stride[i] *= 2
+    return shape, stride
+
+
+# ---------------------------------------------------------------------------
+# Plan walk: the frost entry and the first backend entry of one graph.
+# ---------------------------------------------------------------------------
+
+
+def _plan_indices(g) -> tuple[int | None, int | None]:
+    frost = backend = None
+    for i in range(g.get_execution_plan_count()):
+        name = g.get_plan_name_at_index(i)
+        engine_id, _ = g.get_engine_and_knobs_at_index(i)
+        if name.split("[")[0] == FROST and frost is None:
+            frost = i
+        elif backend is None and not is_python_engine(engine_id) and name != "backend_heuristics":
+            backend = i
+    return frost, backend
+
+
+def _run(build, pack, *, use_frost: bool, override=None):
+    """Build one graph, pin the frost (or first backend) plan, run it.
+
+    Returns ``("ok", out)`` or ``("declined", where, reason)``; any exception
+    from execute after a successful check_support propagates -- that is the
+    contract violation."""
+    handle = cudnn.create_handle()
+    g, out_t = build(handle)
+    g.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
+    frost, backend = _plan_indices(g)
+    idx = frost if use_frost else backend
+    assert idx is not None, f"no {'frost' if use_frost else 'backend'} plan; plans={[g.get_plan_name_at_index(i) for i in range(g.get_execution_plan_count())]}"
+    g.select_plan(idx)
+    try:
+        g.check_support()
+    except (NotImplementedError, cudnn.cudnnGraphNotSupportedError) as exc:
+        return ("declined", "check_support", str(exc))
+    try:
+        g.build_plans()
+    except NotImplementedError as exc:
+        # A build-time decline is still a decline the plan walk would skip; it
+        # is recorded separately because a pinned (autotune) plan cannot skip.
+        return ("declined", "build_plans", str(exc))
+    out = out_t()
+    kwargs = {}
+    if override is not None:
+        uids, shapes, strides = override
+        kwargs = dict(override_uids=uids, override_shapes=shapes, override_strides=strides)
+        ws_bytes = g.get_workspace_size(handle, uids, shapes, strides)
+    else:
+        ws_bytes = g.get_workspace_size()
+    ws = torch.empty(max(int(ws_bytes), 1), dtype=torch.uint8, device="cuda")
+    g.execute({**pack, O_UID: out}, ws, handle=handle, **kwargs)
+    torch.cuda.synchronize()
+    return ("ok", out)
+
+
+def _accept_means_run(build, pack, *, override=None, atol=1e-1, rtol=2e-2):
+    ref = _run(build, pack, use_frost=False, override=override)
+    assert ref[0] == "ok", f"the cuDNN backend itself declined this FlashInfer graph: {ref}"
+    got = _run(build, pack, use_frost=True, override=override)  # an exception here is the finding
+    if got[0] == "declined":
+        pytest.xfail(f"frost_gemm declined at {got[1]}: {got[2][:200]}")
+    torch.testing.assert_close(got[1].float(), ref[1].float(), atol=atol, rtol=rtol)
+
+
+def _graph(handle, **kw):
+    return cudnn.pygraph(
+        handle=handle,
+        io_data_type=cudnn.data_type.FLOAT,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+        **kw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# mm_bf16: A (M, K) row-major, B (K, N) column-major (a transposed view), 2-D
+# buffers bound to a [1, ...] graph.
+# ---------------------------------------------------------------------------
+
+
+def _bf16_case(M: int, N: int, K: int, *, override_cache_m: int | None = None):
+    torch.manual_seed(0)
+    a = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(N, K, device="cuda", dtype=torch.bfloat16).t()  # (K, N), stride (1, K)
+    a_shape, a_stride = _shape3(a)
+    b_shape, b_stride = _shape3(b)
+    if override_cache_m is not None:
+        # build at cache_m, run at M (gemm_base.build_cudnn_gemm_bf16_graph_override_shape)
+        a_decl = ([1, override_cache_m, K], [override_cache_m * K, K, 1])
+        o_decl = ([1, override_cache_m, N], [override_cache_m * N, N, 1])
+    else:
+        a_decl, o_decl = (a_shape, a_stride), ([1, M, N], [M * N, N, 1])
+
+    def build(handle):
+        g = _graph(handle, is_override_shape_enabled=override_cache_m is not None)
+        ta = g.tensor(name="a", dim=a_decl[0], stride=a_decl[1], data_type=cudnn.data_type.BFLOAT16)
+        tb = g.tensor(name="b", dim=b_shape, stride=b_stride, data_type=cudnn.data_type.BFLOAT16)
+        c = g.matmul(name="matmul", A=ta, B=tb, compute_data_type=cudnn.data_type.FLOAT)
+        c.set_data_type(cudnn.data_type.FLOAT)
+        c.set_name("c_final").set_output(True).set_data_type(cudnn.data_type.BFLOAT16)
+        c.set_dim(o_decl[0]).set_stride(o_decl[1])
+        ta.set_uid(A_UID)
+        tb.set_uid(B_UID)
+        c.set_uid(O_UID)
+        g.validate()
+        g.build_operation_graph()
+        return g, lambda: torch.empty(M, N, device="cuda", dtype=torch.bfloat16)
+
+    override = None
+    if override_cache_m is not None:
+        override = ([A_UID, B_UID, O_UID], [a_shape, b_shape, [1, M, N]], [a_stride, b_stride, [M * N, N, 1]])
+    return build, {A_UID: a, B_UID: b}, override
+
+
+@_XFAIL_BUFFER_RANK
+@pytest.mark.parametrize("mnk", [(256, 512, 256), (13, 256, 128)])
+def test_mm_bf16_two_d_buffers(mnk):
+    build, pack, _ = _bf16_case(*mnk)
+    _accept_means_run(build, pack)
+
+
+def test_mm_bf16_override_shape_path():
+    build, pack, override = _bf16_case(200, 512, 256, override_cache_m=256)
+    _accept_means_run(build, pack, override=override)
+
+
+# ---------------------------------------------------------------------------
+# mm_fp4: packed x2 operands, F8_128x4 block scales bound as flat blobs.
+# ---------------------------------------------------------------------------
+
+_FP4_X2 = getattr(torch, "float4_e2m1fn_x2", None)
+
+
+def _fp4_case(M: int, N: int, K: int, *, nvfp4: bool, alpha: bool, override_cache_m: int | None = None):
+    torch.manual_seed(0)
+    block = 16 if nvfp4 else 32
+    a_u8 = torch.randint(0, 256, (M, K // 2), device="cuda", dtype=torch.uint8)
+    b_u8 = torch.randint(0, 256, (N, K // 2), device="cuda", dtype=torch.uint8).t()  # (K/2, N) column-major
+    a, b = a_u8.view(_FP4_X2), b_u8.view(_FP4_X2)
+    a_shape, a_stride = _fp4_shape3(a)  # [1, M, K]
+    b_shape, b_stride = _fp4_shape3(b)  # [1, K, N], stride [K*N, 1, K]
+    bs_m, bs_n, bs_k = _block_scale_dims(M, N, K, block)
+    # FlashInfer binds the quantizer's flat F8_128x4 blob: bs_m * bs_k scale bytes.
+    if nvfp4:
+        sfa = torch.full((bs_m * bs_k,), 1.0, device="cuda").to(torch.float8_e4m3fn)
+        sfb = torch.full((bs_n * bs_k,), 1.0, device="cuda").to(torch.float8_e4m3fn)
+        sf_type = cudnn.data_type.FP8_E4M3
+    else:
+        sfa = torch.full((bs_m * bs_k,), 127, device="cuda", dtype=torch.uint8).view(torch.float8_e8m0fnu)
+        sfb = torch.full((bs_n * bs_k,), 127, device="cuda", dtype=torch.uint8).view(torch.float8_e8m0fnu)
+        sf_type = cudnn.data_type.FP8_E8M0
+    decl_m = override_cache_m if override_cache_m is not None else M
+    d_bs_m, _, d_bs_k = _block_scale_dims(decl_m, N, K, block)
+    sfa_decl = ([1, d_bs_m, d_bs_k], [d_bs_m * d_bs_k, d_bs_k, 1])
+    sfb_decl = ([1, bs_k, bs_n], [bs_n * bs_k, 1, bs_k])
+    a_decl = ([1, decl_m, K], [decl_m * K, K, 1])
+    o_decl = ([1, decl_m, N], [decl_m * N, N, 1])
+    alpha_t = torch.tensor([0.5], device="cuda", dtype=torch.float32) if alpha else None
+
+    def build(handle):
+        g = _graph(handle, is_override_shape_enabled=override_cache_m is not None)
+        ta = g.tensor(name="a", dim=a_decl[0], stride=a_decl[1], data_type=cudnn.data_type.FP4_E2M1)
+        tb = g.tensor(name="b", dim=b_shape, stride=b_stride, data_type=cudnn.data_type.FP4_E2M1)
+        tsa = g.tensor(name="block_descale_a", dim=sfa_decl[0], stride=sfa_decl[1], data_type=sf_type, reordering_type=cudnn.tensor_reordering.F8_128x4)
+        tsb = g.tensor(name="block_descale_b", dim=sfb_decl[0], stride=sfb_decl[1], data_type=sf_type, reordering_type=cudnn.tensor_reordering.F8_128x4)
+        da = g.block_scale_dequantize(ta, tsa, block_size=[1, block], name="dequant_a")
+        da.set_data_type(cudnn.data_type.FLOAT)
+        db = g.block_scale_dequantize(tb, tsb, block_size=[block, 1], name="dequant_b")
+        db.set_data_type(cudnn.data_type.FLOAT)
+        c = g.matmul(da, db, compute_data_type=cudnn.data_type.FLOAT, name="gemm")
+        c.set_data_type(cudnn.data_type.FLOAT)
+        final = c
+        if alpha:
+            tg = g.tensor(name="global_scale", dim=(1, 1, 1), stride=(1, 1, 1), data_type=cudnn.data_type.FLOAT)
+            final = g.mul(name="scale_mul", a=c, b=tg, compute_data_type=cudnn.data_type.FLOAT)
+            tg.set_uid(ALPHA_UID)
+        final.set_name("c_final").set_output(True).set_data_type(cudnn.data_type.BFLOAT16)
+        final.set_dim(o_decl[0]).set_stride(o_decl[1])
+        ta.set_uid(A_UID)
+        tb.set_uid(B_UID)
+        tsa.set_uid(SFA_UID)
+        tsb.set_uid(SFB_UID)
+        final.set_uid(O_UID)
+        g.validate()
+        g.build_operation_graph()
+        return g, lambda: torch.empty(M, N, device="cuda", dtype=torch.bfloat16)
+
+    pack = {A_UID: a, B_UID: b, SFA_UID: sfa, SFB_UID: sfb}
+    if alpha:
+        pack[ALPHA_UID] = alpha_t.view(torch.float)
+    override = None
+    if override_cache_m is not None:
+        # gemm_base.execute_cudnn_gemm_fp4_graph_override_shape: real fp4 dims for A/B,
+        # the scale dims recomputed for the actual M, the output's 3-D dims.
+        override = (
+            [A_UID, B_UID, SFA_UID, SFB_UID, O_UID],
+            [a_shape, b_shape, [1, bs_m, bs_k], [1, bs_k, bs_n], [1, M, N]],
+            [a_stride, b_stride, [bs_m * bs_k, bs_k, 1], [bs_n * bs_k, 1, bs_k], [M * N, N, 1]],
+        )
+    return build, pack, override
+
+
+@pytest.mark.skipif(_FP4_X2 is None, reason="torch has no float4_e2m1fn_x2")
+@pytest.mark.parametrize("mnk", [(256, 512, 256), (13, 256, 128)], ids=["m256", "m13"])
+@pytest.mark.parametrize("kind", ["nvfp4", "mxfp4", "mxfp4_alpha"])
+@_XFAIL_BUFFER_RANK
+def test_mm_fp4_flat_scale_blobs(mnk, kind):
+    build, pack, _ = _fp4_case(*mnk, nvfp4=kind == "nvfp4", alpha=kind.endswith("alpha"))
+    _accept_means_run(build, pack)
+
+
+@pytest.mark.skipif(_FP4_X2 is None, reason="torch has no float4_e2m1fn_x2")
+@pytest.mark.parametrize("kind", ["nvfp4", "mxfp4"])
+@_XFAIL_FP4_K_UNITS
+def test_mm_fp4_override_shape_path(kind):
+    build, pack, override = _fp4_case(200, 512, 256, nvfp4=kind == "nvfp4", alpha=False, override_cache_m=256)
+    _accept_means_run(build, pack, override=override)
+
+
+# ---------------------------------------------------------------------------
+# bmm_fp8: per-tensor scales declared (1, 1, 1), bound as 0-d tensors.
+# ---------------------------------------------------------------------------
+
+
+def _fp8_case(B: int, M: int, N: int, K: int, *, scalar_rank: int):
+    torch.manual_seed(0)
+    a = (torch.randn(B, M, K, device="cuda") * 0.5).to(torch.float8_e4m3fn)
+    b = (torch.randn(B, N, K, device="cuda") * 0.5).to(torch.float8_e4m3fn).transpose(-2, -1)  # (B, K, N)
+    a_shape, a_stride = list(a.shape), list(a.stride())
+    b_shape, b_stride = list(b.shape), list(b.stride())
+    a_scale = torch.tensor(0.5, device="cuda", dtype=torch.float32).reshape([1] * scalar_rank)
+    b_scale = torch.tensor(2.0, device="cuda", dtype=torch.float32).reshape([1] * scalar_rank)
+
+    def build(handle):
+        g = _graph(handle)
+        ta = g.tensor(name="a", dim=a_shape, stride=a_stride, data_type=cudnn.data_type.FP8_E4M3)
+        tb = g.tensor(name="b", dim=b_shape, stride=b_stride, data_type=cudnn.data_type.FP8_E4M3)
+        tsa = g.tensor(name="a_scale", dim=(1, 1, 1), stride=(1, 1, 1), data_type=cudnn.data_type.FLOAT)
+        tsb = g.tensor(name="b_scale", dim=(1, 1, 1), stride=(1, 1, 1), data_type=cudnn.data_type.FLOAT)
+        c = g.matmul(name="matmul", A=ta, B=tb, compute_data_type=cudnn.data_type.FLOAT)
+        c.set_name("c").set_data_type(cudnn.data_type.FLOAT)
+        c1 = g.mul(name="scale_mul_a", a=c, b=tsa, compute_data_type=cudnn.data_type.FLOAT)
+        c2 = g.mul(name="scale_mul_b", a=c1, b=tsb, compute_data_type=cudnn.data_type.FLOAT)
+        c2.set_name("c_final").set_output(True).set_data_type(cudnn.data_type.BFLOAT16)
+        c2.set_dim([B, M, N]).set_stride([M * N, N, 1])
+        ta.set_uid(A_UID)
+        tb.set_uid(B_UID)
+        tsa.set_uid(A_SCALE_UID)
+        tsb.set_uid(B_SCALE_UID)
+        c2.set_uid(O_UID)
+        g.validate()
+        g.build_operation_graph()
+        return g, lambda: torch.empty(B, M, N, device="cuda", dtype=torch.bfloat16)
+
+    return build, {A_UID: a, B_UID: b, A_SCALE_UID: a_scale, B_SCALE_UID: b_scale}
+
+
+@pytest.mark.parametrize("scalar_rank", [0, 1, 3], ids=["scalar_0d", "scalar_1d", "scalar_3d"])
+def test_bmm_fp8_per_tensor_scales(scalar_rank):
+    build, pack = _fp8_case(2, 256, 512, 256, scalar_rank=scalar_rank)
+    _accept_means_run(build, pack)
+
+
+# ---------------------------------------------------------------------------
+# bmm_mxfp8: E8M0 block scales, F8_128x4 reordered, bound as one flat blob per operand.
+# ---------------------------------------------------------------------------
+
+
+def _mxfp8_case(B: int, M: int, N: int, K: int):
+    torch.manual_seed(0)
+    block = 32
+    a = (torch.randn(B, M, K, device="cuda") * 0.5).to(torch.float8_e4m3fn)
+    b = (torch.randn(B, N, K, device="cuda") * 0.5).to(torch.float8_e4m3fn).transpose(-2, -1)  # (B, K, N)
+    bs_m, bs_n, bs_k = _block_scale_dims(M, N, K, block)
+    # mxfp8_quantize(is_sf_swizzled_layout=True) hands back ONE flat blob per operand.
+    sfa = torch.full((B * bs_m * bs_k,), 127, device="cuda", dtype=torch.uint8).view(torch.float8_e8m0fnu)
+    sfb = torch.full((B * bs_n * bs_k,), 127, device="cuda", dtype=torch.uint8).view(torch.float8_e8m0fnu)
+
+    def build(handle):
+        g = _graph(handle)
+        ta = g.tensor(name="a", dim=list(a.shape), stride=list(a.stride()), data_type=cudnn.data_type.FP8_E4M3)
+        tb = g.tensor(name="b", dim=list(b.shape), stride=list(b.stride()), data_type=cudnn.data_type.FP8_E4M3)
+        tsa = g.tensor(
+            name="block_descale_a",
+            dim=[B, bs_m, bs_k],
+            stride=[bs_m * bs_k, bs_k, 1],
+            data_type=cudnn.data_type.FP8_E8M0,
+            reordering_type=cudnn.tensor_reordering.F8_128x4,
+        )
+        tsb = g.tensor(
+            name="block_descale_b",
+            dim=[B, bs_k, bs_n],
+            stride=[bs_n * bs_k, 1, bs_k],
+            data_type=cudnn.data_type.FP8_E8M0,
+            reordering_type=cudnn.tensor_reordering.F8_128x4,
+        )
+        da = g.block_scale_dequantize(ta, tsa, block_size=[1, block], name="dequant_a")
+        da.set_data_type(cudnn.data_type.FLOAT)
+        db = g.block_scale_dequantize(tb, tsb, block_size=[block, 1], name="dequant_b")
+        db.set_data_type(cudnn.data_type.FLOAT)
+        c = g.matmul(da, db, compute_data_type=cudnn.data_type.FLOAT, name="gemm")
+        c.set_data_type(cudnn.data_type.FLOAT)
+        c.set_output(True).set_data_type(cudnn.data_type.BFLOAT16)
+        c.set_dim([B, M, N]).set_stride([M * N, N, 1])
+        ta.set_uid(A_UID)
+        tb.set_uid(B_UID)
+        tsa.set_uid(SFA_UID)
+        tsb.set_uid(SFB_UID)
+        c.set_uid(O_UID)
+        g.validate()
+        g.build_operation_graph()
+        return g, lambda: torch.empty(B, M, N, device="cuda", dtype=torch.bfloat16)
+
+    return build, {A_UID: a, B_UID: b, SFA_UID: sfa, SFB_UID: sfb}
+
+
+@pytest.mark.parametrize("bmnk", [(1, 256, 512, 256), (16, 128, 256, 1024)], ids=["b1", "b16"])
+@_XFAIL_BUFFER_RANK
+def test_bmm_mxfp8_flat_scale_blobs(bmnk):
+    build, pack = _mxfp8_case(*bmnk)
+    _accept_means_run(build, pack)

--- a/test/python/gemm/frost/test_flashinfer_shaped_gemm.py
+++ b/test/python/gemm/frost/test_flashinfer_shaped_gemm.py
@@ -108,9 +108,9 @@ def _plan_indices(g) -> tuple[int | None, int | None]:
 def _run(build, pack, *, use_frost: bool, override=None):
     """Build one graph, pin the frost (or first backend) plan, run it.
 
-    Returns ``("ok", out)`` or ``("declined", where, reason)``; any exception
-    from execute after a successful check_support propagates -- that is the
-    contract violation."""
+    Returns ``("ok", out)`` or ``("declined", "check_support", reason)``; any
+    exception from build_plans or execute after a successful check_support
+    propagates -- that is the contract violation."""
     handle = cudnn.create_handle()
     g, out_t = build(handle)
     g.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
@@ -122,12 +122,7 @@ def _run(build, pack, *, use_frost: bool, override=None):
         g.check_support()
     except (NotImplementedError, cudnn.cudnnGraphNotSupportedError) as exc:
         return ("declined", "check_support", str(exc))
-    try:
-        g.build_plans()
-    except NotImplementedError as exc:
-        # A build-time decline is still a decline the plan walk would skip; it
-        # is recorded separately because a pinned (autotune) plan cannot skip.
-        return ("declined", "build_plans", str(exc))
+    g.build_plans()  # accepted above: a failure from here on is the finding, not a decline
     out = out_t()
     kwargs = {}
     if override is not None:

--- a/test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py
+++ b/test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py
@@ -13,9 +13,9 @@ forms exist: the legacy element-unit offsets, and the token-unit direct form
 
 Contract under test for the frost plan: it serves the graph (FlashInfer is the
 caller this suite exists for, so a decline FAILS), builds, runs, and O / valid
-LSE rows match the cuDNN backend plan. The two known gaps -- the sm100 row's
-THD stride-order decline at b > 1, and the padded LSE rows left unwritten --
-carry ``xfail(strict=True)`` so a fix flips them loud.
+LSE rows match the cuDNN backend plan. The one known gap -- the padded LSE
+rows left unwritten where the backend writes -inf -- carries
+``xfail(strict=True)`` so a fix flips it loud.
 """
 
 from __future__ import annotations
@@ -232,14 +232,18 @@ class _Case:
         return ("ok", out, lse)
 
 
-def _accept_means_run(case: _Case, *, padded_rows_too: bool = True):
+def _accept_means_run(case: _Case, *, padded_rows_too: bool = True, decline_ok: str | None = None):
     """The frost plan must serve the graph (a decline is a failure here: FlashInfer
     is the caller this suite exists for) and match the backend on O and on every
     valid LSE row. ``padded_rows_too`` also holds the rows past each sequence's
-    length to the backend's value (-inf), the contract of the padded form."""
+    length to the backend's value (-inf), the contract of the padded form.
+    ``decline_ok`` names the one reason a decline IS the right answer for the
+    case (a form the kernels cannot address); anything else still fails."""
     ref = case.run(use_frost=False)
     assert ref[0] == "ok", f"the cuDNN backend itself declined this FlashInfer graph: {ref}"
     got = case.run(use_frost=True)
+    if got[0] == "declined" and decline_ok is not None and decline_ok in got[2]:
+        return  # the documented, correct decline: the backend serves this form
     assert got[0] == "ok", f"frost declined FlashInfer's graph at {got[1]}: {got[2][:300]}"
     torch.testing.assert_close(got[1].float(), ref[1].float(), atol=2e-2, rtol=2e-2)
     if not case.padded_lse:
@@ -251,14 +255,9 @@ def _accept_means_run(case: _Case, *, padded_rows_too: bool = True):
             assert torch.equal(got[2][i, n:], ref[2][i, n:]), f"batch {i}: padded LSE rows differ from the backend's (-inf): {got[2][i, n:n + 4, 0].tolist()}"
 
 
-_XFAIL_THD_BATCH = pytest.mark.xfail(
-    strict=True,
-    reason="sdpa_fwd_prefill_sm100 declines FlashInfer's packed THD at b > 1: BSHD-physical stride-order check on a batch stride that ragged offsets never read",
-)
 _XFAIL_PADDED_LSE = pytest.mark.xfail(strict=True, reason="frost leaves the padded LSE rows of a (b, s_max, h) stats buffer unwritten; the backend writes -inf")
 
 
-@_XFAIL_THD_BATCH
 @pytest.mark.parametrize("form", ["legacy_offsets", "tokens"])
 @pytest.mark.parametrize("d", [128, 192])
 def test_ragged_prefill_batch_of_two(form, d):
@@ -266,11 +265,18 @@ def test_ragged_prefill_batch_of_two(form, d):
     _accept_means_run(_Case([68, 87], [400, 512], s_q_max=128, s_kv_max=512, d=d, tokens_form=form == "tokens"))
 
 
-@_XFAIL_THD_BATCH
 @pytest.mark.parametrize("form", ["legacy_offsets", "tokens"])
 def test_ragged_prefill_batch_of_two_padded_lse(form):
-    """b > 1 with FlashInfer's padded (b, s_max, h) LSE buffer and no stats offsets: valid rows match."""
-    _accept_means_run(_Case([68, 87], [400, 512], s_q_max=128, s_kv_max=512, tokens_form=form == "tokens", padded_lse=True), padded_rows_too=False)
+    """b > 1 with FlashInfer's padded (b, s_max, h) LSE buffer and no stats offsets.
+
+    The packed path writes Stats as contiguous (T, h) rows and has no per-sequence
+    stats base, so this form is a documented decline (the backend serves it) --
+    never a plan that writes the second sequence's rows at the wrong place."""
+    _accept_means_run(
+        _Case([68, 87], [400, 512], s_q_max=128, s_kv_max=512, tokens_form=form == "tokens", padded_lse=True),
+        padded_rows_too=False,
+        decline_ok="THD Stats without ragged offsets",
+    )
 
 
 @pytest.mark.parametrize("form", ["legacy_offsets", "tokens"])

--- a/test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py
+++ b/test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py
@@ -11,10 +11,11 @@ equal to the sequence stride) with per-tensor ragged offsets, packed
 forms exist: the legacy element-unit offsets, and the token-unit direct form
 (``cu_seq_len_q/kv`` + ``set_ragged_offset_multiplier``, cuDNN >= 9.24).
 
-Contract under test for the frost plan: accepted at check_support => builds,
-runs, and O / valid LSE rows match the cuDNN backend plan. A decline is xfail
-with the reason (today: the THD stride-order check at b > 1). Known contract
-gaps carry ``xfail(strict=True)`` so a fix flips them loud.
+Contract under test for the frost plan: it serves the graph (FlashInfer is the
+caller this suite exists for, so a decline FAILS), builds, runs, and O / valid
+LSE rows match the cuDNN backend plan. The two known gaps -- the sm100 row's
+THD stride-order decline at b > 1, and the padded LSE rows left unwritten --
+carry ``xfail(strict=True)`` so a fix flips them loud.
 """
 
 from __future__ import annotations
@@ -68,26 +69,47 @@ def _frost_decline_reasons(g) -> str:
 class _Case:
     """One FlashInfer prefill call: lengths, packed buffers, and the graph it builds."""
 
-    def __init__(self, lens_q, lens_kv, *, h_q=8, h_kv=4, d=128, causal=True, tokens_form=False, dtype=torch.bfloat16):
+    def __init__(
+        self,
+        lens_q,
+        lens_kv,
+        *,
+        s_q_max=None,
+        s_kv_max=None,
+        h_q=8,
+        h_kv=4,
+        d=128,
+        d_v=None,
+        causal=True,
+        tokens_form=False,
+        padded_lse=False,
+        dtype=torch.bfloat16,
+    ):
         torch.manual_seed(0)
         dev = torch.device("cuda")
         self.b, self.h_q, self.h_kv, self.d, self.causal, self.tokens_form = len(lens_q), h_q, h_kv, d, causal, tokens_form
+        self.d_v = d if d_v is None else d_v  # FlashInfer's d192/d128 MLA-style shapes split the two
+        # FlashInfer's two Stats bindings: packed (T, h) through ragged stats offsets
+        # (batch_offsets_stats), or the padded (b, s_max, h) buffer with no offsets.
+        self.padded_lse = padded_lse
         self.lens_q = torch.tensor(lens_q, dtype=torch.int32, device=dev)
         self.lens_kv = torch.tensor(lens_kv, dtype=torch.int32, device=dev)
-        self.s_q, self.s_kv = max(lens_q), max(lens_kv)
+        # FlashInfer declares max_token_per_sequence / max_sequence_kv, normally above the longest sequence.
+        self.s_q, self.s_kv = s_q_max or max(lens_q), s_kv_max or max(lens_kv)
+        assert self.s_q >= max(lens_q) and self.s_kv >= max(lens_kv)
         zero = torch.zeros(1, dtype=torch.int32, device=dev)
         self.cu_q = torch.cat([zero, torch.cumsum(self.lens_q, 0).int()])
         self.cu_kv = torch.cat([zero, torch.cumsum(self.lens_kv, 0).int()])
         t_q, t_kv = int(self.cu_q[-1]), int(self.cu_kv[-1])
         self.q = torch.randn(t_q, h_q, d, device=dev, dtype=dtype)
         self.k = torch.randn(t_kv, h_kv, d, device=dev, dtype=dtype)
-        self.v = torch.randn(t_kv, h_kv, d, device=dev, dtype=dtype)
+        self.v = torch.randn(t_kv, h_kv, self.d_v, device=dev, dtype=dtype)
         self.scale = 1.0 / math.sqrt(d)
         self.dtype = dtype
         self.t_q = t_q
 
     def build(self, handle):
-        b, h_q, h_kv, d, s_q, s_kv = self.b, self.h_q, self.h_kv, self.d, self.s_q, self.s_kv
+        b, h_q, h_kv, d, d_v, s_q, s_kv = self.b, self.h_q, self.h_kv, self.d, self.d_v, self.s_q, self.s_kv
         g = cudnn.pygraph(
             handle=handle, io_data_type=cudnn.data_type.BFLOAT16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT
         )
@@ -96,7 +118,7 @@ class _Case:
         # Q: batch stride == one token (h*d) == the s stride; ragged offsets say where each batch starts.
         q = g.tensor(name="q", dim=(b, h_q, s_q, d), stride=(h_q * d, h_stride, s_stride, d_stride), data_type=dt)
         k = g.tensor(name="k", dim=(b, h_kv, s_kv, d), stride=(h_kv * d * s_kv, d, h_kv * d, 1), data_type=dt)
-        v = g.tensor(name="v", dim=(b, h_kv, s_kv, d), stride=(h_kv * d * s_kv, d, h_kv * d, 1), data_type=dt)
+        v = g.tensor(name="v", dim=(b, h_kv, s_kv, d_v), stride=(h_kv * d_v * s_kv, d_v, h_kv * d_v, 1), data_type=dt)
         rq = g.tensor_like(self.cu_q, name="ragged_q")
         rk = g.tensor_like(self.cu_kv, name="ragged_k")
         rv = g.tensor_like(self.cu_kv, name="ragged_v")
@@ -108,7 +130,7 @@ class _Case:
         if self.tokens_form:
             q.set_ragged_offset_multiplier(h_q * d)
             k.set_ragged_offset_multiplier(h_kv * d)
-            v.set_ragged_offset_multiplier(h_kv * d)
+            v.set_ragged_offset_multiplier(h_kv * d_v)
             cu_q = g.tensor_like(self.cu_q, name="cu_seq_lens_q")
             cu_kv = g.tensor_like(self.cu_kv, name="cu_seq_lens_kv")
             cu_q.set_uid(SEQ_Q_UID)
@@ -135,13 +157,15 @@ class _Case:
         ro = g.tensor_like(self.cu_q, name="ragged_o")
         ro.set_uid(RAGGED_O_UID)
         out_t.set_ragged_offset(ro)
-        rs = g.tensor_like(self.cu_q, name="ragged_stats")
-        rs.set_uid(RAGGED_STATS_UID)
-        stats_t.set_ragged_offset(rs)
+        if not self.padded_lse:
+            rs = g.tensor_like(self.cu_q, name="ragged_stats")
+            rs.set_uid(RAGGED_STATS_UID)
+            stats_t.set_ragged_offset(rs)
         if self.tokens_form:
-            out_t.set_ragged_offset_multiplier(h_q * d)
-            stats_t.set_ragged_offset_multiplier(h_q)
-        out_t.set_uid(O_UID).set_output(True).set_dim([b, h_q, s_q, d]).set_stride([s_q * d * h_q, d, d * h_q, 1]).set_data_type(dt)
+            out_t.set_ragged_offset_multiplier(h_q * d_v)
+            if not self.padded_lse:
+                stats_t.set_ragged_offset_multiplier(h_q)
+        out_t.set_uid(O_UID).set_output(True).set_dim([b, h_q, s_q, d_v]).set_stride([s_q * d_v * h_q, d_v, d_v * h_q, 1]).set_data_type(dt)
         stats_t.set_uid(STATS_UID).set_output(True).set_data_type(cudnn.data_type.FLOAT).set_dim([b, h_q, s_q, 1]).set_stride([s_q * h_q, 1, h_q, 1])
         for t, uid in ((q, Q_UID), (k, K_UID), (v, V_UID)):
             t.set_uid(uid)
@@ -150,11 +174,17 @@ class _Case:
         return g
 
     def pack(self, out, lse):
-        b, h_q, h_kv, d = self.b, self.h_q, self.h_kv, self.d
+        b, h_q, h_kv, d, d_v = self.b, self.h_q, self.h_kv, self.d, self.d_v
         if self.tokens_form:
-            offs_q, offs_kv, offs_o, offs_s = self.cu_q, self.cu_kv, self.cu_q, self.cu_q
-        else:  # legacy element-unit offsets
-            offs_q, offs_kv, offs_o, offs_s = self.cu_q * (h_q * d), self.cu_kv * (h_kv * d), self.cu_q * (h_q * d), self.cu_q * h_q
+            offs_q, offs_k, offs_v, offs_o, offs_s = self.cu_q, self.cu_kv, self.cu_kv, self.cu_q, self.cu_q
+        else:  # legacy element-unit offsets (batch_offsets_* = cu * (h * d) per tensor)
+            offs_q, offs_k, offs_v, offs_o, offs_s = (
+                self.cu_q * (h_q * d),
+                self.cu_kv * (h_kv * d),
+                self.cu_kv * (h_kv * d_v),
+                self.cu_q * (h_q * d_v),
+                self.cu_q * h_q,
+            )
         pack = {
             Q_UID: self.q,
             K_UID: self.k,
@@ -162,11 +192,12 @@ class _Case:
             O_UID: out,
             STATS_UID: lse,
             RAGGED_Q_UID: offs_q,
-            RAGGED_K_UID: offs_kv,
-            RAGGED_V_UID: offs_kv,
+            RAGGED_K_UID: offs_k,
+            RAGGED_V_UID: offs_v,
             RAGGED_O_UID: offs_o,
-            RAGGED_STATS_UID: offs_s,
         }
+        if not self.padded_lse:
+            pack[RAGGED_STATS_UID] = offs_s
         if self.tokens_form:
             pack[SEQ_Q_UID], pack[SEQ_KV_UID] = self.cu_q, self.cu_kv
         else:
@@ -190,32 +221,79 @@ class _Case:
         except (NotImplementedError, cudnn.cudnnGraphNotSupportedError) as exc:
             return ("declined", "check_support", str(exc))
         g.build_plans()  # accepted above: a failure from here on is the finding, not a decline
-        out = torch.empty_like(self.q)  # packed (T, h, d)
-        lse = torch.empty(self.t_q, self.h_q, device="cuda", dtype=torch.float32)  # packed (T, h) stats
+        out = torch.empty(self.t_q, self.h_q, self.d_v, device="cuda", dtype=self.dtype)  # packed (T, h, d_v)
+        if self.padded_lse:
+            lse = torch.full((self.b, self.s_q, self.h_q), float("nan"), device="cuda", dtype=torch.float32)  # FlashInfer's lse buffer
+        else:
+            lse = torch.empty(self.t_q, self.h_q, device="cuda", dtype=torch.float32)  # packed (T, h) stats
         ws = torch.empty(max(g.get_workspace_size(), 1), dtype=torch.uint8, device="cuda")
         g.execute(self.pack(out, lse), ws, handle=handle)
         torch.cuda.synchronize()
         return ("ok", out, lse)
 
 
-def _accept_means_run(case: _Case):
+def _accept_means_run(case: _Case, *, padded_rows_too: bool = True):
+    """The frost plan must serve the graph (a decline is a failure here: FlashInfer
+    is the caller this suite exists for) and match the backend on O and on every
+    valid LSE row. ``padded_rows_too`` also holds the rows past each sequence's
+    length to the backend's value (-inf), the contract of the padded form."""
     ref = case.run(use_frost=False)
     assert ref[0] == "ok", f"the cuDNN backend itself declined this FlashInfer graph: {ref}"
     got = case.run(use_frost=True)
-    if got[0] == "declined":
-        pytest.xfail(f"frost declined at {got[1]}: {got[2][:220]}")
+    assert got[0] == "ok", f"frost declined FlashInfer's graph at {got[1]}: {got[2][:300]}"
     torch.testing.assert_close(got[1].float(), ref[1].float(), atol=2e-2, rtol=2e-2)
-    torch.testing.assert_close(got[2], ref[2], atol=2e-3, rtol=2e-3)
+    if not case.padded_lse:
+        torch.testing.assert_close(got[2], ref[2], atol=2e-3, rtol=2e-3)
+        return
+    for i, n in enumerate(case.lens_q.tolist()):
+        torch.testing.assert_close(got[2][i, :n], ref[2][i, :n], atol=2e-3, rtol=2e-3)
+        if padded_rows_too:
+            assert torch.equal(got[2][i, n:], ref[2][i, n:]), f"batch {i}: padded LSE rows differ from the backend's (-inf): {got[2][i, n:n + 4, 0].tolist()}"
 
 
+_XFAIL_THD_BATCH = pytest.mark.xfail(
+    strict=True,
+    reason="sdpa_fwd_prefill_sm100 declines FlashInfer's packed THD at b > 1: BSHD-physical stride-order check on a batch stride that ragged offsets never read",
+)
+_XFAIL_PADDED_LSE = pytest.mark.xfail(strict=True, reason="frost leaves the padded LSE rows of a (b, s_max, h) stats buffer unwritten; the backend writes -inf")
+
+
+@_XFAIL_THD_BATCH
 @pytest.mark.parametrize("form", ["legacy_offsets", "tokens"])
 @pytest.mark.parametrize("d", [128, 192])
 def test_ragged_prefill_batch_of_two(form, d):
     """FlashInfer's main prefill path: b > 1 ragged Q/K/V/O with packed stats."""
-    _accept_means_run(_Case([68, 87], [400, 512], d=d, tokens_form=form == "tokens"))
+    _accept_means_run(_Case([68, 87], [400, 512], s_q_max=128, s_kv_max=512, d=d, tokens_form=form == "tokens"))
+
+
+@_XFAIL_THD_BATCH
+@pytest.mark.parametrize("form", ["legacy_offsets", "tokens"])
+def test_ragged_prefill_batch_of_two_padded_lse(form):
+    """b > 1 with FlashInfer's padded (b, s_max, h) LSE buffer and no stats offsets: valid rows match."""
+    _accept_means_run(_Case([68, 87], [400, 512], s_q_max=128, s_kv_max=512, tokens_form=form == "tokens", padded_lse=True), padded_rows_too=False)
 
 
 @pytest.mark.parametrize("form", ["legacy_offsets", "tokens"])
 def test_ragged_prefill_single_sequence(form):
     """b == 1 (the form frost's THD path serves today): O and packed LSE must match the backend."""
-    _accept_means_run(_Case([68], [400], tokens_form=form == "tokens"))
+    _accept_means_run(_Case([68], [400], s_q_max=87, s_kv_max=512, tokens_form=form == "tokens"))
+
+
+_HEAD_SHAPES = [pytest.param(128, 128, True, id="d128_causal"), pytest.param(192, 128, False, id="d192_128_dense")]
+
+
+@pytest.mark.parametrize("form", ["legacy_offsets", "tokens"])
+@pytest.mark.parametrize("d, d_v, causal", _HEAD_SHAPES)
+def test_ragged_prefill_single_sequence_padded_lse_valid_rows(form, d, d_v, causal):
+    """b == 1, padded LSE buffer: the valid rows match the backend."""
+    _accept_means_run(
+        _Case([68], [400], s_q_max=87, s_kv_max=512, d=d, d_v=d_v, causal=causal, tokens_form=form == "tokens", padded_lse=True), padded_rows_too=False
+    )
+
+
+@_XFAIL_PADDED_LSE
+@pytest.mark.parametrize("form", ["legacy_offsets", "tokens"])
+@pytest.mark.parametrize("d, d_v, causal", _HEAD_SHAPES)
+def test_ragged_prefill_single_sequence_padded_lse_rows(form, d, d_v, causal):
+    """b == 1, padded LSE buffer: the rows past the sequence length hold the backend's -inf."""
+    _accept_means_run(_Case([68], [400], s_q_max=87, s_kv_max=512, d=d, d_v=d_v, causal=causal, tokens_form=form == "tokens", padded_lse=True))

--- a/test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py
+++ b/test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py
@@ -189,10 +189,7 @@ class _Case:
             g.check_support()
         except (NotImplementedError, cudnn.cudnnGraphNotSupportedError) as exc:
             return ("declined", "check_support", str(exc))
-        try:
-            g.build_plans()
-        except NotImplementedError as exc:
-            return ("declined", "build_plans", str(exc))
+        g.build_plans()  # accepted above: a failure from here on is the finding, not a decline
         out = torch.empty_like(self.q)  # packed (T, h, d)
         lse = torch.empty(self.t_q, self.h_q, device="cuda", dtype=torch.float32)  # packed (T, h) stats
         ws = torch.empty(max(g.get_workspace_size(), 1), dtype=torch.uint8, device="cuda")

--- a/test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py
+++ b/test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py
@@ -120,7 +120,7 @@ class _Case:
             lq.set_uid(SEQ_Q_UID)
             lkv.set_uid(SEQ_KV_UID)
             seq_kwargs = dict(seq_len_q=lq, seq_len_kv=lkv)
-        O, Stats = g.sdpa(
+        out_t, stats_t = g.sdpa(
             name="sdpa",
             q=q,
             k=k,
@@ -134,15 +134,15 @@ class _Case:
         )
         ro = g.tensor_like(self.cu_q, name="ragged_o")
         ro.set_uid(RAGGED_O_UID)
-        O.set_ragged_offset(ro)
+        out_t.set_ragged_offset(ro)
         rs = g.tensor_like(self.cu_q, name="ragged_stats")
         rs.set_uid(RAGGED_STATS_UID)
-        Stats.set_ragged_offset(rs)
+        stats_t.set_ragged_offset(rs)
         if self.tokens_form:
-            O.set_ragged_offset_multiplier(h_q * d)
-            Stats.set_ragged_offset_multiplier(h_q)
-        O.set_uid(O_UID).set_output(True).set_dim([b, h_q, s_q, d]).set_stride([s_q * d * h_q, d, d * h_q, 1]).set_data_type(dt)
-        Stats.set_uid(STATS_UID).set_output(True).set_data_type(cudnn.data_type.FLOAT).set_dim([b, h_q, s_q, 1]).set_stride([s_q * h_q, 1, h_q, 1])
+            out_t.set_ragged_offset_multiplier(h_q * d)
+            stats_t.set_ragged_offset_multiplier(h_q)
+        out_t.set_uid(O_UID).set_output(True).set_dim([b, h_q, s_q, d]).set_stride([s_q * d * h_q, d, d * h_q, 1]).set_data_type(dt)
+        stats_t.set_uid(STATS_UID).set_output(True).set_data_type(cudnn.data_type.FLOAT).set_dim([b, h_q, s_q, 1]).set_stride([s_q * h_q, 1, h_q, 1])
         for t, uid in ((q, Q_UID), (k, K_UID), (v, V_UID)):
             t.set_uid(uid)
         g.validate()

--- a/test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py
+++ b/test/python/sdpa/frost/test_flashinfer_shaped_sdpa.py
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""FlashInfer-shaped SDPA prefill graphs under the frost opt-in.
+
+FlashInfer (flashinfer/cudnn/prefill.py) declares its ragged prefill as a dense
+``(b, h, s_max, d)`` graph whose Q/O batch stride is ONE TOKEN (``h * d``,
+equal to the sequence stride) with per-tensor ragged offsets, packed
+``(T, h, d)`` buffers, padded ``(b, s_max, h)`` LSE, per-batch lengths as
+``(b, 1, 1, 1)`` int32 device tensors and a bottom-right causal mask. Two
+forms exist: the legacy element-unit offsets, and the token-unit direct form
+(``cu_seq_len_q/kv`` + ``set_ragged_offset_multiplier``, cuDNN >= 9.24).
+
+Contract under test for the frost plan: accepted at check_support => builds,
+runs, and O / valid LSE rows match the cuDNN backend plan. A decline is xfail
+with the reason (today: the THD stride-order check at b > 1). Known contract
+gaps carry ``xfail(strict=True)`` so a fix flips them loud.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+import cudnn
+from cudnn.engines import is_python_engine
+from frost_test_utils import requires_dsl, requires_pre_rubin_blackwell
+
+pytestmark = [pytest.mark.L0, requires_pre_rubin_blackwell, requires_dsl]
+
+# flashinfer/cudnn/prefill.py UIDs, kept identical.
+Q_UID, K_UID, V_UID, O_UID, STATS_UID = 0, 1, 2, 3, 4
+RAGGED_Q_UID, RAGGED_K_UID, RAGGED_V_UID, RAGGED_O_UID, RAGGED_STATS_UID = 10, 11, 12, 13, 14
+SEQ_Q_UID, SEQ_KV_UID = 20, 21
+FROST_PREFIX = "sdpa_fwd_prefill_"
+
+
+def _plan_indices(g):
+    frost = backend = None
+    for i in range(g.get_execution_plan_count()):
+        name = g.get_plan_name_at_index(i)
+        engine_id, _ = g.get_engine_and_knobs_at_index(i)
+        if name.startswith(FROST_PREFIX) and frost is None:
+            frost = i
+        elif backend is None and not is_python_engine(engine_id) and name != "backend_heuristics":
+            backend = i
+    return frost, backend
+
+
+def _frost_decline_reasons(g) -> str:
+    """Why every offered frost SDPA-forward row declined ``g`` (engine name: reason)."""
+    from cudnn.engines import manifest
+
+    fam = next(f for f in manifest.MANIFEST if f.name == "frost_sdpa_fwd")
+    reasons = []
+    for name, engine_id in fam.offered_ids().items():
+        engine = manifest.engine_for_id(engine_id)
+        if engine is None:
+            continue
+        reason = engine._decline_reason(g, None)
+        if reason is not None and "requires SM" not in reason:  # rows for other archs are not news
+            reasons.append(f"{name}: {reason}")
+    return "; ".join(reasons) or "no frost row offered on this device"
+
+
+class _Case:
+    """One FlashInfer prefill call: lengths, packed buffers, and the graph it builds."""
+
+    def __init__(self, lens_q, lens_kv, *, h_q=8, h_kv=4, d=128, causal=True, tokens_form=False, dtype=torch.bfloat16):
+        torch.manual_seed(0)
+        dev = torch.device("cuda")
+        self.b, self.h_q, self.h_kv, self.d, self.causal, self.tokens_form = len(lens_q), h_q, h_kv, d, causal, tokens_form
+        self.lens_q = torch.tensor(lens_q, dtype=torch.int32, device=dev)
+        self.lens_kv = torch.tensor(lens_kv, dtype=torch.int32, device=dev)
+        self.s_q, self.s_kv = max(lens_q), max(lens_kv)
+        zero = torch.zeros(1, dtype=torch.int32, device=dev)
+        self.cu_q = torch.cat([zero, torch.cumsum(self.lens_q, 0).int()])
+        self.cu_kv = torch.cat([zero, torch.cumsum(self.lens_kv, 0).int()])
+        t_q, t_kv = int(self.cu_q[-1]), int(self.cu_kv[-1])
+        self.q = torch.randn(t_q, h_q, d, device=dev, dtype=dtype)
+        self.k = torch.randn(t_kv, h_kv, d, device=dev, dtype=dtype)
+        self.v = torch.randn(t_kv, h_kv, d, device=dev, dtype=dtype)
+        self.scale = 1.0 / math.sqrt(d)
+        self.dtype = dtype
+        self.t_q = t_q
+
+    def build(self, handle):
+        b, h_q, h_kv, d, s_q, s_kv = self.b, self.h_q, self.h_kv, self.d, self.s_q, self.s_kv
+        g = cudnn.pygraph(
+            handle=handle, io_data_type=cudnn.data_type.BFLOAT16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT
+        )
+        dt = cudnn.datatypes._torch_to_cudnn_data_type(self.dtype)
+        s_stride, h_stride, d_stride = self.q.stride()
+        # Q: batch stride == one token (h*d) == the s stride; ragged offsets say where each batch starts.
+        q = g.tensor(name="q", dim=(b, h_q, s_q, d), stride=(h_q * d, h_stride, s_stride, d_stride), data_type=dt)
+        k = g.tensor(name="k", dim=(b, h_kv, s_kv, d), stride=(h_kv * d * s_kv, d, h_kv * d, 1), data_type=dt)
+        v = g.tensor(name="v", dim=(b, h_kv, s_kv, d), stride=(h_kv * d * s_kv, d, h_kv * d, 1), data_type=dt)
+        rq = g.tensor_like(self.cu_q, name="ragged_q")
+        rk = g.tensor_like(self.cu_kv, name="ragged_k")
+        rv = g.tensor_like(self.cu_kv, name="ragged_v")
+        for t, uid in ((rq, RAGGED_Q_UID), (rk, RAGGED_K_UID), (rv, RAGGED_V_UID)):
+            t.set_uid(uid)
+        q.set_ragged_offset(rq)
+        k.set_ragged_offset(rk)
+        v.set_ragged_offset(rv)
+        if self.tokens_form:
+            q.set_ragged_offset_multiplier(h_q * d)
+            k.set_ragged_offset_multiplier(h_kv * d)
+            v.set_ragged_offset_multiplier(h_kv * d)
+            cu_q = g.tensor_like(self.cu_q, name="cu_seq_lens_q")
+            cu_kv = g.tensor_like(self.cu_kv, name="cu_seq_lens_kv")
+            cu_q.set_uid(SEQ_Q_UID)
+            cu_kv.set_uid(SEQ_KV_UID)
+            seq_kwargs = dict(cu_seq_len_q=cu_q, cu_seq_len_kv=cu_kv, implementation=cudnn.attention_implementation.UNIFIED)
+        else:
+            lq = g.tensor_like(self.lens_q.view(b, 1, 1, 1), name="actual_seq_lens_q")
+            lkv = g.tensor_like(self.lens_kv.view(b, 1, 1, 1), name="actual_seq_lens_kv")
+            lq.set_uid(SEQ_Q_UID)
+            lkv.set_uid(SEQ_KV_UID)
+            seq_kwargs = dict(seq_len_q=lq, seq_len_kv=lkv)
+        O, Stats = g.sdpa(
+            name="sdpa",
+            q=q,
+            k=k,
+            v=v,
+            **seq_kwargs,
+            use_padding_mask=True,
+            attn_scale=self.scale,
+            generate_stats=True,
+            use_causal_mask_bottom_right=self.causal,
+            compute_data_type=cudnn.data_type.FLOAT,
+        )
+        ro = g.tensor_like(self.cu_q, name="ragged_o")
+        ro.set_uid(RAGGED_O_UID)
+        O.set_ragged_offset(ro)
+        rs = g.tensor_like(self.cu_q, name="ragged_stats")
+        rs.set_uid(RAGGED_STATS_UID)
+        Stats.set_ragged_offset(rs)
+        if self.tokens_form:
+            O.set_ragged_offset_multiplier(h_q * d)
+            Stats.set_ragged_offset_multiplier(h_q)
+        O.set_uid(O_UID).set_output(True).set_dim([b, h_q, s_q, d]).set_stride([s_q * d * h_q, d, d * h_q, 1]).set_data_type(dt)
+        Stats.set_uid(STATS_UID).set_output(True).set_data_type(cudnn.data_type.FLOAT).set_dim([b, h_q, s_q, 1]).set_stride([s_q * h_q, 1, h_q, 1])
+        for t, uid in ((q, Q_UID), (k, K_UID), (v, V_UID)):
+            t.set_uid(uid)
+        g.validate()
+        g.build_operation_graph()
+        return g
+
+    def pack(self, out, lse):
+        b, h_q, h_kv, d = self.b, self.h_q, self.h_kv, self.d
+        if self.tokens_form:
+            offs_q, offs_kv, offs_o, offs_s = self.cu_q, self.cu_kv, self.cu_q, self.cu_q
+        else:  # legacy element-unit offsets
+            offs_q, offs_kv, offs_o, offs_s = self.cu_q * (h_q * d), self.cu_kv * (h_kv * d), self.cu_q * (h_q * d), self.cu_q * h_q
+        pack = {
+            Q_UID: self.q,
+            K_UID: self.k,
+            V_UID: self.v,
+            O_UID: out,
+            STATS_UID: lse,
+            RAGGED_Q_UID: offs_q,
+            RAGGED_K_UID: offs_kv,
+            RAGGED_V_UID: offs_kv,
+            RAGGED_O_UID: offs_o,
+            RAGGED_STATS_UID: offs_s,
+        }
+        if self.tokens_form:
+            pack[SEQ_Q_UID], pack[SEQ_KV_UID] = self.cu_q, self.cu_kv
+        else:
+            pack[SEQ_Q_UID], pack[SEQ_KV_UID] = self.lens_q.view(b, 1, 1, 1), self.lens_kv.view(b, 1, 1, 1)
+        return pack
+
+    def run(self, *, use_frost: bool):
+        handle = cudnn.create_handle()
+        g = self.build(handle)
+        g.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
+        frost, backend = _plan_indices(g)
+        if use_frost and frost is None:
+            # The family heuristics list only rows whose capability check admits
+            # the graph, so "not listed" IS the decline; ask the rows why.
+            return ("declined", "recommend", _frost_decline_reasons(g))
+        idx = frost if use_frost else backend
+        assert idx is not None, f"no backend plan; plans={[g.get_plan_name_at_index(i) for i in range(g.get_execution_plan_count())]}"
+        g.select_plan(idx)
+        try:
+            g.check_support()
+        except (NotImplementedError, cudnn.cudnnGraphNotSupportedError) as exc:
+            return ("declined", "check_support", str(exc))
+        try:
+            g.build_plans()
+        except NotImplementedError as exc:
+            return ("declined", "build_plans", str(exc))
+        out = torch.empty_like(self.q)  # packed (T, h, d)
+        lse = torch.empty(self.t_q, self.h_q, device="cuda", dtype=torch.float32)  # packed (T, h) stats
+        ws = torch.empty(max(g.get_workspace_size(), 1), dtype=torch.uint8, device="cuda")
+        g.execute(self.pack(out, lse), ws, handle=handle)
+        torch.cuda.synchronize()
+        return ("ok", out, lse)
+
+
+def _accept_means_run(case: _Case):
+    ref = case.run(use_frost=False)
+    assert ref[0] == "ok", f"the cuDNN backend itself declined this FlashInfer graph: {ref}"
+    got = case.run(use_frost=True)
+    if got[0] == "declined":
+        pytest.xfail(f"frost declined at {got[1]}: {got[2][:220]}")
+    torch.testing.assert_close(got[1].float(), ref[1].float(), atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(got[2], ref[2], atol=2e-3, rtol=2e-3)
+
+
+@pytest.mark.parametrize("form", ["legacy_offsets", "tokens"])
+@pytest.mark.parametrize("d", [128, 192])
+def test_ragged_prefill_batch_of_two(form, d):
+    """FlashInfer's main prefill path: b > 1 ragged Q/K/V/O with packed stats."""
+    _accept_means_run(_Case([68, 87], [400, 512], d=d, tokens_form=form == "tokens"))
+
+
+@pytest.mark.parametrize("form", ["legacy_offsets", "tokens"])
+def test_ragged_prefill_single_sequence(form):
+    """b == 1 (the form frost's THD path serves today): O and packed LSE must match the backend."""
+    _accept_means_run(_Case([68], [400], tokens_form=form == "tokens"))

--- a/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
+++ b/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
@@ -1515,3 +1515,20 @@ def test_paged_split_kv_is_proposed_on_a_decode_launch(monkeypatch):
     facts = _facts(g)
     knob_sets = _knob_sets(spec, facts)
     assert any(k.split_kv and k.split_kv > 1 for k in knob_sets), knob_sets
+
+
+def test_packed_layout_ignores_the_batch_stride_a_ragged_tensor_never_reads():
+    """FlashInfer declares its packed THD Q/O with the batch stride equal to the
+    token stride (h * d): not BSHD-physical over all four axes, but every
+    sequence base comes from the ragged offsets, so only the (H, S, D) order
+    the THD lowering addresses has to hold."""
+    from cudnn.sdpa.graph_analyzer import bshd_layout_ok, packed_layout_ok
+
+    b, h, s, d = 2, 8, 87, 128
+    flashinfer_q = ((b, h, s, d), (h * d, d, h * d, 1))
+    assert not bshd_layout_ok(*flashinfer_q) and packed_layout_ok(*flashinfer_q)
+    dense_bshd = ((b, h, s, d), (s * h * d, d, h * d, 1))
+    assert bshd_layout_ok(*dense_bshd) and packed_layout_ok(*dense_bshd)
+    bhsd = ((b, h, s, d), (h * s * d, s * d, d, 1))  # heads outside tokens: not the packed order
+    assert not packed_layout_ok(*bhsd)
+    assert packed_layout_ok((1, h, s, d), (h * d, d, h * d, 1))  # b == 1 wildcards as before


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches (see [root AGENTS.md § Reviewing a PR](https://github.com/NVIDIA/cudnn-frontend/blob/develop/AGENTS.md#reviewing-a-pr-human-or-agent)) and my changes comply: eligibility changed, so `python/cudnn/sdpa/frost/SUPPORT_MATRIX_TRACKER.md` is updated in the same commit (Rule S2); the gate and the adapter apply one shared predicate.
- [x] I added GitHub labels: `cat-bugfix`, `area:frost`, `orig-nv-eng`.

## Affected area

FE OSS kernels or CuTeDSL — the FROST SDPA forward engine's THD (ragged) eligibility. **Stacked on #1028** (the FlashInfer-shaped conformance suites): review the top commit; the b > 1 strict expected failures of the SDPA suite are removed here because they pass.

## Summary

- **THD layout gate over (H, S, D) only.** The forward engine and the DSL adapter required FlashInfer's packed Q/K/V/O to be BSHD-physical over all four axes. Under ragged offsets the batch stride is never read: every sequence base comes from the offset table and the lowering binds the batch axis at extent 1 (`_thd_view`). FlashInfer declares that stride equal to the token stride (`h * d`), so every ragged prefill at `b > 1` was declined. New `graph_analyzer.packed_layout_ok` (head dim innermost, then heads, then tokens), a `SdpaGraphFacts.packed_layout` fact, and both the `mismatch` gate and the adapter's own check use it.
- **Padded Stats under THD at b > 1 is a decline, not a mis-address.** A Stats tensor with no ragged offsets is the per-batch padded `[b, h, s_max, 1]` form; the packed path writes contiguous `(T, h)` rows and has no per-sequence stats base, so with the layout gate relaxed it would have written the second sequence's LSE rows into the first sequence's padding (the conformance suite caught this: NaN at row 27 of batch 1). `mismatch` now declines that form at `b > 1`; at `b == 1` it coincides with the packed form and keeps working.

## Why

FlashInfer's ragged prefill — its main attention path, both the legacy element-unit offsets and the token-unit `cu_seq_len` form — never reached a frost plan at `b > 1`, on a check of a stride the kernel does not use. With this change the frost SM100 row serves it and matches the cuDNN backend on O and on the packed LSE (d = 128 and 192, GQA, bottom-right causal).

Not in this PR (still a strict xfail in the suite): the padded LSE rows past a sequence's length are left unwritten by the frost row where the backend writes `-inf` (`b == 1`, padded stats form).

## Related issues

- Stacked on #1028; independent of #1029. FlashInfer: flashinfer-ai/flashinfer#5133 (the token-unit path this enables), flashinfer-ai/flashinfer#5163.

## API and compatibility impact

- Eligibility only: graphs the sm100 forward row declined at `b > 1` for the batch-stride order are now served; the per-batch padded Stats form under THD at `b > 1` is declined (it was accepted and mis-addressed before). No public signature changes. `SdpaGraphFacts` gains `packed_layout`.
- Supported GPU / cuDNN / CUDA / Python versions: unchanged.

## Testing

Blackwell SM100, cuDNN 9.25.1, `_compiled_module` built from develop, `nvidia-cutlass-dsl` 4.7.1:

```
cd test/python
python -m pytest -q -m L0 sdpa/frost/test_flashinfer_shaped_sdpa.py sdpa/frost/test_sdpa_graph_analyzer.py sdpa/frost/test_sdpa_fwd_heuristics.py
# 145 passed, 4 xfailed (the padded-LSE tail rows, unchanged by this PR)
```

The FlashInfer-shaped b = 2 cases (both offset forms, d = 128 / 192) now run on `sdpa_fwd_prefill_sm100` and match the backend; the b = 2 padded-Stats form is the documented decline. New unit test: `test_packed_layout_ignores_the_batch_stride_a_ragged_tensor_never_reads`. Forward THD / paged / fp8 / split-KV and backward THD suites on SM100:

```
# SDPA_GPU_RESULT
```

`pre-commit run` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>note to self: claude::61d24ed2-7c90-4a97-9cbb-b91ae18136fd — "PR #5133 auto backend: why not cuDNN" · cwd /home/scratch.yanxu_libs/flashinfer · workspace /home/scratch.yanxu_libs/cudnn_frontend-wt-fishape</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded ragged/packed SDPA support for SM100-compatible layouts, including layouts with unused batch strides.
  * Added support for documented packed statistics requirements and single-sequence padded output behavior.
  * Improved compatibility with FlashInfer-shaped ragged SDPA and GEMM workloads.

* **Bug Fixes**
  * Corrected validation for packed tensor layouts and multi-batch statistics, providing clearer rejection of unsupported configurations.

* **Tests**
  * Added coverage for ragged SDPA, packed layouts, FlashInfer-shaped GEMM operations, scaling formats, and override-shape scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->