### PR TITLE
compiled cache: retire dead environment directories (size cap, oldest first) on a process's first write

### DIFF
--- a/docs/utilities/python_graph_and_execution_backends.md
+++ b/docs/utilities/python_graph_and_execution_backends.md
@@ -740,8 +740,18 @@ artifact can never be reused by accident:
 - Location: `CUDNN_FRONTEND_COMPILED_CACHE`, else
   `$XDG_CACHE_HOME/cudnn_frontend/compiled_plans`; `set_cache_dir()` for a
   caller that owns a workspace (FlashInfer); `CUDNN_FRONTEND_DISABLE_COMPILED_CACHE=1`
-  turns it off; `stats()` reports hits / misses / bypassed / invalid per
-  process. Bump `_SCHEMA` on any incompatible change.
+  turns it off; `stats()` reports hits / misses / bypassed / invalid / pruned
+  per process. Bump `_SCHEMA` on any incompatible change.
+- **Dead environments are retired.** The manifest hashes the package's source,
+  so every edited checkout and every CI commit mints an environment directory
+  that will never be hit again — a few hundred MB per commit on a runner with a
+  persistent home. A process's first write runs `prune()`: whole environment
+  directories go (never single entries), dead schema roots first, then oldest
+  first, until the root is under `CUDNN_FRONTEND_COMPILED_CACHE_MAX_BYTES`
+  (4 GiB by default; 0 disables); the process's own environment is never a
+  candidate. CI should still point `CUDNN_FRONTEND_COMPILED_CACHE` at a
+  job-local directory: nothing there is ever warm across commits, and the cap
+  is a backstop, not a policy.
 
 Not yet routed: kernels compiled from real tensors at call time (the
 linear-attention `chunk_*` launchers, the SDPA adapters' `_dot_fn` /

--- a/python/cudnn/frost/compiled_cache.py
+++ b/python/cudnn/frost/compiled_cache.py
@@ -60,6 +60,7 @@ import inspect
 import json
 import logging
 import os
+import re
 import shutil
 import tempfile
 import threading
@@ -75,6 +76,8 @@ _DEFAULT_MAX_BYTES = 4 * 1024**3  # every environment the root has seen, togethe
 _OBJECT = "kernel.o"
 _ENTRY = "entry.json"
 _MANIFEST = "manifest.json"
+_SCHEMA_DIR = re.compile(r"v[0-9]+")  # the shape of a schema directory name ...
+_DIGEST_DIR = re.compile(r"[0-9a-f]{24}")  # ... and of an environment / entry directory name (see _digest)
 
 _LOG = logging.getLogger("cudnn.frost.compiled_cache")
 _LOCK = threading.Lock()
@@ -398,6 +401,10 @@ def prune(root: Optional[Path] = None, limit: Optional[int] = None, keep: Option
     environment is either current (``keep``, this process's own) or dead.
     Other schema versions' roots are dead outright and go first. A directory
     another live process is still reading only costs that process misses.
+    Only directories this cache made are candidates -- a ``v<N>`` schema
+    directory, under it an environment named by our digest and carrying our
+    manifest; a caller who points the root at a shared directory keeps
+    everything else, uncounted.
     """
     root = Path(root) if root is not None else get_cache_dir()
     limit = max_bytes() if limit is None else limit
@@ -408,12 +415,12 @@ def prune(root: Optional[Path] = None, limit: Optional[int] = None, keep: Option
     # Symlinks are never followed and nothing outside the resolved root is ever
     # a deletion target: a link planted in the cache must not redirect rmtree.
     for schema_dir in root.iterdir():
-        if schema_dir.is_symlink() or not schema_dir.is_dir():
+        if schema_dir.is_symlink() or not schema_dir.is_dir() or not _SCHEMA_DIR.fullmatch(schema_dir.name):
             continue
         for env in schema_dir.iterdir():
-            if env.is_symlink() or not env.is_dir():
+            if env.is_symlink() or not env.is_dir() or not _DIGEST_DIR.fullmatch(env.name):
                 continue
-            if not env.resolve().is_relative_to(resolved_root):
+            if not env.resolve().is_relative_to(resolved_root) or not (env / _MANIFEST).is_file():
                 continue
             size, mtime = _dir_bytes_and_mtime(env)
             envs.append((schema_dir.name != _SCHEMA, mtime, size, env))

--- a/python/cudnn/frost/compiled_cache.py
+++ b/python/cudnn/frost/compiled_cache.py
@@ -44,7 +44,10 @@ cached (the reload path has no converter); everything else is.
 
 Location: ``CUDNN_FRONTEND_COMPILED_CACHE`` (a directory), else
 ``$XDG_CACHE_HOME/cudnn_frontend/compiled_plans`` (``~/.cache`` when unset).
-``CUDNN_FRONTEND_DISABLE_COMPILED_CACHE=1`` turns the cache off. A caller
+``CUDNN_FRONTEND_DISABLE_COMPILED_CACHE=1`` turns the cache off;
+``CUDNN_FRONTEND_COMPILED_CACHE_MAX_BYTES`` caps the root (4 GiB by default, 0 = never
+prune): a process's first write removes whole dead environment directories,
+oldest first, until the root fits. A caller
 that manages its own workspace (FlashInfer) points :func:`set_cache_dir` at
 it once per process.
 """
@@ -57,6 +60,7 @@ import inspect
 import json
 import logging
 import os
+import shutil
 import tempfile
 import threading
 import uuid
@@ -66,6 +70,8 @@ from typing import Any, Callable, Dict, Optional
 _SCHEMA = "v2"  # v2: the record carries the runtime wrapper spec, not a Python signature
 _ENV_DIR = "CUDNN_FRONTEND_COMPILED_CACHE"
 _ENV_DISABLE = "CUDNN_FRONTEND_DISABLE_COMPILED_CACHE"
+_ENV_MAX_BYTES = "CUDNN_FRONTEND_COMPILED_CACHE_MAX_BYTES"
+_DEFAULT_MAX_BYTES = 4 * 1024**3  # every environment the root has seen, together
 _OBJECT = "kernel.o"
 _ENTRY = "entry.json"
 _MANIFEST = "manifest.json"
@@ -73,7 +79,8 @@ _MANIFEST = "manifest.json"
 _LOG = logging.getLogger("cudnn.frost.compiled_cache")
 _LOCK = threading.Lock()
 _dir_override: Optional[Path] = None
-_stats = {"hits": 0, "misses": 0, "bypassed": 0, "invalid": 0, "export_failed": 0}
+_stats = {"hits": 0, "misses": 0, "bypassed": 0, "invalid": 0, "export_failed": 0, "pruned": 0}
+_pruned_this_process = False
 
 
 # ---------------------------------------------------------------------------
@@ -119,7 +126,7 @@ def get_cache_dir() -> Path:
 
 
 def stats() -> Dict[str, int]:
-    """Counters for this process: hits, misses, bypassed (not cacheable), invalid (entry rejected), export_failed."""
+    """Counters for this process: hits, misses, bypassed (not cacheable), invalid (entry rejected), export_failed, pruned (environment directories removed)."""
     with _LOCK:
         return dict(_stats)
 
@@ -130,9 +137,9 @@ def reset_stats() -> None:
             _stats[k] = 0
 
 
-def _count(name: str) -> None:
+def _count(name: str, n: int = 1) -> None:
     with _LOCK:
-        _stats[name] += 1
+        _stats[name] += n
 
 
 # ---------------------------------------------------------------------------
@@ -355,6 +362,89 @@ def _rebuild_wrapper(raw: Callable, spec: Dict[str, Any]) -> Optional[Callable]:
     )
 
 
+def max_bytes() -> int:
+    """The size the whole root may grow to before old environments are removed:
+    ``CUDNN_FRONTEND_COMPILED_CACHE_MAX_BYTES`` (0 disables pruning), else 4 GiB."""
+    raw = os.environ.get(_ENV_MAX_BYTES)
+    if raw is None or raw == "":
+        return _DEFAULT_MAX_BYTES
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return _DEFAULT_MAX_BYTES
+
+
+def _dir_bytes_and_mtime(path: Path):
+    total, newest = 0, 0.0
+    for dirpath, _dirs, files in os.walk(path):
+        for name in files:
+            try:
+                st = os.stat(os.path.join(dirpath, name))
+            except OSError:
+                continue
+            total += st.st_size
+            newest = max(newest, st.st_mtime)
+    return total, newest
+
+
+def prune(root: Optional[Path] = None, limit: Optional[int] = None, keep: Optional[Path] = None) -> int:
+    """Remove whole ENVIRONMENT directories, oldest first, until the root is under
+    ``limit`` bytes. Returns the number removed.
+
+    The manifest hashes the package's source, so every edited checkout -- and
+    every CI commit -- lands in a new environment directory that will never be
+    hit again; on a runner with a persistent home that is a few hundred MB per
+    commit, forever. Whole directories go, never single entries: an
+    environment is either current (``keep``, this process's own) or dead.
+    Other schema versions' roots are dead outright and go first. A directory
+    another live process is still reading only costs that process misses.
+    """
+    root = Path(root) if root is not None else get_cache_dir()
+    limit = max_bytes() if limit is None else limit
+    if limit <= 0 or not root.is_dir():
+        return 0
+    envs = []
+    for schema_dir in root.iterdir():
+        if not schema_dir.is_dir():
+            continue
+        for env in schema_dir.iterdir():
+            if not env.is_dir():
+                continue
+            size, mtime = _dir_bytes_and_mtime(env)
+            envs.append((schema_dir.name != _SCHEMA, mtime, size, env))
+    total = sum(e[2] for e in envs)
+    removed = 0
+    # dead schemas first, then oldest first; the current environment is never a candidate
+    for _dead_schema, _mtime, size, env in sorted(envs, key=lambda e: (not e[0], e[1])):
+        if total <= limit:
+            break
+        if keep is not None and env.resolve() == Path(keep).resolve():
+            continue
+        try:
+            shutil.rmtree(env)
+        except OSError as exc:
+            _LOG.warning("compiled-plan cache: could not remove %s (%s)", env, exc)
+            continue
+        total -= size
+        removed += 1
+    if removed:
+        _count("pruned", removed)
+    return removed
+
+
+def _prune_once(root: Path, current_env: Path) -> None:
+    """Run :func:`prune` the first time this process writes an entry."""
+    global _pruned_this_process
+    with _LOCK:
+        if _pruned_this_process:
+            return
+        _pruned_this_process = True
+    try:
+        prune(root, keep=current_env)
+    except Exception as exc:  # noqa: BLE001 -- housekeeping never fails a compile
+        _LOG.warning("compiled-plan cache: prune failed (%s)", exc)
+
+
 # ---------------------------------------------------------------------------
 # The drop-in
 # ---------------------------------------------------------------------------
@@ -449,6 +539,7 @@ def compile_cached(fn: Callable, *args: Any, cache_key: Optional[str], symbol: s
         _count("export_failed")
         _LOG.warning("compiled-plan cache: could not persist %s (%s); the kernel will be recompiled next process", entry, exc)
         return compiled
+    _prune_once(get_cache_dir(), entry.parent)  # this process's first write: retire dead environments
     # Hand back the artifact rather than the in-process object, so a hit and a
     # miss run the same thing and a bad artifact fails here, not next start-up.
     loaded = _try_load(entry, cache_key, symbol)

--- a/python/cudnn/frost/compiled_cache.py
+++ b/python/cudnn/frost/compiled_cache.py
@@ -376,7 +376,7 @@ def max_bytes() -> int:
 
 def _dir_bytes_and_mtime(path: Path):
     total, newest = 0, 0.0
-    for dirpath, _dirs, files in os.walk(path):
+    for dirpath, _dirs, files in os.walk(path, followlinks=False):
         for name in files:
             try:
                 st = os.stat(os.path.join(dirpath, name))
@@ -403,12 +403,17 @@ def prune(root: Optional[Path] = None, limit: Optional[int] = None, keep: Option
     limit = max_bytes() if limit is None else limit
     if limit <= 0 or not root.is_dir():
         return 0
+    resolved_root = root.resolve()
     envs = []
+    # Symlinks are never followed and nothing outside the resolved root is ever
+    # a deletion target: a link planted in the cache must not redirect rmtree.
     for schema_dir in root.iterdir():
-        if not schema_dir.is_dir():
+        if schema_dir.is_symlink() or not schema_dir.is_dir():
             continue
         for env in schema_dir.iterdir():
-            if not env.is_dir():
+            if env.is_symlink() or not env.is_dir():
+                continue
+            if not env.resolve().is_relative_to(resolved_root):
                 continue
             size, mtime = _dir_bytes_and_mtime(env)
             envs.append((schema_dir.name != _SCHEMA, mtime, size, env))
@@ -520,7 +525,8 @@ def compile_cached(fn: Callable, *args: Any, cache_key: Optional[str], symbol: s
         # incompatible stacks with the same unknowns would otherwise hash alike.
         _count("bypassed")
         return cute.compile(fn, *args, **kwargs)
-    entry = _entry_dir(get_cache_dir(), manifest, f"{cache_key}|{symbol}|{options}")
+    root = get_cache_dir()  # one root for the export and the prune that follows it
+    entry = _entry_dir(root, manifest, f"{cache_key}|{symbol}|{options}")
     loaded = _try_load(entry, cache_key, symbol)
     if loaded is not None:
         _count("hits")
@@ -539,7 +545,7 @@ def compile_cached(fn: Callable, *args: Any, cache_key: Optional[str], symbol: s
         _count("export_failed")
         _LOG.warning("compiled-plan cache: could not persist %s (%s); the kernel will be recompiled next process", entry, exc)
         return compiled
-    _prune_once(get_cache_dir(), entry.parent)  # this process's first write: retire dead environments
+    _prune_once(root, entry.parent)  # this process's first write: retire dead environments
     # Hand back the artifact rather than the in-process object, so a hit and a
     # miss run the same thing and a bad artifact fails here, not next start-up.
     loaded = _try_load(entry, cache_key, symbol)

--- a/test/python/test_compiled_cache.py
+++ b/test/python/test_compiled_cache.py
@@ -204,3 +204,39 @@ def test_the_manifest_carries_the_source_tree_not_a_commit(tmp_path):
     import cudnn
 
     assert cc.environment_manifest()["cudnn_source"] == cc.source_tree_digest(pathlib.Path(cudnn.__file__).resolve().parent)
+
+
+def test_prune_retires_dead_environments_oldest_first_and_keeps_the_current_one(tmp_path, monkeypatch):
+    """Every edited checkout (and every CI commit) mints an environment that is
+    never hit again; a persistent home would grow by hundreds of MB per commit.
+    Whole environment directories go, dead schemas first, then oldest first,
+    until the root fits; the current environment is never a candidate."""
+    import os
+    import time
+
+    def env(schema, name, size, age_s):
+        d = tmp_path / schema / name
+        d.mkdir(parents=True)
+        (d / "manifest.json").write_text("{}")
+        e = d / "entry_x"
+        e.mkdir()
+        (e / cc._OBJECT).write_bytes(b"x" * size)
+        (e / cc._ENTRY).write_text("{}")
+        for f in d.rglob("*"):
+            os.utime(f, (time.time() - age_s, time.time() - age_s))
+        return d
+
+    old = env(cc._SCHEMA, "old", 1000, 3000)
+    mid = env(cc._SCHEMA, "mid", 1000, 2000)
+    cur = env(cc._SCHEMA, "cur", 1000, 4000)  # the oldest by mtime, but this process's own
+    dead = env("v0", "ancient", 100, 10)  # a dead schema goes first whatever its age
+    cc.reset_stats()
+    assert cc.prune(tmp_path, limit=0) == 0  # 0 = never prune
+    assert cc.prune(tmp_path, limit=2500, keep=cur) == 2
+    assert not dead.exists() and not old.exists() and mid.exists() and cur.exists()
+    assert cc.stats()["pruned"] == 2
+    assert cc.prune(tmp_path, limit=2500, keep=cur) == 0  # under the cap: nothing to do
+    monkeypatch.setenv(cc._ENV_MAX_BYTES, "0")
+    assert cc.max_bytes() == 0
+    monkeypatch.setenv(cc._ENV_MAX_BYTES, "not-a-number")
+    assert cc.max_bytes() == cc._DEFAULT_MAX_BYTES

--- a/test/python/test_compiled_cache.py
+++ b/test/python/test_compiled_cache.py
@@ -236,6 +236,13 @@ def test_prune_retires_dead_environments_oldest_first_and_keeps_the_current_one(
     assert not dead.exists() and not old.exists() and mid.exists() and cur.exists()
     assert cc.stats()["pruned"] == 2
     assert cc.prune(tmp_path, limit=2500, keep=cur) == 0  # under the cap: nothing to do
+    # a symlink planted in the root is neither followed nor a deletion target
+    outside = tmp_path.parent / f"{tmp_path.name}_outside"
+    outside.mkdir()
+    (outside / "victim").write_bytes(b"y" * 10_000)
+    (tmp_path / cc._SCHEMA / "link").symlink_to(outside, target_is_directory=True)
+    assert cc.prune(tmp_path, limit=1, keep=cur) == 1 and not mid.exists() and cur.exists()
+    assert (outside / "victim").exists() and (tmp_path / cc._SCHEMA / "link").is_symlink()
     monkeypatch.setenv(cc._ENV_MAX_BYTES, "0")
     assert cc.max_bytes() == 0
     monkeypatch.setenv(cc._ENV_MAX_BYTES, "not-a-number")

--- a/test/python/test_compiled_cache.py
+++ b/test/python/test_compiled_cache.py
@@ -214,10 +214,11 @@ def test_prune_retires_dead_environments_oldest_first_and_keeps_the_current_one(
     import os
     import time
 
-    def env(schema, name, size, age_s):
-        d = tmp_path / schema / name
+    def env(schema, name, size, age_s, manifest=True):
+        d = tmp_path / schema / (cc._digest(name) if len(name) != 24 else name)
         d.mkdir(parents=True)
-        (d / "manifest.json").write_text("{}")
+        if manifest:
+            (d / cc._MANIFEST).write_text("{}")
         e = d / "entry_x"
         e.mkdir()
         (e / cc._OBJECT).write_bytes(b"x" * size)
@@ -230,10 +231,18 @@ def test_prune_retires_dead_environments_oldest_first_and_keeps_the_current_one(
     mid = env(cc._SCHEMA, "mid", 1000, 2000)
     cur = env(cc._SCHEMA, "cur", 1000, 4000)  # the oldest by mtime, but this process's own
     dead = env("v0", "ancient", 100, 10)  # a dead schema goes first whatever its age
+    # not ours, whatever the size or age: a caller's artifacts under a shared root, a directory without
+    # our manifest, a schema-like directory with a foreign name -- never deleted, never counted
+    foreign = tmp_path / "flashinfer" / "existing_artifact"
+    foreign.mkdir(parents=True)
+    (foreign / "caller_owned.bin").write_bytes(b"z" * 100_000)
+    no_manifest = env(cc._SCHEMA, "half_written", 100_000, 9000, manifest=False)
+    odd_name = env(cc._SCHEMA, "x" * 24, 100_000, 9000)  # 24 chars but not a hex digest
     cc.reset_stats()
     assert cc.prune(tmp_path, limit=0) == 0  # 0 = never prune
     assert cc.prune(tmp_path, limit=2500, keep=cur) == 2
     assert not dead.exists() and not old.exists() and mid.exists() and cur.exists()
+    assert (foreign / "caller_owned.bin").exists() and no_manifest.exists() and odd_name.exists()
     assert cc.stats()["pruned"] == 2
     assert cc.prune(tmp_path, limit=2500, keep=cur) == 0  # under the cap: nothing to do
     # a symlink planted in the root is neither followed nor a deletion target


### PR DESCRIPTION
## Before submitting
- [x] Every new or changed first-party source file carries an SPDX-License-Identifier line
- [x] `pre-commit run -a` is clean (clang-format, black)
- [x] The hard rules in AGENTS.md were reviewed against this change
- [x] Labels added (`cat-enhancements`, `area:frost`, `orig-nv-eng`)

## Affected area
`cudnn/frost/compiled_cache.py` (the persistent compiled-plan cache from #1031), its unit tests, design doc.

## Summary
The cache's environment identity hashes the whole `cudnn` package's source (#1031), so every edited checkout and every CI commit mints an environment directory under `<root>/v2/<env_hash>/` that is never hit again. On a CI runner with a persistent home that is a few hundred MB per commit (the SDPA + GEMM suites export ~280 MB), with nothing removing it.

- `prune(root, limit, keep)`: removes **whole environment directories** — dead schema roots (`v1/…`) first, then oldest first — until the root is under `limit` bytes. The process's own environment (`keep`) is never a candidate; a directory another live process is still reading only costs that process misses (a removed entry is a miss, never an error).
- `compile_cached()` runs it once per process, after its first successful export, with the cap from `CUDNN_FRONTEND_COMPILED_CACHE_MAX_BYTES` (default 4 GiB; `0` disables).
- `stats()` gains `pruned`. Doc: the cap is a backstop; CI should point `CUDNN_FRONTEND_COMPILED_CACHE` at a job-local directory since nothing there is ever warm across commits.

## Why
Item ④ of the FlashInfer-readiness list: without it the cache grows without bound wherever the source changes often (developer checkouts, CI runners).

## Related issues
#1031 (the cache), #1035 / #1036 / #1037 (the SDPA items of the same list).

## API and compatibility impact
New public `prune()` / `max_bytes()` and env var; default behaviour changes only in that a root above 4 GiB loses its oldest dead environments on the next process's first write.

## Testing
```
test/python$ pytest test_compiled_cache.py gemm/frost/test_compiled_cache_gpu.py
12 passed   # incl. test_prune_retires_dead_environments_oldest_first_and_keeps_the_current_one (GPU-free: dead schema first, oldest next, current kept, 0 = never)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>note to self: claude::61d24ed2-7c90-4a97-9cbb-b91ae18136fd — "FE knob vocabulary / FI conformance / compiled cache" · cwd /home/scratch.yanxu_libs/flashinfer · workspace /tmp/claude-25653/-home-scratch-yanxu-libs-flashinfer/61d24ed2-7c90-4a97-9cbb-b91ae18136fd/scratchpad</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Compiled-cache storage is automatically pruned when it exceeds the configured size limit.
  - The current environment is preserved while obsolete and oldest environments are removed first.
  - Cache size limits can be configured, with a 4 GiB default; pruning can also be disabled.
  - Cache statistics now include the number of pruned entries.
  - Cache cleanup runs after successful writes without interrupting compilation if cleanup encounters an issue.

- **Documentation**
  - Documented automatic cache cleanup, size limits, and pruning statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->