### PR TITLE
pygraph: the declaration supplies the dtype too; the conformance suite binds fp4 and scales as uint8, as FlashInfer does

### DIFF
--- a/docs/utilities/python_graph_and_execution_backends.md
+++ b/docs/utilities/python_graph_and_execution_backends.md
@@ -135,6 +135,13 @@ address lends the declaration outright — it carries no extent, so there is
 nothing to compare against: the caller guarantees the allocation covers the
 declared bytes and meets the engine's alignment. Rules that follow:
 
+- **The declaration supplies the dtype too.** A buffer re-described from the
+  declaration takes its dtype with the extents (a byte blob covering a bf16
+  output becomes that output), and a buffer of the declared extents whose
+  slots are as wide as the declaration's is read AS the declared dtype
+  (FlashInfer binds packed fp4 data and the e4m3 scale blob as `uint8`; the
+  backend read a pointer and never knew). Only a buffer too small for the
+  declaration keeps its own dtype with its own description.
 - `override_shapes` / `override_strides` speak cuDNN **element** units in the
   graph's axis order, like every declaration. They are written INTO the slot
   (in the buffer's axis order, `_in_axis_order_of`), never carried around it, so

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -30,7 +30,7 @@ from cudnn import _pybind_module
 
 from ._device import ensure_current_context
 from ._handle import Handle, to_backend_handle
-from .datatypes import _buffer_dtype_to_cudnn, _dlpack_code_bits, _torch_to_cudnn_data_type
+from .datatypes import _buffer_dtype_to_cudnn, _dlpack_code_bits, _dlpack_lanes, _torch_to_cudnn_data_type
 from .engines.base import ExecutionContext, VariantPack
 from .engines.engine_ids import is_python_engine
 from .graph_types import NodeType, Tensor, byte_size as _byte_size, describing_tensor, storage_geometry, storage_slot_bytes
@@ -1992,7 +1992,7 @@ class pygraph:
                 # slot that borrowed one is named here.
                 from_graph.append(i)
             ptr, tensor = self._describe(data, order[i])
-            native.set_operand(i, ptr, tuple(tensor.dim), tuple(tensor.stride), *_dlpack_code_bits(tensor.data_type))
+            native.set_operand(i, ptr, tuple(tensor.dim), tuple(tensor.stride), *_dlpack_code_bits(tensor.data_type), _dlpack_lanes(tensor.data_type))
         if strict:
             hole = native.first_unfilled()
             if hole >= 0:
@@ -2032,7 +2032,8 @@ class pygraph:
                         f"override_shapes for tensor uid {uid}: an fp4 tensor packs two elements per storage slot, so its "
                         f"unit-stride extent must be even; got {tuple(override_shapes[j])} / {tuple(override_strides[j])}"
                     )
-                native.override_operand(i, *_in_axis_order_of(storage[0], storage[1], native.stride(i)))
+                dtype = (*_dlpack_code_bits(declared.data_type), _dlpack_lanes(declared.data_type)) if declared is not None else (0, 0, 1)
+                native.override_operand(i, *_in_axis_order_of(storage[0], storage[1], native.stride(i)), *dtype)
         # The workspace has no uid, so it is not an operand — but an engine has
         # to bounds-check its carves, and reading its size here is the same read
         # every other buffer gets rather than a second probe further down.
@@ -2065,7 +2066,14 @@ class pygraph:
                 storage = storage_geometry(declared.dim, declared.stride, declared.data_type)
                 if storage is None:
                     continue
-                layout.set(i, list(storage[0]), list(storage[1]), storage_slot_bytes(declared.data_type) or 0)
+                layout.set(
+                    i,
+                    list(storage[0]),
+                    list(storage[1]),
+                    storage_slot_bytes(declared.data_type) or 0,
+                    *_dlpack_code_bits(declared.data_type),
+                    _dlpack_lanes(declared.data_type),
+                )
             self._declared_layout_native = layout
         return layout
 

--- a/python/cudnn/datatypes.py
+++ b/python/cudnn/datatypes.py
@@ -364,9 +364,23 @@ def _init_dlpack_dtype_tables():
         _CUDNN_TO_DLPACK_CODE_BITS[enum] = code_bits
 
 
+# torch exports float4_e2m1fn_x2 as DLPack (kDLFloat4_e2m1fn = 17, 4 bits, 2 lanes);
+# the frost dtype table has no single-fp4 row, so the pack spells it the way torch does.
+_DLPACK_FP4_CODE_BITS = (17, 4)
+
+
 def _dlpack_code_bits(data_type):
     """``(code, bits)`` for a cuDNN dtype, or ``(0, 0)`` when it has no DLPack
     spelling — a slot with no dtype still carries its pointer and shape."""
     if not _CUDNN_TO_DLPACK_CODE_BITS:
         _init_dlpack_dtype_tables()
-    return _CUDNN_TO_DLPACK_CODE_BITS.get(data_type, (0, 0))
+    got = _CUDNN_TO_DLPACK_CODE_BITS.get(data_type)
+    if got is None:
+        return _DLPACK_FP4_CODE_BITS if data_type == cudnn_data_type.FP4_E2M1 else (0, 0)
+    return got
+
+
+def _dlpack_lanes(data_type) -> int:
+    """DLPack lanes of a cuDNN dtype's storage slot: 2 for fp4 (two elements per
+    slot, as torch spells ``float4_e2m1fn_x2``), 1 otherwise."""
+    return 2 if data_type == cudnn_data_type.FP4_E2M1 else 1

--- a/python/cudnn/engines/base.py
+++ b/python/cudnn/engines/base.py
@@ -135,8 +135,10 @@ class VariantPack:
     A slot describes the buffer as the GRAPH declares it whenever the caller's
     own geometry disagrees but covers the declared bytes (``graph_described``
     names those slots, bare addresses included); only a buffer smaller than its
-    declaration keeps its own description. Overrides are written into the slot
-    too. An engine reads the IR port for the shape the plan was built for and
+    declaration keeps its own description. A described slot carries the
+    DECLARED dtype, as does one of the declared extents whose slots are as wide
+    (FlashInfer binds packed fp4 and e4m3 scale blocks as uint8). Overrides are
+    written into the slot too. An engine reads the IR port for the shape the plan was built for and
     this pack for the shape about to run; frost_gemm takes its M/N/K from here,
     the backend takes only the pointer.
 

--- a/python/pygraph/variant_pack.cpp
+++ b/python/pygraph/variant_pack.cpp
@@ -191,13 +191,20 @@ class DeclaredLayout {
         std::vector<int64_t> stride;
         int64_t slot_bytes = 0;  // 0: width unknown, never re-described from
         int64_t span       = 0;
+        DLDataType dtype   = {0, 0, 1};  // bits == 0: no DLPack spelling, the buffer's own dtype stands
         bool present       = false;
     };
 
     explicit DeclaredLayout(size_t n) : slots_(n) {}
 
     void
-    set(size_t index, std::vector<int64_t> shape, std::vector<int64_t> stride, int64_t slot_bytes) {
+    set(size_t index,
+        std::vector<int64_t> shape,
+        std::vector<int64_t> stride,
+        int64_t slot_bytes,
+        int dtype_code  = 0,
+        int dtype_bits  = 0,
+        int dtype_lanes = 1) {
         if (shape.size() != stride.size()) {
             throw py::value_error("declared shape and stride must have the same rank; got " +
                                   std::to_string(shape.size()) + " and " + std::to_string(stride.size()) +
@@ -208,7 +215,9 @@ class DeclaredLayout {
         slot.shape      = std::move(shape);
         slot.stride     = std::move(stride);
         slot.slot_bytes = slot_bytes;
-        slot.present    = true;
+        slot.dtype      = DLDataType{
+            static_cast<uint8_t>(dtype_code), static_cast<uint8_t>(dtype_bits), static_cast<uint16_t>(dtype_lanes)};
+        slot.present = true;
     }
 
     const std::vector<Slot> &
@@ -568,11 +577,13 @@ class VariantPackNative {
                 std::vector<int64_t> shape,
                 std::vector<int64_t> stride,
                 int dtype_code,
-                int dtype_bits) {
+                int dtype_bits,
+                int dtype_lanes = 1) {
         Operand &operand = operands_.at(index);
         operand.data     = reinterpret_cast<void *>(ptr);
         operand.ndim     = static_cast<int32_t>(shape.size());
-        operand.dtype    = DLDataType{static_cast<uint8_t>(dtype_code), static_cast<uint8_t>(dtype_bits), 1};
+        operand.dtype    = DLDataType{
+            static_cast<uint8_t>(dtype_code), static_cast<uint8_t>(dtype_bits), static_cast<uint16_t>(dtype_lanes)};
         operand.shape    = std::move(shape);
         operand.stride   = std::move(stride);
         operand.filled   = true;
@@ -582,12 +593,29 @@ class VariantPackNative {
     // Re-describe a operand at the shape this execute runs, keeping its buffer.
     // Applying override_shapes here rather than in an engine is what keeps the
     // two paths answering the same question: an engine that reads the pack
-    // honours the override without knowing the concept exists.
+    // honours the override without knowing the concept exists. The override
+    // describes the DECLARED tensor at another size, so the slot takes the
+    // declared dtype too when the buffer's slots are as wide (dtype_bits > 0
+    // names it; FlashInfer binds fp4 and fp8 blocks as uint8).
     void
-    override_operand(size_t index, std::vector<int64_t> shape, std::vector<int64_t> stride) {
+    override_operand(size_t index,
+                     std::vector<int64_t> shape,
+                     std::vector<int64_t> stride,
+                     int dtype_code  = 0,
+                     int dtype_bits  = 0,
+                     int dtype_lanes = 1) {
         Operand &operand = operands_.at(index);
         if (!operand.filled) {
             throw py::value_error("variant-pack operand " + std::to_string(index) + " has no buffer to re-describe");
+        }
+        if (dtype_bits > 0) {
+            const int64_t own_bytes  = (static_cast<int64_t>(operand.dtype.bits) * operand.dtype.lanes + 7) / 8;
+            const int64_t want_bytes = (static_cast<int64_t>(dtype_bits) * dtype_lanes + 7) / 8;
+            if (own_bytes == want_bytes) {
+                operand.dtype = DLDataType{static_cast<uint8_t>(dtype_code),
+                                           static_cast<uint8_t>(dtype_bits),
+                                           static_cast<uint16_t>(dtype_lanes)};
+            }
         }
         // ndim comes from the shape and the stride array is read ndim deep, and
         // this is the one place the two arrive from different lists.
@@ -607,12 +635,16 @@ class VariantPackNative {
         pointers_[index]           = nullptr;
     }
 
-    // The declaration is the contract (see _pygraph._normalize): a filled operand
-    // of OTHER extents that is one dense run of slots and covers the declared
-    // bytes is re-described AS the declaration. The declared extents under the
-    // caller's own strides, a strided view, or a buffer too small keep their own
-    // description. `skip` names the slots already described from the graph (a
-    // bare address). Returns the indices re-described, in slot order.
+    // The declaration is the contract (see _pygraph._normalize). For a filled
+    // operand that has one: OTHER extents that are one dense run of slots and
+    // cover the declared bytes are re-described AS the declaration, dtype
+    // included (a byte blob covering a bf16 output becomes that output; what a
+    // bare address gets). The declared extents keep the caller's strides, and
+    // take the declared dtype when the slots are as wide (FlashInfer binds fp4
+    // and fp8 blocks as uint8; the backend reads a pointer and never knew). A
+    // strided view of other extents, or a buffer too small, keeps its own
+    // description entirely. `skip` names the slots already described from the
+    // graph (a bare address). Returns the indices whose extents were re-described.
     std::vector<size_t>
     describe_from(const DeclaredLayout &declared, const std::vector<size_t> &skip) {
         std::vector<size_t> described;
@@ -622,18 +654,23 @@ class VariantPackNative {
             Operand &operand                 = operands_[i];
             if (!want.present || want.slot_bytes <= 0 || !operand.filled) continue;
             if (std::find(skip.begin(), skip.end(), i) != skip.end()) continue;
-            if (operand.shape == want.shape) continue;
-            const int64_t own_span =
-                operand.stride.empty() ? numel_of(operand.shape) : span_of(operand.shape, operand.stride);
-            if (own_span != numel_of(operand.shape)) continue;
             // BYTES, not slots: a uint8 view spanning as many slots as a bf16
             // declaration covers half its bytes. A width the producer did not
             // spell (bits == 0) never qualifies.
             const int64_t own_bytes = (static_cast<int64_t>(operand.dtype.bits) * operand.dtype.lanes + 7) / 8;
-            if (own_bytes <= 0 || own_span * own_bytes < want.span * want.slot_bytes) continue;
+            if (own_bytes <= 0) continue;
+            if (operand.shape == want.shape) {
+                if (own_bytes == want.slot_bytes && want.dtype.bits > 0) operand.dtype = want.dtype;
+                continue;
+            }
+            const int64_t own_span =
+                operand.stride.empty() ? numel_of(operand.shape) : span_of(operand.shape, operand.stride);
+            if (own_span != numel_of(operand.shape)) continue;
+            if (own_span * own_bytes < want.span * want.slot_bytes) continue;
             operand.ndim   = static_cast<int32_t>(want.shape.size());
             operand.shape  = want.shape;
             operand.stride = want.stride;
+            if (want.dtype.bits > 0) operand.dtype = want.dtype;
             described.push_back(i);
         }
         return described;
@@ -937,7 +974,15 @@ The storage-slot geometry each variant-pack slot was declared with, built once
 per graph; ``VariantPackNative.describe_from`` compares a whole pack against it.
 )")
         .def(py::init<size_t>())
-        .def("set", &DeclaredLayout::set)
+        .def("set",
+             &DeclaredLayout::set,
+             py::arg("index"),
+             py::arg("shape"),
+             py::arg("stride"),
+             py::arg("slot_bytes"),
+             py::arg("dtype_code")  = 0,
+             py::arg("dtype_bits")  = 0,
+             py::arg("dtype_lanes") = 1)
         .def("__len__", &DeclaredLayout::size);
 
     py::class_<VariantPackNative>(m, "VariantPackNative", R"(
@@ -952,8 +997,23 @@ its parts.
         .def("read_operand", &VariantPackNative::read_operand)
         .def("read_from", &VariantPackNative::read_from)
         .def("first_unfilled", &VariantPackNative::first_unfilled)
-        .def("set_operand", &VariantPackNative::set_operand)
-        .def("override_operand", &VariantPackNative::override_operand)
+        .def("set_operand",
+             &VariantPackNative::set_operand,
+             py::arg("index"),
+             py::arg("ptr"),
+             py::arg("shape"),
+             py::arg("stride"),
+             py::arg("dtype_code"),
+             py::arg("dtype_bits"),
+             py::arg("dtype_lanes") = 1)
+        .def("override_operand",
+             &VariantPackNative::override_operand,
+             py::arg("index"),
+             py::arg("shape"),
+             py::arg("stride"),
+             py::arg("dtype_code")  = 0,
+             py::arg("dtype_bits")  = 0,
+             py::arg("dtype_lanes") = 1)
         .def("describe_from", &VariantPackNative::describe_from)
         .def("skip_operand", &VariantPackNative::skip_operand)
         .def("operand_contiguous", &VariantPackNative::operand_contiguous)

--- a/python/pygraph/variant_pack.cpp
+++ b/python/pygraph/variant_pack.cpp
@@ -130,6 +130,8 @@ dtype_name(DLDataType dtype) {
         return "float8_e5m2";
     } else if (code == kDLFloat8_e8m0fnu) {
         return "float8_e8m0fnu";
+    } else if (code == kDLFloat4_e2m1fn && bits == 4) {
+        return "float4_e2m1fn_x2";  // two elements per slot, as torch spells the storage dtype
     }
     return "code" + std::to_string(code) + "_" + std::to_string(bits);
 }
@@ -300,9 +302,10 @@ class OperandBuffer {
         return dtype_name(operand_.dtype);
     }
 
+    // Bytes per storage slot: an fp4 slot is 4 bits x 2 lanes = one byte.
     int64_t
     element_size() const {
-        return operand_.dtype.bits / 8;
+        return (static_cast<int64_t>(operand_.dtype.bits) * operand_.dtype.lanes + 7) / 8;
     }
 
     int64_t

--- a/test/python/gemm/frost/test_flashinfer_shaped_gemm.py
+++ b/test/python/gemm/frost/test_flashinfer_shaped_gemm.py
@@ -204,12 +204,17 @@ def test_mm_bf16_override_shape_path():
 _FP4_X2 = getattr(torch, "float4_e2m1fn_x2", None)
 
 
-def _fp4_case(M: int, N: int, K: int, *, nvfp4: bool, alpha: bool, override_cache_m: int | None = None):
+def _fp4_case(M: int, N: int, K: int, *, nvfp4: bool, alpha: bool, override_cache_m: int | None = None, as_x2: bool = False):
+    """``as_x2=False`` binds what FlashInfer binds: the packed fp4 data as
+    ``uint8`` and, for nvfp4, the e4m3 scale blob viewed as ``uint8`` too
+    (gemm_base: ``a_descale.view(torch.uint8)`` when ``a.dtype == uint8``).
+    The declaration says FP4_E2M1 / FP8_E4M3; the buffer's dtype carries no
+    information of its own. ``as_x2=True`` binds torch's ``float4_e2m1fn_x2``."""
     torch.manual_seed(0)
     block = 16 if nvfp4 else 32
     a_u8 = torch.randint(0, 256, (M, K // 2), device="cuda", dtype=torch.uint8)
     b_u8 = torch.randint(0, 256, (N, K // 2), device="cuda", dtype=torch.uint8).t()  # (K/2, N) column-major
-    a, b = a_u8.view(_FP4_X2), b_u8.view(_FP4_X2)
+    a, b = (a_u8.view(_FP4_X2), b_u8.view(_FP4_X2)) if as_x2 else (a_u8, b_u8)
     a_shape, a_stride = _fp4_shape3(a)  # [1, M, K]
     b_shape, b_stride = _fp4_shape3(b)  # [1, K, N], stride [K*N, 1, K]
     bs_m, bs_n, bs_k = _block_scale_dims(M, N, K, block)
@@ -217,6 +222,8 @@ def _fp4_case(M: int, N: int, K: int, *, nvfp4: bool, alpha: bool, override_cach
     if nvfp4:
         sfa = torch.full((bs_m * bs_k,), 1.0, device="cuda").to(torch.float8_e4m3fn)
         sfb = torch.full((bs_n * bs_k,), 1.0, device="cuda").to(torch.float8_e4m3fn)
+        if not as_x2:
+            sfa, sfb = sfa.view(torch.uint8), sfb.view(torch.uint8)
         sf_type = cudnn.data_type.FP8_E4M3
     else:
         sfa = torch.full((bs_m * bs_k,), 127, device="cuda", dtype=torch.uint8).view(torch.float8_e8m0fnu)
@@ -286,6 +293,15 @@ def test_mm_fp4_flat_scale_blobs(mnk, kind):
 def test_mm_fp4_override_shape_path(kind):
     build, pack, override = _fp4_case(200, 512, 256, nvfp4=kind == "nvfp4", alpha=False, override_cache_m=256)
     _accept_means_run(build, pack, override=override)
+
+
+@pytest.mark.skipif(_FP4_X2 is None, reason="torch has no float4_e2m1fn_x2")
+@pytest.mark.parametrize("kind", ["nvfp4", "mxfp4"])
+def test_mm_fp4_x2_view_binding(kind):
+    """The same graph with torch's own fp4 dtype bound: both spellings of the
+    same bytes must run, and the declaration decides what they mean."""
+    build, pack, _ = _fp4_case(256, 512, 256, nvfp4=kind == "nvfp4", alpha=False, as_x2=True)
+    _accept_means_run(build, pack)
 
 
 # ---------------------------------------------------------------------------

--- a/test/python/test_variant_pack_normalization.py
+++ b/test/python/test_variant_pack_normalization.py
@@ -280,6 +280,53 @@ def test_a_narrower_buffer_covering_the_slot_count_but_not_the_bytes_is_not_re_d
 
 
 @pytest.mark.L0
+@pytest.mark.L0
+def test_a_buffer_of_the_declared_width_is_read_as_the_declared_dtype():
+    """FlashInfer binds packed fp4 as uint8 and the e4m3 scale blob as uint8:
+    the declaration names the dtype, the buffer only has to be as wide. A
+    byte blob covering a bf16 output is re-described as that output, dtype
+    included; a too-small buffer keeps its own dtype and description. Exercised
+    at the native level, where the rule lives; the FlashInfer-shaped GEMM suite
+    runs the whole graph with these bindings."""
+    from cudnn import _pybind_module as native_mod
+    from cudnn.datatypes import _dlpack_code_bits, _dlpack_lanes
+
+    fp4, bf16 = cudnn.data_type.FP4_E2M1, cudnn.data_type.BFLOAT16
+    assert (_dlpack_code_bits(fp4), _dlpack_lanes(fp4)) == ((17, 4), 2)  # spelled as torch exports float4_e2m1fn_x2
+    bf16_dl = (*_dlpack_code_bits(bf16), _dlpack_lanes(bf16))
+    layout = native_mod.DeclaredLayout(4)
+    layout.set(0, [1, M, K // 2], [M * K // 2, K // 2, 1], 1, 17, 4, 2)  # fp4 [1, M, K] declared, in storage slots
+    layout.set(1, [1, M, K // 2], [M * K // 2, K // 2, 1], 1, 17, 4, 2)
+    layout.set(2, [1, M, N], [M * N, N, 1], 2, *bf16_dl)  # bf16 [1, M, N]
+    layout.set(3, [1, M, N], [M * N, N, 1], 2, *bf16_dl)
+    a_u8 = torch.zeros(M, K // 2, device="cuda", dtype=torch.uint8)  # what FlashInfer binds: other extents, same width
+    a_u8_declared = torch.zeros(1, M, K // 2, device="cuda", dtype=torch.uint8)  # the declared storage extents already
+    c_bytes = torch.empty(1, M, N, device="cuda", dtype=torch.bfloat16).view(torch.uint8)  # a byte blob covering the output
+    c_small = torch.empty(1, M, N, device="cuda", dtype=torch.uint8)  # the declared extents at half the width: too small
+    pack = native_mod.VariantPackNative(4)
+    assert pack.read_from({1: a_u8, 2: a_u8_declared, 3: c_bytes, 4: c_small}, [1, 2, 3, 4]) == []
+    assert pack.describe_from(layout, []) == [0, 2]  # extents re-described: the 2-D fp4 buffer and the byte blob
+    assert list(pack.shape(0)) == [1, M, K // 2] and pack.dtype(0) == (17, 4)
+    assert list(pack.shape(1)) == [1, M, K // 2] and pack.dtype(1) == (17, 4)  # dtype reinterpreted even when the extents already matched
+    assert list(pack.shape(2)) == [1, M, N] and pack.dtype(2) == bf16_dl[:2]  # the blob became the declared output
+    assert list(pack.shape(3)) == [1, M, N] and pack.dtype(3) == (1, 8)  # too small: its own dtype and description stand
+    x2 = getattr(torch, "float4_e2m1fn_x2", None)
+    if x2 is not None:  # torch's own spelling arrives as the same dtype and is left alone
+        pack = native_mod.VariantPackNative(4)
+        pack.read_from({1: a_u8.view(x2)}, [1])
+        assert pack.describe_from(layout, []) == [0] and pack.dtype(0) == (17, 4)
+    # override_shapes: a buffer SMALLER than the declaration (a cache-M graph run
+    # at a smaller M) is too small to re-describe, but the override names the
+    # declared tensor at this call's size -- dtype included, when as wide
+    pack = native_mod.VariantPackNative(4)
+    pack.read_from({1: torch.zeros(M // 2, K // 2, device="cuda", dtype=torch.uint8)}, [1])
+    assert pack.describe_from(layout, []) == [] and pack.dtype(0) == (1, 8)
+    pack.override_operand(0, [1, M // 2, K // 2], [M * K // 4, K // 2, 1], 17, 4, 2)
+    assert list(pack.shape(0)) == [1, M // 2, K // 2] and pack.dtype(0) == (17, 4)
+    pack.override_operand(0, [1, M // 2, K // 2], [M * K // 4, K // 2, 1], *bf16_dl)  # a wider dtype: the buffer's stands
+    assert pack.dtype(0) == (17, 4)
+
+
 def test_storage_geometry_packs_fp4_two_per_slot():
     from cudnn.graph_types import storage_geometry as _storage_geometry
 

--- a/test/python/test_variant_pack_normalization.py
+++ b/test/python/test_variant_pack_normalization.py
@@ -309,6 +309,8 @@ def test_a_buffer_of_the_declared_width_is_read_as_the_declared_dtype():
     assert list(pack.shape(0)) == [1, M, K // 2] and pack.dtype(0) == (17, 4)
     assert list(pack.shape(1)) == [1, M, K // 2] and pack.dtype(1) == (17, 4)  # dtype reinterpreted even when the extents already matched
     assert list(pack.shape(2)) == [1, M, N] and pack.dtype(2) == bf16_dl[:2]  # the blob became the declared output
+    slot = pack.operand(0, 0)  # what an engine is handed: one byte per fp4 x2 slot, spelled as torch spells it
+    assert slot.dtype == "float4_e2m1fn_x2" and slot.element_size() == 1 and slot.nbytes == M * K // 2
     assert list(pack.shape(3)) == [1, M, N] and pack.dtype(3) == (1, 8)  # too small: its own dtype and description stand
     x2 = getattr(torch, "float4_e2m1fn_x2", None)
     if x2 is not None:  # torch's own spelling arrives as the same dtype and is left alone


### PR DESCRIPTION
## Before submitting
- [x] Every new or changed first-party source file carries an SPDX-License-Identifier line
- [x] `pre-commit run -a` is clean (clang-format, black)
- [x] The hard rules in AGENTS.md were reviewed against this change
- [x] Labels added (`cat-bugfix`, `area:frost`, `orig-nv-eng`)

## Affected area
Python graph API: variant-pack normalization (`_pygraph._normalize`, `pygraph/variant_pack.cpp`), `datatypes`, the FlashInfer-shaped GEMM conformance suite, design doc.

## Summary
**The graph declaration supplies an operand's dtype too.** #1028 made the declaration the contract for an operand's extents; this closes the same gap for its dtype:

- A buffer re-described from the declaration (other extents, one dense run, bytes covered) takes the declared dtype with the extents — a byte blob covering a bf16 output becomes that output, as a bare address always did.
- A buffer of the declared extents whose storage slots are as wide as the declaration's is read as the declared dtype.
- The `override_shapes` path spells the declared dtype into the slot the same way (a cache-M graph run at a smaller M binds a buffer too small to re-describe, and the override is the description).
- A buffer too small for the declaration keeps its own dtype with its own description; a narrower or wider dtype of the declared extents is never reinterpreted.
- fp4 is spelled the way torch exports `float4_e2m1fn_x2` (DLPack code 17, 4 bits, 2 lanes): `_dlpack_code_bits` gains the FP4 row, `_dlpack_lanes` the lane count, and `set_operand` / `DeclaredLayout.set` / `override_operand` take lanes.

**The conformance suite now binds what FlashInfer binds.** `gemm_base` hands cuDNN the packed fp4 data as `uint8` and, for nvfp4, the e4m3 scale blob viewed as `uint8` (`a_descale.view(torch.uint8)` when `a.dtype == uint8`). The suite bound torch's `float4_e2m1fn_x2` instead, which is why it was green while FlashInfer's own `tests/gemm/test_mm_fp4.py -k cudnn` failed on the frost plan with `Mismatched Tensor on argument #1 … expected dtype=float4_e2m1fnx2` (the kernel was compiled for fp4x2, the pack carried the buffer's uint8). The fp4 cases bind `uint8` by default now and keep one `float4_e2m1fn_x2` case, so both spellings of the same bytes are proven to run.

## Why
FlashInfer is the caller the frost plans exist for, and its fp4 path was refused at execute after `check_support` accepted it — exactly what "accept means run" forbids. The suite that gates default-on has to copy FlashInfer's bindings literally, dtype included, or it gates nothing.

## Related issues
Follows #1028 (operand contract). Found while running FlashInfer's tests against #1031's frontend build.

## API and compatibility impact
No public API change. `VariantPackNative.set_operand` / `override_operand` and `DeclaredLayout.set` gain optional trailing dtype arguments (defaults keep the old behaviour). A buffer whose dtype merely spells the declared bytes differently now reaches a python engine as the declared dtype — the backend never saw the difference.

## Testing
SM100 (B200-class), cuDNN 9.25.1, cutlass-dsl 4.7.1, this branch's pybind module:
```
test/python$ pytest test_variant_pack_normalization.py gemm/frost/test_flashinfer_shaped_gemm.py
34 passed, 1 deselected       # includes the new native-level dtype test and the uint8-bound fp4 cases (+ one x2 case)

flashinfer$ CUDNN_FRONTEND_ENABLE_FROST_ENGINES=1 pytest tests/gemm/test_mm_fp4.py tests/gemm/test_mm_bf16.py -k cudnn
6 passed                       # before: fp4 3/3 failed on the frost plan (or, with FlashInfer's autotuner in the loop, silently fell back to the backend tactic with a "cuDNN fp4 GEMM tactic failed" warning); no fallback warning now
```
Broad regression (every frost GEMM suite, the FI-shaped SDPA suite, the layout-sensitive linear-attention tests): running, results to follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>note to self: claude::61d24ed2-7c90-4a97-9cbb-b91ae18136fd — "FE knob vocabulary / FI conformance / compiled cache" · cwd /home/scratch.yanxu_libs/flashinfer · workspace /tmp/claude-25653/-home-scratch-yanxu-libs-flashinfer/61d24ed2-7c90-4a97-9cbb-b91ae18136fd/scratchpad</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved FP4 tensor handling, including packed buffers and two-lane tensor views.
  - DLPack metadata now preserves tensor type codes, bit widths, and lane counts across graph bindings.
  - Graph-declared shapes, strides, and compatible dtypes are applied more consistently during operand binding and overrides.
  - Compatible same-size buffers can inherit graph-declared dtype information, while smaller or incompatible buffers retain their original descriptions.

- **Documentation**
  - Clarified how graph declarations determine buffer dtype and layout descriptions.
  - Added guidance on persistent compiled-plan caching, including validation, storage, controls, statistics, and unsupported cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->