### PR TITLE
frost: persistent compiled-plan cache (GEMM and SDPA templates reload exported tvm-ffi objects across processes)

### DIFF
--- a/docs/utilities/python_graph_and_execution_backends.md
+++ b/docs/utilities/python_graph_and_execution_backends.md
@@ -691,9 +691,20 @@ DSL's own file cache stores only MLIR bytecode, so a process that warms tens
 of plans pays minutes at start-up. `cudnn.frost.compiled_cache` keeps the
 exported tvm-ffi object of every kernel compiled with `--enable-tvm-ffi` and
 reloads it in milliseconds. `compile_cached(fn, *args, cache_key=, symbol=,
-**kwargs)` is the drop-in for `cute.compile` at a kernel's compile site; the
-FROST GEMM templates route through it with the digest of their generated
-source as the key (44 kernels of the GEMM suites: 44 s cold, 12 s warm).
+**kwargs)` is the drop-in for `cute.compile` at a kernel's compile site. Every FROST kernel template
+routes through it: the GEMM templates with the digest of their generated
+source as the key (the full GEMM suites: 5655 tests, 20:53 cold, 1:35 warm),
+the SDPA forward / backward and linear-attention templates with
+`template_key(globals(), locals(), "<function>")` as the FIRST statement of
+each function that compiles — the file + params digest `template_loader`
+records as `FROST_SOURCE_DIGEST`, joined with the function's name and its
+arguments, which pin shapes, strides and flags the way the params pin dtypes
+and masks (SDPA SM100 graph-API cases: 24.8 s cold, 2.4 s warm). An argument
+that is not a plain value (a tensor, a device, a dtype object) makes the key
+None and the call compiles as before: the linear-attention `chunk_*`
+launchers, which trace real tensors, and the SDPA adapters' helper kernels in
+`api_dsl` are therefore not cached yet. A hit is the same object a miss
+produced, so the reloaded kernel is called exactly as the in-process one.
 
 The rules, borrowed from FlashInfer's autotune cache v2 so that a stale
 artifact can never be reused by accident:
@@ -711,19 +722,26 @@ artifact can never be reused by accident:
 - **Anything doubtful is a miss**: missing, malformed, mismatched, or an
   object `load_module` refuses (an arch the device cannot run). Never an error.
 - **A hit and a miss run the same thing.** A reloaded tvm-ffi function is
-  positional-only, so it is wrapped with a kwargs wrapper built from the
-  kernel's Python signature; the miss path exports and then reloads, so a bad
-  artifact fails at build time, not at the next start-up. Kernels whose
-  in-process object converts raw pointer arguments are not cached.
+  positional-only, so it is wrapped with the kwargs wrapper the DSL itself
+  uses, rebuilt from the RUNTIME spec the record carries (`arg_names`,
+  defaults, keyword-only names) — the Python signature minus
+  `cutlass.Constexpr` and env-stream parameters, which do not exist at run
+  time. A wrapper built from the Python signature would shift every argument
+  after a constexpr one (the fp8 SDPA kernels have one). The miss path
+  exports and then reloads, so a bad artifact fails at build time, not at the
+  next start-up. Kernels whose in-process object converts raw pointer
+  arguments, takes a dataclass argument, or has a default JSON cannot carry
+  are not persisted.
 - Location: `CUDNN_FRONTEND_COMPILED_CACHE`, else
   `$XDG_CACHE_HOME/cudnn_frontend/compiled_plans`; `set_cache_dir()` for a
   caller that owns a workspace (FlashInfer); `CUDNN_FRONTEND_DISABLE_COMPILED_CACHE=1`
   turns it off; `stats()` reports hits / misses / bypassed / invalid per
   process. Bump `_SCHEMA` on any incompatible change.
 
-Not yet routed: the SDPA and linear-attention kernel templates (their
-`cute.compile` calls take per-kernel keyword sets; same hook, one key per
-`(template, params, kwargs)`).
+Not yet routed: kernels compiled from real tensors at call time (the
+linear-attention `chunk_*` launchers, the SDPA adapters' `_dot_fn` /
+`_reduce_fn` / `_setup_fn` helpers): a key for them has to spell the traced
+tensors' dtype, rank and dynamic marks; same hook once it does.
 
 ## Key invariants
 

--- a/docs/utilities/python_graph_and_execution_backends.md
+++ b/docs/utilities/python_graph_and_execution_backends.md
@@ -709,11 +709,15 @@ produced, so the reloaded kernel is called exactly as the in-process one.
 The rules, borrowed from FlashInfer's autotune cache v2 so that a stale
 artifact can never be reused by accident:
 
-- **Identity is the whole manifest, hashed.** Frontend, cutlass-dsl and
-  tvm-ffi versions, the CUDA driver, and the device's name, compute
-  capability, SM count and L2 size (FROST bakes the last two into kernels)
-  name the directory `<root>/v1/<env_hash>/`. Any change lands elsewhere; an
-  unreadable field is hashed as `"unknown"`, never skipped.
+- **Identity is the whole manifest, hashed.** Frontend version AND a digest
+  of every `.py` in the `cudnn` package (a kernel is compiled from the shared
+  helpers it imports as much as from its template, and the version does not
+  move in a checkout someone is editing — an uncommitted edit lands in another
+  directory; a wheel hashes the same every process), cutlass-dsl and tvm-ffi
+  versions, the CUDA driver, and the device's name, compute capability, SM
+  count and L2 size (FROST bakes the last two into kernels) name the directory
+  `<root>/v2/<env_hash>/`. Any change lands elsewhere; an unreadable field is
+  hashed as `"unknown"`, never skipped.
 - **An entry is reused only under its own embedded key.** `entry.json`
   carries the full key, symbol and signature and is compared on load; the
   object is written first and the record after it (the commit marker), both

--- a/docs/utilities/python_graph_and_execution_backends.md
+++ b/docs/utilities/python_graph_and_execution_backends.md
@@ -691,20 +691,21 @@ DSL's own file cache stores only MLIR bytecode, so a process that warms tens
 of plans pays minutes at start-up. `cudnn.frost.compiled_cache` keeps the
 exported tvm-ffi object of every kernel compiled with `--enable-tvm-ffi` and
 reloads it in milliseconds. `compile_cached(fn, *args, cache_key=, symbol=,
-**kwargs)` is the drop-in for `cute.compile` at a kernel's compile site. Every FROST kernel template
-routes through it: the GEMM templates with the digest of their generated
-source as the key (the full GEMM suites: 5655 tests, 20:53 cold, 1:35 warm),
-the SDPA forward / backward and linear-attention templates with
+**kwargs)` is the drop-in for `cute.compile` at a kernel's compile site. Two
+families route through it today: the GEMM templates, with the digest of their
+generated source as the key (the full GEMM suites: 5655 tests, 20:53 cold,
+1:35 warm), and the SDPA forward / backward templates, with
 `template_key(globals(), locals(), "<function>")` as the FIRST statement of
 each function that compiles — the file + params digest `template_loader`
 records as `FROST_SOURCE_DIGEST`, joined with the function's name and its
 arguments, which pin shapes, strides and flags the way the params pin dtypes
-and masks (SDPA SM100 graph-API cases: 24.8 s cold, 2.4 s warm). An argument
-that is not a plain value (a tensor, a device, a dtype object) makes the key
-None and the call compiles as before: the linear-attention `chunk_*`
-launchers, which trace real tensors, and the SDPA adapters' helper kernels in
-`api_dsl` are therefore not cached yet. A hit is the same object a miss
-produced, so the reloaded kernel is called exactly as the in-process one.
+and masks (SDPA + GEMM suites: 5867 tests, 53:06 cold, 2:53 warm). An
+argument that is not a plain value (a tensor, a device, a stream) makes the
+key None and the call compiles as before. Not cached: the linear-attention
+templates (their `compile()` takes traced tensors) and the SDPA adapters'
+helper kernels in `api_dsl`, which compile from real tensors at call time. A
+hit is the same object a miss produced, so the reloaded kernel is called
+exactly as the in-process one.
 
 The rules, borrowed from FlashInfer's autotune cache v2 so that a stale
 artifact can never be reused by accident:
@@ -839,18 +840,6 @@ defaulting to device 0 is how an SM100 suite silently skips in full.
   remove `selected_engine is None` branching, lowering extracted to its own
   module, op-identity dedup (NodeType vs registry keys), longer-term a typed
   `OpSpec` as the single per-op source for builder/validation/lowering.
-- **Persistent compiled-plan cache** for the JIT engines (today `cute.compile`
-  runs once per process; only generated source is cached on disk). Mirror the
-  FlashInfer autotune-cache v2 rules: the environment identity is the content
-  hash of a manifest (frontend version, `nvidia-cutlass-dsl` version incl. its
-  `libs-core` frontend, CUDA driver version, device name + CC + SM count + L2
-  bytes — frost bakes SM count and L2 into kernels) and names the cache
-  directory; every entry embeds its own key (generated-source digest,
-  `cute.compile` options, knobs) and is verified on load; any mismatch,
-  missing or malformed file is a miss, never a partial reuse; writes are
-  temp-file + `os.replace`; an incompatible format bumps the schema directory.
-  Expose the directory / cache object so a caller (FlashInfer) can point it at
-  its own workspace and ship it in an AOT wheel.
 - SDPA forward THD: padded LSE rows of a `(b, s_max, h)` stats buffer past a
   sequence's length — the backend writes `-inf`, the python row leaves them
   unwritten (`b == 1`; at `b > 1` the form is declined) — fill for parity. The

--- a/docs/utilities/python_graph_and_execution_backends.md
+++ b/docs/utilities/python_graph_and_execution_backends.md
@@ -683,6 +683,47 @@ FlashInfer's graphs and buffers byte for byte and assert exactly this; a decline
 at `check_support` is reported as xfail with the row's reason, a refusal after
 acceptance fails. They are the acceptance gate for turning the opt-in rows on
 by default.
+### The compiled-plan cache
+
+`cute.compile` runs the whole backend once per process for every distinct
+kernel — 0.7 s for a FROST GEMM, 2.6 s for an SDPA prefill on SM100 — and the
+DSL's own file cache stores only MLIR bytecode, so a process that warms tens
+of plans pays minutes at start-up. `cudnn.frost.compiled_cache` keeps the
+exported tvm-ffi object of every kernel compiled with `--enable-tvm-ffi` and
+reloads it in milliseconds. `compile_cached(fn, *args, cache_key=, symbol=,
+**kwargs)` is the drop-in for `cute.compile` at a kernel's compile site; the
+FROST GEMM templates route through it with the digest of their generated
+source as the key (44 kernels of the GEMM suites: 44 s cold, 12 s warm).
+
+The rules, borrowed from FlashInfer's autotune cache v2 so that a stale
+artifact can never be reused by accident:
+
+- **Identity is the whole manifest, hashed.** Frontend, cutlass-dsl and
+  tvm-ffi versions, the CUDA driver, and the device's name, compute
+  capability, SM count and L2 size (FROST bakes the last two into kernels)
+  name the directory `<root>/v1/<env_hash>/`. Any change lands elsewhere; an
+  unreadable field is hashed as `"unknown"`, never skipped.
+- **An entry is reused only under its own embedded key.** `entry.json`
+  carries the full key, symbol and signature and is compared on load; the
+  object is written first and the record after it (the commit marker), both
+  via temp file + `os.replace`, so a crash or a concurrent writer never
+  yields a loadable entry without its key.
+- **Anything doubtful is a miss**: missing, malformed, mismatched, or an
+  object `load_module` refuses (an arch the device cannot run). Never an error.
+- **A hit and a miss run the same thing.** A reloaded tvm-ffi function is
+  positional-only, so it is wrapped with a kwargs wrapper built from the
+  kernel's Python signature; the miss path exports and then reloads, so a bad
+  artifact fails at build time, not at the next start-up. Kernels whose
+  in-process object converts raw pointer arguments are not cached.
+- Location: `CUDNN_FRONTEND_COMPILED_CACHE`, else
+  `$XDG_CACHE_HOME/cudnn_frontend/compiled_plans`; `set_cache_dir()` for a
+  caller that owns a workspace (FlashInfer); `CUDNN_FRONTEND_DISABLE_COMPILED_CACHE=1`
+  turns it off; `stats()` reports hits / misses / bypassed / invalid per
+  process. Bump `_SCHEMA` on any incompatible change.
+
+Not yet routed: the SDPA and linear-attention kernel templates (their
+`cute.compile` calls take per-kernel keyword sets; same hook, one key per
+`(template, params, kwargs)`).
 
 ## Key invariants
 

--- a/python/cudnn/frost/compiled_cache.py
+++ b/python/cudnn/frost/compiled_cache.py
@@ -1,0 +1,331 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Persistent cache of compiled FROST kernels, across processes.
+
+``cute.compile`` runs the whole backend (NVVM, ptxas, host stub) once per
+process for every distinct kernel -- 0.7 s for a GEMM, 2.6 s for an SDPA
+prefill on SM100 -- and the DSL's own file cache stores only MLIR bytecode, so
+the heavy part is paid again at every start-up. A serving process that warms
+tens of plans pays minutes. This module keeps the exported object of every
+kernel compiled with ``--enable-tvm-ffi`` and reloads it (a few milliseconds)
+instead.
+
+Layout, and the rules that keep a stale artifact from ever being reused:
+
+    <root>/v1/<env_hash>/manifest.json           the environment identity, human-readable
+    <root>/v1/<env_hash>/<entry_hash>/kernel.o   the exported tvm-ffi object
+    <root>/v1/<env_hash>/<entry_hash>/entry.json the key it was stored under (commit marker)
+
+- ``env_hash`` is the content hash of :func:`environment_manifest`: frontend,
+  cutlass-dsl and tvm-ffi versions, the CUDA driver, and the device's name,
+  compute capability, SM count and L2 size (FROST bakes the last two into
+  kernels). Any change lands in a different directory; nothing is ever
+  "matched approximately".
+- ``entry_hash`` is the content hash of the caller's key -- for the FROST GEMM
+  engine the digest of the generated source, which already carries the tile
+  config, dtypes, fusion chain and ``--gpu-arch`` -- plus the exported symbol
+  and the compile options. ``entry.json`` embeds the full key and is compared
+  on load, so a hash collision or a foreign file is a miss.
+- Missing, unreadable, mismatched: a miss, never an error. The object is
+  written to a temporary name and renamed into place; ``entry.json`` is written
+  after it, so a crash never leaves a loadable entry without its key.
+- Bump ``_SCHEMA`` on any incompatible change to this layout.
+
+``compile_cached`` is a drop-in for ``cute.compile`` at a kernel's compile
+site. A reloaded tvm-ffi function is positional-only, so it is wrapped with a
+kwargs wrapper built from the kernel function's Python signature -- the same
+thing the in-process object does -- and the caller cannot tell a hit from a
+miss. Kernels whose in-process object converts raw pointer arguments are not
+cached (the reload path has no converter); everything else is.
+
+Location: ``CUDNN_FRONTEND_COMPILED_CACHE`` (a directory), else
+``$XDG_CACHE_HOME/cudnn_frontend/compiled_plans`` (``~/.cache`` when unset).
+``CUDNN_FRONTEND_DISABLE_COMPILED_CACHE=1`` turns the cache off. A caller
+that manages its own workspace (FlashInfer) points :func:`set_cache_dir` at
+it once per process.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import logging
+import os
+import tempfile
+import threading
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+_SCHEMA = "v1"
+_ENV_DIR = "CUDNN_FRONTEND_COMPILED_CACHE"
+_ENV_DISABLE = "CUDNN_FRONTEND_DISABLE_COMPILED_CACHE"
+_OBJECT = "kernel.o"
+_ENTRY = "entry.json"
+_MANIFEST = "manifest.json"
+
+_LOG = logging.getLogger("cudnn.frost.compiled_cache")
+_LOCK = threading.Lock()
+_dir_override: Optional[Path] = None
+_stats = {"hits": 0, "misses": 0, "bypassed": 0, "invalid": 0, "export_failed": 0}
+
+
+# ---------------------------------------------------------------------------
+# Location and switches
+# ---------------------------------------------------------------------------
+
+
+def enabled() -> bool:
+    """Whether compiled kernels are persisted and reloaded at all."""
+    return os.environ.get(_ENV_DISABLE, "0").strip().lower() not in ("1", "true", "yes", "on")
+
+
+def set_cache_dir(path) -> None:
+    """Point the cache at ``path`` for this process (``None`` restores the default)."""
+    global _dir_override
+    with _LOCK:
+        _dir_override = None if path is None else Path(path)
+
+
+def get_cache_dir() -> Path:
+    """The cache root: :func:`set_cache_dir`, else ``$CUDNN_FRONTEND_COMPILED_CACHE``,
+    else ``$XDG_CACHE_HOME/cudnn_frontend/compiled_plans``. Falls back to a
+    per-user directory under the system temp dir when that is not writable."""
+    with _LOCK:
+        if _dir_override is not None:
+            return _dir_override
+    base = os.environ.get(_ENV_DIR)
+    if not base:
+        xdg = os.environ.get("XDG_CACHE_HOME") or os.path.join(os.path.expanduser("~"), ".cache")
+        base = os.path.join(xdg, "cudnn_frontend", "compiled_plans")
+    root = Path(base)
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        if not os.access(root, os.W_OK):
+            raise PermissionError(f"{root} is not writable")
+        return root
+    except OSError as exc:
+        suffix = f"-{os.getuid()}" if hasattr(os, "getuid") else ""
+        fallback = Path(tempfile.gettempdir()) / f"cudnn_frontend_compiled_plans{suffix}"
+        fallback.mkdir(parents=True, exist_ok=True)
+        _LOG.warning("compiled-plan cache %s is unusable (%s); using %s. Set %s to choose another location.", root, exc, fallback, _ENV_DIR)
+        return fallback
+
+
+def stats() -> Dict[str, int]:
+    """Counters for this process: hits, misses, bypassed (not cacheable), invalid (entry rejected), export_failed."""
+    with _LOCK:
+        return dict(_stats)
+
+
+def reset_stats() -> None:
+    with _LOCK:
+        for k in _stats:
+            _stats[k] = 0
+
+
+def _count(name: str) -> None:
+    with _LOCK:
+        _stats[name] += 1
+
+
+# ---------------------------------------------------------------------------
+# Identity
+# ---------------------------------------------------------------------------
+
+
+def _dist_version(name: str) -> str:
+    try:
+        from importlib.metadata import version
+
+        return version(name)
+    except Exception:  # noqa: BLE001 -- the package may be vendored or absent
+        return "unknown"
+
+
+def environment_manifest(device: Optional[int] = None) -> Dict[str, str]:
+    """Everything a compiled object depends on, as deterministic strings.
+
+    A field that cannot be read becomes ``"unknown"`` -- and is hashed as such,
+    so an environment that cannot identify itself shares nothing with one that
+    can. Never loosen a field to widen hits: a wrong hit is a wrong kernel.
+    """
+    import cudnn
+
+    manifest: Dict[str, str] = {"schema": _SCHEMA, "cudnn_frontend": str(getattr(cudnn, "__version__", "unknown"))}
+    try:
+        import cutlass
+
+        manifest["cutlass_dsl"] = str(getattr(cutlass, "__version__", _dist_version("nvidia-cutlass-dsl")))
+    except Exception:  # noqa: BLE001
+        manifest["cutlass_dsl"] = "unknown"
+    manifest["tvm_ffi"] = _dist_version("apache-tvm-ffi")
+    try:
+        from cuda.bindings import driver as _cu
+
+        err, ver = _cu.cuDriverGetVersion()
+        manifest["cuda_driver"] = str(ver) if int(err) == 0 else "unknown"
+    except Exception:  # noqa: BLE001
+        manifest["cuda_driver"] = "unknown"
+    try:
+        from cudnn.frost import device as _dev
+
+        d = _dev.resolve_device(device)
+        cc = _dev.compute_capability(d)
+        manifest["device_name"] = str(_dev.device_name(d))
+        manifest["compute_capability"] = f"{cc[0]}.{cc[1]}"
+        manifest["sm_count"] = str(_dev.multiprocessor_count(d))
+        manifest["l2_bytes"] = str(_dev.l2_cache_bytes(d))
+    except Exception:  # noqa: BLE001 -- no device: the manifest still names that fact
+        for k in ("device_name", "compute_capability", "sm_count", "l2_bytes"):
+            manifest[k] = "unknown"
+    return manifest
+
+
+def _canonical(obj: Any) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+def _digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:24]
+
+
+def _entry_dir(root: Path, manifest: Dict[str, str], key: str) -> Path:
+    return root / _SCHEMA / _digest(_canonical(manifest)) / _digest(key)
+
+
+# ---------------------------------------------------------------------------
+# Files
+# ---------------------------------------------------------------------------
+
+
+def _write_atomic(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=f".{os.getpid()}.tmp")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+        os.replace(tmp, path)
+    finally:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:  # noqa: BLE001 -- unreadable is a miss
+        return None
+
+
+def _signature_of(fn: Callable) -> Optional[inspect.Signature]:
+    """The Python signature the in-process kwargs wrapper was built from."""
+    for candidate in (fn, getattr(fn, "__wrapped__", None), getattr(fn, "func", None), getattr(fn, "_func", None)):
+        if candidate is None:
+            continue
+        try:
+            sig = inspect.signature(candidate)
+        except (TypeError, ValueError):
+            continue
+        if any(p.kind in (p.VAR_POSITIONAL, p.VAR_KEYWORD) for p in sig.parameters.values()):
+            return None
+        return sig
+    return None
+
+
+# ---------------------------------------------------------------------------
+# The drop-in
+# ---------------------------------------------------------------------------
+
+
+def _try_load(entry: Path, key: str, symbol: str, fn: Callable):
+    """The reloaded, kwargs-wrapped kernel, or None (missing, mismatched, unloadable)."""
+    record = _read_json(entry / _ENTRY)
+    if not isinstance(record, dict):
+        return None
+    if record.get("schema") != _SCHEMA or record.get("key") != key or record.get("symbol") != symbol:
+        _count("invalid")
+        _LOG.warning("compiled-plan cache: ignoring %s (embedded key does not match); treating as a miss", entry)
+        return None
+    obj = entry / _OBJECT
+    if not obj.is_file():
+        return None
+    sig = _signature_of(fn)
+    if sig is None:
+        return None
+    try:
+        import cutlass
+        from tvm_ffi.utils.kwargs_wrapper import make_kwargs_wrapper_from_signature
+
+        module = cutlass.runtime.load_module(str(obj), enable_tvm_ffi=True)
+        raw = getattr(module, symbol)
+        wrapper = make_kwargs_wrapper_from_signature(raw, sig)
+        wrapper._compiled_cache_module = module  # keep the engine alive as long as the callable
+        wrapper._compiled_cache_entry = str(entry)
+        return wrapper
+    except Exception as exc:  # noqa: BLE001 -- a stale or foreign artifact is a miss
+        _count("invalid")
+        _LOG.warning("compiled-plan cache: could not reload %s (%s); recompiling", obj, exc)
+        return None
+
+
+def _export(entry: Path, compiled: Any, key: str, symbol: str, manifest: Dict[str, str], fn: Callable) -> None:
+    env_dir = entry.parent
+    if not (env_dir / _MANIFEST).exists():
+        _write_atomic(env_dir / _MANIFEST, (_canonical(manifest) + "\n").encode("utf-8"))
+    entry.mkdir(parents=True, exist_ok=True)
+    tmp = entry / f".{_OBJECT}.{os.getpid()}.tmp"
+    try:
+        compiled.export_to_c(str(tmp), function_name=symbol)
+        os.replace(tmp, entry / _OBJECT)
+    finally:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+    sig = _signature_of(fn)
+    record = {"schema": _SCHEMA, "key": key, "symbol": symbol, "signature": str(sig) if sig is not None else None}
+    _write_atomic(entry / _ENTRY, (json.dumps(record, indent=1) + "\n").encode("utf-8"))
+
+
+def compile_cached(fn: Callable, *args: Any, cache_key: Optional[str], symbol: str = "kernel", **kwargs: Any) -> Any:
+    """``cute.compile(fn, *args, **kwargs)`` with a persistent object behind it.
+
+    ``cache_key`` names the kernel exactly (for a generated kernel: the digest
+    of its source); ``None`` means "not cacheable" and compiles as before. The
+    compile options must include ``--enable-tvm-ffi`` -- that is what makes the
+    object exportable and reloadable; other kernels compile as before.
+    """
+    import cutlass.cute as cute
+
+    options = str(kwargs.get("options") or "")
+    if not enabled() or cache_key is None or "--enable-tvm-ffi" not in options:
+        _count("bypassed")
+        return cute.compile(fn, *args, **kwargs)
+    manifest = environment_manifest()
+    entry = _entry_dir(get_cache_dir(), manifest, f"{cache_key}|{symbol}|{options}")
+    loaded = _try_load(entry, cache_key, symbol, fn)
+    if loaded is not None:
+        _count("hits")
+        return loaded
+    compiled = cute.compile(fn, *args, **kwargs)
+    _count("misses")
+    execution_args = getattr(compiled, "execution_args", None)
+    if getattr(execution_args, "has_pointer_address_arg_specs", False) or not hasattr(compiled, "export_to_c"):
+        return compiled  # the in-process object converts raw pointers; a reloaded one could not
+    if _signature_of(fn) is None:
+        return compiled
+    try:
+        _export(entry, compiled, cache_key, symbol, manifest, fn)
+    except Exception as exc:  # noqa: BLE001 -- persistence is best-effort; the kernel is compiled either way
+        _count("export_failed")
+        _LOG.warning("compiled-plan cache: could not persist %s (%s); the kernel will be recompiled next process", entry, exc)
+        return compiled
+    # Hand back the artifact rather than the in-process object, so a hit and a
+    # miss run the same thing and a bad artifact fails here, not next start-up.
+    loaded = _try_load(entry, cache_key, symbol, fn)
+    return loaded if loaded is not None else compiled

--- a/python/cudnn/frost/compiled_cache.py
+++ b/python/cudnn/frost/compiled_cache.py
@@ -55,6 +55,7 @@ import logging
 import os
 import tempfile
 import threading
+import uuid
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
@@ -147,9 +148,10 @@ def _dist_version(name: str) -> str:
 def environment_manifest(device: Optional[int] = None) -> Dict[str, str]:
     """Everything a compiled object depends on, as deterministic strings.
 
-    A field that cannot be read becomes ``"unknown"`` -- and is hashed as such,
-    so an environment that cannot identify itself shares nothing with one that
-    can. Never loosen a field to widen hits: a wrong hit is a wrong kernel.
+    A field that cannot be read becomes ``"unknown"``, and :func:`compile_cached`
+    then persists nothing: an environment that cannot identify itself must not
+    share an entry with one that happens to carry the same unknowns. Never
+    loosen a field to widen hits: a wrong hit is a wrong kernel.
     """
     import cudnn
 
@@ -278,7 +280,10 @@ def _export(entry: Path, compiled: Any, key: str, symbol: str, manifest: Dict[st
     if not (env_dir / _MANIFEST).exists():
         _write_atomic(env_dir / _MANIFEST, (_canonical(manifest) + "\n").encode("utf-8"))
     entry.mkdir(parents=True, exist_ok=True)
-    tmp = entry / f".{_OBJECT}.{os.getpid()}.tmp"
+    # Unique per export, not per process: two threads may export the same
+    # entry concurrently (nothing serializes compiles), and a shared temp name
+    # would let one publish the other's half-written object.
+    tmp = entry / f".{_OBJECT}.{os.getpid()}.{threading.get_ident()}.{uuid.uuid4().hex[:8]}.tmp"
     try:
         compiled.export_to_c(str(tmp), function_name=symbol)
         os.replace(tmp, entry / _OBJECT)
@@ -307,6 +312,11 @@ def compile_cached(fn: Callable, *args: Any, cache_key: Optional[str], symbol: s
         _count("bypassed")
         return cute.compile(fn, *args, **kwargs)
     manifest = environment_manifest()
+    if any(v == "unknown" for v in manifest.values()):
+        # An environment that cannot identify itself shares nothing: two
+        # incompatible stacks with the same unknowns would otherwise hash alike.
+        _count("bypassed")
+        return cute.compile(fn, *args, **kwargs)
     entry = _entry_dir(get_cache_dir(), manifest, f"{cache_key}|{symbol}|{options}")
     loaded = _try_load(entry, cache_key, symbol, fn)
     if loaded is not None:

--- a/python/cudnn/frost/compiled_cache.py
+++ b/python/cudnn/frost/compiled_cache.py
@@ -146,6 +146,42 @@ def _dist_version(name: str) -> str:
         return "unknown"
 
 
+_SOURCE_DIGEST: Optional[str] = None
+
+
+def source_tree_digest(root: Path) -> str:
+    """One digest over every ``.py`` under ``root`` (relative path + bytes, sorted).
+
+    A kernel is compiled from more than its own template: the shared frost
+    helpers, the DSL adapters and the generator it imports all shape the traced
+    code, and none of them is in a template's key. The version string covers a
+    wheel; it does not cover a checkout someone is editing, and a stale hit
+    there is a wrong kernel with no error. So the manifest carries the digest
+    of the whole package instead of a commit hash: an uncommitted edit counts
+    too, and an installed wheel hashes the same every time. Computed once per
+    process (a few tens of milliseconds for the tree).
+    """
+    h = hashlib.sha256()
+    for path in sorted(p for p in root.rglob("*.py") if "__pycache__" not in p.parts):
+        h.update(str(path.relative_to(root)).encode("utf-8"))
+        h.update(b"\0")
+        h.update(path.read_bytes())
+        h.update(b"\0")
+    return h.hexdigest()[:16]
+
+
+def _cudnn_source_digest() -> str:
+    global _SOURCE_DIGEST
+    if _SOURCE_DIGEST is None:
+        try:
+            import cudnn
+
+            _SOURCE_DIGEST = source_tree_digest(Path(cudnn.__file__).resolve().parent)
+        except Exception:  # noqa: BLE001 -- a package that cannot be read shares nothing
+            _SOURCE_DIGEST = "unknown"
+    return _SOURCE_DIGEST
+
+
 def environment_manifest(device: Optional[int] = None) -> Dict[str, str]:
     """Everything a compiled object depends on, as deterministic strings.
 
@@ -156,7 +192,7 @@ def environment_manifest(device: Optional[int] = None) -> Dict[str, str]:
     """
     import cudnn
 
-    manifest: Dict[str, str] = {"schema": _SCHEMA, "cudnn_frontend": str(getattr(cudnn, "__version__", "unknown"))}
+    manifest: Dict[str, str] = {"schema": _SCHEMA, "cudnn_frontend": str(getattr(cudnn, "__version__", "unknown")), "cudnn_source": _cudnn_source_digest()}
     try:
         import cutlass
 

--- a/python/cudnn/frost/compiled_cache.py
+++ b/python/cudnn/frost/compiled_cache.py
@@ -48,6 +48,7 @@ it once per process.
 
 from __future__ import annotations
 
+import dataclasses
 import hashlib
 import inspect
 import json
@@ -59,7 +60,7 @@ import uuid
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
-_SCHEMA = "v1"
+_SCHEMA = "v2"  # v2: the record carries the runtime wrapper spec, not a Python signature
 _ENV_DIR = "CUDNN_FRONTEND_COMPILED_CACHE"
 _ENV_DISABLE = "CUDNN_FRONTEND_DISABLE_COMPILED_CACHE"
 _OBJECT = "kernel.o"
@@ -224,19 +225,95 @@ def _read_json(path: Path) -> Any:
         return None
 
 
-def _signature_of(fn: Callable) -> Optional[inspect.Signature]:
-    """The Python signature the in-process kwargs wrapper was built from."""
-    for candidate in (fn, getattr(fn, "__wrapped__", None), getattr(fn, "func", None), getattr(fn, "_func", None)):
-        if candidate is None:
-            continue
-        try:
-            sig = inspect.signature(candidate)
-        except (TypeError, ValueError):
-            continue
-        if any(p.kind in (p.VAR_POSITIONAL, p.VAR_KEYWORD) for p in sig.parameters.values()):
-            return None
-        return sig
-    return None
+_PLAIN = (int, float, bool, str, type(None))
+
+
+def _plain(value: Any) -> bool:
+    """Whether ``repr(value)`` names the same thing in another process: plain
+    scalars, tuples/lists of them, dataclass instances whose fields are (a
+    template's params record travels into compile() this way), and types
+    (``cutlass.BFloat16`` and friends; a class repr is its qualified name)."""
+    if isinstance(value, _PLAIN) or isinstance(value, type):
+        return True
+    if isinstance(value, (tuple, list)):
+        return all(_plain(v) for v in value)
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return all(_plain(getattr(value, f.name)) for f in dataclasses.fields(value))
+    return False
+
+
+def template_key(module_globals: Dict[str, Any], arguments: Dict[str, Any], function: str = "compile") -> Optional[str]:
+    """The cache key of one ``compile()`` call of a kernel template.
+
+    A template specializes twice: at import, from the file and its
+    ``FROST_TEMPLATE_PARAMS`` (``template_loader`` records that as
+    ``FROST_SOURCE_DIGEST``), and at ``compile()``, from the call's arguments
+    (shapes, strides, flags), which pin the traced code as much as the params
+    do. The key joins the two. Call it as the FIRST statement of the function,
+    with ``locals()``, so the arguments are exactly the parameters. None -- not
+    cacheable -- when the module carries no digest or an argument is not a
+    plain value (a tensor, a device, a stream): its ``repr`` need not name the
+    same kernel in another process.
+    """
+    digest = module_globals.get("FROST_SOURCE_DIGEST")
+    if not digest:
+        return None
+    items = sorted(arguments.items())
+    if not all(_plain(v) for _, v in items):
+        return None
+    return f"{digest}|{function}|{items!r}"
+
+
+def _json_plain(value: Any) -> bool:
+    return value is None or isinstance(value, (bool, int, float, str))
+
+
+def _wrapper_spec_of(compiled: Any, args: tuple, kwargs: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """The calling convention of the in-process object, as JSON.
+
+    The DSL calls a kernel through a kwargs wrapper generated from its
+    ORIGINAL signature minus the parameters that do not exist at run time:
+    ``cutlass.Constexpr`` arguments are baked into the kernel and an
+    env-stream argument is read from the environment. A wrapper built from the
+    Python signature instead would shift every argument after a constexpr one.
+    So the spec is taken the way the DSL takes it: ``execution_args`` names the
+    parameters and their defaults; the in-process wrapper's own signature says
+    which of them survived. None when it cannot be reproduced exactly -- no
+    wrapper, a default that JSON cannot carry, a dataclass argument (the DSL
+    unpacks those through a hook the record does not describe).
+    """
+    wrapper = getattr(compiled, "_kwargs_wrapper", None)
+    execution_args = getattr(compiled, "execution_args", None)
+    if wrapper is None or execution_args is None or not hasattr(execution_args, "get_kwargs_wrapper_spec"):
+        return None
+    if any(dataclasses.is_dataclass(a) and not isinstance(a, type) for a in list(args) + list(kwargs.values())):
+        return None
+    try:
+        survived = set(inspect.signature(wrapper).parameters)
+        full = execution_args.get_kwargs_wrapper_spec(())
+        excluded = [n for n in list(full.arg_names) + list(full.kwonly_names) if n not in survived]
+        spec = execution_args.get_kwargs_wrapper_spec(excluded) if excluded else full
+    except Exception:  # noqa: BLE001 -- a DSL whose executor does not expose the spec
+        return None
+    arg_defaults, kwonly_defaults = list(spec.arg_defaults), dict(spec.kwonly_defaults)
+    if not all(_json_plain(v) for v in arg_defaults + list(kwonly_defaults.values())):
+        return None
+    return {"arg_names": list(spec.arg_names), "arg_defaults": arg_defaults, "kwonly_names": list(spec.kwonly_names), "kwonly_defaults": kwonly_defaults}
+
+
+def _rebuild_wrapper(raw: Callable, spec: Dict[str, Any]) -> Optional[Callable]:
+    """The kwargs wrapper the in-process object had, over the reloaded function."""
+    from tvm_ffi.utils.kwargs_wrapper import make_kwargs_wrapper
+
+    if not isinstance(spec, dict) or not all(k in spec for k in ("arg_names", "arg_defaults", "kwonly_names", "kwonly_defaults")):
+        return None
+    return make_kwargs_wrapper(
+        raw,
+        arg_names=list(spec["arg_names"]),
+        arg_defaults=tuple(spec["arg_defaults"]),
+        kwonly_names=list(spec["kwonly_names"]),
+        kwonly_defaults=dict(spec["kwonly_defaults"]),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -244,8 +321,9 @@ def _signature_of(fn: Callable) -> Optional[inspect.Signature]:
 # ---------------------------------------------------------------------------
 
 
-def _try_load(entry: Path, key: str, symbol: str, fn: Callable):
-    """The reloaded, kwargs-wrapped kernel, or None (missing, mismatched, unloadable)."""
+def _try_load(entry: Path, key: str, symbol: str):
+    """The reloaded kernel behind the in-process calling convention, or None
+    (missing, mismatched, unloadable)."""
     record = _read_json(entry / _ENTRY)
     if not isinstance(record, dict):
         return None
@@ -256,18 +334,17 @@ def _try_load(entry: Path, key: str, symbol: str, fn: Callable):
     obj = entry / _OBJECT
     if not obj.is_file():
         return None
-    sig = _signature_of(fn)
-    if sig is None:
-        return None
     try:
         import cutlass
-        from tvm_ffi.utils.kwargs_wrapper import make_kwargs_wrapper_from_signature
 
         module = cutlass.runtime.load_module(str(obj), enable_tvm_ffi=True)
         raw = getattr(module, symbol)
-        wrapper = make_kwargs_wrapper_from_signature(raw, sig)
+        wrapper = _rebuild_wrapper(raw, record.get("wrapper"))
+        if wrapper is None:
+            return None
         wrapper._compiled_cache_module = module  # keep the engine alive as long as the callable
         wrapper._compiled_cache_entry = str(entry)
+        wrapper._compiled_cache_raw = raw  # positional-only tvm_ffi.Function, for a prepared lane
         return wrapper
     except Exception as exc:  # noqa: BLE001 -- a stale or foreign artifact is a miss
         _count("invalid")
@@ -275,26 +352,23 @@ def _try_load(entry: Path, key: str, symbol: str, fn: Callable):
         return None
 
 
-def _export(entry: Path, compiled: Any, key: str, symbol: str, manifest: Dict[str, str], fn: Callable) -> None:
-    env_dir = entry.parent
-    if not (env_dir / _MANIFEST).exists():
-        _write_atomic(env_dir / _MANIFEST, (_canonical(manifest) + "\n").encode("utf-8"))
+def _export(entry: Path, compiled: Any, key: str, symbol: str, manifest: Dict[str, str], wrapper: Dict[str, Any]) -> None:
+    """Publish ``compiled`` under ``entry``: object first, record last (the commit marker)."""
     entry.mkdir(parents=True, exist_ok=True)
-    # Unique per export, not per process: two threads may export the same
-    # entry concurrently (nothing serializes compiles), and a shared temp name
-    # would let one publish the other's half-written object.
-    tmp = entry / f".{_OBJECT}.{os.getpid()}.{threading.get_ident()}.{uuid.uuid4().hex[:8]}.tmp"
+    manifest_path = entry.parent / _MANIFEST
+    if not manifest_path.exists():
+        _write_atomic(manifest_path, json.dumps(manifest, indent=1, sort_keys=True).encode("utf-8"))
+    # export_to_c writes the file itself, so it gets a unique temp name and is
+    # renamed into place; a reader sees the whole object or nothing.
+    tmp = entry / f"{_OBJECT}.{os.getpid()}.{threading.get_ident()}.{uuid.uuid4().hex}.tmp"
     try:
         compiled.export_to_c(str(tmp), function_name=symbol)
         os.replace(tmp, entry / _OBJECT)
     finally:
-        try:
-            os.unlink(tmp)
-        except FileNotFoundError:
-            pass
-    sig = _signature_of(fn)
-    record = {"schema": _SCHEMA, "key": key, "symbol": symbol, "signature": str(sig) if sig is not None else None}
-    _write_atomic(entry / _ENTRY, (json.dumps(record, indent=1) + "\n").encode("utf-8"))
+        if tmp.exists():
+            tmp.unlink()
+    record = {"schema": _SCHEMA, "key": key, "symbol": symbol, "wrapper": wrapper}
+    _write_atomic(entry / _ENTRY, json.dumps(record, indent=1, sort_keys=True).encode("utf-8"))
 
 
 def compile_cached(fn: Callable, *args: Any, cache_key: Optional[str], symbol: str = "kernel", **kwargs: Any) -> Any:
@@ -318,7 +392,7 @@ def compile_cached(fn: Callable, *args: Any, cache_key: Optional[str], symbol: s
         _count("bypassed")
         return cute.compile(fn, *args, **kwargs)
     entry = _entry_dir(get_cache_dir(), manifest, f"{cache_key}|{symbol}|{options}")
-    loaded = _try_load(entry, cache_key, symbol, fn)
+    loaded = _try_load(entry, cache_key, symbol)
     if loaded is not None:
         _count("hits")
         return loaded
@@ -327,15 +401,16 @@ def compile_cached(fn: Callable, *args: Any, cache_key: Optional[str], symbol: s
     execution_args = getattr(compiled, "execution_args", None)
     if getattr(execution_args, "has_pointer_address_arg_specs", False) or not hasattr(compiled, "export_to_c"):
         return compiled  # the in-process object converts raw pointers; a reloaded one could not
-    if _signature_of(fn) is None:
-        return compiled
+    wrapper = _wrapper_spec_of(compiled, args, kwargs)
+    if wrapper is None:
+        return compiled  # a calling convention the record cannot reproduce exactly
     try:
-        _export(entry, compiled, cache_key, symbol, manifest, fn)
+        _export(entry, compiled, cache_key, symbol, manifest, wrapper)
     except Exception as exc:  # noqa: BLE001 -- persistence is best-effort; the kernel is compiled either way
         _count("export_failed")
         _LOG.warning("compiled-plan cache: could not persist %s (%s); the kernel will be recompiled next process", entry, exc)
         return compiled
     # Hand back the artifact rather than the in-process object, so a hit and a
     # miss run the same thing and a bad artifact fails here, not next start-up.
-    loaded = _try_load(entry, cache_key, symbol, fn)
+    loaded = _try_load(entry, cache_key, symbol)
     return loaded if loaded is not None else compiled

--- a/python/cudnn/frost/compiled_cache.py
+++ b/python/cudnn/frost/compiled_cache.py
@@ -13,12 +13,15 @@ instead.
 
 Layout, and the rules that keep a stale artifact from ever being reused:
 
-    <root>/v1/<env_hash>/manifest.json           the environment identity, human-readable
-    <root>/v1/<env_hash>/<entry_hash>/kernel.o   the exported tvm-ffi object
-    <root>/v1/<env_hash>/<entry_hash>/entry.json the key it was stored under (commit marker)
+    <root>/v2/<env_hash>/manifest.json           the environment identity, human-readable
+    <root>/v2/<env_hash>/<entry_hash>/kernel.o   the exported tvm-ffi object
+    <root>/v2/<env_hash>/<entry_hash>/entry.json the key and calling convention it was stored under (commit marker)
 
-- ``env_hash`` is the content hash of :func:`environment_manifest`: frontend,
-  cutlass-dsl and tvm-ffi versions, the CUDA driver, and the device's name,
+- ``env_hash`` is the content hash of :func:`environment_manifest`: frontend
+  version and a digest of the whole ``cudnn`` package's source (the shared
+  helpers a kernel imports are not in its own key; an edited checkout must
+  not hit a wheel's entries), cutlass-dsl and tvm-ffi versions, the CUDA
+  driver, and the device's name,
   compute capability, SM count and L2 size (FROST bakes the last two into
   kernels). Any change lands in a different directory; nothing is ever
   "matched approximately".

--- a/python/cudnn/frost/template_loader.py
+++ b/python/cudnn/frost/template_loader.py
@@ -47,7 +47,9 @@ Roads not taken
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
+import pathlib
 import threading
 from typing import Any, Hashable
 
@@ -55,6 +57,7 @@ _MODULES: dict = {}
 _LOCK = threading.Lock()
 
 PARAMS_GLOBAL = "FROST_TEMPLATE_PARAMS"
+DIGEST_GLOBAL = "FROST_SOURCE_DIGEST"
 
 
 def load_template(path: str, params: Hashable, tag: str = "template") -> Any:
@@ -73,6 +76,10 @@ def load_template(path: str, params: Hashable, tag: str = "template") -> Any:
         spec = importlib.util.spec_from_file_location(name, path)
         mod = importlib.util.module_from_spec(spec)
         setattr(mod, PARAMS_GLOBAL, params)
+        # What the module's kernels are compiled FROM: this file, specialized by
+        # these params. compiled_cache.template_key joins it with a compile()
+        # call's arguments to name a persistent object.
+        setattr(mod, DIGEST_GLOBAL, hashlib.sha256(pathlib.Path(path).read_bytes() + repr(params).encode("utf-8")).hexdigest()[:16])
         spec.loader.exec_module(mod)
         _MODULES[key] = mod
         return mod

--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -2821,6 +2821,10 @@ def _import_kernel(src: str) -> object:
     mod = importlib.util.module_from_spec(spec)
     sys.modules[mod_name] = mod
     spec.loader.exec_module(mod)
+    # The template's compile() keys its persistent object on this digest: the
+    # rendered source carries the tile config, dtypes, fusion chain and the
+    # --gpu-arch option, so it IS the kernel's identity.
+    mod.FROST_SOURCE_DIGEST = digest
     return mod
 
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul.py
@@ -57,6 +57,7 @@ from cudnn.gemm.frost.kernel_templates._tile_helpers import (
 import cutlass.experimental.cuda.tensor_map as _tma
 import cutlass._mlir_helpers.vector as _cvec
 import cutlass
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached
 import cutlass.cute as cute
 from cutlass.cute.runtime import make_fake_compact_tensor
 from cutlass.cute.runtime import make_fake_stream
@@ -1861,7 +1862,7 @@ def compile() -> Callable:
     # @@SPLITK_ONLY:END@@
 
     _fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
-    return cute.compile(
+    return _compile_cached(
         _host,
         problem_size,
         # @@INJECT_COMPILE_AB_PASS@@
@@ -1875,4 +1876,7 @@ def compile() -> Callable:
         # @@SPLITK_ONLY:END@@
         stream=_fake_stream,
         options=frost_compile_options,
+        # persistent object across processes (cudnn.frost.compiled_cache); the digest of THIS source is the key
+        cache_key=globals().get("FROST_SOURCE_DIGEST"),
+        symbol="frost_gemm",
     )

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul.py
@@ -55,6 +55,7 @@ from cudnn.gemm.frost.kernel_templates._tile_helpers import (
 import cutlass.experimental.cuda.tensor_map as _tma
 import cutlass._mlir_helpers.vector as _cvec
 import cutlass
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached
 import cutlass.cute as cute
 from cutlass.cute.runtime import make_fake_compact_tensor, make_fake_tensor
 from cutlass.cute.runtime import make_fake_stream
@@ -1501,7 +1502,7 @@ def compile() -> Callable:
     fake_splitk_partials = make_fake_tensor(cutlass.Float32, (sym_partials_elems,), stride=(1,), assumed_align=16)
     # @@SPLITK_ONLY:END@@
     _fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
-    return cute.compile(
+    return _compile_cached(
         _host,
         problem_size,
         # @@INJECT_COMPILE_AB_PASS@@
@@ -1515,4 +1516,7 @@ def compile() -> Callable:
         # @@SPLITK_ONLY:END@@
         stream=_fake_stream,
         options=frost_compile_options,
+        # persistent object across processes (cudnn.frost.compiled_cache); the digest of THIS source is the key
+        cache_key=globals().get("FROST_SOURCE_DIGEST"),
+        symbol="frost_gemm",
     )

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop.py
@@ -44,6 +44,7 @@ from cudnn.gemm.frost.kernel_templates._tile_helpers import (
 import cutlass.experimental.cuda.tensor_map as _tma
 import cutlass._mlir_helpers.vector as _cvec
 import cutlass
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached
 import cutlass.cute as cute
 from cutlass.cute.runtime import make_fake_compact_tensor, make_fake_tensor
 from cutlass.cute.runtime import make_fake_stream
@@ -1774,7 +1775,7 @@ def compile() -> Callable:
     fake_splitk_partials = make_fake_tensor(cutlass.Float32, (sym_partials_elems,), stride=(1,), assumed_align=16)
     # @@SPLITK_ONLY:END@@
     _fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
-    return cute.compile(
+    return _compile_cached(
         _host,
         problem_size,
         # @@INJECT_COMPILE_AB_PASS@@
@@ -1788,4 +1789,7 @@ def compile() -> Callable:
         # @@SPLITK_ONLY:END@@
         stream=_fake_stream,
         options=frost_compile_options,
+        # persistent object across processes (cudnn.frost.compiled_cache); the digest of THIS source is the key
+        cache_key=globals().get("FROST_SOURCE_DIGEST"),
+        symbol="frost_gemm",
     )

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd.py
@@ -46,6 +46,7 @@ from cudnn.gemm.frost.kernel_templates._tile_helpers import (
 )
 import cutlass.experimental.cuda.tensor_map as _tma
 import cutlass
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached
 import cutlass.cute as cute
 from cutlass.cute.runtime import make_fake_compact_tensor
 from cutlass.cute.runtime import make_fake_stream
@@ -2118,7 +2119,7 @@ def compile() -> Callable:
     # @@INJECT_COMPILE_AUX_FAKES@@
 
     _fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
-    return cute.compile(
+    return _compile_cached(
         _host,
         problem_size,
         fake_first_token_offset,
@@ -2131,4 +2132,7 @@ def compile() -> Callable:
         # @@TMA_STORE_ONLY:END@@
         stream=_fake_stream,
         options=frost_compile_options,
+        # persistent object across processes (cudnn.frost.compiled_cache); the digest of THIS source is the key
+        cache_key=globals().get("FROST_SOURCE_DIGEST"),
+        symbol="frost_gemm",
     )

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd.py
@@ -38,6 +38,7 @@ from cudnn.gemm.frost.kernel_templates._tile_helpers import (
 )
 import cutlass.experimental.cuda.tensor_map as _tma
 import cutlass
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached
 import cutlass.cute as cute
 from cutlass.cute.runtime import make_fake_compact_tensor
 from cutlass.cute.runtime import make_fake_stream
@@ -1524,7 +1525,7 @@ def compile() -> Callable:
     )
     # @@INJECT_COMPILE_AUX_FAKES@@
     _fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
-    return cute.compile(
+    return _compile_cached(
         _host,
         problem_size,
         fake_first_token_offset,
@@ -1537,4 +1538,7 @@ def compile() -> Callable:
         # @@TMA_STORE_ONLY:END@@
         stream=_fake_stream,
         options=frost_compile_options,
+        # persistent object across processes (cudnn.frost.compiled_cache); the digest of THIS source is the key
+        cache_key=globals().get("FROST_SOURCE_DIGEST"),
+        symbol="frost_gemm",
     )

--- a/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul.py
@@ -45,6 +45,7 @@ from cudnn.gemm.frost.kernel_templates._tile_helpers import (
 import cutlass.experimental.cuda.tensor_map as _tma
 import cutlass._mlir_helpers.vector as _cvec
 import cutlass
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached
 import cutlass.cute as cute
 from cutlass.cute.runtime import make_fake_compact_tensor
 from cutlass.cute.runtime import make_fake_stream
@@ -1917,7 +1918,7 @@ def compile() -> Callable:
     # @@SPLITK_ONLY:END@@
 
     _fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
-    return cute.compile(
+    return _compile_cached(
         _host,
         problem_size,
         # @@INJECT_COMPILE_AB_PASS@@
@@ -1931,4 +1932,7 @@ def compile() -> Callable:
         # @@SPLITK_ONLY:END@@
         stream=_fake_stream,
         options=frost_compile_options,
+        # persistent object across processes (cudnn.frost.compiled_cache); the digest of THIS source is the key
+        cache_key=globals().get("FROST_SOURCE_DIGEST"),
+        symbol="frost_gemm",
     )

--- a/python/cudnn/gemm/frost/kernel_templates/sm120_block_scale_matmul.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm120_block_scale_matmul.py
@@ -51,6 +51,7 @@ import cutlass.experimental.cuda.tensor_map as _tma
 import cutlass._mlir_helpers.vector as _cvec
 from cutlass import apply_swizzle as _apply_smem_swizzle
 import cutlass
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached
 import cutlass.cute as cute
 from cutlass.cute.runtime import make_fake_compact_tensor, make_fake_tensor
 from cutlass.cute.runtime import make_fake_stream
@@ -1253,7 +1254,7 @@ def compile() -> Callable:
     # @@SPLITK_ONLY:END@@
 
     _fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
-    return cute.compile(
+    return _compile_cached(
         _host,
         problem_size,
         # @@INJECT_COMPILE_AB_PASS@@
@@ -1264,4 +1265,7 @@ def compile() -> Callable:
         # @@SPLITK_ONLY:END@@
         stream=_fake_stream,
         options=frost_compile_options,
+        # persistent object across processes (cudnn.frost.compiled_cache); the digest of THIS source is the key
+        cache_key=globals().get("FROST_SOURCE_DIGEST"),
+        symbol="frost_gemm",
     )

--- a/python/cudnn/gemm/frost/kernel_templates/sm120_matmul.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm120_matmul.py
@@ -25,6 +25,7 @@ import cutlass.experimental.cuda.tensor_map as _tma
 import cutlass._mlir_helpers.vector as _cvec
 from cutlass import apply_swizzle as _apply_smem_swizzle
 import cutlass
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached
 import cutlass.cute as cute
 from cutlass.cute.runtime import make_fake_compact_tensor, make_fake_tensor
 from cutlass.cute.runtime import make_fake_stream
@@ -1059,7 +1060,7 @@ def compile() -> Callable:
     fake_splitk_partials = make_fake_tensor(cutlass.Float32, (sym_partials_elems,), stride=(1,), assumed_align=16)
     # @@SPLITK_ONLY:END@@
     _fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
-    return cute.compile(
+    return _compile_cached(
         _host,
         problem_size,
         # @@INJECT_COMPILE_AB_PASS@@
@@ -1070,4 +1071,7 @@ def compile() -> Callable:
         # @@SPLITK_ONLY:END@@
         stream=_fake_stream,
         options=frost_compile_options,
+        # persistent object across processes (cudnn.frost.compiled_cache); the digest of THIS source is the key
+        cache_key=globals().get("FROST_SOURCE_DIGEST"),
+        symbol="frost_gemm",
     )

--- a/python/cudnn/sdpa/bwd/kernels/bprop_d512_f16_sm100.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_d512_f16_sm100.py
@@ -37,6 +37,7 @@ a crash -- it surfaces as an intermittent hang whose output is correct on every
 launch that completes.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 from functools import lru_cache
 from typing import Callable, NamedTuple, Optional, Tuple
 
@@ -1557,6 +1558,7 @@ def compile(  # noqa: A001
     chunk.  ``head_base`` / ``batch_base`` are RUNTIME args, so one
     compiled artifact serves every chunk.
     """
+    _cache_key = _template_key(globals(), locals(), "compile")
     if CFG.THD_VARLEN:
         # Packed token totals are RUNTIME values (they change every step under
         # continuous batching), so the token extents compile DYNAMIC and the
@@ -1669,7 +1671,7 @@ def compile(  # noqa: A001
         fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (b,), stride_order=(0,), assumed_align=16)
         fake_desc_words = cute.runtime.make_fake_compact_tensor(cutlass.Int64, (1,), stride_order=(0,), assumed_align=16)
 
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -1692,6 +1694,8 @@ def compile(  # noqa: A001
         cutlass.Int32(0),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_bwd",
     )
 
 

--- a/python/cudnn/sdpa/bwd/kernels/bprop_d64_f16_sm80.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_d64_f16_sm80.py
@@ -44,6 +44,7 @@ Validation: f16 rel ~3.8e-4, bf16 ~3.4e-3 (dQ/dK/dV) at S=512; multi-tile
 (S_q=768) also validated.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 import math
 from functools import lru_cache
 from typing import Optional, Tuple
@@ -637,6 +638,7 @@ def _bprop_host(
 
 @lru_cache(maxsize=None)
 def _compile_main(B, H, SQ, SKV, d, io_is_bf16):
+    _cache_key = _template_key(globals(), locals(), "_compile_main")
     io_dtype = cutlass.BFloat16 if io_is_bf16 else cutlass.Float16
     mk = cute.runtime.make_fake_compact_tensor
     fq = mk(io_dtype, (B, SQ, H, d), stride_order=(3, 2, 1, 0), assumed_align=16)
@@ -650,7 +652,7 @@ def _compile_main(B, H, SQ, SKV, d, io_is_bf16):
     fdv = mk(io_dtype, (B, SKV, H, d), stride_order=(3, 2, 1, 0), assumed_align=16)
     fl = mk(cutlass.Float32, (B, H, SQ), stride_order=(2, 1, 0), assumed_align=16)
     fdt = mk(cutlass.Float32, (B, H, SQ), stride_order=(2, 1, 0), assumed_align=16)
-    return cute.compile(
+    return _compile_cached(
         _bprop_host,
         fq,
         fk,
@@ -668,16 +670,30 @@ def _compile_main(B, H, SQ, SKV, d, io_is_bf16):
         cutlass.Float32(0.0),
         cuda.CUstream(0),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_bwd",
     )
 
 
 @lru_cache(maxsize=None)
 def _compile_unpermute(B, H, SQ, d, io_is_bf16):
+    _cache_key = _template_key(globals(), locals(), "_compile_unpermute")
     io_dtype = cutlass.BFloat16 if io_is_bf16 else cutlass.Float16
     mk = cute.runtime.make_fake_compact_tensor
     fdq_acc = mk(cutlass.Float32, (B, H, SQ, d), stride_order=(3, 2, 1, 0), assumed_align=16)
     fdq_out = mk(io_dtype, (B, SQ, H, d), stride_order=(3, 2, 1, 0), assumed_align=16)
-    return cute.compile(_unpermute_host, fdq_acc, fdq_out, d, io_dtype, cutlass.Int32(0), cuda.CUstream(0), options="--enable-tvm-ffi")
+    return _compile_cached(
+        _unpermute_host,
+        fdq_acc,
+        fdq_out,
+        d,
+        io_dtype,
+        cutlass.Int32(0),
+        cuda.CUstream(0),
+        options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_bwd",
+    )
 
 
 def scratch_bytes(*, B: int, SQ: int, SKV: int, H: int, io_bytes: int = 2, need_do_dot: bool = True) -> int:

--- a/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm120.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm120.py
@@ -51,6 +51,7 @@ separate ``dq2k`` kernel (``bprop_chain_f16_sm120.py``) that replaces
 not fit in device memory.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 from functools import lru_cache
 from types import SimpleNamespace
 from typing import Optional, Type
@@ -1493,6 +1494,7 @@ def compile(  # noqa: A001
     their declared strides as compile-time constants.
     """
 
+    _cache_key = _template_key(globals(), locals(), "compile")
     kvh = int(kvh) or int(qh)
     d_v = int(d_v) or int(d_qk)
     if qh % kvh:
@@ -1581,7 +1583,7 @@ def compile(  # noqa: A001
     fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
     options = "--enable-tvm-ffi"
 
-    compiled_dot = cute.compile(
+    compiled_dot = _compile_cached(
         dot_do_o_host,
         fake_o,
         fake_do,
@@ -1596,8 +1598,10 @@ def compile(  # noqa: A001
         bwd.deterministic,
         fake_stream,
         options=options,
+        cache_key=_cache_key,
+        symbol="frost_sdpa_bwd",
     )
-    compiled_main = cute.compile(
+    compiled_main = _compile_cached(
         bwd,
         fake_q,
         fake_k,
@@ -1618,6 +1622,8 @@ def compile(  # noqa: A001
         cutlass.Float32(1.0),
         fake_stream,
         options=options,
+        cache_key=_cache_key,
+        symbol="frost_sdpa_bwd_1",
     )
     compiled_cvt = None
     compiled_dq2k = None
@@ -1633,7 +1639,7 @@ def compile(  # noqa: A001
             ws_q_tile=bwd.q_tile,
             use_pdl=PARAMS.use_pdl,
         )
-        compiled_dq2k = cute.compile(
+        compiled_dq2k = _compile_cached(
             dq_gemm,
             fake_k,
             fake_ds_ws,
@@ -1641,9 +1647,11 @@ def compile(  # noqa: A001
             cutlass.Float32(1.0),
             fake_stream,
             options=options,
+            cache_key=_cache_key,
+            symbol="frost_sdpa_bwd_2",
         )
     else:
-        compiled_cvt = cute.compile(
+        compiled_cvt = _compile_cached(
             convert_dq_host,
             fake_dq_accum,
             fake_dq,
@@ -1656,10 +1664,12 @@ def compile(  # noqa: A001
             bwd.use_pdl,
             fake_stream,
             options=options,
+            cache_key=_cache_key,
+            symbol="frost_sdpa_bwd_3",
         )
     compiled_reduce = None
     if has_gqa:
-        compiled_reduce = cute.compile(
+        compiled_reduce = _compile_cached(
             dkv_reduce_host,
             fake_dk_ws,
             fake_dv_ws,
@@ -1672,11 +1682,13 @@ def compile(  # noqa: A001
             bwd.use_pdl,
             fake_stream,
             options=options,
+            cache_key=_cache_key,
+            symbol="frost_sdpa_bwd_4",
         )
     compiled_dbias_cvt = None
     if PARAMS.dbias_present and not PARAMS.dbias_is_fp32:
         dbias_total = bias_batch * qh * sq * skv
-        compiled_dbias_cvt = cute.compile(
+        compiled_dbias_cvt = _compile_cached(
             convert_dbias_host,
             _fake(cutlass.Float32, (dbias_total,)),
             _fake(STORAGE_DTYPE, (dbias_total,)),
@@ -1684,12 +1696,14 @@ def compile(  # noqa: A001
             bwd.use_pdl,
             fake_stream,
             options=options,
+            cache_key=_cache_key,
+            symbol="frost_sdpa_bwd_5",
         )
     compiled_dsink = None
     if PARAMS.dsink_present:
         fake_sink = _fake(cutlass.Float32, (qh,))
         fake_dsink = _fake(cutlass.Float32, (qh,))
-        compiled_dsink = cute.compile(
+        compiled_dsink = _compile_cached(
             dsink_host,
             fake_lse,
             fake_delta,
@@ -1699,6 +1713,8 @@ def compile(  # noqa: A001
             bwd.use_pdl,
             fake_stream,
             options=options,
+            cache_key=_cache_key,
+            symbol="frost_sdpa_bwd_6",
         )
     return SimpleNamespace(
         dot=compiled_dot,

--- a/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
@@ -88,6 +88,7 @@ registers.  The only d-specific subtlety was the dQ d-col-split swizzle, now
 handled d-agnostically via load_b_smem_x4(col_base=...).
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 import math
 from functools import lru_cache
 from typing import Optional, Tuple
@@ -1615,11 +1616,14 @@ def _dsink_host(
 # ===========================================================================
 @lru_cache(maxsize=None)
 def _compile_do_dot(B, H, SQ, d_v, io_is_bf16):
+    _cache_key = _template_key(globals(), locals(), "_compile_do_dot")
     io_dtype = cutlass.BFloat16 if io_is_bf16 else cutlass.Float16
     fo = cute.runtime.make_fake_compact_tensor(io_dtype, (B, SQ, H, d_v), stride_order=(3, 2, 1, 0), assumed_align=16)
     fdo = cute.runtime.make_fake_compact_tensor(io_dtype, (B, SQ, H, d_v), stride_order=(3, 2, 1, 0), assumed_align=16)
     fdt = cute.runtime.make_fake_compact_tensor(cutlass.Float32, (B, H, SQ), stride_order=(2, 1, 0), assumed_align=16)
-    return cute.compile(_do_dot_host, fo, fdo, fdt, d_v, io_dtype, cutlass.Int32(0), cuda.CUstream(0), options="--enable-tvm-ffi")
+    return _compile_cached(
+        _do_dot_host, fo, fdo, fdt, d_v, io_dtype, cutlass.Int32(0), cuda.CUstream(0), options="--enable-tvm-ffi", cache_key=_cache_key, symbol="frost_sdpa_bwd"
+    )
 
 
 def scratch_bytes(
@@ -1717,6 +1721,7 @@ def compile(  # noqa: A001 — the template contract's entry point
     that layout (the #712 analogue for the backward's loads; ``None`` keeps
     the packed compact fake, byte-identical codegen).
     """
+    _cache_key = _template_key(globals(), locals(), "compile")
     p = PARAMS
     io_dtype = cutlass.BFloat16 if p.io_bf16 else cutlass.Float16
     mask_flags = (MASK_CAUSAL if p.is_causal else MASK_NONE) | (MASK_SWA if p.has_swa else 0) | (MASK_PADDED if p.has_seq_kv_lens else 0)
@@ -1776,7 +1781,7 @@ def compile(  # noqa: A001 — the template contract's entry point
     fsem = _fake(cutlass.Int32, (cute.sym_int(divisibility=1) if sem_units is None else sem_units,), (0,), align=4)
     fstream = cuda.CUstream(0)
 
-    main = cute.compile(
+    main = _compile_cached(
         _bprop_host,
         fq,
         fk,
@@ -1826,20 +1831,65 @@ def compile(  # noqa: A001 — the template contract's entry point
         cutlass.Int32(0),
         fstream,
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_bwd",
     )
     fo = _fake(io_dtype, (_b, _sq, h, p.d_v), r4)
-    do_dot = cute.compile(_do_dot_host, fo, fdo, fdt, p.d_v, io_dtype, cutlass.Int32(0), fstream, options="--enable-tvm-ffi")
+    do_dot = _compile_cached(
+        _do_dot_host, fo, fdo, fdt, p.d_v, io_dtype, cutlass.Int32(0), fstream, options="--enable-tvm-ffi", cache_key=_cache_key, symbol="frost_sdpa_bwd_1"
+    )
     fdq_out = _fake(io_dtype, (_b, _sq, h, p.d_qk), r4)
-    cast = cute.compile(_cast_host, fdq_acc, fdq_out, io_dtype, cutlass.Int32(0), fstream, options="--enable-tvm-ffi")
+    cast = _compile_cached(
+        _cast_host, fdq_acc, fdq_out, io_dtype, cutlass.Int32(0), fstream, options="--enable-tvm-ffi", cache_key=_cache_key, symbol="frost_sdpa_bwd_2"
+    )
     reduce_k = reduce_v = None
     if gqa:
         fdk_out = _fake(io_dtype, (_b, _skv, h_kv, p.d_qk), r4)
         fdv_out = _fake(io_dtype, (_b, _skv, h_kv, p.d_v), r4)
-        reduce_k = cute.compile(_dkv_reduce_host, fdk_ws, fdk_out, p.d_qk, h, h_kv, io_dtype, cutlass.Int32(0), fstream, options="--enable-tvm-ffi")
-        reduce_v = cute.compile(_dkv_reduce_host, fdv_ws, fdv_out, p.d_v, h, h_kv, io_dtype, cutlass.Int32(0), fstream, options="--enable-tvm-ffi")
+        reduce_k = _compile_cached(
+            _dkv_reduce_host,
+            fdk_ws,
+            fdk_out,
+            p.d_qk,
+            h,
+            h_kv,
+            io_dtype,
+            cutlass.Int32(0),
+            fstream,
+            options="--enable-tvm-ffi",
+            cache_key=_cache_key,
+            symbol="frost_sdpa_bwd_3",
+        )
+        reduce_v = _compile_cached(
+            _dkv_reduce_host,
+            fdv_ws,
+            fdv_out,
+            p.d_v,
+            h,
+            h_kv,
+            io_dtype,
+            cutlass.Int32(0),
+            fstream,
+            options="--enable-tvm-ffi",
+            cache_key=_cache_key,
+            symbol="frost_sdpa_bwd_4",
+        )
     dsink = None
     if p.has_sink:
         fsinks = _fake(cutlass.Float32, (h,), (0,), align=4)
         fdsink = _fake(cutlass.Float32, (h,), (0,), align=4)
-        dsink = cute.compile(_dsink_host, fl, fdt, fsinks, fdsink, fcuq, bool(p.thd_varlen), cutlass.Int32(0), fstream, options="--enable-tvm-ffi")
+        dsink = _compile_cached(
+            _dsink_host,
+            fl,
+            fdt,
+            fsinks,
+            fdsink,
+            fcuq,
+            bool(p.thd_varlen),
+            cutlass.Int32(0),
+            fstream,
+            options="--enable-tvm-ffi",
+            cache_key=_cache_key,
+            symbol="frost_sdpa_bwd_5",
+        )
     return CompiledBwd(main=main, do_dot=do_dot, cast=cast, reduce_k=reduce_k, reduce_v=reduce_v, dsink=dsink, sem_q_stride=sem_q_stride)

--- a/python/cudnn/sdpa/bwd/kernels/bprop_matmul_sm100.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_matmul_sm100.py
@@ -43,6 +43,7 @@ without making the same change upstream.
 
 from __future__ import annotations
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 from functools import lru_cache
 from typing import Callable
 
@@ -1887,6 +1888,7 @@ _CODEGEN_TARGET_SMS = frozenset({100, 103, 107, 110})
 
 @lru_cache(maxsize=None)
 def compile(device) -> Callable:
+    _cache_key = _template_key(globals(), locals(), "compile")
     major, minor = compute_capability(resolve_device(device))
     sm = major * 10 + minor
     # This is the source-level CODEGEN domain, not the engine's advertised
@@ -1995,7 +1997,7 @@ def compile(device) -> Callable:
     # serves every sequence count either way.
     fake_meta = make_fake_compact_tensor(cutlass.Int32, (cute.sym_int64(),), stride_order=(0,), assumed_align=16)
     fake_desc = make_fake_compact_tensor(cutlass.Int64, (cute.sym_int64(),), stride_order=(0,), assumed_align=16)
-    return cute.compile(
+    return _compile_cached(
         _host,
         problem_size,
         fake_a_0,
@@ -2005,6 +2007,8 @@ def compile(device) -> Callable:
         fake_desc,
         stream=_fake_stream,
         options=f"--enable-tvm-ffi --gpu-arch {gpu_arch}",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_bwd",
     )
 
 

--- a/python/cudnn/sdpa/bwd/kernels/bprop_matmul_sm100.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_matmul_sm100.py
@@ -1888,9 +1888,11 @@ _CODEGEN_TARGET_SMS = frozenset({100, 103, 107, 110})
 
 @lru_cache(maxsize=None)
 def compile(device) -> Callable:
-    _cache_key = _template_key(globals(), locals(), "compile")
     major, minor = compute_capability(resolve_device(device))
     sm = major * 10 + minor
+    # The device reaches the kernel only as its architecture (--gpu-arch below),
+    # so that is the key; the device object itself would make the call uncacheable.
+    _cache_key = _template_key(globals(), {"sm": sm}, "compile")
     # This is the source-level CODEGEN domain, not the engine's advertised
     # support contract.  The complete three-stage engine remains qualified only
     # on SM100/SM103; SM107/SM110 targets are kept available for isolated

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d128_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d128_f16.py
@@ -88,6 +88,7 @@ paged-attention kernel has.  The per-batch length rides the existing
 ``max_pages * page_size``, so nothing is read back to the host (Rule 3).
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 from functools import lru_cache
 from typing import Callable, Optional, Tuple
 
@@ -2590,6 +2591,7 @@ def compile(  # noqa: A001
     store — the kernel body is unchanged. Constraint: every non-innermost TMA
     global stride must be a 16-byte multiple; the compact BSHD H-stride is
     d * BPE, so d must be a multiple of 8 at 2 bytes/elem."""
+    _cache_key = _template_key(globals(), locals(), "compile")
     if not (0 < d_qk <= CFG.TILE_K and 0 < d_v <= CFG.TILE_O):
         raise ValueError(f"d128 envelope: need 0 < d_qk <= {CFG.TILE_K} and 0 < d_v <= {CFG.TILE_O}; got ({d_qk}, {d_v})")
     if (d_qk * CFG.BPE) % 16 != 0 or (d_v * CFG.BPE_O) % 16 != 0:
@@ -2760,7 +2762,7 @@ def compile(  # noqa: A001
         fake_thd_q_lens = None
         fake_thd_kv_lens = None
         fake_thd_lens_form = None
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -2785,4 +2787,6 @@ def compile(  # noqa: A001
         *((fake_block_table, fake_block_table_v) if PAGED_KV else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d128_fp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d128_fp8.py
@@ -35,6 +35,7 @@ head-major); the amax_o atomicMax is gated on live rows. Dense path
 byte-identical.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 import os
 import sys
 from functools import lru_cache
@@ -2336,6 +2337,7 @@ def compile(  # noqa: A001
     ``has_lse=False`` compiles the LSE store out (the kernel specializes on a
     ``None`` LSE argument) — callers without a Stats output pass no LSE buffer
     at all; the amax_o atomicMax write is independent and unchanged."""
+    _cache_key = _template_key(globals(), locals(), "compile")
     if SPLIT_KV > 1 and not has_lse:
         # Each split's LSE is not optional under KV split — it IS the weight
         # the combine reduces with.  Without it the partials cannot be recombined.
@@ -2484,7 +2486,7 @@ def compile(  # noqa: A001
         fake_thd_q_lens = None
         fake_thd_kv_lens = None
         fake_thd_lens_form = None
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -2513,4 +2515,6 @@ def compile(  # noqa: A001
         *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d128_mxfp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d128_mxfp8.py
@@ -21,6 +21,7 @@ plus the MXFP8 TMEM scale-factor (SF) relayout:
      one tcgen05.ld.red.f32.max for unmasked tiles.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 import os
 import sys
 from functools import lru_cache
@@ -2714,6 +2715,7 @@ def compile(  # noqa: A001
     ``has_lse=False`` compiles the LSE store out (the kernel specializes on a
     ``None`` LSE argument) — callers without a Stats output pass no LSE buffer
     at all; the amax_o atomicMax write is independent and unchanged."""
+    _cache_key = _template_key(globals(), locals(), "compile")
     if SPLIT_KV > 1 and not has_lse:
         # Each split's LSE is not optional under KV split — it IS the weight
         # the combine reduces with.  Without it the partials cannot be recombined.
@@ -2870,7 +2872,7 @@ def compile(  # noqa: A001
         fake_thd_q_lens = None
         fake_thd_kv_lens = None
         fake_thd_lens_form = None
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -2895,4 +2897,6 @@ def compile(  # noqa: A001
         *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d192_d128_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d192_d128_f16.py
@@ -35,6 +35,7 @@ the shared ``_common_blackwell`` / ``thd_helpers`` mechanism (same as the SM100 
 
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 from functools import lru_cache
 from typing import Callable, NamedTuple, Optional, Tuple
 
@@ -2862,6 +2863,7 @@ def compile(  # noqa: A001
     store — the kernel body is unchanged. Constraint: every non-innermost TMA
     global stride must be a 16-byte multiple; the compact BSHD H-stride is
     d * BPE, so d must be a multiple of 8 at 2 bytes/elem."""
+    _cache_key = _template_key(globals(), locals(), "compile")
     if not (0 < d_qk <= CFG.TILE_K and 0 < d_v <= CFG.TILE_O):
         raise ValueError(f"d192 envelope: need 0 < d_qk <= {CFG.TILE_K} and 0 < d_v <= {CFG.TILE_O}; got ({d_qk}, {d_v})")
     if (d_qk * CFG.BPE) % 16 != 0 or (d_v * CFG.BPE_O) % 16 != 0:
@@ -3005,7 +3007,7 @@ def compile(  # noqa: A001
         fake_thd_q_lens = None
         fake_thd_kv_lens = None
         fake_thd_lens_form = None
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -3027,4 +3029,6 @@ def compile(  # noqa: A001
         *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d192_d128_fp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d192_d128_fp8.py
@@ -26,6 +26,7 @@ metadata and runtime TMA descriptors, and a device-bounded work counter. Dense
 specializations fold the THD path out.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 from functools import lru_cache
 from typing import Callable, NamedTuple, Optional, Tuple
 
@@ -2911,6 +2912,7 @@ def compile(  # noqa: A001
     Under THD, ``sq``/``skv`` become dynamic packed-token extents and ``b``
     remains the logical sequence count. ``has_lse=False`` specializes the LSE
     argument to ``None`` and removes the Stats store while retaining amax."""
+    _cache_key = _template_key(globals(), locals(), "compile")
     if not (0 < d_qk <= CFG.TILE_K and 0 < d_v <= CFG.TILE_O):
         raise ValueError(f"fp8 d192 envelope: need 0 < d_qk <= {CFG.TILE_K} and 0 < d_v <= {CFG.TILE_O}; got ({d_qk}, {d_v})")
     if (d_qk * CFG.BPE) % 16 != 0 or (d_v * CFG.BPE) % 16 != 0:
@@ -3030,7 +3032,7 @@ def compile(  # noqa: A001
         fake_thd_q_lens = None
         fake_thd_kv_lens = None
         fake_thd_lens_form = None
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -3055,4 +3057,6 @@ def compile(  # noqa: A001
         *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d192_d128_mxfp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d192_d128_mxfp8.py
@@ -22,6 +22,7 @@ plus the MXFP8 TMEM scale-factor (SF) relayout:
      one tcgen05.ld.red.f32.max for unmasked tiles.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 from functools import lru_cache
 from typing import Callable, NamedTuple, Optional, Tuple
 
@@ -3343,6 +3344,7 @@ def compile(  # noqa: A001
 
     THD token and scale-factor tile extents are dynamic. Split-KV stacks its
     partial O and LSE workspaces on a split-major batch axis."""
+    _cache_key = _template_key(globals(), locals(), "compile")
     if SPLIT_KV > 1 and not has_lse:
         raise ValueError("split_kv > 1 requires has_lse=True (the per-split LSE drives the combine)")
     if lse_stride is not None and (CFG.THD_VARLEN or SPLIT_KV > 1):
@@ -3472,7 +3474,7 @@ def compile(  # noqa: A001
         fake_thd_q_lens = None
         fake_thd_kv_lens = None
         fake_thd_lens_form = None
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -3495,4 +3497,6 @@ def compile(  # noqa: A001
         *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d256_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d256_f16.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 from functools import lru_cache
 from typing import Callable, Optional, Tuple
 
@@ -2069,6 +2070,7 @@ def compile(  # noqa: A001
     the fake binds the token stride for the extent-1 batch dim, exactly as
     ``_thd_view`` does at runtime (``T * token_stride`` is never stepped and
     overflows the int32 stride slot on long packed KV, GitHub #980)."""
+    _cache_key = _template_key(globals(), locals(), "compile")
     if not (0 < d_qk <= CFG.TILE_K and 0 < d_v <= CFG.TILE_O):
         raise ValueError(f"d256 envelope: need 0 < d_qk <= {CFG.TILE_K} and 0 < d_v <= {CFG.TILE_O}; got ({d_qk}, {d_v})")
     if (d_qk * CFG.BPE) % 16 != 0 or (d_v * CFG.BPE_O) % 16 != 0:
@@ -2234,7 +2236,7 @@ def compile(  # noqa: A001
         fake_thd_q_lens = None
         fake_thd_kv_lens = None
         fake_thd_lens_form = None
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -2259,6 +2261,8 @@ def compile(  # noqa: A001
         *((fake_block_table, fake_block_table_v) if PAGED_KV else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )
 
 

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d256_fp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d256_fp8.py
@@ -13,6 +13,7 @@ design used by the D128 FP8 sibling. Packed token totals stay dynamic and the
 setup kernel builds per-sequence O plus packed-total-clamped K/V descriptors.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 from functools import lru_cache
 from typing import Callable, Optional, Tuple
 
@@ -2823,6 +2824,7 @@ def compile(  # noqa: A001
     stays the compile-time TILE geometry: loads past d_qk / d_v zero-fill
     (exact zeros in the QK^T / P·V contractions), O stores past d_v clip.
     d * BPE must be a 16-byte multiple (TMA global-stride rule -> d % 8)."""
+    _cache_key = _template_key(globals(), locals(), "compile")
     if not (0 < d_qk <= CFG.TILE_K and 0 < d_v <= CFG.TILE_O):
         raise ValueError(f"d256 envelope: need 0 < d_qk <= {CFG.TILE_K} and 0 < d_v <= {CFG.TILE_O}; got ({d_qk}, {d_v})")
     if (d_qk * CFG.BPE) % 16 != 0 or (d_v * CFG.BPE_O) % 16 != 0:
@@ -2958,7 +2960,7 @@ def compile(  # noqa: A001
         fake_thd_kv_lens = None
         fake_thd_lens_form = None
 
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -2985,6 +2987,8 @@ def compile(  # noqa: A001
         *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )
 
 

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d256_mxfp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d256_mxfp8.py
@@ -13,6 +13,7 @@ device setup kernel builds ragged metadata and runtime O/K/V tensor maps; the
 main launch uses a persistent grid and dynamic packed extents.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 from functools import lru_cache
 from typing import Callable, Optional, Tuple
 
@@ -3402,6 +3403,7 @@ def compile(  # noqa: A001
     lse_stride: Optional[tuple[int, int, int]] = None,
 ) -> Callable:
     """Compile the exact D256 MXFP8 kernel and its per-tile SF views."""
+    _cache_key = _template_key(globals(), locals(), "compile")
     if SPLIT_KV > 1 and not has_lse:
         raise ValueError("split_kv > 1 requires has_lse=True (the per-split LSE drives the combine)")
     if lse_stride is not None and SPLIT_KV > 1:
@@ -3509,7 +3511,7 @@ def compile(  # noqa: A001
         fake_thd_kv_lens = None
         fake_thd_lens_form = None
 
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -3533,6 +3535,8 @@ def compile(  # noqa: A001
         *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )
 
 

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d512_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d512_f16.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: MIT
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 from functools import lru_cache
 from typing import Callable, Optional, Tuple
 from dataclasses import dataclass
@@ -2146,6 +2147,7 @@ def compile(  # noqa: A001
     the fake binds the token stride for the extent-1 batch dim, exactly as
     ``_thd_view`` does at runtime (``T * token_stride`` is never stepped and
     overflows the int32 stride slot on long packed KV, GitHub #980)."""
+    _cache_key = _template_key(globals(), locals(), "compile")
     if not (0 < d_qk <= CFG.TILE_K and 0 < d_v <= CFG.TILE_O):
         raise ValueError(f"d512 envelope: need 0 < d_qk <= {CFG.TILE_K} and 0 < d_v <= {CFG.TILE_O}; got ({d_qk}, {d_v})")
     if (d_qk * CFG.BPE) % 16 != 0 or (d_v * CFG.BPE_O) % 16 != 0:
@@ -2281,7 +2283,7 @@ def compile(  # noqa: A001
         fake_thd_q_lens = None
         fake_thd_kv_lens = None
         fake_thd_lens_form = None
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -2303,4 +2305,6 @@ def compile(  # noqa: A001
         *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d512_fp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d512_fp8.py
@@ -41,6 +41,7 @@ them is derived from ``CFG`` rather than spelled as a literal:
 MXFP8 (block-scale) is NOT served by this file — d512 has no MXFP8 kernel.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 from functools import lru_cache
 from typing import Callable, Optional, Tuple
 from dataclasses import dataclass
@@ -2366,6 +2367,7 @@ def compile(  # noqa: A001
     the fake binds the token stride for the extent-1 batch dim, exactly as
     ``_thd_view`` does at runtime (``T * token_stride`` is never stepped and
     overflows the int32 stride slot on long packed KV, GitHub #980)."""
+    _cache_key = _template_key(globals(), locals(), "compile")
     if not (0 < d_qk <= CFG.TILE_K and 0 < d_v <= CFG.TILE_O):
         raise ValueError(f"d512 envelope: need 0 < d_qk <= {CFG.TILE_K} and 0 < d_v <= {CFG.TILE_O}; got ({d_qk}, {d_v})")
     if (d_qk * CFG.BPE) % 16 != 0 or (d_v * CFG.BPE_O) % 16 != 0:
@@ -2512,7 +2514,7 @@ def compile(  # noqa: A001
     fake_descale_v = _fake_scalar_f32()
     fake_scale_o = _fake_scalar_f32()
     fake_amax_o = _fake_scalar_f32()
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -2540,4 +2542,6 @@ def compile(  # noqa: A001
         *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d512_mxfp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/prefill_d512_mxfp8.py
@@ -8,6 +8,7 @@ computes two 256-column V/O slices. This geometry stays within the SM100 SMEM
 and 512-column TMEM limits and outperforms the validated two-CTA M128 design.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 from functools import lru_cache
 from typing import Callable, Optional, Tuple
 
@@ -3732,6 +3733,7 @@ def compile(  # noqa: A001
     lse_stride: Optional[tuple[int, int, int]] = None,
 ) -> Callable:
     """Compile the exact D512 MXFP8 kernel and its per-tile SF views."""
+    _cache_key = _template_key(globals(), locals(), "compile")
     if SPLIT_KV > 1 and not has_lse:
         raise ValueError("split_kv > 1 requires has_lse=True (the per-split LSE drives the combine)")
     if lse_stride is not None and SPLIT_KV > 1:
@@ -3839,7 +3841,7 @@ def compile(  # noqa: A001
         fake_thd_kv_lens = None
         fake_thd_lens_form = None
 
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -3862,6 +3864,8 @@ def compile(  # noqa: A001
         fake_thd_lens_form,
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )
 
 

--- a/python/cudnn/sdpa/fwd/kernels/sm100/split_combine.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm100/split_combine.py
@@ -14,6 +14,7 @@ One block per (q_row, head, batch); the block's threads stride over d_v, and
 each thread walks the split axis in registers.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 from typing import Callable, Optional, Tuple
 
 from functools import lru_cache
@@ -215,6 +216,7 @@ def compile(  # noqa: A001
     performs the only cast down to ``dtype_o``, applying ``scale_o``
     (``has_scale_o``) at that single point.  It defaults to ``dtype_o``.
     """
+    _cache_key = _template_key(globals(), locals(), "compile")
     elem = _ELEM[dtype_o]
     elem_partial = _ELEM[dtype_partial or dtype_o]
 
@@ -233,7 +235,7 @@ def compile(  # noqa: A001
     fake_amax_o = cute.runtime.make_fake_compact_tensor(cutlass.Float32, (1,), stride_order=(0,), assumed_align=4) if has_amax else None
     fake_scale_o = cute.runtime.make_fake_compact_tensor(cutlass.Float32, (1,), stride_order=(0,), assumed_align=4) if has_scale_o else None
 
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_o_partial,
         fake_lse_partial,
@@ -245,4 +247,6 @@ def compile(  # noqa: A001
         cutlass.Int32(0),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d128_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d128_f16.py
@@ -41,6 +41,7 @@ rejects THD for f16/bf16, and no engine row advertises it.  Only the dense
 ``[B,S,H,D]`` path is served.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 import os
 import sys
 from functools import lru_cache
@@ -2141,6 +2142,7 @@ def compile(  # noqa: A001
     # it cannot honor RAISES rather than being silently ignored: a raise here
     # means the engine's Capabilities row is lying, which is the failure we
     # want loud.  (Capabilities: lse_optional=False, no strided Stats.)
+    _cache_key = _template_key(globals(), locals(), "compile")
     if lse_stride is not None:
         raise NotImplementedError(f"{__name__}: strided Stats not ported (contiguous [B, H, S] only)")
     if d_qk > CFG.TILE_K or d_v > CFG.TILE_O or d_qk <= 0 or d_v <= 0:
@@ -2255,7 +2257,7 @@ def compile(  # noqa: A001
         fake_thd_lens_form = cutlass.Int32(0)
     else:
         fake_thd_q_lens = fake_thd_kv_lens = fake_thd_lens_form = None
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -2274,4 +2276,6 @@ def compile(  # noqa: A001
         fake_thd_lens_form,
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d128_fp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d128_fp8.py
@@ -48,6 +48,7 @@ head-major); the amax_o atomicMax is gated on live rows. Dense path
 byte-identical. Hunk-symmetric with sm100/prefill_d128_fp8.py.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 import os
 import sys
 from functools import lru_cache
@@ -2608,6 +2609,7 @@ def compile(  # noqa: A001
     ``has_lse=False`` compiles the LSE store out (the kernel specializes on a
     ``None`` LSE argument) — callers without a Stats output pass no LSE buffer
     at all; the amax_o atomicMax write is independent and unchanged."""
+    _cache_key = _template_key(globals(), locals(), "compile")
     if not (0 < d_qk <= CFG.TILE_K and 0 < d_v <= CFG.TILE_O):
         raise ValueError(f"fp8 d128 envelope: need 0 < d_qk <= {CFG.TILE_K} and 0 < d_v <= {CFG.TILE_O}; got ({d_qk}, {d_v})")
     if (d_qk * CFG.BPE) % 16 != 0 or (d_v * CFG.BPE) % 16 != 0:
@@ -2755,7 +2757,7 @@ def compile(  # noqa: A001
         fake_thd_kv_lens = None
         fake_thd_lens_form = None
 
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -2782,4 +2784,6 @@ def compile(  # noqa: A001
         *((fake_o,) if _FP32_PARTIALS else ()),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d128_mxfp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d128_mxfp8.py
@@ -7,6 +7,7 @@
 scheduler).  Same pipeline structure as the FP8 twin.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 import os
 import sys
 from functools import lru_cache
@@ -2329,6 +2330,7 @@ def compile(  # noqa: A001
     # let it fail as an arity error deep in the trace -- and so no engine row
     # can advertise thd=True for this kernel and appear to work.  The dense
     # path is unaffected: CFG.THD_VARLEN is 0 and every THD branch folds out.
+    _cache_key = _template_key(globals(), locals(), "compile")
     if CFG.THD_VARLEN:
         raise NotImplementedError(f"{__name__}: THD/varlen not ported to the FROST setup-kernel contract")
     # ---- FROST adapter ABI ------------------------------------------------
@@ -2442,7 +2444,7 @@ def compile(  # noqa: A001
         stride_order=(0,),
         assumed_align=16,
     )
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -2464,4 +2466,6 @@ def compile(  # noqa: A001
         cutlass.Int32(_kv_sf_tiles),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d192_d128_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d192_d128_f16.py
@@ -45,6 +45,7 @@ rejects THD for f16/bf16, and no engine row advertises it.  Only the dense
 ``[B,S,H,D]`` path is served.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 import os
 import sys
 from functools import lru_cache
@@ -2145,6 +2146,7 @@ def compile(  # noqa: A001
     # it cannot honor RAISES rather than being silently ignored: a raise here
     # means the engine's Capabilities row is lying, which is the failure we
     # want loud.  (Capabilities: lse_optional=False, no strided Stats.)
+    _cache_key = _template_key(globals(), locals(), "compile")
     if lse_stride is not None:
         raise NotImplementedError(f"{__name__}: strided Stats not ported (contiguous [B, H, S] only)")
     if d_qk > CFG.TILE_K or d_v > CFG.TILE_O or d_qk <= 0 or d_v <= 0:
@@ -2259,7 +2261,7 @@ def compile(  # noqa: A001
         fake_thd_lens_form = cutlass.Int32(0)
     else:
         fake_thd_q_lens = fake_thd_kv_lens = fake_thd_lens_form = None
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -2278,4 +2280,6 @@ def compile(  # noqa: A001
         fake_thd_lens_form,
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d192_d128_fp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d192_d128_fp8.py
@@ -70,6 +70,7 @@ head-major); the amax_o atomicMax is gated on live rows. Dense path
 byte-identical. Hunk-symmetric with sm100/prefill_d128_fp8.py.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 import os
 import sys
 from functools import lru_cache
@@ -2587,6 +2588,7 @@ def compile(  # noqa: A001
     ``has_lse=False`` compiles the LSE store out (the kernel specializes on a
     ``None`` LSE argument) — callers without a Stats output pass no LSE buffer
     at all; the amax_o atomicMax write is independent and unchanged."""
+    _cache_key = _template_key(globals(), locals(), "compile")
     if not (0 < d_qk <= CFG.TILE_K and 0 < d_v <= CFG.TILE_O):
         raise ValueError(f"fp8 d128 envelope: need 0 < d_qk <= {CFG.TILE_K} and 0 < d_v <= {CFG.TILE_O}; got ({d_qk}, {d_v})")
     if (d_qk * CFG.BPE) % 16 != 0 or (d_v * CFG.BPE) % 16 != 0:
@@ -2734,7 +2736,7 @@ def compile(  # noqa: A001
         fake_thd_kv_lens = None
         fake_thd_lens_form = None
 
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -2760,4 +2762,6 @@ def compile(  # noqa: A001
         fake_thd_lens_form,
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d192_d128_mxfp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d192_d128_mxfp8.py
@@ -41,6 +41,7 @@ reason a d128 MXFP8 kernel passes with either descriptor builder.  Do not read
 this file as evidence that a V-SF builder is correct.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 import os
 import sys
 from functools import lru_cache
@@ -2373,6 +2374,7 @@ def compile(  # noqa: A001
     # let it fail as an arity error deep in the trace -- and so no engine row
     # can advertise thd=True for this kernel and appear to work.  The dense
     # path is unaffected: CFG.THD_VARLEN is 0 and every THD branch folds out.
+    _cache_key = _template_key(globals(), locals(), "compile")
     if CFG.THD_VARLEN:
         raise NotImplementedError(f"{__name__}: THD/varlen not ported to the FROST setup-kernel contract")
     # ---- FROST adapter ABI ------------------------------------------------
@@ -2486,7 +2488,7 @@ def compile(  # noqa: A001
         stride_order=(0,),
         assumed_align=16,
     )
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -2508,4 +2510,6 @@ def compile(  # noqa: A001
         cutlass.Int32(_kv_sf_tiles),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d256_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d256_f16.py
@@ -14,6 +14,7 @@ is supported (f16/bf16) via the shared mechanism (packed ``[1,T,H,D]`` +
 LSE); the dense ``[B,S,H,D]`` path is byte-identical.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 import os
 import sys
 from functools import lru_cache
@@ -1931,6 +1932,7 @@ def compile(  # noqa: A001
     # it cannot honor RAISES rather than being silently ignored: a raise here
     # means the engine's Capabilities row is lying, which is the failure we
     # want loud.  (Capabilities: lse_optional=False, no strided Stats.)
+    _cache_key = _template_key(globals(), locals(), "compile")
     if lse_stride is not None:
         raise NotImplementedError(f"{__name__}: strided Stats not ported (contiguous [B, H, S] only)")
     if d_qk > CFG.TILE_K or d_v > CFG.TILE_O or d_qk <= 0 or d_v <= 0:
@@ -2027,7 +2029,7 @@ def compile(  # noqa: A001
         fake_thd_lens_form = cutlass.Int32(0)
     else:
         fake_thd_q_lens = fake_thd_kv_lens = fake_thd_lens_form = None
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -2046,6 +2048,8 @@ def compile(  # noqa: A001
         fake_thd_lens_form,
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )
 
 

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d256_fp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d256_fp8.py
@@ -14,6 +14,7 @@ mechanism (FP8 element-addressed, no block-scale SF; same path as f16); dense
 byte-identical.  Public-API fp8 THD glue is a follow-up (THD-aware quantizer).
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 import os
 import sys
 from functools import lru_cache
@@ -1976,6 +1977,7 @@ def compile(  # noqa: A001
     # it cannot honor RAISES rather than being silently ignored: a raise here
     # means the engine's Capabilities row is lying, which is the failure we
     # want loud.  (Capabilities: lse_optional=False, no strided Stats.)
+    _cache_key = _template_key(globals(), locals(), "compile")
     if lse_stride is not None:
         raise NotImplementedError(f"{__name__}: strided Stats not ported (contiguous [B, H, S] only)")
     if d_qk > CFG.TILE_K or d_v > CFG.TILE_O or d_qk <= 0 or d_v <= 0:
@@ -2082,7 +2084,7 @@ def compile(  # noqa: A001
         fake_thd_lens_form = cutlass.Int32(0)
     else:
         fake_thd_q_lens = fake_thd_kv_lens = fake_thd_lens_form = None
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -2107,6 +2109,8 @@ def compile(  # noqa: A001
         fake_thd_lens_form,
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )
 
 

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d256_mxfp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d256_mxfp8.py
@@ -29,6 +29,7 @@ Dense path (THD_VARLEN=0) folds to identity (cu_sf=0, tma_batch=batch_idx) —
 byte-identical.  Public-API MXFP8 THD glue is a follow-up (THD-aware quantizer).
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 import os
 import sys
 from functools import lru_cache
@@ -2295,6 +2296,7 @@ def compile(  # noqa: A001
     # let it fail as an arity error deep in the trace -- and so no engine row
     # can advertise thd=True for this kernel and appear to work.  The dense
     # path is unaffected: CFG.THD_VARLEN is 0 and every THD branch folds out.
+    _cache_key = _template_key(globals(), locals(), "compile")
     if CFG.THD_VARLEN:
         raise NotImplementedError(f"{__name__}: THD/varlen not ported to the FROST setup-kernel contract")
     # ---- FROST adapter ABI ------------------------------------------------
@@ -2408,7 +2410,7 @@ def compile(  # noqa: A001
         stride_order=(0,),
         assumed_align=16,
     )
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -2434,6 +2436,8 @@ def compile(  # noqa: A001
         total_kv_sf_tiles=cutlass.Int32(_kv_sf_tiles),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )
 
 

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d512_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d512_f16.py
@@ -45,6 +45,7 @@ DSL-only adjustments applied (per the C++-to-DSL porting notes):
     (per project memory: bare nvvm op silently fires sender's local mbar).
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 import os
 import sys
 from functools import lru_cache
@@ -2549,6 +2550,7 @@ def compile(  # noqa: A001
     # it cannot honor RAISES rather than being silently ignored: a raise here
     # means the engine's Capabilities row is lying, which is the failure we
     # want loud.  (Capabilities: lse_optional=False, no strided Stats.)
+    _cache_key = _template_key(globals(), locals(), "compile")
     if lse_stride is not None:
         raise NotImplementedError(f"{__name__}: strided Stats not ported (contiguous [B, H, S] only)")
     if d_qk > CFG.TILE_K or d_v > CFG.TILE_O or d_qk <= 0 or d_v <= 0:
@@ -2641,7 +2643,7 @@ def compile(  # noqa: A001
         fake_thd_lens_form = cutlass.Int32(0)
     else:
         fake_thd_q_lens = fake_thd_kv_lens = fake_thd_lens_form = None
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -2660,4 +2662,6 @@ def compile(  # noqa: A001
         fake_thd_lens_form,
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d512_fp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d512_fp8.py
@@ -62,6 +62,7 @@ DSL-only adjustments applied (per the C++-to-DSL porting notes):
     wrap; pass raw vec to store_swizzled / slice via vec_slice on Float32.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 import os
 import sys
 from functools import lru_cache
@@ -2623,6 +2624,7 @@ def compile(  # noqa: A001
     # it cannot honor RAISES rather than being silently ignored: a raise here
     # means the engine's Capabilities row is lying, which is the failure we
     # want loud.  (Capabilities: lse_optional=False, no strided Stats.)
+    _cache_key = _template_key(globals(), locals(), "compile")
     if lse_stride is not None:
         raise NotImplementedError(f"{__name__}: strided Stats not ported (contiguous [B, H, S] only)")
     if d_qk > CFG.TILE_K or d_v > CFG.TILE_O or d_qk <= 0 or d_v <= 0:
@@ -2731,7 +2733,7 @@ def compile(  # noqa: A001
         fake_thd_lens_form = cutlass.Int32(0)
     else:
         fake_thd_q_lens = fake_thd_kv_lens = fake_thd_lens_form = None
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -2759,4 +2761,6 @@ def compile(  # noqa: A001
         None,
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d512_mxfp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm107/prefill_d512_mxfp8.py
@@ -81,6 +81,7 @@ folds to identity (cu_sf=0, tma_batch=batch_idx) — byte-identical.  Public-API
 MXFP8 THD glue is a follow-up (THD-aware quantizer); drive via the kernel module directly.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 import os
 import sys
 from functools import lru_cache
@@ -2945,6 +2946,7 @@ def compile(  # noqa: A001
     # let it fail as an arity error deep in the trace -- and so no engine row
     # can advertise thd=True for this kernel and appear to work.  The dense
     # path is unaffected: CFG.THD_VARLEN is 0 and every THD branch folds out.
+    _cache_key = _template_key(globals(), locals(), "compile")
     if CFG.THD_VARLEN:
         raise NotImplementedError(f"{__name__}: THD/varlen not ported to the FROST setup-kernel contract")
     # ---- FROST adapter ABI ------------------------------------------------
@@ -3062,7 +3064,7 @@ def compile(  # noqa: A001
         stride_order=(0,),
         assumed_align=16,
     )
-    return cute.compile(
+    return _compile_cached(
         _host,
         fake_q,
         fake_k,
@@ -3088,4 +3090,6 @@ def compile(  # noqa: A001
         total_kv_sf_tiles=cutlass.Int32(_kv_sf_tiles),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm120/prefill_d256_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm120/prefill_d256_f16.py
@@ -41,6 +41,7 @@ Constraints:
   capacity
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 from functools import lru_cache, partial
 from types import SimpleNamespace
 from typing import Callable, Optional, Type
@@ -1743,6 +1744,7 @@ def compile(  # noqa: A001
     """
 
     # Head dims that do not tile to (256, 256) belong to sm120/prefill_f16.py.
+    _cache_key = _template_key(globals(), locals(), "compile")
     if pick_flavor(d_qk, d_v, fp8=False) != D256_FLAVOR:
         raise ValueError(f"SM120 SDPA d256 kernel: head dims ({d_qk}, {d_v}) do not tile to {D256_FLAVOR}")
     kernel = SM120FusedMultiHeadAttentionForward(
@@ -1850,7 +1852,7 @@ def compile(  # noqa: A001
         fake_thd_q_lens = None
         fake_thd_kv_lens = None
         fake_thd_lens_form = None
-    return cute.compile(
+    return _compile_cached(
         kernel,
         fake_q,
         fake_k,
@@ -1868,4 +1870,6 @@ def compile(  # noqa: A001
         cutlass.Int32(0),  # thd_n_ctas: persistent THD grid extent (runtime)
         cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm120/prefill_d512_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm120/prefill_d512_f16.py
@@ -61,6 +61,7 @@ Constraints:
   the target SM120 SMEM capacity
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 from functools import lru_cache, partial
 from types import SimpleNamespace
 from typing import Callable, Optional, Type
@@ -2100,6 +2101,7 @@ def compile(  # noqa: A001
     caller-declared head-row stride (``>= T``, a shape — part of the cache key).
     """
 
+    _cache_key = _template_key(globals(), locals(), "compile")
     if pick_flavor(d_qk, d_v, fp8=False) != D512_FLAVOR:
         raise ValueError(f"SM120 SDPA d512 kernel: head dimensions must both be in (256, 512]; got ({d_qk}, {d_v})")
     kernel = SM120FusedMultiHeadAttentionForward(
@@ -2206,7 +2208,7 @@ def compile(  # noqa: A001
         fake_thd_q_lens = None
         fake_thd_kv_lens = None
         fake_thd_lens_form = None
-    return cute.compile(
+    return _compile_cached(
         kernel,
         fake_q,
         fake_k,
@@ -2224,4 +2226,6 @@ def compile(  # noqa: A001
         cutlass.Int32(0),  # thd_n_ctas: persistent THD grid extent (runtime)
         cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm120/prefill_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm120/prefill_f16.py
@@ -40,6 +40,7 @@ Constraints:
   capacity
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 from functools import lru_cache, partial
 from types import SimpleNamespace
 from typing import Callable, Optional, Type
@@ -1754,6 +1755,7 @@ def compile(  # noqa: A001
     caller-declared head-row stride (``>= T``, a shape — part of the cache key).
     """
 
+    _cache_key = _template_key(globals(), locals(), "compile")
     kernel = SM120FusedMultiHeadAttentionForward(
         in_dtype=STORAGE_DTYPE,
         out_dtype=STORAGE_DTYPE,
@@ -1859,7 +1861,7 @@ def compile(  # noqa: A001
         fake_thd_q_lens = None
         fake_thd_kv_lens = None
         fake_thd_lens_form = None
-    return cute.compile(
+    return _compile_cached(
         kernel,
         fake_q,
         fake_k,
@@ -1877,4 +1879,6 @@ def compile(  # noqa: A001
         cutlass.Int32(0),  # thd_n_ctas: persistent THD grid extent (runtime)
         cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm120/prefill_fp8.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm120/prefill_fp8.py
@@ -53,6 +53,7 @@ Constraints:
 - THD (ragged) is supported with token-major or head-major Stats
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 from functools import lru_cache, partial
 from types import SimpleNamespace
 from typing import Callable, Optional, Type
@@ -1780,6 +1781,7 @@ def compile(  # noqa: A001
     head-row stride (``>= T``, a shape — part of the cache key).
     """
 
+    _cache_key = _template_key(globals(), locals(), "compile")
     kernel = SM120FusedMultiHeadAttentionForward(
         in_dtype=IN_DTYPE,
         out_dtype=OUT_DTYPE,
@@ -1910,7 +1912,7 @@ def compile(  # noqa: A001
             assumed_align=4,
         )
 
-    return cute.compile(
+    return _compile_cached(
         kernel,
         fake_q,
         fake_k,
@@ -1934,4 +1936,6 @@ def compile(  # noqa: A001
         cutlass.Int32(0),  # thd_n_ctas: unused on this path (no persistent grid)
         cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm80/prefill_d256_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm80/prefill_d256_f16.py
@@ -77,6 +77,7 @@ Layout choices (same as the shared kernel):
   the inner-loop ldmatrix instruction count vs the x2 helper.
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 from functools import lru_cache
 from typing import Optional
 
@@ -1722,6 +1723,7 @@ def compile(  # noqa: A001 — the template contract's entry point (matches the 
     ``PARAMS.has_lse = False`` compiles the LSE store out entirely (the LSE
     argument is None-specialized) — no buffer and no dummy at any level.
     """
+    _cache_key = _template_key(globals(), locals(), "compile")
     p = PARAMS
     if p.thd_varlen and p.has_bias:
         raise ValueError("sm80: bias + THD is not supported (varlen has no single [1,H,SQ,SKV] bias shape)")
@@ -1832,7 +1834,7 @@ def compile(  # noqa: A001 — the template contract's entry point (matches the 
     # Stream not used during trace; passed through to launch().  Use a
     # null stream sentinel — cute.compile only inspects type, not value.
     fake_stream = cuda.CUstream(0)
-    return cute.compile(
+    return _compile_cached(
         _sdpa_host,
         fake_q,
         fake_k,
@@ -1877,4 +1879,6 @@ def compile(  # noqa: A001 — the template contract's entry point (matches the 
         fake_thd_nb,
         fake_stream,
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/python/cudnn/sdpa/fwd/kernels/sm80/prefill_f16.py
+++ b/python/cudnn/sdpa/fwd/kernels/sm80/prefill_f16.py
@@ -93,6 +93,7 @@ Layout choices:
       matching mma B col-major b0 at (K=2p..2p+1, N=g).
 """
 
+from cudnn.frost.compiled_cache import compile_cached as _compile_cached, template_key as _template_key
 from functools import lru_cache
 from typing import Optional
 
@@ -1721,6 +1722,7 @@ def compile(  # noqa: A001 — the template contract's entry point (matches the 
     ``PARAMS.has_lse = False`` compiles the LSE store out entirely (the LSE
     argument is None-specialized) — no buffer and no dummy at any level.
     """
+    _cache_key = _template_key(globals(), locals(), "compile")
     p = PARAMS
     if p.thd_varlen and p.has_bias:
         raise ValueError("sm80: bias + THD is not supported (varlen has no single [1,H,SQ,SKV] bias shape)")
@@ -1831,7 +1833,7 @@ def compile(  # noqa: A001 — the template contract's entry point (matches the 
     # Stream not used during trace; passed through to launch().  Use a
     # null stream sentinel — cute.compile only inspects type, not value.
     fake_stream = cuda.CUstream(0)
-    return cute.compile(
+    return _compile_cached(
         _sdpa_host,
         fake_q,
         fake_k,
@@ -1876,4 +1878,6 @@ def compile(  # noqa: A001 — the template contract's entry point (matches the 
         fake_thd_nb,
         fake_stream,
         options="--enable-tvm-ffi",
+        cache_key=_cache_key,
+        symbol="frost_sdpa_fwd",
     )

--- a/test/python/gemm/frost/test_compiled_cache_gpu.py
+++ b/test/python/gemm/frost/test_compiled_cache_gpu.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A frost GEMM plan compiled in one process is reloaded, not recompiled, in the
+next -- and computes the same thing. Two child processes share a fresh cache
+directory; the first must miss and export, the second must hit."""
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+from gemm_test_utils import requires_sm100
+
+pytestmark = [pytest.mark.L0, requires_sm100]
+
+_CHILD = r"""
+import hashlib, json, sys, torch, cudnn
+from cudnn.frost import compiled_cache as cc
+M, N, K = 256, 512, 256
+torch.manual_seed(0)
+a = torch.randn(1, M, K, device="cuda", dtype=torch.bfloat16)
+b = torch.randn(1, N, K, device="cuda", dtype=torch.bfloat16).transpose(1, 2)
+handle = cudnn.create_handle()
+g = cudnn.pygraph(handle=handle, io_data_type=cudnn.data_type.BFLOAT16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+A, B = g.tensor_like(a), g.tensor_like(b)
+C = g.matmul(A=A, B=B); C.set_output(True).set_data_type(cudnn.data_type.BFLOAT16)
+g.validate(); g.build_operation_graph(); g.create_execution_plans([cudnn.heur_mode.A])
+idx = next(i for i in range(g.get_execution_plan_count()) if g.get_plan_name_at_index(i).startswith("frost_gemm"))
+g.select_plan(idx); g.check_support(); g.build_plans()
+c = torch.empty(1, M, N, device="cuda", dtype=torch.bfloat16)
+ws = torch.empty(max(g.get_workspace_size(), 1), dtype=torch.uint8, device="cuda")
+g.execute({A: a, B: b, C: c}, ws, handle=handle); torch.cuda.synchronize()
+launch = g._compiled_plans[idx]._compiled._launchable
+print(json.dumps({"stats": cc.stats(), "digest": hashlib.sha256(c.view(torch.int16).cpu().numpy().tobytes()).hexdigest(), "reloaded": hasattr(launch, "_compiled_cache_entry"), "root": str(cc.get_cache_dir())}))
+"""
+
+
+def _run(cache_dir):
+    env = dict(os.environ, CUDNN_FRONTEND_ENABLE_FROST_ENGINES="1", CUDNN_FRONTEND_COMPILED_CACHE=str(cache_dir))
+    env.pop("CUDNN_FRONTEND_DISABLE_COMPILED_CACHE", None)
+    out = subprocess.run([sys.executable, "-c", _CHILD], env=env, capture_output=True, text=True, timeout=600)
+    assert out.returncode == 0, out.stderr[-2000:]
+    return json.loads(out.stdout.strip().splitlines()[-1])
+
+
+def test_second_process_reloads_the_exported_kernel(tmp_path):
+    first = _run(tmp_path)
+    assert first["stats"]["misses"] >= 1 and first["stats"]["hits"] == 0, first
+    assert first["reloaded"], "the miss path hands back the reloaded artifact so hit and miss run the same thing"
+    entries = list((tmp_path / "v1").glob("*/*/entry.json"))
+    assert entries, "no entry committed"
+    record = json.loads(entries[0].read_text())
+    assert record["schema"] == "v1" and record["symbol"] == "frost_gemm" and (entries[0].parent / "kernel.o").stat().st_size > 0
+    assert json.loads((entries[0].parent.parent / "manifest.json").read_text())["schema"] == "v1"
+
+    second = _run(tmp_path)
+    assert second["stats"]["misses"] == 0 and second["stats"]["hits"] >= 1, second
+    assert second["digest"] == first["digest"], "the reloaded kernel must compute exactly what the compiled one did"

--- a/test/python/gemm/frost/test_compiled_cache_gpu.py
+++ b/test/python/gemm/frost/test_compiled_cache_gpu.py
@@ -12,6 +12,8 @@ import sys
 
 import pytest
 
+from cudnn.frost import compiled_cache as cc
+
 from gemm_test_utils import requires_sm100
 
 pytestmark = [pytest.mark.L0, requires_sm100]
@@ -50,11 +52,11 @@ def test_second_process_reloads_the_exported_kernel(tmp_path):
     first = _run(tmp_path)
     assert first["stats"]["misses"] >= 1 and first["stats"]["hits"] == 0, first
     assert first["reloaded"], "the miss path hands back the reloaded artifact so hit and miss run the same thing"
-    entries = list((tmp_path / "v1").glob("*/*/entry.json"))
+    entries = list((tmp_path / cc._SCHEMA).glob("*/*/entry.json"))
     assert entries, "no entry committed"
     record = json.loads(entries[0].read_text())
-    assert record["schema"] == "v1" and record["symbol"] == "frost_gemm" and (entries[0].parent / "kernel.o").stat().st_size > 0
-    assert json.loads((entries[0].parent.parent / "manifest.json").read_text())["schema"] == "v1"
+    assert record["schema"] == cc._SCHEMA and record["symbol"] == "frost_gemm" and (entries[0].parent / "kernel.o").stat().st_size > 0
+    assert json.loads((entries[0].parent.parent / "manifest.json").read_text())["schema"] == cc._SCHEMA
 
     second = _run(tmp_path)
     assert second["stats"]["misses"] == 0 and second["stats"]["hits"] >= 1, second

--- a/test/python/sdpa/frost/test_sdpa_compiled_cache_gpu.py
+++ b/test/python/sdpa/frost/test_sdpa_compiled_cache_gpu.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A frost SDPA forward plan compiled in one process is reloaded, not recompiled,
+in the next -- and writes the same O. The template's key is its file + params
+digest joined with the compile() call's arguments (compiled_cache.template_key)."""
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+from cudnn.frost import compiled_cache as cc
+
+from frost_test_utils import requires_blackwell, requires_dsl
+
+pytestmark = [pytest.mark.L0, requires_blackwell, requires_dsl]
+
+_CHILD = r"""
+import hashlib, json, math, sys, torch, cudnn, cudnn.sdpa
+from cudnn.frost import compiled_cache as cc
+sys.path.insert(0, %(tests)r)
+from frost_test_utils import select_engine, _SM
+from cudnn.sdpa.fwd.engines import engine_name
+_ARCH = "sm107" if _SM == 107 else "sm100"
+b, h, s, d = 2, 8, 256, 128
+torch.manual_seed(0)
+mk = lambda: torch.randn(b, s, h, d, device="cuda", dtype=torch.bfloat16).transpose(1, 2)
+q_gpu, k_gpu, v_gpu = mk(), mk(), mk()
+o_gpu = torch.empty(b, s, h, d, device="cuda", dtype=torch.bfloat16).transpose(1, 2)
+g = cudnn.pygraph(io_data_type=cudnn.data_type.BFLOAT16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+q, k, v = g.tensor_like(q_gpu), g.tensor_like(k_gpu), g.tensor_like(v_gpu)
+o, _ = g.sdpa(name="sdpa", q=q, k=k, v=v, generate_stats=False, attn_scale=1.0 / math.sqrt(d), use_causal_mask=True)
+o.set_output(True).set_dim(q_gpu.shape).set_stride(q_gpu.stride())
+g.validate(); g.build_operation_graph(); g.create_execution_plans([cudnn.heur_mode.A])
+select_engine(g, engine_name(arch=_ARCH)); g.check_support(); g.build_plans()
+ws = torch.empty(max(g.get_workspace_size(), 1), device="cuda", dtype=torch.uint8)
+g.execute({q: q_gpu, k: k_gpu, v: v_gpu, o: o_gpu}, ws); torch.cuda.synchronize()
+print(json.dumps({"stats": cc.stats(), "digest": hashlib.sha256(o_gpu.contiguous().view(torch.int16).cpu().numpy().tobytes()).hexdigest()}))
+"""
+
+
+def _run(cache_dir):
+    env = dict(os.environ, CUDNN_FRONTEND_COMPILED_CACHE=str(cache_dir))
+    env.pop("CUDNN_FRONTEND_DISABLE_COMPILED_CACHE", None)
+    child = _CHILD % {"tests": os.path.dirname(os.path.abspath(__file__))}
+    out = subprocess.run([sys.executable, "-c", child], env=env, capture_output=True, text=True, timeout=900)
+    assert out.returncode == 0, out.stderr[-3000:]
+    return json.loads(out.stdout.strip().splitlines()[-1])
+
+
+def test_second_process_reloads_the_sdpa_forward_kernel(tmp_path):
+    first = _run(tmp_path)
+    assert first["stats"]["misses"] >= 1 and first["stats"]["hits"] == 0, first
+    entries = list((tmp_path / cc._SCHEMA).glob("*/*/entry.json"))
+    assert entries, "no entry committed"
+    record = json.loads(entries[0].read_text())
+    assert record["symbol"] == "frost_sdpa_fwd" and "|compile|" in record["key"], record
+    assert "('b', 2)" in record["key"] and "('qh', 8)" in record["key"], "the compile() arguments are part of the key"
+
+    second = _run(tmp_path)
+    assert second["stats"]["misses"] == 0 and second["stats"]["hits"] >= 1, second
+    assert second["digest"] == first["digest"], "the reloaded kernel must write exactly what the compiled one did"

--- a/test/python/test_compiled_cache.py
+++ b/test/python/test_compiled_cache.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The compiled-plan cache's rules, without a GPU or the DSL: identity is the
+whole manifest, an entry is only ever reused under its own embedded key, and
+anything doubtful is a miss."""
+
+import json
+
+import pytest
+
+import cudnn
+from cudnn.frost import compiled_cache as cc
+
+pytestmark = pytest.mark.L0
+
+
+def test_manifest_names_every_dependency_and_is_deterministic():
+    m = cc.environment_manifest()
+    for field in ("schema", "cudnn_frontend", "cutlass_dsl", "tvm_ffi", "cuda_driver", "device_name", "compute_capability", "sm_count", "l2_bytes"):
+        assert field in m and isinstance(m[field], str) and m[field], field
+    assert m["schema"] == cc._SCHEMA and m["cudnn_frontend"] == cudnn.__version__
+    assert cc.environment_manifest() == m  # same process, same answer
+
+
+def test_entry_location_is_the_content_hash_of_manifest_and_key(tmp_path):
+    m = {"schema": cc._SCHEMA, "cudnn_frontend": "1.30.0", "cutlass_dsl": "4.7.1"}
+    a = cc._entry_dir(tmp_path, m, "k1")
+    b = cc._entry_dir(tmp_path, m, "k2")
+    c = cc._entry_dir(tmp_path, dict(m, cutlass_dsl="4.8.0"), "k1")
+    assert a.parent == b.parent and a != b  # same environment, different kernels
+    assert c.parent != a.parent  # a dependency moved: a different directory outright
+    assert a.parts[-3] == cc._SCHEMA
+
+
+def test_cache_dir_override_and_env(tmp_path, monkeypatch):
+    monkeypatch.setenv(cc._ENV_DIR, str(tmp_path / "from_env"))
+    assert cc.get_cache_dir() == tmp_path / "from_env"
+    cc.set_cache_dir(tmp_path / "explicit")
+    try:
+        assert cc.get_cache_dir() == tmp_path / "explicit"
+    finally:
+        cc.set_cache_dir(None)
+    assert cc.get_cache_dir() == tmp_path / "from_env"
+
+
+def test_disabled_or_uncacheable_compiles_as_before(monkeypatch):
+    import cutlass.cute as cute
+
+    calls = []
+    monkeypatch.setattr(cute, "compile", lambda fn, *a, **k: calls.append((fn, a, k)) or "compiled")
+    cc.reset_stats()
+    monkeypatch.setenv(cc._ENV_DISABLE, "1")
+    assert cc.compile_cached(lambda: None, 1, cache_key="k", options="--enable-tvm-ffi") == "compiled"
+    monkeypatch.delenv(cc._ENV_DISABLE)
+    assert cc.compile_cached(lambda: None, 1, cache_key=None, options="--enable-tvm-ffi") == "compiled"  # no key: not cacheable
+    assert cc.compile_cached(lambda: None, 1, cache_key="k", options="") == "compiled"  # no tvm-ffi: not exportable
+    assert len(calls) == 3 and cc.stats()["bypassed"] == 3
+
+
+def test_a_foreign_or_corrupt_entry_is_a_miss(tmp_path):
+    cc.reset_stats()
+    entry = tmp_path / "e"
+    entry.mkdir()
+    (entry / cc._OBJECT).write_bytes(b"not an object")
+    (entry / cc._ENTRY).write_text(json.dumps({"schema": cc._SCHEMA, "key": "other", "symbol": "frost_gemm"}))
+    assert cc._try_load(entry, "mine", "frost_gemm", lambda x: x) is None  # embedded key differs
+    (entry / cc._ENTRY).write_text("{not json")
+    assert cc._try_load(entry, "mine", "frost_gemm", lambda x: x) is None  # unreadable record
+    (entry / cc._ENTRY).unlink()
+    assert cc._try_load(entry, "mine", "frost_gemm", lambda x: x) is None  # no record at all
+    assert cc.stats()["invalid"] == 1  # only the key mismatch is worth a warning; the others are plain misses
+
+
+def test_signature_of_rejects_varargs():
+    def ok(a, b, *, stream=None):
+        return None
+
+    def bad(*args, **kwargs):
+        return None
+
+    assert [p for p in cc._signature_of(ok).parameters] == ["a", "b", "stream"]
+    assert cc._signature_of(bad) is None

--- a/test/python/test_compiled_cache.py
+++ b/test/python/test_compiled_cache.py
@@ -58,6 +58,20 @@ def test_disabled_or_uncacheable_compiles_as_before(monkeypatch):
     assert len(calls) == 3 and cc.stats()["bypassed"] == 3
 
 
+def test_an_environment_that_cannot_identify_itself_persists_nothing(monkeypatch, tmp_path):
+    import cutlass.cute as cute
+
+    monkeypatch.setattr(cute, "compile", lambda fn, *a, **k: "compiled")
+    monkeypatch.setattr(cc, "environment_manifest", lambda device=None: {"schema": cc._SCHEMA, "cudnn_frontend": "1.30.0", "cuda_driver": "unknown"})
+    cc.set_cache_dir(tmp_path)
+    try:
+        cc.reset_stats()
+        assert cc.compile_cached(lambda x: x, 1, cache_key="k", options="--enable-tvm-ffi") == "compiled"
+    finally:
+        cc.set_cache_dir(None)
+    assert cc.stats()["bypassed"] == 1 and not list(tmp_path.rglob("*"))
+
+
 def test_a_foreign_or_corrupt_entry_is_a_miss(tmp_path):
     cc.reset_stats()
     entry = tmp_path / "e"

--- a/test/python/test_compiled_cache.py
+++ b/test/python/test_compiled_cache.py
@@ -6,6 +6,7 @@ whole manifest, an entry is only ever reused under its own embedded key, and
 anything doubtful is a miss."""
 
 import json
+import pathlib
 
 import pytest
 
@@ -17,7 +18,18 @@ pytestmark = pytest.mark.L0
 
 def test_manifest_names_every_dependency_and_is_deterministic():
     m = cc.environment_manifest()
-    for field in ("schema", "cudnn_frontend", "cutlass_dsl", "tvm_ffi", "cuda_driver", "device_name", "compute_capability", "sm_count", "l2_bytes"):
+    for field in (
+        "schema",
+        "cudnn_frontend",
+        "cudnn_source",
+        "cutlass_dsl",
+        "tvm_ffi",
+        "cuda_driver",
+        "device_name",
+        "compute_capability",
+        "sm_count",
+        "l2_bytes",
+    ):
         assert field in m and isinstance(m[field], str) and m[field], field
     assert m["schema"] == cc._SCHEMA and m["cudnn_frontend"] == cudnn.__version__
     assert cc.environment_manifest() == m  # same process, same answer
@@ -173,3 +185,22 @@ def test_the_loader_digests_the_file_and_the_params(tmp_path):
     src.write_text("CFG = FROST_TEMPLATE_PARAMS  # edited\n")
     c = template_loader.load_template(str(src), Params(None), tag="tiny")  # a new params value forces a re-read
     assert c.FROST_SOURCE_DIGEST not in (a.FROST_SOURCE_DIGEST, b.FROST_SOURCE_DIGEST)
+
+
+def test_the_manifest_carries_the_source_tree_not_a_commit(tmp_path):
+    """An edit anywhere in the package -- committed or not -- lands in another
+    environment directory; a wheel hashes the same every process."""
+    (tmp_path / "a.py").write_text("x = 1\n")
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "b.py").write_text("y = 2\n")
+    (tmp_path / "sub" / "__pycache__").mkdir()
+    (tmp_path / "sub" / "__pycache__" / "b.cpython-312.pyc").write_bytes(b"ignored")
+    before = cc.source_tree_digest(tmp_path)
+    assert before == cc.source_tree_digest(tmp_path) and len(before) == 16
+    (tmp_path / "sub" / "__pycache__" / "b.cpython-312.pyc").write_bytes(b"still ignored")
+    assert cc.source_tree_digest(tmp_path) == before
+    (tmp_path / "sub" / "b.py").write_text("y = 3\n")  # a shared helper edited, no version bump
+    assert cc.source_tree_digest(tmp_path) != before
+    import cudnn
+
+    assert cc.environment_manifest()["cudnn_source"] == cc.source_tree_digest(pathlib.Path(cudnn.__file__).resolve().parent)

--- a/test/python/test_compiled_cache.py
+++ b/test/python/test_compiled_cache.py
@@ -78,20 +78,98 @@ def test_a_foreign_or_corrupt_entry_is_a_miss(tmp_path):
     entry.mkdir()
     (entry / cc._OBJECT).write_bytes(b"not an object")
     (entry / cc._ENTRY).write_text(json.dumps({"schema": cc._SCHEMA, "key": "other", "symbol": "frost_gemm"}))
-    assert cc._try_load(entry, "mine", "frost_gemm", lambda x: x) is None  # embedded key differs
+    assert cc._try_load(entry, "mine", "frost_gemm") is None  # embedded key differs
     (entry / cc._ENTRY).write_text("{not json")
-    assert cc._try_load(entry, "mine", "frost_gemm", lambda x: x) is None  # unreadable record
+    assert cc._try_load(entry, "mine", "frost_gemm") is None  # unreadable record
     (entry / cc._ENTRY).unlink()
-    assert cc._try_load(entry, "mine", "frost_gemm", lambda x: x) is None  # no record at all
+    assert cc._try_load(entry, "mine", "frost_gemm") is None  # no record at all
     assert cc.stats()["invalid"] == 1  # only the key mismatch is worth a warning; the others are plain misses
 
 
-def test_signature_of_rejects_varargs():
-    def ok(a, b, *, stream=None):
+def test_the_record_carries_the_in_process_calling_convention():
+    """A kernel's runtime signature is its Python signature MINUS constexpr and
+    env-stream parameters; the record must say what the DSL's wrapper said."""
+    import inspect
+    from collections import namedtuple
+
+    Spec = namedtuple("Spec", "arg_names arg_defaults kwonly_names kwonly_defaults")
+
+    class ExecutionArgs:  # what jit_executor exposes
+        def get_kwargs_wrapper_spec(self, exclude=()):
+            names = [n for n in ("q", "flag", "count", "tail") if n not in exclude]
+            defaults = {"count": 0, "tail": None}
+            return Spec(names, tuple(defaults[n] for n in names if n in defaults), [n for n in ("stream",) if n not in exclude], {})
+
+    def in_process_wrapper(q, count=0, tail=None, *, stream):  # 'flag' was a Constexpr: gone at run time
         return None
 
-    def bad(*args, **kwargs):
-        return None
+    class Compiled:
+        execution_args = ExecutionArgs()
+        _kwargs_wrapper = staticmethod(in_process_wrapper)
 
-    assert [p for p in cc._signature_of(ok).parameters] == ["a", "b", "stream"]
-    assert cc._signature_of(bad) is None
+    spec = cc._wrapper_spec_of(Compiled(), (1, True, 0, None), {})
+    assert spec == {"arg_names": ["q", "count", "tail"], "arg_defaults": [0, None], "kwonly_names": ["stream"], "kwonly_defaults": {}}
+    calls = []
+    rebuilt = cc._rebuild_wrapper(lambda *a: calls.append(a), spec)
+    rebuilt("Q", stream="S")
+    rebuilt("Q", 7, tail="T", stream="S")
+    assert calls == [("Q", 0, None, "S"), ("Q", 7, "T", "S")]  # defaults filled, kwargs placed, positional-only underneath
+    assert list(inspect.signature(rebuilt).parameters) == ["q", "count", "tail", "stream"]
+
+    # not reproducible exactly -> no record
+    class NoWrapper:
+        execution_args = ExecutionArgs()
+
+    assert cc._wrapper_spec_of(NoWrapper(), (), {}) is None
+    from dataclasses import dataclass
+
+    @dataclass
+    class Op:
+        k: int = 1
+
+    assert cc._wrapper_spec_of(Compiled(), (Op(),), {}) is None  # a dataclass argument goes through a hook the record cannot describe
+    assert cc._rebuild_wrapper(lambda *a: None, None) is None  # an entry from before the record carried a spec is a miss
+
+
+def test_template_key_joins_the_digest_with_plain_arguments_only():
+    g = {"FROST_SOURCE_DIGEST": "abc123"}
+    key = cc.template_key(g, {"b": 2, "qh": 8, "lse_stride": (1, 2, 3), "flag": True, "opt": None}, "compile")
+    assert key.startswith("abc123|compile|") and "('b', 2)" in key and "('lse_stride', (1, 2, 3))" in key
+    assert cc.template_key(g, {"qh": 8, "b": 2}, "compile") == cc.template_key(g, {"b": 2, "qh": 8}, "compile")  # order-free
+    assert cc.template_key(g, {"b": 2}, "compile") != cc.template_key(g, {"b": 2}, "other")  # the function is named
+    assert cc.template_key({}, {"b": 2}) is None  # no digest: the loader did not produce this module
+    assert cc.template_key(g, {"b": 2, "device": object()}) is None  # a repr that need not survive a process
+
+    from dataclasses import dataclass
+
+    @dataclass(frozen=True)
+    class P:
+        d: int = 128
+        thd: bool = False
+
+    assert "P(d=128, thd=False)" in cc.template_key(g, {"p": P()}, "compile")  # a params record of plain fields is plain
+    assert cc.template_key(g, {"p": P(d=object())}, "compile") is None  # unless one of its fields is not
+    import cutlass
+
+    assert "cutlass" in cc.template_key(g, {"io_dtype": cutlass.BFloat16}, "compile")  # a dtype CLASS names itself
+
+
+def test_the_loader_digests_the_file_and_the_params(tmp_path):
+    from dataclasses import dataclass
+
+    from cudnn.frost import template_loader
+
+    @dataclass(frozen=True)
+    class Params:
+        causal: bool = False
+
+    src = tmp_path / "tiny_template.py"
+    src.write_text("CFG = FROST_TEMPLATE_PARAMS\n")
+    a = template_loader.load_template(str(src), Params(False), tag="tiny")
+    b = template_loader.load_template(str(src), Params(True), tag="tiny")
+    assert a.FROST_SOURCE_DIGEST and len(a.FROST_SOURCE_DIGEST) == 16
+    assert a.FROST_SOURCE_DIGEST != b.FROST_SOURCE_DIGEST  # the params are part of it
+    assert template_loader.load_template(str(src), Params(False), tag="tiny") is a  # the module cache still keys on (path, params)
+    src.write_text("CFG = FROST_TEMPLATE_PARAMS  # edited\n")
+    c = template_loader.load_template(str(src), Params(None), tag="tiny")  # a new params value forces a re-read
+    assert c.FROST_SOURCE_DIGEST not in (a.FROST_SOURCE_DIGEST, b.FROST_SOURCE_DIGEST)


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I reviewed the Hard Rules in the `AGENTS.md` for each directory this PR touches (see [root AGENTS.md § Reviewing a PR](https://github.com/NVIDIA/cudnn-frontend/blob/develop/AGENTS.md#reviewing-a-pr-human-or-agent)) and my changes comply: no public signature changes; the kernel templates' `compile()` contract is unchanged (a drop-in for `cute.compile`); the design doc gains the section in the same commit.
- [x] I added GitHub labels: `cat-feature`, `area:frost`, `orig-nv-eng`.

## Affected area

FE OSS kernels or CuTeDSL — the FROST GEMM engine's kernel templates and a new `cudnn.frost.compiled_cache` module.

## Summary

A persistent, cross-process cache of compiled FROST kernels.

- `cudnn/frost/compiled_cache.py` (new): `compile_cached(fn, *args, cache_key=, symbol=, **kwargs)` is a drop-in for `cute.compile`. On a miss it compiles, exports the tvm-ffi object (`export_to_c`) and reloads it (`cutlass.runtime.load_module`); on a hit it reloads. A reloaded tvm-ffi function is positional-only, so it is wrapped with the kwargs wrapper the DSL itself uses, rebuilt from the runtime spec the record carries (the Python signature minus `cutlass.Constexpr` and env-stream parameters) — the caller cannot tell a hit from a miss, and the miss path hands back the reloaded artifact too, so a bad artifact fails at build time rather than at the next start-up.
- Layout `<root>/v2/<env_hash>/<entry_hash>/{kernel.o, entry.json}` + `manifest.json`. **Identity is the whole manifest, hashed**: frontend version **and a digest of every `.py` in the `cudnn` package** (a kernel is compiled from the shared helpers it imports as much as from its template; the version does not move in a checkout someone is editing, so an uncommitted edit lands in another directory while a wheel hashes the same every process — 749 files, 48 ms once per process), cutlass-dsl and tvm-ffi versions, CUDA driver, device name + compute capability + SM count + L2 bytes (FROST bakes the last two into kernels). **An entry is reused only under its own embedded key**; the object is written first, the record after it (commit marker), both temp-file + `os.replace`. **Anything doubtful is a miss**, never an error. Kernels whose in-process object converts raw pointer arguments are not cached (the reload path has no converter). `CUDNN_FRONTEND_COMPILED_CACHE` / `set_cache_dir()` choose the root (default `$XDG_CACHE_HOME/cudnn_frontend/compiled_plans`); `CUDNN_FRONTEND_DISABLE_COMPILED_CACHE=1` turns it off; `stats()` reports hits / misses / bypassed / invalid.
- The eight FROST GEMM kernel templates route their `cute.compile` through it; `_import_kernel` hands each generated module the digest of its rendered source as `FROST_SOURCE_DIGEST` — that source already carries the tile config, dtypes, fusion chain and `--gpu-arch`, so it is the kernel's identity.
- Design doc: new *The compiled-plan cache* section.

Not in this PR: the linear-attention templates and the SDPA `api_dsl` helper kernels, which compile from traced tensors at call time (a key for them has to spell the traced tensors' dtype, rank and dynamic marks) — follow-up.

## Why

`cute.compile` runs the whole backend once per process for every distinct kernel — measured 0.7 s for a FROST GEMM and 2.6 s for an SDPA prefill on SM100 — and the DSL's own file cache stores only MLIR bytecode (its `load_cache_from_path` re-runs the backend), so the heavy part is paid again at every start-up. A serving process that warms tens of plans, or autotunes over them, pays minutes per process per rank. Export is 0.08 s and reload is milliseconds; the object for a GEMM is ~70 KB.

Rules follow FlashInfer's autotune-cache v2 (content-hashed environment identity, embedded key, miss-on-invalid, atomic publish, schema directory), agreed with FlashInfer as the contract they will point their workspace at.

## Related issues

- Follows #1024 / #1026 / #1028. FlashInfer: the persistent-cache half of flashinfer-ai/flashinfer#5163's context (their `JitSpecCuteDsl` does the same for their own kernels).

## API and compatibility impact

- Additive: `cudnn.frost.compiled_cache` (`compile_cached`, `get_cache_dir`, `set_cache_dir`, `enabled`, `environment_manifest`, `stats`, `reset_stats`). The GEMM templates' `compile()` returns a callable with the same call contract; its concrete type is now the kwargs-wrapped reloaded function instead of the in-process `TVMFFIJitCompiledFunctionWithKwargs` when the cache is on.
- New environment variables `CUDNN_FRONTEND_COMPILED_CACHE`, `CUDNN_FRONTEND_DISABLE_COMPILED_CACHE`. Writes to the user cache directory (never into the package). Supported GPU / cuDNN / CUDA / Python versions: unchanged.

## Testing

Blackwell SM100, cuDNN 9.25.1, `_compiled_module` built from develop, `nvidia-cutlass-dsl` 4.7.1, `apache-tvm-ffi` 0.1.11:

```
cd test/python
python -m pytest -q -m L0 test_compiled_cache.py gemm/frost/test_compiled_cache_gpu.py
# 7 passed: manifest fields + determinism; content-addressed entry dirs; dir override / env; disabled and
# uncacheable calls compile as before; foreign / corrupt entries are misses; and two child processes sharing a
# fresh cache dir -- the first misses, exports and hands back the reloaded artifact, the second hits and computes
# a bit-identical result.
python -m pytest -q -m L0 gemm/frost/test_frontend_integration.py gemm/frost/test_public_execute_flavors.py gemm/frost/test_execute_recipe.py
# 121 passed: 44 s cold (44 kernels exported, 4.3 MB) -> 12 s warm
```

Every frost GEMM suite cold then warm through the cache:

| pass (SM100, shared GPU; every `gemm/frost` suite incl. MoE, block-scale, epilogue fusion, multi-GEMM, integration) | result | wall |
|---|---|---|
| cold (fresh cache dir) | 5655 passed, 2660 skipped | 20 min 53 s — 1416 kernels exported, 127 MB |
| warm (same dir, every kernel reloaded) | 5655 passed, 2660 skipped | 1 min 35 s |

Identical pass set; the warm run is the same tests with every `cute.compile` replaced by a reload.

`pre-commit run` clean.

## SDPA templates routed too (second commit)

The same hook now serves the SDPA forward / backward kernel templates (36 files, 49 `cute.compile` sites). A template specializes twice — at import from the file + `FROST_TEMPLATE_PARAMS`, at `compile()` from the call's arguments — so `template_loader` records `FROST_SOURCE_DIGEST` (file bytes + params) and `compiled_cache.template_key(globals(), locals(), "<function>")`, the first statement of every function that compiles, joins it with the function's arguments. An argument that is not a plain value (tensor, device, stream) makes the key `None` and the call compiles as before, which is why the linear-attention templates (their `compile()` takes traced tensors) and the `api_dsl` helper kernels are left for a follow-up.

Routing the fp8 kernels exposed a reload bug in the first commit: a kernel with a `cutlass.Constexpr` parameter was called with every argument shifted by one, because the wrapper over the reloaded positional-only function was built from the Python signature while the DSL builds its own from the runtime spec (constexpr and env-stream parameters dropped). The record now carries that runtime spec (schema `v2`; a `v1` entry is a miss) and the reloaded function is wrapped with tvm-ffi's `make_kwargs_wrapper` from it — the same object the DSL hands back, so hit and miss are called identically.

| pass (SM100, shared GPU) | result | wall |
|---|---|---|
| SDPA fwd/bwd suites (`test_sdpa_fwd_dsl/fp8/mxfp8/paged/split_kv_sm100`, `test_sdpa_bwd_dsl/thd_sm100`, `test_sdpa_frontend_integration`) + GEMM `test_matmul`, `test_block_scale_matmul`, cold (fresh cache dir) | 5867 passed, 2623 skipped | 53 min 06 s — 1902 kernels exported (895 `frost_sdpa_fwd`, 50 `frost_sdpa_bwd`, 957 `frost_gemm`), 284 MB |
| same, warm (every kernel reloaded) | 5867 passed, 2623 skipped | 2 min 53 s |
| SDPA forward graph-API cases (12 kernels) | 12 passed / 12 passed | 24.8 s → 2.4 s |


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>note to self: claude::61d24ed2-7c90-4a97-9cbb-b91ae18136fd — "PR #5133 auto backend: why not cuDNN" · cwd /home/scratch.yanxu_libs/flashinfer · workspace /home/scratch.yanxu_libs/cudnn_frontend-wt-fishape (branch yanxu/frost-compiled-cache)</sub>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added compiled-kernel caching across GEMM and SDPA workloads, enabling reuse across processes.
  - Added deterministic cache identification based on kernel content and supported compilation parameters.
  - Added configurable cache locations, cache statistics, and runtime argument reconstruction for supported cached kernels.
  - Cache entries now use validation and safer temporary artifact handling, with unsupported cases falling back to normal compilation.

- **Documentation**
  - Expanded guidance on cache behavior, persistence limits, benchmark results, and uncached kernel cases.

- **Tests**
  - Added coverage for cache export, reloads, cross-process reuse, cache keys, runtime signatures, and invalid records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

